### PR TITLE
beam_call_types: Fix inconsistency

### DIFF
--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -60,8 +60,8 @@ will_succeed(erlang, Op, [LHS, RHS]) when Op =:= '+';
                                           Op =:= '-';
                                           Op =:= '*' ->
     succeeds_if_smallish(LHS, RHS);
-will_succeed(erlang, Op, [LHS, RHS]) when Op =:= 'div';
-                                          Op =:= 'rem' ->
+will_succeed(erlang, Op, [LHS, RHS]=Args) when Op =:= 'div';
+                                               Op =:= 'rem' ->
     case {meet(LHS, #t_integer{}), meet(RHS, #t_integer{})} of
         {#t_integer{elements={_,_}}=LHS,
          #t_integer{elements={Min,Max}}=RHS}
@@ -69,28 +69,28 @@ will_succeed(erlang, Op, [LHS, RHS]) when Op =:= 'div';
                is_integer(Max), Max < -1 ->
             'yes';
         {#t_integer{}, #t_integer{}} ->
-            'maybe';
+            fails_on_conflict(erlang, Op, Args);
         {_, _} ->
             no
     end;
-will_succeed(erlang, 'bsr', [LHS, RHS]) ->
+will_succeed(erlang, 'bsr'=Op, [LHS, RHS]=Args) ->
     case {meet(LHS, #t_integer{}), meet(RHS, #t_integer{})} of
         {#t_integer{elements={_,_}}=LHS,
          #t_integer{elements={Shift,_}}=RHS}
           when is_integer(Shift), Shift >= 0 ->
             'yes';
         {#t_integer{}, #t_integer{}} ->
-            'maybe';
+            fails_on_conflict(erlang, Op, Args);
         {_, _} ->
             no
     end;
-will_succeed(erlang, 'bsl', [LHS, RHS]) ->
+will_succeed(erlang, 'bsl'=Op, [LHS, RHS]=Args) ->
     case {meet(LHS, #t_integer{}), meet(RHS, #t_integer{})} of
         {LHS, #t_integer{elements={Shift,_}}=RHS}
           when is_integer(Shift), Shift < 64 ->
             succeeds_if_smallish(LHS);
         {#t_integer{}, #t_integer{}} ->
-            'maybe';
+            fails_on_conflict(erlang, Op, Args);
         {_, _} ->
             no
     end;
@@ -115,21 +115,20 @@ will_succeed(erlang, element, [Pos, Tuple]=Args) ->
             case meet(Pos, #t_integer{elements={1,Sz}}) of
                 Pos -> yes;
                 none when Exact -> no;
-                _ -> 'maybe'
+                _ -> fails_on_conflict(erlang, element, Args)
+
             end;
         _ ->
-            Required = [#t_integer{elements={1,?MAX_TUPLE_SIZE}},
-                        #t_tuple{size=1}],
-            fails_on_conflict(Args, Required)
+            fails_on_conflict(erlang, element, Args)
     end;
 will_succeed(erlang, hd, [Arg]) ->
     succeeds_if_type(Arg, #t_cons{});
-will_succeed(erlang, is_function, [_, Arity]) ->
+will_succeed(erlang, is_function, [_, Arity]=Args) ->
     case meet(Arity, #t_integer{}) of
         #t_integer{elements={Min,_}}=Arity when is_integer(Min), Min >= 0 ->
             yes;
         #t_integer{} ->
-            'maybe';
+            fails_on_conflict(erlang, is_function, Args);
         _ ->
             no
     end;
@@ -149,7 +148,7 @@ will_succeed(erlang, 'or', [_, _]=Args) ->
     succeeds_if_types(Args, beam_types:make_boolean());
 will_succeed(erlang, 'xor', [_, _]=Args) ->
     succeeds_if_types(Args, beam_types:make_boolean());
-will_succeed(erlang, setelement, [Pos, Tuple0, _Value]) ->
+will_succeed(erlang, setelement, [Pos, Tuple0, _Value]=Args) ->
     PosRange = #t_integer{elements={1,?MAX_TUPLE_SIZE}},
     case {meet(Pos, PosRange), meet(Tuple0, #t_tuple{size=1})} of
         {none, _} ->
@@ -169,10 +168,10 @@ will_succeed(erlang, setelement, [Pos, Tuple0, _Value]) ->
                 true ->
                     %% We may or may not have a tuple, and the index may or may
                     %% not be in range if we do.
-                    'maybe'
+                    fails_on_conflict(erlang, setelement, Args)
             end;
         {_, _} ->
-            'maybe'
+            fails_on_conflict(erlang, setelement, Args)
     end;
 will_succeed(erlang, size, [Arg]) ->
     ArgType = join(#t_tuple{}, #t_bitstring{}),
@@ -197,14 +196,7 @@ will_succeed(Mod, Func, Args) ->
                 true ->
                     no;
                 false ->
-                    %% While we can't infer success for functions outside the
-                    %% 'erlang' module (see above comment), it's safe to infer
-                    %% failure when we know they return none or if the
-                    %% arguments must have certain types.
-                    case types(Mod, Func, Args) of
-                        {none, _, _} -> no;
-                        {_, ArgTypes, _} -> fails_on_conflict(Args, ArgTypes)
-                    end
+                    fails_on_conflict(Mod, Func, Args)
             end
     end.
 
@@ -217,12 +209,23 @@ max_tuple_size(#t_tuple{exact=true,size=Size}) ->
 max_tuple_size(#t_tuple{exact=false}) ->
     ?MAX_TUPLE_SIZE.
 
-fails_on_conflict([ArgType | Args], [Required | Types]) ->
+%% While we can't infer success for functions outside the 'erlang'
+%% module, it's safe to infer failure when we know they return `none` or
+%% if the arguments must have certain types.
+%%
+%% Returns: 'maybe' or 'no'
+fails_on_conflict(Mod, Func, Args) ->
+    case types(Mod, Func, Args) of
+        {none, _, _} -> no;
+        {_, ArgTypes, _} -> fails_on_conflict_1(Args, ArgTypes)
+    end.
+
+fails_on_conflict_1([ArgType | Args], [Required | Types]) ->
     case meet(ArgType, Required) of
         none -> no;
-        _ -> fails_on_conflict(Args, Types)
+        _ -> fails_on_conflict_1(Args, Types)
     end;
-fails_on_conflict([], []) ->
+fails_on_conflict_1([], []) ->
     'maybe'.
 
 succeeds_if_types([LHS, RHS], Required) ->

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -680,6 +680,9 @@ tuple(_Config) ->
     {'EXIT',{function_clause,_}} = catch gh_6458(id({42})),
     {'EXIT',{function_clause,_}} = catch gh_6458(id(a)),
 
+    {'EXIT',{badarg,_}} = catch gh_6927(id({a,b})),
+    {'EXIT',{badarg,_}} = catch gh_6927(id([])),
+
     ok.
 
 do_tuple() ->
@@ -710,6 +713,15 @@ gh_6458({X}) when X; (X orelse false) ->
 
 gh_6458() ->
     true.
+
+gh_6927(X) ->
+    %% beam_validator would complain because beam_call_types:will_succeed/3
+    %% said `maybe`, but beam_call_types:types/3 returned the type `none`.
+    element(42,
+            case X of
+                {_,_} -> X;
+                _ -> ok
+            end).
 
 -record(x, {a}).
 


### PR DESCRIPTION
The `beam_validator` pass would reject the following code:

    f(X) ->
        element(42,
                case X of
                    {_,_} -> X;
                    _ -> ok
                end).

The reason is an inconsistency between the return values of the functions `will_succeed/3` and `types/3` in the `beam_call_types` module. When `types/3` returns `none` (indicating that the call always fails), `will_succeed/3` MUST return `no`. Otherwise, `beam_validator` will reject the code.

In this case, when asked whether the call to `element/2` would succeed, `will_succeed/3` answered `maybe`, while `types/3` returned `none`.

To avoid similar bugs in the future, this commit not only fixes the inconsistency, but also refactors `will_succeed/3` to always let the new helper function `fails_on_conflict/3` handle the `maybe` case, ensuring that whenever `types/3` returns `none`, then `will_succeed/3` returns `no`.

Co-authored-by: John Högberg <john@erlang.org>

Closes #6927