### PR TITLE
Add missing message send operator ! to erl_parse:binary_op/0 type

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -965,7 +965,7 @@ Erlang code.
 -type binary_op() :: '/' | '*' | 'div' | 'rem' | 'band' | 'and' | '+' | '-'
                    | 'bor' | 'bxor' | 'bsl' | 'bsr' | 'or' | 'xor' | '++'
                    | '--' | '==' | '/=' | '=<' | '<'  | '>=' | '>' | '=:='
-                   | '=/='.
+                   | '=/=' | '!'.
 
 -type af_unary_op(T) :: {'op', anno(), unary_op(), T}.
 


### PR DESCRIPTION
The message send operator `!` is listed in terminals of the grammar and an expression node for it is built using `?mkop2()` macro, but it's not listed as a valid operator in the definition of the `binary_op/0` type. This commit adds it there.