### PR TITLE
erts: Reintroduce literal fun optimization

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2545,6 +2545,15 @@ of Floating Point Numbers</seeguide>.</p>
               <c>Fun</c> was statically allocated when module was
               loaded (this optimisation is performed for local
               functions that do not capture the environment).</p>
+            <change>
+              <p>In Erlang/OTP 27, we plan to change the return value so that
+                it always points to the local <c>init</c> process, regardless
+                of which process or node the fun was originally created on. See
+                <seeguide marker="system/general_info:upcoming_incompatibilities#fun_creator_pid">
+                  Upcoming Potential Incompatibilities
+                </seeguide>.
+              </p>
+            </change>
           </item>
           <tag><c>{index, Index}</c></tag>
           <item>

--- a/erts/emulator/beam/beam_file.h
+++ b/erts/emulator/beam/beam_file.h
@@ -253,10 +253,14 @@ beamfile_read(const byte *data, size_t size, BeamFile *beam);
  * it. */
 void beamfile_free(BeamFile *beam);
 
-/** @brief Copies a term into the dynamic literal table.
+/** @brief Copies a term into the dynamic literal table
+ *
+ * @param[in] deduplicate Whether to try to deduplicate the term before
+ * insertion. Set to zero if you require a new unique literal, for example if
+ * it needs to be modified in the late stages of loading.
  *
  * @return A literal index that can be used in beamfile_get_literal */
-Sint beamfile_add_literal(BeamFile *beam, Eterm term);
+Sint beamfile_add_literal(BeamFile *beam, Eterm term, int deduplicate);
 
 /** @brief Gets a term from the literal table.
  *

--- a/erts/emulator/beam/emu/generators.tab
+++ b/erts/emulator/beam/emu/generators.tab
@@ -590,7 +590,7 @@ gen.new_small_map_lit(Dst, Live, Size, Rest) {
         *dst++ = Rest[i + 1];
     }
 
-    lit = beamfile_add_literal(&S->beam, keys);
+    lit = beamfile_add_literal(&S->beam, keys, 1);
     erts_free(ERTS_ALC_T_LOADER_TMP, tmp);
 
     op->a[0] = Dst;

--- a/erts/emulator/beam/emu/load.h
+++ b/erts/emulator/beam/emu/load.h
@@ -142,6 +142,11 @@ struct LoaderState_ {
     unsigned int current_li;	/* Current line instruction */
     unsigned int* func_line;	/* Mapping from function to first line instr */
 
+    /* Translates lambda indexes to their literals, if any. Lambdas that lack
+     * a literal (for example if they have an environment) are represented by
+     * ERTS_SWORD_MAX. */
+    SWord *lambda_literals;
+
     int otp_20_or_higher;
 
     Uint last_func_start;

--- a/erts/emulator/beam/generators.tab
+++ b/erts/emulator/beam/generators.tab
@@ -300,75 +300,133 @@ gen.skip_bits2(Fail, Ms, Size, Unit, Flags) {
     return op;
 }
 
-gen.make_fun2(idx) {
+// Creates an instruction that moves a literal lambda to a register.
+MakeLiteralLambda(Op, Index, DstType, DstVal) {
+    BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[Idx.val];
+    SWord literal;
+
+    ASSERT(entry->num_free == 0);
+
+    /* If we haven't already done so, we need to create a placeholder for the
+     * lambda. */
+    if (S->lambda_literals[$Index] == ERTS_SWORD_MAX) {
+        Eterm tmp_hp[ERL_FUN_SIZE];
+        ErlFunThing *funp;
+
+        /* The placeholder is an external fun with the export field set to
+         * NULL, preventing it from colliding with external fun literals
+         * created by the user. We also disable deduplication to prevent it
+         * from colliding with other placeholder lambdas of the same arity. */
+        funp = (ErlFunThing*)tmp_hp;
+        funp->thing_word = HEADER_FUN;
+        funp->entry.exp = NULL;
+        funp->next = NULL;
+        funp->arity = entry->arity;
+        funp->num_free = 0;
+        funp->creator = am_external;
+
+        literal = beamfile_add_literal(&S->beam, make_fun(tmp_hp), 0);
+        S->lambda_literals[$Index] = literal;
+    } else {
+        literal = S->lambda_literals[$Index];
+    }
+
+    $BeamOpNameArity($Op, move, 2);
+    ($Op)->a[0].type = TAG_q;
+    ($Op)->a[0].val = literal;
+    ($Op)->a[1].type = $DstType;
+    ($Op)->a[1].val = $DstVal;
+}
+
+gen.make_fun2(Idx) {
     BeamOp* op;
     BeamOp* th;
 
     $NewBeamOp(S, op);
 
-    if (idx.val >= S->beam.lambdas.count) {
+    if (Idx.val >= S->beam.lambdas.count) {
         $BeamOpNameArity(op, i_lambda_error, 1);
         op->a[0].type = TAG_o;
         op->a[0].val = 0;
-	return op;
+        return op;
     } else {
-	int i;
-        BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[idx.val];
-	unsigned num_free = entry->num_free;
-	unsigned arity = entry->arity;
+        BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[Idx.val];
+        unsigned num_free = entry->num_free;
+        unsigned arity = entry->arity;
+        int i;
 
-	$NewBeamOp(S, th);
+        /* Literal lambdas are all owned by the init process as a workaround
+         * for all local funs needing a creator pid. Skip the optimization if
+         * this module is being loaded before said process has started
+         * (just preloaded modules, really). */
+        if (num_free == 0 && erts_init_process_id != ERTS_INVALID_PID) {
+            $MakeLiteralLambda(op, Idx.val, TAG_x, 0);
+            return op;
+        }
 
-	$BeamOpNameArity(th, test_heap, 2);
-	th->a[0].type = TAG_u;
-	th->a[0].val = ERL_FUN_SIZE + num_free;
-	th->a[1].type = TAG_u;
-	th->a[1].val = num_free;
-	th->next = op;
+        $NewBeamOp(S, th);
 
-	$BeamOpNameArity(op, i_make_fun3, 4);
-	$BeamOpArity(op, 4 + num_free);
-	op->a[0].type = TAG_u;
-	op->a[0].val = idx.val;
-	op->a[1].type = TAG_x;
-	op->a[1].val = 0;
-	op->a[2].type = TAG_u;
-	op->a[2].val = arity - num_free;
-	op->a[3].type = TAG_u;
-	op->a[3].val = num_free;
-	for (i = 0; i < num_free; i++) {
-	    op->a[i+4].type = TAG_x;
-	    op->a[i+4].val = i;
-	}
-	return th;
+        $BeamOpNameArity(th, test_heap, 2);
+        th->a[0].type = TAG_u;
+        th->a[0].val = ERL_FUN_SIZE + num_free;
+        th->a[1].type = TAG_u;
+        th->a[1].val = num_free;
+        th->next = op;
+
+        $BeamOpNameArity(op, i_make_fun3, 4);
+        $BeamOpArity(op, 4 + num_free);
+        op->a[0].type = TAG_u;
+        op->a[0].val = Idx.val;
+        op->a[1].type = TAG_x;
+        op->a[1].val = 0;
+        op->a[2].type = TAG_u;
+        op->a[2].val = arity - num_free;
+        op->a[3].type = TAG_u;
+        op->a[3].val = num_free;
+
+        for (i = 0; i < num_free; i++) {
+            op->a[i+4].type = TAG_x;
+            op->a[i+4].val = i;
+        }
+
+        return th;
     }
 }
 
-gen.make_fun3(idx, Dst, NumFree, Env) {
+gen.make_fun3(Idx, Dst, NumFree, Env) {
     BeamOp* op;
 
     $NewBeamOp(S, op);
 
-    if (idx.val < S->beam.lambdas.count) {
-        BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[idx.val];
-	if (NumFree.val == entry->num_free) {
-	    int i;
+    if (Idx.val < S->beam.lambdas.count) {
+        BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[Idx.val];
 
-	    $BeamOpNameArity(op, i_make_fun3, 4);
-	    $BeamOpArity(op, 4 + NumFree.val);
-	    op->a[0].type = TAG_u;
-	    op->a[0].val = idx.val;
-	    op->a[1] = Dst;
-	    op->a[2].type = TAG_u;
-	    op->a[2].val = entry->arity - entry->num_free;
-	    op->a[3].type = TAG_u;
-	    op->a[3].val = entry->num_free;
-	    for (i = 0; i < NumFree.val; i++) {
-		op->a[i+4] = Env[i];
-	    }
-	    return op;
-	}
+        if (NumFree.val == entry->num_free) {
+            int i;
+
+            if (NumFree.val == 0 && erts_init_process_id != ERTS_INVALID_PID) {
+                $MakeLiteralLambda(op, Idx.val, Dst.type, Dst.val);
+            } else {
+                $BeamOpNameArity(op, i_make_fun3, 4);
+                $BeamOpArity(op, 4 + NumFree.val);
+
+                op->a[0].type = TAG_u;
+                op->a[0].val = Idx.val;
+                op->a[1] = Dst;
+                op->a[2].type = TAG_u;
+                op->a[2].val = entry->arity - entry->num_free;
+                op->a[3].type = TAG_u;
+                op->a[3].val = entry->num_free;
+
+                for (i = 0; i < NumFree.val; i++) {
+                    op->a[i+4] = Env[i];
+                }
+            }
+
+            return op;
+        }
     }
+
     $BeamOpNameArity(op, i_lambda_error, 1);
     op->a[0].type = TAG_o;
     op->a[0].val = 0;

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1184,9 +1184,9 @@ public:
     const ErtsCodeInfo *getOnLoad(void);
 
     unsigned patchCatches(char *rw_base);
-    void patchLambda(char *rw_base, unsigned index, BeamInstr I);
+    void patchLambda(char *rw_base, unsigned index, const ErlFunEntry *fe);
     void patchLiteral(char *rw_base, unsigned index, Eterm lit);
-    void patchImport(char *rw_base, unsigned index, BeamInstr I);
+    void patchImport(char *rw_base, unsigned index, const Export *import);
     void patchStrings(char *rw_base, const byte *string);
 
 protected:

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -504,25 +504,25 @@ unsigned BeamModuleAssembler::patchCatches(char *rw_base) {
 
 void BeamModuleAssembler::patchImport(char *rw_base,
                                       unsigned index,
-                                      BeamInstr I) {
+                                      const Export *import) {
     for (const auto &patch : imports[index].patches) {
         auto offset = code.labelOffsetFromBase(patch.where);
         auto where = (Eterm *)&rw_base[offset];
 
         ASSERT(LLONG_MAX == *where);
-        *where = I + patch.val_offs;
+        *where = reinterpret_cast<Eterm>(import) + patch.val_offs;
     }
 }
 
 void BeamModuleAssembler::patchLambda(char *rw_base,
                                       unsigned index,
-                                      BeamInstr I) {
+                                      const ErlFunEntry *fe) {
     for (const auto &patch : lambdas[index].patches) {
         auto offset = code.labelOffsetFromBase(patch.where);
         auto where = (Eterm *)&rw_base[offset];
 
         ASSERT(LLONG_MAX == *where);
-        *where = I + patch.val_offs;
+        *where = reinterpret_cast<Eterm>(fe) + patch.val_offs;
     }
 }
 

--- a/erts/emulator/beam/jit/arm/generators.tab
+++ b/erts/emulator/beam/jit/arm/generators.tab
@@ -289,7 +289,7 @@ gen.new_small_map_lit(Dst, Live, Size, Rest) {
         *dst++ = Rest[i + 1];
     }
 
-    lit = beamfile_add_literal(&S->beam, keys);
+    lit = beamfile_add_literal(&S->beam, keys, 1);
     erts_free(ERTS_ALC_T_LOADER_TMP, tmp);
 
     op->a[0] = Dst;

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -23,6 +23,7 @@
 
 #    include "sys.h"
 #    include "bif.h"
+#    include "erl_fun.h"
 #    include "erl_process.h"
 #    include "beam_code.h"
 #    include "beam_file.h"
@@ -73,9 +74,15 @@ void beamasm_embed_rodata(void *ba,
 void beamasm_embed_bss(void *ba, char *labelName, size_t size);
 
 unsigned int beamasm_patch_catches(void *ba, char *rw_base);
-void beamasm_patch_import(void *ba, char *rw_base, int index, BeamInstr import);
+void beamasm_patch_import(void *ba,
+                          char *rw_base,
+                          int index,
+                          const Export *import);
 void beamasm_patch_literal(void *ba, char *rw_base, int index, Eterm lit);
-void beamasm_patch_lambda(void *ba, char *rw_base, int index, BeamInstr fe);
+void beamasm_patch_lambda(void *ba,
+                          char *rw_base,
+                          int index,
+                          const ErlFunEntry *fe);
 void beamasm_patch_strings(void *ba, char *rw_base, const byte *strtab);
 
 void beamasm_emit_call_nif(const ErtsCodeInfo *info,

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -577,7 +577,7 @@ extern "C"
     void beamasm_patch_import(void *instance,
                               char *rw_base,
                               int index,
-                              BeamInstr import) {
+                              const Export *import) {
         BeamModuleAssembler *ba = static_cast<BeamModuleAssembler *>(instance);
         ba->patchImport(rw_base, index, import);
     }
@@ -593,7 +593,7 @@ extern "C"
     void beamasm_patch_lambda(void *instance,
                               char *rw_base,
                               int index,
-                              BeamInstr fe) {
+                              const ErlFunEntry *fe) {
         BeamModuleAssembler *ba = static_cast<BeamModuleAssembler *>(instance);
         ba->patchLambda(rw_base, index, fe);
     }

--- a/erts/emulator/beam/jit/load.h
+++ b/erts/emulator/beam/jit/load.h
@@ -82,6 +82,11 @@ struct LoaderState_ {
     unsigned int current_li; /* Current line instruction */
     unsigned int *func_line; /* Mapping from function to first line instr */
 
+    /* Translates lambda indexes to their literals, if any. Lambdas that lack
+     * a literal (for example if they have an environment) are represented by
+     * ERTS_SWORD_MAX. */
+    SWord *lambda_literals;
+
     void *ba; /* Assembler used to create x86 assembly */
 
     const void *native_module_exec; /* Native module after codegen */

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1243,9 +1243,9 @@ public:
     const ErtsCodeInfo *getOnLoad(void);
 
     unsigned patchCatches(char *rw_base);
-    void patchLambda(char *rw_base, unsigned index, BeamInstr I);
+    void patchLambda(char *rw_base, unsigned index, const ErlFunEntry *fe);
     void patchLiteral(char *rw_base, unsigned index, Eterm lit);
-    void patchImport(char *rw_base, unsigned index, BeamInstr I);
+    void patchImport(char *rw_base, unsigned index, const Export *import);
     void patchStrings(char *rw_base, const byte *string);
 
 protected:

--- a/erts/emulator/beam/jit/x86/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_module.cpp
@@ -431,25 +431,25 @@ unsigned BeamModuleAssembler::patchCatches(char *rw_base) {
 
 void BeamModuleAssembler::patchImport(char *rw_base,
                                       unsigned index,
-                                      BeamInstr I) {
+                                      const Export *import) {
     for (const auto &patch : imports[index].patches) {
         auto offset = code.labelOffsetFromBase(patch.where);
         auto where = (Eterm *)&rw_base[offset + patch.ptr_offs];
 
         ASSERT(LLONG_MAX == *where);
-        *where = I + patch.val_offs;
+        *where = reinterpret_cast<Eterm>(import) + patch.val_offs;
     }
 }
 
 void BeamModuleAssembler::patchLambda(char *rw_base,
                                       unsigned index,
-                                      BeamInstr I) {
+                                      const ErlFunEntry *fe) {
     for (const auto &patch : lambdas[index].patches) {
         auto offset = code.labelOffsetFromBase(patch.where);
         auto where = (Eterm *)&rw_base[offset + patch.ptr_offs];
 
         ASSERT(LLONG_MAX == *where);
-        *where = I + patch.val_offs;
+        *where = reinterpret_cast<Eterm>(fe) + patch.val_offs;
     }
 }
 

--- a/erts/emulator/beam/jit/x86/generators.tab
+++ b/erts/emulator/beam/jit/x86/generators.tab
@@ -359,7 +359,7 @@ gen.new_small_map_lit(Dst, Live, Size, Rest) {
         *dst++ = Rest[i + 1];
     }
 
-    lit = beamfile_add_literal(&S->beam, keys);
+    lit = beamfile_add_literal(&S->beam, keys, 1);
     erts_free(ERTS_ALC_T_LOADER_TMP, tmp);
 
     op->a[0] = Dst;

--- a/erts/emulator/test/fun_SUITE.erl
+++ b/erts/emulator/test/fun_SUITE.erl
@@ -585,7 +585,7 @@ refc_dist(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     Pid = spawn_link(Node, fun() -> receive
                                         Fun when is_function(Fun) ->
-                                            2 = fun_refc(Fun),
+                                            3 = fun_refc(Fun),
                                             exit({normal,Fun}) end
                            end),
     F = fun() -> 42 end,
@@ -608,7 +608,7 @@ refc_dist_send(Node, F) ->
     Pid = spawn_link(Node, fun() -> receive
                                         {To,Fun} when is_function(Fun) ->
                                             wait_until(fun () ->
-                                                               2 =:= fun_refc(Fun)
+                                                               3 =:= fun_refc(Fun)
                                                        end),
                                             To ! Fun
                                     end
@@ -636,7 +636,7 @@ refc_dist_reg_send(Node, F) ->
                                    Me ! Ref,
                                    receive
                                        {Me,Fun} when is_function(Fun) ->
-                                           2 = fun_refc(Fun),
+                                           3 = fun_refc(Fun),
                                            Me ! Fun
                                    end
                            end),

--- a/erts/emulator/test/trace_call_time_SUITE.erl
+++ b/erts/emulator/test/trace_call_time_SUITE.erl
@@ -798,7 +798,7 @@ setup() ->
 
 setup(Opts) ->
     Pid = spawn_opt(fun() -> loop() end,
-                   [link, {max_heap_size, 10000}]),
+                   [link, {max_heap_size, 12000}]),
     1 = erlang:trace(Pid, true, [call|Opts]),
     Pid.
 

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -108,6 +108,25 @@
         </item>
       </list>
     </section>
-
   </section>
+
+  <section>
+    <title>OTP 27</title>
+
+    <section>
+      <marker id="fun_creator_pid"/>
+      <title>Fun creator pid will be removed</title>
+      <p>
+        As of OTP 27, the functions
+        <seemfa marker="erts:erlang#fun_info/1">
+        <c>erlang:fun_info/1,2</c></seemfa> will always say that the local
+        <c>init</c> process created all funs, regardless of which process or
+        node the fun was originally created on.
+      </p>
+      <p>
+        In OTP 28, the <c>{pid,_}</c>element will be removed altogether.
+      </p>
+    </section>
+  </section>
+
 </chapter>


### PR DESCRIPTION
The optimization that turned `make_fun2`/`3` instructions of funs lacking an environment into literals was lost during the pre-JIT refactoring of the loader, as creation of fun entries was now (rightly) deferred until the very last stages of module loading.

This commit restores that optimization by creating placeholders in the form of external funs, which are then converted to local funs during the last stages of module loading.