### PR TITLE
Rename function `map/0` in `uri_string_recompose` property test

### DIFF
--- a/lib/stdlib/test/property_test/uri_string_recompose.erl
+++ b/lib/stdlib/test/property_test/uri_string_recompose.erl
@@ -84,7 +84,7 @@ prop_recompose() ->
            Map =:= uri_string:parse(uri_string:recompose(Map))).
 
 prop_normalize() ->
-    ?FORALL(Map, map(),
+    ?FORALL(Map, property_map(),
             uri_string:percent_decode(
               uri_string:normalize(Map, [return_map])) =:=
                 uri_string:percent_decode(
@@ -94,11 +94,11 @@ prop_normalize() ->
 
 %% Stats
 prop_map_key_length_collect() ->
-    ?FORALL(List, map(),
+    ?FORALL(List, property_map(),
             collect(length(maps:keys(List)), true)).
 
 prop_map_collect() ->
-    ?FORALL(List, map(),
+    ?FORALL(List, property_map(),
             collect(lists:sort(maps:keys(List)), true)).
 
 prop_scheme_collect() ->
@@ -110,7 +110,7 @@ prop_scheme_collect() ->
 %%% Generators
 %%%========================================================================
 
-map() ->
+property_map() ->
     ?LET(Gen, comp_proplist(), proplist_to_map(Gen)).
 
 map_no_unicode() ->


### PR DESCRIPTION
The property test module `uri_string_recompose` in `stdlib` defines a function `map/0`. In current `proper` master (and therefore, in the next release), a generator function with the same name and arity has been added (https://github.com/proper-testing/proper/commit/b4a6374540e7f1aff100e92069124b48e5903da2), which will resulting in a clash in the future.

This PR renames the function `uri_string_recompose:map/0` to `property_map/0` (ie, a map made up from a proplist). It cannot be removed/replaced by `proper`'s `map/0` since the behavior is different.