### PR TITLE
Add "since" versions to XML taglist

### DIFF
--- a/lib/erl_docgen/priv/dtd/common.dtd
+++ b/lib/erl_docgen/priv/dtd/common.dtd
@@ -54,6 +54,7 @@
 <!ATTLIST list                 type (ordered|bulleted) "bulleted" >
 <!ELEMENT taglist             (tag,item+)+ >
 <!ELEMENT tag                 (#PCDATA|c|i|em|br|%refs;|marker|anno)* >
+<!ATTLIST tag                 since CDATA #IMPLIED>
 <!ELEMENT item                (%inline;|%block;|warning|note|change|dont|do|quote|table)* >
 
 <!-- References -->

--- a/lib/erl_docgen/priv/xsl/db_html.xsl
+++ b/lib/erl_docgen/priv/xsl/db_html.xsl
@@ -1251,10 +1251,15 @@
 
   <xsl:template match="taglist/tag">
     <xsl:param name="chapnum"/>
-    <dt>
+    <dt class="title-link">
       <strong>
         <xsl:apply-templates/>
       </strong>
+      <xsl:if test="string-length(@since) > 0">
+	<div class="title-since since">
+	  <xsl:value-of select="@since"/>
+	</div>
+      </xsl:if>
     </dt>
   </xsl:template>
 

--- a/lib/erl_docgen/src/docgen_xml_to_chunk.erl
+++ b/lib/erl_docgen/src/docgen_xml_to_chunk.erl
@@ -485,12 +485,22 @@ transform_types(Dom,Acc) ->
 
 transform_taglist(Attr,Content) ->
     Items =
-        lists:map(fun({tag,A,C}) ->
-                          {dt,A,C};
+        lists:map(fun({tag,_A,_C}=Tag) ->
+                          transform_tag(Tag);
                      ({item,A,C}) ->
                           {dd,A,C}
                   end, Content),
     {dl,Attr,Items}.
+
+transform_tag({tag, Attr0, C}) ->
+    Attr1 = lists:map(fun({since,Vsn}) ->
+                              {since,
+                               unicode:characters_to_binary(Vsn)};
+                         (A) ->
+                              A
+                      end,
+                      Attr0),
+    {dt,Attr1,C}.
 
 %% if we have {func,[],[{name,...},{name,....},...]}
 %% we convert it to one {func,[],[{name,...}] per arity lowest first.

--- a/lib/stdlib/doc/src/ets.xml
+++ b/lib/stdlib/doc/src/ets.xml
@@ -1387,7 +1387,7 @@ ets:select(Table, MatchSpec),</code>
             </note>
             <marker id="new_2_read_concurrency"></marker>
           </item>
-          <tag><c>{read_concurrency,boolean()}</c></tag>
+          <tag since="OTP R14B"><c>{read_concurrency,boolean()}</c></tag>
           <item>
             <p>Performance tuning. Defaults to <c>false</c>. When set to
               <c>true</c>, the table is optimized for concurrent read
@@ -1412,7 +1412,7 @@ ets:select(Table, MatchSpec),</code>
               read bursts and large concurrent write bursts are common.</p>
             <marker id="new_2_decentralized_counters"></marker>
           </item>
-          <tag><c>{decentralized_counters,boolean()}</c></tag>
+          <tag since="OTP 23.0"><c>{decentralized_counters,boolean()}</c></tag>
           <item>
             <p>
               Performance tuning. Defaults to <c>true</c> for all
@@ -1447,7 +1447,7 @@ ets:select(Table, MatchSpec),</code>
             </p>
               <marker id="new_2_compressed"></marker>
           </item>
-          <tag><c>compressed</c></tag>
+          <tag since="OTP R14B01"><c>compressed</c></tag>
           <item>
             <p>If this option is present, the table data is stored in a more
               compact format to consume less memory. However, it will make

--- a/lib/stdlib/doc/src/rand.xml
+++ b/lib/stdlib/doc/src/rand.xml
@@ -78,7 +78,7 @@
     </p>
 
     <taglist>
-      <tag><c>exsss</c></tag>
+      <tag since="OTP 22.0"><c>exsss</c></tag>
       <item>
         <p>Xorshift116**, 58 bits precision and period of 2^116-1</p>
         <p>Jump function: equivalent to 2^64 calls</p>
@@ -104,7 +104,7 @@
           thanks to its statistical qualities.
 	</p>
       </item>
-      <tag><c>exro928ss</c></tag>
+      <tag since="OTP 22.0"><c>exro928ss</c></tag>
       <item>
         <p>Xoroshiro928**, 58 bits precision and a period of 2^928-1</p>
         <p>Jump function: equivalent to 2^512 calls</p>
@@ -127,17 +127,17 @@
 	  the 58 bit adaption.
 	</p>
       </item>
-      <tag><c>exrop</c></tag>
+      <tag since="OTP 20.0"><c>exrop</c></tag>
       <item>
         <p>Xoroshiro116+, 58 bits precision and period of 2^116-1</p>
         <p>Jump function: equivalent to 2^64 calls</p>
       </item>
-      <tag><c>exs1024s</c></tag>
+      <tag since="OTP 20.0"><c>exs1024s</c></tag>
       <item>
         <p>Xorshift1024*, 64 bits precision and a period of 2^1024-1</p>
         <p>Jump function: equivalent to 2^512 calls</p>
       </item>
-      <tag><c>exsp</c></tag>
+      <tag since="OTP 20.0"><c>exsp</c></tag>
       <item>
         <p>Xorshift116+, 58 bits precision and period of 2^116-1</p>
         <p>Jump function: equivalent to 2^64 calls</p>

--- a/lib/stdlib/src/shell_docs.erl
+++ b/lib/stdlib/src/shell_docs.erl
@@ -872,10 +872,16 @@ render_element({li,[],Content},[l | _] = State, Pos, Ind,D) ->
 
 render_element({dl,_,Content},State,Pos,Ind,D) ->
     render_docs(Content, [dl|State], Pos, Ind,D);
-render_element({dt,_,Content},[dl | _] = State,Pos,Ind,D) ->
+render_element({dt,Since,Content},[dl | _] = State,Pos,Ind,D) ->
+    Suffix = case Since of
+                 [{since, Vsn}] ->
+                     ":     (since " ++ unicode:characters_to_list(Vsn) ++ ")\n";
+                 _ ->
+                     ":\n"
+             end,
     Underline = sansi(underline),
     {Docs, _NewPos} = render_docs(Content, [li | State], Pos, Ind, D),
-    {[Underline,Docs,ransi(underline),":","\n"], 0};
+    {[Underline,Docs,ransi(underline),Suffix], 0};
 render_element({dd,_,Content},[dl | _] = State,Pos,Ind,D) ->
     trimnlnl(render_docs(Content, [li | State], Pos, Ind + 2, D));
 


### PR DESCRIPTION
Usable to document OTP version when a particular option/feature was introduced.

Example for module `rand`:
```
    <p>
      The following algorithms are provided:
    </p>
    <taglist>
      <tag since="OTP 22.0"><c>exsss</c></tag>
```
The version is shown similar to "since" versions for functions out in right margin.

This PR contains only usage in modules `ets` and `rand`.