### PR TITLE
Optimize maps:merge/2 of small maps

### DIFF
--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -1407,6 +1407,16 @@ static Eterm flatmap_merge(Process *p, Eterm map1, Eterm map2) {
 
         if (n == n2) {
             /* Reuse entire map2 */
+            if (n == n1
+                &&  erts_is_literal(mp1->keys, boxed_val(mp1->keys))
+                && !erts_is_literal(mp2->keys, boxed_val(mp2->keys))) {
+                /*
+                 * We want map2, but map1 has a nice literal key tuple.
+                 * Solution: MUTATE HEAP to get both.
+                 */
+                ASSERT(eq(mp1->keys, mp2->keys));
+                mp2->keys = mp1->keys;
+            }
             HRelease(p, hp, (Eterm *)mp_new);
             return map2;
         }

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -2207,6 +2207,8 @@ t_bif_map_merge(Config) when is_list(Config) ->
     false = erts_debug:same(erts_internal:map_to_tuple_keys(MS_c), MS_keys),
     MS_cc = maps:merge(MS, MS_c),
     true = erts_debug:same(MS_cc, MS_c),
+    %% not only do we reuse MS_c, it has mutated to use the literal keys of MS
+    true = erts_debug:same(erts_internal:map_to_tuple_keys(MS_c), MS_keys),
 
     MS_d = maps:merge(MS_c, MS),
     true = erts_debug:same(MS_d, MS),


### PR DESCRIPTION
Save heap space when any of the maps have all the keys.

- ~~If one of the maps have all the keys we reuse its key tuple.~~
- ~~If both maps have all the keys we prefer a literal key tuple.~~

ok, here is the new deal:

maps:merge(A,B)  % map B has priority and will supersede values in map A

- If only map B has all the keys, return the entire map B as-is.
- If only map A has all the keys, reuse its key tuple.
- If both have all the keys return B, but if A has a literal key tuple and B does not, first **mutate map B** to use A's key tuple.