### PR TITLE
Make term_to_binary encode atoms as UTF-8 by default

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -11873,37 +11873,26 @@ hello
 	  <taglist>
 	    <tag><c>0</c></tag>
 	    <item>
-              <p>Floats are encoded using a textual representation.
-	      This option is useful to ensure that releases before Erlang/OTP
-	      R11B-4 can decode resulting binary.</p>
-	      <p>This version encode atoms that can be represented by a
-	      latin1 string using latin1 encoding while only atoms that
-	      cannot be represented by latin1 are encoded using utf8.</p>
+              <p>Floats are encoded using a textual representation.</p>
+	      <p>Atoms that can be represented by a latin1 string are encoded
+	      using latin1 while only atoms that cannot be represented by latin1
+	      are encoded using utf8.</p>
 	    </item>
 	    <tag><c>1</c></tag>
 	    <item>
-              <p>This is as of Erlang/OTP 17.0 the <em>default</em>. It forces any floats
-	      in the term to be encoded in a more space-efficient and exact way
+              <p>Floats are encoded in a more space-efficient and exact way
 	      (namely in the 64-bit IEEE format, rather than converted to a
 	      textual representation). As from Erlang/OTP R11B-4,
 	      <c>binary_to_term/1</c> can decode this representation.</p>
-	      <p>This version encode atoms that can be represented by a
-	      latin1 string using latin1 encoding while only atoms that
-	      cannot be represented by latin1 are encoded using utf8.</p>
+	      <p>Atoms that can be represented by a latin1 string are encoded
+	      using latin1 while only atoms that cannot be represented by latin1
+	      are encoded using utf8.</p>
 	    </item>
 	    <tag><c>2</c></tag>
 	    <item>
-              <p>Drops usage of the latin1 atom encoding and unconditionally
-	      use utf8 encoding for all atoms. Erlang/OTP
-	      systems as of R16B can decode this representation.</p>
-              <change>
-                <p>In Erlang/OTP 26, the default <c>minor_version</c> is planned
-                to change from 1 to 2. See
-                <seeguide marker="system/general_info:upcoming_incompatibilities#atoms_be_utf8">
-                  Upcoming Potential Incompatibilities
-                </seeguide>.
-                </p>
-              </change>
+              <p>This is as of Erlang/OTP 26.0 the <em>default</em>. Atoms are
+	      unconditionally encoded using utf8. Erlang/OTP systems as of R16B
+	      can decode this representation.</p>
 	    </item>
 	  </taglist>
           <p>Option <c>deterministic</c> (introduced in OTP 24.1) can

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -128,7 +128,8 @@
 #define DFLAG_DIST_STRICT_ORDER DFLAG_DIST_HDR_ATOM_CACHE
 
 /* All flags that should be enabled when term_to_binary/1 is used. */
-#define TERM_TO_BINARY_DFLAGS DFLAG_NEW_FLOATS
+#define TERM_TO_BINARY_DFLAGS (DFLAG_NEW_FLOATS                  \
+                               | DFLAG_UTF8_ATOMS)
 
 /* opcodes used in distribution messages */
 enum dop {

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -1422,13 +1422,14 @@ parse_t2b_opts(Eterm opts, Uint *flagsp, int *levelp, int *iovecp, Uint *fsizep)
 	    if (tp[1] == am_minor_version && is_small(tp[2])) {
 		switch (signed_val(tp[2])) {
 		case 0:
-		    flags = TERM_TO_BINARY_DFLAGS & ~DFLAG_NEW_FLOATS;
+		    flags = (TERM_TO_BINARY_DFLAGS
+                             & ~(DFLAG_NEW_FLOATS | DFLAG_UTF8_ATOMS));
 		    break;
 		case 1: /* Current default... */
-		    flags = TERM_TO_BINARY_DFLAGS;
+		    flags = TERM_TO_BINARY_DFLAGS & ~DFLAG_UTF8_ATOMS;
                     break;
                 case 2:
-                    flags = TERM_TO_BINARY_DFLAGS | DFLAG_UTF8_ATOMS;
+                    flags = TERM_TO_BINARY_DFLAGS;
 		    break;
 		default:
                     return 0; /* badarg */

--- a/lib/erl_interface/test/ei_decode_SUITE_data/ei_decode_test.c
+++ b/lib/erl_interface/test/ei_decode_SUITE_data/ei_decode_test.c
@@ -742,11 +742,11 @@ TESTCASE(test_ei_decode_misc)
     decode_double(-1.0);
     decode_double(1.0);
 
-    EI_DECODE_2(decode_boolean, 8, int, 0);
-    EI_DECODE_2(decode_boolean, 7, int, 1);
+    EI_DECODE_2(decode_boolean, 7, int, 0);
+    EI_DECODE_2(decode_boolean, 6, int, 1);
 
-    EI_DECODE_STRING(decode_my_atom, 6, "foo");
-    EI_DECODE_STRING(decode_my_atom, 3, "");
+    EI_DECODE_STRING(decode_my_atom, 5, "foo");
+    EI_DECODE_STRING(decode_my_atom, 2, "");
     EI_DECODE_STRING(decode_my_atom, 9, "≈ƒ÷Â‰ˆ");
 
     EI_DECODE_STRING(decode_my_string, 6, "foo");
@@ -802,10 +802,10 @@ TESTCASE(test_ei_decode_utf8_atom)
 		   P99({ERLANG_ANY,ERLANG_LATIN1,ERLANG_ASCII}));
   EI_DECODE_STRING_4(decode_my_atom_as, 4, "b",
 		     P99({ERLANG_UTF8,ERLANG_LATIN1,ERLANG_ASCII}));
-  EI_DECODE_STRING_4(decode_my_atom_as, 4, "c",
-		     P99({ERLANG_LATIN1,ERLANG_LATIN1,ERLANG_ASCII}));
-  EI_DECODE_STRING_4(decode_my_atom_as, 4, "d",
-		     P99({ERLANG_ASCII,ERLANG_LATIN1,ERLANG_ASCII}));
+  EI_DECODE_STRING_4(decode_my_atom_as, 3, "c",
+		     P99({ERLANG_LATIN1,ERLANG_UTF8,ERLANG_ASCII}));
+  EI_DECODE_STRING_4(decode_my_atom_as, 3, "d",
+		     P99({ERLANG_ASCII,ERLANG_UTF8,ERLANG_ASCII}));
 
   report(1);
 }

--- a/lib/kernel/test/disk_log_SUITE.erl
+++ b/lib/kernel/test/disk_log_SUITE.erl
@@ -462,7 +462,7 @@ halt_ro_crash(Conf) when is_list(Conf) ->
     %% This is how it was before R6B:
     %% {C1,T1,15} = disk_log:chunk(a,start),
     %% {C2,T2} = disk_log:chunk(a,C1),
-    {C1,_OneItem,7478} = disk_log:chunk(a,start),
+    {C1,_OneItem,7476} = disk_log:chunk(a,start),
     {C2, [], 7} = disk_log:chunk(a,C1),
     eof = disk_log:chunk(a,C2),
     ok = disk_log:close(a),
@@ -2568,16 +2568,16 @@ error_repair(Conf) when is_list(Conf) ->
     %% repair a file
     P1 = pps(),
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, wrap},
-			     {format, internal}, {size, {40,No}}]),
+			     {format, internal}, {size, {38,No}}]),
     ok = disk_log:log_terms(n, [{this,is}]), % first file full
     ok = disk_log:log_terms(n, [{some,terms}]), % second file full
     ok = disk_log:close(n),
     BadFile = add_ext(File, 2), % current file
     set_opened(BadFile),
-    crash(BadFile, 28), % the binary is now invalid
-    {repaired,n,{recovered,0},{badbytes,26}} =
+    crash(BadFile, 26), % the binary is now invalid
+    {repaired,n,{recovered,0},{badbytes,24}} =
 	disk_log:open([{name, n}, {file, File}, {type, wrap},
-		       {format, internal}, {size, {40,No}}]),
+		       {format, internal}, {size, {38,No}}]),
     ok = disk_log:close(n),
     check_pps(P1),
     del(File, No),
@@ -2592,8 +2592,8 @@ error_repair(Conf) when is_list(Conf) ->
     ok = disk_log:close(n),
     BadFile2 = add_ext(File, 1), % current file
     set_opened(BadFile2),
-    crash(BadFile2, 51), % the second binary is now invalid
-    {repaired,n,{recovered,1},{badbytes,26}} =
+    crash(BadFile2, 47), % the second binary is now invalid
+    {repaired,n,{recovered,1},{badbytes,24}} =
 	disk_log:open([{name, n}, {file, File}, {type, wrap},
 		       {format, internal}, {size, {4000,No}}]),
     ok = disk_log:close(n),
@@ -2651,7 +2651,7 @@ error_repair(Conf) when is_list(Conf) ->
     ok = disk_log:close(n),
     set_opened(File),
     crash(File, 30),
-    {repaired,n,{recovered,3},{badbytes,16}} =
+    {repaired,n,{recovered,3},{badbytes,15}} =
         disk_log:open([{name, n}, {file, File}, {type, halt},
 		       {format, internal},{repair,true}, {quiet, true},
 		       {head_func, {?MODULE, head_fun, [{ok,"head"}]}}]),
@@ -2873,12 +2873,12 @@ chunk(Conf) when is_list(Conf) ->
     %% Two wrap log files, writing the second one, then reading the first
     %% one, where a bogus term resides.
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, wrap},
-			     {format, internal}, {size, {40,No}}]),
+			     {format, internal}, {size, {38,No}}]),
     ok = disk_log:log_terms(n, [{this,is}]), % first file full
     ok = disk_log:log_terms(n, [{some,terms}]), % second file full
     2 = curf(n),
     BadFile = add_ext(File, 1),
-    crash(BadFile, 28), % the _binary_ is now invalid
+    crash(BadFile, 26), % the _binary_ is now invalid
     {error, {corrupt_log_file, BFile}} = disk_log:chunk(n, start, 1),
     BadFile = BFile,
     ok = disk_log:close(n),
@@ -2888,7 +2888,7 @@ chunk(Conf) when is_list(Conf) ->
 			     {format, internal}]),
     ok = disk_log:log_terms(n, [{this,is}]),
     ok = disk_log:sync(n),
-    crash(File, 28), % the _binary_ is now invalid
+    crash(File, 26), % the _binary_ is now invalid
     {error, {corrupt_log_file, File2}} = disk_log:chunk(n, start, 1),
     crash(File, 10),
     {error,{corrupt_log_file,_}} = disk_log:bchunk(n, start, 1),
@@ -2982,8 +2982,8 @@ chunk(Conf) when is_list(Conf) ->
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, wrap},
 			     {format, internal}, {mode, read_only}]),
     CrashFile = add_ext(File, 1),
-    crash(CrashFile, 51), % the binary term {some,terms} is now bad
-    {H1, [{this,is}], 18} = disk_log:chunk(n, start, 10),
+    crash(CrashFile, 47), % the binary term {some,terms} is now bad
+    {H1, [{this,is}], 16} = disk_log:chunk(n, start, 10),
     {H2, [{on,a},{wrap,file}]} = disk_log:chunk(n, H1),
     eof = disk_log:chunk(n, H2),
     ok = disk_log:close(n),
@@ -2997,8 +2997,8 @@ chunk(Conf) when is_list(Conf) ->
     ok = disk_log:close(n),
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, halt},
 			     {format, internal}, {mode, read_only}]),
-    crash(File, 51), % the binary term {some,terms} is now bad
-    {J1, [{this,is}], 18} = disk_log:chunk(n, start, 10),
+    crash(File, 47), % the binary term {some,terms} is now bad
+    {J1, [{this,is}], 16} = disk_log:chunk(n, start, 10),
     {J2, [{on,a},{halt,file}]} = disk_log:chunk(n, J1),
     eof = disk_log:chunk(n, J2),
     ok = disk_log:close(n),
@@ -3013,8 +3013,8 @@ chunk(Conf) when is_list(Conf) ->
     ok = disk_log:close(n),
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, halt},
 			     {format, internal}, {mode, read_only}]),
-    crash(File, 44), % the binary term {s} is now bad
-    {J11, [{this,is}], 7} = disk_log:chunk(n, start, 10),
+    crash(File, 41), % the binary term {s} is now bad
+    {J11, [{this,is}], 6} = disk_log:chunk(n, start, 10),
     {J21, [{on,a},{halt,file}]} = disk_log:chunk(n, J11),
     eof = disk_log:chunk(n, J21),
     ok = disk_log:close(n),
@@ -3133,7 +3133,7 @@ truncate(Conf) when is_list(Conf) ->
     ok = disk_log:truncate(n, apa),
     rec(1, {disk_log, node(), n, {truncated, 6}}),
     {0, 0} = no_overflows(n),
-    23 = curb(n),
+    22 = curb(n),
     1 = curf(n),
     1 = cur_cnt(n),
     true = (Size == sz(n)),
@@ -3153,7 +3153,7 @@ truncate(Conf) when is_list(Conf) ->
     ok = disk_log:truncate(n, apa),
     rec(1, {disk_log, node(), n, {truncated, 3}}),
     {0, 0} = no_overflows(n),
-    23 = curb(n),
+    22 = curb(n),
     1 = curf(n),
     1 = cur_cnt(n),
     true = (Size == sz(n)),
@@ -3262,45 +3262,45 @@ info_current(Conf) when is_list(Conf) ->
     %% Internal with header.
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, wrap},
 			     {head, header}, {size, {100,No}}]),
-    {26, 1} = {curb(n), cur_cnt(n)},
+    {25, 1} = {curb(n), cur_cnt(n)},
     {1, 1}  = {no_written_items(n), no_items(n)},
     ok = disk_log:log(n, B),
-    {94, 2} = {curb(n), cur_cnt(n)},
+    {93, 2} = {curb(n), cur_cnt(n)},
     {2, 2}  = {no_written_items(n), no_items(n)},
     ok = disk_log:close(n),
     {ok, n} = disk_log:open([{name, n}, {file, File}, {type, wrap},
 			     {notify, true},
 			     {head, header}, {size, {100,No}}]),
-    {94, 2} = {curb(n), cur_cnt(n)},
+    {93, 2} = {curb(n), cur_cnt(n)},
     {0, 2}  = {no_written_items(n), no_items(n)},
     ok = disk_log:log(n, B),
     rec(1, {disk_log, node(), n, {wrap, 0}}),
-    {94, 2} = {curb(n), cur_cnt(n)},
+    {93, 2} = {curb(n), cur_cnt(n)},
     {2, 4}  = {no_written_items(n), no_items(n)},
     disk_log:inc_wrap_file(n),
     rec(1, {disk_log, node(), n, {wrap, 0}}),
-    {26, 1} = {curb(n), cur_cnt(n)},
+    {25, 1} = {curb(n), cur_cnt(n)},
     {3, 4}  = {no_written_items(n), no_items(n)},
     ok = disk_log:log_terms(n, [B,B,B]),
     %% Used to be one message, but now one per wrapped file.
     rec(1, {disk_log, node(), n, {wrap, 0}}),
     rec(1, {disk_log, node(), n, {wrap, 2}}),
-    {94, 2} = {curb(n), cur_cnt(n)},
+    {93, 2} = {curb(n), cur_cnt(n)},
     {8, 7}  = {no_written_items(n), no_items(n)},
     ok = disk_log:log_terms(n, [B]),
     rec(1, {disk_log, node(), n, {wrap, 2}}),
     ok = disk_log:log_terms(n, [B]),
     rec(1, {disk_log, node(), n, {wrap, 2}}),
-    {94, 2} = {curb(n), cur_cnt(n)},
+    {93, 2} = {curb(n), cur_cnt(n)},
     {12, 7}  = {no_written_items(n), no_items(n)},
     ok = disk_log:log_terms(n, [BB,BB]),
     %% Used to be one message, but now one per wrapped file.
     rec(2, {disk_log, node(), n, {wrap, 2}}),
-    {194, 2} = {curb(n), cur_cnt(n)},
+    {193, 2} = {curb(n), cur_cnt(n)},
     {16, 7}  = {no_written_items(n), no_items(n)},
     ok = disk_log:log_terms(n, [SB,SB,SB]),
     rec(1, {disk_log, node(), n, {wrap, 2}}),
-    {80, 4} = {curb(n), cur_cnt(n)},
+    {79, 4} = {curb(n), cur_cnt(n)},
     {20, 9}  = {no_written_items(n), no_items(n)},
     ok = disk_log:close(n),
     del(File, No),

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -36,50 +36,6 @@
   </section>
 
   <section>
-    <title>OTP 26</title>
-
-    <section>
-      <marker id="atoms_be_utf8"/>
-      <title>Atoms will be encoded as UTF-8 by default</title>
-      <p>
-	As of OTP 26, the functions
-        <seemfa marker="erts:erlang#term_to_binary/1">
-        <c>erlang:term_to_binary/1,2</c></seemfa> and
-        <seemfa marker="erts:erlang#term_to_iovec/1">
-        <c>erlang:term_to_iovec/1,2</c></seemfa> will encode all atoms as
-        UTF-8 by default. The current default behavior is to encode atoms as
-        Latin-1 if possible.
-      </p>
-      <p>
-	If you implement your own decoding of the Erlang external format you
-        must either:
-      </p>
-      <list type="bulleted">
-        <item>
-          <p>
-            Make sure your implementation supports the UTF-8 encodings
-            <seeguide marker="erts:erl_ext_dist#ATOM_UTF8_EXT">
-              <c>ATOM_UTF8_EXT</c></seeguide> and
-            <seeguide marker="erts:erl_ext_dist#SMALL_ATOM_UTF8_EXT">
-              <c>SMALL_ATOM_UTF8_EXT</c></seeguide>.
-          </p>
-        </item>
-        <item>
-          <p>
-            Call <seemfa marker="erts:erlang#term_to_binary/2">
-            <c>erlang:term_to_binary/2</c></seemfa> or
-            <seemfa marker="erts:erlang#term_to_iovec/2">
-            <c>erlang:term_to_iovec/2</c></seemfa>
-            with option <c>{minor_version,1}</c> to force Latin-1 encoding. This
-            is a more short-term solution as Latin-1 encoding may be phased out
-            and removed in later OTP releases.
-          </p>
-        </item>
-      </list>
-    </section>
-  </section>
-
-  <section>
     <title>OTP 27</title>
 
     <section>


### PR DESCRIPTION
The default `minor_version` option is changed from 1 to 2 for `term_to_binary` and `term_to_iovec`.
