### PR TITLE
Eliminate assertion failure in beam_ssa_codegen

### DIFF
--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -3022,6 +3022,8 @@ collect_arg_literals([V|Vs], Info, X, Acc0) ->
 collect_arg_literals([], _Info, _X, Acc) ->
     Acc.
 
+unfold_literals([?EXCEPTION_BLOCK|Ls], LitMap, SafeMap, Blocks) ->
+    unfold_literals(Ls, LitMap, SafeMap,Blocks);
 unfold_literals([L|Ls], LitMap, SafeMap0, Blocks0) ->
     {Blocks,Safe} =
         case map_get(L, SafeMap0) of


### PR DESCRIPTION
If the code in `?EXCEPTION_BLOCK` is modified in any way, the `beam_ssa_codegen:assert_exception_block/1` function will cause an internal compiler error. Ensure that the literal unfolding optimization in `beam_ssa_opt` will not modify the code in `?EXCEPTION_BLOCK`.