### PR TITLE
erts: Don't block thread progress when setting debug breakpoints

### DIFF
--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -693,7 +693,6 @@ erts_clear_mtrace_break(BpFunctions* f)
 void
 erts_clear_debug_break(BpFunctions* f)
 {
-    ERTS_LC_ASSERT(erts_thr_progress_is_blocking());
     clear_break(f, ERTS_BPF_DEBUG);
 }
 


### PR DESCRIPTION
74eee7564d64091dcf42f9361be5381f9fbec0ab fixed a bug in how we handle code barriers while thread progress is blocked, which manifested when using the debugger to set and clear breakpoints in quick sequence.

It's better not to block thread progress at all though, so this PR makes debug breakpoints yield properly instead.