### PR TITLE
Make maps_order optional in io_lib:format_spec()

### DIFF
--- a/lib/stdlib/src/io_lib.erl
+++ b/lib/stdlib/src/io_lib.erl
@@ -125,7 +125,8 @@
            pad_char     := char(),
            encoding     := 'unicode' | 'latin1',
            strings      := boolean(),
-           maps_order   := maps:iterator_order()
+           % `maps_order` has been added since OTP26 and is optional
+           maps_order   => maps:iterator_order()
          }.
 
 %%----------------------------------------------------------------------

--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -116,10 +116,11 @@ args([]) ->
     [].
 
 print([#{control_char := C, width := F, adjust := Ad, precision := P,
-         pad_char := Pad, encoding := Encoding, strings := Strings,
-         maps_order := MapsOrder} | Cs]) ->
+         pad_char := Pad, encoding := Encoding, strings := Strings
+        } = Map | Cs]) ->
+    MapsOrder = maps:get(maps_order, Map, undefined),
     print(C, F, Ad, P, Pad, Encoding, Strings, MapsOrder) ++ print(Cs);
-print([C | Cs]) ->
+print([C | Cs]) when is_integer(C) ->
     [C | print(Cs)];
 print([]) ->
     [].

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -33,7 +33,8 @@
 	 maps/1, coverage/1, otp_14178_unicode_atoms/1, otp_14175/1,
          otp_14285/1, limit_term/1, otp_14983/1, otp_15103/1, otp_15076/1,
          otp_15159/1, otp_15639/1, otp_15705/1, otp_15847/1, otp_15875/1,
-         github_4801/1, chars_limit/1, error_info/1, otp_17525/1]).
+         github_4801/1, chars_limit/1, error_info/1, otp_17525/1,
+         unscan_format_without_maps_order/1]).
 
 -export([pretty/2, trf/3]).
 
@@ -67,7 +68,7 @@ all() ->
      format_string, maps, coverage, otp_14178_unicode_atoms, otp_14175,
      otp_14285, limit_term, otp_14983, otp_15103, otp_15076, otp_15159,
      otp_15639, otp_15705, otp_15847, otp_15875, github_4801, chars_limit,
-     error_info, otp_17525].
+     error_info, otp_17525, unscan_format_without_maps_order].
 
 %% Error cases for output.
 error_1(Config) when is_list(Config) ->
@@ -3182,3 +3183,16 @@ otp_17525(_Config) ->
     "                                                                         {...}|...]" =
     lists:flatten(S),
     ok.
+
+unscan_format_without_maps_order(_Config) ->
+    FormatSpec = #{
+        adjust => right,
+        args => [[<<"1">>]],
+        control_char => 115,
+        encoding => unicode,
+        pad_char => 32,
+        precision => none,
+        strings => true,
+        width => none
+    },
+    {"~ts",[[<<"1">>]]} = io_lib:unscan_format([FormatSpec]).


### PR DESCRIPTION
The 'maps_order' key has been added to the public type io_lib:format_spec() in OTP26 RC1, as a required key. Besides, the key presence is assumed in the implementation of io_lib:unscan_format/1. This makes it a breaking change, resulting in unexpected behavior for existing code calling it on a map without the key (returns a list of maps).

- fix the typespec to make the key optional

- don't require the key in io_lib:unscan_format/1

- add a guard to detect we're not building a correct charlist

### Reproduction of the breaking change

(same as the added test)

```erlang
Erlang/OTP 26 [RELEASE CANDIDATE 1] [erts-14.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V14.0 (press Ctrl+G to abort, type help(). for help)
1> io_lib:unscan_format([
1>     #{
1>       adjust => right,
1>       args => [[<<"1">>]],
1>       control_char => 115,
1>       encoding => unicode,
1>       pad_char => 32,
1>       precision => none,
1>       strings => true,
1>       width => none
1>     }
1>   ]).
{[#{args => [[<<"1">>]],
    encoding => unicode,adjust => right,width => none,
    strings => true,precision => none,pad_char => 32,
    control_char => 115}],
 [[<<"1">>]]}
```

instead of before:

```erlang
Erlang/OTP 25 [erts-13.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V13.0  (abort with ^G)
1> io_lib:unscan_format([
1>     #{
1>       adjust => right,
1>       args => [[<<"1">>]],
1>       control_char => 115,
1>       encoding => unicode,
1>       pad_char => 32,
1>       precision => none,
1>       strings => true,
1>       width => none
1>     }
1>   ]).
{"~ts",[[<<"1">>]]}
```