### PR TITLE
asn1: fix RELATIVE-OID validation

### DIFF
--- a/lib/asn1/src/asn1ct_check.erl
+++ b/lib/asn1/src/asn1ct_check.erl
@@ -1855,8 +1855,8 @@ validate_oid(S, OidType, [{'NamedNumber',_Name,Value}|Vrest], Acc)
     validate_oid(S, OidType, Vrest, [Value|Acc]);
 validate_oid(S, OidType, [#'Externalvaluereference'{}=Id|Vrest], Acc) ->
     NeededOidType = case Acc of
-			[] -> o_id;
-			[_|_] -> rel_oid
+			[] when OidType =:= o_id -> o_id;
+			_ -> rel_oid
 		    end,
     try get_oid_value(S, NeededOidType, true, Id) of
 	Val when is_integer(Val) ->

--- a/lib/asn1/test/asn1_SUITE_data/ValueTest.asn
+++ b/lib/asn1/test/asn1_SUITE_data/ValueTest.asn
@@ -33,6 +33,10 @@ include-roid OBJECT IDENTIFIER ::= {0 rel-oid-1}
 include-oid OBJECT IDENTIFIER ::= {integer-first 1}
 include-all OBJECT IDENTIFIER ::= {integer-first 1 rel-oid-1 42}
 
+-- RELATIVE-OID
+rel-oid-2 RELATIVE-OID ::= {rel-oid-1 6}
+rel-oid-3 RELATIVE-OID ::= {rel-oid-1 rel-oid-2 7}
+
 --Character strings
 numericstring NumericString ::= "01234567"
 printablestring PrintableString ::= "PrintableString"

--- a/lib/asn1/test/error_SUITE.erl
+++ b/lib/asn1/test/error_SUITE.erl
@@ -478,6 +478,7 @@ rel_oids(Config) ->
 	     "wrong-type-rel-oid-5 RELATIVE-OID ::= object-1.&undef\n"
 
 	     "oid-bad-first OBJECT IDENTIFIER ::= {legal-roid 3}\n"
+	     "roid-bad-first RELATIVE-OID ::= {legal-oid 3}\n"
 	     "END\n">>},
     {error,
      [
@@ -486,7 +487,8 @@ rel_oids(Config) ->
       {structured_error,{M,14},asn1ct_check,{illegal_oid,rel_oid}},
       {structured_error,{M,15},asn1ct_check,{illegal_oid,rel_oid}},
       {structured_error,{M,16},asn1ct_check,{undefined_field,undef}},
-      {structured_error,{M,17},asn1ct_check,{illegal_oid,o_id}}
+      {structured_error,{M,17},asn1ct_check,{illegal_oid,o_id}},
+      {structured_error,{M,18},asn1ct_check,{illegal_oid,rel_oid}}
      ]
     } = run(P, Config),
     ok.


### PR DESCRIPTION
While trying to compile the ASN.1 specification of the latest version of the ETSI 102 232-2 norm ([EmailPDU.txt](https://github.com/erlang/otp/files/11039662/EmailPDU.txt)), I found a bug in the validation of RELATIVE-OID values. The current ASN.1 compiler rejects RELATIVE-OID values containing other RELATIVE-OID values when it's perfectly valid according to the ASN.1 specification (see https://www.itu.int/rec/T-REC-X.680-202102-I/en, section 33.5). This PR fixes this bug and adds more tests to check the behaviour of the compiler regarding RELATIVE-OID validation.