### PR TITLE
gh: Add a label which forces all tests to be run

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         BASE_BUILD: ${{ steps.base-build.outputs.BASE_BUILD }}
-        changes: ${{ steps.changes.outputs.changes }}
+        changes: ${{ steps.changes-override.outputs.changes }}
         all: ${{ steps.apps.outputs.all }}
     steps:
       - uses: actions/checkout@v3
@@ -46,6 +46,23 @@ jobs:
         id: changes
         with:
           filters: .github/scripts/path-filters.yaml
+      - if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-build-and-check') }}
+        id: should-enable-full-build-and-check
+        env:
+            ALL_APPS: ${{ steps.apps.outputs.all }}
+        run: |
+          echo "enable-full-build-and-check=1" >> $GITHUB_ENV
+      - name: Override changes
+        id: changes-override
+        env:
+            ALL_APPS: ${{ steps.apps.outputs.all }}
+            CHANGED_APPS: ${{ steps.changes.outputs.changes }}
+        run: |
+          if [[ enable-full-build-and-check ]]; then
+              echo "changes=${ALL_APPS}" >> "$GITHUB_OUTPUT"
+          else
+              echo "changes=${CHANGED_APPS}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create initial pre-release tar
         run: .github/scripts/init-pre-release.sh otp_archive.tar.gz
       - name: Upload source tar archive


### PR DESCRIPTION
Adds a check in CI that looks for the `full-build-and-check` label, and if it is present, overrides the checking of which apps have changed, and tests everything.

This is useful for changes which can have consequences beyond the modules which were directly modified, giving confidence without needing to wait for the daily tests (which most contributors don't have access to). In the future, we could expand this to run an even broader suite of checks.