### PR TITLE
Make maps_order optional in io_lib:build_text/1

### DIFF
--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -289,8 +289,9 @@ build_small([]) -> [].
 
 build_limited([#{control_char := C, args := As, width := F, adjust := Ad,
                  precision := P, pad_char := Pad, encoding := Enc,
-                 strings := Str, maps_order := Ord} | Cs],
+                 strings := Str} = Map | Cs],
               NumOfPs0, Count0, MaxLen0, I) ->
+    Ord = maps:get(maps_order, Map, undefined),
     MaxChars = if
                    MaxLen0 < 0 -> MaxLen0;
                    true -> MaxLen0 div Count0
@@ -314,7 +315,7 @@ build_limited([$\n|Cs], NumOfPs, Count, MaxLen, _I) ->
     [$\n|build_limited(Cs, NumOfPs, Count, MaxLen, 0)];
 build_limited([$\t|Cs], NumOfPs, Count, MaxLen, I) ->
     [$\t|build_limited(Cs, NumOfPs, Count, MaxLen, ((I + 8) div 8) * 8)];
-build_limited([C|Cs], NumOfPs, Count, MaxLen, I) ->
+build_limited([C|Cs], NumOfPs, Count, MaxLen, I) when is_integer(C) ->
     [C|build_limited(Cs, NumOfPs, Count, MaxLen, I+1)];
 build_limited([], _, _, _, _) -> [].
 

--- a/lib/stdlib/test/io_SUITE.erl
+++ b/lib/stdlib/test/io_SUITE.erl
@@ -34,7 +34,7 @@
          otp_14285/1, limit_term/1, otp_14983/1, otp_15103/1, otp_15076/1,
          otp_15159/1, otp_15639/1, otp_15705/1, otp_15847/1, otp_15875/1,
          github_4801/1, chars_limit/1, error_info/1, otp_17525/1,
-         unscan_format_without_maps_order/1]).
+         unscan_format_without_maps_order/1, build_text_without_maps_order/1]).
 
 -export([pretty/2, trf/3]).
 
@@ -68,7 +68,8 @@ all() ->
      format_string, maps, coverage, otp_14178_unicode_atoms, otp_14175,
      otp_14285, limit_term, otp_14983, otp_15103, otp_15076, otp_15159,
      otp_15639, otp_15705, otp_15847, otp_15875, github_4801, chars_limit,
-     error_info, otp_17525, unscan_format_without_maps_order].
+     error_info, otp_17525, unscan_format_without_maps_order,
+     build_text_without_maps_order].
 
 %% Error cases for output.
 error_1(Config) when is_list(Config) ->
@@ -3196,3 +3197,16 @@ unscan_format_without_maps_order(_Config) ->
         width => none
     },
     {"~ts",[[<<"1">>]]} = io_lib:unscan_format([FormatSpec]).
+
+build_text_without_maps_order(_Config) ->
+    FormatSpec = #{
+        adjust => right,
+        args => [[<<"1">>]],
+        control_char => 115,
+        encoding => unicode,
+        pad_char => 32,
+        precision => none,
+        strings => true,
+        width => none
+    },
+    [["1"]] = io_lib:build_text([FormatSpec]).


### PR DESCRIPTION
The presence of the optional `maps_order` key is assumed in the implementation of `io_lib:build_text/1` introduced in OTP26 rc. This makes it a breaking change, resulting in unexpected behavior for existing code calling it on a map without the key (returns a list of maps).

- don't require the key in io_lib:build_text/1

- add a guard to detect we're not building a correct charlist

Similar to https://github.com/erlang/otp/pull/6949.

## Reproduction of the breaking change

(same as the added test)

```erlang
Erlang/OTP 26 [RELEASE CANDIDATE 2] [erts-14.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V14.0 (press Ctrl+G to abort, type help(). for help)
1> io_lib:build_text([#{
1>     adjust => right,
1>     args => [[<<"1">>]],
1>     control_char => 115,
1>     encoding => unicode,
1>     pad_char => 32,
1>     precision => none,
1>     strings => true,
1>     width => none
1> }]).
[#{args => [[<<"1">>]],
   encoding => unicode,adjust => right,width => none,
   strings => true,precision => none,pad_char => 32,
   control_char => 115}]
```

instead of before:

```erlang
Erlang/OTP 25 [erts-13.0] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]

Eshell V13.0  (abort with ^G)
1> io_lib:build_text([#{
1>     adjust => right,
1>     args => [[<<"1">>]],
1>     control_char => 115,
1>     encoding => unicode,
1>     pad_char => 32,
1>     precision => none,
1>     strings => true,
1>     width => none
1> }]).
[["1"]]
```