### PR TITLE
ssl: replace hardcoded numbers by macros

### DIFF
--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -633,7 +633,7 @@ next_dtls_record(Data, StateName, #state{protocol_buffers = #protocol_buffers{
                                          ssl_options = SslOpts} = State0) ->
     case dtls_record:get_dtls_records(Data,
                                       {DataTag, StateName, Version, 
-                                       [dtls_record:protocol_version(Vsn) || Vsn <- ?ALL_AVAILABLE_DATAGRAM_VERSIONS]}, 
+                                       [dtls_record:protocol_version_name(Vsn) || Vsn <- ?ALL_AVAILABLE_DATAGRAM_VERSIONS]},
                                       Buf0, SslOpts) of
 	{Records, Buf1} ->
 	    CT1 = CT0 ++ Records,

--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -545,10 +545,11 @@ handle_info({CloseTag, Socket}, StateName,
     %% with widespread implementation practice.
     case (Active == false) andalso (CTs =/= []) of
         false ->
-            case Version of
-                {254, N} when N =< 253 ->
+            %% the =< is a leaking implementation detail.
+            %% this means `Version={254, N} when N =< 253`
+            if (Version =< ?'DTLS-1.2') ->
                     ok;
-                _ ->
+               true ->
                     %% As invalidate_sessions here causes performance issues,
                     %% we will conform to the widespread implementation
                     %% practice and go against the spec

--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -545,9 +545,7 @@ handle_info({CloseTag, Socket}, StateName,
     %% with widespread implementation practice.
     case (Active == false) andalso (CTs =/= []) of
         false ->
-            %% the =< is a leaking implementation detail.
-            %% this means `Version={254, N} when N =< 253`
-            if (Version =< ?'DTLS-1.2') ->
+            if (?DTLS_GE(Version, ?DTLS_1_2)) ->
                     ok;
                true ->
                     %% As invalidate_sessions here causes performance issues,

--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -545,7 +545,7 @@ handle_info({CloseTag, Socket}, StateName,
     %% with widespread implementation practice.
     case (Active == false) andalso (CTs =/= []) of
         false ->
-            if (?DTLS_GE(Version, ?DTLS_1_2)) ->
+            if (?DTLS_GTE(Version, ?DTLS_1_2)) ->
                     ok;
                true ->
                     %% As invalidate_sessions here causes performance issues,

--- a/lib/ssl/src/dtls_handshake.erl
+++ b/lib/ssl/src/dtls_handshake.erl
@@ -118,11 +118,12 @@ hello(#client_hello{client_version = ClientVersion} = Hello,
     Version = ssl_handshake:select_version(dtls_record, ClientVersion, Versions),
     handle_client_hello(Version, Hello, SslOpts, Info, Renegotiation).
 
-cookie(Key, Address, Port, #client_hello{client_version = {Major, Minor},
+cookie(Key, Address, Port, #client_hello{client_version = Version,
 					 random = Random,
 					 session_id = SessionId,
 					 cipher_suites = CipherSuites,
 					 compression_methods = CompressionMethods}) ->
+    {Major, Minor} = Version,
     CookieData = [address_to_bin(Address, Port),
 		  <<?BYTE(Major), ?BYTE(Minor)>>,
 		  Random, SessionId, CipherSuites, CompressionMethods],
@@ -238,15 +239,16 @@ handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
 
 %%--------------------------------------------------------------------
 
-enc_handshake(#hello_verify_request{protocol_version = {Major, Minor},
+enc_handshake(#hello_verify_request{protocol_version = Version,
  				       cookie = Cookie}, _Version) ->
     CookieLength = byte_size(Cookie),
+    {Major,Minor} = Version,
     {?HELLO_VERIFY_REQUEST, <<?BYTE(Major), ?BYTE(Minor),
  			      ?BYTE(CookieLength),
  			      Cookie:CookieLength/binary>>};
 enc_handshake(#hello_request{}, _Version) ->
     {?HELLO_REQUEST, <<>>};
-enc_handshake(#client_hello{client_version = {Major, Minor},
+enc_handshake(#client_hello{client_version = ClientVersion,
 			       random = Random,
 			       session_id = SessionID,
 			       cookie = Cookie,
@@ -259,8 +261,8 @@ enc_handshake(#client_hello{client_version = {Major, Minor},
     CmLength = byte_size(BinCompMethods),
     BinCipherSuites = list_to_binary(CipherSuites),
     CsLength = byte_size(BinCipherSuites),
-    ExtensionsBin = ssl_handshake:encode_hello_extensions(HelloExtensions, 
-                                                          dtls_v1:corresponding_tls_version({Major, Minor})),
+    ExtensionsBin = ssl_handshake:encode_hello_extensions(HelloExtensions),
+    {Major,Minor} = ClientVersion,
 
     {?CLIENT_HELLO, <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,
  		      ?BYTE(SIDLength), SessionID/binary,
@@ -364,8 +366,8 @@ decode_handshake(_Version, ?HELLO_VERIFY_REQUEST, <<?UINT24(_), ?UINT16(_),
 						    ?BYTE(Major), ?BYTE(Minor),
 						    ?BYTE(CookieLength),
 						    Cookie:CookieLength/binary>>) ->
-    #hello_verify_request{protocol_version = {Major, Minor},
-			  cookie = Cookie};
+    #hello_verify_request{protocol_version = {Major,Minor},
+                          cookie = Cookie};
 decode_handshake(Version, Tag,  <<?UINT24(_), ?UINT16(_),
 				  ?UINT24(_),  ?UINT24(_), Msg/binary>>) -> 
     %% DTLS specifics stripped
@@ -390,9 +392,9 @@ decode_handshake_fragments(<<?BYTE(Type), ?UINT24(Length),
 
 reassemble(Version,  #handshake_fragment{message_seq = Seq} = Fragment, 
 	   #protocol_buffers{dtls_handshake_next_seq = Seq,
-			     dtls_handshake_next_fragments = Fragments0,
-			     dtls_handshake_later_fragments = LaterFragments0} = 
-	       Buffers0)-> 
+                         dtls_handshake_next_fragments = Fragments0,
+                         dtls_handshake_later_fragments = LaterFragments0} =
+               Buffers0)->
     case reassemble_fragments(Fragment, Fragments0) of
 	{more_data, Fragments} ->
 	    {more_data,  Buffers0#protocol_buffers{dtls_handshake_next_fragments = Fragments}};

--- a/lib/ssl/src/dtls_handshake.erl
+++ b/lib/ssl/src/dtls_handshake.erl
@@ -189,7 +189,7 @@ handle_client_hello(Version,
 	    TLSVersion = dtls_v1:corresponding_tls_version(Version),
 	    AvailableHashSigns = ssl_handshake:available_signature_algs(
 				   ClientHashSigns, SupportedHashSigns, TLSVersion),
-	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, TLSVersion, ECCOrder),
+	    ECCCurve = ssl_handshake:select_curve(Curves, SupportedECCs, ECCOrder),
 	    {Type, #session{cipher_suite = CipherSuite,
                             own_certificates = [OwnCert |_]} = Session1}
 		= ssl_handshake:select_session(SugesstedId, CipherSuites, 

--- a/lib/ssl/src/dtls_handshake.hrl
+++ b/lib/ssl/src/dtls_handshake.hrl
@@ -29,9 +29,10 @@
 -include("tls_handshake.hrl"). %% Common TLS and DTLS records and Constantes
 -include("ssl_handshake.hrl"). %% Common TLS and DTLS records and Constantes
 -include("ssl_api.hrl").
+-include("ssl_record.hrl").
 
 -define(HELLO_VERIFY_REQUEST, 3).
--define(HELLO_VERIFY_REQUEST_VERSION, {254, 255}).
+-define(HELLO_VERIFY_REQUEST_VERSION, ?DTLS_1_0).
 
 -record(hello_verify_request, {
 	  protocol_version,

--- a/lib/ssl/src/dtls_record.erl
+++ b/lib/ssl/src/dtls_record.erl
@@ -283,7 +283,7 @@ protocol_version(?DTLS_1_0) ->
 %%
 %% Description: Lowes protocol version of two given versions
 %%--------------------------------------------------------------------
-lowest_protocol_version(Version1, Version2) when ?DTLS_L(Version1, Version2) ->
+lowest_protocol_version(Version1, Version2) when ?DTLS_LT(Version1, Version2) ->
     Version1;
 lowest_protocol_version(_, Version2) ->
     Version2.
@@ -314,7 +314,7 @@ check_protocol_version([Ver | Versions], Fun) -> lists:foldl(Fun, Ver, Versions)
 %% Description: Highest protocol version of two given versions
 %%--------------------------------------------------------------------
 
-highest_protocol_version(Version1, Version2) when ?DTLS_G(Version1, Version2) ->
+highest_protocol_version(Version1, Version2) when ?DTLS_GT(Version1, Version2) ->
     Version1;
 highest_protocol_version(_, Version2) ->
     Version2.
@@ -324,7 +324,7 @@ highest_protocol_version(_, Version2) ->
 %%
 %% Description: Is V1 > V2
 %%--------------------------------------------------------------------
-is_higher(V1, V2) when ?DTLS_G(V1, V2) ->
+is_higher(V1, V2) when ?DTLS_GT(V1, V2) ->
     true;
 is_higher(_, _) ->
     false.
@@ -385,7 +385,7 @@ is_acceptable_version(Version, Versions) ->
 -spec hello_version(ssl_record:ssl_version(), [ssl_record:ssl_version()]) -> ssl_record:ssl_version().
 hello_version(Version, Versions) ->
     case dtls_v1:corresponding_tls_version(Version) of
-        TLSVersion when ?TLS_GE(TLSVersion, ?TLS_1_2) ->
+        TLSVersion when ?TLS_GTE(TLSVersion, ?TLS_1_2) ->
             Version;
         _ ->
             lowest_protocol_version(Versions)

--- a/lib/ssl/src/dtls_record.erl
+++ b/lib/ssl/src/dtls_record.erl
@@ -43,7 +43,7 @@
 -export([decode_cipher_text/2]).
 
 %% Protocol version handling
--export([protocol_version/1, lowest_protocol_version/1, lowest_protocol_version/2,
+-export([protocol_version/1, protocol_version_name/1, lowest_protocol_version/1, lowest_protocol_version/2,
 	 highest_protocol_version/1, highest_protocol_version/2,
 	 is_higher/2, supported_protocol_versions/0,
 	 is_acceptable_version/2, hello_version/2]).
@@ -263,17 +263,27 @@ decode_cipher_text(#ssl_tls{epoch = Epoch} = CipherText, ConnnectionStates0) ->
 %% Protocol version handling
 %%====================================================================
 
+
 %%--------------------------------------------------------------------
--spec protocol_version(dtls_atom_version() | ssl_record:ssl_version()) ->
-			      ssl_record:ssl_version() | dtls_atom_version().
+-spec protocol_version_name(dtls_atom_version()) -> ssl_record:ssl_version().
 %%
 %% Description: Creates a protocol version record from a version atom
 %% or vice versa.
 %%--------------------------------------------------------------------
-protocol_version('dtlsv1.2') ->
+
+protocol_version_name('dtlsv1.2') ->
     ?DTLS_1_2;
-protocol_version(dtlsv1) ->
-    ?DTLS_1_0;
+protocol_version_name(dtlsv1) ->
+    ?DTLS_1_0.
+
+%%--------------------------------------------------------------------
+-spec protocol_version(ssl_record:ssl_version()) -> dtls_atom_version().
+
+%%
+%% Description: Creates a protocol version record from a version atom
+%% or vice versa.
+%%--------------------------------------------------------------------
+
 protocol_version(?DTLS_1_2) ->
     'dtlsv1.2';
 protocol_version(?DTLS_1_0) ->
@@ -337,7 +347,7 @@ is_higher(_, _) ->
 %%--------------------------------------------------------------------
 supported_protocol_versions() ->
     Fun = fun(Version) ->
-		  protocol_version(Version)
+		  protocol_version_name(Version)
 	  end,
     case application:get_env(ssl, dtls_protocol_version) of
 	undefined ->

--- a/lib/ssl/src/dtls_v1.erl
+++ b/lib/ssl/src/dtls_v1.erl
@@ -20,6 +20,7 @@
 -module(dtls_v1).
 
 -include("ssl_cipher.hrl").
+-include("ssl_record.hrl").
 
 -export([suites/1,
          all_suites/1,
@@ -35,13 +36,13 @@
 
 -define(COOKIE_BASE_TIMEOUT, 30000).
 
--spec suites(Minor:: 253|255) -> [ssl_cipher_format:cipher_suite()].
+-spec suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 
-suites(Minor) ->
+suites(Version) ->
     lists:filter(fun(Cipher) -> 
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher)) 
                  end,
-                 tls_v1:suites(corresponding_minor_tls_version(Minor))).
+                 tls_v1:suites(corresponding_tls_version(Version))).
 all_suites(Version) ->
     lists:filter(fun(Cipher) -> 
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher)) 
@@ -54,27 +55,30 @@ anonymous_suites(Version) ->
                  end, 
                  ssl_cipher:anonymous_suites(corresponding_tls_version(Version))).
 
-exclusive_suites(Minor) ->
+exclusive_suites(Version) ->
     lists:filter(fun(Cipher) ->
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher))
                  end,
-                 tls_v1:exclusive_suites(corresponding_minor_tls_version(Minor))).
+                 tls_v1:exclusive_suites(corresponding_tls_version(Version))).
 
-exclusive_anonymous_suites(Minor) ->
+exclusive_anonymous_suites(Version) ->
     lists:filter(fun(Cipher) ->
                          is_acceptable_cipher(ssl_cipher_format:suite_bin_to_map(Cipher))
                  end,
-                 tls_v1:exclusive_anonymous_suites(corresponding_minor_tls_version(Minor))).
+                 tls_v1:exclusive_anonymous_suites(corresponding_tls_version(Version))).
 
 
 hmac_hash(MacAlg, MacSecret, Value) ->
     tls_v1:hmac_hash(MacAlg, MacSecret, Value).
 
-ecc_curves({_Major, Minor}) ->
-    tls_v1:ecc_curves(corresponding_minor_tls_version(Minor)).
+ecc_curves(Version) ->
+    tls_v1:ecc_curves(corresponding_tls_version(Version)).
 
-corresponding_tls_version({254, Minor}) ->
-    {3, corresponding_minor_tls_version(Minor)}.
+
+corresponding_tls_version(?'DTLS-1.0') ->
+    ?'TLS-1.1';
+corresponding_tls_version(?'DTLS-1.2') ->
+    ?'TLS-1.2'.
 
 cookie_secret() ->
     crypto:strong_rand_bytes(32).
@@ -82,18 +86,12 @@ cookie_secret() ->
 cookie_timeout() ->
     %% Cookie will live for two timeouts periods
     round(rand:uniform() * ?COOKIE_BASE_TIMEOUT/2).
-    
-corresponding_minor_tls_version(255) ->
-    2;
-corresponding_minor_tls_version(253) ->
-    3.
 
-corresponding_dtls_version({3, Minor}) -> 
-    {254, corresponding_minor_dtls_version(Minor)}.
 
-corresponding_minor_dtls_version(2) ->
-    255;
-corresponding_minor_dtls_version(3) ->
-    253.
+corresponding_dtls_version(?'TLS-1.1') ->
+    ?'DTLS-1.0';
+corresponding_dtls_version(?'TLS-1.2') ->
+    ?'DTLS-1.2'.
+
 is_acceptable_cipher(Suite) ->
     not ssl_cipher:is_stream_ciphersuite(Suite).

--- a/lib/ssl/src/dtls_v1.erl
+++ b/lib/ssl/src/dtls_v1.erl
@@ -75,10 +75,10 @@ ecc_curves(Version) ->
     tls_v1:ecc_curves(corresponding_tls_version(Version)).
 
 
-corresponding_tls_version(?'DTLS-1.0') ->
-    ?'TLS-1.1';
-corresponding_tls_version(?'DTLS-1.2') ->
-    ?'TLS-1.2'.
+corresponding_tls_version(?DTLS_1_0) ->
+    ?TLS_1_1;
+corresponding_tls_version(?DTLS_1_2) ->
+    ?TLS_1_2.
 
 cookie_secret() ->
     crypto:strong_rand_bytes(32).
@@ -88,10 +88,10 @@ cookie_timeout() ->
     round(rand:uniform() * ?COOKIE_BASE_TIMEOUT/2).
 
 
-corresponding_dtls_version(?'TLS-1.1') ->
-    ?'DTLS-1.0';
-corresponding_dtls_version(?'TLS-1.2') ->
-    ?'DTLS-1.2'.
+corresponding_dtls_version(?TLS_1_1) ->
+    ?DTLS_1_0;
+corresponding_dtls_version(?TLS_1_2) ->
+    ?DTLS_1_2.
 
 is_acceptable_cipher(Suite) ->
     not ssl_cipher:is_stream_ciphersuite(Suite).

--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -48,6 +48,7 @@
 -include("ssl_api.hrl").
 -include("ssl_cipher.hrl").
 -include("ssl_internal.hrl").
+-include("ssl_record.hrl").
 -include_lib("kernel/include/logger.hrl").
 
 -define(FAMILY, inet).
@@ -1049,7 +1050,7 @@ ktls_opt_ulp(_OS) ->
 
 ktls_opt_cipher(
   _OS,
-  _TLS_version = {3,4}, % 'tlsv1.3'
+  _TLS_version = ?TLS_1_3, % 'tlsv1.3'
   _CipherSpec = ?TLS_AES_256_GCM_SHA384,
   #cipher_state{
      key = <<Key:32/bytes>>,

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2530,10 +2530,7 @@ warn_override(_, _UserOpts, _NewOpt, _OldOpts, _LogLevel) ->
     ok.
 
 is_dtls_configured(Versions) ->
-    Fun = fun (Version) when ?DTLS_1_X(Version) -> true;
-              (_) -> false
-          end,
-    lists:any(Fun, Versions).
+    lists:any(fun (Ver) -> ?DTLS_1_X(Ver) end, Versions).
 
 handle_hashsigns_option(Value, Version) ->
     try

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2011,7 +2011,7 @@ server_name_indication_default(_) ->
 opt_signature_algs(UserOpts, #{versions := Versions} = Opts, _Env) ->
     [TlsVersion|_] = TlsVsns = [tls_version(V) || V <- Versions],
     SA = case get_opt_list(signature_algs, undefined, UserOpts, Opts) of
-             {default, undefined} when ?TLS_GE(TlsVersion, ?TLS_1_2) ->
+             {default, undefined} when ?TLS_GTE(TlsVersion, ?TLS_1_2) ->
                  DefAlgs = tls_v1:default_signature_algs(TlsVsns),
                  handle_hashsigns_option(DefAlgs, TlsVersion);
              {new, Algs} ->
@@ -2077,7 +2077,7 @@ validate_protocols(true, Opt, List) ->
     lists:foreach(Check, List).
 
 opt_mitigation(UserOpts, #{versions := Versions} = Opts, _Env) ->
-    DefBeast = case ?TLS_G(lists:last(Versions), ?TLS_1_0) of
+    DefBeast = case ?TLS_GT(lists:last(Versions), ?TLS_1_0) of
                    true -> disabled;
                    false -> one_n_minus_one
                end,
@@ -2537,7 +2537,7 @@ is_dtls_configured(Versions) ->
 
 handle_hashsigns_option(Value, Version) ->
     try
-        if ?TLS_GE(Version, ?TLS_1_3) ->
+        if ?TLS_GTE(Version, ?TLS_1_3) ->
                 tls_v1:signature_schemes(Version, Value);
            (Version =:= ?TLS_1_2) ->
                 tls_v1:signature_algs(Version, Value);

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1143,14 +1143,14 @@ eccs_filter_supported(Curves) ->
 %% Description: returns all supported groups (TLS 1.3 and later)
 %%--------------------------------------------------------------------
 groups() ->
-    tls_v1:groups(4).
+    tls_v1:groups().
 
 %%--------------------------------------------------------------------
 -spec groups(default) -> [group()].
 %% Description: returns the default groups (TLS 1.3 and later)
 %%--------------------------------------------------------------------
 groups(default) ->
-    tls_v1:default_groups(4).
+    tls_v1:default_groups().
 
 %%--------------------------------------------------------------------
 -spec getopts(SslSocket, OptionNames) ->
@@ -1432,9 +1432,9 @@ format_error({error, Reason}) ->
 format_error(Reason) ->
     do_format_error(Reason).
 
-tls_version({3, _} = Version) ->
+tls_version(?'TLS-1.X'=Version) ->
     Version;
-tls_version({254, _} = Version) ->
+tls_version(?'DTLS-1.X' = Version) ->
     dtls_v1:corresponding_tls_version(Version).
 
 %%--------------------------------------------------------------------
@@ -1484,20 +1484,20 @@ str_to_suite(CipherSuiteName) ->
 %%%--------------------------------------------------------------
 %%% Internal functions
 %%%--------------------------------------------------------------------
-supported_suites(exclusive, {3,Minor}) ->
-    tls_v1:exclusive_suites(Minor);
-supported_suites(exclusive, {254, Minor}) ->
-    dtls_v1:exclusive_suites(Minor);
+supported_suites(exclusive, ?'TLS-1.X'=Version) ->
+    tls_v1:exclusive_suites(Version);
+supported_suites(exclusive, ?'DTLS-1.X'=Version) ->
+    dtls_v1:exclusive_suites(Version);
 supported_suites(default, Version) ->  
     ssl_cipher:suites(Version);
 supported_suites(all, Version) ->  
     ssl_cipher:all_suites(Version);
 supported_suites(anonymous, Version) ->
     ssl_cipher:anonymous_suites(Version);
-supported_suites(exclusive_anonymous, {3, Minor}) ->
-    tls_v1:exclusive_anonymous_suites(Minor);
-supported_suites(exclusive_anonymous, {254, Minor}) ->
-    dtls_v1:exclusive_anonymous_suites(Minor).
+supported_suites(exclusive_anonymous, ?'TLS-1.X'=Version) ->
+    tls_v1:exclusive_anonymous_suites(Version);
+supported_suites(exclusive_anonymous, ?'DTLS-1.X'=Version) ->
+    dtls_v1:exclusive_anonymous_suites(Version).
 
 do_listen(Port, #config{transport_info = {Transport, _, _, _,_}} = Config, tls_gen_connection) ->
     tls_socket:listen(Transport, Port, Config);
@@ -2530,20 +2530,19 @@ warn_override(_, _UserOpts, _NewOpt, _OldOpts, _LogLevel) ->
     ok.
 
 is_dtls_configured(Versions) ->
-    Fun = fun (Version) when Version =:= {254, 253} orelse
-                             Version =:= {254, 255} ->
+    Fun = fun (Version) when Version =:= ?'DTLS-1.2' orelse
+                             Version =:= ?'DTLS-1.0' ->
                   true;
               (_) ->
                   false
           end,
     lists:any(Fun, Versions).
 
-
 handle_hashsigns_option(Value, Version) ->
     try
-        if Version >= {3,4} ->
+        if Version >= ?'TLS-1.3' ->
                 tls_v1:signature_schemes(Version, Value);
-           Version =:= {3,3} ->
+           Version =:= ?'TLS-1.2' ->
                 tls_v1:signature_algs(Version, Value);
            true ->
                 undefined
@@ -2606,11 +2605,11 @@ handle_cipher_option(Value, Versions)  when is_list(Value) ->
 	    option_error(ciphers, Value)
     end.
 
-binary_cipher_suites([{3,4} = Version], []) -> 
+binary_cipher_suites([?'TLS-1.3'], []) ->
     %% Defaults to all supported suites that does
     %% not require explicit configuration TLS-1.3
     %% only mode.
-    default_binary_suites(exclusive, Version);
+    default_binary_suites(exclusive, ?'TLS-1.3');
 binary_cipher_suites([Version| _], []) -> 
     %% Defaults to all supported suites that does
     %% not require explicit configuration
@@ -2640,15 +2639,15 @@ binary_cipher_suites(Versions, Ciphers0)  ->
     Ciphers = [ssl_cipher_format:suite_openssl_str_to_map(C) || C <- string:lexemes(Ciphers0, ":")],
     binary_cipher_suites(Versions, Ciphers).
 
-default_binary_suites(exclusive, {_, Minor}) ->
-    ssl_cipher:filter_suites(tls_v1:exclusive_suites(Minor));
+default_binary_suites(exclusive, Version) ->
+    ssl_cipher:filter_suites(tls_v1:exclusive_suites(Version));
 default_binary_suites(default, Version) ->
     ssl_cipher:filter_suites(ssl_cipher:suites(Version)).
 
-all_suites([{3, 4 = Minor}]) ->
-    tls_v1:exclusive_suites(Minor);
-all_suites([{3, 4} = Version0, Version1 |_]) ->
-    all_suites([Version0]) ++
+all_suites([?'TLS-1.3']) ->
+    tls_v1:exclusive_suites(?'TLS-1.3');
+all_suites([?'TLS-1.3', Version1 |_]) ->
+    all_suites([?'TLS-1.3']) ++
         ssl_cipher:all_suites(Version1) ++
         ssl_cipher:anonymous_suites(Version1);
 all_suites([Version|_]) ->
@@ -2676,8 +2675,9 @@ tuple_to_map_mac(chacha20_poly1305, _) ->
 tuple_to_map_mac(_, MAC) ->
     MAC.
 
-handle_eccs_option(Value, {_Major, Minor}) when is_list(Value) ->
-    try tls_v1:ecc_curves(Minor, Value) of
+%% TODO: remove Version
+handle_eccs_option(Value, _Version0) when is_list(Value) ->
+    try tls_v1:ecc_curves(Value) of
         Curves ->
             option_error(Curves =:= [], eccs, none_valid),
             #elliptic_curves{elliptic_curve_list = Curves}
@@ -2686,9 +2686,9 @@ handle_eccs_option(Value, {_Major, Minor}) when is_list(Value) ->
         error:_ -> option_error(eccs, Value)
     end.
 
-handle_supported_groups_option(Value, Version) when is_list(Value) ->
-    {_Major, Minor} = tls_version(Version),
-    try tls_v1:groups(Minor, Value) of
+%% TODO: remove Version
+handle_supported_groups_option(Value, _Version0) when is_list(Value) ->
+    try tls_v1:groups(Value) of
         Groups ->
             option_error(Groups =:= [], supported_groups, none_valid),
             #supported_groups{supported_groups = Groups}
@@ -2830,7 +2830,6 @@ map_log_level(true) ->
     notice;
 map_log_level(false) ->
     none.
-
 
 include_security_info([]) ->
     false;

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -346,14 +346,14 @@ available_cert_key_pairs(CertKeyGroups) ->
 
 %% Create the prioritized list of cert key pairs that
 %% are availble for use in the negotiated version
-available_cert_key_pairs(CertKeyGroups, ?'TLS-1.3') ->
+available_cert_key_pairs(CertKeyGroups, ?TLS_1_3) ->
     RevAlgos = [rsa, rsa_pss_pss, ecdsa, eddsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
-available_cert_key_pairs(CertKeyGroups, ?'TLS-1.2') ->
+available_cert_key_pairs(CertKeyGroups, ?TLS_1_2) ->
      RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
-available_cert_key_pairs(CertKeyGroups, ?'TLS-1.X'=Version)
-  when Version < ?'TLS-1.2'->
+available_cert_key_pairs(CertKeyGroups, Version)
+  when ?TLS_L(Version, ?TLS_1_2) ->
     RevAlgos = [dsa, rsa, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []).
 
@@ -598,22 +598,22 @@ verify_cert_extensions(Cert, UserState, [_|Exts], Context) ->
     %% Skip unknown extensions!
     verify_cert_extensions(Cert, UserState, Exts, Context).
 
-verify_sign(_, #{version := ?'TLS-1.X'=Version})
-            when Version < ?'TLS-1.2' ->
+verify_sign(_, #{version := Version})
+            when ?TLS_L(Version, ?TLS_1_2) ->
     %% This verification is not applicable pre TLS-1.2 
     true; 
-verify_sign(Cert, #{version := ?'TLS-1.2',
+verify_sign(Cert, #{version := ?TLS_1_2,
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := ?'TLS-1.2',
+verify_sign(Cert, #{version := ?TLS_1_2,
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := ?'TLS-1.3',
+verify_sign(Cert, #{version := ?TLS_1_3,
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs);
-verify_sign(Cert, #{version := ?'TLS-1.3',
+verify_sign(Cert, #{version := ?TLS_1_3,
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs).
 

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -65,6 +65,7 @@
 -include("ssl_handshake.hrl").
 -include("ssl_alert.hrl").
 -include("ssl_internal.hrl").
+-include("ssl_record.hrl").
 -include_lib("public_key/include/public_key.hrl"). 
 
 -export([trusted_cert_and_paths/4,
@@ -345,13 +346,14 @@ available_cert_key_pairs(CertKeyGroups) ->
 
 %% Create the prioritized list of cert key pairs that
 %% are availble for use in the negotiated version
-available_cert_key_pairs(CertKeyGroups, {3, 4}) ->
+available_cert_key_pairs(CertKeyGroups, ?'TLS-1.3') ->
     RevAlgos = [rsa, rsa_pss_pss, ecdsa, eddsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
-available_cert_key_pairs(CertKeyGroups, {3, 3}) ->
+available_cert_key_pairs(CertKeyGroups, ?'TLS-1.2') ->
      RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
-available_cert_key_pairs(CertKeyGroups, {3, N}) when N < 3->
+available_cert_key_pairs(CertKeyGroups, ?'TLS-1.X'=Version)
+  when Version < ?'TLS-1.2'->
     RevAlgos = [dsa, rsa, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []).
 
@@ -596,21 +598,22 @@ verify_cert_extensions(Cert, UserState, [_|Exts], Context) ->
     %% Skip unknown extensions!
     verify_cert_extensions(Cert, UserState, Exts, Context).
 
-verify_sign(_, #{version := {_, Minor}}) when Minor < 3 ->
+verify_sign(_, #{version := ?'TLS-1.X'=Version})
+            when Version < ?'TLS-1.2' ->
     %% This verification is not applicable pre TLS-1.2 
     true; 
-verify_sign(Cert, #{version := {3, 3},
+verify_sign(Cert, #{version := ?'TLS-1.2',
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := {3, 3},
+verify_sign(Cert, #{version := ?'TLS-1.2',
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_2(Cert, SignAlgs);
-verify_sign(Cert, #{version := {3, 4},
+verify_sign(Cert, #{version := ?'TLS-1.3',
                     signature_algs := SignAlgs,
                     signature_algs_cert := undefined}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs);
-verify_sign(Cert, #{version := {3, 4},
+verify_sign(Cert, #{version := ?'TLS-1.3',
                     signature_algs_cert := SignAlgs}) ->
     is_supported_signature_algorithm_1_3(Cert, SignAlgs).
 

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -353,7 +353,7 @@ available_cert_key_pairs(CertKeyGroups, ?TLS_1_2) ->
      RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
 available_cert_key_pairs(CertKeyGroups, Version)
-  when ?TLS_L(Version, ?TLS_1_2) ->
+  when ?TLS_LT(Version, ?TLS_1_2) ->
     RevAlgos = [dsa, rsa, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []).
 
@@ -599,7 +599,7 @@ verify_cert_extensions(Cert, UserState, [_|Exts], Context) ->
     verify_cert_extensions(Cert, UserState, Exts, Context).
 
 verify_sign(_, #{version := Version})
-            when ?TLS_L(Version, ?TLS_1_2) ->
+            when ?TLS_LT(Version, ?TLS_1_2) ->
     %% This verification is not applicable pre TLS-1.2 
     true; 
 verify_sign(Cert, #{version := ?TLS_1_2,

--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -222,7 +222,7 @@ block_cipher(Fun, BlockSz, #cipher_state{key=Key, iv=IV} = CS0,
 
 block_cipher(Fun, BlockSz, #cipher_state{key=Key, iv=IV, state = IV_Cache0} = CS0,
 	     Mac, Fragment, Version)
-  when ?TLS_G(Version, ?TLS_1_0)->
+  when ?TLS_GT(Version, ?TLS_1_0)->
     IV_Size = byte_size(IV),
     <<NextIV:IV_Size/binary, IV_Cache/binary>> =
         case IV_Cache0 of
@@ -673,7 +673,7 @@ mac_hash({_,_}, ?NULL, _MacSecret, _SeqNo, _Type,
 	 _Length, _Fragment) ->
     <<>>;
 mac_hash(Version, MacAlg, MacSecret, SeqNo, Type, Length, Fragment)
-  when ?TLS_LE(Version, ?TLS_1_2), Version =/= ?SSL_3_0 ->
+  when ?TLS_LTE(Version, ?TLS_1_2), Version =/= ?SSL_3_0 ->
     tls_v1:mac_hash(MacAlg, MacSecret, SeqNo, Type, Version,
 		      Length, Fragment).
 
@@ -1037,7 +1037,7 @@ filter_suites_pubkey(ecdsa, Ciphers, _, OtpCert) ->
                                    ec_ecdhe_suites(Ciphers)),
     filter_keyuse_suites(keyAgreement, Uses, CiphersSuites, ec_ecdh_suites(Ciphers)).
 
-filter_suites_signature(_, Ciphers, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
+filter_suites_signature(_, Ciphers, Version) when ?TLS_GTE(Version, ?TLS_1_2) ->
      Ciphers;
 filter_suites_signature(rsa, Ciphers, Version) ->
     (Ciphers -- ecdsa_signed_suites(Ciphers, Version)) -- dsa_signed_suites(Ciphers);
@@ -1084,7 +1084,7 @@ rsa_signed(_) ->
 rsa_signed_suites(Ciphers, Version) ->
     filter_kex(Ciphers, rsa_signed(Version)).
 
-ecdsa_signed(Version) when ?TLS_GE(Version, ?TLS_1_2) ->
+ecdsa_signed(Version) when ?TLS_GTE(Version, ?TLS_1_2) ->
     fun(ecdhe_ecdsa) -> true;
        (_) -> false
     end;

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1167,7 +1167,7 @@ handle_alert(#alert{level = ?WARNING} = Alert, StateName,
 	     #state{static_env = #static_env{role = Role,
                                              protocol_cb = Connection},
                     connection_env = #connection_env{negotiated_version = Version},
-                    ssl_options = #{log_level := LogLevel}} = State) when ?TLS_L(Version, ?TLS_1_3) ->
+                    ssl_options = #{log_level := LogLevel}} = State) when ?TLS_LT(Version, ?TLS_1_3) ->
     log_alert(LogLevel, Role,
               Connection:protocol_name(), StateName,
               Alert#alert{role = opposite_role(Role)}),
@@ -1203,7 +1203,7 @@ handle_trusted_certs_db(#state{static_env = #static_env{cert_db_ref = Ref,
 
 maybe_invalidate_session(?TLS_1_3,_, _, _, _, _) ->
     ok;
-maybe_invalidate_session(Version, Type, Role, Host, Port, Session) when ?TLS_L(Version, ?TLS_1_3) ->
+maybe_invalidate_session(Version, Type, Role, Host, Port, Session) when ?TLS_LT(Version, ?TLS_1_3) ->
     maybe_invalidate_session(Type, Role, Host, Port, Session).
 
 maybe_invalidate_session({false, first}, server = Role, Host, Port, Session) ->

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1167,7 +1167,7 @@ handle_alert(#alert{level = ?WARNING} = Alert, StateName,
 	     #state{static_env = #static_env{role = Role,
                                              protocol_cb = Connection},
                     connection_env = #connection_env{negotiated_version = Version},
-                    ssl_options = #{log_level := LogLevel}} = State) when Version < {3,4} ->
+                    ssl_options = #{log_level := LogLevel}} = State) when Version < ?'TLS-1.3' ->
     log_alert(LogLevel, Role,
               Connection:protocol_name(), StateName,
               Alert#alert{role = opposite_role(Role)}),
@@ -1201,9 +1201,9 @@ handle_trusted_certs_db(#state{static_env = #static_env{cert_db_ref = Ref,
 	    ok
     end.
 
-maybe_invalidate_session({3, 4},_, _, _, _, _) ->
+maybe_invalidate_session(?'TLS-1.3',_, _, _, _, _) ->
     ok;
-maybe_invalidate_session({3, N}, Type, Role, Host, Port, Session) when N < 4 ->
+maybe_invalidate_session(?'TLS-1.X'=Version, Type, Role, Host, Port, Session) when Version < ?'TLS-1.3' ->
     maybe_invalidate_session(Type, Role, Host, Port, Session).
 
 maybe_invalidate_session({false, first}, server = Role, Host, Port, Session) ->
@@ -1285,14 +1285,14 @@ format_status(terminate, [_, StateName, State]) ->
 %%--------------------------------------------------------------------
 next_statem_state([Version], client) ->
     case ssl:tls_version(Version) of
-        {3,4} ->
+        ?'TLS-1.3' ->
             wait_sh;
         _  ->
             hello
     end;
 next_statem_state([Version], server) ->
     case ssl:tls_version(Version) of
-        {3,4} ->
+        ?'TLS-1.3' ->
             start;
         _  ->
             hello
@@ -2234,7 +2234,7 @@ maybe_generate_client_shares(#{versions := [Version|_],
                                supported_groups :=
                                    #supported_groups{
                                       supported_groups = [Group|_]}})
-  when Version =:= {3,4} ->
+  when Version =:= ?'TLS-1.3' ->
     %% Generate only key_share entry for the most preferred group
     ssl_cipher:generate_client_shares([Group]);
 maybe_generate_client_shares(_) ->

--- a/lib/ssl/src/ssl_logger.erl
+++ b/lib/ssl/src/ssl_logger.erl
@@ -290,19 +290,20 @@ get_server_version(Version, Extensions) ->
             Version
     end.
 
-version({3,4}) ->
+-spec version(ssl_record:ssl_version()) -> string().
+version(?'TLS-1.3') ->
     "TLS 1.3";
-version({3,3}) ->
+version(?'TLS-1.2') ->
     "TLS 1.2";
-version({3,2}) ->
+version(?'TLS-1.1') ->
     "TLS 1.1";
-version({3,1}) ->
+version(?'TLS-1.0') ->
     "TLS 1.0";
-version({3,0}) ->
+version(?'SSL-3.0') ->
     "SSL 3.0";
-version({254,253}) ->
+version(?'DTLS-1.2') ->
     "DTLS 1.2";
-version({254,255}) ->
+version(?'DTLS-1.0') ->
     "DTLS 1.0";
 version({M,N}) ->
     io_lib:format("TLS/DTLS [0x0~B0~B]", [M,N]).

--- a/lib/ssl/src/ssl_logger.erl
+++ b/lib/ssl/src/ssl_logger.erl
@@ -291,19 +291,19 @@ get_server_version(Version, Extensions) ->
     end.
 
 -spec version(ssl_record:ssl_version()) -> string().
-version(?'TLS-1.3') ->
+version(?TLS_1_3) ->
     "TLS 1.3";
-version(?'TLS-1.2') ->
+version(?TLS_1_2) ->
     "TLS 1.2";
-version(?'TLS-1.1') ->
+version(?TLS_1_1) ->
     "TLS 1.1";
-version(?'TLS-1.0') ->
+version(?TLS_1_0) ->
     "TLS 1.0";
-version(?'SSL-3.0') ->
+version(?SSL_3_0) ->
     "SSL 3.0";
-version(?'DTLS-1.2') ->
+version(?DTLS_1_2) ->
     "DTLS 1.2";
-version(?'DTLS-1.0') ->
+version(?DTLS_1_0) ->
     "DTLS 1.0";
 version({M,N}) ->
     io_lib:format("TLS/DTLS [0x0~B0~B]", [M,N]).

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -55,11 +55,10 @@
 -export([cipher/4, cipher/5, decipher/4,
          cipher_aead/4, cipher_aead/5, decipher_aead/5,
          is_correct_mac/2, nonce_seed/3]).
--define(TLS_1_3, {3, 4}).
 
 -export_type([ssl_version/0, ssl_atom_version/0, connection_states/0, connection_state/0]).
 
--type ssl_version()       :: {integer(), integer()}.
+-type ssl_version()       :: {non_neg_integer(), non_neg_integer()}.
 -type ssl_atom_version() :: tls_record:tls_atom_version().
 -type connection_states() :: map(). %% Map
 -type connection_state() :: map(). %% Map
@@ -496,7 +495,7 @@ init_security_parameters(?SERVER, Version) ->
     #security_parameters{connection_end = ?SERVER,
                          server_random = make_random(Version)}.
 
-make_random({_Major, _Minor} = Version) when Version >= ?TLS_1_3 ->
+make_random(Version) when Version >= ?'TLS-1.3' ->
     ssl_cipher:random_bytes(32);
 make_random(_Version) ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -59,9 +59,9 @@
 -export_type([ssl_version/0, ssl_atom_version/0, connection_states/0, connection_state/0]).
 
 -type ssl_version()       :: {non_neg_integer(), non_neg_integer()}.
--type ssl_atom_version() :: tls_record:tls_atom_version().
+-type ssl_atom_version()  :: tls_record:tls_atom_version().
 -type connection_states() :: map(). %% Map
--type connection_state() :: map(). %% Map
+-type connection_state()  :: map(). %% Map
 
 %%====================================================================
 %% Connection state handling
@@ -495,7 +495,7 @@ init_security_parameters(?SERVER, Version) ->
     #security_parameters{connection_end = ?SERVER,
                          server_random = make_random(Version)}.
 
-make_random(Version) when Version >= ?'TLS-1.3' ->
+make_random(Version) when ?TLS_GE(Version, ?TLS_1_3) ->
     ssl_cipher:random_bytes(32);
 make_random(_Version) ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(

--- a/lib/ssl/src/ssl_record.erl
+++ b/lib/ssl/src/ssl_record.erl
@@ -495,7 +495,7 @@ init_security_parameters(?SERVER, Version) ->
     #security_parameters{connection_end = ?SERVER,
                          server_random = make_random(Version)}.
 
-make_random(Version) when ?TLS_GE(Version, ?TLS_1_3) ->
+make_random(Version) when ?TLS_GTE(Version, ?TLS_1_3) ->
     ssl_cipher:random_bytes(32);
 make_random(_Version) ->
     Secs_since_1970 = calendar:datetime_to_gregorian_seconds(

--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -183,15 +183,15 @@
 -define(TLS_1_X(Version), (element(1,Version) == 3)).
 -define(DTLS_1_X(Version), (element(1,Version) == 254)).
 
--define(TLS_GE(Version1, Version2), (Version1 >= Version2)).
--define(TLS_G(Version1, Version2),  (Version1 > Version2)).
--define(TLS_LE(Version1, Version2), (Version1 =< Version2)).
--define(TLS_L(Version1, Version2),  (Version1 < Version2)).
+-define(TLS_GTE(Version1, Version2), (Version1 >= Version2)).
+-define(TLS_GT(Version1, Version2),  (Version1 > Version2)).
+-define(TLS_LTE(Version1, Version2), (Version1 =< Version2)).
+-define(TLS_LT(Version1, Version2),  (Version1 < Version2)).
 
--define(DTLS_GE(Version1, Version2), (Version1 =< Version2)).
--define(DTLS_G(Version1, Version2),  (Version1 < Version2)).
--define(DTLS_LE(Version1, Version2), (Version >= Version2)).
--define(DTLS_L(Version1, Version2),  (Version1 > Version2)).
+-define(DTLS_GTE(Version1, Version2), (Version1 =< Version2)).
+-define(DTLS_GT(Version1, Version2),  (Version1 < Version2)).
+-define(DTLS_LTE(Version1, Version2), (Version >= Version2)).
+-define(DTLS_LT(Version1, Version2),  (Version1 > Version2)).
 
 %% Atoms used to refer to protocols
 

--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -180,4 +180,16 @@
           next_iv  % opaque IV[SecurityParameters.record_iv_length];
          }). 
 
+
+-define('TLS-1.X', {3, _}).
+-define('TLS-1.3', {3, 4}).
+-define('TLS-1.2', {3, 3}).
+-define('TLS-1.1', {3, 2}).
+-define('TLS-1.0', {3, 1}).
+-define('DTLS-1.X', {254, _}).
+-define('DTLS-1.0', {254, 255}).
+-define('DTLS-1.2', {254, 253}).
+-define('SSL-2.0', {2, 0}).
+-define('SSL-3.0', {3, 0}).
+
 -endif. % -ifdef(ssl_record).

--- a/lib/ssl/src/ssl_record.hrl
+++ b/lib/ssl/src/ssl_record.hrl
@@ -163,9 +163,6 @@
 %% 	  minor   % unit 8
 %% 	 }).
 
--define(LOWEST_MAJOR_SUPPORTED_VERSION, 3).
-	
-
 -record(generic_stream_cipher, {
           content,  % opaque content[TLSCompressed.length];
           mac       % opaque MAC[CipherSpec.hash_size]; 
@@ -180,16 +177,33 @@
           next_iv  % opaque IV[SecurityParameters.record_iv_length];
          }). 
 
+-define(PROTOCOL_TO_BINARY_VERSION(Version), (Version)).
+-define(BINARY_PROTOCOL_TO_INTERNAL_REPRESENTATION(Version), (Version)).
 
--define('TLS-1.X', {3, _}).
--define('TLS-1.3', {3, 4}).
--define('TLS-1.2', {3, 3}).
--define('TLS-1.1', {3, 2}).
--define('TLS-1.0', {3, 1}).
--define('DTLS-1.X', {254, _}).
--define('DTLS-1.0', {254, 255}).
--define('DTLS-1.2', {254, 253}).
--define('SSL-2.0', {2, 0}).
--define('SSL-3.0', {3, 0}).
+-define(TLS_1_X(Version), (element(1,Version) == 3)).
+-define(DTLS_1_X(Version), (element(1,Version) == 254)).
+
+-define(TLS_GE(Version1, Version2), (Version1 >= Version2)).
+-define(TLS_G(Version1, Version2),  (Version1 > Version2)).
+-define(TLS_LE(Version1, Version2), (Version1 =< Version2)).
+-define(TLS_L(Version1, Version2),  (Version1 < Version2)).
+
+-define(DTLS_GE(Version1, Version2), (Version1 =< Version2)).
+-define(DTLS_G(Version1, Version2),  (Version1 < Version2)).
+-define(DTLS_LE(Version1, Version2), (Version >= Version2)).
+-define(DTLS_L(Version1, Version2),  (Version1 > Version2)).
+
+%% Atoms used to refer to protocols
+
+-define(TLS_1_3, {3,4}).
+-define(TLS_1_2, {3,3}).
+-define(TLS_1_1, {3,2}).
+-define(TLS_1_0, {3,1}).
+
+-define(DTLS_1_2, {254,253}).
+-define(DTLS_1_0, {254,255}).
+
+-define(SSL_3_0, {3,0}).
+-define(SSL_2_0, {2,0}).
 
 -endif. % -ifdef(ssl_record).

--- a/lib/ssl/src/ssl_session.erl
+++ b/lib/ssl/src/ssl_session.erl
@@ -28,6 +28,7 @@
 -include("ssl_handshake.hrl").
 -include("ssl_internal.hrl").
 -include("ssl_api.hrl").
+-include("ssl_record.hrl").
 
 %% Internal application API
 -export([is_new/2,
@@ -89,7 +90,7 @@ client_select_session({_, _, #{versions := Versions,
     HVersion = RecordCb:highest_protocol_version(Versions),
 
     case LVersion of
-        {3, 4} ->
+        ?'TLS-1.3' ->
             %% Session reuse is not supported, do pure legacy
             %% middlebox comp mode negotiation, by providing either
             %% empty session id (no middle box) or random id (middle
@@ -241,7 +242,7 @@ record_cb(dtls) ->
 legacy_session_id() ->
     crypto:strong_rand_bytes(32).
 
-maybe_handle_middlebox({3, 4}, #session{session_id = ?EMPTY_ID} = Session, Options)->
+maybe_handle_middlebox(?'TLS-1.3', #session{session_id = ?EMPTY_ID} = Session, Options)->
     case maps:get(middlebox_comp_mode, Options,true) of
         true ->
             Session#session{session_id = legacy_session_id()};

--- a/lib/ssl/src/ssl_session.erl
+++ b/lib/ssl/src/ssl_session.erl
@@ -90,7 +90,7 @@ client_select_session({_, _, #{versions := Versions,
     HVersion = RecordCb:highest_protocol_version(Versions),
 
     case LVersion of
-        ?'TLS-1.3' ->
+        ?TLS_1_3 ->
             %% Session reuse is not supported, do pure legacy
             %% middlebox comp mode negotiation, by providing either
             %% empty session id (no middle box) or random id (middle
@@ -242,7 +242,7 @@ record_cb(dtls) ->
 legacy_session_id() ->
     crypto:strong_rand_bytes(32).
 
-maybe_handle_middlebox(?'TLS-1.3', #session{session_id = ?EMPTY_ID} = Session, Options)->
+maybe_handle_middlebox(?TLS_1_3, #session{session_id = ?EMPTY_ID} = Session, Options)->
     case maps:get(middlebox_comp_mode, Options,true) of
         true ->
             Session#session{session_id = legacy_session_id()};

--- a/lib/ssl/src/tls_client_connection_1_3.erl
+++ b/lib/ssl/src/tls_client_connection_1_3.erl
@@ -736,12 +736,11 @@ maybe_send_early_data(#state{
                          handshake_env =
                              #handshake_env{tls_handshake_history = {Hist, _}},
                          protocol_specific = #{sender := _Sender},
-                         ssl_options = #{versions := [Version|_],
+                         ssl_options = #{versions := [?TLS_1_3|_],
                                          use_ticket := UseTicket,
                                          session_tickets := SessionTickets,
                                          early_data := EarlyData} = _SslOpts0
-                        } = State0) when Version =:= {3,4} andalso
-                                         UseTicket =/= [undefined] andalso
+                        } = State0) when UseTicket =/= [undefined] andalso
                                          EarlyData =/= undefined ->
     %% D.4.  Middlebox Compatibility Mode
     State1 = tls_gen_connection_1_3:maybe_queue_change_cipher_spec(State0, last),
@@ -772,12 +771,11 @@ maybe_send_end_of_early_data(
   #state{
      handshake_env = #handshake_env{early_data_accepted = true},
      protocol_specific = #{sender := _Sender},
-     ssl_options = #{versions := [Version|_],
+     ssl_options = #{versions := [?TLS_1_3|_],
                      use_ticket := UseTicket,
                      early_data := EarlyData},
      static_env = #static_env{protocol_cb = Connection}
-    } = State0) when Version =:= {3,4} andalso
-                     UseTicket =/= [undefined] andalso
+    } = State0) when UseTicket =/= [undefined] andalso
                      EarlyData =/= undefined ->
     %% EndOfEarlydata is encrypted with the 0-RTT traffic keys
     State1 = Connection:queue_handshake(#end_of_early_data{}, State0),
@@ -796,7 +794,7 @@ maybe_automatic_session_resumption(#state{ssl_options =
                                                 server_name_indication := SNI}
                                           = SslOpts0
                                          } = State0)
-  when Version >= {3,4} andalso
+  when ?TLS_GE(Version, ?TLS_1_3) andalso
        SessionTickets =:= auto ->
     AvailableCipherSuites = ssl_handshake:available_suites(UserSuites, Version),
     HashAlgos = cipher_hash_algos(AvailableCipherSuites),
@@ -850,12 +848,11 @@ client_private_key(Group, ClientShares) ->
 maybe_check_early_data_indication(EarlyDataIndication,
                                   #state{
                                      handshake_env = HsEnv,
-                                     ssl_options = #{versions := [Version|_],
+                                     ssl_options = #{versions := [?TLS_1_3|_],
                                                      use_ticket := UseTicket,
                                                      early_data := EarlyData}
                                     } = State)
-  when Version =:= {3,4} andalso
-       UseTicket =/= [undefined] andalso
+  when UseTicket =/= [undefined] andalso
        EarlyData =/= undefined andalso
        EarlyDataIndication =/= undefined ->
     signal_user_early_data(State, accepted),
@@ -863,13 +860,12 @@ maybe_check_early_data_indication(EarlyDataIndication,
 maybe_check_early_data_indication(EarlyDataIndication,
                                   #state{
                                      protocol_specific = #{sender := _Sender},
-                                     ssl_options = #{versions := [Version|_],
+                                     ssl_options = #{versions := [?TLS_1_3|_],
                                                      use_ticket := UseTicket,
                                                      early_data := EarlyData}
                                      = _SslOpts0
                                     } = State)
-  when Version =:= {3,4} andalso
-       UseTicket =/= [undefined] andalso
+  when UseTicket =/= [undefined] andalso
        EarlyData =/= undefined andalso
        EarlyDataIndication =:= undefined ->
     signal_user_early_data(State, rejected),

--- a/lib/ssl/src/tls_client_connection_1_3.erl
+++ b/lib/ssl/src/tls_client_connection_1_3.erl
@@ -794,7 +794,7 @@ maybe_automatic_session_resumption(#state{ssl_options =
                                                 server_name_indication := SNI}
                                           = SslOpts0
                                          } = State0)
-  when ?TLS_GE(Version, ?TLS_1_3) andalso
+  when ?TLS_GTE(Version, ?TLS_1_3) andalso
        SessionTickets =:= auto ->
     AvailableCipherSuites = ssl_handshake:available_suites(UserSuites, Version),
     HashAlgos = cipher_hash_algos(AvailableCipherSuites),

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -597,7 +597,7 @@ choose_tls_fsm(#{versions := Versions},
                                 }
                  }) ->
     case ssl_handshake:select_supported_version(ClientVersions, Versions) of
-        ?'TLS-1.3' ->
+        ?TLS_1_3 ->
             tls_1_3_fsm;
         _Else ->
             tls_1_0_to_1_2_fsm

--- a/lib/ssl/src/tls_connection.erl
+++ b/lib/ssl/src/tls_connection.erl
@@ -597,7 +597,7 @@ choose_tls_fsm(#{versions := Versions},
                                 }
                  }) ->
     case ssl_handshake:select_supported_version(ClientVersions, Versions) of
-        {3,4} ->
+        ?'TLS-1.3' ->
             tls_1_3_fsm;
         _Else ->
             tls_1_0_to_1_2_fsm

--- a/lib/ssl/src/tls_dtls_connection.erl
+++ b/lib/ssl/src/tls_dtls_connection.erl
@@ -1647,8 +1647,9 @@ handle_resumed_session(SessId, #state{static_env = #static_env{host = Host,
             throw(Alert)
     end.
 
-make_premaster_secret({MajVer, MinVer}, rsa) ->
+make_premaster_secret(Version, rsa) ->
     Rand = ssl_cipher:random_bytes(?NUM_OF_PREMASTERSECRET_BYTES-2),
+    {MajVer,MinVer} = Version,
     <<?BYTE(MajVer), ?BYTE(MinVer), Rand/binary>>;
 make_premaster_secret(_, _) ->
     undefined.
@@ -1677,7 +1678,7 @@ handle_sni_extension(#state{static_env =
             throw(Alert)
     end.
 
-ensure_tls({254, _} = Version) -> 
+ensure_tls(Version) when ?DTLS_1_X(Version) ->
     dtls_v1:corresponding_tls_version(Version);
 ensure_tls(Version) -> 
     Version.

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -639,7 +639,7 @@ next_tls_record(Data, StateName,
                 %% This does not allow SSL-3.0 connections, that we do not support
                 %% or interfere with TLS-1.3 extensions to handle version negotiation.
                 AllHelloVersions = [ 'sslv3' | ?ALL_AVAILABLE_VERSIONS],
-                [tls_record:protocol_version(Vsn) || Vsn <- AllHelloVersions];
+                [tls_record:protocol_version_name(Vsn) || Vsn <- AllHelloVersions];
             _ ->
                 State0#state.connection_env#connection_env.negotiated_version
         end,

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -742,7 +742,7 @@ activate_socket(#state{protocol_specific = #{active_n_toggle := true, active_n :
 next_record(State, CipherTexts, ConnectionStates, Check) ->
     next_record(State, CipherTexts, ConnectionStates, Check, [], false).
 %%
-next_record(#state{connection_env = #connection_env{negotiated_version = ?'TLS-1.3' = Version}} = State,
+next_record(#state{connection_env = #connection_env{negotiated_version = ?TLS_1_3 = Version}} = State,
             [CT|CipherTexts], ConnectionStates0, Check, Acc, IsEarlyData) ->
     case tls_record:decode_cipher_text(Version, CT, ConnectionStates0, Check) of
         {Record = #ssl_tls{type = ?APPLICATION_DATA, fragment = Fragment}, ConnectionStates} ->
@@ -832,7 +832,7 @@ next_record_done(#state{protocol_buffers = Buffers} = State, CipherTexts, Connec
 %% field in TLS-1.3 client hello). The versions are instead negotiated with an hello extension. When
 %% decoding the server_hello messages we want to go through TLS-1.3 decode functions to be able
 %% to handle TLS-1.3 extensions if TLS-1.3 will be the negotiated version.
-handle_unnegotiated_version(?LEGACY_VERSION , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, hello) ->
+handle_unnegotiated_version(?LEGACY_VERSION , #{versions := [?TLS_1_3 = Version |_]} = Options, Data, Buffer, client, hello) ->
     %% The effective version for decoding the server hello message should be the TLS-1.3. Possible coalesced TLS-1.2
     %% server handshake messages should be decoded with the negotiated version in later state.
     <<_:8, ?UINT24(Length), _/binary>> = Data,
@@ -840,7 +840,7 @@ handle_unnegotiated_version(?LEGACY_VERSION , #{versions := [?'TLS-1.3' = Versio
     {HSPacket, <<>> = NewHsBuffer} = tls_handshake:get_tls_handshakes(Version, FirstPacket, Buffer, Options),
     {HSPacket, NewHsBuffer, RecordRest};
 %% TLS-1.3 RetryRequest
-handle_unnegotiated_version(?'TLS-1.2' , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
+handle_unnegotiated_version(?TLS_1_2 , #{versions := [?TLS_1_3 = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
     tls_handshake:get_tls_handshakes(Version, Data, Buffer, Options);
 %% When the `negotiated_version` variable is not yet set use the highest supported version.
 handle_unnegotiated_version(undefined, #{versions := [Version|_]} = Options, Data, Buff, _, _) ->

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -33,6 +33,7 @@
 -include("ssl_alert.hrl").
 -include("ssl_api.hrl").
 -include("ssl_internal.hrl").
+-include("tls_record_1_3.hrl").
 
 %% Setup
 -export([start_fsm/8,
@@ -741,7 +742,7 @@ activate_socket(#state{protocol_specific = #{active_n_toggle := true, active_n :
 next_record(State, CipherTexts, ConnectionStates, Check) ->
     next_record(State, CipherTexts, ConnectionStates, Check, [], false).
 %%
-next_record(#state{connection_env = #connection_env{negotiated_version = {3,4} = Version}} = State,
+next_record(#state{connection_env = #connection_env{negotiated_version = ?'TLS-1.3' = Version}} = State,
             [CT|CipherTexts], ConnectionStates0, Check, Acc, IsEarlyData) ->
     case tls_record:decode_cipher_text(Version, CT, ConnectionStates0, Check) of
         {Record = #ssl_tls{type = ?APPLICATION_DATA, fragment = Fragment}, ConnectionStates} ->
@@ -831,7 +832,7 @@ next_record_done(#state{protocol_buffers = Buffers} = State, CipherTexts, Connec
 %% field in TLS-1.3 client hello). The versions are instead negotiated with an hello extension. When
 %% decoding the server_hello messages we want to go through TLS-1.3 decode functions to be able
 %% to handle TLS-1.3 extensions if TLS-1.3 will be the negotiated version.
-handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Options, Data, Buffer, client, hello) ->
+handle_unnegotiated_version(?LEGACY_VERSION , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, hello) ->
     %% The effective version for decoding the server hello message should be the TLS-1.3. Possible coalesced TLS-1.2
     %% server handshake messages should be decoded with the negotiated version in later state.
     <<_:8, ?UINT24(Length), _/binary>> = Data,
@@ -839,7 +840,7 @@ handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Option
     {HSPacket, <<>> = NewHsBuffer} = tls_handshake:get_tls_handshakes(Version, FirstPacket, Buffer, Options),
     {HSPacket, NewHsBuffer, RecordRest};
 %% TLS-1.3 RetryRequest
-handle_unnegotiated_version({3,3} , #{versions := [{3,4} = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
+handle_unnegotiated_version(?'TLS-1.2' , #{versions := [?'TLS-1.3' = Version |_]} = Options, Data, Buffer, client, wait_sh) ->
     tls_handshake:get_tls_handshakes(Version, Data, Buffer, Options);
 %% When the `negotiated_version` variable is not yet set use the highest supported version.
 handle_unnegotiated_version(undefined, #{versions := [Version|_]} = Options, Data, Buff, _, _) ->

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -74,9 +74,9 @@ client_hello(_Host, _Port, ConnectionStates,
     %% legacy_version field MUST be set to 0x0303, which is the version
     %% number for TLS 1.2.
     LegacyVersion =
-        case tls_record:is_higher(Version, ?'TLS-1.1') of
+        case tls_record:is_higher(Version, ?TLS_1_1) of
             true ->
-                ?'TLS-1.2';
+                ?TLS_1_2;
             false ->
                 Version
         end,
@@ -168,15 +168,15 @@ hello(#server_hello{server_version = LegacyVersion,
     %% (Section 4.2.1), and the legacy_version field MUST be set to 0x0303, which is the version
     %% number for TLS 1.2.
     %% The "supported_versions" extension is supported from TLS 1.2.
-    case LegacyVersion > ?'TLS-1.2' orelse
-        LegacyVersion =:= ?'TLS-1.2' andalso Version < ?'TLS-1.2' of
+    case ?TLS_L(LegacyVersion, ?TLS_1_2) orelse
+        LegacyVersion =:= ?TLS_1_2 andalso ?TLS_L(Version,  ?TLS_1_2) of
         true ->
             throw(?ALERT_REC(?FATAL, ?ILLEGAL_PARAMETER));
         false ->
             case tls_record:is_acceptable_version(Version, SupportedVersions) of
                 true ->
                     case Version of
-                        ?'TLS-1.2' ->
+                        ?TLS_1_2 ->
                             IsNew = ssl_session:is_new(OldId, SessionId),
                             %% TLS 1.2 ServerHello with "supported_versions" (special case)
                             handle_server_hello_extensions(Version, SessionId, Random, CipherSuite,
@@ -409,9 +409,9 @@ do_hello(Version, Versions, CipherSuites, Hello, SslOpts, Info, Renegotiation) -
     end.
 
 %%--------------------------------------------------------------------
-enc_handshake(#hello_request{}, ?'TLS-1.X'=Version) when Version < ?'TLS-1.3' ->
+enc_handshake(#hello_request{}, Version) when ?TLS_L(Version, ?TLS_1_3)->
     {?HELLO_REQUEST, <<>>};
-enc_handshake(#client_hello{client_version = {Major, Minor} = Version,
+enc_handshake(#client_hello{client_version = ServerVersion,
 		     random = Random,
 		     session_id = SessionID,
 		     cipher_suites = CipherSuites,
@@ -422,36 +422,37 @@ enc_handshake(#client_hello{client_version = {Major, Minor} = Version,
     CmLength = byte_size(BinCompMethods),
     BinCipherSuites = list_to_binary(CipherSuites),
     CsLength = byte_size(BinCipherSuites),
-    ExtensionsBin = ssl_handshake:encode_hello_extensions(HelloExtensions, Version),
+    ExtensionsBin = ssl_handshake:encode_hello_extensions(HelloExtensions),
+    {Major,Minor} = ServerVersion,
 
     {?CLIENT_HELLO, <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,
 		      ?BYTE(SIDLength), SessionID/binary,
 		      ?UINT16(CsLength), BinCipherSuites/binary,
 		      ?BYTE(CmLength), BinCompMethods/binary, ExtensionsBin/binary>>};
-enc_handshake(HandshakeMsg, ?'TLS-1.3') ->
+enc_handshake(HandshakeMsg, ?TLS_1_3) ->
     tls_handshake_1_3:encode_handshake(HandshakeMsg);
 enc_handshake(HandshakeMsg, Version) ->
     ssl_handshake:encode_handshake(HandshakeMsg, Version).
 
 %%--------------------------------------------------------------------
 get_tls_handshakes_aux(Version, <<?BYTE(Type), ?UINT24(Length),
-				 Body:Length/binary,Rest/binary>>, 
+                                  Body:Length/binary,Rest/binary>>,
                       #{log_level := LogLevel} = Opts,  Acc) ->
     Raw = <<?BYTE(Type), ?UINT24(Length), Body/binary>>,
     try decode_handshake(Version, Type, Body) of
-	Handshake ->
+        Handshake ->
             ssl_logger:debug(LogLevel, inbound, 'handshake', Handshake),
-	    get_tls_handshakes_aux(Version, Rest, Opts, [{Handshake,Raw} | Acc])
+            get_tls_handshakes_aux(Version, Rest, Opts, [{Handshake,Raw} | Acc])
     catch
-	error:Reason:ST ->
+        error:Reason:ST ->
             ?SSL_LOG(info, handshake_error, [{reason,Reason}, {stacktrace, ST}]),
-	    throw(?ALERT_REC(?FATAL, ?DECODE_ERROR, handshake_decode_error))
+            throw(?ALERT_REC(?FATAL, ?DECODE_ERROR, handshake_decode_error))
     end;
 get_tls_handshakes_aux(_Version, Data, _, Acc) ->
     {lists:reverse(Acc), Data}.
 
-decode_handshake(?'TLS-1.X'=Version, ?HELLO_REQUEST, <<>>)
-  when Version < ?'TLS-1.3' ->
+decode_handshake(Version, ?HELLO_REQUEST, <<>>)
+  when ?TLS_L(Version, ?TLS_1_3) ->
     #hello_request{};
 decode_handshake(Version, ?CLIENT_HELLO,
                  <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,
@@ -470,7 +471,7 @@ decode_handshake(Version, ?CLIENT_HELLO,
        compression_methods = erlang:binary_to_list(Comp_methods),
        extensions = DecodedExtensions
       };
-decode_handshake(?'TLS-1.3', Tag, Msg) ->
+decode_handshake(?TLS_1_3, Tag, Msg) ->
     tls_handshake_1_3:decode_handshake(Tag, Msg);
 decode_handshake(Version, Tag, Msg) ->
     ssl_handshake:decode_handshake(Version, Tag, Msg).
@@ -481,7 +482,7 @@ ocsp_expect(true) ->
 ocsp_expect(_) ->
     no_staple.
 
-get_signature_ext(Ext, HelloExt, ?'TLS-1.2') ->
+get_signature_ext(Ext, HelloExt, ?TLS_1_2) ->
     case maps:get(Ext, HelloExt, undefined) of
         %% Signature algorithms was not sent
         undefined ->

--- a/lib/ssl/src/tls_handshake.erl
+++ b/lib/ssl/src/tls_handshake.erl
@@ -168,8 +168,8 @@ hello(#server_hello{server_version = LegacyVersion,
     %% (Section 4.2.1), and the legacy_version field MUST be set to 0x0303, which is the version
     %% number for TLS 1.2.
     %% The "supported_versions" extension is supported from TLS 1.2.
-    case ?TLS_L(LegacyVersion, ?TLS_1_2) orelse
-        LegacyVersion =:= ?TLS_1_2 andalso ?TLS_L(Version,  ?TLS_1_2) of
+    case ?TLS_LT(LegacyVersion, ?TLS_1_2) orelse
+        LegacyVersion =:= ?TLS_1_2 andalso ?TLS_LT(Version,  ?TLS_1_2) of
         true ->
             throw(?ALERT_REC(?FATAL, ?ILLEGAL_PARAMETER));
         false ->
@@ -409,7 +409,7 @@ do_hello(Version, Versions, CipherSuites, Hello, SslOpts, Info, Renegotiation) -
     end.
 
 %%--------------------------------------------------------------------
-enc_handshake(#hello_request{}, Version) when ?TLS_L(Version, ?TLS_1_3)->
+enc_handshake(#hello_request{}, Version) when ?TLS_LT(Version, ?TLS_1_3)->
     {?HELLO_REQUEST, <<>>};
 enc_handshake(#client_hello{client_version = ServerVersion,
 		     random = Random,
@@ -452,7 +452,7 @@ get_tls_handshakes_aux(_Version, Data, _, Acc) ->
     {lists:reverse(Acc), Data}.
 
 decode_handshake(Version, ?HELLO_REQUEST, <<>>)
-  when ?TLS_L(Version, ?TLS_1_3) ->
+  when ?TLS_LT(Version, ?TLS_1_3) ->
     #hello_request{};
 decode_handshake(Version, ?CLIENT_HELLO,
                  <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -123,19 +123,20 @@ server_hello(MsgType, SessionId, KeyShare, PSK, ConnectionStates) ->
 %% ClientHello, with the exception of optionally the "cookie" (see
 %% Section 4.2.2) extension.
 server_hello_extensions(hello_retry_request = MsgType, KeyShare, _) ->
-    SupportedVersions = #server_hello_selected_version{selected_version = ?'TLS-1.3'},
-    Extensions = #{server_hello_selected_version => SupportedVersions},
+    Extensions = server_hello_extensions_versions(),
     ssl_handshake:add_server_share(MsgType, Extensions, KeyShare);
 server_hello_extensions(MsgType, KeyShare, undefined) ->
-    SupportedVersions = #server_hello_selected_version{selected_version = ?'TLS-1.3'},
-    Extensions = #{server_hello_selected_version => SupportedVersions},
+    Extensions = server_hello_extensions_versions(),
     ssl_handshake:add_server_share(MsgType, Extensions, KeyShare);
 server_hello_extensions(MsgType, KeyShare, {SelectedIdentity, _}) ->
-    SupportedVersions = #server_hello_selected_version{selected_version = ?'TLS-1.3'},
+    Extensions = server_hello_extensions_versions(),
     PreSharedKey = #pre_shared_key_server_hello{selected_identity = SelectedIdentity},
-    Extensions = #{server_hello_selected_version => SupportedVersions,
-                   pre_shared_key => PreSharedKey},
-    ssl_handshake:add_server_share(MsgType, Extensions, KeyShare).
+    ssl_handshake:add_server_share(MsgType, Extensions#{pre_shared_key => PreSharedKey}, KeyShare).
+
+server_hello_extensions_versions() ->
+    SupportedVersions = #server_hello_selected_version{selected_version = ?TLS_1_3},
+    #{server_hello_selected_version => SupportedVersions}.
+
 
 
 server_hello_random(server_hello, #security_parameters{server_random = Random}) ->
@@ -571,7 +572,7 @@ encode_handshake(#key_update{request_update = Update}) ->
     EncUpdate = encode_key_update(Update),
     {?KEY_UPDATE, <<EncUpdate/binary>>};
 encode_handshake(HandshakeMsg) ->
-    ssl_handshake:encode_handshake(HandshakeMsg, ?'TLS-1.3').
+    ssl_handshake:encode_handshake(HandshakeMsg, ?TLS_1_3).
 
 encode_early_data(Cipher,
                   #state{
@@ -604,7 +605,7 @@ decode_handshake(?SERVER_HELLO, <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,
                                   Cipher_suite:2/binary, ?BYTE(Comp_method),
                                   ?UINT16(ExtLen), Extensions:ExtLen/binary>>)
   when Random =:= ?HELLO_RETRY_REQUEST_RANDOM ->
-    HelloExtensions = ssl_handshake:decode_hello_extensions(Extensions, ?'TLS-1.3', {Major, Minor},
+    HelloExtensions = ssl_handshake:decode_hello_extensions(Extensions, ?TLS_1_3, {Major, Minor},
                                                             hello_retry_request),
     #server_hello{
        server_version = {Major,Minor},
@@ -661,7 +662,7 @@ decode_handshake(?END_OF_EARLY_DATA, _) ->
 decode_handshake(?KEY_UPDATE, <<?BYTE(Update)>>) ->
     #key_update{request_update = decode_key_update(Update)};
 decode_handshake(Tag, HandshakeMsg) ->
-    ssl_handshake:decode_handshake(?'TLS-1.3', Tag, HandshakeMsg).
+    ssl_handshake:decode_handshake(?TLS_1_3, Tag, HandshakeMsg).
 
 is_valid_binder(Binder, HHistory, PSK, Hash) ->
     case HHistory of
@@ -727,21 +728,14 @@ decode_key_update(N) ->
     throw(?ALERT_REC(?FATAL, ?ILLEGAL_PARAMETER, {request_update,N})).
 
 decode_cert_entries(Entries) ->
-    decode_cert_entries(Entries, []).
-
-decode_cert_entries(<<>>, Acc) ->
-    lists:reverse(Acc);
-decode_cert_entries(<<?UINT24(DSize), Data:DSize/binary, ?UINT16(Esize), BinExts:Esize/binary,
-                      Rest/binary>>, Acc) ->
-    Exts = decode_extensions(BinExts, certificate_request),
-    decode_cert_entries(Rest, [#certificate_entry{data = Data,
-                                                  extensions = Exts} | Acc]).
+    [ #certificate_entry{data = Data, extensions = decode_extensions(BinExts, certificate_request)}
+      || <<?UINT24(DSize), Data:DSize/binary, ?UINT16(Esize), BinExts:Esize/binary>> <= Entries ].
 
 encode_extensions(Exts)->
     ssl_handshake:encode_extensions(extensions_list(Exts)).
 
 decode_extensions(Exts, MessageType) ->
-    ssl_handshake:decode_extensions(Exts, ?'TLS-1.3', MessageType).
+    ssl_handshake:decode_extensions(Exts, ?TLS_1_3, MessageType).
 
 extensions_list(Extensions) ->
     [Ext || {_, Ext} <- maps:to_list(Extensions)].
@@ -780,7 +774,7 @@ certificate_entry(DER) ->
 sign(THash, Context, HashAlgo, PrivateKey, SignAlgo) ->
     Content = build_content(Context, THash),
     try
-        {ok, ssl_handshake:digitally_signed(?'TLS-1.3', Content, HashAlgo, PrivateKey, SignAlgo)}
+        {ok, ssl_handshake:digitally_signed(?TLS_1_3, Content, HashAlgo, PrivateKey, SignAlgo)}
     catch throw:Alert ->
             {error, Alert}
     end.
@@ -788,7 +782,7 @@ sign(THash, Context, HashAlgo, PrivateKey, SignAlgo) ->
 
 verify(THash, Context, HashAlgo, SignAlgo, Signature, PublicKeyInfo) ->
     Content = build_content(Context, THash),
-    try ssl_handshake:verify_signature(?'TLS-1.3', Content, {HashAlgo, SignAlgo}, Signature, PublicKeyInfo) of
+    try ssl_handshake:verify_signature(?TLS_1_3, Content, {HashAlgo, SignAlgo}, Signature, PublicKeyInfo) of
         Result ->
             {ok, Result}
     catch
@@ -824,7 +818,7 @@ validate_certificate_chain(CertEntries, CertDbHandle, CertDbRef,
                 ?DEFAULT_OCSP_RESPONDER_CERTS
         end,
     ssl_handshake:certify(#certificate{asn1_certificates = Certs}, CertDbHandle, CertDbRef,
-                          SslOptions, CRLDbHandle, Role, Host, ?'TLS-1.3',
+                          SslOptions, CRLDbHandle, Role, Host, ?TLS_1_3,
                           #{cert_ext => CertExt,
                             ocsp_state => OcspState,
                             ocsp_responder_certs => OcspResponderCerts}).
@@ -1265,7 +1259,7 @@ update_start_state(#state{connection_states = ConnectionStates0,
                                           sign_alg = SelectedSignAlg,
                                           dh_public_value = PeerPublicKey,
                                           cipher_suite = Cipher},
-                connection_env = CEnv#connection_env{negotiated_version = ?'TLS-1.3'}}.
+                connection_env = CEnv#connection_env{negotiated_version = ?TLS_1_3}}.
 
 
 update_resumption_master_secret(#state{connection_states = ConnectionStates0} = State,
@@ -1640,25 +1634,25 @@ handle_pre_shared_key(#state{ssl_options = #{session_tickets := Tickets},
 %% message, as described in Section 4.4.1.
 maybe_add_binders(Hello, undefined, _) ->
     Hello;
-maybe_add_binders(Hello0, TicketData, Version) when Version =:= ?'TLS-1.3' ->
+maybe_add_binders(Hello0, TicketData, ?TLS_1_3=Version) ->
     HelloBin0 = tls_handshake:encode_handshake(Hello0, Version),
     HelloBin1 = iolist_to_binary(HelloBin0),
     Truncated = truncate_client_hello(HelloBin1),
     Binders = create_binders([Truncated], TicketData),
     update_binders(Hello0, Binders);
-maybe_add_binders(Hello, _, Version) when Version =< ?'TLS-1.2' ->
+maybe_add_binders(Hello, _, Version) when ?TLS_LE(Version, ?TLS_1_2) ->
     Hello.
 %%
 %% HelloRetryRequest
 maybe_add_binders(Hello, _, undefined, _) ->
     Hello;
-maybe_add_binders(Hello0, {[HRR,MessageHash|_], _}, TicketData, Version) when Version =:= ?'TLS-1.3' ->
+maybe_add_binders(Hello0, {[HRR,MessageHash|_], _}, TicketData, ?TLS_1_3=Version) ->
     HelloBin0 = tls_handshake:encode_handshake(Hello0, Version),
     HelloBin1 = iolist_to_binary(HelloBin0),
     Truncated = truncate_client_hello(HelloBin1),
     Binders = create_binders([MessageHash,HRR,Truncated], TicketData),
     update_binders(Hello0, Binders);
-maybe_add_binders(Hello, _, _, Version) when Version =< ?'TLS-1.2' ->
+maybe_add_binders(Hello, _, _, Version) when ?TLS_LE(Version, ?TLS_1_2) ->
     Hello.
 
 create_binders(Context, TicketData) ->
@@ -1684,7 +1678,7 @@ truncate_client_hello(HelloBin0) ->
     <<?BYTE(Type), ?UINT24(_Length), Body/binary>> = HelloBin0,
     CH0 = #client_hello{
              extensions = #{pre_shared_key := PSK0} = Extensions0} =
-        tls_handshake:decode_handshake(?'TLS-1.3', Type, Body),
+        tls_handshake:decode_handshake(?TLS_1_3, Type, Body),
     #pre_shared_key_client_hello{offered_psks = OfferedPsks0} = PSK0,
     OfferedPsks = OfferedPsks0#offered_psks{binders = []},
     PSK = PSK0#pre_shared_key_client_hello{offered_psks = OfferedPsks},
@@ -1697,8 +1691,8 @@ truncate_client_hello(HelloBin0) ->
     %% The original length of the binders can still be determined by
     %% re-encoding the original ClientHello and using its size as reference
     %% when we subtract the size of the truncated binary.
-    TruncatedSize = iolist_size(tls_handshake:encode_handshake(CH, ?'TLS-1.3')),
-    RefSize = iolist_size(tls_handshake:encode_handshake(CH0, ?'TLS-1.3')),
+    TruncatedSize = iolist_size(tls_handshake:encode_handshake(CH, ?TLS_1_3)),
+    RefSize = iolist_size(tls_handshake:encode_handshake(CH0, ?TLS_1_3)),
     BindersSize = RefSize - TruncatedSize,
 
     %% Return the truncated ClientHello by cutting of the binders from the original
@@ -1709,9 +1703,8 @@ truncate_client_hello(HelloBin0) ->
 maybe_add_early_data_indication(#client_hello{
                                    extensions = Extensions0} = ClientHello,
                                 EarlyData,
-                                Version)
-  when Version =:= ?'TLS-1.3' andalso
-       is_binary(EarlyData) andalso
+                                ?TLS_1_3)
+  when is_binary(EarlyData) andalso
        byte_size(EarlyData) > 0 ->
     Extensions = Extensions0#{early_data =>
                                   #early_data_indication{}},
@@ -1783,13 +1776,16 @@ choose_ticket(_, _) ->
     undefined.
 
 ciphers_for_early_data(CipherSuites0) ->
-    %% Use only supported TLS 1.3 cipher suites
-    Supported = lists:filter(fun(CipherSuite) ->
-                                     lists:member(CipherSuite, tls_v1:exclusive_suites(?'TLS-1.3')) end,
-                             CipherSuites0),
     %% Return supported block cipher algorithms
-    lists:map(fun(#{cipher := Cipher}) -> Cipher end,
-              lists:map(fun ssl_cipher_format:suite_bin_to_map/1, Supported)).
+    lists:filtermap(fun ciphers_for_early_data0/1, CipherSuites0).
+
+ciphers_for_early_data0(CipherSuite) ->
+    %% Use only supported TLS 1.3 cipher suites
+    case lists:member(CipherSuite, tls_v1:exclusive_suites(?TLS_1_3)) of
+        true -> {true, maps:get(cipher, ssl_cipher_format:suite_bin_to_map(CipherSuite))};
+        false -> false
+    end.
+
 
 get_ticket_data(_, undefined, _) ->
     undefined;

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -1640,7 +1640,7 @@ maybe_add_binders(Hello0, TicketData, ?TLS_1_3=Version) ->
     Truncated = truncate_client_hello(HelloBin1),
     Binders = create_binders([Truncated], TicketData),
     update_binders(Hello0, Binders);
-maybe_add_binders(Hello, _, Version) when ?TLS_LE(Version, ?TLS_1_2) ->
+maybe_add_binders(Hello, _, Version) when ?TLS_LTE(Version, ?TLS_1_2) ->
     Hello.
 %%
 %% HelloRetryRequest
@@ -1652,7 +1652,7 @@ maybe_add_binders(Hello0, {[HRR,MessageHash|_], _}, TicketData, ?TLS_1_3=Version
     Truncated = truncate_client_hello(HelloBin1),
     Binders = create_binders([MessageHash,HRR,Truncated], TicketData),
     update_binders(Hello0, Binders);
-maybe_add_binders(Hello, _, _, Version) when ?TLS_LE(Version, ?TLS_1_2) ->
+maybe_add_binders(Hello, _, _, Version) when ?TLS_LTE(Version, ?TLS_1_2) ->
     Hello.
 
 create_binders(Context, TicketData) ->

--- a/lib/ssl/src/tls_handshake_1_3.erl
+++ b/lib/ssl/src/tls_handshake_1_3.erl
@@ -106,7 +106,7 @@ server_hello(MsgType, SessionId, KeyShare, PSK, ConnectionStates) ->
     #{security_parameters := SecParams} =
 	ssl_record:pending_connection_state(ConnectionStates, read),
     Extensions = server_hello_extensions(MsgType, KeyShare, PSK),
-    #server_hello{server_version = {3,3}, %% legacy_version
+    #server_hello{server_version = ?LEGACY_VERSION, %% legacy_version
 		  cipher_suite = SecParams#security_parameters.cipher_suite,
                   compression_method = 0, %% legacy attribute
 		  random = server_hello_random(MsgType, SecParams),
@@ -123,15 +123,15 @@ server_hello(MsgType, SessionId, KeyShare, PSK, ConnectionStates) ->
 %% ClientHello, with the exception of optionally the "cookie" (see
 %% Section 4.2.2) extension.
 server_hello_extensions(hello_retry_request = MsgType, KeyShare, _) ->
-    SupportedVersions = #server_hello_selected_version{selected_version = {3,4}},
+    SupportedVersions = #server_hello_selected_version{selected_version = ?'TLS-1.3'},
     Extensions = #{server_hello_selected_version => SupportedVersions},
     ssl_handshake:add_server_share(MsgType, Extensions, KeyShare);
 server_hello_extensions(MsgType, KeyShare, undefined) ->
-    SupportedVersions = #server_hello_selected_version{selected_version = {3,4}},
+    SupportedVersions = #server_hello_selected_version{selected_version = ?'TLS-1.3'},
     Extensions = #{server_hello_selected_version => SupportedVersions},
     ssl_handshake:add_server_share(MsgType, Extensions, KeyShare);
 server_hello_extensions(MsgType, KeyShare, {SelectedIdentity, _}) ->
-    SupportedVersions = #server_hello_selected_version{selected_version = {3,4}},
+    SupportedVersions = #server_hello_selected_version{selected_version = ?'TLS-1.3'},
     PreSharedKey = #pre_shared_key_server_hello{selected_identity = SelectedIdentity},
     Extensions = #{server_hello_selected_version => SupportedVersions,
                    pre_shared_key => PreSharedKey},
@@ -571,7 +571,7 @@ encode_handshake(#key_update{request_update = Update}) ->
     EncUpdate = encode_key_update(Update),
     {?KEY_UPDATE, <<EncUpdate/binary>>};
 encode_handshake(HandshakeMsg) ->
-    ssl_handshake:encode_handshake(HandshakeMsg, {3,4}).
+    ssl_handshake:encode_handshake(HandshakeMsg, ?'TLS-1.3').
 
 encode_early_data(Cipher,
                   #state{
@@ -604,7 +604,7 @@ decode_handshake(?SERVER_HELLO, <<?BYTE(Major), ?BYTE(Minor), Random:32/binary,
                                   Cipher_suite:2/binary, ?BYTE(Comp_method),
                                   ?UINT16(ExtLen), Extensions:ExtLen/binary>>)
   when Random =:= ?HELLO_RETRY_REQUEST_RANDOM ->
-    HelloExtensions = ssl_handshake:decode_hello_extensions(Extensions, {3,4}, {Major, Minor},
+    HelloExtensions = ssl_handshake:decode_hello_extensions(Extensions, ?'TLS-1.3', {Major, Minor},
                                                             hello_retry_request),
     #server_hello{
        server_version = {Major,Minor},
@@ -661,7 +661,7 @@ decode_handshake(?END_OF_EARLY_DATA, _) ->
 decode_handshake(?KEY_UPDATE, <<?BYTE(Update)>>) ->
     #key_update{request_update = decode_key_update(Update)};
 decode_handshake(Tag, HandshakeMsg) ->
-    ssl_handshake:decode_handshake({3,4}, Tag, HandshakeMsg).
+    ssl_handshake:decode_handshake(?'TLS-1.3', Tag, HandshakeMsg).
 
 is_valid_binder(Binder, HHistory, PSK, Hash) ->
     case HHistory of
@@ -741,7 +741,7 @@ encode_extensions(Exts)->
     ssl_handshake:encode_extensions(extensions_list(Exts)).
 
 decode_extensions(Exts, MessageType) ->
-    ssl_handshake:decode_extensions(Exts, {3,4}, MessageType).
+    ssl_handshake:decode_extensions(Exts, ?'TLS-1.3', MessageType).
 
 extensions_list(Extensions) ->
     [Ext || {_, Ext} <- maps:to_list(Extensions)].
@@ -780,7 +780,7 @@ certificate_entry(DER) ->
 sign(THash, Context, HashAlgo, PrivateKey, SignAlgo) ->
     Content = build_content(Context, THash),
     try
-        {ok, ssl_handshake:digitally_signed({3,4}, Content, HashAlgo, PrivateKey, SignAlgo)}
+        {ok, ssl_handshake:digitally_signed(?'TLS-1.3', Content, HashAlgo, PrivateKey, SignAlgo)}
     catch throw:Alert ->
             {error, Alert}
     end.
@@ -788,7 +788,7 @@ sign(THash, Context, HashAlgo, PrivateKey, SignAlgo) ->
 
 verify(THash, Context, HashAlgo, SignAlgo, Signature, PublicKeyInfo) ->
     Content = build_content(Context, THash),
-    try ssl_handshake:verify_signature({3, 4}, Content, {HashAlgo, SignAlgo}, Signature, PublicKeyInfo) of
+    try ssl_handshake:verify_signature(?'TLS-1.3', Content, {HashAlgo, SignAlgo}, Signature, PublicKeyInfo) of
         Result ->
             {ok, Result}
     catch
@@ -824,7 +824,7 @@ validate_certificate_chain(CertEntries, CertDbHandle, CertDbRef,
                 ?DEFAULT_OCSP_RESPONDER_CERTS
         end,
     ssl_handshake:certify(#certificate{asn1_certificates = Certs}, CertDbHandle, CertDbRef,
-                          SslOptions, CRLDbHandle, Role, Host, {3,4},
+                          SslOptions, CRLDbHandle, Role, Host, ?'TLS-1.3',
                           #{cert_ext => CertExt,
                             ocsp_state => OcspState,
                             ocsp_responder_certs => OcspResponderCerts}).
@@ -1265,7 +1265,7 @@ update_start_state(#state{connection_states = ConnectionStates0,
                                           sign_alg = SelectedSignAlg,
                                           dh_public_value = PeerPublicKey,
                                           cipher_suite = Cipher},
-                connection_env = CEnv#connection_env{negotiated_version = {3,4}}}.
+                connection_env = CEnv#connection_env{negotiated_version = ?'TLS-1.3'}}.
 
 
 update_resumption_master_secret(#state{connection_states = ConnectionStates0} = State,
@@ -1640,25 +1640,25 @@ handle_pre_shared_key(#state{ssl_options = #{session_tickets := Tickets},
 %% message, as described in Section 4.4.1.
 maybe_add_binders(Hello, undefined, _) ->
     Hello;
-maybe_add_binders(Hello0, TicketData, Version) when Version =:= {3,4} ->
+maybe_add_binders(Hello0, TicketData, Version) when Version =:= ?'TLS-1.3' ->
     HelloBin0 = tls_handshake:encode_handshake(Hello0, Version),
     HelloBin1 = iolist_to_binary(HelloBin0),
     Truncated = truncate_client_hello(HelloBin1),
     Binders = create_binders([Truncated], TicketData),
     update_binders(Hello0, Binders);
-maybe_add_binders(Hello, _, Version) when Version =< {3,3} ->
+maybe_add_binders(Hello, _, Version) when Version =< ?'TLS-1.2' ->
     Hello.
 %%
 %% HelloRetryRequest
 maybe_add_binders(Hello, _, undefined, _) ->
     Hello;
-maybe_add_binders(Hello0, {[HRR,MessageHash|_], _}, TicketData, Version) when Version =:= {3,4} ->
+maybe_add_binders(Hello0, {[HRR,MessageHash|_], _}, TicketData, Version) when Version =:= ?'TLS-1.3' ->
     HelloBin0 = tls_handshake:encode_handshake(Hello0, Version),
     HelloBin1 = iolist_to_binary(HelloBin0),
     Truncated = truncate_client_hello(HelloBin1),
     Binders = create_binders([MessageHash,HRR,Truncated], TicketData),
     update_binders(Hello0, Binders);
-maybe_add_binders(Hello, _, _, Version) when Version =< {3,3} ->
+maybe_add_binders(Hello, _, _, Version) when Version =< ?'TLS-1.2' ->
     Hello.
 
 create_binders(Context, TicketData) ->
@@ -1684,7 +1684,7 @@ truncate_client_hello(HelloBin0) ->
     <<?BYTE(Type), ?UINT24(_Length), Body/binary>> = HelloBin0,
     CH0 = #client_hello{
              extensions = #{pre_shared_key := PSK0} = Extensions0} =
-        tls_handshake:decode_handshake({3,4}, Type, Body),
+        tls_handshake:decode_handshake(?'TLS-1.3', Type, Body),
     #pre_shared_key_client_hello{offered_psks = OfferedPsks0} = PSK0,
     OfferedPsks = OfferedPsks0#offered_psks{binders = []},
     PSK = PSK0#pre_shared_key_client_hello{offered_psks = OfferedPsks},
@@ -1697,8 +1697,8 @@ truncate_client_hello(HelloBin0) ->
     %% The original length of the binders can still be determined by
     %% re-encoding the original ClientHello and using its size as reference
     %% when we subtract the size of the truncated binary.
-    TruncatedSize = iolist_size(tls_handshake:encode_handshake(CH, {3,4})),
-    RefSize = iolist_size(tls_handshake:encode_handshake(CH0, {3,4})),
+    TruncatedSize = iolist_size(tls_handshake:encode_handshake(CH, ?'TLS-1.3')),
+    RefSize = iolist_size(tls_handshake:encode_handshake(CH0, ?'TLS-1.3')),
     BindersSize = RefSize - TruncatedSize,
 
     %% Return the truncated ClientHello by cutting of the binders from the original
@@ -1710,7 +1710,7 @@ maybe_add_early_data_indication(#client_hello{
                                    extensions = Extensions0} = ClientHello,
                                 EarlyData,
                                 Version)
-  when Version =:= {3,4} andalso
+  when Version =:= ?'TLS-1.3' andalso
        is_binary(EarlyData) andalso
        byte_size(EarlyData) > 0 ->
     Extensions = Extensions0#{early_data =>
@@ -1785,7 +1785,7 @@ choose_ticket(_, _) ->
 ciphers_for_early_data(CipherSuites0) ->
     %% Use only supported TLS 1.3 cipher suites
     Supported = lists:filter(fun(CipherSuite) ->
-                                     lists:member(CipherSuite, tls_v1:exclusive_suites(4)) end,
+                                     lists:member(CipherSuite, tls_v1:exclusive_suites(?'TLS-1.3')) end,
                              CipherSuites0),
     %% Return supported block cipher algorithms
     lists:map(fun(#{cipher := Cipher}) -> Cipher end,

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -49,7 +49,7 @@
 -export([build_tls_record/1]).
 
 %% Protocol version handling
--export([protocol_version/1,  lowest_protocol_version/1, lowest_protocol_version/2,
+-export([protocol_version/1, protocol_version_name/1,  lowest_protocol_version/1, lowest_protocol_version/2,
 	 highest_protocol_version/1, highest_protocol_version/2,
 	 is_higher/2, supported_protocol_versions/0, sufficient_crypto_support/1,
 	 is_acceptable_version/1, is_acceptable_version/2, hello_version/1]).
@@ -273,24 +273,31 @@ decode_cipher_text(_, #ssl_tls{version = Version,
 %%====================================================================
 
 %%--------------------------------------------------------------------
--spec protocol_version(tls_atom_version() | tls_version()) -> 
-			      tls_version() | tls_atom_version().		      
+-spec protocol_version_name(tls_atom_version()) -> tls_version().
 %%     
 %% Description: Creates a protocol version record from a version atom
 %% or vice versa.
 %%--------------------------------------------------------------------
-protocol_version('tlsv1.3') ->
+protocol_version_name('tlsv1.3') ->
     ?TLS_1_3;
-protocol_version('tlsv1.2') ->
+protocol_version_name('tlsv1.2') ->
     ?TLS_1_2;
-protocol_version('tlsv1.1') ->
+protocol_version_name('tlsv1.1') ->
     ?TLS_1_1;
-protocol_version(tlsv1) ->
+protocol_version_name(tlsv1) ->
     ?TLS_1_0;
-protocol_version(sslv3) ->
+protocol_version_name(sslv3) ->
     ?SSL_3_0;
-protocol_version(sslv2) -> %% Backwards compatibility
-    ?SSL_2_0;
+protocol_version_name(sslv2) -> %% Backwards compatibility
+    ?SSL_2_0.
+
+%%--------------------------------------------------------------------
+-spec protocol_version(tls_version()) -> tls_atom_version().
+%%
+%% Description: Creates a protocol version record from a version atom
+%% or vice versa.
+%%--------------------------------------------------------------------
+
 protocol_version(?TLS_1_3) ->
     'tlsv1.3';
 protocol_version(?TLS_1_2) ->
@@ -359,7 +366,7 @@ is_higher(_, _) ->
 %%--------------------------------------------------------------------
 supported_protocol_versions() ->
     Fun = fun(Version) ->
-		  protocol_version(Version) 
+		  protocol_version_name(Version)
 	  end,
     case application:get_env(ssl, protocol_version) of
 	undefined ->

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -306,7 +306,7 @@ protocol_version(?SSL_3_0) ->
 %%     
 %% Description: Lowes protocol version of two given versions 
 %%--------------------------------------------------------------------
-lowest_protocol_version(Version1, Version2) when ?TLS_L(Version1, Version2) ->
+lowest_protocol_version(Version1, Version2) when ?TLS_LT(Version1, Version2) ->
     Version1;
 lowest_protocol_version(_, Version2) ->
     Version2.
@@ -336,7 +336,7 @@ check_protocol_version([Ver | Versions], Fun) -> lists:foldl(Fun, Ver, Versions)
 %%     
 %% Description: Highest protocol version of two given versions 
 %%--------------------------------------------------------------------
-highest_protocol_version(Version1, Version2) when ?TLS_G(Version1, Version2) ->
+highest_protocol_version(Version1, Version2) when ?TLS_GT(Version1, Version2) ->
     Version1;
 highest_protocol_version(_, Version2) ->
     Version2.
@@ -346,7 +346,7 @@ highest_protocol_version(_, Version2) ->
 %%     
 %% Description: Is V1 > V2
 %%--------------------------------------------------------------------
-is_higher(V1, V2) when ?TLS_G(V1, V2) ->
+is_higher(V1, V2) when ?TLS_GT(V1, V2) ->
     true;
 is_higher(_, _) ->
     false.
@@ -457,7 +457,7 @@ is_acceptable_version(Version, Versions) ->
     ?TLS_1_X(Version) andalso lists:member(Version, Versions).
 
 -spec hello_version([tls_version()]) -> tls_version().
-hello_version([Highest|_]) when ?TLS_GE(Highest, ?TLS_1_2) ->
+hello_version([Highest|_]) when ?TLS_GTE(Highest, ?TLS_1_2) ->
     ?TLS_1_2;
 hello_version(Versions) ->
     lowest_protocol_version(Versions).

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -130,7 +130,7 @@ get_tls_records(Data, Versions, {Hdr, {Front,Size,Rear}}, MaxFragLen, SslOpts) -
 %
 %% Description: Encodes a handshake message to send on the ssl-socket.
 %%--------------------------------------------------------------------
-encode_handshake(Frag, ?'TLS-1.3', ConnectionStates) ->
+encode_handshake(Frag, ?TLS_1_3, ConnectionStates) ->
     tls_record_1_3:encode_handshake(Frag, ConnectionStates);
 encode_handshake(Frag, Version, 
 		 #{current_write :=
@@ -158,7 +158,7 @@ encode_handshake(Frag, Version,
 %%
 %% Description: Encodes an alert message to send on the ssl-socket.
 %%--------------------------------------------------------------------
-encode_alert_record(Alert, ?'TLS-1.3', ConnectionStates) ->
+encode_alert_record(Alert, ?TLS_1_3, ConnectionStates) ->
     tls_record_1_3:encode_alert_record(Alert, ConnectionStates);
 encode_alert_record(#alert{level = Level, description = Description},
                     Version, ConnectionStates) ->
@@ -180,7 +180,7 @@ encode_change_cipher_spec(Version, ConnectionStates) ->
 %%
 %% Description: Encodes data to send on the ssl-socket.
 %%--------------------------------------------------------------------
-encode_data(Data, ?'TLS-1.3', ConnectionStates) ->
+encode_data(Data, ?TLS_1_3, ConnectionStates) ->
     tls_record_1_3:encode_data(Data, ConnectionStates);
 encode_data(Data, Version,
 	    #{current_write := #{beast_mitigation := BeastMitigation,
@@ -207,7 +207,7 @@ encode_data(Data, Version,
 %%
 %% Description: Decode cipher text
 %%--------------------------------------------------------------------
-decode_cipher_text(?'TLS-1.3', CipherTextRecord, ConnectionStates, _) ->
+decode_cipher_text(?TLS_1_3, CipherTextRecord, ConnectionStates, _) ->
     tls_record_1_3:decode_cipher_text(CipherTextRecord, ConnectionStates);
 decode_cipher_text(_, CipherTextRecord,
 		   #{current_read :=
@@ -219,7 +219,8 @@ decode_cipher_text(_, CipherTextRecord,
                           }
                     } = ConnectionStates0, _) ->
     SeqBin = <<?UINT64(Seq)>>,
-    #ssl_tls{type = Type, version = {MajVer,MinVer} = Version, fragment = Fragment} = CipherTextRecord,
+    #ssl_tls{type = Type, version = Version, fragment = Fragment} = CipherTextRecord,
+    {MajVer,MinVer} = Version,
     StartAdditionalData = <<SeqBin/binary, ?BYTE(Type), ?BYTE(MajVer), ?BYTE(MinVer)>>,
     CipherS = ssl_record:nonce_seed(BulkCipherAlgo, SeqBin, CipherS0),
     case ssl_record:decipher_aead(
@@ -279,92 +280,77 @@ decode_cipher_text(_, #ssl_tls{version = Version,
 %% or vice versa.
 %%--------------------------------------------------------------------
 protocol_version('tlsv1.3') ->
-    ?'TLS-1.3';
+    ?TLS_1_3;
 protocol_version('tlsv1.2') ->
-    ?'TLS-1.2';
+    ?TLS_1_2;
 protocol_version('tlsv1.1') ->
-    ?'TLS-1.1';
+    ?TLS_1_1;
 protocol_version(tlsv1) ->
-    ?'TLS-1.0';
+    ?TLS_1_0;
 protocol_version(sslv3) ->
-    ?'SSL-3.0';
+    ?SSL_3_0;
 protocol_version(sslv2) -> %% Backwards compatibility
-    ?'SSL-2.0';
-protocol_version(?'TLS-1.3') ->
+    ?SSL_2_0;
+protocol_version(?TLS_1_3) ->
     'tlsv1.3';
-protocol_version(?'TLS-1.2') ->
+protocol_version(?TLS_1_2) ->
     'tlsv1.2';
-protocol_version(?'TLS-1.1') ->
+protocol_version(?TLS_1_1) ->
     'tlsv1.1';
-protocol_version(?'TLS-1.0') ->
+protocol_version(?TLS_1_0) ->
     tlsv1;
-protocol_version(?'SSL-3.0') ->
+protocol_version(?SSL_3_0) ->
     sslv3.
 %%--------------------------------------------------------------------
 -spec lowest_protocol_version(tls_version(), tls_version()) -> tls_version().
 %%     
 %% Description: Lowes protocol version of two given versions 
 %%--------------------------------------------------------------------
-lowest_protocol_version(Version = {M, N}, {M, O})   when N < O ->
-    Version;
-lowest_protocol_version({M, _}, 
-			Version = {M, _}) ->
-    Version;
-lowest_protocol_version(Version = {M,_}, 
-			{N, _}) when M < N ->
-    Version;
-lowest_protocol_version(_,Version) ->
-    Version.
+lowest_protocol_version(Version1, Version2) when ?TLS_L(Version1, Version2) ->
+    Version1;
+lowest_protocol_version(_, Version2) ->
+    Version2.
 
 %%--------------------------------------------------------------------
 -spec lowest_protocol_version([tls_version()]) -> tls_version().
 %%     
 %% Description: Lowest protocol version present in a list
 %%--------------------------------------------------------------------
-lowest_protocol_version([]) ->
-    lowest_protocol_version();
 lowest_protocol_version(Versions) ->
-    [Ver | Vers] = Versions,
-    lowest_list_protocol_version(Ver, Vers).
+    check_protocol_version(Versions, fun lowest_protocol_version/2).
 
 %%--------------------------------------------------------------------
 -spec highest_protocol_version([tls_version()]) -> tls_version().
 %%     
 %% Description: Highest protocol version present in a list
 %%--------------------------------------------------------------------
-highest_protocol_version([]) ->
-    highest_protocol_version();
 highest_protocol_version(Versions) ->
-    [Ver | Vers] = Versions,
-    highest_list_protocol_version(Ver, Vers).
+    check_protocol_version(Versions, fun highest_protocol_version/2).
+
+
+check_protocol_version([], Fun) -> check_protocol_version(supported_protocol_versions(), Fun);
+check_protocol_version([Ver | Versions], Fun) -> lists:foldl(Fun, Ver, Versions).
 
 %%--------------------------------------------------------------------
 -spec highest_protocol_version(tls_version(), tls_version()) -> tls_version().
 %%     
 %% Description: Highest protocol version of two given versions 
 %%--------------------------------------------------------------------
-highest_protocol_version(Version = {M, N}, {M, O})   when N > O ->
-    Version;
-highest_protocol_version({M, _}, 
-			Version = {M, _}) ->
-    Version;
-highest_protocol_version(Version = {M,_}, 
-			{N, _}) when M > N ->
-    Version;
-highest_protocol_version(_,Version) ->
-    Version.
+highest_protocol_version(Version1, Version2) when ?TLS_G(Version1, Version2) ->
+    Version1;
+highest_protocol_version(_, Version2) ->
+    Version2.
 
 %%--------------------------------------------------------------------
 -spec is_higher(V1 :: tls_version(), V2::tls_version()) -> boolean().
 %%     
 %% Description: Is V1 > V2
 %%--------------------------------------------------------------------
-is_higher({M, N}, {M, O}) when N > O ->
+is_higher(V1, V2) when ?TLS_G(V1, V2) ->
     true;
-is_higher({M, _}, {N, _}) when M > N ->
-    true; 
 is_higher(_, _) ->
     false.
+
 
 %%--------------------------------------------------------------------
 -spec supported_protocol_versions() -> [tls_version()].					 
@@ -399,8 +385,6 @@ supported_protocol_versions([_|_] = Vsns) ->
 sufficient_crypto_support(Version) ->
     sufficient_crypto_support(crypto:supports(), Version).
 
-sufficient_crypto_support(CryptoSupport, {_,_} = Version) ->
-    sufficient_crypto_support(CryptoSupport, protocol_version(Version));
 sufficient_crypto_support(CryptoSupport, Version) when Version == 'tlsv1';
                                                        Version == 'tlsv1.1' ->
     Hashes =  proplists:get_value(hashs, CryptoSupport),
@@ -453,28 +437,28 @@ sufficient_crypto_support(CryptoSupport, 'tlsv1.3') ->
          %% {public_keys, eddsa},  %% TODO
          {curves, secp256r1},               %% key exchange with secp256r1
          {curves, x25519}],                 %% key exchange with X25519
-    lists:all(Fun, L).
+    lists:all(Fun, L);
+sufficient_crypto_support(CryptoSupport, Version) ->
+    sufficient_crypto_support(CryptoSupport, protocol_version(Version)).
+
 
 is_algorithm_supported(CryptoSupport, Group, Algorithm) ->
     proplists:get_bool(Algorithm, proplists:get_value(Group, CryptoSupport)).
 
 -spec is_acceptable_version(tls_version()) -> boolean().
-is_acceptable_version({N,_}) 
-  when N >= ?LOWEST_MAJOR_SUPPORTED_VERSION ->
+is_acceptable_version(Version)
+  when ?TLS_1_X(Version) ->
     true;
 is_acceptable_version(_) ->
     false.
 
 -spec is_acceptable_version(tls_version(), Supported :: [tls_version()]) -> boolean().
-is_acceptable_version({N,_} = Version, Versions)   
-  when N >= ?LOWEST_MAJOR_SUPPORTED_VERSION ->
-    lists:member(Version, Versions);
-is_acceptable_version(_,_) ->
-    false.
+is_acceptable_version(Version, Versions) ->
+    ?TLS_1_X(Version) andalso lists:member(Version, Versions).
 
 -spec hello_version([tls_version()]) -> tls_version().
-hello_version([Highest|_]) when Highest >= ?'TLS-1.2' ->
-    ?'TLS-1.2';
+hello_version([Highest|_]) when ?TLS_GE(Highest, ?TLS_1_2) ->
+    ?TLS_1_2;
 hello_version(Versions) ->
     lowest_protocol_version(Versions).
 
@@ -505,8 +489,9 @@ initial_connection_state(ConnectionEnd, BeastMitigation, MaxEarlyDataSize) ->
      }.
 
 %% Used by logging to recreate the received bytes
-build_tls_record(#ssl_tls{type = Type, version = {MajVer, MinVer}, fragment = Fragment}) ->
+build_tls_record(#ssl_tls{type = Type, version = Version, fragment = Fragment}) ->
     Length = byte_size(Fragment),
+    {MajVer, MinVer} = Version,
     <<?BYTE(Type),?BYTE(MajVer),?BYTE(MinVer),?UINT16(Length), Fragment/binary>>.
 
 
@@ -520,10 +505,13 @@ decode_tls_records(Versions, {_,Size,_} = Q0, MaxFragLen, SslOpts, Acc, undefine
     if
         5 =< Size ->
             {<<?BYTE(Type),?BYTE(MajVer),?BYTE(MinVer), ?UINT16(Length)>>, Q} = binary_from_front(5, Q0),
-            validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, {MajVer,MinVer}, Length);
+            %% TODO: convert the MajVer and MinVer to corresponding macro
+            Version = {MajVer,MinVer},
+            validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
         3 =< Size ->
             {<<?BYTE(Type),?BYTE(MajVer),?BYTE(MinVer)>>, Q} = binary_from_front(3, Q0),
-            validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, {MajVer,MinVer}, undefined);
+            Version = {MajVer,MinVer},
+            validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, undefined);
         1 =< Size ->
             {<<?BYTE(Type)>>, Q} = binary_from_front(1, Q0),
             validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, undefined, undefined);
@@ -534,10 +522,12 @@ decode_tls_records(Versions, {_,Size,_} = Q0, MaxFragLen, SslOpts, Acc, Type, un
     if
         4 =< Size ->
             {<<?BYTE(MajVer),?BYTE(MinVer), ?UINT16(Length)>>, Q} = binary_from_front(4, Q0),
-            validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, {MajVer,MinVer}, Length);
+            Version = {MajVer,MinVer},
+            validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
         2 =< Size ->
             {<<?BYTE(MajVer),?BYTE(MinVer)>>, Q} = binary_from_front(2, Q0),
-            validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, {MajVer,MinVer}, undefined);
+            Version = {MajVer,MinVer},
+            validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, undefined);
         true ->
             validate_tls_record_version(Versions, Q0, MaxFragLen, SslOpts, Acc, Type, undefined, undefined)
     end;
@@ -552,38 +542,36 @@ decode_tls_records(Versions, {_,Size,_} = Q0, MaxFragLen, SslOpts, Acc, Type, Ve
 decode_tls_records(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length) ->
     validate_tls_record_length(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length).
 
+
+%% TODO: separate validation logic from modification of the record
 validate_tls_records_type(_Versions, Q, _MaxFragLen, _SslOpts, Acc, undefined, _Version, _Length) ->
     {lists:reverse(Acc),
      {undefined, Q}};
-validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length) ->
-    if
-        ?KNOWN_RECORD_TYPE(Type) ->
-            validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
-        true ->
-            %% Not ?KNOWN_RECORD_TYPE(Type)
-            ?ALERT_REC(?FATAL, ?UNEXPECTED_MESSAGE, {unsupported_record_type, Type})
-    end.
+validate_tls_records_type(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length) when ?KNOWN_RECORD_TYPE(Type) ->
+    validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
+validate_tls_records_type(_Versions, _Q, _MaxFragLen, _SslOpts, _Acc, Type, _Version, _Length) ->
+    %% Not ?KNOWN_RECORD_TYPE(Type)
+    ?ALERT_REC(?FATAL, ?UNEXPECTED_MESSAGE, {unsupported_record_type, Type}).
+
 
 validate_tls_record_version(_Versions, Q, _MaxFragLen, _SslOpts, Acc, Type, undefined, _Length) ->
     {lists:reverse(Acc),
      {#ssl_tls{type = Type, version = undefined, fragment = undefined}, Q}};
-validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length) ->
-    case Versions of
-        _ when is_list(Versions) ->
-            case is_acceptable_version(Version, Versions) of
-                true ->
-                    validate_tls_record_length(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
-                false ->
-                    ?ALERT_REC(?FATAL, ?BAD_RECORD_MAC, {unsupported_version, Version})
-            end;
-        ?'TLS-1.3' when Version =:= ?'TLS-1.2' ->
+validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length) when is_list(Versions) ->
+    case is_acceptable_version(Version, Versions) of
+        true ->
             validate_tls_record_length(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
-        Version ->
-            %% Exact version match
-            validate_tls_record_length(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
-        _ ->
+        false ->
             ?ALERT_REC(?FATAL, ?BAD_RECORD_MAC, {unsupported_version, Version})
-    end.
+    end;
+validate_tls_record_version(?TLS_1_3=Versions, Q, MaxFragLen, SslOpts, Acc, Type, ?TLS_1_2=Version, Length) ->
+    validate_tls_record_length(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
+validate_tls_record_version(Version, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length) ->
+    %% Exact version match
+    validate_tls_record_length(Version, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
+validate_tls_record_version(_Versions, _Q, _MaxFragLen, _SslOpts, _Acc, _Type, Version, _Length) ->
+    ?ALERT_REC(?FATAL, ?BAD_RECORD_MAC, {unsupported_version, Version}).
+
 
 validate_tls_record_length(_Versions, Q, _MaxFragLen, _SslOpts, Acc, Type, Version, undefined) ->
     {lists:reverse(Acc),
@@ -713,18 +701,20 @@ encode_fragments(Type, Version, [Text|Data],
     CipherHeader = <<?BYTE(Type), ?BYTE(MajVer), ?BYTE(MinVer), ?UINT16(Length)>>,
     encode_fragments(Type, Version, Data, CS, CompS, CipherS, Seq + 1,
                      [[CipherHeader, CipherFragment] | CipherFragments]).
+
+
 %%--------------------------------------------------------------------
 
 %% 1/n-1 splitting countermeasure Rizzo/Duong-Beast, RC4 ciphers are
 %% not vulnerable to this attack.
-split_iovec(Data, Version, BCA, one_n_minus_one, MaxLength)
-  when BCA =/= ?RC4, ?'TLS-1.0' == Version ->
+split_iovec(Data, ?TLS_1_0, BCA, one_n_minus_one, MaxLength)
+  when BCA =/= ?RC4 ->
     {Part, RestData} = split_iovec(Data, 1, []),
     [Part|split_iovec(RestData, MaxLength)];
 %% 0/n splitting countermeasure for clients that are incompatible with 1/n-1
 %% splitting.
-split_iovec(Data, Version, BCA, zero_n, MaxLength)
-  when BCA =/= ?RC4, ?'TLS-1.0' == Version ->
+split_iovec(Data, ?TLS_1_0, BCA, zero_n, MaxLength)
+  when BCA =/= ?RC4 ->
     {Part, RestData} = split_iovec(Data, 0, []),
     [Part|split_iovec(RestData, MaxLength)];
 split_iovec(Data, _Version, _BCA, _BeatMitigation, MaxLength) ->
@@ -745,23 +735,9 @@ split_iovec([], _SplitSize, Acc) ->
     {lists:reverse(Acc),[]}.
 
 %%--------------------------------------------------------------------
-lowest_list_protocol_version(Ver, []) ->
-    Ver;
-lowest_list_protocol_version(Ver1,  [Ver2 | Rest]) ->
-    lowest_list_protocol_version(lowest_protocol_version(Ver1, Ver2), Rest).
 
-highest_list_protocol_version(Ver, []) ->
-    Ver;
-highest_list_protocol_version(Ver1,  [Ver2 | Rest]) ->
-    highest_list_protocol_version(highest_protocol_version(Ver1, Ver2), Rest).
 
-highest_protocol_version() ->
-    highest_protocol_version(supported_protocol_versions()).
-
-lowest_protocol_version() ->
-    lowest_protocol_version(supported_protocol_versions()).
-
-max_len([?'TLS-1.3'|_])->
+max_len([?TLS_1_3|_])->
     ?TLS13_MAX_CIPHER_TEXT_LENGTH;
 max_len(_) ->
     ?MAX_CIPHER_TEXT_LENGTH.

--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -130,7 +130,7 @@ get_tls_records(Data, Versions, {Hdr, {Front,Size,Rear}}, MaxFragLen, SslOpts) -
 %
 %% Description: Encodes a handshake message to send on the ssl-socket.
 %%--------------------------------------------------------------------
-encode_handshake(Frag, {3, 4}, ConnectionStates) ->
+encode_handshake(Frag, ?'TLS-1.3', ConnectionStates) ->
     tls_record_1_3:encode_handshake(Frag, ConnectionStates);
 encode_handshake(Frag, Version, 
 		 #{current_write :=
@@ -158,7 +158,7 @@ encode_handshake(Frag, Version,
 %%
 %% Description: Encodes an alert message to send on the ssl-socket.
 %%--------------------------------------------------------------------
-encode_alert_record(Alert, {3, 4}, ConnectionStates) ->
+encode_alert_record(Alert, ?'TLS-1.3', ConnectionStates) ->
     tls_record_1_3:encode_alert_record(Alert, ConnectionStates);
 encode_alert_record(#alert{level = Level, description = Description},
                     Version, ConnectionStates) ->
@@ -180,7 +180,7 @@ encode_change_cipher_spec(Version, ConnectionStates) ->
 %%
 %% Description: Encodes data to send on the ssl-socket.
 %%--------------------------------------------------------------------
-encode_data(Data, {3, 4}, ConnectionStates) ->
+encode_data(Data, ?'TLS-1.3', ConnectionStates) ->
     tls_record_1_3:encode_data(Data, ConnectionStates);
 encode_data(Data, Version,
 	    #{current_write := #{beast_mitigation := BeastMitigation,
@@ -207,7 +207,7 @@ encode_data(Data, Version,
 %%
 %% Description: Decode cipher text
 %%--------------------------------------------------------------------
-decode_cipher_text({3,4}, CipherTextRecord, ConnectionStates, _) -> 
+decode_cipher_text(?'TLS-1.3', CipherTextRecord, ConnectionStates, _) ->
     tls_record_1_3:decode_cipher_text(CipherTextRecord, ConnectionStates);
 decode_cipher_text(_, CipherTextRecord,
 		   #{current_read :=
@@ -279,26 +279,26 @@ decode_cipher_text(_, #ssl_tls{version = Version,
 %% or vice versa.
 %%--------------------------------------------------------------------
 protocol_version('tlsv1.3') ->
-    {3, 4};
+    ?'TLS-1.3';
 protocol_version('tlsv1.2') ->
-    {3, 3};
+    ?'TLS-1.2';
 protocol_version('tlsv1.1') ->
-    {3, 2};
+    ?'TLS-1.1';
 protocol_version(tlsv1) ->
-    {3, 1};
+    ?'TLS-1.0';
 protocol_version(sslv3) ->
-    {3, 0};
+    ?'SSL-3.0';
 protocol_version(sslv2) -> %% Backwards compatibility
-    {2, 0};
-protocol_version({3, 4}) ->
+    ?'SSL-2.0';
+protocol_version(?'TLS-1.3') ->
     'tlsv1.3';
-protocol_version({3, 3}) ->
+protocol_version(?'TLS-1.2') ->
     'tlsv1.2';
-protocol_version({3, 2}) ->
+protocol_version(?'TLS-1.1') ->
     'tlsv1.1';
-protocol_version({3, 1}) ->
+protocol_version(?'TLS-1.0') ->
     tlsv1;
-protocol_version({3, 0}) ->
+protocol_version(?'SSL-3.0') ->
     sslv3.
 %%--------------------------------------------------------------------
 -spec lowest_protocol_version(tls_version(), tls_version()) -> tls_version().
@@ -473,8 +473,8 @@ is_acceptable_version(_,_) ->
     false.
 
 -spec hello_version([tls_version()]) -> tls_version().
-hello_version([Highest|_]) when Highest >= {3,3} ->
-    {3,3};
+hello_version([Highest|_]) when Highest >= ?'TLS-1.2' ->
+    ?'TLS-1.2';
 hello_version(Versions) ->
     lowest_protocol_version(Versions).
 
@@ -576,7 +576,7 @@ validate_tls_record_version(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version
                 false ->
                     ?ALERT_REC(?FATAL, ?BAD_RECORD_MAC, {unsupported_version, Version})
             end;
-        {3, 4} when Version =:= {3, 3} ->
+        ?'TLS-1.3' when Version =:= ?'TLS-1.2' ->
             validate_tls_record_length(Versions, Q, MaxFragLen, SslOpts, Acc, Type, Version, Length);
         Version ->
             %% Exact version match
@@ -718,15 +718,13 @@ encode_fragments(Type, Version, [Text|Data],
 %% 1/n-1 splitting countermeasure Rizzo/Duong-Beast, RC4 ciphers are
 %% not vulnerable to this attack.
 split_iovec(Data, Version, BCA, one_n_minus_one, MaxLength)
-  when (BCA =/= ?RC4) andalso ({3, 1} == Version orelse
-                               {3, 0} == Version) ->
+  when BCA =/= ?RC4, ?'TLS-1.0' == Version ->
     {Part, RestData} = split_iovec(Data, 1, []),
     [Part|split_iovec(RestData, MaxLength)];
 %% 0/n splitting countermeasure for clients that are incompatible with 1/n-1
 %% splitting.
 split_iovec(Data, Version, BCA, zero_n, MaxLength)
-  when (BCA =/= ?RC4) andalso ({3, 1} == Version orelse
-                               {3, 0} == Version) ->
+  when BCA =/= ?RC4, ?'TLS-1.0' == Version ->
     {Part, RestData} = split_iovec(Data, 0, []),
     [Part|split_iovec(RestData, MaxLength)];
 split_iovec(Data, _Version, _BCA, _BeatMitigation, MaxLength) ->
@@ -763,7 +761,7 @@ highest_protocol_version() ->
 lowest_protocol_version() ->
     lowest_protocol_version(supported_protocol_versions()).
 
-max_len([{3,4}|_])->
+max_len([?'TLS-1.3'|_])->
     ?TLS13_MAX_CIPHER_TEXT_LENGTH;
 max_len(_) ->
     ?MAX_CIPHER_TEXT_LENGTH.

--- a/lib/ssl/src/tls_record.hrl
+++ b/lib/ssl/src/tls_record.hrl
@@ -32,7 +32,7 @@
 %% Used to handle tls_plain_text, tls_compressed and tls_cipher_text
 -record(ssl_tls, {
                   type,
-                  version, 
+                  version :: tls_record:tls_version() | undefined,
                   fragment,
                   early_data = false % TLS-1.3
                  }).

--- a/lib/ssl/src/tls_record_1_3.erl
+++ b/lib/ssl/src/tls_record_1_3.erl
@@ -171,7 +171,7 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
                             fragment = <<?FATAL,?ILLEGAL_PARAMETER>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?ALERT,
-              version = ?'TLS-1.3', %% Internally use real version
+              version = ?TLS_1_3, %% Internally use real version
               fragment = <<?FATAL,?ILLEGAL_PARAMETER>>}, ConnectionStates0};
 %% TLS 1.3 server can receive a User Cancelled Alert when handshake is
 %% paused and then cancelled on the client side.
@@ -180,7 +180,7 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
                             fragment = <<?FATAL,?USER_CANCELED>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?ALERT,
-              version = ?'TLS-1.3', %% Internally use real version
+              version = ?TLS_1_3, %% Internally use real version
               fragment = <<?FATAL,?USER_CANCELED>>}, ConnectionStates0};
 %% RFC8446 - TLS 1.3
 %% D.4.  Middlebox Compatibility Mode
@@ -195,7 +195,7 @@ decode_cipher_text(#ssl_tls{type = ?CHANGE_CIPHER_SPEC,
                             fragment = <<1>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?CHANGE_CIPHER_SPEC,
-              version = ?'TLS-1.3', %% Internally use real version
+              version = ?TLS_1_3, %% Internally use real version
               fragment = <<1>>}, ConnectionStates0};
 decode_cipher_text(#ssl_tls{type = Type,
                             version = ?LEGACY_VERSION,
@@ -206,7 +206,7 @@ decode_cipher_text(#ssl_tls{type = Type,
                                   cipher_suite = ?TLS_NULL_WITH_NULL_NULL}
 			  }} = ConnnectionStates0) ->
     {#ssl_tls{type = Type,
-              version = ?'TLS-1.3', %% Internally use real version
+              version = ?TLS_1_3, %% Internally use real version
               fragment = CipherFragment}, ConnnectionStates0};
 decode_cipher_text(#ssl_tls{type = Type}, _) ->
     %% Version mismatch is already asserted
@@ -301,7 +301,7 @@ encode_plain_text(#inner_plaintext{
     %% When record protection has not yet been engaged, TLSPlaintext
     %% structures are written directly onto the wire.
     #tls_cipher_text{opaque_type = Type,
-                      legacy_version = ?'TLS-1.2',
+                      legacy_version = ?TLS_1_2,
                       encoded_record = Data}.
 
 additional_data(Length) ->
@@ -330,10 +330,11 @@ cipher_aead(Fragment, BulkCipherAlgo, Key, Seq, IV, TagLen) ->
     <<Content/binary, CipherTag/binary>>.
 
 encode_tls_cipher_text(#tls_cipher_text{opaque_type = Type,
-                                        legacy_version = {MajVer, MinVer},
+                                        legacy_version = Version,
                                         encoded_record = Encoded},
                        #{sequence_number := Seq} = Write) ->
     Length = erlang:iolist_size(Encoded),
+    {MajVer,MinVer} = Version,
     {[<<?BYTE(Type), ?BYTE(MajVer), ?BYTE(MinVer), ?UINT16(Length)>>, Encoded],
      Write#{sequence_number => Seq +1}}.
 
@@ -375,7 +376,7 @@ decode_inner_plaintext(PlainText) ->
                   Type =:= ?HANDSHAKE orelse
                   Type =:= ?ALERT ->
             #ssl_tls{type = Type,
-                     version = ?'TLS-1.3', %% Internally use real version
+                     version = ?TLS_1_3, %% Internally use real version
                      fragment = init_binary(PlainText)};
         _Else ->
             ?ALERT_REC(?FATAL, ?UNEXPECTED_MESSAGE, empty_alert)

--- a/lib/ssl/src/tls_record_1_3.erl
+++ b/lib/ssl/src/tls_record_1_3.erl
@@ -171,7 +171,7 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
                             fragment = <<?FATAL,?ILLEGAL_PARAMETER>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?ALERT,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = <<?FATAL,?ILLEGAL_PARAMETER>>}, ConnectionStates0};
 %% TLS 1.3 server can receive a User Cancelled Alert when handshake is
 %% paused and then cancelled on the client side.
@@ -180,7 +180,7 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
                             fragment = <<?FATAL,?USER_CANCELED>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?ALERT,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = <<?FATAL,?USER_CANCELED>>}, ConnectionStates0};
 %% RFC8446 - TLS 1.3
 %% D.4.  Middlebox Compatibility Mode
@@ -195,7 +195,7 @@ decode_cipher_text(#ssl_tls{type = ?CHANGE_CIPHER_SPEC,
                             fragment = <<1>>},
 		   ConnectionStates0) ->
     {#ssl_tls{type = ?CHANGE_CIPHER_SPEC,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = <<1>>}, ConnectionStates0};
 decode_cipher_text(#ssl_tls{type = Type,
                             version = ?LEGACY_VERSION,
@@ -206,7 +206,7 @@ decode_cipher_text(#ssl_tls{type = Type,
                                   cipher_suite = ?TLS_NULL_WITH_NULL_NULL}
 			  }} = ConnnectionStates0) ->
     {#ssl_tls{type = Type,
-              version = {3,4}, %% Internally use real version
+              version = ?'TLS-1.3', %% Internally use real version
               fragment = CipherFragment}, ConnnectionStates0};
 decode_cipher_text(#ssl_tls{type = Type}, _) ->
     %% Version mismatch is already asserted
@@ -288,7 +288,7 @@ encode_plain_text(#inner_plaintext{
     Encoded = cipher_aead(PlainText, BulkCipherAlgo, Key, Seq, IV, TagLen),
     %% 23 (application_data) for outward compatibility
     #tls_cipher_text{opaque_type = ?OPAQUE_TYPE,
-                     legacy_version = {3,3},
+                     legacy_version = ?LEGACY_VERSION,
                      encoded_record = Encoded};
 encode_plain_text(#inner_plaintext{
                      content = Data,
@@ -301,7 +301,7 @@ encode_plain_text(#inner_plaintext{
     %% When record protection has not yet been engaged, TLSPlaintext
     %% structures are written directly onto the wire.
     #tls_cipher_text{opaque_type = Type,
-                      legacy_version = {3,3},
+                      legacy_version = ?'TLS-1.2',
                       encoded_record = Data}.
 
 additional_data(Length) ->
@@ -375,7 +375,7 @@ decode_inner_plaintext(PlainText) ->
                   Type =:= ?HANDSHAKE orelse
                   Type =:= ?ALERT ->
             #ssl_tls{type = Type,
-                     version = {3,4}, %% Internally use real version
+                     version = ?'TLS-1.3', %% Internally use real version
                      fragment = init_binary(PlainText)};
         _Else ->
             ?ALERT_REC(?FATAL, ?UNEXPECTED_MESSAGE, empty_alert)

--- a/lib/ssl/src/tls_record_1_3.hrl
+++ b/lib/ssl/src/tls_record_1_3.hrl
@@ -43,7 +43,7 @@
 %%     } ContentType;
 
 -define(INVALID, 0).
--define(LEGACY_VERSION, {3,3}).
+-define(LEGACY_VERSION, ?'TLS-1.2').
 -define(OPAQUE_TYPE, 23).
 
 -record(inner_plaintext, {

--- a/lib/ssl/src/tls_record_1_3.hrl
+++ b/lib/ssl/src/tls_record_1_3.hrl
@@ -43,7 +43,7 @@
 %%     } ContentType;
 
 -define(INVALID, 0).
--define(LEGACY_VERSION, ?'TLS-1.2').
+-define(LEGACY_VERSION, ?TLS_1_2).
 -define(OPAQUE_TYPE, 23).
 
 -record(inner_plaintext, {
@@ -55,7 +55,7 @@
                             %% decrypted version will still use #ssl_tls for code reuse purposes
                             %% with real values for content type and version
                             opaque_type = ?OPAQUE_TYPE,
-                            legacy_version = ?LEGACY_VERSION,
+                            legacy_version = ?LEGACY_VERSION :: ssl_record:ssl_version(),
                             encoded_record
                          }).
 

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -575,7 +575,7 @@ maybe_update_cipher_key(#data{connection_states = ConnectionStates0,
 maybe_update_cipher_key(StateData, _) ->
     StateData.
 
-update_bytes_sent(Version, StateData, _) when ?TLS_L(Version, ?TLS_1_3) ->
+update_bytes_sent(Version, StateData, _) when ?TLS_LT(Version, ?TLS_1_3) ->
     StateData;
 %% Count bytes sent in TLS 1.3 for AES-GCM
 update_bytes_sent(_, #data{static = #static{key_update_at = seq_num_wrap}} = StateData, _) ->
@@ -616,11 +616,11 @@ set_opts(SocketOptions, [{packet, N}]) ->
 
 time_to_rekey(Version, _Data,
               #{current_write := #{sequence_number := ?MAX_SEQUENCE_NUMBER}},
-              _, _, _) when ?TLS_GE(Version, ?TLS_1_3) ->
+              _, _, _) when ?TLS_GTE(Version, ?TLS_1_3) ->
     key_update;
-time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when ?TLS_GE(Version, ?TLS_1_3) ->
+time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when ?TLS_GTE(Version, ?TLS_1_3) ->
     false;
-time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when ?TLS_GE(Version, ?TLS_1_3) ->
+time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when ?TLS_GTE(Version, ?TLS_1_3) ->
     DataSize = iolist_size(Data),
     case (BytesSent + DataSize) > KeyUpdateAt of
         true ->

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -575,7 +575,7 @@ maybe_update_cipher_key(#data{connection_states = ConnectionStates0,
 maybe_update_cipher_key(StateData, _) ->
     StateData.
 
-update_bytes_sent(Version, StateData, _) when Version < ?'TLS-1.3' ->
+update_bytes_sent(Version, StateData, _) when ?TLS_L(Version, ?TLS_1_3) ->
     StateData;
 %% Count bytes sent in TLS 1.3 for AES-GCM
 update_bytes_sent(_, #data{static = #static{key_update_at = seq_num_wrap}} = StateData, _) ->
@@ -588,11 +588,11 @@ update_bytes_sent(_, #data{static = #static{bytes_sent = Sent} = Static} = State
 %% approximately 2^-57 for Authenticated Encryption (AE) security.  For
 %% ChaCha20/Poly1305, the record sequence number would wrap before the
 %% safety limit is reached.
-key_update_at(?'TLS-1.3', #{security_parameters :=
+key_update_at(?TLS_1_3, #{security_parameters :=
                              #security_parameters{
                                 bulk_cipher_algorithm = ?CHACHA20_POLY1305}}, _KeyUpdateAt) ->
     seq_num_wrap;
-key_update_at(?'TLS-1.3', _, KeyUpdateAt) ->
+key_update_at(?TLS_1_3, _, KeyUpdateAt) ->
     KeyUpdateAt;
 key_update_at(_, _, KeyUpdateAt) ->
     KeyUpdateAt.
@@ -616,11 +616,11 @@ set_opts(SocketOptions, [{packet, N}]) ->
 
 time_to_rekey(Version, _Data,
               #{current_write := #{sequence_number := ?MAX_SEQUENCE_NUMBER}},
-              _, _, _) when Version >= ?'TLS-1.3' ->
+              _, _, _) when ?TLS_GE(Version, ?TLS_1_3) ->
     key_update;
-time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when Version >= ?'TLS-1.3' ->
+time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when ?TLS_GE(Version, ?TLS_1_3) ->
     false;
-time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when Version >= ?'TLS-1.3' ->
+time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when ?TLS_GE(Version, ?TLS_1_3) ->
     DataSize = iolist_size(Data),
     case (BytesSent + DataSize) > KeyUpdateAt of
         true ->

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -575,7 +575,7 @@ maybe_update_cipher_key(#data{connection_states = ConnectionStates0,
 maybe_update_cipher_key(StateData, _) ->
     StateData.
 
-update_bytes_sent(Version, StateData, _) when Version < {3,4} ->
+update_bytes_sent(Version, StateData, _) when Version < ?'TLS-1.3' ->
     StateData;
 %% Count bytes sent in TLS 1.3 for AES-GCM
 update_bytes_sent(_, #data{static = #static{key_update_at = seq_num_wrap}} = StateData, _) ->
@@ -588,20 +588,12 @@ update_bytes_sent(_, #data{static = #static{bytes_sent = Sent} = Static} = State
 %% approximately 2^-57 for Authenticated Encryption (AE) security.  For
 %% ChaCha20/Poly1305, the record sequence number would wrap before the
 %% safety limit is reached.
-key_update_at(Version, #{security_parameters :=
+key_update_at(?'TLS-1.3', #{security_parameters :=
                              #security_parameters{
-                                bulk_cipher_algorithm = CipherAlgo}}, KeyUpdateAt)
-  when Version >= {3,4} ->
-    case CipherAlgo of
-        ?AES_GCM ->
-            KeyUpdateAt;
-        ?CHACHA20_POLY1305 ->
-            seq_num_wrap;
-        ?AES_CCM ->
-            KeyUpdateAt;
-        ?AES_CCM_8 ->
-            KeyUpdateAt
-    end;
+                                bulk_cipher_algorithm = ?CHACHA20_POLY1305}}, _KeyUpdateAt) ->
+    seq_num_wrap;
+key_update_at(?'TLS-1.3', _, KeyUpdateAt) ->
+    KeyUpdateAt;
 key_update_at(_, _, KeyUpdateAt) ->
     KeyUpdateAt.
 
@@ -624,11 +616,11 @@ set_opts(SocketOptions, [{packet, N}]) ->
 
 time_to_rekey(Version, _Data,
               #{current_write := #{sequence_number := ?MAX_SEQUENCE_NUMBER}},
-              _, _, _) when Version >= {3,4} ->
+              _, _, _) when Version >= ?'TLS-1.3' ->
     key_update;
-time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when Version >= {3,4} ->
+time_to_rekey(Version, _Data, _, _, seq_num_wrap, _) when Version >= ?'TLS-1.3' ->
     false;
-time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when Version >= {3,4} ->
+time_to_rekey(Version, Data, _, _, KeyUpdateAt, BytesSent) when Version >= ?'TLS-1.3' ->
     DataSize = iolist_size(Data),
     case (BytesSent + DataSize) > KeyUpdateAt of
         true ->

--- a/lib/ssl/src/tls_server_connection_1_3.erl
+++ b/lib/ssl/src/tls_server_connection_1_3.erl
@@ -174,7 +174,7 @@ user_hello({call, From}, {handshake_continue, NewOptions, Timeout},
         Options = #{versions := Versions} ->
             State = ssl_gen_statem:ssl_config(Options, ?SERVER_ROLE, State0),
             case ssl_handshake:select_supported_version(ClientVersions, Versions) of
-                ?'TLS-1.3' ->
+                ?TLS_1_3 ->
                     {next_state, start, State#state{start_or_recv_from = From,
                                                     handshake_env = HSEnv#handshake_env{continue_status = continue}},
                      [{{timeout, handshake}, Timeout, close}]};
@@ -216,7 +216,7 @@ start(internal, #client_hello{extensions = #{client_hello_versions :=
                                                  #client_hello_versions{versions = ClientVersions}
                                             }} = Hello,
       #state{ssl_options = #{handshake := full}} = State) ->
-    case tls_record:is_acceptable_version(?'TLS-1.3', ClientVersions) of
+    case tls_record:is_acceptable_version(?TLS_1_3, ClientVersions) of
         true ->
             handle_client_hello(Hello, State);
         false ->
@@ -435,7 +435,7 @@ do_handle_client_hello(#client_hello{cipher_suites = ClientCiphers,
         Groups = Maybe(tls_handshake_1_3:select_common_groups(ServerGroups, ClientGroups)),
         Maybe(validate_client_key_share(ClientGroups,
                                         ClientShares#key_share_client_hello.client_shares)),
-        CertKeyPairs = ssl_certificate:available_cert_key_pairs(CertKeyAlts, ?'TLS-1.3'),
+        CertKeyPairs = ssl_certificate:available_cert_key_pairs(CertKeyAlts, ?TLS_1_3),
         #session{own_certificates = [Cert|_]} = Session =
             Maybe(select_server_cert_key_pair(Session0, CertKeyPairs, ClientSignAlgs,
                                               ClientSignAlgsCert, CertAuths, State0,
@@ -883,7 +883,7 @@ select_cipher_suite(_, [], _) ->
 select_cipher_suite(true, ClientCiphers, ServerCiphers) ->
     select_cipher_suite(false, ServerCiphers, ClientCiphers);
 select_cipher_suite(false, [Cipher|ClientCiphers], ServerCiphers) ->
-    case lists:member(Cipher, tls_v1:exclusive_suites(?'TLS-1.3')) andalso
+    case lists:member(Cipher, tls_v1:exclusive_suites(?TLS_1_3)) andalso
         lists:member(Cipher, ServerCiphers) of
         true ->
             {ok, Cipher};

--- a/lib/ssl/src/tls_server_connection_1_3.erl
+++ b/lib/ssl/src/tls_server_connection_1_3.erl
@@ -174,7 +174,7 @@ user_hello({call, From}, {handshake_continue, NewOptions, Timeout},
         Options = #{versions := Versions} ->
             State = ssl_gen_statem:ssl_config(Options, ?SERVER_ROLE, State0),
             case ssl_handshake:select_supported_version(ClientVersions, Versions) of
-                {3,4} ->
+                ?'TLS-1.3' ->
                     {next_state, start, State#state{start_or_recv_from = From,
                                                     handshake_env = HSEnv#handshake_env{continue_status = continue}},
                      [{{timeout, handshake}, Timeout, close}]};
@@ -216,7 +216,7 @@ start(internal, #client_hello{extensions = #{client_hello_versions :=
                                                  #client_hello_versions{versions = ClientVersions}
                                             }} = Hello,
       #state{ssl_options = #{handshake := full}} = State) ->
-    case tls_record:is_acceptable_version({3,4}, ClientVersions) of
+    case tls_record:is_acceptable_version(?'TLS-1.3', ClientVersions) of
         true ->
             handle_client_hello(Hello, State);
         false ->
@@ -435,7 +435,7 @@ do_handle_client_hello(#client_hello{cipher_suites = ClientCiphers,
         Groups = Maybe(tls_handshake_1_3:select_common_groups(ServerGroups, ClientGroups)),
         Maybe(validate_client_key_share(ClientGroups,
                                         ClientShares#key_share_client_hello.client_shares)),
-        CertKeyPairs = ssl_certificate:available_cert_key_pairs(CertKeyAlts, {3,4}),
+        CertKeyPairs = ssl_certificate:available_cert_key_pairs(CertKeyAlts, ?'TLS-1.3'),
         #session{own_certificates = [Cert|_]} = Session =
             Maybe(select_server_cert_key_pair(Session0, CertKeyPairs, ClientSignAlgs,
                                               ClientSignAlgsCert, CertAuths, State0,
@@ -883,7 +883,7 @@ select_cipher_suite(_, [], _) ->
 select_cipher_suite(true, ClientCiphers, ServerCiphers) ->
     select_cipher_suite(false, ServerCiphers, ClientCiphers);
 select_cipher_suite(false, [Cipher|ClientCiphers], ServerCiphers) ->
-    case lists:member(Cipher, tls_v1:exclusive_suites(4)) andalso
+    case lists:member(Cipher, tls_v1:exclusive_suites(?'TLS-1.3')) andalso
         lists:member(Cipher, ServerCiphers) of
         true ->
             {ok, Cipher};

--- a/lib/ssl/src/tls_socket.erl
+++ b/lib/ssl/src/tls_socket.erl
@@ -23,6 +23,7 @@
 
 -include("ssl_internal.hrl").
 -include("ssl_api.hrl").
+-include("ssl_record.hrl").
 
 -export([send/3, 
          listen/3, 
@@ -282,7 +283,7 @@ session_tickets_tracker(ListenSocket, Lifetime, TicketStoreSize, MaxEarlyDataSiz
                                                TicketStoreSize, MaxEarlyDataSize,
                                                AntiReplay, Seed]).
 
-session_id_tracker(_, #{versions := [{3,4}]}) ->
+session_id_tracker(_, #{versions := [?'TLS-1.3']}) ->
     {ok, not_relevant};
 %% Regardless of the option reuse_sessions we need the session_id_tracker
 %% to generate session ids, but no sessions will be stored unless

--- a/lib/ssl/src/tls_socket.erl
+++ b/lib/ssl/src/tls_socket.erl
@@ -283,7 +283,7 @@ session_tickets_tracker(ListenSocket, Lifetime, TicketStoreSize, MaxEarlyDataSiz
                                                TicketStoreSize, MaxEarlyDataSize,
                                                AntiReplay, Seed]).
 
-session_id_tracker(_, #{versions := [?'TLS-1.3']}) ->
+session_id_tracker(_, #{versions := [?TLS_1_3]}) ->
     {ok, not_relevant};
 %% Regardless of the option reuse_sessions we need the session_id_tracker
 %% to generate session ids, but no sessions will be stored unless

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -921,7 +921,7 @@ default_pre_1_3_signature_algs_only() ->
     signature_algs(?TLS_1_2, Default).
 
 signature_schemes(Version, [_|_] =SignatureSchemes) when is_tuple(Version)
-                                                         andalso ?TLS_GE(Version, ?TLS_1_2) ->
+                                                         andalso ?TLS_GTE(Version, ?TLS_1_2) ->
     CryptoSupports =  crypto:supports(),
     Hashes = proplists:get_value(hashs, CryptoSupports),
     PubKeys = proplists:get_value(public_keys, CryptoSupports),

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -29,13 +29,13 @@
 -include("ssl_internal.hrl").
 -include("ssl_record.hrl").
 
--export([master_secret/4, 
-         finished/5, 
-         certificate_verify/3, 
-         mac_hash/7, 
+-export([master_secret/4,
+         finished/5,
+         certificate_verify/2,
+         mac_hash/7,
          hmac_hash/3,
-	 setup_keys/8, 
-         suites/1, 
+         setup_keys/8,
+         suites/1,
          exclusive_suites/1,
          exclusive_anonymous_suites/1,
          psk_suites/1,
@@ -44,50 +44,49 @@
          srp_suites/1,
          srp_suites_anon/1,
          srp_exclusive/1,
-	 rc4_suites/1,
+         rc4_suites/1,
          rc4_exclusive/1,
          des_suites/1,
          des_exclusive/1,
          rsa_suites/1,
          rsa_exclusive/1,
          prf/5,
-	 ecc_curves/1, 
-         ecc_curves/2, 
-         oid_to_enum/1, 
-         enum_to_oid/1, 
-	 default_signature_algs/1, 
+         ecc_curves/1,
+         oid_to_enum/1,
+         enum_to_oid/1,
+         default_signature_algs/1,
          signature_algs/2,
          signature_schemes/2,
          rsa_schemes/0,
-         groups/1, 
-         groups/2, 
-         group_to_enum/1, 
-         enum_to_group/1, 
-         default_groups/1]).
+         groups/0,
+         groups/1,
+         group_to_enum/1,
+         enum_to_group/1,
+         default_groups/0]).
 
--export([derive_secret/4, 
-         hkdf_expand_label/5, 
-         hkdf_extract/3, 
+-export([derive_secret/4,
+         hkdf_expand_label/5,
+         hkdf_extract/3,
          hkdf_expand/4,
          key_length/1,
-         key_schedule/3, 
-         key_schedule/4, 
+         key_schedule/3,
+         key_schedule/4,
          create_info/3,
-         external_binder_key/2, 
+         external_binder_key/2,
          resumption_binder_key/2,
-         client_early_traffic_secret/3, 
+         client_early_traffic_secret/3,
          early_exporter_master_secret/3,
-         client_handshake_traffic_secret/3, 
+         client_handshake_traffic_secret/3,
          server_handshake_traffic_secret/3,
-         client_application_traffic_secret_0/3, 
+         client_application_traffic_secret_0/3,
          server_application_traffic_secret_0/3,
-         exporter_master_secret/3, 
+         exporter_master_secret/3,
          resumption_master_secret/3,
-         update_traffic_secret/2, 
+         update_traffic_secret/2,
          calculate_traffic_keys/3,
-         transcript_hash/2, 
-         finished_key/2, 
-         finished_verify_data/3, 
+         transcript_hash/2,
+         finished_key/2,
+         finished_verify_data/3,
          pre_shared_key/3]).
 
 %% Tracing
@@ -118,7 +117,7 @@ derive_secret(Secret, Label, Messages, Algo) ->
                       Hash, ssl_cipher:hash_size(Algo), Algo).
 
 -spec hkdf_expand_label(Secret::binary(), Label0::binary(),
-                        Context::binary(), Length::integer(),  
+                        Context::binary(), Length::integer(),
                         Algo::ssl:hash()) -> KeyingMaterial::binary().
 hkdf_expand_label(Secret, Label0, Context, Length, Algo) ->
     HkdfLabel = create_info(Label0, Context, Length),
@@ -143,14 +142,14 @@ create_info(Label0, Context0, Length) ->
 -spec hkdf_extract(MacAlg::ssl:hash(), Salt::binary(),
                    KeyingMaterial::binary()) -> PseudoRandKey::binary().
 
-hkdf_extract(MacAlg, Salt, KeyingMaterial) -> 
+hkdf_extract(MacAlg, Salt, KeyingMaterial) ->
     hmac_hash(MacAlg, Salt, KeyingMaterial).
 
 
 -spec hkdf_expand(PseudoRandKey::binary(), ContextInfo::binary(),
                   Length::integer(), Algo::ssl:hash()) -> KeyingMaterial::binary().
-                     
-hkdf_expand(PseudoRandKey, ContextInfo, Length, Algo) -> 
+
+hkdf_expand(PseudoRandKey, ContextInfo, Length, Algo) ->
     Iterations = erlang:ceil(Length / ssl_cipher:hash_size(Algo)),
     hkdf_expand(Algo, PseudoRandKey, ContextInfo, Length, 1, Iterations, <<>>, <<>>).
 
@@ -173,10 +172,15 @@ master_secret(PrfAlgo, PreMasterSecret, ClientRandom, ServerRandom) ->
 	[ClientRandom, ServerRandom], 48).
 %% TLS 1.0 -1.2  ---------------------------------------------------
 
--spec finished(client | server, integer(), integer(), binary(), [binary()]) -> binary().
+-spec finished(Role, Version, PrfAlgo, MasterSecret, Handshake) -> binary() when
+      Role :: client | server,
+      Version :: ssl_record:ssl_version(),
+      PrfAlgo :: integer(),
+      MasterSecret :: binary(),
+      Handshake    :: [binary()].
 %% TLS 1.0 -1.1  ---------------------------------------------------
 finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
-  when Version == 1; Version == 2; PrfAlgo == ?MD5SHA ->
+  when Version == ?'TLS-1.0'; Version == ?'TLS-1.1'; PrfAlgo == ?MD5SHA ->
     %% RFC 2246 & 4346 - 7.4.9. Finished
     %% struct {
     %%          opaque verify_data[12];
@@ -192,7 +196,7 @@ finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
 
 %% TLS 1.2 ---------------------------------------------------
 finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
-  when Version == 3 ->
+  when Version == ?'TLS-1.2' ->
     %% RFC 5246 - 7.4.9. Finished
     %% struct {
     %%          opaque verify_data[12];
@@ -206,30 +210,29 @@ finished(Role, Version, PrfAlgo, MasterSecret, Handshake)
 
 %% TODO 1.3 finished
 
--spec certificate_verify(md5sha | sha, integer(), [binary()]) -> binary().
-
+-spec certificate_verify(HashAlgo, Handshake) -> binary() when
+      HashAlgo :: md5sha | ssl:hash(),
+      Handshake :: [binary()].
 %% TLS 1.0 -1.1  ---------------------------------------------------
-certificate_verify(md5sha, _Version, Handshake) ->
+certificate_verify(md5sha, Handshake) ->
     MD5 = crypto:hash(md5, Handshake),
     SHA = crypto:hash(sha, Handshake),
     {digest, <<MD5/binary, SHA/binary>>};
 %% TLS 1.0 -1.1  ---------------------------------------------------
 
 %% TLS 1.2 ---------------------------------------------------
-certificate_verify(_HashAlgo, _Version, Handshake) ->
+certificate_verify(_HashAlgo, Handshake) ->
     %% crypto:hash(HashAlgo, Handshake).
     %% Optimization: Let crypto calculate the hash in sign/verify call
     Handshake.
 
 %% TLS 1.2 ---------------------------------------------------
-
--spec setup_keys(integer(), integer(), binary(), binary(), binary(), integer(),
+-spec setup_keys(ssl_record:ssl_version(), integer(), binary(), binary(), binary(), integer(),
 		 integer(), integer()) -> {binary(), binary(), binary(),
 					  binary(), binary(), binary()}.
 %% TLS v1.0  ---------------------------------------------------
-setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
-	   KeyMatLen, IVSize)
-  when Version == 1 ->
+setup_keys(?'TLS-1.0', _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+	   KeyMatLen, IVSize) ->
     %% RFC 2246 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",
@@ -254,9 +257,8 @@ setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize
 %% TLS v1.0  ---------------------------------------------------
 
 %% TLS v1.1 ---------------------------------------------------
-setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
-	   KeyMatLen, IVSize)
-  when Version == 2 ->
+setup_keys(?'TLS-1.1', _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+	   KeyMatLen, IVSize) ->
     %% RFC 4346 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",
@@ -282,9 +284,8 @@ setup_keys(Version, _PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize
 %% TLS v1.1 ---------------------------------------------------
 
 %% TLS v1.2  ---------------------------------------------------
-setup_keys(Version, PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
-	   KeyMatLen, IVSize)
-  when Version == 3; Version == 4 ->
+setup_keys(?'TLS-1.2', PrfAlgo, MasterSecret, ServerRandom, ClientRandom, HashSize,
+	   KeyMatLen, IVSize) ->
     %% RFC 5246 - 6.3. Key calculation
     %% key_block = PRF(SecurityParameters.master_secret,
     %%                      "key expansion",
@@ -508,19 +509,19 @@ mac_hash(Method, Mac_write_secret, Seq_num, Type, {Major, Minor},
     Mac.
 %% TLS 1.0 -1.2  ---------------------------------------------------
 
-%% TODO 1.3 same as above?
+-spec suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 
--spec suites(1|2|3|4) -> [ssl_cipher_format:cipher_suite()].
+suites(?'TLS-1.X'=Version) ->
+    lists:flatmap(fun exclusive_suites/1, suites_to_test(Version)).
 
-suites(Minor) when Minor == 1; Minor == 2 ->
-    exclusive_suites(1);
-suites(3) ->
-    exclusive_suites(3) ++ suites(2);
+suites_to_test(?'TLS-1.0') -> [?'TLS-1.0'];
+suites_to_test(?'TLS-1.1') -> [?'TLS-1.0'];
+suites_to_test(?'TLS-1.2') -> [?'TLS-1.2', ?'TLS-1.0'];
+suites_to_test(?'TLS-1.3') -> [?'TLS-1.3', ?'TLS-1.2', ?'TLS-1.0'].
 
-suites(4) ->
-    exclusive_suites(4) ++ suites(3).
+-spec exclusive_suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 
-exclusive_suites(4) ->
+exclusive_suites(?'TLS-1.3') ->
     [?TLS_AES_256_GCM_SHA384,
      ?TLS_AES_128_GCM_SHA256,
 
@@ -529,7 +530,7 @@ exclusive_suites(4) ->
      ?TLS_AES_128_CCM_SHA256,
      ?TLS_AES_128_CCM_8_SHA256
     ];
-exclusive_suites(3) ->
+exclusive_suites(?'TLS-1.2') ->
     [?TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
      ?TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 
@@ -568,12 +569,12 @@ exclusive_suites(3) ->
 
      ?TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,
      ?TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
-    
+
      ?TLS_DHE_RSA_WITH_AES_128_GCM_SHA256,
      ?TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
-     
+
      ?TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-     
+
      ?TLS_DHE_RSA_WITH_AES_128_CBC_SHA256,
      ?TLS_DHE_DSS_WITH_AES_128_CBC_SHA256
 
@@ -583,13 +584,13 @@ exclusive_suites(3) ->
      %% ?TLS_DH_RSA_WITH_AES_128_GCM_SHA256,
      %% ?TLS_DH_DSS_WITH_AES_128_GCM_SHA256
     ];
-exclusive_suites(2) ->
+exclusive_suites(?'TLS-1.1') ->
     [];
-exclusive_suites(1) ->
+exclusive_suites(?'TLS-1.0') ->
     [
      ?TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
      ?TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-    
+
      ?TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
      ?TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,
 
@@ -604,17 +605,18 @@ exclusive_suites(1) ->
      ?TLS_DHE_RSA_WITH_AES_128_CBC_SHA,
      ?TLS_DHE_DSS_WITH_AES_128_CBC_SHA
     ].
-    
+
 %%--------------------------------------------------------------------
--spec exclusive_anonymous_suites(Minor:: integer()) -> [ssl_cipher_format:cipher_suite()].
+-spec exclusive_anonymous_suites(ssl_record:ssl_version()) ->
+          [ssl_cipher_format:cipher_suite()].
 %%
 %% Description: Returns a list of the anonymous cipher suites introduced
 %% in Version, only supported if explicitly set by user.
 %%--------------------------------------------------------------------
-exclusive_anonymous_suites(4) ->
+exclusive_anonymous_suites(?'TLS-1.3') ->
     [];
-exclusive_anonymous_suites(3 = N) ->
-    psk_anon_exclusive(N) ++
+exclusive_anonymous_suites(?'TLS-1.2') ->
+    psk_anon_exclusive(?'TLS-1.2') ++
         [?TLS_DH_anon_WITH_AES_128_GCM_SHA256,
          ?TLS_DH_anon_WITH_AES_256_GCM_SHA384,
          ?TLS_DH_anon_WITH_AES_128_CBC_SHA256,
@@ -625,35 +627,34 @@ exclusive_anonymous_suites(3 = N) ->
          ?TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA,
 
          ?TLS_DH_anon_WITH_RC4_128_MD5];
-exclusive_anonymous_suites(2 = N) ->
-    psk_anon_exclusive(N) ++
+exclusive_anonymous_suites(?'TLS-1.1') ->
+    psk_anon_exclusive(?'TLS-1.1') ++
         [?TLS_ECDH_anon_WITH_AES_128_CBC_SHA,
          ?TLS_ECDH_anon_WITH_AES_256_CBC_SHA,
          ?TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA,
-         
+
          ?TLS_DH_anon_WITH_DES_CBC_SHA,
          ?TLS_DH_anon_WITH_RC4_128_MD5];
-exclusive_anonymous_suites(N = 1) ->
-    psk_anon_exclusive(N) ++
+exclusive_anonymous_suites(?'TLS-1.0') ->
+    psk_anon_exclusive(?'TLS-1.0') ++
         [?TLS_DH_anon_WITH_RC4_128_MD5,
          ?TLS_DH_anon_WITH_3DES_EDE_CBC_SHA,
          ?TLS_DH_anon_WITH_DES_CBC_SHA
-        ] ++ srp_suites_anon({3,1}).
+        ] ++ srp_suites_anon(?'TLS-1.0').
 
 %%--------------------------------------------------------------------
--spec psk_suites(ssl_record:ssl_version() | integer()) -> [ssl_cipher_format:cipher_suite()].
+-spec psk_suites(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 %%
 %% Description: Returns a list of the PSK cipher suites, only supported
 %% if explicitly set by user.
 %%--------------------------------------------------------------------
-psk_suites({3, 3})  ->
-    psk_exclusive(3);
-psk_suites({3, N}) ->
-    psk_exclusive(N).
+psk_suites(?'TLS-1.X'=Version) ->
+    psk_exclusive(Version).
 
-psk_exclusive(3) ->
-    psk_exclusive(1) -- [?TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA];
-psk_exclusive(1) ->
+-spec psk_exclusive(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
+psk_exclusive(?'TLS-1.2') ->
+    psk_exclusive(?'TLS-1.0') -- [?TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA];
+psk_exclusive(?'TLS-1.0') ->
     [
      ?TLS_RSA_PSK_WITH_AES_256_GCM_SHA384,
      ?TLS_RSA_PSK_WITH_AES_256_CBC_SHA384,
@@ -667,15 +668,17 @@ psk_exclusive(_) ->
     [].
 
 %%--------------------------------------------------------------------
--spec psk_suites_anon(ssl_record:ssl_version() | integer()) -> [ssl_cipher_format:cipher_suite()].
+-spec psk_suites_anon(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 %%
 %% Description: Returns a list of the anonymous PSK cipher suites, only supported
 %% if explicitly set by user.
 %%--------------------------------------------------------------------
-psk_suites_anon({3, _}) ->
-    psk_anon_exclusive(3) ++ psk_anon_exclusive(1).
+psk_suites_anon(?'TLS-1.X') ->
+    psk_anon_exclusive(?'TLS-1.2') ++ psk_anon_exclusive(?'TLS-1.0').
 
-psk_anon_exclusive(3) ->
+-spec psk_anon_exclusive(ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
+
+psk_anon_exclusive(?'TLS-1.2') ->
     [
      ?TLS_DHE_PSK_WITH_AES_256_GCM_SHA384,
      ?TLS_PSK_WITH_AES_256_GCM_SHA384,
@@ -695,7 +698,7 @@ psk_anon_exclusive(3) ->
      ?TLS_PSK_WITH_AES_128_CCM,
      ?TLS_PSK_WITH_AES_128_CCM_8
     ];
-psk_anon_exclusive(1) ->
+psk_anon_exclusive(?'TLS-1.0') ->
 	[
          ?TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384,
          ?TLS_DHE_PSK_WITH_AES_256_CBC_SHA384,
@@ -723,15 +726,19 @@ psk_anon_exclusive(_) ->
 %% Description: Returns a list of the SRP cipher suites, only supported
 %% if explicitly set by user.
 %%--------------------------------------------------------------------
-srp_suites({3, 3}) ->
-    srp_exclusive(1) -- [?TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA,
-                         ?TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA
-                        ];
-srp_suites({3, N}) when N == 1;
-                        N == 2 ->
-    srp_exclusive(1).
+srp_suites(?'TLS-1.2') ->
+    srp_exclusive(?'TLS-1.0') -- [?TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA,
+                                  ?TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA
+                                 ];
+srp_suites(?'TLS-1.1') ->
+    srp_exclusive(?'TLS-1.0');
+srp_suites(?'TLS-1.0') ->
+    srp_exclusive(?'TLS-1.0').
 
-srp_exclusive(1) ->
+
+-spec srp_exclusive(tls_record:tls_version()) -> [ssl_cipher_format:cipher_suite()].
+
+srp_exclusive(?'TLS-1.0') ->
     [?TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA,
      ?TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA,
      ?TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA,
@@ -748,30 +755,36 @@ srp_exclusive(_) ->
 %% Description: Returns a list of the SRP anonymous cipher suites, only supported
 %% if explicitly set by user.
 %%--------------------------------------------------------------------
-srp_suites_anon({3, 3}) ->
-    srp_exclusive_anon(1) -- [?TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA];
-srp_suites_anon({3, N}) when N == 1;
-                             N == 2 ->
-    srp_exclusive_anon(1).
-srp_exclusive_anon(1) ->
+srp_suites_anon(?'TLS-1.2') ->
+    srp_exclusive_anon(?'TLS-1.0') -- [?TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA];
+srp_suites_anon(?'TLS-1.1') ->
+    srp_exclusive_anon(?'TLS-1.0');
+srp_suites_anon(?'TLS-1.0') ->
+    srp_exclusive_anon(?'TLS-1.0').
+
+
+srp_exclusive_anon(?'TLS-1.0') ->
     [?TLS_SRP_SHA_WITH_AES_128_CBC_SHA,
      ?TLS_SRP_SHA_WITH_AES_256_CBC_SHA,
      ?TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA
     ].
 
 %%--------------------------------------------------------------------
--spec rc4_suites(Version::ssl_record:ssl_version() | integer()) ->
-                        [ssl_cipher_format:cipher_suite()].
+-spec rc4_suites(Version::ssl_record:ssl_version()) ->
+          [ssl_cipher_format:cipher_suite()].
 %%
 %% Description: Returns a list of the RSA|(ECDH/RSA)| (ECDH/ECDSA)
 %% with RC4 cipher suites, only supported if explicitly set by user.
 %% Are not considered secure any more. Other RC4 suites already
 %% belonged to the user configured only category.
 %%--------------------------------------------------------------------
-rc4_suites({3, _}) ->
-    rc4_exclusive(1).
+rc4_suites(?'TLS-1.X') ->
+    rc4_exclusive(?'TLS-1.0').
 
-rc4_exclusive(1) ->
+-spec rc4_exclusive(Version::ssl_record:ssl_version()) ->
+          [ssl_cipher_format:cipher_suite()].
+
+rc4_exclusive(?'TLS-1.0') ->
     [?TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
      ?TLS_ECDHE_RSA_WITH_RC4_128_SHA,
      ?TLS_ECDH_ECDSA_WITH_RC4_128_SHA,
@@ -788,10 +801,10 @@ rc4_exclusive(_) ->
 %% with DES cipher, only supported if explicitly set by user.
 %% Are not considered secure any more.
 %%--------------------------------------------------------------------
-des_suites({3, _}) ->
-    des_exclusive(1).
+des_suites(?'TLS-1.X') ->
+    des_exclusive(?'TLS-1.0').
 
-des_exclusive(1)->
+des_exclusive(?'TLS-1.0')->
     [?TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA,
      ?TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
      ?TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA,
@@ -803,27 +816,28 @@ des_exclusive(1)->
 des_exclusive(_) ->
     [].
 %%--------------------------------------------------------------------
--spec rsa_suites(Version::ssl_record:ssl_version() | integer()) -> [ssl_cipher_format:cipher_suite()].
+-spec rsa_suites(Version::ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
 %%
 %% Description: Returns a list of the RSA key exchange
 %% cipher suites, only supported if explicitly set by user.
 %% Are not considered secure any more.
 %%--------------------------------------------------------------------
-rsa_suites({3, 3}) ->
-    rsa_exclusive(3) ++ rsa_exclusive(1);
-rsa_suites({3, 2}) ->
-    rsa_exclusive(1);
-rsa_suites({3, 1}) ->
-    rsa_exclusive(1).
+rsa_suites(?'TLS-1.X'=Version) ->
+    lists:flatmap(fun rsa_exclusive/1, rsa_suites_to_test(Version)).
 
-rsa_exclusive(3) ->
+rsa_suites_to_test(?'TLS-1.2') -> [?'TLS-1.2', ?'TLS-1.0'];
+rsa_suites_to_test(?'TLS-1.1') -> [?'TLS-1.0'];
+rsa_suites_to_test(?'TLS-1.0') -> [?'TLS-1.0'].
+
+-spec rsa_exclusive(Version::ssl_record:ssl_version()) -> [ssl_cipher_format:cipher_suite()].
+rsa_exclusive(?'TLS-1.2') ->
     [
      ?TLS_RSA_WITH_AES_256_GCM_SHA384,
      ?TLS_RSA_WITH_AES_256_CBC_SHA256,
      ?TLS_RSA_WITH_AES_128_GCM_SHA256,
      ?TLS_RSA_WITH_AES_128_CBC_SHA256
     ];
-rsa_exclusive(1) ->
+rsa_exclusive(?'TLS-1.0') ->
     [?TLS_RSA_WITH_AES_256_CBC_SHA,
      ?TLS_RSA_WITH_AES_128_CBC_SHA,
      ?TLS_RSA_WITH_3DES_EDE_CBC_SHA
@@ -831,15 +845,15 @@ rsa_exclusive(1) ->
 rsa_exclusive(_) ->
     [].
 
-signature_algs({3, 4}, HashSigns) ->
-    signature_algs({3, 3}, HashSigns);
-signature_algs({3, 3}, HashSigns) ->
+signature_algs(?'TLS-1.3', HashSigns) ->
+    signature_algs(?'TLS-1.2', HashSigns);
+signature_algs(?'TLS-1.2', HashSigns) ->
     CryptoSupports =  crypto:supports(),
     Hashes = proplists:get_value(hashs, CryptoSupports),
     PubKeys = proplists:get_value(public_keys, CryptoSupports),
     Schemes =  rsa_schemes(),
     Supported = lists:foldl(fun({Hash, dsa = Sign} = Alg, Acc) ->
-				    case proplists:get_bool(dss, PubKeys) 
+				    case proplists:get_bool(dss, PubKeys)
 					andalso proplists:get_bool(Hash, Hashes)
 					andalso is_pair(Hash, Sign, Hashes)
 				    of
@@ -848,9 +862,9 @@ signature_algs({3, 3}, HashSigns) ->
 					false ->
 					    Acc
 				    end;
-			       ({Hash, Sign} = Alg, Acc) -> 
-				    case proplists:get_bool(Sign, PubKeys) 
-					andalso proplists:get_bool(Hash, Hashes) 
+			       ({Hash, Sign} = Alg, Acc) ->
+				    case proplists:get_bool(Sign, PubKeys)
+					andalso proplists:get_bool(Hash, Hashes)
 					andalso is_pair(Hash, Sign, Hashes)
 				    of
 					true ->
@@ -861,7 +875,7 @@ signature_algs({3, 3}, HashSigns) ->
                                (Alg, Acc) when is_atom(Alg) ->
                                     case lists:member(Alg, Schemes) of
                                         true ->
-                                            [NewAlg] = signature_schemes({3,4}, [Alg]),
+                                            [NewAlg] = signature_schemes(?'TLS-1.3', [Alg]),
                                             [NewAlg| Acc];
 					false ->
 					    Acc
@@ -869,11 +883,11 @@ signature_algs({3, 3}, HashSigns) ->
 			    end, [], HashSigns),
     lists:reverse(Supported).
 
-default_signature_algs([{3, 4} = Version]) ->
-    default_signature_schemes(Version) ++ legacy_signature_schemes(Version);
-default_signature_algs([{3, 4}, {3,3} | _]) ->
-    default_signature_schemes({3,4}) ++ default_pre_1_3_signature_algs_only();
-default_signature_algs([{3, 3} = Version |_]) ->
+default_signature_algs([?'TLS-1.3']) ->
+    default_signature_schemes(?'TLS-1.3') ++ legacy_signature_schemes(?'TLS-1.3');
+default_signature_algs([?'TLS-1.3', ?'TLS-1.2' | _]) ->
+    default_signature_schemes(?'TLS-1.3') ++ default_pre_1_3_signature_algs_only();
+default_signature_algs([?'TLS-1.2' = Version |_]) ->
     Default = [%% SHA2 ++ PSS
                {sha512, ecdsa},
                rsa_pss_pss_sha512,
@@ -905,10 +919,10 @@ default_pre_1_3_signature_algs_only() ->
                {sha224, ecdsa},
                {sha224, rsa}
               ],
-    signature_algs({3,3}, Default).
+    signature_algs(?'TLS-1.2', Default).
 
 signature_schemes(Version, [_|_] =SignatureSchemes) when is_tuple(Version)
-                                                  andalso Version >= {3, 3} ->
+                                                  andalso Version >= ?'TLS-1.2' ->
     CryptoSupports =  crypto:supports(),
     Hashes = proplists:get_value(hashs, CryptoSupports),
     PubKeys = proplists:get_value(public_keys, CryptoSupports),
@@ -991,7 +1005,7 @@ legacy_signature_schemes(Version) ->
     %% MAY appear in "signature_algorithms" and
     %% "signature_algorithms_cert" for backward compatibility with
     %% TLS 1.2.
-    LegacySchemes = 
+    LegacySchemes =
         [rsa_pkcs1_sha512,
          rsa_pkcs1_sha384,
          rsa_pkcs1_sha256],
@@ -1031,7 +1045,7 @@ hmac_hash(?NULL, _, _) ->
 hmac_hash(Alg, Key, Value) ->
     crypto:mac(hmac, mac_algo(Alg), Key, Value).
 
-mac_algo(Alg) when is_atom(Alg) -> 
+mac_algo(Alg) when is_atom(Alg) ->
     Alg;
 mac_algo(?MD5)    -> md5;
 mac_algo(?SHA)    -> sha;
@@ -1121,19 +1135,23 @@ is_pair(Hash, rsa, Hashs) ->
 is_pair(_,_,_) ->
     false.
 
+%% Should we create a new function for ecc_curves(Version)
+%% and another explicit one for ecc_curve_named([TLSCurves])?
 %% list ECC curves in preferred order
--spec ecc_curves(1..3 | all) -> [named_curve()].
+-spec ecc_curves(TLS | DTLS | all) -> [named_curve()] when
+      TLS :: ?'TLS-1.0' | ?'TLS-1.1' | ?'TLS-1.2',
+      DTLS :: ?'DTLS-1.X';
+                ([named_curve()]) -> [named_curve()].
 ecc_curves(all) ->
     [sect571r1,sect571k1,secp521r1,brainpoolP512r1,
      sect409k1,sect409r1,brainpoolP384r1,secp384r1,
      sect283k1,sect283r1,brainpoolP256r1,secp256k1,secp256r1];
 
-ecc_curves(Minor) ->
+ecc_curves(Version) when is_tuple(Version) ->
     TLSCurves = ecc_curves(all),
-    ecc_curves(Minor, TLSCurves).
+    ecc_curves(TLSCurves);
 
--spec ecc_curves(1..3, [named_curve()]) -> [named_curve()].
-ecc_curves(_Minor, TLSCurves) ->
+ecc_curves(TLSCurves) when is_list(TLSCurves) ->
     CryptoCurves = crypto:ec_curves(),
     lists:foldr(fun(Curve, Curves) ->
 			case proplists:get_bool(Curve, CryptoCurves) of
@@ -1142,7 +1160,11 @@ ecc_curves(_Minor, TLSCurves) ->
 			end
 		end, [], TLSCurves).
 
--spec groups(4 | all | default) -> [group()].
+groups() ->
+    TLSGroups = groups(all),
+    groups(TLSGroups).
+
+-spec groups(all | default | TLSGroups :: list()) -> [group()].
 groups(all) ->
     [x25519,
      x448,
@@ -1159,18 +1181,13 @@ groups(default) ->
      x448,
      secp256r1,
      secp384r1];
-groups(Minor) ->
-    TLSGroups = groups(all),
-    groups(Minor, TLSGroups).
-%%
--spec groups(4, [group()]) -> [group()].
-groups(_Minor, TLSGroups) ->
+groups(TLSGroups) when is_list(TLSGroups) ->
     CryptoGroups = supported_groups(),
     lists:filter(fun(Group) -> proplists:get_bool(Group, CryptoGroups) end, TLSGroups).
 
-default_groups(Minor) ->
+default_groups() ->
     TLSGroups = groups(default),
-    groups(Minor, TLSGroups).
+    groups(TLSGroups).
 
 supported_groups() ->
     %% TODO: Add new function to crypto?

--- a/lib/ssl/test/cryptcookie.erl
+++ b/lib/ssl/test/cryptcookie.erl
@@ -32,6 +32,7 @@
 -export([ktls_info/1, ktls_info/0]).
 -include_lib("ssl/src/ssl_cipher.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
+-include_lib("ssl/src/ssl_record.hrl").
 
 
 -define(PROTOCOL, (?MODULE)).
@@ -52,7 +53,7 @@
 -define(HMAC, sha384).
 
 %% kTLS integration
--define(TLS_VERSION, {3,4}).
+-define(TLS_VERSION, ?TLS_1_3).
 -define(CIPHER_SUITE, (?TLS_AES_256_GCM_SHA384)).
 
 

--- a/lib/ssl/test/property_test/ssl_eqc_handshake.erl
+++ b/lib/ssl/test/property_test/ssl_eqc_handshake.erl
@@ -642,12 +642,12 @@ signature_algs(?TLS_1_3) ->
          Algs);
 signature_algs(?TLS_1_2 = Version) ->
         #hash_sign_algos{hash_sign_algos = hash_alg_list(Version)};
-signature_algs(Version) when ?TLS_L(Version, ?TLS_1_2) ->
+signature_algs(Version) when ?TLS_LT(Version, ?TLS_1_2) ->
     undefined.
 
 
 
-hashsign_algorithms(Version) when ?TLS_GE(Version, ?TLS_1_2) ->
+hashsign_algorithms(Version) when ?TLS_GTE(Version, ?TLS_1_2) ->
     #hash_sign_algos{hash_sign_algos = hash_alg_list(Version)};
 hashsign_algorithms(_) -> 
     undefined.
@@ -715,12 +715,12 @@ ec_point_formats() ->
 ec_point_format_list() ->
     [?ECPOINT_UNCOMPRESSED].
 
-elliptic_curves(Version) when ?TLS_L(Version, ?TLS_1_3) ->
+elliptic_curves(Version) when ?TLS_LT(Version, ?TLS_1_3) ->
     Curves = tls_v1:ecc_curves(Version),
     #elliptic_curves{elliptic_curve_list = Curves}.
 
 %% RFC 8446 (TLS 1.3) renamed the "elliptic_curve" extension.
-supported_groups(Version) when ?TLS_GE(Version, ?TLS_1_3) ->
+supported_groups(Version) when ?TLS_GTE(Version, ?TLS_1_3) ->
     SupportedGroups = tls_v1:groups(),
     #supported_groups{supported_groups = SupportedGroups}.
 

--- a/lib/ssl/test/property_test/ssl_eqc_handshake.erl
+++ b/lib/ssl/test/property_test/ssl_eqc_handshake.erl
@@ -57,11 +57,8 @@
 -include_lib("ssl/src/ssl_handshake.hrl").
 -include_lib("ssl/src/ssl_alert.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
+-include_lib("ssl/src/ssl_record.hrl").
 
--define('TLS_v1.3', {3,4}).
--define('TLS_v1.2', {3,3}).
--define('TLS_v1.1', {3,2}).
--define('TLS_v1',   {3,1}).
 
 %%--------------------------------------------------------------------
 %% Properties --------------------------------------------------------
@@ -87,7 +84,7 @@ prop_tls_hs_encode_decode() ->
 %% Message Generators  -----------------------------------------------
 %%--------------------------------------------------------------------
 
-tls_msg(?'TLS_v1.3'= Version) ->
+tls_msg(?'TLS-1.3'= Version) ->
     oneof([client_hello(Version),
            server_hello(Version),
            %%new_session_ticket()
@@ -116,9 +113,9 @@ tls_msg(Version) ->
 %%
 %% Shared messages
 %%
-client_hello(?'TLS_v1.3' = Version) ->
+client_hello(?'TLS-1.3' = Version) ->
     #client_hello{session_id = session_id(),
-                  client_version = ?'TLS_v1.2',
+                  client_version = ?'TLS-1.2',
                   cipher_suites = cipher_suites(Version),
                   compression_methods = compressions(Version),
                   random = client_random(Version),
@@ -133,8 +130,8 @@ client_hello(Version) ->
 		  extensions = client_hello_extensions(Version)    
                  }.
 
-server_hello(?'TLS_v1.3' = Version) ->
-    #server_hello{server_version = ?'TLS_v1.2',
+server_hello(?'TLS-1.3' = Version) ->
+    #server_hello{server_version = ?'TLS-1.2',
 		  session_id = session_id(),
                   random = server_random(Version),
                   cipher_suite = cipher_suite(Version),
@@ -184,7 +181,7 @@ finished() ->
 %%
 
 encrypted_extensions() ->
-    ?LET(Exts, extensions(?'TLS_v1.3', encrypted_extensions),
+    ?LET(Exts, extensions(?'TLS-1.3', encrypted_extensions),
          #encrypted_extensions{extensions = Exts}).
 
 
@@ -197,7 +194,7 @@ key_update() ->
 %%--------------------------------------------------------------------
 
 tls_version() ->
-    oneof([?'TLS_v1.3', ?'TLS_v1.2', ?'TLS_v1.1', ?'TLS_v1']).
+    oneof([?'TLS-1.3', ?'TLS-1.2', ?'TLS-1.1', ?'TLS-1.0']).
 
 cipher_suite(Version) ->
     oneof(cipher_suites(Version)).
@@ -290,7 +287,7 @@ pre_shared_keyextension() ->
 %% |                                                  |             |
 %% | signature_algorithms_cert (RFC 8446)             |      CH, CR |
 %% +--------------------------------------------------+-------------+
-extensions(?'TLS_v1.3' = Version, MsgType = client_hello) ->
+extensions(?'TLS-1.3' = Version, MsgType = client_hello) ->
      ?LET({
            ServerName,
            %% MaxFragmentLength,
@@ -398,7 +395,7 @@ extensions(Version, client_hello) ->
                        srp => SRP
                        %% renegotiation_info => RenegotiationInfo
                       }));
-extensions(?'TLS_v1.3' = Version, MsgType = server_hello) ->
+extensions(?'TLS-1.3' = Version, MsgType = server_hello) ->
     ?LET({
           KeyShare,
           PreSharedKey,
@@ -443,7 +440,7 @@ extensions(Version, server_hello) ->
                        next_protocol_negotiation => NextP
                        %% renegotiation_info => RenegotiationInfo
                       }));
-extensions(?'TLS_v1.3' = Version, encrypted_extensions) ->
+extensions(?'TLS-1.3' = Version, encrypted_extensions) ->
      ?LET({
            ServerName,
            %% MaxFragmentLength,
@@ -551,7 +548,7 @@ signature() ->
       76,105,212,176,25,6,148,49,194,106,253,241,212,200,
       37,154,227,53,49,216,72,82,163>>.
 
-client_hello_versions(?'TLS_v1.3') ->
+client_hello_versions(?'TLS-1.3') ->
     ?LET(SupportedVersions,
          oneof([[{3,4}],
                 %% This list breaks the property but can be used for negative tests
@@ -626,11 +623,11 @@ cert_conf()->
                                       peer => [{key, ssl_test_lib:hardcode_rsa_key(6)}]}}).
 
 cert_auths() ->
-    certificate_authorities(?'TLS_v1.3').
+    certificate_authorities(?'TLS-1.3').
 
 certificate_request_1_3() ->
     #certificate_request_1_3{certificate_request_context = <<>>,
-                             extensions = #{certificate_authorities => certificate_authorities(?'TLS_v1.3')}
+                             extensions = #{certificate_authorities => certificate_authorities(?'TLS-1.3')}
                             }.
 certificate_request(Version) ->
     #certificate_request{certificate_types = certificate_types(Version),
@@ -666,9 +663,9 @@ hash_alg(Version) ->
          {hash_algorithm(Version, Alg), Alg}
        ).
 
-hash_algorithm(?'TLS_v1.3', _) ->
+hash_algorithm(?'TLS-1.3', _) ->
     oneof([sha, sha224, sha256, sha384, sha512]);
-hash_algorithm(?'TLS_v1.2', rsa) ->
+hash_algorithm(?'TLS-1.2', rsa) ->
     oneof([sha, sha224, sha256, sha384, sha512]);
 hash_algorithm(_, rsa) ->
     oneof([md5, sha, sha224, sha256, sha384, sha512]);
@@ -677,19 +674,19 @@ hash_algorithm(_, ecdsa) ->
 hash_algorithm(_, dsa) ->
     sha.
 
-sign_algorithm(?'TLS_v1.3') ->
+sign_algorithm(?'TLS-1.3') ->
     oneof([rsa, ecdsa]);
 sign_algorithm(_) ->
     oneof([rsa, dsa, ecdsa]).
-
 
 use_srtp() ->
     FullProfiles = [<<0,1>>, <<0,2>>, <<0,5>>],
     NullProfiles = [<<0,5>>],
     ?LET(PP, oneof([FullProfiles, NullProfiles]), #use_srtp{protection_profiles = PP, mki = <<>>}).
 
-certificate_authorities(?'TLS_v1.3') ->
-    Auths = certificate_authorities(?'TLS_v1.2'),
+certificate_authorities(?'TLS-1.3') ->
+    Auths = certificate_authorities(?'TLS-1.2'),
+
     #certificate_authorities{authorities = Auths};
 certificate_authorities(_) ->
     #{server_config := ServerConf} = cert_conf(), 
@@ -718,13 +715,13 @@ ec_point_formats() ->
 ec_point_format_list() ->
     [?ECPOINT_UNCOMPRESSED].
 
-elliptic_curves({_, Minor}) when Minor < 4 ->
-    Curves = tls_v1:ecc_curves(Minor),
+elliptic_curves(Version) when Version < ?'TLS-1.3' ->
+    Curves = tls_v1:ecc_curves(Version),
     #elliptic_curves{elliptic_curve_list = Curves}.
 
 %% RFC 8446 (TLS 1.3) renamed the "elliptic_curve" extension.
-supported_groups({_, Minor}) when Minor >= 4 ->
-    SupportedGroups = tls_v1:groups(Minor),
+supported_groups(?'TLS-1.X'=Version) when Version >= ?'TLS-1.3' ->
+    SupportedGroups = tls_v1:groups(),
     #supported_groups{supported_groups = SupportedGroups}.
 
 

--- a/lib/ssl/test/ssl_ECC_SUITE.erl
+++ b/lib/ssl/test/ssl_ECC_SUITE.erl
@@ -24,6 +24,7 @@
 
 -behaviour(ct_suite).
 
+-include_lib("ssl/src/ssl_record.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
@@ -180,7 +181,7 @@ client_ecdsa_server_ecdsa_with_raw_key(Config)  when is_list(Config) ->
 
 ecc_default_order(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -195,7 +196,7 @@ ecc_default_order(Config) ->
 
 ecc_default_order_custom_curves(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -210,7 +211,7 @@ ecc_default_order_custom_curves(Config) ->
 
 ecc_client_order(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -225,7 +226,7 @@ ecc_client_order(Config) ->
 
 ecc_client_order_custom_curves(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                         {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -252,7 +253,7 @@ ecc_unknown_curve(Config) ->
 
 client_ecdh_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdh_rsa, ecdhe_ecdsa, Config),
@@ -266,7 +267,7 @@ client_ecdh_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdh_rsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdh_rsa, ecdhe_rsa, Config),
@@ -281,7 +282,7 @@ client_ecdh_rsa_server_ecdhe_rsa_server_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_rsa, ecdhe_ecdsa, Config),
@@ -295,7 +296,7 @@ client_ecdhe_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_rsa, ecdhe_rsa, Config),
@@ -309,7 +310,7 @@ client_ecdhe_rsa_server_ecdhe_rsa_server_custom(Config) ->
      end.
 client_ecdhe_rsa_server_ecdh_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     Ext = x509_test:extensions([{key_usage, [keyEncipherment]}]),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, [[], [], [{extensions, Ext}]]},
                                                          {client_chain, Default}],
@@ -327,7 +328,7 @@ client_ecdhe_rsa_server_ecdh_rsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa, Config),
@@ -341,7 +342,7 @@ client_ecdhe_ecdsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_rsa, Config),
@@ -355,7 +356,7 @@ client_ecdhe_ecdsa_server_ecdhe_rsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_ecdsa_client_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa, Config),
@@ -369,7 +370,7 @@ client_ecdhe_ecdsa_server_ecdhe_ecdsa_client_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_ecdsa_client_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(1))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                          ecdhe_rsa, ecdhe_ecdsa, Config),

--- a/lib/ssl/test/ssl_ECC_SUITE.erl
+++ b/lib/ssl/test/ssl_ECC_SUITE.erl
@@ -181,7 +181,7 @@ client_ecdsa_server_ecdsa_with_raw_key(Config)  when is_list(Config) ->
 
 ecc_default_order(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -196,7 +196,7 @@ ecc_default_order(Config) ->
 
 ecc_default_order_custom_curves(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -211,7 +211,7 @@ ecc_default_order_custom_curves(Config) ->
 
 ecc_client_order(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -226,7 +226,7 @@ ecc_client_order(Config) ->
 
 ecc_client_order_custom_curves(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                         {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa,
@@ -253,7 +253,7 @@ ecc_unknown_curve(Config) ->
 
 client_ecdh_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdh_rsa, ecdhe_ecdsa, Config),
@@ -267,7 +267,7 @@ client_ecdh_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdh_rsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdh_rsa, ecdhe_rsa, Config),
@@ -282,7 +282,7 @@ client_ecdh_rsa_server_ecdhe_rsa_server_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_rsa, ecdhe_ecdsa, Config),
@@ -296,7 +296,7 @@ client_ecdhe_rsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_rsa, ecdhe_rsa, Config),
@@ -310,7 +310,7 @@ client_ecdhe_rsa_server_ecdhe_rsa_server_custom(Config) ->
      end.
 client_ecdhe_rsa_server_ecdh_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     Ext = x509_test:extensions([{key_usage, [keyEncipherment]}]),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, [[], [], [{extensions, Ext}]]},
                                                          {client_chain, Default}],
@@ -328,7 +328,7 @@ client_ecdhe_rsa_server_ecdh_rsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_ecdsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa, Config),
@@ -342,7 +342,7 @@ client_ecdhe_ecdsa_server_ecdhe_ecdsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_rsa_server_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_rsa, Config),
@@ -356,7 +356,7 @@ client_ecdhe_ecdsa_server_ecdhe_rsa_server_custom(Config) ->
 
 client_ecdhe_ecdsa_server_ecdhe_ecdsa_client_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                        {client_chain, Default}],
                                                         ecdhe_ecdsa, ecdhe_ecdsa, Config),
@@ -370,7 +370,7 @@ client_ecdhe_ecdsa_server_ecdhe_ecdsa_client_custom(Config) ->
 
 client_ecdhe_rsa_server_ecdhe_ecdsa_client_custom(Config) ->
     Default = ssl_test_lib:default_cert_chain_conf(),
-    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?'TLS-1.0'))),
+    DefaultCurve = pubkey_cert_records:namedCurves(hd(tls_v1:ecc_curves(?TLS_1_0))),
     {COpts0, SOpts0} = ssl_test_lib:make_ec_cert_chains([{server_chain, Default},
                                                          {client_chain, Default}],
                                                          ecdhe_rsa, ecdhe_ecdsa, Config),

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -27,6 +27,7 @@
 -include_lib("ssl/src/ssl_api.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
 -include_lib("public_key/include/public_key.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -3856,13 +3857,10 @@ active_n_common(S, N) ->
 ok({ok,V}) -> V.
 
 repeat(N, Fun) ->
-    repeat(N, N, Fun).
+    Repeat = fun F(Arg) when is_integer(Arg), Arg > 0 -> Fun(N - Arg), F(Arg - 1);
+                        F(_) -> ok end,
+    Repeat(N).
 
-repeat(N, T, Fun) when is_integer(N), N > 0 ->
-    Fun(T-N),
-    repeat(N-1, T, Fun);
-repeat(_, _, _) ->
-    ok.
 
 get_close(Pid, Where) ->
     receive
@@ -4022,55 +4020,63 @@ log(#{msg:={report,_Report}},#{config:=Pid}) ->
 log(_,_) ->
     ok.
 
-length_exclusive({3,_} = Version) ->
+length_exclusive(?'TLS-1.X' = Version) ->
     length(exclusive_default_up_to_version(Version, [])) +
         length(exclusive_non_default_up_to_version(Version, []));
-length_exclusive({254,_} = Version) ->
+length_exclusive(?'DTLS-1.X' = Version) ->
     length(dtls_exclusive_default_up_to_version(Version, [])) +
         length(dtls_exclusive_non_default_up_to_version(Version, [])).
 
 length_all(Version) ->
     length(ssl:cipher_suites(all, Version)).
 
-exclusive_default_up_to_version({3, 1} = Version, Acc) ->
-    ssl:cipher_suites(exclusive, Version) ++ Acc;
-exclusive_default_up_to_version({3, Minor} = Version, Acc) when Minor =< 4 ->
-    Suites = ssl:cipher_suites(exclusive, Version),
-    exclusive_default_up_to_version({3, Minor-1}, Suites ++ Acc).
+exclusive_default_up_to_version(?'TLS-1.0', Acc) ->
+    lists:flatmap(fun (Vsn) -> ssl:cipher_suites(exclusive, Vsn) end
+                 , [?'TLS-1.0' | Acc]);
+exclusive_default_up_to_version(?'TLS-1.1', Acc) ->
+    exclusive_default_up_to_version(?'TLS-1.0', [?'TLS-1.1' | Acc]);
+exclusive_default_up_to_version(?'TLS-1.2', Acc) ->
+    exclusive_default_up_to_version(?'TLS-1.1', [?'TLS-1.2' | Acc]);
+exclusive_default_up_to_version(?'TLS-1.3', Acc) ->
+    exclusive_default_up_to_version(?'TLS-1.2', [?'TLS-1.3' | Acc]).
 
-dtls_exclusive_default_up_to_version({254, 255} = Version, Acc) ->
-    ssl:cipher_suites(exclusive, Version) ++ Acc;
-dtls_exclusive_default_up_to_version({254, 253} = Version, Acc) ->
-    Suites = ssl:cipher_suites(exclusive, Version),
-    dtls_exclusive_default_up_to_version({254, 255}, Suites ++ Acc).
+dtls_exclusive_default_up_to_version(?'DTLS-1.0', Acc) ->
+    lists:flatmap( fun (Vsn) -> ssl:cipher_suites(exclusive, Vsn) end
+                 , [?'DTLS-1.0' | Acc]);
+dtls_exclusive_default_up_to_version(?'DTLS-1.2', Acc) ->
+    dtls_exclusive_default_up_to_version(?'DTLS-1.0', [?'DTLS-1.2' | Acc]).
 
-exclusive_non_default_up_to_version({3, 1} = Version, Acc) ->
-    exclusive_non_default_version(Version) ++ Acc;
-exclusive_non_default_up_to_version({3, 4}, Acc) ->
-    exclusive_non_default_up_to_version({3, 3}, Acc);
-exclusive_non_default_up_to_version({3, Minor} = Version, Acc) when Minor =< 3 ->
-    Suites = exclusive_non_default_version(Version),
-    exclusive_non_default_up_to_version({3, Minor-1}, Suites ++ Acc).
+%% TODO: wip
+exclusive_non_default_up_to_version(?'TLS-1.0', Acc) ->
+    lists:flatmap(fun exclusive_non_default_version/1, [?'TLS-1.0' | Acc]);
+exclusive_non_default_up_to_version(?'TLS-1.1', Acc) ->
+    exclusive_non_default_up_to_version(?'TLS-1.0', [?'TLS-1.1' | Acc]);
+exclusive_non_default_up_to_version(?'TLS-1.2', Acc) ->
+    exclusive_non_default_up_to_version(?'TLS-1.1', [?'TLS-1.2' | Acc]);
+exclusive_non_default_up_to_version(?'TLS-1.3', Acc) ->
+    exclusive_non_default_up_to_version(?'TLS-1.2', Acc).
 
-dtls_exclusive_non_default_up_to_version({254, 255} = Version, Acc) ->
-    dtls_exclusive_non_default_version(Version) ++ Acc;
-dtls_exclusive_non_default_up_to_version({254, 253} = Version, Acc) ->
-    Suites = dtls_exclusive_non_default_version(Version),
-    dtls_exclusive_non_default_up_to_version({254, 255}, Suites ++ Acc).
 
-exclusive_non_default_version({_, Minor}) ->
-    tls_v1:psk_exclusive(Minor) ++
-        tls_v1:srp_exclusive(Minor) ++
-        tls_v1:rsa_exclusive(Minor) ++
-        tls_v1:des_exclusive(Minor) ++
-        tls_v1:rc4_exclusive(Minor).
+dtls_exclusive_non_default_up_to_version(?'DTLS-1.0', Acc) ->
+    lists:flatmap(fun dtls_exclusive_non_default_version/1, [?'DTLS-1.0' | Acc]);
+dtls_exclusive_non_default_up_to_version(?'DTLS-1.2', Acc) ->
+    dtls_exclusive_non_default_up_to_version(?'DTLS-1.0', [?'DTLS-1.2' | Acc]).
+
+exclusive_non_default_version(Version) ->
+    Ls = [ fun tls_v1:psk_exclusive/1
+         , fun tls_v1:srp_exclusive/1
+         , fun tls_v1:rsa_exclusive/1
+         , fun tls_v1:des_exclusive/1
+         , fun tls_v1:rc4_exclusive/1],
+    lists:flatmap(fun(Fn) -> Fn(Version) end, Ls).
 
 dtls_exclusive_non_default_version(DTLSVersion) ->        
-    {_,Minor} = ssl:tls_version(DTLSVersion),
-    tls_v1:psk_exclusive(Minor) ++
-        tls_v1:srp_exclusive(Minor) ++
-        tls_v1:rsa_exclusive(Minor) ++ 
-        tls_v1:des_exclusive(Minor).
+    Version = ssl:tls_version(DTLSVersion),
+    Fns = [ fun tls_v1:psk_exclusive/1
+          , fun tls_v1:srp_exclusive/1
+          , fun tls_v1:rsa_exclusive/1
+          , fun tls_v1:des_exclusive/1],
+    lists:flatmap(fun (Fn) -> Fn(Version) end, Fns).
 
 selected_peer(ExpectedClient,
               ExpectedServer, ClientOpts, ServerOpts, Config) ->

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -1378,7 +1378,7 @@ rsa_alg(rsa_pss_pss_1_3) ->
 rsa_alg(Atom) ->
     Atom.
 
-no_reuse(?'TLS-1.3') ->
+no_reuse(?TLS_1_3) ->
     [];
 no_reuse(_) ->
     [{reuse_sessions, false}].

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -25,6 +25,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("public_key/include/public_key.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -1377,7 +1378,7 @@ rsa_alg(rsa_pss_pss_1_3) ->
 rsa_alg(Atom) ->
     Atom.
 
-no_reuse({3, N}) when N >= 4 ->
+no_reuse(?'TLS-1.3') ->
     [];
 no_reuse(_) ->
     [{reuse_sessions, false}].

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -467,7 +467,7 @@ test_ciphers(_, 'tlsv1.3' = Version) ->
                  end, Ciphers);
 test_ciphers(_, Version) when Version == 'dtlsv1';
                                 Version == 'dtlsv1.2' ->
-    NVersion = dtls_record:protocol_version(Version),
+    NVersion = dtls_record:protocol_version_name(Version),
     Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(NVersion)],
     ct:log("Version ~p Testing  ~p~n", [Version, Ciphers]),
     OpenSSLCiphers = openssl_ciphers(),

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -467,8 +467,8 @@ test_ciphers(_, 'tlsv1.3' = Version) ->
                  end, Ciphers);
 test_ciphers(_, Version) when Version == 'dtlsv1';
                                 Version == 'dtlsv1.2' ->
-    {_, Minor} = dtls_record:protocol_version(Version),
-    Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(Minor)],
+    NVersion = dtls_record:protocol_version(Version),
+    Ciphers = [ssl_cipher_format:suite_bin_to_map(Bin) ||  Bin <- dtls_v1:suites(NVersion)],
     ct:log("Version ~p Testing  ~p~n", [Version, Ciphers]),
     OpenSSLCiphers = openssl_ciphers(),
     ct:log("OpenSSLCiphers ~p~n", [OpenSSLCiphers]),

--- a/lib/ssl/test/ssl_cipher_SUITE.erl
+++ b/lib/ssl/test/ssl_cipher_SUITE.erl
@@ -25,6 +25,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include("tls_record.hrl").
 -include("ssl_cipher.hrl").
+-include("ssl_record.hrl").
 
 %% Callback functions
 -export([all/0,
@@ -96,10 +97,9 @@ aes_decipher_good() ->
 aes_decipher_good(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = correct_cipher_state(),
-    decipher_check_good(HashSz, CipherState, {3,0}),
-    decipher_check_good(HashSz, CipherState, {3,1}),
-    decipher_check_good(HashSz, CipherState, {3,2}),
-    decipher_check_good(HashSz, CipherState, {3,3}).
+    decipher_check_good(HashSz, CipherState, ?'TLS-1.0'),
+    decipher_check_good(HashSz, CipherState, ?'TLS-1.1'),
+    decipher_check_good(HashSz, CipherState, ?'TLS-1.2').
 
 %%--------------------------------------------------------------------
 aes_decipher_fail() ->
@@ -108,19 +108,17 @@ aes_decipher_fail() ->
 aes_decipher_fail(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = incorrect_cipher_state(),
-    decipher_check_fail(HashSz, CipherState, {3,0}),
-    decipher_check_fail(HashSz, CipherState, {3,1}),
-    decipher_check_fail(HashSz, CipherState, {3,2}),
-    decipher_check_fail(HashSz, CipherState, {3,3}).
+    decipher_check_fail(HashSz, CipherState, ?'TLS-1.0'),
+    decipher_check_fail(HashSz, CipherState, ?'TLS-1.1'),
+    decipher_check_fail(HashSz, CipherState, ?'TLS-1.2').
 
 %%--------------------------------------------------------------------
 padding_test(Config) when is_list(Config)  ->
     HashSz = 16,
     CipherState = correct_cipher_state(),
-    pad_test(HashSz, CipherState, {3,0}),
-    pad_test(HashSz, CipherState, {3,1}),
-    pad_test(HashSz, CipherState, {3,2}),
-    pad_test(HashSz, CipherState, {3,3}).
+    pad_test(HashSz, CipherState, ?'TLS-1.0'),
+    pad_test(HashSz, CipherState, ?'TLS-1.1'),
+    pad_test(HashSz, CipherState, ?'TLS-1.2').
 
 %%--------------------------------------------------------------------    
 % Internal functions  --------------------------------------------------------
@@ -135,21 +133,14 @@ decipher_check_fail(HashSz, CipherState, Version) ->
     true = {Content, Mac, #cipher_state{iv = NextIV}} =/= 
 	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, aes_fragment(Version), Version, true).
 
-pad_test(HashSz, CipherState, {3,0} = Version) ->
-    %% 3.0 does not have padding test
-    {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
-    {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,0}), {3,0}, true),    
-    {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,0}), {3,0}, false);
-pad_test(HashSz, CipherState, {3,1} = Version) ->
+pad_test(HashSz, CipherState, ?'TLS-1.0' = Version) ->
     %% 3.1 should have padding test, but may be disabled
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
     BadCont = badpad_content(Content),
     {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,1}) , {3,1}, false),
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'TLS-1.0') , ?'TLS-1.0', false),
     {BadCont, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment({3,1}), {3,1}, true);
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'TLS-1.0'), ?'TLS-1.0', true);
 pad_test(HashSz, CipherState, Version) ->
     %% 3.2 and 3.3 must have padding test
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
@@ -159,7 +150,7 @@ pad_test(HashSz, CipherState, Version) ->
     {BadCont, Mac, #cipher_state{iv = NextIV}} = ssl_cipher:decipher(?AES_CBC, HashSz, CipherState,  
 								     badpad_aes_fragment(Version), Version, true).
     
-aes_fragment({3,N}) when N == 0; N == 1->
+aes_fragment(?'TLS-1.0') ->
     <<197,9,6,109,242,87,80,154,85,250,110,81,119,95,65,185,53,206,216,153,246,169,
       119,177,178,238,248,174,253,220,242,81,33,0,177,251,91,44,247,53,183,198,165,
       63,20,194,159,107>>;
@@ -170,7 +161,7 @@ aes_fragment(_) ->
       198,181,81,19,98,162,213,228,74,224,253,168,156,59,195,122,
       108,101,107,242,20,15,169,150,163,107,101,94,93,104,241,165>>.
 
-badpad_aes_fragment({3,N})  when N == 0; N == 1 ->
+badpad_aes_fragment(?'TLS-1.0') ->
     <<186,139,125,10,118,21,26,248,120,108,193,104,87,118,145,79,225,55,228,10,105,
       30,190,37,1,88,139,243,210,99,65,41>>;
 badpad_aes_fragment(_) ->
@@ -178,7 +169,7 @@ badpad_aes_fragment(_) ->
       94,121,137,117,157,109,99,113,61,190,138,131,229,201,120,142,179,172,48,77,
       234,19,240,33,38,91,93>>.
 
-content_nextiv_mac({3,N})  when N == 0; N == 1 ->
+content_nextiv_mac(?'TLS-1.0') ->
     {<<"HELLO\n">>,
      <<72,196,247,97,62,213,222,109,210,204,217,186,172,184, 197,148>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>};
@@ -187,7 +178,7 @@ content_nextiv_mac(_) ->
      <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>}.
 
-badpad_content_nextiv_mac({3,N})  when N == 0; N == 1 ->
+badpad_content_nextiv_mac(?'TLS-1.0') ->
     {<<"HELLO\n">>,
      <<225,55,228,10,105,30,190,37,1,88,139,243,210,99,65,41>>,
       <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>

--- a/lib/ssl/test/ssl_cipher_SUITE.erl
+++ b/lib/ssl/test/ssl_cipher_SUITE.erl
@@ -97,9 +97,9 @@ aes_decipher_good() ->
 aes_decipher_good(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = correct_cipher_state(),
-    decipher_check_good(HashSz, CipherState, ?'TLS-1.0'),
-    decipher_check_good(HashSz, CipherState, ?'TLS-1.1'),
-    decipher_check_good(HashSz, CipherState, ?'TLS-1.2').
+    decipher_check_good(HashSz, CipherState, ?TLS_1_0),
+    decipher_check_good(HashSz, CipherState, ?TLS_1_1),
+    decipher_check_good(HashSz, CipherState, ?TLS_1_2).
 
 %%--------------------------------------------------------------------
 aes_decipher_fail() ->
@@ -108,17 +108,17 @@ aes_decipher_fail() ->
 aes_decipher_fail(Config) when is_list(Config) ->
     HashSz = 32,
     CipherState = incorrect_cipher_state(),
-    decipher_check_fail(HashSz, CipherState, ?'TLS-1.0'),
-    decipher_check_fail(HashSz, CipherState, ?'TLS-1.1'),
-    decipher_check_fail(HashSz, CipherState, ?'TLS-1.2').
+    decipher_check_fail(HashSz, CipherState, ?TLS_1_0),
+    decipher_check_fail(HashSz, CipherState, ?TLS_1_1),
+    decipher_check_fail(HashSz, CipherState, ?TLS_1_2).
 
 %%--------------------------------------------------------------------
 padding_test(Config) when is_list(Config)  ->
     HashSz = 16,
     CipherState = correct_cipher_state(),
-    pad_test(HashSz, CipherState, ?'TLS-1.0'),
-    pad_test(HashSz, CipherState, ?'TLS-1.1'),
-    pad_test(HashSz, CipherState, ?'TLS-1.2').
+    pad_test(HashSz, CipherState, ?TLS_1_0),
+    pad_test(HashSz, CipherState, ?TLS_1_1),
+    pad_test(HashSz, CipherState, ?TLS_1_2).
 
 %%--------------------------------------------------------------------    
 % Internal functions  --------------------------------------------------------
@@ -133,14 +133,14 @@ decipher_check_fail(HashSz, CipherState, Version) ->
     true = {Content, Mac, #cipher_state{iv = NextIV}} =/= 
 	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, aes_fragment(Version), Version, true).
 
-pad_test(HashSz, CipherState, ?'TLS-1.0' = Version) ->
+pad_test(HashSz, CipherState, ?TLS_1_0 = Version) ->
     %% 3.1 should have padding test, but may be disabled
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
     BadCont = badpad_content(Content),
     {Content, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'TLS-1.0') , ?'TLS-1.0', false),
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?TLS_1_0) , ?TLS_1_0, false),
     {BadCont, Mac, #cipher_state{iv = NextIV}} = 
-	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?'TLS-1.0'), ?'TLS-1.0', true);
+	ssl_cipher:decipher(?AES_CBC, HashSz, CipherState, badpad_aes_fragment(?TLS_1_0), ?TLS_1_0, true);
 pad_test(HashSz, CipherState, Version) ->
     %% 3.2 and 3.3 must have padding test
     {Content, NextIV, Mac} = badpad_content_nextiv_mac(Version),
@@ -150,7 +150,7 @@ pad_test(HashSz, CipherState, Version) ->
     {BadCont, Mac, #cipher_state{iv = NextIV}} = ssl_cipher:decipher(?AES_CBC, HashSz, CipherState,  
 								     badpad_aes_fragment(Version), Version, true).
     
-aes_fragment(?'TLS-1.0') ->
+aes_fragment(?TLS_1_0) ->
     <<197,9,6,109,242,87,80,154,85,250,110,81,119,95,65,185,53,206,216,153,246,169,
       119,177,178,238,248,174,253,220,242,81,33,0,177,251,91,44,247,53,183,198,165,
       63,20,194,159,107>>;
@@ -161,7 +161,7 @@ aes_fragment(_) ->
       198,181,81,19,98,162,213,228,74,224,253,168,156,59,195,122,
       108,101,107,242,20,15,169,150,163,107,101,94,93,104,241,165>>.
 
-badpad_aes_fragment(?'TLS-1.0') ->
+badpad_aes_fragment(?TLS_1_0) ->
     <<186,139,125,10,118,21,26,248,120,108,193,104,87,118,145,79,225,55,228,10,105,
       30,190,37,1,88,139,243,210,99,65,41>>;
 badpad_aes_fragment(_) ->
@@ -169,7 +169,7 @@ badpad_aes_fragment(_) ->
       94,121,137,117,157,109,99,113,61,190,138,131,229,201,120,142,179,172,48,77,
       234,19,240,33,38,91,93>>.
 
-content_nextiv_mac(?'TLS-1.0') ->
+content_nextiv_mac(?TLS_1_0) ->
     {<<"HELLO\n">>,
      <<72,196,247,97,62,213,222,109,210,204,217,186,172,184, 197,148>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>};
@@ -178,7 +178,7 @@ content_nextiv_mac(_) ->
      <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>,
      <<71,136,212,107,223,200,70,232,127,116,148,205,232,35,158,113,237,174,15,217,192,168,35,8,6,107,107,233,25,174,90,111>>}.
 
-badpad_content_nextiv_mac(?'TLS-1.0') ->
+badpad_content_nextiv_mac(?TLS_1_0) ->
     {<<"HELLO\n">>,
      <<225,55,228,10,105,30,190,37,1,88,139,243,210,99,65,41>>,
       <<183,139,16,132,10,209,67,86,168,100,61,217,145,57,36,56>>

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -126,7 +126,7 @@ decode_hello_handshake(_Config) ->
 		    16#00, 16#00, 16#33, 16#74, 16#00, 16#07, 16#06, 16#73,
 		    16#70, 16#64, 16#79, 16#2f, 16#32>>,
 	
-    Version = ?'SSL-3.0',
+    Version = ?SSL_3_0,
     DefOpts = ssl:update_options([{verify, verify_none}], client, #{}),
     {Records, _Buffer} = tls_handshake:get_tls_handshakes(Version, HelloPacket, <<>>, DefOpts),
 
@@ -136,7 +136,7 @@ decode_hello_handshake(_Config) ->
 
 decode_single_hello_extension_correctly(_Config) -> 
     Renegotiation = <<?UINT16(?RENEGOTIATION_EXT), ?UINT16(1), 0>>,
-    Extensions = ssl_handshake:decode_extensions(Renegotiation, ?'TLS-1.2', undefined),
+    Extensions = ssl_handshake:decode_extensions(Renegotiation, ?TLS_1_2, undefined),
     #{renegotiation_info := #renegotiation_info{renegotiated_connection = <<0>>}} = Extensions.
 
 decode_supported_elliptic_curves_hello_extension_correctly(_Config) ->
@@ -148,13 +148,13 @@ decode_supported_elliptic_curves_hello_extension_correctly(_Config) ->
     Len = ListLen + 2,
     Extension = <<?UINT16(?ELLIPTIC_CURVES_EXT), ?UINT16(Len), ?UINT16(ListLen), EllipticCurveList/binary>>,
     % after decoding we should see only valid curves
-    Extensions = ssl_handshake:decode_hello_extensions(Extension, ?'TLS-1.1', ?'TLS-1.1', client),
+    Extensions = ssl_handshake:decode_hello_extensions(Extension, ?TLS_1_1, ?TLS_1_1, client),
     #{elliptic_curves := #elliptic_curves{elliptic_curve_list = [?sect233k1, ?sect193r2]}} = Extensions. 
 
 decode_unknown_hello_extension_correctly(_Config) ->
     FourByteUnknown = <<16#CA,16#FE, ?UINT16(4), 3, 0, 1, 2>>,
     Renegotiation = <<?UINT16(?RENEGOTIATION_EXT), ?UINT16(1), 0>>,
-    Extensions = ssl_handshake:decode_hello_extensions(<<FourByteUnknown/binary, Renegotiation/binary>>, ?'TLS-1.1', ?'TLS-1.1', client),
+    Extensions = ssl_handshake:decode_hello_extensions(<<FourByteUnknown/binary, Renegotiation/binary>>, ?TLS_1_1, ?TLS_1_1, client),
     #{renegotiation_info := #renegotiation_info{renegotiated_connection = <<0>>}} = Extensions.
 
 
@@ -169,21 +169,21 @@ encode_single_hello_sni_extension_correctly(_Config) ->
 decode_single_hello_sni_extension_correctly(_Config) ->
     SNI = <<16#00, 16#00, 16#00, 16#0d, 16#00, 16#0b, 16#00, 16#00, 16#08,
 	    $t,    $e,    $s,    $t,    $.,    $c,    $o,    $m>>,
-    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?'TLS-1.2', ?'TLS-1.2', client),
+    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?TLS_1_2, ?TLS_1_2, client),
     #{sni := #sni{hostname = "test.com"}} = Decoded.
 
 decode_empty_server_sni_correctly(_Config) ->
     SNI = <<?UINT16(?SNI_EXT),?UINT16(0)>>,
-    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?'TLS-1.2', ?'TLS-1.2', server),
+    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?TLS_1_2, ?TLS_1_2, server),
     #{sni := #sni{hostname = ""}} = Decoded.
 
 
 select_proper_tls_1_2_rsa_default_hashsign(_Config) ->
     % RFC 5246 section 7.4.1.4.1 tells to use {sha1,rsa} as default signature_algorithm for RSA key exchanges
-    {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'TLS-1.2'),
+    {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?TLS_1_2),
     % Older versions use MD5/SHA1 combination
-    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'TLS-1.1'),
-    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'SSL-3.0').
+    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?TLS_1_1),
+    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?SSL_3_0).
 
 
 ignore_hassign_extension_pre_tls_1_2(Config) ->
@@ -191,10 +191,10 @@ ignore_hassign_extension_pre_tls_1_2(Config) ->
     CertFile = proplists:get_value(certfile, Opts),
     [{_, Cert, _}] = ssl_test_lib:pem_to_der(CertFile),
     HashSigns = #hash_sign_algos{hash_sign_algos = [{sha512, rsa}, {sha, dsa}, {sha256, rsa}]},
-    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'TLS-1.2']), ?'TLS-1.2'),
+    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?TLS_1_2]), ?TLS_1_2),
     %%% Ignore
-    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'TLS-1.1']), ?'TLS-1.1'),
-    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'SSL-3.0']), ?'SSL-3.0').
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?TLS_1_1]), ?TLS_1_1),
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?SSL_3_0]), ?SSL_3_0).
 
 signature_algorithms(Config) ->
     Opts = proplists:get_value(server_opts, Config),
@@ -211,16 +211,16 @@ signature_algorithms(Config) ->
     {sha512, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns0, Schemes0},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([?'TLS-1.2']),
-                      ?'TLS-1.2'),
+                      tls_v1:default_signature_algs([?TLS_1_2]),
+                      ?TLS_1_2),
     HashSigns1 = #hash_sign_algos{
                     hash_sign_algos = [{sha, dsa},
                                        {sha256, rsa}]},
     {sha256, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns1, Schemes0},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([?'TLS-1.2']),
-                      ?'TLS-1.2'),
+                      tls_v1:default_signature_algs([?TLS_1_2]),
+                      ?TLS_1_2),
     Schemes1 = #signature_algorithms_cert{
                   signature_scheme_list = [rsa_pkcs1_sha1,
                                            ecdsa_sha1]},
@@ -228,22 +228,22 @@ signature_algorithms(Config) ->
     #alert{} = ssl_handshake:select_hashsign(
                  {HashSigns1, Schemes1},
                  Cert, ecdhe_rsa,
-                 tls_v1:default_signature_algs([?'TLS-1.2']),
-                 ?'TLS-1.2'),
+                 tls_v1:default_signature_algs([?TLS_1_2]),
+                 ?TLS_1_2),
     %% No scheme, hashsign is used
     {sha256, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns1, undefined},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([?'TLS-1.2']),
-                      ?'TLS-1.2'),
+                      tls_v1:default_signature_algs([?TLS_1_2]),
+                      ?TLS_1_2),
     HashSigns2 = #hash_sign_algos{
                     hash_sign_algos = [{sha, dsa}]},
     %% Signature not supported
     #alert{} = ssl_handshake:select_hashsign(
                  {HashSigns2, Schemes1},
                  Cert, ecdhe_rsa,
-                 tls_v1:default_signature_algs([?'TLS-1.2']),
-                 ?'TLS-1.2').
+                 tls_v1:default_signature_algs([?TLS_1_2]),
+                 ?TLS_1_2).
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -126,7 +126,7 @@ decode_hello_handshake(_Config) ->
 		    16#00, 16#00, 16#33, 16#74, 16#00, 16#07, 16#06, 16#73,
 		    16#70, 16#64, 16#79, 16#2f, 16#32>>,
 	
-    Version = {3, 0},
+    Version = ?'SSL-3.0',
     DefOpts = ssl:update_options([{verify, verify_none}], client, #{}),
     {Records, _Buffer} = tls_handshake:get_tls_handshakes(Version, HelloPacket, <<>>, DefOpts),
 
@@ -136,7 +136,7 @@ decode_hello_handshake(_Config) ->
 
 decode_single_hello_extension_correctly(_Config) -> 
     Renegotiation = <<?UINT16(?RENEGOTIATION_EXT), ?UINT16(1), 0>>,
-    Extensions = ssl_handshake:decode_extensions(Renegotiation, {3,3}, undefined),
+    Extensions = ssl_handshake:decode_extensions(Renegotiation, ?'TLS-1.2', undefined),
     #{renegotiation_info := #renegotiation_info{renegotiated_connection = <<0>>}} = Extensions.
 
 decode_supported_elliptic_curves_hello_extension_correctly(_Config) ->
@@ -148,13 +148,13 @@ decode_supported_elliptic_curves_hello_extension_correctly(_Config) ->
     Len = ListLen + 2,
     Extension = <<?UINT16(?ELLIPTIC_CURVES_EXT), ?UINT16(Len), ?UINT16(ListLen), EllipticCurveList/binary>>,
     % after decoding we should see only valid curves
-    Extensions = ssl_handshake:decode_hello_extensions(Extension, {3,2}, {3,2}, client),
+    Extensions = ssl_handshake:decode_hello_extensions(Extension, ?'TLS-1.1', ?'TLS-1.1', client),
     #{elliptic_curves := #elliptic_curves{elliptic_curve_list = [?sect233k1, ?sect193r2]}} = Extensions. 
 
 decode_unknown_hello_extension_correctly(_Config) ->
     FourByteUnknown = <<16#CA,16#FE, ?UINT16(4), 3, 0, 1, 2>>,
     Renegotiation = <<?UINT16(?RENEGOTIATION_EXT), ?UINT16(1), 0>>,
-    Extensions = ssl_handshake:decode_hello_extensions(<<FourByteUnknown/binary, Renegotiation/binary>>, {3,2}, {3,2}, client),
+    Extensions = ssl_handshake:decode_hello_extensions(<<FourByteUnknown/binary, Renegotiation/binary>>, ?'TLS-1.1', ?'TLS-1.1', client),
     #{renegotiation_info := #renegotiation_info{renegotiated_connection = <<0>>}} = Extensions.
 
 
@@ -169,21 +169,21 @@ encode_single_hello_sni_extension_correctly(_Config) ->
 decode_single_hello_sni_extension_correctly(_Config) ->
     SNI = <<16#00, 16#00, 16#00, 16#0d, 16#00, 16#0b, 16#00, 16#00, 16#08,
 	    $t,    $e,    $s,    $t,    $.,    $c,    $o,    $m>>,
-    Decoded = ssl_handshake:decode_hello_extensions(SNI, {3,3}, {3,3}, client),
+    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?'TLS-1.2', ?'TLS-1.2', client),
     #{sni := #sni{hostname = "test.com"}} = Decoded.
 
 decode_empty_server_sni_correctly(_Config) ->
     SNI = <<?UINT16(?SNI_EXT),?UINT16(0)>>,
-    Decoded = ssl_handshake:decode_hello_extensions(SNI, {3,3}, {3,3}, server),
+    Decoded = ssl_handshake:decode_hello_extensions(SNI, ?'TLS-1.2', ?'TLS-1.2', server),
     #{sni := #sni{hostname = ""}} = Decoded.
 
 
 select_proper_tls_1_2_rsa_default_hashsign(_Config) ->
     % RFC 5246 section 7.4.1.4.1 tells to use {sha1,rsa} as default signature_algorithm for RSA key exchanges
-    {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,3}),
+    {sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'TLS-1.2'),
     % Older versions use MD5/SHA1 combination
-    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,2}),
-    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, {3,0}).
+    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'TLS-1.1'),
+    {md5sha, rsa} = ssl_handshake:select_hashsign_algs(undefined, ?rsaEncryption, ?'SSL-3.0').
 
 
 ignore_hassign_extension_pre_tls_1_2(Config) ->
@@ -191,11 +191,10 @@ ignore_hassign_extension_pre_tls_1_2(Config) ->
     CertFile = proplists:get_value(certfile, Opts),
     [{_, Cert, _}] = ssl_test_lib:pem_to_der(CertFile),
     HashSigns = #hash_sign_algos{hash_sign_algos = [{sha512, rsa}, {sha, dsa}, {sha256, rsa}]},
-    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([{3,3}]), {3,3}),
+    {sha512, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'TLS-1.2']), ?'TLS-1.2'),
     %%% Ignore
-    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([{3,2}]), {3,2}),
-    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([{3,0}]), {3,0}).
-
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'TLS-1.1']), ?'TLS-1.1'),
+    {md5sha, rsa} = ssl_handshake:select_hashsign({HashSigns, undefined}, Cert, ecdhe_rsa, tls_v1:default_signature_algs([?'SSL-3.0']), ?'SSL-3.0').
 
 signature_algorithms(Config) ->
     Opts = proplists:get_value(server_opts, Config),
@@ -212,16 +211,16 @@ signature_algorithms(Config) ->
     {sha512, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns0, Schemes0},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([{3,3}]),
-                      {3,3}),
+                      tls_v1:default_signature_algs([?'TLS-1.2']),
+                      ?'TLS-1.2'),
     HashSigns1 = #hash_sign_algos{
                     hash_sign_algos = [{sha, dsa},
                                        {sha256, rsa}]},
     {sha256, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns1, Schemes0},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([{3,3}]),
-                      {3,3}),
+                      tls_v1:default_signature_algs([?'TLS-1.2']),
+                      ?'TLS-1.2'),
     Schemes1 = #signature_algorithms_cert{
                   signature_scheme_list = [rsa_pkcs1_sha1,
                                            ecdsa_sha1]},
@@ -229,22 +228,22 @@ signature_algorithms(Config) ->
     #alert{} = ssl_handshake:select_hashsign(
                  {HashSigns1, Schemes1},
                  Cert, ecdhe_rsa,
-                 tls_v1:default_signature_algs([{3,3}]),
-                 {3,3}),
+                 tls_v1:default_signature_algs([?'TLS-1.2']),
+                 ?'TLS-1.2'),
     %% No scheme, hashsign is used
     {sha256, rsa} = ssl_handshake:select_hashsign(
                       {HashSigns1, undefined},
                       Cert, ecdhe_rsa,
-                      tls_v1:default_signature_algs([{3,3}]),
-                      {3,3}),
+                      tls_v1:default_signature_algs([?'TLS-1.2']),
+                      ?'TLS-1.2'),
     HashSigns2 = #hash_sign_algos{
                     hash_sign_algos = [{sha, dsa}]},
     %% Signature not supported
     #alert{} = ssl_handshake:select_hashsign(
                  {HashSigns2, Schemes1},
                  Cert, ecdhe_rsa,
-                 tls_v1:default_signature_algs([{3,3}]),
-                 {3,3}).
+                 tls_v1:default_signature_algs([?'TLS-1.2']),
+                 ?'TLS-1.2').
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------

--- a/lib/ssl/test/ssl_mfl_SUITE.erl
+++ b/lib/ssl/test/ssl_mfl_SUITE.erl
@@ -187,7 +187,7 @@ run_mfl_handshake_continue(Config, MFL) ->
                     receive {Client, {ext, ClientExt}} ->
                             ct:log("Client handshake Ext ~p~n", [ClientExt]),
                             case maps:get(server_hello_selected_version, ClientExt, undefined) of
-                                ?'TLS-1.3' ->
+                                ?TLS_1_3 ->
                                     %% For TLS 1.3 the ssl {handshake, hello} API is inconsistent:
                                     %% the server gets all the extensions CH+EE, but the client only CH
                                     ignore;

--- a/lib/ssl/test/ssl_mfl_SUITE.erl
+++ b/lib/ssl/test/ssl_mfl_SUITE.erl
@@ -22,6 +22,7 @@
 -behaviour(ct_suite).
 
 -include_lib("common_test/include/ct.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -186,7 +187,7 @@ run_mfl_handshake_continue(Config, MFL) ->
                     receive {Client, {ext, ClientExt}} ->
                             ct:log("Client handshake Ext ~p~n", [ClientExt]),
                             case maps:get(server_hello_selected_version, ClientExt, undefined) of
-                                {3,4} ->
+                                ?'TLS-1.3' ->
                                     %% For TLS 1.3 the ssl {handshake, hello} API is inconsistent:
                                     %% the server gets all the extensions CH+EE, but the client only CH
                                     ignore;

--- a/lib/ssl/test/ssl_npn_hello_SUITE.erl
+++ b/lib/ssl/test/ssl_npn_hello_SUITE.erl
@@ -123,12 +123,12 @@ encode_and_decode_npn_server_hello_test(Config) ->
 
 %%--------------------------------------------------------------------
 create_server_hello_with_no_advertised_protocols_test(_Config) ->
-    Hello = ssl_handshake:server_hello(<<>>, ?'SSL-3.0', create_connection_states(), #{}),
+    Hello = ssl_handshake:server_hello(<<>>, ?SSL_3_0, create_connection_states(), #{}),
     Extensions = Hello#server_hello.extensions,
     #{} = Extensions.
 %%--------------------------------------------------------------------
 create_server_hello_with_advertised_protocols_test(_Config) ->
-    Hello = ssl_handshake:server_hello(<<>>, ?'SSL-3.0', create_connection_states(),
+    Hello = ssl_handshake:server_hello(<<>>, ?SSL_3_0, create_connection_states(),
 				       #{next_protocol_negotiation => [<<"spdy/1">>, <<"http/1.0">>, <<"http/1.1">>]}),
     Extensions = Hello#server_hello.extensions,
     #{next_protocol_negotiation := [<<"spdy/1">>, <<"http/1.0">>, <<"http/1.1">>]} = Extensions.

--- a/lib/ssl/test/ssl_npn_hello_SUITE.erl
+++ b/lib/ssl/test/ssl_npn_hello_SUITE.erl
@@ -123,12 +123,12 @@ encode_and_decode_npn_server_hello_test(Config) ->
 
 %%--------------------------------------------------------------------
 create_server_hello_with_no_advertised_protocols_test(_Config) ->
-    Hello = ssl_handshake:server_hello(<<>>, {3, 0}, create_connection_states(), #{}),
+    Hello = ssl_handshake:server_hello(<<>>, ?'SSL-3.0', create_connection_states(), #{}),
     Extensions = Hello#server_hello.extensions,
     #{} = Extensions.
 %%--------------------------------------------------------------------
 create_server_hello_with_advertised_protocols_test(_Config) ->
-    Hello = ssl_handshake:server_hello(<<>>, {3, 0}, create_connection_states(),
+    Hello = ssl_handshake:server_hello(<<>>, ?'SSL-3.0', create_connection_states(),
 				       #{next_protocol_negotiation => [<<"spdy/1">>, <<"http/1.0">>, <<"http/1.1">>]}),
     Extensions = Hello#server_hello.extensions,
     #{next_protocol_negotiation := [<<"spdy/1">>, <<"http/1.0">>, <<"http/1.1">>]} = Extensions.

--- a/lib/ssl/test/ssl_reject_SUITE.erl
+++ b/lib/ssl/test/ssl_reject_SUITE.erl
@@ -48,15 +48,15 @@
          accept_sslv3_record_hello/1
         ]).
 
--define(TLS_MAJOR,     (element(1, ?'TLS-1.2'))).
--define(SSL_3_0_MAJOR, (element(1, ?'SSL-3.0'))).
--define(SSL_3_0_MINOR, (element(2, ?'SSL-3.0'))).
--define(TLS_1_0_MINOR, (element(2, ?'TLS-1.0'))).
--define(TLS_1_1_MINOR, (element(2, ?'TLS-1.1'))).
--define(TLS_1_2_MINOR, (element(2, ?'TLS-1.2'))).
--define(TLS_1_3_MINOR, (element(2, ?'TLS-1.3'))).
--define(SSL_2_0_MAJOR, (element(1, ?'SSL-2.0'))).
--define(SSL_2_0_MINOR, (element(2, ?'SSL-2.0'))).
+-define(TLS_MAJOR,     (element(1, ?TLS_1_2))).
+-define(SSL_3_0_MAJOR, (element(1, ?SSL_3_0))).
+-define(SSL_3_0_MINOR, (element(2, ?SSL_3_0))).
+-define(TLS_1_0_MINOR, (element(2, ?TLS_1_0))).
+-define(TLS_1_1_MINOR, (element(2, ?TLS_1_1))).
+-define(TLS_1_2_MINOR, (element(2, ?TLS_1_2))).
+-define(TLS_1_3_MINOR, (element(2, ?TLS_1_3))).
+-define(SSL_2_0_MAJOR, (element(1, ?SSL_2_0))).
+-define(SSL_2_0_MINOR, (element(2, ?SSL_2_0))).
 
 %%--------------------------------------------------------------------
 %% Common Test interface functions -----------------------------------

--- a/lib/ssl/test/ssl_reject_SUITE.erl
+++ b/lib/ssl/test/ssl_reject_SUITE.erl
@@ -22,7 +22,7 @@
 -module(ssl_reject_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("ssl/src/ssl_record.hrl").
+-include("ssl_record.hrl").
 -include_lib("ssl/src/ssl_alert.hrl").
 -include_lib("ssl/src/ssl_handshake.hrl").
 
@@ -48,15 +48,15 @@
          accept_sslv3_record_hello/1
         ]).
 
--define(TLS_MAJOR, 3).
--define(SSL_3_0_MAJOR, 3).
--define(SSL_3_0_MINOR, 0).
--define(TLS_1_0_MINOR, 1).
--define(TLS_1_1_MINOR, 2).
--define(TLS_1_2_MINOR, 3).
--define(TLS_1_3_MINOR, 4).
--define(SSL_2_0_MAJOR, 0).
--define(SSL_2_0_MINOR, 1).
+-define(TLS_MAJOR,     (element(1, ?'TLS-1.2'))).
+-define(SSL_3_0_MAJOR, (element(1, ?'SSL-3.0'))).
+-define(SSL_3_0_MINOR, (element(2, ?'SSL-3.0'))).
+-define(TLS_1_0_MINOR, (element(2, ?'TLS-1.0'))).
+-define(TLS_1_1_MINOR, (element(2, ?'TLS-1.1'))).
+-define(TLS_1_2_MINOR, (element(2, ?'TLS-1.2'))).
+-define(TLS_1_3_MINOR, (element(2, ?'TLS-1.3'))).
+-define(SSL_2_0_MAJOR, (element(1, ?'SSL-2.0'))).
+-define(SSL_2_0_MINOR, (element(2, ?'SSL-2.0'))).
 
 %%--------------------------------------------------------------------
 %% Common Test interface functions -----------------------------------
@@ -194,10 +194,11 @@ accept_sslv3_record_hello(Config) when is_list(Config) ->
 
     {ok, Socket} = gen_tcp:connect(Hostname, Port, [{active, false}]),
     gen_tcp:send(Socket, ClientHello),
+    TLS_Major = ?TLS_MAJOR,
     case gen_tcp:recv(Socket, 3, 5000) of
         %% Minor needs to be a TLS version that is a version
         %% above SSL-3.0
-        {ok, [?HANDSHAKE, ?TLS_MAJOR, Minor]} when Minor > ?SSL_3_0_MINOR ->
+        {ok, [?HANDSHAKE, TLS_Major, Minor]} when Minor > ?SSL_3_0_MINOR ->
             ok;
         {error, timeout} ->
             ct:fail(ssl3_record_not_accepted)

--- a/lib/ssl/test/ssl_renegotiate_SUITE.erl
+++ b/lib/ssl/test/ssl_renegotiate_SUITE.erl
@@ -26,6 +26,7 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("public_key/include/public_key.hrl").
+-include("ssl_record.hrl").
 
 %% Common test
 -export([all/0,
@@ -87,11 +88,10 @@ all() ->
 
 groups() ->
     [{'dtlsv1.2', [], renegotiate_tests()},
-     {'dtlsv1', [], renegotiate_tests()},
-     {'tlsv1.3', [], renegotiate_tests()},
-     {'tlsv1.2', [], renegotiate_tests()},
-     {'tlsv1.1', [], renegotiate_tests()},
-     {'tlsv1', [], renegotiate_tests()}
+     {'dtlsv1',   [], renegotiate_tests()},
+     {'tlsv1.2',  [], renegotiate_tests()},
+     {'tlsv1.1',  [], renegotiate_tests()},
+     {'tlsv1',    [], renegotiate_tests()}
     ].
 
 renegotiate_tests() ->
@@ -99,17 +99,6 @@ renegotiate_tests() ->
      server_renegotiate,
      client_secure_renegotiate,
      client_secure_renegotiate_fallback,
-     client_renegotiate_reused_session,
-     server_renegotiate_reused_session,
-     client_no_wrap_sequence_number,
-     server_no_wrap_sequence_number,
-     renegotiate_dos_mitigate_active,
-     renegotiate_dos_mitigate_passive,
-     renegotiate_dos_mitigate_absolute].
-
-ssl3_renegotiate_tests() ->
-    [client_renegotiate,
-     server_renegotiate,
      client_renegotiate_reused_session,
      server_renegotiate_reused_session,
      client_no_wrap_sequence_number,
@@ -518,9 +507,7 @@ renegotiate_rejected(Socket) ->
     ok.
 
 %% First two clauses handles 1/n-1 splitting countermeasure Rizzo/Duong-Beast
-treashold(N, {3,0}) ->
-    (N div 2) + 1;
-treashold(N, {3,1}) ->
+treashold(N, ?'TLS-1.0') ->
     (N div 2) + 1;
 treashold(N, _) ->
     N + 1.

--- a/lib/ssl/test/ssl_renegotiate_SUITE.erl
+++ b/lib/ssl/test/ssl_renegotiate_SUITE.erl
@@ -507,7 +507,7 @@ renegotiate_rejected(Socket) ->
     ok.
 
 %% First two clauses handles 1/n-1 splitting countermeasure Rizzo/Duong-Beast
-treashold(N, ?'TLS-1.0') ->
+treashold(N, ?TLS_1_0) ->
     (N div 2) + 1;
 treashold(N, _) ->
     N + 1.

--- a/lib/ssl/test/ssl_session_SUITE.erl
+++ b/lib/ssl/test/ssl_session_SUITE.erl
@@ -660,9 +660,9 @@ faulty_client(Host, Port) ->
 
 
 encode_client_hello(CH, Random) ->
-    HSBin = tls_handshake:encode_handshake(CH, ?'TLS-1.2'),
+    HSBin = tls_handshake:encode_handshake(CH, ?TLS_1_2),
     CS = connection_states(Random),
-    {Encoded, _} = tls_record:encode_handshake(HSBin, ?'TLS-1.2', CS),
+    {Encoded, _} = tls_record:encode_handshake(HSBin, ?TLS_1_2, CS),
     Encoded.
 
 client_hello(Random) ->
@@ -738,7 +738,7 @@ client_hello(Random) ->
 		   srp =>
 		       undefined},
 
-    #client_hello{client_version = ?'TLS-1.2',
+    #client_hello{client_version = ?TLS_1_2,
 		  random = Random,
 		  session_id = crypto:strong_rand_bytes(32),
 		  cipher_suites = CipherSuites,

--- a/lib/ssl/test/ssl_session_SUITE.erl
+++ b/lib/ssl/test/ssl_session_SUITE.erl
@@ -660,9 +660,9 @@ faulty_client(Host, Port) ->
 
 
 encode_client_hello(CH, Random) ->
-    HSBin = tls_handshake:encode_handshake(CH, {3,3}),
+    HSBin = tls_handshake:encode_handshake(CH, ?'TLS-1.2'),
     CS = connection_states(Random),
-    {Encoded, _} = tls_record:encode_handshake(HSBin, {3,3}, CS),
+    {Encoded, _} = tls_record:encode_handshake(HSBin, ?'TLS-1.2', CS),
     Encoded.
 
 client_hello(Random) ->
@@ -738,7 +738,7 @@ client_hello(Random) ->
 		   srp =>
 		       undefined},
 
-    #client_hello{client_version = {3,3},
+    #client_hello{client_version = ?'TLS-1.2',
 		  random = Random,
 		  session_id = crypto:strong_rand_bytes(32),
 		  cipher_suites = CipherSuites,

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -467,7 +467,7 @@ sig_algs(rsa_pss_rsae, _) ->
     [{signature_algs, [rsa_pss_rsae_sha512,
                        rsa_pss_rsae_sha384,
                        rsa_pss_rsae_sha256]}];
-sig_algs(rsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
+sig_algs(rsa, Version) when ?TLS_GTE(Version, ?TLS_1_2) ->
     [{signature_algs, [rsa_pss_rsae_sha512,
                        rsa_pss_rsae_sha384,
                        rsa_pss_rsae_sha256,
@@ -476,13 +476,13 @@ sig_algs(rsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
                        {sha256, rsa},
                        {sha, rsa}
                       ]}];
-sig_algs(ecdsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
+sig_algs(ecdsa, Version) when ?TLS_GTE(Version, ?TLS_1_2) ->
     [{signature_algs, [
                        {sha512, ecdsa},
                        {sha384, ecdsa},
                        {sha256, ecdsa},
                        {sha, ecdsa}]}];
-sig_algs(dsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
+sig_algs(dsa, Version) when ?TLS_GTE(Version, ?TLS_1_2) ->
     [{signature_algs, [{sha,dsa}]}];
 sig_algs(_,_) ->
     [].

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -27,6 +27,7 @@
 -include_lib("ssl/src/tls_handshake_1_3.hrl").
 -include_lib("ssl/src/ssl_cipher.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
+-include_lib("ssl/src/ssl_record.hrl").
 
 -export([clean_start/0,
          clean_start/1,
@@ -466,7 +467,7 @@ sig_algs(rsa_pss_rsae, _) ->
     [{signature_algs, [rsa_pss_rsae_sha512,
                        rsa_pss_rsae_sha384,
                        rsa_pss_rsae_sha256]}];
-sig_algs(rsa, Version) when Version >= {3,3} ->
+sig_algs(rsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
     [{signature_algs, [rsa_pss_rsae_sha512,
                        rsa_pss_rsae_sha384,
                        rsa_pss_rsae_sha256,
@@ -475,13 +476,13 @@ sig_algs(rsa, Version) when Version >= {3,3} ->
                        {sha256, rsa},
                        {sha, rsa}
                       ]}];
-sig_algs(ecdsa, Version) when Version >= {3,3} ->
+sig_algs(ecdsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
     [{signature_algs, [
                        {sha512, ecdsa},
                        {sha384, ecdsa},
                        {sha256, ecdsa},
                        {sha, ecdsa}]}];
-sig_algs(dsa, Version) when Version >= {3,3} ->
+sig_algs(dsa, Version) when ?TLS_GE(Version, ?TLS_1_2) ->
     [{signature_algs, [{sha,dsa}]}];
 sig_algs(_,_) ->
     [].
@@ -4242,7 +4243,7 @@ ktls_set_ulp(Socket, OS) ->
       OS).
 
 ktls_set_cipher(Socket, OS, TxRx, Seed) ->
-    TLS_version = {3,4},
+    TLS_version = ?TLS_1_3,
     TLS_cipher = ?TLS_AES_256_GCM_SHA384,
     TLS_IV   = binary:copy(<<(Seed + 0)>>, 8),
     TLS_KEY  = binary:copy(<<(Seed + 1)>>, 32),

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -2836,7 +2836,7 @@ openssl_tls_version_support(Version, Config0) ->
         true ->
             openssl_tls_version_support(tls, TLSOpts, Port, Exe, TLSArgs);
         false ->
-            DTLSTupleVersion = dtls_record:protocol_version(Version),
+            DTLSTupleVersion = dtls_record:protocol_version_name(Version),
             CorrespondingTLSVersion = dtls_v1:corresponding_tls_version(DTLSTupleVersion),
             AtomTLSVersion = tls_record:protocol_version(CorrespondingTLSVersion),
             CorrTLSOpts = [{protocol,tls}, {versions, [AtomTLSVersion]},
@@ -3660,8 +3660,8 @@ protocol_version(Config, atom) ->
     case proplists:get_value(protocol, Config) of
 	dtls ->
 	   dtls_record:protocol_version(protocol_version(Config, tuple));
-	_ ->							 
-           tls_record:protocol_version(protocol_version(Config, tuple))	
+	_ ->
+            tls_record:protocol_version(protocol_version(Config, tuple))
    end.
 
 protocol_options(Config, Options) ->
@@ -3715,11 +3715,11 @@ clean_start(keep_version) ->
 
 
 tls_version('dtlsv1' = Atom) ->
-    dtls_v1:corresponding_tls_version(dtls_record:protocol_version(Atom));
+    dtls_v1:corresponding_tls_version(dtls_record:protocol_version_name(Atom));
 tls_version('dtlsv1.2' = Atom) ->
-    dtls_v1:corresponding_tls_version(dtls_record:protocol_version(Atom));
+    dtls_v1:corresponding_tls_version(dtls_record:protocol_version_name(Atom));
 tls_version(Atom) ->
-    tls_record:protocol_version(Atom).
+    tls_record:protocol_version_name(Atom).
 
 
 n_version(Version) when
@@ -3728,10 +3728,10 @@ n_version(Version) when
       Version == 'tlsv1.1';
       Version == 'tlsv1';
       Version == 'sslv3' ->
-    tls_record:protocol_version(Version);
+    tls_record:protocol_version_name(Version);
 n_version(Version) when Version == 'dtlsv1.2';
                         Version == 'dtlsv1' ->
-    dtls_record:protocol_version(Version).
+    dtls_record:protocol_version_name(Version).
 
 consume_port_exit(OpenSSLPort) ->
     receive    	

--- a/lib/ssl/test/tls_1_3_record_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_record_SUITE.erl
@@ -174,9 +174,9 @@ encode_decode(_Config) ->
                    146,152,146,151,107,126,216,210,9,93,0,0>>],
 
     {[_Header|Encoded], _} = tls_record_1_3:encode_plain_text(22, PlainText, ConnectionStates),
-    CipherText = #ssl_tls{type = 23, version = ?'TLS-1.2', fragment = Encoded},
+    CipherText = #ssl_tls{type = 23, version = ?TLS_1_2, fragment = Encoded},
 
-    {#ssl_tls{type = 22, version = ?'TLS-1.3', fragment = DecodedText}, _} =
+    {#ssl_tls{type = 22, version = ?TLS_1_3, fragment = DecodedText}, _} =
         tls_record_1_3:decode_cipher_text(CipherText, ConnectionStates),
 
     DecodedText = iolist_to_binary(PlainText),
@@ -260,7 +260,7 @@ encode_decode(_Config) ->
           01 04 02 05 02 06 02 02 02 00 2d 00 02 01 01 00 1c 00 02 40 01"),
 
     {CHEncrypted, _} =
-	tls_record:encode_handshake(ClientHello, ?'TLS-1.3', ConnStatesNull),
+	tls_record:encode_handshake(ClientHello, ?TLS_1_3, ConnStatesNull),
     ClientHelloRecord = iolist_to_binary(CHEncrypted),
 
     %% {server}  extract secret "early":
@@ -515,7 +515,7 @@ encode_decode(_Config) ->
           cc 25 3b 83 3d f1 dd 69 b1 b0 4e 75 1f 0f 00 2b 00 02 03 04"),
 
     {SHEncrypted, _} =
-	tls_record:encode_handshake(ServerHello, ?'TLS-1.3', ConnStatesNull),
+	tls_record:encode_handshake(ServerHello, ?TLS_1_3, ConnStatesNull),
     ServerHelloRecord = iolist_to_binary(SHEncrypted),
 
     %% {server}  derive write traffic keys for handshake data:
@@ -685,7 +685,7 @@ encode_decode(_Config) ->
 
     FinishedHS = #finished{verify_data = FinishedVerifyData},
 
-    FinishedIOList = tls_handshake:encode_handshake(FinishedHS, ?'TLS-1.3'),
+    FinishedIOList = tls_handshake:encode_handshake(FinishedHS, ?TLS_1_3),
     FinishedHSBin = iolist_to_binary(FinishedIOList),
 
     %% {server}  derive secret "tls13 c ap traffic":
@@ -907,7 +907,7 @@ encode_decode(_Config) ->
 
     CFinished = #finished{verify_data = CFinishedVerifyData},
 
-    CFinishedIOList = tls_handshake:encode_handshake(CFinished, ?'TLS-1.3'),
+    CFinishedIOList = tls_handshake:encode_handshake(CFinished, ?TLS_1_3),
     CFinishedBin = iolist_to_binary(CFinishedIOList),
 
     %% {client}  derive write traffic keys for application data:
@@ -1054,7 +1054,7 @@ encode_decode(_Config) ->
        ticket_nonce = Nonce,
        ticket = Ticket,
        extensions = _Extensions
-      } = tls_handshake:decode_handshake(?'TLS-1.3', NWT, TicketBody),
+      } = tls_handshake:decode_handshake(?TLS_1_3, NWT, TicketBody),
 
     %% ResPRK = resumption master secret
     ResExpanded = tls_v1:pre_shared_key(ResPRK, Nonce, HKDFAlgo),
@@ -1288,7 +1288,7 @@ encode_decode(_Config) ->
 
     <<?BYTE(CH), ?UINT24(_Length), ClientHelloBody/binary>> = ClientHelloRecord,
     #client_hello{extensions = #{pre_shared_key := PreSharedKey}} =
-        tls_handshake:decode_handshake(?'TLS-1.3', CH, ClientHelloBody),
+        tls_handshake:decode_handshake(?TLS_1_3, CH, ClientHelloBody),
 
     #pre_shared_key_client_hello{
        offered_psks = #offered_psks{

--- a/lib/ssl/test/tls_1_3_record_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_record_SUITE.erl
@@ -174,9 +174,9 @@ encode_decode(_Config) ->
                    146,152,146,151,107,126,216,210,9,93,0,0>>],
 
     {[_Header|Encoded], _} = tls_record_1_3:encode_plain_text(22, PlainText, ConnectionStates),
-    CipherText = #ssl_tls{type = 23, version = {3,3}, fragment = Encoded},
+    CipherText = #ssl_tls{type = 23, version = ?'TLS-1.2', fragment = Encoded},
 
-    {#ssl_tls{type = 22, version = {3,4}, fragment = DecodedText}, _} =
+    {#ssl_tls{type = 22, version = ?'TLS-1.3', fragment = DecodedText}, _} =
         tls_record_1_3:decode_cipher_text(CipherText, ConnectionStates),
 
     DecodedText = iolist_to_binary(PlainText),
@@ -260,7 +260,7 @@ encode_decode(_Config) ->
           01 04 02 05 02 06 02 02 02 00 2d 00 02 01 01 00 1c 00 02 40 01"),
 
     {CHEncrypted, _} =
-	tls_record:encode_handshake(ClientHello, {3,4}, ConnStatesNull),
+	tls_record:encode_handshake(ClientHello, ?'TLS-1.3', ConnStatesNull),
     ClientHelloRecord = iolist_to_binary(CHEncrypted),
 
     %% {server}  extract secret "early":
@@ -515,7 +515,7 @@ encode_decode(_Config) ->
           cc 25 3b 83 3d f1 dd 69 b1 b0 4e 75 1f 0f 00 2b 00 02 03 04"),
 
     {SHEncrypted, _} =
-	tls_record:encode_handshake(ServerHello, {3,4}, ConnStatesNull),
+	tls_record:encode_handshake(ServerHello, ?'TLS-1.3', ConnStatesNull),
     ServerHelloRecord = iolist_to_binary(SHEncrypted),
 
     %% {server}  derive write traffic keys for handshake data:
@@ -685,7 +685,7 @@ encode_decode(_Config) ->
 
     FinishedHS = #finished{verify_data = FinishedVerifyData},
 
-    FinishedIOList = tls_handshake:encode_handshake(FinishedHS, {3,4}),
+    FinishedIOList = tls_handshake:encode_handshake(FinishedHS, ?'TLS-1.3'),
     FinishedHSBin = iolist_to_binary(FinishedIOList),
 
     %% {server}  derive secret "tls13 c ap traffic":
@@ -907,7 +907,7 @@ encode_decode(_Config) ->
 
     CFinished = #finished{verify_data = CFinishedVerifyData},
 
-    CFinishedIOList = tls_handshake:encode_handshake(CFinished, {3,4}),
+    CFinishedIOList = tls_handshake:encode_handshake(CFinished, ?'TLS-1.3'),
     CFinishedBin = iolist_to_binary(CFinishedIOList),
 
     %% {client}  derive write traffic keys for application data:
@@ -1054,7 +1054,7 @@ encode_decode(_Config) ->
        ticket_nonce = Nonce,
        ticket = Ticket,
        extensions = _Extensions
-      } = tls_handshake:decode_handshake({3,4}, NWT, TicketBody),
+      } = tls_handshake:decode_handshake(?'TLS-1.3', NWT, TicketBody),
 
     %% ResPRK = resumption master secret
     ResExpanded = tls_v1:pre_shared_key(ResPRK, Nonce, HKDFAlgo),
@@ -1288,7 +1288,7 @@ encode_decode(_Config) ->
 
     <<?BYTE(CH), ?UINT24(_Length), ClientHelloBody/binary>> = ClientHelloRecord,
     #client_hello{extensions = #{pre_shared_key := PreSharedKey}} =
-        tls_handshake:decode_handshake({3,4}, CH, ClientHelloBody),
+        tls_handshake:decode_handshake(?'TLS-1.3', CH, ClientHelloBody),
 
     #pre_shared_key_client_hello{
        offered_psks = #offered_psks{

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -788,10 +788,10 @@ tls_reject_warning_alert_in_initial_hs() ->
     [{doc,"Test sending warning ALERT instead of client hello"}].
 tls_reject_warning_alert_in_initial_hs(Config) when is_list(Config) ->
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
-    {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
+    {_Clientnode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     {Major, Minor} = case ssl_test_lib:protocol_version(Config, tuple) of
-                         ?'TLS-1.3' ->
-                             ?'TLS-1.2';
+                         ?TLS_1_3 ->
+                             ?TLS_1_2;
                          Other ->
                              Other
                      end,
@@ -814,8 +814,8 @@ tls_reject_fake_warning_alert_in_initial_hs(Config) when is_list(Config) ->
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     {Major, Minor} = case ssl_test_lib:protocol_version(Config, tuple) of
-                         ?'TLS-1.3' ->
-                             ?'TLS-1.2';
+                         ?TLS_1_3 ->
+                             ?TLS_1_2;
                          Other ->
                              Other
                      end,
@@ -840,8 +840,8 @@ tls_app_data_in_initial_hs_state(Config) when is_list(Config) ->
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     Version = ssl_test_lib:protocol_version(Config, tuple),
     {Major, Minor} = case Version of
-                         ?'TLS-1.3' ->
-                             ?'TLS-1.2';
+                         ?TLS_1_3 ->
+                             ?TLS_1_2;
                          Other ->
                              Other
                      end,
@@ -852,7 +852,7 @@ tls_app_data_in_initial_hs_state(Config) when is_list(Config) ->
     Port = ssl_test_lib:inet_port(Server),
     {ok, Socket}  = gen_tcp:connect("localhost", Port, [{active, false}, binary]),
     AppData = case Version of
-                  ?'TLS-1.3' ->
+                  ?TLS_1_3 ->
                       <<?BYTE(?APPLICATION_DATA), ?BYTE(3), ?BYTE(3), ?UINT16(4), ?BYTE($F), 
                         ?BYTE($O), ?BYTE($O), ?BYTE(?APPLICATION_DATA)>>;
                   _ ->

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -790,8 +790,8 @@ tls_reject_warning_alert_in_initial_hs(Config) when is_list(Config) ->
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     {Major, Minor} = case ssl_test_lib:protocol_version(Config, tuple) of
-                         {3,4} ->
-                             {3,3};
+                         ?'TLS-1.3' ->
+                             ?'TLS-1.2';
                          Other ->
                              Other
                      end,
@@ -814,8 +814,8 @@ tls_reject_fake_warning_alert_in_initial_hs(Config) when is_list(Config) ->
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     {Major, Minor} = case ssl_test_lib:protocol_version(Config, tuple) of
-                         {3,4} ->
-                             {3,3};
+                         ?'TLS-1.3' ->
+                             ?'TLS-1.2';
                          Other ->
                              Other
                      end,
@@ -840,8 +840,8 @@ tls_app_data_in_initial_hs_state(Config) when is_list(Config) ->
     {_ClientNode, ServerNode, _Hostname} = ssl_test_lib:run_where(Config),
     Version = ssl_test_lib:protocol_version(Config, tuple),
     {Major, Minor} = case Version of
-                         {3,4} ->
-                             {3,3};
+                         ?'TLS-1.3' ->
+                             ?'TLS-1.2';
                          Other ->
                              Other
                      end,
@@ -852,7 +852,7 @@ tls_app_data_in_initial_hs_state(Config) when is_list(Config) ->
     Port = ssl_test_lib:inet_port(Server),
     {ok, Socket}  = gen_tcp:connect("localhost", Port, [{active, false}, binary]),
     AppData = case Version of
-                  {3, 4} ->
+                  ?'TLS-1.3' ->
                       <<?BYTE(?APPLICATION_DATA), ?BYTE(3), ?BYTE(3), ?UINT16(4), ?BYTE($F), 
                         ?BYTE($O), ?BYTE($O), ?BYTE(?APPLICATION_DATA)>>;
                   _ ->

--- a/lib/ssl/test/tls_server_session_ticket_SUITE.erl
+++ b/lib/ssl/test/tls_server_session_ticket_SUITE.erl
@@ -25,6 +25,7 @@
 -include_lib("ssl/src/ssl_cipher.hrl").
 -include_lib("ssl/src/ssl_internal.hrl").
 -include_lib("ssl/src/tls_handshake_1_3.hrl").
+-include("ssl_record.hrl").
 
 %% Callback functions
 -export([all/0,
@@ -53,7 +54,7 @@
 -define(TICKET_STORE_SIZE, 1).
 -define(MASTER_SECRET, "master_secret").
 -define(PRF, sha).
--define(VERSION, {3,4}).
+-define(VERSION, ?'TLS-1.3').
 -define(PSK, <<15,168,18,43,216,33,227,142,114,190,70,183,137,57,64,64,66,152,115,94>>).
 -define(WINDOW_SIZE, 1).
 -define(SEED, <<1,2,3,4,5>>).

--- a/lib/ssl/test/tls_server_session_ticket_SUITE.erl
+++ b/lib/ssl/test/tls_server_session_ticket_SUITE.erl
@@ -54,7 +54,7 @@
 -define(TICKET_STORE_SIZE, 1).
 -define(MASTER_SECRET, "master_secret").
 -define(PRF, sha).
--define(VERSION, ?'TLS-1.3').
+-define(VERSION, ?TLS_1_3).
 -define(PSK, <<15,168,18,43,216,33,227,142,114,190,70,183,137,57,64,64,66,152,115,94>>).
 -define(WINDOW_SIZE, 1).
 -define(SEED, <<1,2,3,4,5>>).


### PR DESCRIPTION
Replaces TLS and SSL version tuple codes (e.g., {3,4} for means TLS-1.3) by a macro descriptive name, and some refactorings as follows:

- addition of macros `?'TLS-1.3`, `?'TLS-1.2`, `?'TLS-1.1`, `?'TLS-1.0`, `?'TLS-1.0`, `?'TLS-1.X`,
- addition of macros `?'SSL-3.0`, `?'SSL-2.0`,
- addition of macros `?'DTLS-1.2`, `?'DTLS-1.1`, `?'DTLS-1.0`
- refactor of functions that receive arguments which are not used

The addition of the macros is self-contained in its own commit. The refactorings are placed in different commits for ease of scanning and reversal (if necessary).

**Note: This PR has not yet changed the internal representation of the version numbers**

This PR is almost the same as #6938 except for some refactorings
