### PR TITLE
beam_disasm: Deserialize the version 1 type table format

### DIFF
--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -262,14 +262,19 @@ disasm_literals(<<>>, _) -> [].
 %% Disassembles the type table of a BEAM file.
 %%-----------------------------------------------------------------------
 
--spec beam_disasm_types('none' | binary()) -> literals().
+-spec beam_disasm_types('none' | binary()) -> types().
 
 beam_disasm_types(none) ->
     none;
-beam_disasm_types(<<?BEAM_TYPES_VERSION:32,Count:32,Table/binary>>) ->
-    Res = gb_trees:from_orddict(disasm_types(Table, 0)),
-    Count = gb_trees:size(Res),                 %Assertion.
-    Res;
+beam_disasm_types(<<Version:32,Count:32,Table0/binary>>) ->
+    case beam_types:convert_ext(Version, Table0) of
+        none ->
+            ?exit({beam_disasm_types,{unknown_type_version,Version}});
+        Table ->
+            Res = gb_trees:from_orddict(disasm_types(Table, 0)),
+            Count = gb_trees:size(Res),                 %Assertion.
+            Res
+    end;
 beam_disasm_types(<<_/binary>>) ->
     none.
 


### PR DESCRIPTION
OTP 26 `beam_disasm` crashes when dissassembling some BEAM files created with the OTP 25 compiler. OTP 26 adds a new version 2 format for the `Type` BEAM chunk. `beam_disasm:beam_disasm_types/1` and `beam_types:decode_ext/1` only handle the chunk successfully if it is in the version 2 format (matching on the `?BEAM_TYPES_VERSION` constant). This change deserializes the version 1 format from OTP 25 as well which fixes the crashes.

<details><summary>A reproduction case for an example crash...</summary>

Create a file `ieq.erl`

```erl
-module(ieq).
-export([eq/2]).
eq(A, B) when is_integer(A) andalso is_integer(B) -> A =:= B.
```

Compile `ieq.erl` with the OTP 25 compiler (`path/to/OTP-25/bin/erlc ieq.erl`). Then use `beam_disasm:file/1` from the OTP 26 compiler app:

```
$ path/to/OTP-26/bin/erl -noshell -eval 'beam_disasm:file("ieq.beam"), erlang:halt()'
Error! Failed to eval: beam_disasm:file("ieq.beam")

Runtime terminating during boot ({beam_disasm,432,{cannot_disasm_instr,{bif2,5,function_clause}}})

Crash dump is being written to: erl_crash.dump...done
```

The crash occurs within `beam_disasm:decode_tr/2`: that function uses `gb_trees:get/2` which asserts that the type is included in the gb_tree of types, however `beam_disasm:beam_disasm_types/1` returns `none` because the `Version` part of the type table for `ieq.beam` is `1` rather than `2` (`?BEAM_TYPES_VERSION`).

</details>