### PR TITLE
dialyzer: Add the --no_spec option for ignoring specs

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -86,8 +86,8 @@ dialyzer [--add_to_plt] [--apps applications] [--build_plt]
          [--check_plt] [-Ddefine]* [-Dname]* [--dump_callgraph file]
          [--error_location flag] [files_or_dirs] [--fullpath]
          [--get_warnings] [--gui] [--help] [-I include_dir]*
-         [--incremental] [--no_check_plt] [--no_indentation] [-o outfile]
-         [--output_plt file] [-pa dir]* [--plt plt] [--plt_info]
+         [--incremental] [--no_check_plt] [--no_indentation] [--no_spec]
+         [-o outfile] [--output_plt file] [-pa dir]* [--plt plt] [--plt_info]
          [--plts plt*] [--quiet] [-r dirs] [--raw] [--remove_from_plt]
          [--shell] [--src] [--statistics] [--verbose] [--version]
          [-Wwarn]*</code>
@@ -208,6 +208,11 @@ dialyzer --apps inets ssl ./ebin ../other_lib/ebin/my_module.beam</code>
       <item>
 	<p>Do not insert line breaks in types, contracts, and Erlang
 	  Code when formatting warnings.</p>
+      </item>
+      <tag><c>--no_spec</c></tag>
+      <item>
+	<p>Ignore functions specs. This is useful for debugging when
+	one suspects that some specs are incorrect.</p>
       </item>
       <tag><c>-o outfile</c> (or
         <c>--output outfile</c>)</tag>

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -420,8 +420,8 @@ help_message() ->
                 [--check_plt] [-Ddefine]* [-Dname]* [--dump_callgraph file]
                 [--error_location flag] [files_or_dirs] [--fullpath]
                 [--get_warnings] [--gui] [--help] [-I include_dir]*
-                [--incremental] [--no_check_plt] [--no_indentation] [-o outfile]
-                [--output_plt file] [-pa dir]* [--plt plt] [--plt_info]
+                [--incremental] [--no_check_plt] [--no_indentation] [--no_spec]
+                [-o outfile] [--output_plt file] [-pa dir]* [--plt plt] [--plt_info]
                 [--plts plt*] [--quiet] [-r dirs] [--raw] [--remove_from_plt]
                 [--shell] [--src] [--statistics] [--verbose] [--version]
                 [-Wwarn]*
@@ -550,6 +550,9 @@ Options:
   --no_indentation
       Do not indent contracts and success typings. Note that this option has
       no effect when combined with the --raw option.
+  --no_spec
+      Ignore functions specs. This is useful for debugging when one suspects
+      that some specs are incorrect.
   --gui
       Use the GUI.
 

--- a/lib/dialyzer/src/dialyzer_options.erl
+++ b/lib/dialyzer/src/dialyzer_options.erl
@@ -279,8 +279,10 @@ build_options([{OptionName, Value} = Term|Rest], Options) ->
       OldVal = Options#options.include_dirs,
       NewVal = ordsets:union(ordsets:from_list(Value), OldVal),
       build_options(Rest, Options#options{include_dirs = NewVal});
-    use_spec ->
+    use_spec when is_boolean(Value) ->
       build_options(Rest, Options#options{use_contracts = Value});
+    no_spec when is_boolean(Value) ->
+      build_options(Rest, Options#options{use_contracts = not Value});
     old_style ->
       bad_option("Analysis type is no longer supported", old_style);
     output_file ->

--- a/lib/dialyzer/src/dialyzer_typegraph.erl
+++ b/lib/dialyzer/src/dialyzer_typegraph.erl
@@ -29,7 +29,7 @@ module_type_deps(UseContracts, CodeServer, Modules) ->
   Contracts =
     case UseContracts of
       true -> maps:from_list(dict:to_list(dialyzer_codeserver:get_contracts(CodeServer)));
-      false -> []
+      false -> #{}
     end,
   Callbacks = maps:from_list(dialyzer_codeserver:get_callbacks(CodeServer)),
   TypeDefinitions =

--- a/lib/dialyzer/test/options3_SUITE_data/dialyzer_options
+++ b/lib/dialyzer/test/options3_SUITE_data/dialyzer_options
@@ -1,0 +1,1 @@
+{dialyzer_options, [{use_spec, false}]}.

--- a/lib/dialyzer/test/options3_SUITE_data/src/bad_specs.erl
+++ b/lib/dialyzer/test/options3_SUITE_data/src/bad_specs.erl
@@ -1,0 +1,8 @@
+-module(bad_specs).
+-export([f/1]).
+
+%% There will be a warning unless specs are ignored.
+-spec f(integer()) -> integer().
+f(F) when is_float(F) ->
+    F + 1.
+


### PR DESCRIPTION
This option is useful for debugging when one suspects that some specs are incorrect.

(Technically, this option is not new, but it was broken and undocumented.)