### PR TITLE
erts: Fix process_info(_, garbage_collection) for max_heap_size

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -1954,8 +1954,8 @@ process_info_aux(Process *c_p,
 	t = TUPLE2(hp, am_min_bin_vheap_size, make_small(rp->min_vheap_size)); hp += 3;
 	res = CONS(hp, t, res); hp += 2;
 
-	t = TUPLE2(hp, am_max_heap_size, t); hp += 3;
-	res = CONS(hp, mhs_map, res); hp += 2;
+	t = TUPLE2(hp, am_max_heap_size, mhs_map); hp += 3;
+	res = CONS(hp, t, res); hp += 2;
 	break;
     }
 

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -1084,6 +1084,20 @@ check_proc_infos(A, B) ->
 
     GC = lists:keysearch(garbage_collection, 1, A),
     GC = lists:keysearch(garbage_collection, 1, B),
+    {value, {garbage_collection, GClist}} = GC,
+
+    %% This is not really documented
+    true = is_integer(gv(minor_gcs, GClist)),
+    true = is_integer(gv(fullsweep_after, GClist)),
+    true = is_integer(gv(min_heap_size, GClist)),
+    #{error_logger := Bool1,
+      include_shared_binaries := Bool2,
+      kill := Bool3,
+      size := MaxHeapSize} = gv(max_heap_size, GClist),
+    true = is_boolean(Bool1),
+    true = is_boolean(Bool2),
+    true = is_boolean(Bool3),
+    true = is_integer(MaxHeapSize),
 
     ok.
 


### PR DESCRIPTION
Fix #6922.

The 2-tuple {max_heap_size, Map} was accidentally lost.


Introduced by 8d5f5ef0b5bd87a79390fe767cbfed9827ba66fe in OTP 26.0-rc1.