### PR TITLE
Support untagged aliases in gen:reply/2

### DIFF
--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -542,10 +542,23 @@ reqids_to_list(_) ->
 %%
 %% Send a reply to the client.
 %%
+%% The untagged_alias is not used by Erlang/OTP but
+%% needed by languages like Elixir which provide
+%% features like send_request/receive_response and
+%% require the reply to be an untagged reference.
+%%
+%% The nested cons are defined forwards compatibility
+%% reasons in case more metadata needs to be added to
+%% the tag.
+%%
 reply({_To, [alias|Alias] = Tag}, Reply) when is_reference(Alias) ->
     Alias ! {Tag, Reply}, ok;
 reply({_To, [[alias|Alias] | _] = Tag}, Reply) when is_reference(Alias) ->
     Alias ! {Tag, Reply}, ok;
+reply({_To, [untagged_alias|Alias]}, Reply) when is_reference(Alias) ->
+    Alias ! {Alias, Reply}, ok;
+reply({_To, [[untagged_alias|Alias] | _]}, Reply) when is_reference(Alias) ->
+    Alias ! {Alias, Reply}, ok;
 reply({To, Tag}, Reply) ->
     try To ! {Tag, Reply}, ok catch _:_ -> ok end.
 


### PR DESCRIPTION
The untagged_alias is not used by Erlang/OTP but needed by languages like Elixir which provide features like send_request/receive_response and require the reply to be an untagged reference.

### Additional context

Elixir has a feature called tasks, which are similar to gen:send_request/2 and gen:receive_response/2 (and ReqIds) but predates them. Instead of exposing the functionality within each behaviour (gen_server:send_request/2, gen_event:send_request/2, etc), it is provided by a single and public API module called Task.

Our abstractions currently require the `Tag` in `{Tag, Reply}` and the `Ref` in `{'DOWN', Ref, _, _ _}` to be the same. We tried working around this in an opaque way, [by making the Tag and Ref differ in the GenServer case](https://github.com/elixir-lang/elixir/commit/b20ad8a1514008595bebe95ed9f8dfc67380a779) but we learned it breaks selective receives because the optimization requires a single reference.

Therefore, I can't think of any other solution than changing Erlang/OTP to be aware of additional reply formats. I personally try to avoid adding functionality to Erlang/OTP that is not directly used by OTP itself but I believe it is the best solution right now (luckily, it is only 4 LOC and it may even be used by OTP in the future). This means Elixir will have to wait at least 2 years to have this feature (or 3 if it doesn't make to Erlang/OTP 26) but that's better than never.

The only other alternative I can think right now is to make the reply dynamic:

```erlang
reply(To, [Mod|Ref]) when is_atom(Mod) ->
  Mod:reply(To, Ref);
```

But this may open up another can of works that you may not want to go into.