### PR TITLE
Fixes bug in shell completion

### DIFF
--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -403,7 +403,7 @@ expand_function_parameter_type(Mod, MFA, FunType, Args, Unfinished, Nestings, FT
                                  end,
     case match_arguments(TypeTree, Args) of
         false -> {no, [], []};
-        true when Parameters == [] -> {yes, ")", []};
+        true when Parameters == [] -> {yes, ")", [#{title=>MFA, elems=>[")"], options=>[]}]};
         true ->
             Parameter = lists:nth(length(Args)+1, Parameters),
             {T, _Name} = case Parameter of

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -261,7 +261,11 @@ function_parameter_completion(Config) ->
                             elems:=[#{title:="types",
                                     elems:=[{"integer()",[]}],
                                     options:=[{hide,title}]}],
-                            options:=[{highlight_param,1}]}],
+                            options:=[{highlight_param,1}]},
+                            #{title:=
+                                "complete_function_parameter:multi_arity_fun()",
+                            options:=[],
+                            elems:=[")"]}],
                 options:=[highlight_all]}]} = do_expand("complete_function_parameter:multi_arity_fun("),
     {no, [], [#{elems:=[#{elems:=[#{elems:=[{"true",[]},{"false",[]}]}]}]}]} = do_expand("complete_function_parameter:multi_arity_fun(1,"),
     {no,[],


### PR DESCRIPTION
It was reported in the OTP 26 rc1 thread that zero arity functions was omitted if there was part of a multi arity function definition, this fixes this issue.