### PR TITLE
Fix shell and arguments types in user_drv.erl

### DIFF
--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -91,9 +91,9 @@
                  current_group :: pid() | undefined,
                  groups, queue }).
 
--type shell() :: {module(), atom(), arity()} | {node(), module(), atom(), arity()}.
+-type shell() :: {module(), atom(), [term()]} | {node(), module(), atom(), [term()]}.
 -type arguments() :: #{ initial_shell => noshell | shell() |
-                        {remote, unicode:charlist()} | {remote, unicode:charlist(), mfa()},
+                        {remote, unicode:charlist()} | {remote, unicode:charlist(), {module(), atom(), [term()]}},
                         input => boolean() }.
 
 %% Default line editing shell


### PR DESCRIPTION
The last tuple element is a list of arguments, not arity, see group.erl:
https://github.com/erlang/otp/blob/fb6db5909a48d828f334824f3e1b952e9e521566/lib/kernel/src/group.erl#L67