### PR TITLE
Improve `lists:nth/2` and `nthtail/2`

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -196,8 +196,12 @@ reverse([A, B | L]) ->
       T :: term().
 
 nth(1, [H|_]) -> H;
-nth(N, [_|T]) when N > 1 ->
-    nth(N - 1, T).
+nth(N, [_|_]=L) when is_integer(N), N > 1 ->
+    nth_1(N, L).
+
+nth_1(1, [H|_]) -> H;
+nth_1(N, [_|T]) ->
+    nth_1(N - 1, T).
 
 -spec nthtail(N, List) -> Tail when
       N :: non_neg_integer(),
@@ -205,10 +209,15 @@ nth(N, [_|T]) when N > 1 ->
       Tail :: [T],
       T :: term().
 
+nthtail(0, []) -> [];
+nthtail(0, [_|_]=L) -> L;
 nthtail(1, [_|T]) -> T;
-nthtail(N, [_|T]) when N > 1 ->
-    nthtail(N - 1, T);
-nthtail(0, L) when is_list(L) -> L.
+nthtail(N, [_|_]=L) when is_integer(N), N > 1 ->
+    nthtail_1(N, L).
+
+nthtail_1(1, [_|T]) -> T;
+nthtail_1(N, [_|T]) ->
+    nthtail_1(N - 1, T).
 
 %% prefix(Prefix, List) -> (true | false)
 


### PR DESCRIPTION
This PR provides performance improvements for `nth/2`, `nthtail/2` ~and `append/1,2`~ in the `lists` module.

* `nth/2` and `nthtail/2`: There was a guard in one of the clauses that would be checked in each step of the recursion. Another drawback was that both functions would accept floats as values for the index, and only crash after having gone through the recursion to the point where it dropped below 1.
I moved this check, augmented to also check for the indexes being integers, plus some shortcuts for common edge cases, in front functions and put the actual work in helper functions that run unchecked. This implementation is (AFAICS) fully equivalent to the old implementation, but performs better, with back-off-a-napkin benchmarks showing the runtime being around 75% of that of the old implementation.

* ~`append/1`: The old implementation appended everything by means of `++`. In the case of appending an empty list to non-empty lists, this is wasteful, as the non-empty list still needs to be traversed.
In my implementation, empty lists are ignored. Also, I added a shortcut that, when a list consists only of a single element, this element is consed instead of the entire singleton list being prepended via `++` (TBH, I didn't expect much from this, but benchmarking with long lists of singletons showed the runtime to be at about 50% of the old implementation).
This implementation is _not_ fully equivalent to the old one, but still in accordance with the documentation.~
  * ~The old implementation allowed the last element of the argument list to be any term, with the result being an improper list or the term itself if it was the only term in the list or all other elements before it were empty lists.
In my implementation, non-list arguments are not allowed anywhere in the argument list.~
  * ~The old implementation would accept an improper list only if it was the last or only element in the list of lists.
In my implementation, an improper list is also allowed if it is followed by only empty lists.~

* ~`append/2`: The old implementation simply mapped to `++`. If the second list was empty, this was wasteful for the same reasons as outlined in `append/1`.
In my implementation, if either of the input lists is empty, the respective other is simply returned, thereby avoiding the needless appending of an empty list.
This implementation is _not_ fully equivalent to the old one.~
  * ~The old implementation allowed the second argument to be any term, with the result being an improper list or the term itself if the first argument was an empty list.
In my implementation, non-list arguments are not allowed. And while this is in accordance with the documented specs, the documentation unfortunately contains the sentence "`lists:append(A, B)` is equivalent to `A ++ B`", and `A ++ B` _allows_ `B` to be any term (which actually contradicts the specs). This behavior can be added back if you think this is required, but given the choice, I'd rather not :sweat_smile:~
  * ~The old implementation would accept improper lists only in the second argument.
In my implementation, an improper list is allowed as first argument if the second argument is an empty list. This also contradicts the stated equivalence to `A ++ B`, which does _not_ allow `A` to be an improper list even if `B` is an empty list.~