### PR TITLE
dialyzer: do not report warnings for functions marked as `nowarn_function`

### DIFF
--- a/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
@@ -117,25 +117,16 @@ loop(#server_state{parent = Parent} = State,
 analysis_start(Parent, Analysis, LegalWarnings) ->
   CServer = dialyzer_codeserver:new(),
   Plt = Analysis#analysis.plt,
-  State = #analysis_state{codeserver = CServer,
-			  analysis_type = Analysis#analysis.type,
-			  defines = Analysis#analysis.defines,
-			  doc_plt = Analysis#analysis.doc_plt,
-			  include_dirs = Analysis#analysis.include_dirs,
-			  plt = Plt,
-			  parent = Parent,
-                          legal_warnings = LegalWarnings,
-			  start_from = Analysis#analysis.start_from,
-			  use_contracts = Analysis#analysis.use_contracts,
-			  timing_server = Analysis#analysis.timing_server,
-                          solvers = Analysis#analysis.solvers
-			 },
+  Args = {Plt, Analysis, Parent},
+  State = create_analysis_state(Args, LegalWarnings, CServer),
+
   Files = ordsets:from_list(Analysis#analysis.files),
   {Callgraph, ModCallDeps, Modules, TmpCServer0} = compile_and_store(Files, State),
-  %% Remote type postprocessing
-  Args = {Plt, Analysis, Parent},
+
+ %% Remote type postprocessing
   NewCServer = remote_type_postprocessing(TmpCServer0, Args),
   dump_callgraph(Callgraph, State, Analysis),
+
   %% Remove all old versions of the files being analyzed
   AllNodes = dialyzer_callgraph:all_nodes(Callgraph),
   Plt1_a = dialyzer_plt:delete_list(Plt, AllNodes),
@@ -159,6 +150,21 @@ analysis_start(Parent, Analysis, LegalWarnings) ->
   dialyzer_plt:delete(DummyPlt),
   Plt4 = dialyzer_plt:delete_list(Plt3, NonExportsList),
   send_analysis_done(Parent, Plt4, DocPlt).
+
+create_analysis_state({Plt, Analysis, Parent}, LegalWarnings, CServer) ->
+  #analysis_state{ codeserver = CServer
+                 , analysis_type = Analysis#analysis.type
+                 , defines = Analysis#analysis.defines
+                 , doc_plt = Analysis#analysis.doc_plt
+                 , include_dirs = Analysis#analysis.include_dirs
+                 , plt = Plt
+                 , parent = Parent
+                 , legal_warnings = LegalWarnings
+                 , start_from = Analysis#analysis.start_from
+                 , use_contracts = Analysis#analysis.use_contracts
+                 , timing_server = Analysis#analysis.timing_server
+                 , solvers = Analysis#analysis.solvers }.
+
 
 remote_type_postprocessing(TmpCServer, Args) ->
   Fun = fun() ->

--- a/lib/dialyzer/src/dialyzer_cl.erl
+++ b/lib/dialyzer/src/dialyzer_cl.erl
@@ -634,14 +634,15 @@ cl_error(State, Msg) ->
   maybe_close_output_file(State),
   throw({dialyzer_error, lists:flatten(Msg)}).
 
-return_value(State = #cl_state{code_server = CodeServer,
-                               erlang_mode = ErlangMode,
-			       mod_deps = ModDeps,
-			       output_plt = OutputPlt,
-			       plt_info = PltInfo,
-                               error_location = EOpt,
-			       stored_warnings = StoredWarnings},
-	     Plt) ->
+return_value(#cl_state{code_server = CodeServer,
+                       erlang_mode = ErlangMode,
+                       mod_deps = ModDeps,
+                       output_plt = OutputPlt,
+                       plt_info = PltInfo,
+                       error_location = EOpt,
+                       stored_warnings = StoredWarnings}=State,
+             Plt) ->
+  UnknownWarnings = unknown_warnings(State),
   %% Just for now:
   case CodeServer =:= none of
     true ->
@@ -655,7 +656,6 @@ return_value(State = #cl_state{code_server = CodeServer,
     false ->
       dialyzer_cplt:to_file(OutputPlt, Plt, ModDeps, PltInfo)
   end,
-  UnknownWarnings = unknown_warnings(State),
   RetValue =
     case StoredWarnings =:= [] andalso UnknownWarnings =:= [] of
       true -> ?RET_NOTHING_SUSPICIOUS;
@@ -684,8 +684,10 @@ unknown_warnings_by_module(#cl_state{legal_warnings = LegalWarnings} = State) ->
     false -> []
   end.
 
-unknown_functions(#cl_state{external_calls = Calls}) ->
-  [{Mod, {?WARN_UNKNOWN, WarningInfo, {unknown_function, MFA}}} || {MFA, WarningInfo = {_, _, {Mod, _, _}}} <- Calls].
+unknown_functions(#cl_state{ external_calls = Calls
+                           , code_server = CodeServer}) ->
+  [{Mod, {?WARN_UNKNOWN, WarningInfo, {unknown_function, MFA}}} || {MFA, WarningInfo = {_, _, {Mod, _, _}=WarnMFA}} <- Calls,
+                                                                   {ok, [{nowarn_function, func}]} =/= dialyzer_codeserver:lookup_meta_info(WarnMFA, CodeServer)].
 
 unknown_types(#cl_state{external_types = Types}) ->
   [{Mod, {?WARN_UNKNOWN, WarningInfo, {unknown_type, MFA}}} ||

--- a/lib/dialyzer/src/dialyzer_cl.erl
+++ b/lib/dialyzer/src/dialyzer_cl.erl
@@ -663,10 +663,9 @@ return_value(#cl_state{code_server = CodeServer,
     end,
   case ErlangMode of
     false ->
-      print_warnings(State),
-      print_ext_calls(State),
-      print_ext_types(State),
-      maybe_close_output_file(State),
+      Fns = [ fun print_warnings/1, fun print_ext_calls/1
+            , fun print_ext_types/1, fun maybe_close_output_file/1],
+      lists:foreach(fun (F) -> F(State) end, Fns),
       {RetValue, []};
     true ->
       ResultingWarnings = process_warnings(StoredWarnings ++ UnknownWarnings),


### PR DESCRIPTION
skip warnings about functions that have inlined nowarn_function flags, e.g.,

```erlang
-dialyzer({nowarn_function, find_release/0}).
find_release() ->
  non_existing_function:foo().
```

closes GH-6942
