### PR TITLE
beam_validator: Skip unnecessary type updates

### DIFF
--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -2299,6 +2299,8 @@ update_type(Merge, With, #value_ref{}=Ref, Vst0) ->
     case Merge(Current, With) of
         none ->
             throw({type_conflict, Current, With});
+        Current ->
+            Vst0;
         Type ->
             Vst = update_container_type(Type, Ref, Vst0),
             set_type(Type, Ref, Vst)

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -41,7 +41,8 @@
          missing_return_type/1,will_succeed/1,
          bs_saved_position_units/1,parent_container/1,
          container_performance/1,
-         not_equal_inference/1]).
+         not_equal_inference/1,
+         inert_update_type/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -77,7 +78,8 @@ groups() ->
        missing_return_type,will_succeed,
        bs_saved_position_units,parent_container,
        container_performance,
-       not_equal_inference]}].
+       not_equal_inference,
+       inert_update_type]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -1044,6 +1046,19 @@ not_equal_inference(_Config) ->
 
 not_equal_inference_1(X) when (X /= []) /= is_port(0 div 0) ->
     [X || _ <- []].
+
+%% GH-6969: A type was made concrete even though that added no additional
+%% information.
+inert_update_type(_Config) ->
+    hello(<<"string">>, id(42)).
+
+hello(A, B) ->
+    mike([{sys_period, {A, B}}, {some_atom, B}]).
+
+mike([Head | _Rest]) -> joe(Head).
+
+joe({Name, 42}) -> Name;
+joe({sys_period, {A, _B}}) -> {41, 42, A}.
 
 id(I) ->
     I.


### PR DESCRIPTION
Fixes #6969 