### PR TITLE
ssl: use macros instead of hardcoded version numbers

### DIFF
--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -545,6 +545,8 @@ handle_info({CloseTag, Socket}, StateName,
     %% with widespread implementation practice.
     case (Active == false) andalso (CTs =/= []) of
         false ->
+            %% the =< is a leaking implementation detail.
+            %% this means `Version={254, N} when N =< 253`
             if (Version =< ?'DTLS-1.2') ->
                     ok;
                true ->

--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -545,10 +545,9 @@ handle_info({CloseTag, Socket}, StateName,
     %% with widespread implementation practice.
     case (Active == false) andalso (CTs =/= []) of
         false ->
-            case Version of
-                {254, N} when N =< 253 ->
+            if (Version =< ?'DTLS-1.2') ->
                     ok;
-                _ ->
+               true ->
                     %% As invalidate_sessions here causes performance issues,
                     %% we will conform to the widespread implementation
                     %% practice and go against the spec

--- a/lib/ssl/src/dtls_handshake.erl
+++ b/lib/ssl/src/dtls_handshake.erl
@@ -189,7 +189,7 @@ handle_client_hello(Version,
 	    TLSVersion = dtls_v1:corresponding_tls_version(Version),
 	    AvailableHashSigns = ssl_handshake:available_signature_algs(
 				   ClientHashSigns, SupportedHashSigns, TLSVersion),
-	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, TLSVersion, ECCOrder),
+	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, ECCOrder),
 	    {Type, #session{cipher_suite = CipherSuite,
                             own_certificates = [OwnCert |_]} = Session1}
 		= ssl_handshake:select_session(SugesstedId, CipherSuites, 

--- a/lib/ssl/src/dtls_v1.erl
+++ b/lib/ssl/src/dtls_v1.erl
@@ -20,6 +20,7 @@
 -module(dtls_v1).
 
 -include("ssl_cipher.hrl").
+-include("ssl_record.hrl").
 
 -export([suites/1,
          all_suites/1,
@@ -35,13 +36,13 @@
 
 -define(COOKIE_BASE_TIMEOUT, 30000).
 
--spec suites(Minor:: 253|255) -> [ssl_cipher_format:cipher_suite()].
+-spec suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 
-suites(Minor) ->
+suites(Version) ->
     lists:filter(fun(Cipher) -> 
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher)) 
                  end,
-                 tls_v1:suites(corresponding_minor_tls_version(Minor))).
+                 tls_v1:suites(corresponding_tls_version(Version))).
 all_suites(Version) ->
     lists:filter(fun(Cipher) -> 
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher)) 
@@ -54,27 +55,30 @@ anonymous_suites(Version) ->
                  end, 
                  ssl_cipher:anonymous_suites(corresponding_tls_version(Version))).
 
-exclusive_suites(Minor) ->
+exclusive_suites(Version) ->
     lists:filter(fun(Cipher) ->
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher))
                  end,
-                 tls_v1:exclusive_suites(corresponding_minor_tls_version(Minor))).
+                 tls_v1:exclusive_suites(corresponding_tls_version(Version))).
 
-exclusive_anonymous_suites(Minor) ->
+exclusive_anonymous_suites(Version) ->
     lists:filter(fun(Cipher) ->
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher))
                  end,
-                 tls_v1:exclusive_anonymous_suites(corresponding_minor_tls_version(Minor))).
+                 tls_v1:exclusive_anonymous_suites(corresponding_tls_version(Version))).
 
 
 hmac_hash(MacAlg, MacSecret, Value) ->
     tls_v1:hmac_hash(MacAlg, MacSecret, Value).
 
-ecc_curves({_Major, Minor}) ->
-    tls_v1:ecc_curves(corresponding_minor_tls_version(Minor)).
+ecc_curves(Version) ->
+    tls_v1:ecc_curves(corresponding_tls_version(Version)).
 
-corresponding_tls_version({254, Minor}) ->
-    {3, corresponding_minor_tls_version(Minor)}.
+
+corresponding_tls_version(?'DTLS-1.0') ->
+    ?'TLS-1.1';
+corresponding_tls_version(?'DTLS-1.2') ->
+    ?'TLS-1.2'.
 
 cookie_secret() ->
     crypto:strong_rand_bytes(32).
@@ -82,18 +86,12 @@ cookie_secret() ->
 cookie_timeout() ->
     %% Cookie will live for two timeouts periods
     round(rand:uniform() * ?COOKIE_BASE_TIMEOUT/2).
-    
-corresponding_minor_tls_version(255) ->
-    2;
-corresponding_minor_tls_version(253) ->
-    3.
 
-corresponding_dtls_version({3, Minor}) -> 
-    {254, corresponding_minor_dtls_version(Minor)}.
 
-corresponding_minor_dtls_version(2) ->
-    255;
-corresponding_minor_dtls_version(3) ->
-    253.
+corresponding_dtls_version(?'TLS-1.1') ->
+    ?'DTLS-1.0';
+corresponding_dtls_version(?'TLS-1.2') ->
+    ?'DTLS-1.2'.
+
 is_acceptable_cipher(Suite) ->
     not ssl_cipher:is_stream_ciphersuite(Suite).

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2663,7 +2663,7 @@ tuple_to_map_mac(_, MAC) ->
 
 handle_eccs_option(Value, Version0) when is_list(Value) ->
     Version1 = tls_version(Version0),
-    try tls_v1:ecc_curves(Version1, Value) of
+    try tls_v1:ecc_curves(Version1) of
         Curves ->
             option_error(Curves =:= [], eccs, none_valid),
             #elliptic_curves{elliptic_curve_list = Curves}

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1141,14 +1141,14 @@ eccs_filter_supported(Curves) ->
 %% Description: returns all supported groups (TLS 1.3 and later)
 %%--------------------------------------------------------------------
 groups() ->
-    tls_v1:groups(?'TLS-1.3').
+    tls_v1:groups().
 
 %%--------------------------------------------------------------------
 -spec groups(default) -> [group()].
 %% Description: returns the default groups (TLS 1.3 and later)
 %%--------------------------------------------------------------------
 groups(default) ->
-    tls_v1:default_groups(?'TLS-1.3').
+    tls_v1:default_groups().
 
 %%--------------------------------------------------------------------
 -spec getopts(SslSocket, OptionNames) ->
@@ -2674,7 +2674,7 @@ handle_eccs_option(Value, Version0) when is_list(Value) ->
 
 handle_supported_groups_option(Value, Version0) when is_list(Value) ->
     Version1 = tls_version(Version0),
-    try tls_v1:groups(Version1, Value) of
+    try tls_v1:groups(Version1) of
         Groups ->
             option_error(Groups =:= [], supported_groups, none_valid),
             #supported_groups{supported_groups = Groups}

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2661,9 +2661,9 @@ tuple_to_map_mac(chacha20_poly1305, _) ->
 tuple_to_map_mac(_, MAC) ->
     MAC.
 
-handle_eccs_option(Value, Version0) when is_list(Value) ->
-    Version1 = tls_version(Version0),
-    try tls_v1:ecc_curves(Version1) of
+%% TODO: remove Version
+handle_eccs_option(Value, _Version0) when is_list(Value) ->
+    try tls_v1:ecc_curves(Value) of
         Curves ->
             option_error(Curves =:= [], eccs, none_valid),
             #elliptic_curves{elliptic_curve_list = Curves}
@@ -2672,9 +2672,9 @@ handle_eccs_option(Value, Version0) when is_list(Value) ->
         error:_ -> option_error(eccs, Value)
     end.
 
-handle_supported_groups_option(Value, Version0) when is_list(Value) ->
-    Version1 = tls_version(Version0),
-    try tls_v1:groups(Version1) of
+%% TODO: remove Version
+handle_supported_groups_option(Value, _Version0) when is_list(Value) ->
+    try tls_v1:groups(Value) of
         Groups ->
             option_error(Groups =:= [], supported_groups, none_valid),
             #supported_groups{supported_groups = Groups}

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -65,6 +65,7 @@
 -include("ssl_handshake.hrl").
 -include("ssl_alert.hrl").
 -include("ssl_internal.hrl").
+-include("ssl_record.hrl").
 -include_lib("public_key/include/public_key.hrl"). 
 
 -export([trusted_cert_and_paths/4,
@@ -345,13 +346,14 @@ available_cert_key_pairs(CertKeyGroups) ->
 
 %% Create the prioritized list of cert key pairs that
 %% are availble for use in the negotiated version
-available_cert_key_pairs(CertKeyGroups, {3, 4}) ->
+available_cert_key_pairs(CertKeyGroups, ?'TLS-1.3') ->
     RevAlgos = [rsa, rsa_pss_pss, ecdsa, eddsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
-available_cert_key_pairs(CertKeyGroups, {3, 3}) ->
+available_cert_key_pairs(CertKeyGroups, ?'TLS-1.2') ->
      RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
-available_cert_key_pairs(CertKeyGroups, {3, N}) when N < 3->
+available_cert_key_pairs(CertKeyGroups, ?'TLS-1.X'=Version)
+  when Version < ?'TLS-1.2'->
     RevAlgos = [dsa, rsa, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []).
 
@@ -596,21 +598,22 @@ verify_cert_extensions(Cert, UserState, [_|Exts], Context) ->
     %% Skip unknown extensions!
     verify_cert_extensions(Cert, UserState, Exts, Context).
 
-verify_sign(_, #{version := {_, Minor}}) when Minor < 3 ->
+verify_sign(_, #{version := ?'TLS-1.X'=Version})
+            when Version < ?'TLS-1.2' ->
     %% This verification is not applicable pre TLS-1.2 
     true; 
-verify_sign(Cert, #{version := {3, 3},
+verify_sign(Cert, #{version := ?'TLS-1.2',
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := {3, 3},
+verify_sign(Cert, #{version := ?'TLS-1.2',
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := {3, 4},
+verify_sign(Cert, #{version := 'TLS-1.3',
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs);
-verify_sign(Cert, #{version := {3, 4},
+verify_sign(Cert, #{version := ?'TLS-1.3',
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs).
 

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -609,7 +609,7 @@ verify_sign(Cert, #{version := ?'TLS-1.2',
 verify_sign(Cert, #{version := ?'TLS-1.2',
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := 'TLS-1.3',
+verify_sign(Cert, #{version := ?'TLS-1.3',
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs);

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -328,7 +328,7 @@ suites(?'DTLS-1.X'=Version) ->
 all_suites(?'TLS-1.3' = Version) ->
     suites(Version) ++ tls_testing_suites(?'TLS-1.2');
 all_suites(?'TLS-1.X' = Version) ->
-    suites(Version) ++ tls_testing_suites(?'TLS-1.2');
+    suites(Version) ++ tls_testing_suites(Version);
 all_suites(Version) ->
     dtls_v1:all_suites(Version).
 

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -214,16 +214,16 @@ build_cipher_block(BlockSz, Mac, Fragment) ->
     [Fragment, Mac, padding_with_len(TotSz, BlockSz)].
 
 block_cipher(Fun, BlockSz, #cipher_state{key=Key, iv=IV} = CS0,
-	     Mac, Fragment, {3, N})
-  when N == 0; N == 1 ->
+	     Mac, Fragment, Version)
+  when Version == ?'SSL-3.0'; Version == ?'TLS-1.0' ->
     L = build_cipher_block(BlockSz, Mac, Fragment),
     T = Fun(Key, IV, L),
     NextIV = next_iv(T, IV),
     {T, CS0#cipher_state{iv=NextIV}};
 
 block_cipher(Fun, BlockSz, #cipher_state{key=Key, iv=IV, state = IV_Cache0} = CS0,
-	     Mac, Fragment, {3, N})
-  when N == 2; N == 3; N == 4 ->
+	     Mac, Fragment, ?'TLS-1.X'=Version)
+  when Version == ?'TLS-1.1'; Version == ?'TLS-1.2'; Version == ?'TLS-1.3' ->
     IV_Size = byte_size(IV),
     <<NextIV:IV_Size/binary, IV_Cache/binary>> =
         case IV_Cache0 of
@@ -321,45 +321,42 @@ block_decipher(Fun, #cipher_state{key=Key, iv=IV} = CipherState0,
 %%
 %% Description: Returns a list of supported cipher suites.
 %%--------------------------------------------------------------------
-suites({3, Minor}) ->
-    tls_v1:suites(Minor);
-suites({_, Minor}) ->
-    dtls_v1:suites(Minor).
-all_suites({3, 4} = Version) ->
-    suites(Version)
-	++ tls_v1:psk_suites({3,3})
-	++ tls_v1:srp_suites({3,3})
-        ++ tls_v1:rsa_suites({3,3})
-        ++ tls_v1:des_suites({3,3})
-        ++ tls_v1:rc4_suites({3,3});
-all_suites({3, _} = Version) ->
-    suites(Version)
-	++ tls_v1:psk_suites(Version)
-	++ tls_v1:srp_suites(Version)
-        ++ tls_v1:rsa_suites(Version)
-        ++ tls_v1:des_suites(Version)
-        ++ tls_v1:rc4_suites(Version);
+suites(?'TLS-1.X'=Version) ->
+    tls_v1:suites(Version);
+suites(?'DTLS-1.X'=Version) ->
+    dtls_v1:suites(Version).
+all_suites(?'TLS-1.3' = Version) ->
+    suites(Version) ++ tls_testing_suites(?'TLS-1.2');
+all_suites(?'TLS-1.X' = Version) ->
+    suites(Version) ++ tls_testing_suites(?'TLS-1.2');
 all_suites(Version) ->
     dtls_v1:all_suites(Version).
 
+tls_testing_suites(Version) ->
+    Tests = [ fun tls_v1:psk_suites/1
+            , fun tls_v1:srp_suites/1
+            , fun tls_v1:rsa_suites/1
+            , fun tls_v1:des_suites/1
+            , fun tls_v1:rc4_suites/1],
+    lists:flatmap(fun (Fun) -> Fun(Version) end, Tests).
+
 %%--------------------------------------------------------------------
--spec anonymous_suites(ssl_record:ssl_version() | integer()) ->
-                              [ssl_cipher_format:cipher_suite()].
+-spec anonymous_suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 %%
 %% Description: Returns a list of the anonymous cipher suites, only supported
 %% if explicitly set by user. Intended only for testing.
 %%--------------------------------------------------------------------
-anonymous_suites({3, N}) ->
-    anonymous_suites(N);
-anonymous_suites({254, _} = Version) ->
-    dtls_v1:anonymous_suites(Version);
 
-anonymous_suites(1 = N) ->
-    tls_v1:exclusive_anonymous_suites(N);
-anonymous_suites(4 = N) ->
-    tls_v1:exclusive_anonymous_suites(N);
-anonymous_suites(N) when N > 1->
-    tls_v1:exclusive_anonymous_suites(N) ++ anonymous_suites(N-1).
+anonymous_suites(?'TLS-1.X'=Version) ->
+    SuitesToTest = anonymous_suite_to_test(Version),
+    lists:flatmap(fun tls_v1:exclusive_anonymous_suites/1, SuitesToTest);
+anonymous_suites(?'DTLS-1.X'=Version) ->
+    dtls_v1:anonymous_suites(Version).
+
+anonymous_suite_to_test(?'TLS-1.0') -> [?'TLS-1.0'];
+anonymous_suite_to_test(?'TLS-1.1') -> [?'TLS-1.1', ?'TLS-1.0'];
+anonymous_suite_to_test(?'TLS-1.2') -> [?'TLS-1.2', ?'TLS-1.1', ?'TLS-1.0'];
+anonymous_suite_to_test(?'TLS-1.3') -> [?'TLS-1.3'].
 
 %%--------------------------------------------------------------------
 -spec filter(undefined | binary(), [ssl_cipher_format:cipher_suite()],
@@ -687,8 +684,8 @@ scheme_to_components({Hash,Sign}) -> {Hash, Sign, undefined}.
 mac_hash({_,_}, ?NULL, _MacSecret, _SeqNo, _Type,
 	 _Length, _Fragment) ->
     <<>>;
-mac_hash({3, N} = Version, MacAlg, MacSecret, SeqNo, Type, Length, Fragment)  
-  when N =:= 1; N =:= 2; N =:= 3; N =:= 4 ->
+mac_hash(?'TLS-1.X' = Version, MacAlg, MacSecret, SeqNo, Type, Length, Fragment)
+  when Version =/= ?'SSL-3.0' ->
     tls_v1:mac_hash(MacAlg, MacSecret, SeqNo, Type, Version,
 		      Length, Fragment).
 
@@ -828,9 +825,9 @@ block_size(Cipher) when Cipher == aes_128_cbc;
 			Cipher == chacha20_poly1305 ->
     16.
 
-prf_algorithm(default_prf, {3, N}) when N >= 3 ->
+prf_algorithm(default_prf, ?'TLS-1.X'=Version) when Version >= ?'TLS-1.2' ->
     ?SHA256;
-prf_algorithm(default_prf, {3, _}) ->
+prf_algorithm(default_prf, ?'TLS-1.X') ->
     ?MD5SHA;
 prf_algorithm(Algo, _) ->
     hash_algorithm(Algo).
@@ -933,8 +930,8 @@ signature_algorithm_to_scheme(#'SignatureAlgorithm'{algorithm = ?'id-RSASSA-PSS'
 %%   We return the original (possibly invalid) PadLength in any case.
 %%   An invalid PadLength will be caught by is_correct_padding/2
 %%
-generic_block_cipher_from_bin({3, N}, T, IV, HashSize)
-  when N == 0; N == 1 ->
+generic_block_cipher_from_bin(Version, T, IV, HashSize)
+  when Version == ?'SSL-3.0'; Version == ?'TLS-1.0' ->
     Sz1 = byte_size(T) - 1,
     <<_:Sz1/binary, ?BYTE(PadLength0)>> = T,
     PadLength = if
@@ -948,8 +945,8 @@ generic_block_cipher_from_bin({3, N}, T, IV, HashSize)
 			  padding=Padding, padding_length=PadLength0,
 			  next_iv = IV};
 
-generic_block_cipher_from_bin({3, N}, T, IV, HashSize)
-  when N == 2; N == 3; N == 4 ->
+generic_block_cipher_from_bin(Version, T, IV, HashSize)
+  when Version == ?'TLS-1.1'; Version == ?'TLS-1.2'; Version == ?'TLS-1.3' ->
     Sz1 = byte_size(T) - 1,
     <<_:Sz1/binary, ?BYTE(PadLength)>> = T,
     IVLength = byte_size(IV),
@@ -968,14 +965,14 @@ generic_stream_cipher_from_bin(T, HashSz) ->
 			   mac=Mac}.
 
 is_correct_padding(#generic_block_cipher{padding_length = Len,
-					 padding = Padding}, {3, 0}, _) ->
+					 padding = Padding}, ?'SSL-3.0', _) ->
     Len == byte_size(Padding); %% Only length check is done in SSL 3.0 spec
 %% For interoperability reasons it is possible to disable
 %% the padding check when using TLS 1.0, as it is not strictly required 
 %% in the spec (only recommended), however this makes TLS 1.0 vunrable to the Poodle attack 
 %% so by default this clause will not match
-is_correct_padding(GenBlockCipher, {3, 1}, false) ->
-    is_correct_padding(GenBlockCipher, {3, 0}, false);
+is_correct_padding(GenBlockCipher, ?'TLS-1.0', false) ->
+    is_correct_padding(GenBlockCipher, ?'SSL-3.0', false);
 %% Padding must be checked in TLS 1.1 and after  
 is_correct_padding(#generic_block_cipher{padding_length = Len,
 					 padding = Padding}, _, _) ->
@@ -1053,7 +1050,7 @@ filter_suites_pubkey(ecdsa, Ciphers, _, OtpCert) ->
                                    ec_ecdhe_suites(Ciphers)),
     filter_keyuse_suites(keyAgreement, Uses, CiphersSuites, ec_ecdh_suites(Ciphers)).
 
-filter_suites_signature(_, Ciphers, {3, N}) when N >= 3 ->
+filter_suites_signature(_, Ciphers, ?'TLS-1.X'=Version) when Version >= ?'TLS-1.2' ->
      Ciphers;
 filter_suites_signature(rsa, Ciphers, Version) ->
     (Ciphers -- ecdsa_signed_suites(Ciphers, Version)) -- dsa_signed_suites(Ciphers, Version);
@@ -1079,7 +1076,7 @@ filter_suites_signature(ecdsa, Ciphers, Version) ->
 %% extension.  The names DH_DSS, DH_RSA, ECDH_ECDSA, and ECDH_RSA are
 %% historical.
 %% Note: DH_DSS and DH_RSA is not supported
-rsa_signed({3,N}) when N >= 3 ->
+rsa_signed(?'TLS-1.X'=Version) when Version >= ?'TLS-1.2' ->
     fun(rsa) -> true;
        (dhe_rsa) -> true;
        (ecdhe_rsa) -> true;
@@ -1102,7 +1099,7 @@ rsa_signed_suites(Ciphers, Version) ->
                              cipher_filters => [],
                              mac_filters => [],
                              prf_filters => []}).
-ecdsa_signed({3,N}) when N >= 3 ->
+ecdsa_signed(?'TLS-1.X'=Version) when Version >= ?'TLS-1.2' ->
     fun(ecdhe_ecdsa) -> true;
        (_) -> false
     end;

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2363,9 +2363,9 @@ master_secret(Version, MasterSecret,
     {MasterSecret,
      ssl_record:set_pending_cipher_state(ConnStates2, ClientCipherState,
 					 ServerCipherState, Role)}.
-setup_keys({3,N}, PrfAlgo, MasterSecret,
+setup_keys({3,_}=Version, PrfAlgo, MasterSecret,
 	   ServerRandom, ClientRandom, HashSize, KML, _EKML, IVS) ->
-    tls_v1:setup_keys(N, PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+    tls_v1:setup_keys(Version, PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
 			KML, IVS).
 calc_master_secret(?'TLS-1.X', PrfAlgo, PremasterSecret, ClientRandom, ServerRandom) ->
     tls_v1:master_secret(PrfAlgo, PremasterSecret, ClientRandom, ServerRandom).

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -600,8 +600,6 @@ encode_handshake(#certificate_verify{signature = BinSig, hashsign_algorithm = Ha
 encode_handshake(#finished{verify_data = VerifyData}, _Version) ->
     {?FINISHED, VerifyData}.
 
-encode_hello_extensions(_, ?'SSL-3.0') ->
-    <<>>;
 encode_hello_extensions(Extensions, _) ->
     encode_extensions(hello_extensions_list(Extensions), <<>>).
 
@@ -2490,8 +2488,6 @@ encode_server_key(#server_srp_params{srp_n = N, srp_g = G,	srp_s = S, srp_b = B}
     <<?UINT16(NLen), N/binary, ?UINT16(GLen), G/binary,
       ?BYTE(SLen), S/binary, ?UINT16(BLen), B/binary>>.
 
-encode_client_key(#encrypted_premaster_secret{premaster_secret = PKEPMS},?'SSL-3.0') ->
-    PKEPMS;
 encode_client_key(#encrypted_premaster_secret{premaster_secret = PKEPMS}, _) ->
     PKEPMSLen = byte_size(PKEPMS),
     <<?UINT16(PKEPMSLen), PKEPMS/binary>>;
@@ -2725,8 +2721,6 @@ dec_server_key(<<?UINT16(NLen), N:NLen/binary,
 dec_server_key(_, KeyExchange, _) ->
     throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, {unknown_or_malformed_key_exchange, KeyExchange})).
 
-dec_client_key(PKEPMS, ?KEY_EXCHANGE_RSA, ?'SSL-3.0') ->
-    #encrypted_premaster_secret{premaster_secret = PKEPMS};
 dec_client_key(<<?UINT16(_), PKEPMS/binary>>, ?KEY_EXCHANGE_RSA, _) ->
     #encrypted_premaster_secret{premaster_secret = PKEPMS};
 dec_client_key(<<>>, ?KEY_EXCHANGE_DIFFIE_HELLMAN, _) ->
@@ -2750,10 +2744,6 @@ dec_client_key(<<?UINT16(Len), Id:Len/binary,
 		 ?BYTE(DH_YLen), DH_Y:DH_YLen/binary>>,
 	       ?KEY_EXCHANGE_EC_DIFFIE_HELLMAN_PSK, _) ->
     #client_ecdhe_psk_identity{identity = Id, dh_public = DH_Y};
-dec_client_key(<<?UINT16(Len), Id:Len/binary, PKEPMS/binary>>,
-	       ?KEY_EXCHANGE_RSA_PSK, ?'SSL-3.0') ->
-    #client_rsa_psk_identity{identity = Id,
-			     exchange_keys = #encrypted_premaster_secret{premaster_secret = PKEPMS}};
 dec_client_key(<<?UINT16(Len), Id:Len/binary, ?UINT16(_), PKEPMS/binary>>,
 	       ?KEY_EXCHANGE_RSA_PSK, _) ->
     #client_rsa_psk_identity{identity = Id,

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2331,8 +2331,8 @@ encrypted_premaster_secret(Secret, RSAPublicKey) ->
     end.
 
 -spec calc_certificate_verify(ssl_record:ssl_version(), md5sha | sha, _, [binary()]) -> binary().
-calc_certificate_verify(?'TLS-1.X'=Version, HashAlgo, _MasterSecret, Handshake) ->
-    tls_v1:certificate_verify(HashAlgo, Version, lists:reverse(Handshake)).
+calc_certificate_verify(?'TLS-1.X', HashAlgo, _MasterSecret, Handshake) ->
+    tls_v1:certificate_verify(HashAlgo, lists:reverse(Handshake)).
 
 calc_finished(?'TLS-1.X'=Version, Role, PrfAlgo, MasterSecret, Handshake) ->
     tls_v1:finished(Role, Version, PrfAlgo, MasterSecret, lists:reverse(Handshake)).

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1142,15 +1142,6 @@ is_acceptable_cert(_,_,_) ->
     %% Not negotiable pre TLS-1.2. So if cert is available for version it is acceptable
     true.
 
-supported_ecc(?'TLS-1.X'=Version) ->
-    Curves = tls_v1:ecc_curves(Version),
-    #elliptic_curves{elliptic_curve_list = Curves};
-supported_ecc(?'DTLS-1.X'=Version) ->
-    Curves = tls_v1:ecc_curves(Version),
-    #elliptic_curves{elliptic_curve_list = Curves};
-supported_ecc(_) ->
-    #elliptic_curves{elliptic_curve_list = []}.
-
 premaster_secret(OtherPublicDhKey, MyPrivateKey, #'DHParameter'{} = Params) ->
     try
 	public_key:compute_key(OtherPublicDhKey, MyPrivateKey, Params)

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2330,8 +2330,10 @@ encrypted_premaster_secret(Secret, RSAPublicKey) ->
             throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, premaster_encryption_failed))
     end.
 
+-spec calc_certificate_verify(ssl_record:ssl_version(), md5sha | sha, _, [binary()]) -> binary().
 calc_certificate_verify(?'TLS-1.X'=Version, HashAlgo, _MasterSecret, Handshake) ->
     tls_v1:certificate_verify(HashAlgo, Version, lists:reverse(Handshake)).
+
 calc_finished(?'TLS-1.X'=Version, Role, PrfAlgo, MasterSecret, Handshake) ->
     tls_v1:finished(Role, Version, PrfAlgo, MasterSecret, lists:reverse(Handshake)).
 

--- a/lib/ssl/src/ssl_logger.erl
+++ b/lib/ssl/src/ssl_logger.erl
@@ -290,19 +290,20 @@ get_server_version(Version, Extensions) ->
             Version
     end.
 
-version({3,4}) ->
+-spec version(ssl_record:ssl_version()) -> string().
+version(?'TLS-1.3') ->
     "TLS 1.3";
-version({3,3}) ->
+version(?'TLS-1.2') ->
     "TLS 1.2";
-version({3,2}) ->
+version(?'TLS-1.1') ->
     "TLS 1.1";
-version({3,1}) ->
+version(?'TLS-1.0') ->
     "TLS 1.0";
-version({3,0}) ->
+version(?'SSL-3.0') ->
     "SSL 3.0";
-version({254,253}) ->
+version(?'DTLS-1.2') ->
     "DTLS 1.2";
-version({254,255}) ->
+version(?'DTLS-1.0') ->
     "DTLS 1.0";
 version({M,N}) ->
     io_lib:format("TLS/DTLS [0x0~B0~B]", [M,N]).

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -58,7 +58,7 @@
 
 -export_type([ssl_version/0, ssl_atom_version/0, connection_states/0, connection_state/0]).
 
--type ssl_version()       :: {integer(), integer()}.
+-type ssl_version()       :: {non_neg_integer(), non_neg_integer()}.
 -type ssl_atom_version() :: tls_record:tls_atom_version().
 -type connection_states() :: map(). %% Map
 -type connection_state() :: map(). %% Map

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -55,7 +55,6 @@
 -export([cipher/4, cipher/5, decipher/4,
          cipher_aead/4, cipher_aead/5, decipher_aead/5,
          is_correct_mac/2, nonce_seed/3]).
--define(TLS_1_3, {3, 4}).
 
 -export_type([ssl_version/0, ssl_atom_version/0, connection_states/0, connection_state/0]).
 
@@ -496,7 +495,7 @@ init_security_parameters(?SERVER, Version) ->
     #security_parameters{connection_end = ?SERVER,
                          server_random = make_random(Version)}.
 
-make_random({_Major, _Minor} = Version) when Version >= ?TLS_1_3 ->
+make_random(Version) when Version >= ?'TLS-1.3' ->
     ssl_cipher:random_bytes(32);
 make_random(_Version) ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(

--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -188,7 +188,6 @@
 -define('TLS-1.0', {3, 1}).
 -define('DTLS-1.X', {254, _}).
 -define('DTLS-1.0', {254, 255}).
--define('DTLS-1.1', {254, 254}).
 -define('DTLS-1.2', {254, 253}).
 -define('SSL-2.0', {2, 0}).
 -define('SSL-3.0', {3, 0}).

--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -180,4 +180,17 @@
           next_iv  % opaque IV[SecurityParameters.record_iv_length];
          }). 
 
+
+-define('TLS-1.X', {3, _}).
+-define('TLS-1.3', {3, 4}).
+-define('TLS-1.2', {3, 3}).
+-define('TLS-1.1', {3, 2}).
+-define('TLS-1.0', {3, 1}).
+-define('DTLS-1.X', {254, _}).
+-define('DTLS-1.0', {254, 255}).
+-define('DTLS-1.1', {254, 254}).
+-define('DTLS-1.2', {254, 253}).
+-define('SSL-2.0', {2, 0}).
+-define('SSL-3.0', {3, 0}).
+
 -endif. % -ifdef(ssl_record).

--- a/lib/ssl/src/ssl_session.erl
+++ b/lib/ssl/src/ssl_session.erl
@@ -28,6 +28,7 @@
 -include("ssl_handshake.hrl").
 -include("ssl_internal.hrl").
 -include("ssl_api.hrl").
+-include("ssl_record.hrl").
 
 %% Internal application API
 -export([is_new/2,
@@ -89,7 +90,7 @@ client_select_session({_, _, #{versions := Versions,
     HVersion = RecordCb:highest_protocol_version(Versions),
 
     case LVersion of
-        {3, 4} ->
+        ?'TLS-1.3' ->
             %% Session reuse is not supported, do pure legacy
             %% middlebox comp mode negotiation, by providing either
             %% empty session id (no middle box) or random id (middle
@@ -241,7 +242,7 @@ record_cb(dtls) ->
 legacy_session_id() ->
     crypto:strong_rand_bytes(32).
 
-maybe_handle_middlebox({3, 4}, #session{session_id = ?EMPTY_ID} = Session, Options)->
+maybe_handle_middlebox(?'TLS-1.3', #session{session_id = ?EMPTY_ID} = Session, Options)->
     case maps:get(middlebox_comp_mode, Options,true) of
         true ->
             Session#session{session_id = legacy_session_id()};

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -597,7 +597,7 @@ choose_tls_fsm(#{versions := Versions},
                                 }
                  }) ->
     case ssl_handshake:select_supported_version(ClientVersions, Versions) of
-        {3,4} ->
+        ?'TLS-1.3' ->
             tls_1_3_fsm;
         _Else ->
             tls_1_0_to_1_2_fsm

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -33,6 +33,7 @@
 -include("ssl_alert.hrl").
 -include("ssl_api.hrl").
 -include("ssl_internal.hrl").
+-include("tls_record_1_3.hrl").
 
 %% Setup
 -export([start_fsm/8,
@@ -831,7 +832,7 @@ next_record_done(#state{protocol_buffers = Buffers} = State, CipherTexts, Connec
 %% field in TLS-1.3 client hello). The versions are instead negotiated with an hello extension. When
 %% decoding the server_hello messages we want to go through TLS-1.3 decode functions to be able
 %% to handle TLS-1.3 extensions if TLS-1.3 will be the negotiated version.
-handle_unnegotiated_version(?'TLS-1.2' , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, hello) ->
+handle_unnegotiated_version(?LEGACY_VERSION , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, hello) ->
     %% The effective version for decoding the server hello message should be the TLS-1.3. Possible coalesced TLS-1.2
     %% server handshake messages should be decoded with the negotiated version in later state.
     <<_:8, ?UINT24(Length), _/binary>> = Data,

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -741,7 +741,7 @@ activate_socket(#state{protocol_specific = #{active_n_toggle := true, active_n :
 next_record(State, CipherTexts, ConnectionStates, Check) ->
     next_record(State, CipherTexts, ConnectionStates, Check, [], false).
 %%
-next_record(#state{connection_env = #connection_env{negotiated_version = {3,4} = Version}} = State,
+next_record(#state{connection_env = #connection_env{negotiated_version = ?'TLS-1.3' = Version}} = State,
             [CT|CipherTexts], ConnectionStates0, Check, Acc, IsEarlyData) ->
     case tls_record:decode_cipher_text(Version, CT, ConnectionStates0, Check) of
         {Record = #ssl_tls{type = ?APPLICATION_DATA, fragment = Fragment}, ConnectionStates} ->
@@ -831,7 +831,7 @@ next_record_done(#state{protocol_buffers = Buffers} = State, CipherTexts, Connec
 %% field in TLS-1.3 client hello). The versions are instead negotiated with an hello extension. When
 %% decoding the server_hello messages we want to go through TLS-1.3 decode functions to be able
 %% to handle TLS-1.3 extensions if TLS-1.3 will be the negotiated version.
-handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Options, Data, Buffer, client, hello) ->
+handle_unnegotiated_version(?'TLS-1.2' , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, hello) ->
     %% The effective version for decoding the server hello message should be the TLS-1.3. Possible coalesced TLS-1.2
     %% server handshake messages should be decoded with the negotiated version in later state.
     <<_:8, ?UINT24(Length), _/binary>> = Data,
@@ -839,7 +839,7 @@ handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Option
     {HSPacket, <<>> = NewHsBuffer} = tls_handshake:get_tls_handshakes(Version, FirstPacket, Buffer, Options),
     {HSPacket, NewHsBuffer, RecordRest};
 %% TLS-1.3 RetryRequest
-handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
+handle_unnegotiated_version(?'TLS-1.2' , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
     tls_handshake:get_tls_handshakes(Version, Data, Buffer, Options);
 %% When the `negotiated_version` variable is not yet set use the highest supported version.
 handle_unnegotiated_version(undefined, #{versions := [Version|_]} = Options, Data, Buff, _, _) ->

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -338,7 +338,7 @@ handle_client_hello(Version,
             ClientSignatureSchemes = get_signature_ext(signature_algs_cert, HelloExt, Version),
 	    AvailableHashSigns = ssl_handshake:available_signature_algs(
 				   ClientHashSigns, SupportedHashSigns, Version),
-	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, Version, ECCOrder),
+	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, ECCOrder),
 	    {Type, #session{cipher_suite = CipherSuite,
                             own_certificates = [OwnCert |_]} = Session1}
 		= ssl_handshake:select_session(SugesstedId, CipherSuites,

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -74,9 +74,9 @@ client_hello(_Host, _Port, ConnectionStates,
     %% legacy_version field MUST be set to 0x0303, which is the version
     %% number for TLS 1.2.
     LegacyVersion =
-        case tls_record:is_higher(Version, {3,2}) of
+        case tls_record:is_higher(Version, ?'TLS-1.1') of
             true ->
-                {3,3};
+                ?'TLS-1.2';
             false ->
                 Version
         end,
@@ -167,15 +167,15 @@ hello(#server_hello{server_version = LegacyVersion,
     %% (Section 4.2.1), and the legacy_version field MUST be set to 0x0303, which is the version
     %% number for TLS 1.2.
     %% The "supported_versions" extension is supported from TLS 1.2.
-    case LegacyVersion > {3,3} orelse
-        LegacyVersion =:= {3,3} andalso Version < {3,3} of
+    case LegacyVersion > ?'TLS-1.2' orelse
+        LegacyVersion =:= ?'TLS-1.2' andalso Version < ?'TLS-1.2' of
         true ->
             throw(?ALERT_REC(?FATAL, ?ILLEGAL_PARAMETER));
         false ->
             case tls_record:is_acceptable_version(Version, SupportedVersions) of
                 true ->
                     case Version of
-                        {3,3} ->
+                        ?'TLS-1.2' ->
                             IsNew = ssl_session:is_new(OldId, SessionId),
                             %% TLS 1.2 ServerHello with "supported_versions" (special case)
                             handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
@@ -405,7 +405,7 @@ do_hello(Version, Versions, CipherSuites, Hello, SslOpts, Info, Renegotiation) -
     end.
 
 %%--------------------------------------------------------------------
-enc_handshake(#hello_request{}, {3, N}) when N < 4 ->
+enc_handshake(#hello_request{}, ?'TLS-1.X'=Version) when Version < ?'TLS-1.3' ->
     {?HELLO_REQUEST, <<>>};
 enc_handshake(#client_hello{client_version = {Major, Minor} = Version,
 		     random = Random,
@@ -424,7 +424,7 @@ enc_handshake(#client_hello{client_version = {Major, Minor} = Version,
 		      ?BYTE(SIDLength), SessionID/binary,
 		      ?UINT16(CsLength), BinCipherSuites/binary,
 		      ?BYTE(CmLength), BinCompMethods/binary, ExtensionsBin/binary>>};
-enc_handshake(HandshakeMsg, {3, 4}) ->
+enc_handshake(HandshakeMsg, ?'TLS-1.3') ->
     tls_handshake_1_3:encode_handshake(HandshakeMsg);
 enc_handshake(HandshakeMsg, Version) ->
     ssl_handshake:encode_handshake(HandshakeMsg, Version).
@@ -446,7 +446,8 @@ get_tls_handshakes_aux(Version, <<?BYTE(Type), ?UINT24(Length),
 get_tls_handshakes_aux(_Version, Data, _, Acc) ->
     {lists:reverse(Acc), Data}.
 
-decode_handshake({3, N}, ?HELLO_REQUEST, <<>>) when N < 4 ->
+decode_handshake(?'TLS-1.X'=Version, ?HELLO_REQUEST, <<>>)
+  when Version < ?'TLS-1.3' ->
     #hello_request{};
 decode_handshake(Version, ?CLIENT_HELLO,
                  <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,
@@ -465,7 +466,7 @@ decode_handshake(Version, ?CLIENT_HELLO,
        compression_methods = erlang:binary_to_list(Comp_methods),
        extensions = DecodedExtensions
       };
-decode_handshake({3, 4}, Tag, Msg) ->
+decode_handshake(?'TLS-1.3', Tag, Msg) ->
     tls_handshake_1_3:decode_handshake(Tag, Msg);
 decode_handshake(Version, Tag, Msg) ->
     ssl_handshake:decode_handshake(Version, Tag, Msg).
@@ -476,7 +477,7 @@ ocsp_expect(true) ->
 ocsp_expect(_) ->
     no_staple.
 
-get_signature_ext(Ext, HelloExt, {3,3}) ->
+get_signature_ext(Ext, HelloExt, ?'TLS-1.2') ->
     case maps:get(Ext, HelloExt, undefined) of
         %% Signature algorithms was not sent
         undefined ->

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -106,7 +106,7 @@ server_hello(MsgType, SessionId, KeyShare, PSK, ConnectionStates) ->
     #{security_parameters := SecParams} =
 	ssl_record:pending_connection_state(ConnectionStates, read),
     Extensions = server_hello_extensions(MsgType, KeyShare, PSK),
-    #server_hello{server_version = ?'TLS-1.2', %% legacy_version
+    #server_hello{server_version = ?LEGACY_VERSION, %% legacy_version
 		  cipher_suite = SecParams#security_parameters.cipher_suite,
                   compression_method = 0, %% legacy attribute
 		  random = server_hello_random(MsgType, SecParams),

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -718,15 +718,13 @@ encode_fragments(Type, Version, [Text|Data],
 %% 1/n-1 splitting countermeasure Rizzo/Duong-Beast, RC4 ciphers are
 %% not vulnerable to this attack.
 split_iovec(Data, Version, BCA, one_n_minus_one, MaxLength)
-  when (BCA =/= ?RC4) andalso (?'TLS-1.0' == Version orelse
-                               ?'SSL-3.0' == Version) ->
+  when BCA =/= ?RC4, ?'TLS-1.0' == Version ->
     {Part, RestData} = split_iovec(Data, 1, []),
     [Part|split_iovec(RestData, MaxLength)];
 %% 0/n splitting countermeasure for clients that are incompatible with 1/n-1
 %% splitting.
 split_iovec(Data, Version, BCA, zero_n, MaxLength)
-  when (BCA =/= ?RC4) andalso (?'TLS-1.0' == Version orelse
-                               ?'SSL-3.0' == Version) ->
+  when BCA =/= ?RC4, ?'TLS-1.0' == Version ->
     {Part, RestData} = split_iovec(Data, 0, []),
     [Part|split_iovec(RestData, MaxLength)];
 split_iovec(Data, _Version, _BCA, _BeatMitigation, MaxLength) ->

--- a/lib/ssl/src/tls_record_1_3.erl
+++ b/lib/ssl/src/tls_record_1_3.erl
@@ -288,7 +288,7 @@ encode_plain_text(#inner_plaintext{
     Encoded = cipher_aead(PlainText, BulkCipherAlgo, Key, Seq, IV, TagLen),
     %% 23 (application_data) for outward compatibility
     #tls_cipher_text{opaque_type = ?OPAQUE_TYPE,
-                     legacy_version = ?'TLS-1.2',
+                     legacy_version = ?LEGACY_VERSION,
                      encoded_record = Encoded};
 encode_plain_text(#inner_plaintext{
                      content = Data,

--- a/lib/ssl/src/tls_record_1_3.erl
+++ b/lib/ssl/src/tls_record_1_3.erl
@@ -171,7 +171,7 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
                             fragment = <<?FATAL,?ILLEGAL_PARAMETER>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?ALERT,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = <<?FATAL,?ILLEGAL_PARAMETER>>}, ConnectionStates0};
 %% TLS 1.3 server can receive a User Cancelled Alert when handshake is
 %% paused and then cancelled on the client side.
@@ -180,7 +180,7 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
                             fragment = <<?FATAL,?USER_CANCELED>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?ALERT,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = <<?FATAL,?USER_CANCELED>>}, ConnectionStates0};
 %% RFC8446 - TLS 1.3
 %% D.4.  Middlebox Compatibility Mode
@@ -195,7 +195,7 @@ decode_cipher_text(#ssl_tls{type = ?CHANGE_CIPHER_SPEC,
                             fragment = <<1>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?CHANGE_CIPHER_SPEC,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = <<1>>}, ConnectionStates0};
 decode_cipher_text(#ssl_tls{type = Type,
                             version = ?LEGACY_VERSION,
@@ -206,7 +206,7 @@ decode_cipher_text(#ssl_tls{type = Type,
                                   cipher_suite = ?TLS_NULL_WITH_NULL_NULL}
 			  }} = ConnnectionStates0) ->
     {#ssl_tls{type = Type,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = CipherFragment}, ConnnectionStates0};
 decode_cipher_text(#ssl_tls{type = Type}, _) ->
     %% Version mismatch is already asserted
@@ -288,7 +288,7 @@ encode_plain_text(#inner_plaintext{
     Encoded = cipher_aead(PlainText, BulkCipherAlgo, Key, Seq, IV, TagLen),
     %% 23 (application_data) for outward compatibility
     #tls_cipher_text{opaque_type = ?OPAQUE_TYPE,
-                     legacy_version = {3,3},
+                     legacy_version = ?'TLS-1.2',
                      encoded_record = Encoded};
 encode_plain_text(#inner_plaintext{
                      content = Data,
@@ -301,7 +301,7 @@ encode_plain_text(#inner_plaintext{
     %% When record protection has not yet been engaged, TLSPlaintext
     %% structures are written directly onto the wire.
     #tls_cipher_text{opaque_type = Type,
-                      legacy_version = {3,3},
+                      legacy_version = ?'TLS-1.2',
                       encoded_record = Data}.
 
 additional_data(Length) ->
@@ -375,7 +375,7 @@ decode_inner_plaintext(PlainText) ->
                   Type =:= ?HANDSHAKE orelse
                   Type =:= ?ALERT ->
             #ssl_tls{type = Type,
-                     version = {3,4}, %% Internally use real version
+                     version = ?'TLS-1.3', %% Internally use real version
                      fragment = init_binary(PlainText)};
         _Else ->
             ?ALERT_REC(?FATAL, ?UNEXPECTED_MESSAGE, empty_alert)

--- a/lib/ssl/src/tls_record_1_3.hrl
+++ b/lib/ssl/src/tls_record_1_3.hrl
@@ -43,7 +43,7 @@
 %%     } ContentType;
 
 -define(INVALID, 0).
--define(LEGACY_VERSION, {3,3}).
+-define(LEGACY_VERSION, ?'TLS-1.2').
 -define(OPAQUE_TYPE, 23).
 
 -record(inner_plaintext, {

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -588,20 +588,12 @@ update_bytes_sent(_, #data{static = #static{bytes_sent = Sent} = Static} = State
 %% approximately 2^-57 for Authenticated Encryption (AE) security.  For
 %% ChaCha20/Poly1305, the record sequence number would wrap before the
 %% safety limit is reached.
-key_update_at(Version, #{security_parameters :=
+key_update_at(?'TLS-1.3', #{security_parameters :=
                              #security_parameters{
-                                bulk_cipher_algorithm = CipherAlgo}}, KeyUpdateAt)
-  when Version >= ?'TLS-1.3' ->
-    case CipherAlgo of
-        ?AES_GCM ->
-            KeyUpdateAt;
-        ?CHACHA20_POLY1305 ->
-            seq_num_wrap;
-        ?AES_CCM ->
-            KeyUpdateAt;
-        ?AES_CCM_8 ->
-            KeyUpdateAt
-    end;
+                                bulk_cipher_algorithm = ?CHACHA20_POLY1305}}, _KeyUpdateAt) ->
+    seq_num_wrap;
+key_update_at(?'TLS-1.3', _, KeyUpdateAt) ->
+    KeyUpdateAt;
 key_update_at(_, _, KeyUpdateAt) ->
     KeyUpdateAt.
 

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -575,7 +575,7 @@ maybe_update_cipher_key(#data{connection_states = ConnectionStates0,
 maybe_update_cipher_key(StateData, _) ->
     StateData.
 
-update_bytes_sent(Version, StateData, _) when Version < {3,4} ->
+update_bytes_sent(Version, StateData, _) when Version < ?'TLS-1.3' ->
     StateData;
 %% Count bytes sent in TLS 1.3 for AES-GCM
 update_bytes_sent(_, #data{static = #static{key_update_at = seq_num_wrap}} = StateData, _) ->
@@ -591,7 +591,7 @@ update_bytes_sent(_, #data{static = #static{bytes_sent = Sent} = Static} = State
 key_update_at(Version, #{security_parameters :=
                              #security_parameters{
                                 bulk_cipher_algorithm = CipherAlgo}}, KeyUpdateAt)
-  when Version >= {3,4} ->
+  when Version >= ?'TLS-1.3' ->
     case CipherAlgo of
         ?AES_GCM ->
             KeyUpdateAt;
@@ -624,11 +624,11 @@ set_opts(SocketOptions, [{packet, N}]) ->
 
 time_to_rekey(Version, _Data,
               #{current_write := #{sequence_number := ?MAX_SEQUENCE_NUMBER}},
-              _, _, _) when Version >= {3,4} ->
+              _, _, _) when Version >= ?'TLS-1.3' ->
     key_update;
-time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when Version >= {3,4} ->
+time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when Version >= ?'TLS-1.3' ->
     false;
-time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when Version >= {3,4} ->
+time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when Version >= ?'TLS-1.3' ->
     DataSize = iolist_size(Data),
     case (BytesSent + DataSize) > KeyUpdateAt of
         true ->

--- a/lib/ssl/src/tls_server_connection_1_3.erl
+++ b/lib/ssl/src/tls_server_connection_1_3.erl
@@ -174,7 +174,7 @@ user_hello({call, From}, {handshake_continue, NewOptions, Timeout},
         Options = #{versions := Versions} ->
             State = ssl_gen_statem:ssl_config(Options, ?SERVER_ROLE, State0),
             case ssl_handshake:select_supported_version(ClientVersions, Versions) of
-                {3,4} ->
+                ?'TLS-1.3' ->
                     {next_state, start, State#state{start_or_recv_from = From,
                                                     handshake_env = HSEnv#handshake_env{continue_status = continue}},
                      [{{timeout, handshake}, Timeout, close}]};
@@ -216,7 +216,7 @@ start(internal, #client_hello{extensions = #{client_hello_versions :=
                                                  #client_hello_versions{versions = ClientVersions}
                                             }} = Hello,
       #state{ssl_options = #{handshake := full}} = State) ->
-    case tls_record:is_acceptable_version({3,4}, ClientVersions) of
+    case tls_record:is_acceptable_version(?'TLS-1.3', ClientVersions) of
         true ->
             handle_client_hello(Hello, State);
         false ->
@@ -435,7 +435,7 @@ do_handle_client_hello(#client_hello{cipher_suites = ClientCiphers,
         Groups = Maybe(tls_handshake_1_3:select_common_groups(ServerGroups, ClientGroups)),
         Maybe(validate_client_key_share(ClientGroups,
                                         ClientShares#key_share_client_hello.client_shares)),
-        CertKeyPairs = ssl_certificate:available_cert_key_pairs(CertKeyAlts, {3,4}),
+        CertKeyPairs = ssl_certificate:available_cert_key_pairs(CertKeyAlts, ?'TLS-1.3'),
         #session{own_certificates = [Cert|_]} = Session =
             Maybe(select_server_cert_key_pair(Session0, CertKeyPairs, ClientSignAlgs,
                                               ClientSignAlgsCert, CertAuths, State0,
@@ -883,7 +883,7 @@ select_cipher_suite(_, [], _) ->
 select_cipher_suite(true, ClientCiphers, ServerCiphers) ->
     select_cipher_suite(false, ServerCiphers, ClientCiphers);
 select_cipher_suite(false, [Cipher|ClientCiphers], ServerCiphers) ->
-    case lists:member(Cipher, tls_v1:exclusive_suites(4)) andalso
+    case lists:member(Cipher, tls_v1:exclusive_suites(?'TLS-1.3')) andalso
         lists:member(Cipher, ServerCiphers) of
         true ->
             {ok, Cipher};

--- a/lib/ssl/src/tls_socket.erl
+++ b/lib/ssl/src/tls_socket.erl
@@ -23,6 +23,7 @@
 
 -include("ssl_internal.hrl").
 -include("ssl_api.hrl").
+-include("ssl_record.hrl").
 
 -export([send/3, 
          listen/3, 
@@ -282,7 +283,7 @@ session_tickets_tracker(ListenSocket, Lifetime, TicketStoreSize, MaxEarlyDataSiz
                                                TicketStoreSize, MaxEarlyDataSize,
                                                AntiReplay, Seed]).
 
-session_id_tracker(_, #{versions := [{3,4}]}) ->
+session_id_tracker(_, #{versions := [?'TLS-1.3']}) ->
     {ok, not_relevant};
 %% Regardless of the option reuse_sessions we need the session_id_tracker
 %% to generate session ids, but no sessions will be stored unless

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -31,7 +31,7 @@
 
 -export([master_secret/4,
          finished/5,
-         certificate_verify/3,
+         certificate_verify/2,
          mac_hash/7,
          hmac_hash/3,
          setup_keys/8,
@@ -211,20 +211,18 @@ finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
 
 %% TODO 1.3 finished
 
--spec certificate_verify(HashAlgo, Version, Handshake) -> binary() when
+-spec certificate_verify(HashAlgo, Handshake) -> binary() when
       HashAlgo :: md5sha | sha,
-      Version  :: {non_neg_integer(), non_neg_integer()},
       Handshake :: [binary()].
-%% TODO: remove 'Version', not used
 %% TLS 1.0 -1.1  ---------------------------------------------------
-certificate_verify(md5sha, _Version, Handshake) ->
+certificate_verify(md5sha, Handshake) ->
     MD5 = crypto:hash(md5, Handshake),
     SHA = crypto:hash(sha, Handshake),
     {digest, <<MD5/binary, SHA/binary>>};
 %% TLS 1.0 -1.1  ---------------------------------------------------
 
 %% TLS 1.2 ---------------------------------------------------
-certificate_verify(_HashAlgo, _Version, Handshake) ->
+certificate_verify(_HashAlgo, Handshake) ->
     %% crypto:hash(HashAlgo, Handshake).
     %% Optimization: Let crypto calculate the hash in sign/verify call
     Handshake.

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -52,7 +52,6 @@
          rsa_exclusive/1,
          prf/5,
          ecc_curves/1,
-         ecc_curves/2,
          oid_to_enum/1,
          enum_to_oid/1,
          default_signature_algs/1,
@@ -1139,11 +1138,13 @@ is_pair(Hash, rsa, Hashs) ->
 is_pair(_,_,_) ->
     false.
 
-%% TODO: remove 'Version' since it is not used
+%% Should we create a new function for ecc_curves(Version)
+%% and another explicit one for ecc_curve_named([TLSCurves])?
 %% list ECC curves in preferred order
 -spec ecc_curves(TLS | DTLS | all) -> [named_curve()] when
       TLS :: ?'TLS-1.0' | ?'TLS-1.1' | ?'TLS-1.2',
-      DTLS :: ?'DTLS-1.X'.
+      DTLS :: ?'DTLS-1.X';
+                ([named_curve()]) -> [named_curve()].
 ecc_curves(all) ->
     [sect571r1,sect571k1,secp521r1,brainpoolP512r1,
      sect409k1,sect409r1,brainpoolP384r1,secp384r1,
@@ -1152,13 +1153,11 @@ ecc_curves(all) ->
      sect193r1,sect193r2,secp192k1,secp192r1,sect163k1,
      sect163r1,sect163r2,secp160k1,secp160r1,secp160r2];
 
-ecc_curves(Version) ->
+ecc_curves(Version) when is_tuple(Version) ->
     TLSCurves = ecc_curves(all),
-    ecc_curves(Version, TLSCurves).
+    ecc_curves(TLSCurves);
 
-%% TODO: remove 'Version' since it is not used
--spec ecc_curves(?'TLS-1.0' | ?'TLS-1.1' | ?'TLS-1.2', [named_curve()]) -> [named_curve()].
-ecc_curves(_Version, TLSCurves) ->
+ecc_curves(TLSCurves) when is_list(TLSCurves) ->
     CryptoCurves = crypto:ec_curves(),
     lists:foldr(fun(Curve, Curves) ->
 			case proplists:get_bool(Curve, CryptoCurves) of

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -173,7 +173,12 @@ master_secret(PrfAlgo, PreMasterSecret, ClientRandom, ServerRandom) ->
 	[ClientRandom, ServerRandom], 48).
 %% TLS 1.0 -1.2  ---------------------------------------------------
 
--spec finished(client | server, integer(), integer(), binary(), [binary()]) -> binary().
+-spec finished(Role, Version, PrfAlgo, MasterSecret, Handshake) -> binary() when
+      Role :: client | server,
+      Version :: {non_neg_integer(), non_neg_integer()},
+      PrfAlgo :: integer(),
+      MasterSecret :: binary(),
+      Handshake    :: [binary()].
 %% TLS 1.0 -1.1  ---------------------------------------------------
 finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
   when Version == ?'TLS-1.0'; Version == ?'TLS-1.1'; PrfAlgo == ?MD5SHA ->
@@ -206,7 +211,10 @@ finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
 
 %% TODO 1.3 finished
 
--spec certificate_verify(md5sha | sha, integer(), [binary()]) -> binary().
+-spec certificate_verify(HashAlgo, Version, Handshake) -> binary() when
+      HashAlgo :: md5sha | sha,
+      Version  :: {non_neg_integer(), non_neg_integer()},
+      Handshake :: [binary()].
 %% TODO: remove 'Version', not used
 %% TLS 1.0 -1.1  ---------------------------------------------------
 certificate_verify(md5sha, _Version, Handshake) ->
@@ -1138,7 +1146,9 @@ is_pair(_,_,_) ->
 
 %% TODO: remove 'Version' since it is not used
 %% list ECC curves in preferred order
--spec ecc_curves(?'TLS-1.0' | ?'TLS-1.1' | ?'TLS-1.2' | all) -> [named_curve()].
+-spec ecc_curves(TLS | DTLS | all) -> [named_curve()] when
+      TLS :: ?'TLS-1.0' | ?'TLS-1.1' | ?'TLS-1.2',
+      DTLS :: ?'DTLS-1.X'.
 ecc_curves(all) ->
     [sect571r1,sect571k1,secp521r1,brainpoolP512r1,
      sect409k1,sect409r1,brainpoolP384r1,secp384r1,

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -58,11 +58,11 @@
          signature_algs/2,
          signature_schemes/2,
          rsa_schemes/0,
+         groups/0,
          groups/1,
-         groups/2,
          group_to_enum/1,
          enum_to_group/1,
-         default_groups/1]).
+         default_groups/0]).
 
 -export([derive_secret/4,
          hkdf_expand_label/5,
@@ -1166,7 +1166,11 @@ ecc_curves(TLSCurves) when is_list(TLSCurves) ->
 			end
 		end, [], TLSCurves).
 
--spec groups(?'TLS-1.3' | all | default) -> [group()].
+groups() ->
+    TLSGroups = groups(all),
+    groups(TLSGroups).
+
+-spec groups(all | default | TLSGroups :: list()) -> [group()].
 groups(all) ->
     [x25519,
      x448,
@@ -1183,20 +1187,13 @@ groups(default) ->
      x448,
      secp256r1,
      secp384r1];
-groups(Version) ->
-    TLSGroups = groups(all),
-    groups(Version, TLSGroups).
-%%
-%% TODO: Version is not used. remove it.
--spec groups(?'TLS-1.3', [group()]) -> [group()].
-groups(_Version, TLSGroups) ->
+groups(TLSGroups) when is_list(TLSGroups) ->
     CryptoGroups = supported_groups(),
     lists:filter(fun(Group) -> proplists:get_bool(Group, CryptoGroups) end, TLSGroups).
 
-%% TODO: 'Version' is not used, so why pass it at all?
-default_groups(Version) ->
+default_groups() ->
     TLSGroups = groups(default),
-    groups(Version, TLSGroups).
+    groups(TLSGroups).
 
 supported_groups() ->
     %% TODO: Add new function to crypto?

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -174,7 +174,7 @@ master_secret(PrfAlgo, PreMasterSecret, ClientRandom, ServerRandom) ->
 
 -spec finished(Role, Version, PrfAlgo, MasterSecret, Handshake) -> binary() when
       Role :: client | server,
-      Version :: {non_neg_integer(), non_neg_integer()},
+      Version :: ssl_record:ssl_version(),
       PrfAlgo :: integer(),
       MasterSecret :: binary(),
       Handshake    :: [binary()].
@@ -211,7 +211,7 @@ finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
 %% TODO 1.3 finished
 
 -spec certificate_verify(HashAlgo, Handshake) -> binary() when
-      HashAlgo :: md5sha | sha,
+      HashAlgo :: md5sha | ssl:hash(),
       Handshake :: [binary()].
 %% TLS 1.0 -1.1  ---------------------------------------------------
 certificate_verify(md5sha, Handshake) ->
@@ -284,9 +284,8 @@ setup_keys(?'TLS-1.1', _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashS
 %% TLS v1.1 ---------------------------------------------------
 
 %% TLS v1.2  ---------------------------------------------------
-setup_keys(?'TLS-1.X'=Version, PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
-	   KeyMatLen, IVSize)
-  when Version == ?'TLS-1.2'; Version == ?'TLS-1.3' ->
+setup_keys(?'TLS-1.2', PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+	   KeyMatLen, IVSize) ->
     %% RFC 5246 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",
@@ -509,8 +508,6 @@ mac_hash(Method, Mac_write_secret, Seq_num, Type, {Major, Minor},
 		     Fragment]),
     Mac.
 %% TLS 1.0 -1.2  ---------------------------------------------------
-
-%% TODO 1.3 same as above?
 
 -spec suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -228,14 +228,12 @@ certificate_verify(_HashAlgo, Handshake) ->
     Handshake.
 
 %% TLS 1.2 ---------------------------------------------------
-%% TODO: replace Version :: integer() to tuple()
--spec setup_keys(integer(), integer(), binary(), binary(), binary(), integer(),
+-spec setup_keys(ssl_record:ssl_version(), integer(), binary(), binary(), binary(), integer(),
 		 integer(), integer()) -> {binary(), binary(), binary(),
 					  binary(), binary(), binary()}.
 %% TLS v1.0  ---------------------------------------------------
-setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
-	   KeyMatLen, IVSize)
-  when Version == 1 ->
+setup_keys(?'TLS-1.0', _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+	   KeyMatLen, IVSize) ->
     %% RFC 2246 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",
@@ -260,9 +258,8 @@ setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize
 %% TLS v1.0  ---------------------------------------------------
 
 %% TLS v1.1 ---------------------------------------------------
-setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
-	   KeyMatLen, IVSize)
-  when Version == 2 ->
+setup_keys(?'TLS-1.1', _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+	   KeyMatLen, IVSize) ->
     %% RFC 4346 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",
@@ -288,9 +285,9 @@ setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize
 %% TLS v1.1 ---------------------------------------------------
 
 %% TLS v1.2  ---------------------------------------------------
-setup_keys(Version, PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+setup_keys(?'TLS-1.X'=Version, PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
 	   KeyMatLen, IVSize)
-  when Version == 3; Version == 4 ->
+  when Version == ?'TLS-1.2'; Version == ?'TLS-1.3' ->
     %% RFC 5246 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",

--- a/lib/ssl/test/property_test/ssl_eqc_handshake.erl
+++ b/lib/ssl/test/property_test/ssl_eqc_handshake.erl
@@ -57,7 +57,7 @@
 -include_lib("ssl/src/ssl_handshake.hrl").
 -include_lib("ssl/src/ssl_alert.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
--include("ssl_record.hrl").
+-include_lib("ssl/src/ssl_record.hrl").
 
 
 %%--------------------------------------------------------------------

--- a/lib/ssl/test/property_test/ssl_eqc_handshake.erl
+++ b/lib/ssl/test/property_test/ssl_eqc_handshake.erl
@@ -57,11 +57,8 @@
 -include_lib("ssl/src/ssl_handshake.hrl").
 -include_lib("ssl/src/ssl_alert.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
+-include("ssl_record.hrl").
 
--define('TLS_v1.3', {3,4}).
--define('TLS_v1.2', {3,3}).
--define('TLS_v1.1', {3,2}).
--define('TLS_v1',   {3,1}).
 
 %%--------------------------------------------------------------------
 %% Properties --------------------------------------------------------
@@ -87,7 +84,7 @@ prop_tls_hs_encode_decode() ->
 %% Message Generators  -----------------------------------------------
 %%--------------------------------------------------------------------
 
-tls_msg(?'TLS_v1.3'= Version) ->
+tls_msg(?'TLS-1.3'= Version) ->
     oneof([client_hello(Version),
            server_hello(Version),
            %%new_session_ticket()
@@ -116,9 +113,9 @@ tls_msg(Version) ->
 %%
 %% Shared messages
 %%
-client_hello(?'TLS_v1.3' = Version) ->
+client_hello(?'TLS-1.3' = Version) ->
     #client_hello{session_id = session_id(),
-                  client_version = ?'TLS_v1.2',
+                  client_version = ?'TLS-1.2',
                   cipher_suites = cipher_suites(Version),
                   compression_methods = compressions(Version),
                   random = client_random(Version),
@@ -133,8 +130,8 @@ client_hello(Version) ->
 		  extensions = client_hello_extensions(Version)    
                  }.
 
-server_hello(?'TLS_v1.3' = Version) ->
-    #server_hello{server_version = ?'TLS_v1.2',
+server_hello(?'TLS-1.3' = Version) ->
+    #server_hello{server_version = ?'TLS-1.2',
 		  session_id = session_id(),
                   random = server_random(Version),
                   cipher_suite = cipher_suite(Version),
@@ -184,7 +181,7 @@ finished() ->
 %%
 
 encrypted_extensions() ->
-    ?LET(Exts, extensions(?'TLS_v1.3', encrypted_extensions),
+    ?LET(Exts, extensions(?'TLS-1.3', encrypted_extensions),
          #encrypted_extensions{extensions = Exts}).
 
 
@@ -197,7 +194,7 @@ key_update() ->
 %%--------------------------------------------------------------------
 
 tls_version() ->
-    oneof([?'TLS_v1.3', ?'TLS_v1.2', ?'TLS_v1.1', ?'TLS_v1']).
+    oneof([?'TLS-1.3', ?'TLS-1.2', ?'TLS-1.1', ?'TLS-1.0']).
 
 cipher_suite(Version) ->
     oneof(cipher_suites(Version)).
@@ -290,7 +287,7 @@ pre_shared_keyextension() ->
 %% |                                                  |             |
 %% | signature_algorithms_cert (RFC 8446)             |      CH, CR |
 %% +--------------------------------------------------+-------------+
-extensions(?'TLS_v1.3' = Version, MsgType = client_hello) ->
+extensions(?'TLS-1.3' = Version, MsgType = client_hello) ->
      ?LET({
            ServerName,
            %% MaxFragmentLength,
@@ -398,7 +395,7 @@ extensions(Version, client_hello) ->
                        srp => SRP
                        %% renegotiation_info => RenegotiationInfo
                       }));
-extensions(?'TLS_v1.3' = Version, MsgType = server_hello) ->
+extensions(?'TLS-1.3' = Version, MsgType = server_hello) ->
     ?LET({
           KeyShare,
           PreSharedKey,
@@ -443,7 +440,7 @@ extensions(Version, server_hello) ->
                        next_protocol_negotiation => NextP
                        %% renegotiation_info => RenegotiationInfo
                       }));
-extensions(?'TLS_v1.3' = Version, encrypted_extensions) ->
+extensions(?'TLS-1.3' = Version, encrypted_extensions) ->
      ?LET({
            ServerName,
            %% MaxFragmentLength,
@@ -551,7 +548,7 @@ signature() ->
       76,105,212,176,25,6,148,49,194,106,253,241,212,200,
       37,154,227,53,49,216,72,82,163>>.
 
-client_hello_versions(?'TLS_v1.3') ->
+client_hello_versions(?'TLS-1.3') ->
     ?LET(SupportedVersions,
          oneof([[{3,4}],
                 %% This list breaks the property but can be used for negative tests
@@ -626,11 +623,11 @@ cert_conf()->
                                       peer => [{key, ssl_test_lib:hardcode_rsa_key(6)}]}}).
 
 cert_auths() ->
-    certificate_authorities(?'TLS_v1.3').
+    certificate_authorities(?'TLS-1.3').
 
 certificate_request_1_3() ->
     #certificate_request_1_3{certificate_request_context = <<>>,
-                             extensions = #{certificate_authorities => certificate_authorities(?'TLS_v1.3')}
+                             extensions = #{certificate_authorities => certificate_authorities(?'TLS-1.3')}
                             }.
 certificate_request(Version) ->
     #certificate_request{certificate_types = certificate_types(Version),
@@ -666,9 +663,9 @@ hash_alg(Version) ->
          {hash_algorithm(Version, Alg), Alg}
        ).
 
-hash_algorithm(?'TLS_v1.3', _) ->
+hash_algorithm(?'TLS-1.3', _) ->
     oneof([sha, sha224, sha256, sha384, sha512]);
-hash_algorithm(?'TLS_v1.2', rsa) ->
+hash_algorithm(?'TLS-1.2', rsa) ->
     oneof([sha, sha224, sha256, sha384, sha512]);
 hash_algorithm(_, rsa) ->
     oneof([md5, sha, sha224, sha256, sha384, sha512]);
@@ -677,19 +674,19 @@ hash_algorithm(_, ecdsa) ->
 hash_algorithm(_, dsa) ->
     sha.
 
-sign_algorithm(?'TLS_v1.3') ->
+sign_algorithm(?'TLS-1.3') ->
     oneof([rsa, ecdsa]);
 sign_algorithm(_) ->
     oneof([rsa, dsa, ecdsa]).
-
 
 use_srtp() ->
     FullProfiles = [<<0,1>>, <<0,2>>, <<0,5>>],
     NullProfiles = [<<0,5>>],
     ?LET(PP, oneof([FullProfiles, NullProfiles]), #use_srtp{protection_profiles = PP, mki = <<>>}).
 
-certificate_authorities(?'TLS_v1.3') ->
-    Auths = certificate_authorities(?'TLS_v1.2'),
+certificate_authorities(?'TLS-1.3') ->
+    Auths = certificate_authorities(?'TLS-1.2'),
+
     #certificate_authorities{authorities = Auths};
 certificate_authorities(_) ->
     #{server_config := ServerConf} = cert_conf(), 
@@ -718,13 +715,13 @@ ec_point_formats() ->
 ec_point_format_list() ->
     [?ECPOINT_UNCOMPRESSED].
 
-elliptic_curves({_, Minor}) when Minor < 4 ->
-    Curves = tls_v1:ecc_curves(Minor),
+elliptic_curves(Version) when Version < ?'TLS-1.3' ->
+    Curves = tls_v1:ecc_curves(Version),
     #elliptic_curves{elliptic_curve_list = Curves}.
 
 %% RFC 8446 (TLS 1.3) renamed the "elliptic_curve" extension.
-supported_groups({_, Minor}) when Minor >= 4 ->
-    SupportedGroups = tls_v1:groups(Minor),
+supported_groups(?'TLS-1.X'=Version) when Version >= ?'TLS-1.3' ->
+    SupportedGroups = tls_v1:groups(Version),
     #supported_groups{supported_groups = SupportedGroups}.
 
 

--- a/lib/ssl/test/property_test/ssl_eqc_handshake.erl
+++ b/lib/ssl/test/property_test/ssl_eqc_handshake.erl
@@ -721,7 +721,7 @@ elliptic_curves(Version) when Version < ?'TLS-1.3' ->
 
 %% RFC 8446 (TLS 1.3) renamed the "elliptic_curve" extension.
 supported_groups(?'TLS-1.X'=Version) when Version >= ?'TLS-1.3' ->
-    SupportedGroups = tls_v1:groups(Version),
+    SupportedGroups = tls_v1:groups(),
     #supported_groups{supported_groups = SupportedGroups}.
 
 

--- a/lib/ssl/test/ssl_ECC_SUITE.erl
+++ b/lib/ssl/test/ssl_ECC_SUITE.erl
@@ -24,6 +24,7 @@
 
 -behaviour(ct_suite).
 
+-include_lib("ssl/src/ssl_record.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
@@ -180,7 +181,7 @@ client_ecdsa_server_ecdsa_with_raw_key(Config)  when is_list(Config) ->
 
 ecc_default_order(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -195,7 +196,7 @@ ecc_default_order(Config) ->
 
 ecc_default_order_custom_curves(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -210,7 +211,7 @@ ecc_default_order_custom_curves(Config) ->
 
 ecc_client_order(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -225,7 +226,7 @@ ecc_client_order(Config) ->
 
 ecc_client_order_custom_curves(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                         {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -252,7 +253,7 @@ ecc_unknown_curve(Config) ->
 
 client_ecdh_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdh_rsa, ecdhe_ecdsa, Config),
@@ -266,7 +267,7 @@ client_ecdh_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdh_rsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdh_rsa, ecdhe_rsa, Config),
@@ -281,7 +282,7 @@ client_ecdh_rsa_server_ecdhe_rsa_server_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_rsa, ecdhe_ecdsa, Config),
@@ -295,7 +296,7 @@ client_ecdhe_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_rsa, ecdhe_rsa, Config),
@@ -309,7 +310,7 @@ client_ecdhe_rsa_server_ecdhe_rsa_server_custom(Config) ->
      end.
 client_ecdhe_rsa_server_ecdh_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     Ext = x509_test:extensions([{key_usage, [keyEncipherment]}]),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, [[], [], [{extensions, Ext}]]},
                                                          {client_chain, Default}],
@@ -327,7 +328,7 @@ client_ecdhe_rsa_server_ecdh_rsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa, Config),
@@ -341,7 +342,7 @@ client_ecdhe_ecdsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_rsa, Config),
@@ -355,7 +356,7 @@ client_ecdhe_ecdsa_server_ecdhe_rsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_ecdsa_client_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa, Config),
@@ -369,7 +370,7 @@ client_ecdhe_ecdsa_server_ecdhe_ecdsa_client_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_ecdsa_client_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                          ecdhe_rsa, ecdhe_ecdsa, Config),

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -23,6 +23,9 @@
 
 -behaviour(ct_suite).
 
+
+-compile({inline,[exclusive_default_up_to_version/2]}).
+
 -include_lib("common_test/include/ct.hrl").
 -include_lib("ssl/src/ssl_api.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -23,9 +23,6 @@
 
 -behaviour(ct_suite).
 
-
--compile({inline,[exclusive_default_up_to_version/1]}).
-
 -include_lib("common_test/include/ct.hrl").
 -include_lib("ssl/src/ssl_api.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -24,7 +24,7 @@
 -behaviour(ct_suite).
 
 
--compile({inline,[exclusive_default_up_to_version/2]}).
+-compile({inline,[exclusive_default_up_to_version/1]}).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("ssl/src/ssl_api.hrl").
@@ -3852,13 +3852,10 @@ active_n_common(S, N) ->
 ok({ok,V}) -> V.
 
 repeat(N, Fun) ->
-    repeat(N, N, Fun).
+    Repeat = fun F(Arg) when is_integer(Arg), Arg > 0 -> Fun(N - Arg), F(Arg - 1);
+                        F(_) -> ok end,
+    Repeat(N).
 
-repeat(N, T, Fun) when is_integer(N), N > 0 ->
-    Fun(T-N),
-    repeat(N-1, T, Fun);
-repeat(_, _, _) ->
-    ok.
 
 get_close(Pid, Where) ->
     receive

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -25,6 +25,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("public_key/include/public_key.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -1376,7 +1377,7 @@ rsa_alg(rsa_pss_pss_1_3) ->
 rsa_alg(Atom) ->
     Atom.
 
-no_reuse({3, N}) when N >= 4 ->
+no_reuse(?'TLS-1.X'=Version) when Version >= ?'TLS-1.3' ->
     [];
 no_reuse(_) ->
     [{reuse_sessions, false}].

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -1377,7 +1377,7 @@ rsa_alg(rsa_pss_pss_1_3) ->
 rsa_alg(Atom) ->
     Atom.
 
-no_reuse(?'TLS-1.X'=Version) when Version >= ?'TLS-1.3' ->
+no_reuse(?'TLS-1.3') ->
     [];
 no_reuse(_) ->
     [{reuse_sessions, false}].

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -467,8 +467,8 @@ test_ciphers(_, 'tlsv1.3' = Version) ->
                  end, Ciphers);
 test_ciphers(_, Version) when Version == 'dtlsv1';
                                 Version == 'dtlsv1.2' ->
-    {_, Minor} = dtls_record:protocol_version(Version),
-    Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(Minor)],
+    Versioning = dtls_record:protocol_version(Version),
+    Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(Versioning)],
     ct:log("Version ~p Testing  ~p~n", [Version, Ciphers]),
     OpenSSLCiphers = openssl_ciphers(),
     ct:log("OpenSSLCiphers ~p~n", [OpenSSLCiphers]),

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -467,8 +467,8 @@ test_ciphers(_, 'tlsv1.3' = Version) ->
                  end, Ciphers);
 test_ciphers(_, Version) when Version == 'dtlsv1';
                                 Version == 'dtlsv1.2' ->
-    Versioning = dtls_record:protocol_version(Version),
-    Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(Versioning)],
+    NVersion = dtls_record:protocol_version(Version),
+    Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(NVersion)],
     ct:log("Version ~p Testing  ~p~n", [Version, Ciphers]),
     OpenSSLCiphers = openssl_ciphers(),
     ct:log("OpenSSLCiphers ~p~n", [OpenSSLCiphers]),

--- a/lib/ssl/test/ssl_cipher_SUITE.erl
+++ b/lib/ssl/test/ssl_cipher_SUITE.erl
@@ -133,13 +133,6 @@ decipher_check_fail(HashSz, CipherState, Version) ->
     true = {Content, Mac, #cipher_state{iv = NextIV}} =/= 
 	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, aes_fragment(Version), Version, true).
 
-pad_test(HashSz, CipherState, ?'SSL-3.0' = Version) ->
-    %% 3.0 does not have padding test
-    {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
-    {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'SSL-3.0'), ?'SSL-3.0', true),
-    {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'SSL-3.0'), ?'SSL-3.0', false);
 pad_test(HashSz, CipherState, ?'TLS-1.0' = Version) ->
     %% 3.1 should have padding test, but may be disabled
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
@@ -157,7 +150,7 @@ pad_test(HashSz, CipherState, Version) ->
     {BadCont, Mac, #cipher_state{iv = NextIV}} = ssl_cipher:decipher(?AES_CBC, HashSz, CipherState,  
 								     badpad_aes_fragment(Version), Version, true).
     
-aes_fragment(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
+aes_fragment(?'TLS-1.0') ->
     <<197,9,6,109,242,87,80,154,85,250,110,81,119,95,65,185,53,206,216,153,246,169,
       119,177,178,238,248,174,253,220,242,81,33,0,177,251,91,44,247,53,183,198,165,
       63,20,194,159,107>>;
@@ -168,7 +161,7 @@ aes_fragment(_) ->
       198,181,81,19,98,162,213,228,74,224,253,168,156,59,195,122,
       108,101,107,242,20,15,169,150,163,107,101,94,93,104,241,165>>.
 
-badpad_aes_fragment(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
+badpad_aes_fragment(?'TLS-1.0') ->
     <<186,139,125,10,118,21,26,248,120,108,193,104,87,118,145,79,225,55,228,10,105,
       30,190,37,1,88,139,243,210,99,65,41>>;
 badpad_aes_fragment(_) ->
@@ -176,7 +169,7 @@ badpad_aes_fragment(_) ->
       94,121,137,117,157,109,99,113,61,190,138,131,229,201,120,142,179,172,48,77,
       234,19,240,33,38,91,93>>.
 
-content_nextiv_mac(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
+content_nextiv_mac(?'TLS-1.0') ->
     {<<"HELLO\n">>,
      <<72,196,247,97,62,213,222,109,210,204,217,186,172,184, 197,148>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>};
@@ -185,7 +178,7 @@ content_nextiv_mac(_) ->
      <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>}.
 
-badpad_content_nextiv_mac(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
+badpad_content_nextiv_mac(?'TLS-1.0') ->
     {<<"HELLO\n">>,
      <<225,55,228,10,105,30,190,37,1,88,139,243,210,99,65,41>>,
       <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>

--- a/lib/ssl/test/ssl_cipher_SUITE.erl
+++ b/lib/ssl/test/ssl_cipher_SUITE.erl
@@ -97,7 +97,6 @@ aes_decipher_good() ->
 aes_decipher_good(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = correct_cipher_state(),
-    decipher_check_good(HashSz, CipherState, ?'SSL-3.0'),
     decipher_check_good(HashSz, CipherState, ?'TLS-1.0'),
     decipher_check_good(HashSz, CipherState, ?'TLS-1.1'),
     decipher_check_good(HashSz, CipherState, ?'TLS-1.2').
@@ -109,7 +108,6 @@ aes_decipher_fail() ->
 aes_decipher_fail(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = incorrect_cipher_state(),
-    decipher_check_fail(HashSz, CipherState, ?'SSL-3.0'),
     decipher_check_fail(HashSz, CipherState, ?'TLS-1.0'),
     decipher_check_fail(HashSz, CipherState, ?'TLS-1.1'),
     decipher_check_fail(HashSz, CipherState, ?'TLS-1.2').
@@ -118,7 +116,6 @@ aes_decipher_fail(Config) when is_list(Config) ->
 padding_test(Config) when is_list(Config)  ->
     HashSz = 16,
     CipherState = correct_cipher_state(),
-    pad_test(HashSz, CipherState, ?'SSL-3.0'),
     pad_test(HashSz, CipherState, ?'TLS-1.0'),
     pad_test(HashSz, CipherState, ?'TLS-1.1'),
     pad_test(HashSz, CipherState, ?'TLS-1.2').

--- a/lib/ssl/test/ssl_cipher_SUITE.erl
+++ b/lib/ssl/test/ssl_cipher_SUITE.erl
@@ -25,6 +25,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include("tls_record.hrl").
 -include("ssl_cipher.hrl").
+-include("ssl_record.hrl").
 
 %% Callback functions
 -export([all/0,
@@ -96,10 +97,10 @@ aes_decipher_good() ->
 aes_decipher_good(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = correct_cipher_state(),
-    decipher_check_good(HashSz, CipherState, {3,0}),
-    decipher_check_good(HashSz, CipherState, {3,1}),
-    decipher_check_good(HashSz, CipherState, {3,2}),
-    decipher_check_good(HashSz, CipherState, {3,3}).
+    decipher_check_good(HashSz, CipherState, ?'SSL-3.0'),
+    decipher_check_good(HashSz, CipherState, ?'TLS-1.0'),
+    decipher_check_good(HashSz, CipherState, ?'TLS-1.1'),
+    decipher_check_good(HashSz, CipherState, ?'TLS-1.2').
 
 %%--------------------------------------------------------------------
 aes_decipher_fail() ->
@@ -108,19 +109,19 @@ aes_decipher_fail() ->
 aes_decipher_fail(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = incorrect_cipher_state(),
-    decipher_check_fail(HashSz, CipherState, {3,0}),
-    decipher_check_fail(HashSz, CipherState, {3,1}),
-    decipher_check_fail(HashSz, CipherState, {3,2}),
-    decipher_check_fail(HashSz, CipherState, {3,3}).
+    decipher_check_fail(HashSz, CipherState, ?'SSL-3.0'),
+    decipher_check_fail(HashSz, CipherState, ?'TLS-1.0'),
+    decipher_check_fail(HashSz, CipherState, ?'TLS-1.1'),
+    decipher_check_fail(HashSz, CipherState, ?'TLS-1.2').
 
 %%--------------------------------------------------------------------
 padding_test(Config) when is_list(Config)  ->
     HashSz = 16,
     CipherState = correct_cipher_state(),
-    pad_test(HashSz, CipherState, {3,0}),
-    pad_test(HashSz, CipherState, {3,1}),
-    pad_test(HashSz, CipherState, {3,2}),
-    pad_test(HashSz, CipherState, {3,3}).
+    pad_test(HashSz, CipherState, ?'SSL-3.0'),
+    pad_test(HashSz, CipherState, ?'TLS-1.0'),
+    pad_test(HashSz, CipherState, ?'TLS-1.1'),
+    pad_test(HashSz, CipherState, ?'TLS-1.2').
 
 %%--------------------------------------------------------------------    
 % Internal functions  --------------------------------------------------------
@@ -135,21 +136,21 @@ decipher_check_fail(HashSz, CipherState, Version) ->
     true = {Content, Mac, #cipher_state{iv = NextIV}} =/= 
 	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, aes_fragment(Version), Version, true).
 
-pad_test(HashSz, CipherState, {3,0} = Version) ->
+pad_test(HashSz, CipherState, ?'SSL-3.0' = Version) ->
     %% 3.0 does not have padding test
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
     {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,0}), {3,0}, true),    
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'SSL-3.0'), ?'SSL-3.0', true),
     {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,0}), {3,0}, false);
-pad_test(HashSz, CipherState, {3,1} = Version) ->
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'SSL-3.0'), ?'SSL-3.0', false);
+pad_test(HashSz, CipherState, ?'TLS-1.0' = Version) ->
     %% 3.1 should have padding test, but may be disabled
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
     BadCont = badpad_content(Content),
     {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,1}) , {3,1}, false),
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'TLS-1.0') , ?'TLS-1.0', false),
     {BadCont, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,1}), {3,1}, true);
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'TLS-1.0'), ?'TLS-1.0', true);
 pad_test(HashSz, CipherState, Version) ->
     %% 3.2 and 3.3 must have padding test
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
@@ -159,7 +160,7 @@ pad_test(HashSz, CipherState, Version) ->
     {BadCont, Mac, #cipher_state{iv = NextIV}} = ssl_cipher:decipher(?AES_CBC, HashSz, CipherState,  
 								     badpad_aes_fragment(Version), Version, true).
     
-aes_fragment({3,N}) when N == 0; N == 1->
+aes_fragment(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
     <<197,9,6,109,242,87,80,154,85,250,110,81,119,95,65,185,53,206,216,153,246,169,
       119,177,178,238,248,174,253,220,242,81,33,0,177,251,91,44,247,53,183,198,165,
       63,20,194,159,107>>;
@@ -170,7 +171,7 @@ aes_fragment(_) ->
       198,181,81,19,98,162,213,228,74,224,253,168,156,59,195,122,
       108,101,107,242,20,15,169,150,163,107,101,94,93,104,241,165>>.
 
-badpad_aes_fragment({3,N})  when N == 0; N == 1 ->
+badpad_aes_fragment(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
     <<186,139,125,10,118,21,26,248,120,108,193,104,87,118,145,79,225,55,228,10,105,
       30,190,37,1,88,139,243,210,99,65,41>>;
 badpad_aes_fragment(_) ->
@@ -178,7 +179,7 @@ badpad_aes_fragment(_) ->
       94,121,137,117,157,109,99,113,61,190,138,131,229,201,120,142,179,172,48,77,
       234,19,240,33,38,91,93>>.
 
-content_nextiv_mac({3,N})  when N == 0; N == 1 ->
+content_nextiv_mac(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
     {<<"HELLO\n">>,
      <<72,196,247,97,62,213,222,109,210,204,217,186,172,184, 197,148>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>};
@@ -187,7 +188,7 @@ content_nextiv_mac(_) ->
      <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>}.
 
-badpad_content_nextiv_mac({3,N})  when N == 0; N == 1 ->
+badpad_content_nextiv_mac(?'TLS-1.X'=Version) when Version == ?'SSL-3.0'; Version == ?'TLS-1.0'->
     {<<"HELLO\n">>,
      <<225,55,228,10,105,30,190,37,1,88,139,243,210,99,65,41>>,
       <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -126,7 +126,7 @@ decode_hello_handshake(_Config) ->
 		    16#00, 16#00, 16#33, 16#74, 16#00, 16#07, 16#06, 16#73,
 		    16#70, 16#64, 16#79, 16#2f, 16#32>>,
 	
-    Version = {3, 0},
+    Version = ?'SSL-3.0',
     DefOpts = ssl:update_options([{verify, verify_none}], client, #{}),
     {Records, _Buffer} = tls_handshake:get_tls_handshakes(Version, HelloPacket, <<>>, DefOpts),
 
@@ -136,7 +136,7 @@ decode_hello_handshake(_Config) ->
 
 decode_single_hello_extension_correctly(_Config) -> 
     Renegotiation = <<?UINT16(?RENEGOTIATION_EXT), ?UINT16(1), 0>>,
-    Extensions = ssl_handshake:decode_extensions(Renegotiation, {3,3}, undefined),
+    Extensions = ssl_handshake:decode_extensions(Renegotiation, ?'TLS-1.2', undefined),
     #{renegotiation_info := #renegotiation_info{renegotiated_connection = <<0>>}} = Extensions.
 
 decode_supported_elliptic_curves_hello_extension_correctly(_Config) ->
@@ -148,13 +148,13 @@ decode_supported_elliptic_curves_hello_extension_correctly(_Config) ->
     Len = ListLen + 2,
     Extension = <<?UINT16(?ELLIPTIC_CURVES_EXT), ?UINT16(Len), ?UINT16(ListLen), EllipticCurveList/binary>>,
     % after decoding we should see only valid curves
-    Extensions = ssl_handshake:decode_hello_extensions(Extension, {3,2}, {3,2}, client),
+    Extensions = ssl_handshake:decode_hello_extensions(Extension, ?'TLS-1.1', ?'TLS-1.1', client),
     #{elliptic_curves := #elliptic_curves{elliptic_curve_list = [?sect233k1, ?sect193r2]}} = Extensions. 
 
 decode_unknown_hello_extension_correctly(_Config) ->
     FourByteUnknown = <<16#CA,16#FE, ?UINT16(4), 3, 0, 1, 2>>,
     Renegotiation = <<?UINT16(?RENEGOTIATION_EXT), ?UINT16(1), 0>>,
-    Extensions = ssl_handshake:decode_hello_extensions(<<FourByteUnknown/binary, Renegotiation/binary>>, {3,2}, {3,2}, client),
+    Extensions = ssl_handshake:decode_hello_extensions(<<FourByteUnknown/binary, Renegotiation/binary>>, ?'TLS-1.1', ?'TLS-1.1', client),
     #{renegotiation_info := #renegotiation_info{renegotiated_connection = <<0>>}} = Extensions.
 
 
@@ -169,21 +169,21 @@ encode_single_hello_sni_extension_correctly(_Config) ->
 decode_single_hello_sni_extension_correctly(_Config) ->
     SNI = <<16#00, 16#00, 16#00, 16#0d, 16#00, 16#0b, 16#00, 16#00, 16#08,
 	    $t,    $e,    $s,    $t,    $.,    $c,    $o,    $m>>,
-    Decoded = ssl_handshake:decode_hello_extensions(SNI, {3,3}, {3,3}, client),
+    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?'TLS-1.2', ?'TLS-1.2', client),
     #{sni := #sni{hostname = "test.com"}} = Decoded.
 
 decode_empty_server_sni_correctly(_Config) ->
     SNI = <<?UINT16(?SNI_EXT),?UINT16(0)>>,
-    Decoded = ssl_handshake:decode_hello_extensions(SNI, {3,3}, {3,3}, server),
+    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?'TLS-1.2', ?'TLS-1.2', server),
     #{sni := #sni{hostname = ""}} = Decoded.
 
 
 select_proper_tls_1_2_rsa_default_hashsign(_Config) ->
     % RFC 5246 section 7.4.1.4.1 tells to use {sha1,rsa} as default signature_algorithm for RSA key exchanges
-    {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,3}),
+    {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'TLS-1.2'),
     % Older versions use MD5/SHA1 combination
-    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,2}),
-    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,0}).
+    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'TLS-1.1'),
+    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'SSL-3.0').
 
 
 ignore_hassign_extension_pre_tls_1_2(Config) ->
@@ -191,11 +191,10 @@ ignore_hassign_extension_pre_tls_1_2(Config) ->
     CertFile = proplists:get_value(certfile, Opts),
     [{_, Cert, _}] = ssl_test_lib:pem_to_der(CertFile),
     HashSigns = #hash_sign_algos{hash_sign_algos = [{sha512, rsa}, {sha, dsa}, {sha256, rsa}]},
-    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([{3,3}]), {3,3}),
+    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'TLS-1.2']), ?'TLS-1.2'),
     %%% Ignore
-    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([{3,2}]), {3,2}),
-    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([{3,0}]), {3,0}).
-
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'TLS-1.1']), ?'TLS-1.1'),
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'SSL-3.0']), ?'SSL-3.0').
 
 signature_algorithms(Config) ->
     Opts = proplists:get_value(server_opts, Config),
@@ -212,16 +211,16 @@ signature_algorithms(Config) ->
     {sha512, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns0, Schemes0},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([{3,3}]),
-                      {3,3}),
+                      tls_v1:default_signature_algs([?'TLS-1.2']),
+                      ?'TLS-1.2'),
     HashSigns1 = #hash_sign_algos{
                     hash_sign_algos = [{sha, dsa},
                                        {sha256, rsa}]},
     {sha256, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns1, Schemes0},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([{3,3}]),
-                      {3,3}),
+                      tls_v1:default_signature_algs([?'TLS-1.2']),
+                      ?'TLS-1.2'),
     Schemes1 = #signature_algorithms_cert{
                   signature_scheme_list = [rsa_pkcs1_sha1,
                                            ecdsa_sha1]},
@@ -229,22 +228,22 @@ signature_algorithms(Config) ->
     #alert{} = ssl_handshake:select_hashsign(
                  {HashSigns1, Schemes1},
                  Cert, ecdhe_rsa,
-                 tls_v1:default_signature_algs([{3,3}]),
-                 {3,3}),
+                 tls_v1:default_signature_algs([?'TLS-1.2']),
+                 ?'TLS-1.2'),
     %% No scheme, hashsign is used
     {sha256, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns1, undefined},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([{3,3}]),
-                      {3,3}),
+                      tls_v1:default_signature_algs([?'TLS-1.2']),
+                      ?'TLS-1.2'),
     HashSigns2 = #hash_sign_algos{
                     hash_sign_algos = [{sha, dsa}]},
     %% Signature not supported
     #alert{} = ssl_handshake:select_hashsign(
                  {HashSigns2, Schemes1},
                  Cert, ecdhe_rsa,
-                 tls_v1:default_signature_algs([{3,3}]),
-                 {3,3}).
+                 tls_v1:default_signature_algs([?'TLS-1.2']),
+                 ?'TLS-1.2').
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------

--- a/lib/ssl/test/ssl_mfl_SUITE.erl
+++ b/lib/ssl/test/ssl_mfl_SUITE.erl
@@ -22,6 +22,7 @@
 -behaviour(ct_suite).
 
 -include_lib("common_test/include/ct.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -186,7 +187,7 @@ run_mfl_handshake_continue(Config, MFL) ->
                     receive {Client, {ext, ClientExt}} ->
                             ct:log("Client handshake Ext ~p~n", [ClientExt]),
                             case maps:get(server_hello_selected_version, ClientExt, undefined) of
-                                {3,4} ->
+                                ?'TLS-1.3' ->
                                     %% For TLS 1.3 the ssl {handshake, hello} API is inconsistent:
                                     %% the server gets all the extensions CH+EE, but the client only CH
                                     ignore;

--- a/lib/ssl/test/ssl_npn_hello_SUITE.erl
+++ b/lib/ssl/test/ssl_npn_hello_SUITE.erl
@@ -123,12 +123,12 @@ encode_and_decode_npn_server_hello_test(Config) ->
 
 %%--------------------------------------------------------------------
 create_server_hello_with_no_advertised_protocols_test(_Config) ->
-    Hello = ssl_handshake:server_hello(<<>>, {3, 0}, create_connection_states(), #{}),
+    Hello = ssl_handshake:server_hello(<<>>, ?'SSL-3.0', create_connection_states(), #{}),
     Extensions = Hello#server_hello.extensions,
     #{} = Extensions.
 %%--------------------------------------------------------------------
 create_server_hello_with_advertised_protocols_test(_Config) ->
-    Hello = ssl_handshake:server_hello(<<>>, {3, 0}, create_connection_states(),
+    Hello = ssl_handshake:server_hello(<<>>, ?'SSL-3.0', create_connection_states(),
 				       #{next_protocol_negotiation => [<<"spdy/1">>, <<"http/1.0">>, <<"http/1.1">>]}),
     Extensions = Hello#server_hello.extensions,
     #{next_protocol_negotiation := [<<"spdy/1">>, <<"http/1.0">>, <<"http/1.1">>]} = Extensions.

--- a/lib/ssl/test/ssl_reject_SUITE.erl
+++ b/lib/ssl/test/ssl_reject_SUITE.erl
@@ -22,7 +22,7 @@
 -module(ssl_reject_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("ssl/src/ssl_record.hrl").
+-include("ssl_record.hrl").
 -include_lib("ssl/src/ssl_alert.hrl").
 -include_lib("ssl/src/ssl_handshake.hrl").
 
@@ -48,15 +48,15 @@
          accept_sslv3_record_hello/1
         ]).
 
--define(TLS_MAJOR, 3).
--define(SSL_3_0_MAJOR, 3).
--define(SSL_3_0_MINOR, 0).
--define(TLS_1_0_MINOR, 1).
--define(TLS_1_1_MINOR, 2).
--define(TLS_1_2_MINOR, 3).
--define(TLS_1_3_MINOR, 4).
--define(SSL_2_0_MAJOR, 0).
--define(SSL_2_0_MINOR, 1).
+-define(TLS_MAJOR,     (element(1, ?'TLS-1.2'))).
+-define(SSL_3_0_MAJOR, (element(1, ?'SSL-3.0'))).
+-define(SSL_3_0_MINOR, (element(2, ?'SSL-3.0'))).
+-define(TLS_1_0_MINOR, (element(2, ?'TLS-1.0'))).
+-define(TLS_1_1_MINOR, (element(2, ?'TLS-1.1'))).
+-define(TLS_1_2_MINOR, (element(2, ?'TLS-1.2'))).
+-define(TLS_1_3_MINOR, (element(2, ?'TLS-1.3'))).
+-define(SSL_2_0_MAJOR, (element(1, ?'SSL-2.0'))).
+-define(SSL_2_0_MINOR, (element(2, ?'SSL-2.0'))).
 
 %%--------------------------------------------------------------------
 %% Common Test interface functions -----------------------------------
@@ -194,10 +194,11 @@ accept_sslv3_record_hello(Config) when is_list(Config) ->
 
     {ok, Socket} = gen_tcp:connect(Hostname, Port, [{active, false}]),
     gen_tcp:send(Socket, ClientHello),
+    TLS_Major = ?TLS_MAJOR,
     case gen_tcp:recv(Socket, 3, 5000) of
         %% Minor needs to be a TLS version that is a version
         %% above SSL-3.0
-        {ok, [?HANDSHAKE, ?TLS_MAJOR, Minor]} when Minor > ?SSL_3_0_MINOR ->
+        {ok, [?HANDSHAKE, TLS_Major, Minor]} when Minor > ?SSL_3_0_MINOR ->
             ok;
         {error, timeout} ->
             ct:fail(ssl3_record_not_accepted)

--- a/lib/ssl/test/ssl_renegotiate_SUITE.erl
+++ b/lib/ssl/test/ssl_renegotiate_SUITE.erl
@@ -26,6 +26,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("public_key/include/public_key.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -82,16 +83,18 @@ all() ->
      {group, 'tlsv1.1'},
      {group, 'tlsv1'},
      {group, 'dtlsv1.2'},
-     {group, 'dtlsv1'}
+     {group, 'dtlsv1'},
+     {group, 'sslv3'}
     ].
 
 groups() ->
     [{'dtlsv1.2', [], renegotiate_tests()},
-     {'dtlsv1', [], renegotiate_tests()},
-     {'tlsv1.3', [], renegotiate_tests()},
-     {'tlsv1.2', [], renegotiate_tests()},
-     {'tlsv1.1', [], renegotiate_tests()},
-     {'tlsv1', [], renegotiate_tests()}
+     {'dtlsv1',   [], renegotiate_tests()},
+     {'tlsv1.3',  [], renegotiate_tests()},
+     {'tlsv1.2',  [], renegotiate_tests()},
+     {'tlsv1.1',  [], renegotiate_tests()},
+     {'tlsv1',    [], renegotiate_tests()},
+     {'sslv3',    [], ssl3_renegotiate_tests()}
     ].
 
 renegotiate_tests() ->
@@ -518,9 +521,9 @@ renegotiate_rejected(Socket) ->
     ok.
 
 %% First two clauses handles 1/n-1 splitting countermeasure Rizzo/Duong-Beast
-treashold(N, {3,0}) ->
+treashold(N, ?'SSL-3.0') ->
     (N div 2) + 1;
-treashold(N, {3,1}) ->
+treashold(N, ?'TLS-1.0') ->
     (N div 2) + 1;
 treashold(N, _) ->
     N + 1.

--- a/lib/ssl/test/ssl_renegotiate_SUITE.erl
+++ b/lib/ssl/test/ssl_renegotiate_SUITE.erl
@@ -83,8 +83,7 @@ all() ->
      {group, 'tlsv1.1'},
      {group, 'tlsv1'},
      {group, 'dtlsv1.2'},
-     {group, 'dtlsv1'},
-     {group, 'sslv3'}
+     {group, 'dtlsv1'}
     ].
 
 groups() ->

--- a/lib/ssl/test/ssl_renegotiate_SUITE.erl
+++ b/lib/ssl/test/ssl_renegotiate_SUITE.erl
@@ -507,8 +507,6 @@ renegotiate_rejected(Socket) ->
     ok.
 
 %% First two clauses handles 1/n-1 splitting countermeasure Rizzo/Duong-Beast
-treashold(N, ?'SSL-3.0') ->
-    (N div 2) + 1;
 treashold(N, ?'TLS-1.0') ->
     (N div 2) + 1;
 treashold(N, _) ->

--- a/lib/ssl/test/ssl_renegotiate_SUITE.erl
+++ b/lib/ssl/test/ssl_renegotiate_SUITE.erl
@@ -90,11 +90,9 @@ all() ->
 groups() ->
     [{'dtlsv1.2', [], renegotiate_tests()},
      {'dtlsv1',   [], renegotiate_tests()},
-     {'tlsv1.3',  [], renegotiate_tests()},
      {'tlsv1.2',  [], renegotiate_tests()},
      {'tlsv1.1',  [], renegotiate_tests()},
-     {'tlsv1',    [], renegotiate_tests()},
-     {'sslv3',    [], ssl3_renegotiate_tests()}
+     {'tlsv1',    [], renegotiate_tests()}
     ].
 
 renegotiate_tests() ->
@@ -102,17 +100,6 @@ renegotiate_tests() ->
      server_renegotiate,
      client_secure_renegotiate,
      client_secure_renegotiate_fallback,
-     client_renegotiate_reused_session,
-     server_renegotiate_reused_session,
-     client_no_wrap_sequence_number,
-     server_no_wrap_sequence_number,
-     renegotiate_dos_mitigate_active,
-     renegotiate_dos_mitigate_passive,
-     renegotiate_dos_mitigate_absolute].
-
-ssl3_renegotiate_tests() ->
-    [client_renegotiate,
-     server_renegotiate,
      client_renegotiate_reused_session,
      server_renegotiate_reused_session,
      client_no_wrap_sequence_number,

--- a/lib/ssl/test/ssl_session_SUITE.erl
+++ b/lib/ssl/test/ssl_session_SUITE.erl
@@ -660,9 +660,9 @@ faulty_client(Host, Port) ->
 
 
 encode_client_hello(CH, Random) ->
-    HSBin = tls_handshake:encode_handshake(CH, {3,3}),
+    HSBin = tls_handshake:encode_handshake(CH, ?'TLS-1.2'),
     CS = connection_states(Random),
-    {Encoded, _} = tls_record:encode_handshake(HSBin, {3,3}, CS),
+    {Encoded, _} = tls_record:encode_handshake(HSBin, ?'TLS-1.2', CS),
     Encoded.
 
 client_hello(Random) ->
@@ -738,7 +738,7 @@ client_hello(Random) ->
 		   srp =>
 		       undefined},
 
-    #client_hello{client_version = {3,3},
+    #client_hello{client_version = ?'TLS-1.2',
 		  random = Random,
 		  session_id = crypto:strong_rand_bytes(32),
 		  cipher_suites = CipherSuites,

--- a/lib/ssl/test/tls_1_3_record_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_record_SUITE.erl
@@ -174,9 +174,9 @@ encode_decode(_Config) ->
                    146,152,146,151,107,126,216,210,9,93,0,0>>],
 
     {[_Header|Encoded], _} = tls_record_1_3:encode_plain_text(22, PlainText, ConnectionStates),
-    CipherText = #ssl_tls{type = 23, version = {3,3}, fragment = Encoded},
+    CipherText = #ssl_tls{type = 23, version = ?'TLS-1.2', fragment = Encoded},
 
-    {#ssl_tls{type = 22, version = {3,4}, fragment = DecodedText}, _} =
+    {#ssl_tls{type = 22, version = ?'TLS-1.3', fragment = DecodedText}, _} =
         tls_record_1_3:decode_cipher_text(CipherText, ConnectionStates),
 
     DecodedText = iolist_to_binary(PlainText),
@@ -260,7 +260,7 @@ encode_decode(_Config) ->
           01 04 02 05 02 06 02 02 02 00 2d 00 02 01 01 00 1c 00 02 40 01"),
 
     {CHEncrypted, _} =
-	tls_record:encode_handshake(ClientHello, {3,4}, ConnStatesNull),
+	tls_record:encode_handshake(ClientHello, ?'TLS-1.3', ConnStatesNull),
     ClientHelloRecord = iolist_to_binary(CHEncrypted),
 
     %% {server}  extract secret "early":
@@ -515,7 +515,7 @@ encode_decode(_Config) ->
           cc 25 3b 83 3d f1 dd 69 b1 b0 4e 75 1f 0f 00 2b 00 02 03 04"),
 
     {SHEncrypted, _} =
-	tls_record:encode_handshake(ServerHello, {3,4}, ConnStatesNull),
+	tls_record:encode_handshake(ServerHello, ?'TLS-1.3', ConnStatesNull),
     ServerHelloRecord = iolist_to_binary(SHEncrypted),
 
     %% {server}  derive write traffic keys for handshake data:
@@ -685,7 +685,7 @@ encode_decode(_Config) ->
 
     FinishedHS = #finished{verify_data = FinishedVerifyData},
 
-    FinishedIOList = tls_handshake:encode_handshake(FinishedHS, {3,4}),
+    FinishedIOList = tls_handshake:encode_handshake(FinishedHS, ?'TLS-1.3'),
     FinishedHSBin = iolist_to_binary(FinishedIOList),
 
     %% {server}  derive secret "tls13 c ap traffic":
@@ -907,7 +907,7 @@ encode_decode(_Config) ->
 
     CFinished = #finished{verify_data = CFinishedVerifyData},
 
-    CFinishedIOList = tls_handshake:encode_handshake(CFinished, {3,4}),
+    CFinishedIOList = tls_handshake:encode_handshake(CFinished, ?'TLS-1.3'),
     CFinishedBin = iolist_to_binary(CFinishedIOList),
 
     %% {client}  derive write traffic keys for application data:
@@ -1054,7 +1054,7 @@ encode_decode(_Config) ->
        ticket_nonce = Nonce,
        ticket = Ticket,
        extensions = _Extensions
-      } = tls_handshake:decode_handshake({3,4}, NWT, TicketBody),
+      } = tls_handshake:decode_handshake(?'TLS-1.3', NWT, TicketBody),
 
     %% ResPRK = resumption master secret
     ResExpanded = tls_v1:pre_shared_key(ResPRK, Nonce, HKDFAlgo),
@@ -1288,7 +1288,7 @@ encode_decode(_Config) ->
 
     <<?BYTE(CH), ?UINT24(_Length), ClientHelloBody/binary>> = ClientHelloRecord,
     #client_hello{extensions = #{pre_shared_key := PreSharedKey}} =
-        tls_handshake:decode_handshake({3,4}, CH, ClientHelloBody),
+        tls_handshake:decode_handshake(?'TLS-1.3', CH, ClientHelloBody),
 
     #pre_shared_key_client_hello{
        offered_psks = #offered_psks{

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -790,8 +790,8 @@ tls_reject_warning_alert_in_initial_hs(Config) when is_list(Config) ->
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     {Major, Minor} = case ssl_test_lib:protocol_version(Config, tuple) of
-                         {3,4} ->
-                             {3,3};
+                         ?'TLS-1.3' ->
+                             ?'TLS-1.2';
                          Other ->
                              Other
                      end,
@@ -814,8 +814,8 @@ tls_reject_fake_warning_alert_in_initial_hs(Config) when is_list(Config) ->
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     {Major, Minor} = case ssl_test_lib:protocol_version(Config, tuple) of
-                         {3,4} ->
-                             {3,3};
+                         ?'TLS-1.3' ->
+                             ?'TLS-1.2';
                          Other ->
                              Other
                      end,
@@ -840,8 +840,8 @@ tls_app_data_in_initial_hs_state(Config) when is_list(Config) ->
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     Version = ssl_test_lib:protocol_version(Config, tuple),
     {Major, Minor} = case Version of
-                         {3,4} ->
-                             {3,3};
+                         ?'TLS-1.3' ->
+                             ?'TLS-1.2';
                          Other ->
                              Other
                      end,
@@ -852,7 +852,7 @@ tls_app_data_in_initial_hs_state(Config) when is_list(Config) ->
     Port = ssl_test_lib:inet_port(Server),
     {ok, Socket}  = gen_tcp:connect("localhost", Port, [{active, false}, binary]),
     AppData = case Version of
-                  {3, 4} ->
+                  ?'TLS-1.3' ->
                       <<?BYTE(?APPLICATION_DATA), ?BYTE(3), ?BYTE(3), ?UINT16(4), ?BYTE($F), 
                         ?BYTE($O), ?BYTE($O), ?BYTE(?APPLICATION_DATA)>>;
                   _ ->

--- a/lib/ssl/test/tls_server_session_ticket_SUITE.erl
+++ b/lib/ssl/test/tls_server_session_ticket_SUITE.erl
@@ -25,6 +25,7 @@
 -include_lib("ssl/src/ssl_cipher.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
 -include_lib("ssl/src/tls_handshake_1_3.hrl").
+-include("ssl_record.hrl").
 
 %% Callback functions
 -export([all/0,
@@ -53,7 +54,7 @@
 -define(TICKET_STORE_SIZE, 1).
 -define(MASTER_SECRET, "master_secret").
 -define(PRF, sha).
--define(VERSION, {3,4}).
+-define(VERSION, ?'TLS-1.3').
 -define(PSK, <<15,168,18,43,216,33,227,142,114,190,70,183,137,57,64,64,66,152,115,94>>).
 -define(WINDOW_SIZE, 1).
 -define(SEED, <<1,2,3,4,5>>).


### PR DESCRIPTION
Replaces TLS and SSL version tuple codes (e.g., `{3,4}` for means TLS-1.3) by a macro descriptive name, and some refactorings as follows:
- addition of macros `?'TLS-1.3`, `?'TLS-1.2`, `?'TLS-1.1`, `?'TLS-1.0`, `?'TLS-1.0`, `?'TLS-1.X`,
- addition of macros `?'SSL-3.0`, `?'SSL-2.0`,
- addition of macros  `?'DTLS-1.2`, `?'DTLS-1.1`, `?'DTLS-1.0`
- refactor of functions that receive arguments which are not used

The addition of the macros is self-contained in its own commit. The refactorings are placed in different commits for ease of scanning and reversal (if necessary). 