### PR TITLE
fix return value 'undefined' of v(N) is treated as missing command

### DIFF
--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -482,7 +482,7 @@ expand_expr({call,A,{atom,_,e},[N]}, C) ->
     end;
 expand_expr({call,CA,{atom,VA,v},[N]}, C) ->
     case get_cmd(N, C) of
-        {_,undefined,_} ->
+        {undefined,_,_} ->
             no_command(N);
         {Ces,_V,CommandN} when is_list(Ces) ->
             {call,CA,{atom,VA,v},[{integer,VA,CommandN}]}


### PR DESCRIPTION
fix the following issue:

```erl
Erlang/OTP 26 [erts-14.0] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit:ns]

Eshell V14.0 (press Ctrl+G to abort, type help(). for help)
(asuka@eva.org)1> ets:info(ets_worker, size).
undefined
(asuka@eva.org)2> v(1).
* 1: command not found
(asuka@eva.org)3> undefined.
undefined
(asuka@eva.org)4> v(-1).
* -1: command not found
```