### PR TITLE
Misc improvements using async_dist

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1677,6 +1677,12 @@ Z = erlang:crc32_combine(X,Y,iolist_size(Data2)).</code>
           <c>demonitor(<anno>MonitorRef</anno>, [flush])</c></seemfa>
           can be used instead of <c>demonitor(<anno>MonitorRef</anno>)</c>
           if this cleanup is wanted.</p>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
         <change>
           <p>Before Erlang/OTP R11B (ERTS 5.5) <c>demonitor/1</c>
             behaved completely asynchronously, that is, the monitor was active
@@ -2284,6 +2290,12 @@ example_fun(A1, A2) ->
             reasons.
           </p>
         </warning>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
       </desc>
     </func>
 
@@ -2926,6 +2938,12 @@ uncompiled code with the same arity are mapped to the same list by
           and <seeguide marker="system/design_principles:applications#stopping">OTP
           design principles</seeguide> related to starting and stopping
           applications.</p>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
       </desc>
     </func>
 
@@ -3674,6 +3692,12 @@ is_process_alive(P2Pid),
 	  chapter of the <i>ERTS User's Guide</i>.
 	</p>
 
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
 	<p>Failure:</p>
 	<list>
 	  <item><c>badarg</c> if <c><anno>PidOrPort</anno></c> does not identify
@@ -4684,6 +4708,12 @@ RealSystem = system + MissedSystem</code>
             possible values for <c>Tag</c>, <c>Object</c>, and
             <c>Info</c> in the monitor message will be introduced.</p>
         </note>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
       </desc>
     </func>
 
@@ -7464,6 +7494,12 @@ true</pre>
 	<c><anno>Dest</anno></c> is an atom name, but this name is not
 	registered. This is the only case when <c>send</c> fails for an
 	unreachable destination <c><anno>Dest</anno></c> (of correct type).</p>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
       </desc>
     </func>
 
@@ -7491,6 +7527,12 @@ true</pre>
              instead.
           </item>
         </taglist>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
         <warning>
           <p>As with <c>erlang:send_nosuspend/2,3</c>: use with extreme
             care.</p>
@@ -8450,6 +8492,12 @@ true</pre>
 	  A spawn request can be abandoned by calling
 	  <seemfa marker="#spawn_request_abandon/1"><c>spawn_request_abandon/1</c></seemfa>.
 	</p>
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
       </desc>
     </func>
 
@@ -13808,7 +13856,12 @@ end</code>
 	  protocol</seeguide> can be found in the <i>Distribution Protocol</i>
 	  chapter of the <i>ERTS User's Guide</i>.
 	</p>
-
+        <note><p>
+          For some important information about distributed signals, see the
+          <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+            <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+          <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        </p></note>
         <p>
 	  Failure: <c>badarg</c> if <c>Id</c> does not identify a process
 	  or a node local port.

--- a/lib/kernel/doc/src/erpc.xml
+++ b/lib/kernel/doc/src/erpc.xml
@@ -57,6 +57,14 @@
       Note that it is up to the user to ensure that correct code to
       execute via <c>erpc</c> is available on the involved nodes.
     </p>
+    <note><p>
+      For some important information about distributed signals, see the
+      <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+        Blocking Signaling Over Distribution</seeguide> section in the
+      <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+      Blocking signaling can, for example, cause timeouts in <c>erpc</c>
+      to be significantly delayed.
+    </p></note>
   </description>
 
   <datatypes>

--- a/lib/kernel/doc/src/rpc.xml
+++ b/lib/kernel/doc/src/rpc.xml
@@ -53,6 +53,14 @@
 	<c>erpc</c>, so the <c>rpc</c> module won't not suffer scalability
 	wise and performance wise compared to <c>erpc</c>.
       </p></note>
+      <note><p>
+        For some important information about distributed signals, see the
+        <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+          Blocking Signaling Over Distribution</seeguide> section in the
+        <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+        Blocking signaling can, for example, cause timeouts in <c>rpc</c>
+        to be significantly delayed.
+      </p></note>
   </description>
 
   <datatypes>

--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -497,6 +497,7 @@ disconnect() ->
 -spec init([]) -> {'ok', state()}.
 
 init([]) ->
+    _ = process_flag(async_dist, true),
     process_flag(trap_exit, true),
 
     %% Monitor all 'nodeup'/'nodedown' messages of visible nodes.
@@ -2762,9 +2763,7 @@ inform_connection_loss(_Node, #state{}) ->
 %%
 
 gns_volatile_send(Node, Msg) ->
-    OldAsyncDist = process_flag(async_dist, true),
     _ = erlang:send({global_name_server, Node}, Msg, [noconnect]),
-    _ = process_flag(async_dist, OldAsyncDist),
     ok.
 
 %%
@@ -2774,7 +2773,6 @@ gns_volatile_send(Node, Msg) ->
 %%
 gns_volatile_multicast(Msg, IgnoreNode, MinVer,
                        AlsoPend, #state{known = Known}) ->
-    OldAsyncDist = process_flag(async_dist, true),
     maps:foreach(fun (Node, Ver) when is_atom(Node),
                                       Node =/= IgnoreNode,
                                       Ver >= MinVer ->
@@ -2788,7 +2786,6 @@ gns_volatile_multicast(Msg, IgnoreNode, MinVer,
                      (_, _) ->
                          ok
                  end, Known),
-    _ = process_flag(async_dist, OldAsyncDist),
     ok.
 
 is_node_potentially_known(Node, #state{known = Known}) ->

--- a/lib/kernel/src/global_group.erl
+++ b/lib/kernel/src/global_group.erl
@@ -260,6 +260,7 @@ start_link() -> gen_server:start_link({local, global_group}, global_group,[],[])
 stop() -> gen_server:call(global_group, stop, infinity).
 
 init([]) ->
+    _ = process_flag(async_dist, true),
     process_flag(priority, max),
     ok = net_kernel:monitor_nodes(true, #{connection_id => true}),
     put(registered_names, [undefined]),

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -113,6 +113,15 @@ gen_event:stop             ----->  Module:terminate/2
     <p>Unless otherwise stated, all functions in this module fail if
       the specified event manager does not exist or if bad arguments are
       specified.</p>
+
+    <note><p>
+      For some important information about distributed signals, see the
+      <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+        <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+      <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+      Blocking signaling can, for example, cause call timeouts in
+      <c>gen_event</c> to be significantly delayed.
+    </p></note>
   </description>
 
   <datatypes>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -107,6 +107,15 @@ gen_server:abcast     -----> Module:handle_cast/2
       Processes</seeguide> in the Reference Manual for details
       regarding error handling using exit signals.</p>
 
+    <note><p>
+      For some important information about distributed signals, see the
+      <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+        <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+      <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+      Blocking signaling can, for example, cause call timeouts in
+      <c>gen_server</c> to be significantly delayed.
+    </p></note>
+
   </description>
 
 

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -381,6 +381,14 @@ erlang:'!'            -----> Module:StateName/3
       Processes</seeguide> in the Reference Manual for details regarding error
       handling using exit signals.
     </p>
+    <note><p>
+      For some important information about distributed signals, see the
+      <seeguide marker="system/reference_manual:processes#blocking-signaling-over-distribution">
+        <i>Blocking Signaling Over Distribution</i></seeguide> section in the
+      <i>Processes</i> chapter of the <i>Erlang Reference Manual</i>.
+      Blocking signaling can, for example, cause call timeouts in
+      <c>gen_statem</c> to be significantly delayed.
+    </p></note>
   </description>
 
   <section>

--- a/system/doc/reference_manual/processes.xml
+++ b/system/doc/reference_manual/processes.xml
@@ -680,7 +680,10 @@ spawn(Module, Name, Args) -> pid()
 	    while it can be trapped if the signal was sent due to a link.
 	  </p>
 	</item>
-	<tag>Blocking Signaling Over Distribution</tag>
+	<tag>
+          Blocking Signaling Over Distribution
+          <marker id="blocking-signaling-over-distribution"/>
+        </tag>
 	<item>
 	  <p>
 	    When sending a signal over a distribution channel, the sending
@@ -690,24 +693,34 @@ spawn(Module, Name, Args) -> pid()
 	    size of the output buffer for the channel reach the <i>distribution
 	    buffer busy limit</i>, processes sending on the channel will be
 	    suspended until the size of the buffer shrinks below the limit.
-	    The size of the limit can be inspected by calling
+          </p>
+          <p>
+            Depending on the reason for why the buffer got full, the time it
+            takes before suspended processes are resumed can vary <em>very
+            much</em>. A consequence of this can, for example, be that a
+            timeout in a call to
+            <seemfa marker="kernel:erpc#call/5">erpc:call()</seemfa>
+            is significantly delayed.
+          </p>
+          <p>
+            Since this functionality has been present for so long, it is not
+	    possible to remove it, but it is possible to enable <i>fully
+            asynchronous distributed signaling</i> on a per process level
+            using <seeerl marker="erts:erlang#process_flag_async_dist">
+              <c>process_flag(async_dist, Bool)</c></seeerl> which can be
+            used to solve problems occuring due to blocking signaling.
+            However, note that you need to make sure that flow control for
+            data sent using <i>fully asynchronous distributed signaling</i>
+            is implemented, or that the amount of such data is known to
+            always be limited; otherwise, you may get into a situation with
+            excessive memory usage.
+          </p>
+          <p>
+	    The size of the <i>distribution buffer busy limit</i> can be
+            inspected by calling
 	    <seeerl marker="erts:erlang#system_info_dist_buf_busy_limit">
 	      <c>erlang:system_info(dist_buf_busy_limit)</c></seeerl>.
-	    Since this functionality has been present for so long, it is not
-	    possible to remove it, but it is possible to increase the limit
-	    to a point where it more or less never is reached using the
-	    <c>erl</c> command line argument
-	    <seecom marker="erts:erl#+zdbbl"><c>+zdbbl</c></seecom>. Note
-	    that if you do raise the limit like this, you need to take care
-	    of flow control yourself to ensure that you do not get into a
-	  situation with excessive memory usage.</p>
-          <change><p>As of OTP 25.3 it is
-            also possible to enable <i>fully asynchronous distributed
-            signaling</i> on a per process level using
-            <seeerl marker="erts:erlang#process_flag_async_dist">
-              <c>process_flag(async_dist, Bool)</c></seeerl>. Also in this case
-            you need to take care of flow control yourself.
-	  </p></change>
+          </p>
 	</item>
       </taglist>
       <p>


### PR DESCRIPTION
The `net_kernel`, `global`, and `global_group` servers now execute with *fully asynchronous distributed signaling* enabled all the time which prevents them from ever getting blocked on send of distributed signals.

Documentation about blocking distributed signals has also been improved.