### PR TITLE
Fix multi_load_SUITE, by updating verify_prepared

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -661,7 +661,7 @@ partition_on_load(Prep) ->
 	end,
     lists:partition(P, Prep).
 
-verify_prepared([{M,{Prep,Name,_Native}}|T])
+verify_prepared([{M,{Prep,Name}}|T])
   when is_atom(M), is_list(Name) ->
     try erlang:has_prepared_code_on_load(Prep) of
 	false ->


### PR DESCRIPTION
This was missed when merging commit
eacdabcf8e9fba1b4d32dbd0caf60ea9d9161a38 which removed the native flag from prepared_code()