### PR TITLE
Remove --enable-sanitizers configure options

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -868,7 +868,6 @@ with_clock_gettime_monotonic_id
 enable_prefer_elapsed_monotonic_time_during_suspend
 enable_gettimeofday_as_os_system_time
 with_javac
-enable_sanitizers
 enable_deterministic_build
 '
       ac_precious_vars='build_alias
@@ -1610,8 +1609,6 @@ Optional Features:
                           elapsed time during suspend
   --enable-gettimeofday-as-os-system-time
                           Force usage of gettimeofday() for OS system time
-  --enable-sanitizers[=comma-separated list of sanitizers]
-                          Default=address,undefined
   --enable-deterministic-build
                           enable build determinism, stripping absolute paths
                           from build output
@@ -25758,23 +25755,6 @@ CFLAGS="$saved_CFLAGS"
 if test "x$GCC" = xyes; then
   CFLAGS="$WERRORFLAGS $CFLAGS"
 fi
-
-
-
-# Check whether --enable-sanitizers was given.
-if test ${enable_sanitizers+y}
-then :
-  enableval=$enable_sanitizers;
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=address,undefined" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-
-fi
-
 
 
 # Check whether --enable-deterministic-build was given.

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -3541,26 +3541,6 @@ if test "x$GCC" = xyes; then
 fi
 
 dnl ----------------------------------------------------------------------
-dnl Enable -fsanitize= flags.
-dnl ----------------------------------------------------------------------
-
-m4_define(DEFAULT_SANITIZERS, [address,undefined])
-AC_ARG_ENABLE(
-    sanitizers,
-    AS_HELP_STRING(
-        [--enable-sanitizers@<:@=comma-separated list of sanitizers@:>@],
-	    [Default=DEFAULT_SANITIZERS]),
-[
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=DEFAULT_SANITIZERS" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-])
-
-dnl ----------------------------------------------------------------------
 dnl Enable build determinism flag
 dnl ----------------------------------------------------------------------
 

--- a/erts/lib_src/yielding_c_fun/main_target.mk
+++ b/erts/lib_src/yielding_c_fun/main_target.mk
@@ -26,16 +26,18 @@ YCF_SOURCES = $(sort $(wildcard $(YCF_SOURCE_DIR)/*.c) $(YCF_EXTRA_SOURCES))
 
 YCF_OBJECTS = $(addprefix $(YCF_OBJ_DIR)/,$(notdir $(YCF_SOURCES:.c=.o)))
 
-YCF_CFLAGS = $(filter-out -Wstrict-prototypes -Wdeclaration-after-statement -Wmissing-prototypes,$(CFLAGS))
+# YCF is a short lived tool leaking memory deliberately. Disable all sanitizers.
+YCF_CFLAGS = $(filter-out -Wstrict-prototypes -Wdeclaration-after-statement -Wmissing-prototypes -fsanitize%,$(CFLAGS))
+YCF_LDFLAGS = $(filter-out -fsanitize%,$(LDFLAGS))
 
 $(YCF_EXECUTABLE): $(YCF_OBJECTS)
-	$(V_LD) $(YCF_CFLAGS) $(LDFLAGS) $(YCF_OBJECTS) -o $@
+	$(V_LD) $(YCF_CFLAGS) $(YCF_LDFLAGS) $(YCF_OBJECTS) -o $@
 
 $(YCF_OBJ_DIR)/%.o: $(YCF_SOURCE_DIR)/lib/tiny_regex_c/%.c $(YCF_HEADERS)
-	$(V_CC) $(YCF_CFLAGS) $(LDFLAGS) $(YCF_INCLUDE_DIRS) -c $< -o $@
+	$(V_CC) $(YCF_CFLAGS) $(YCF_LDFLAGS) $(YCF_INCLUDE_DIRS) -c $< -o $@
 
 $(YCF_OBJ_DIR)/%.o: $(YCF_SOURCE_DIR)/lib/simple_c_gc/%.c $(YCF_HEADERS)
-	$(V_CC) $(YCF_CFLAGS) $(LDFLAGS) $(YCF_INCLUDE_DIRS) -c $< -o $@
+	$(V_CC) $(YCF_CFLAGS) $(YCF_LDFLAGS) $(YCF_INCLUDE_DIRS) -c $< -o $@
 
 $(YCF_OBJ_DIR)/%.o: $(YCF_SOURCE_DIR)/%.c $(YCF_HEADERS)
-	$(V_CC) $(YCF_CFLAGS) $(LDFLAGS) $(YCF_INCLUDE_DIRS) -c $< -o $@
+	$(V_CC) $(YCF_CFLAGS) $(YCF_LDFLAGS) $(YCF_INCLUDE_DIRS) -c $< -o $@

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -750,7 +750,6 @@ enable_threads
 enable_mask_real_errno
 enable_ei_dynamic_lib
 with_gmp
-enable_sanitizers
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1385,8 +1384,6 @@ Optional Features:
   --disable-threads       use to only build single threaded libs
   --disable-mask-real-errno do not mask real 'errno'
   --enable-ei-dynamic-lib  build ei as a dynamic library
-  --enable-sanitizers[=comma-separated list of sanitizers]
-                          Default=address,undefined
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -9624,23 +9621,6 @@ fi
 
 
 
-
-
-
-
-# Check whether --enable-sanitizers was given.
-if test ${enable_sanitizers+y}
-then :
-  enableval=$enable_sanitizers;
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=address,undefined" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-
-fi
 
 
 # ---------------------------------------------------------------------------

--- a/lib/erl_interface/configure.ac
+++ b/lib/erl_interface/configure.ac
@@ -361,26 +361,6 @@ fi
 ERL_DED_FLAT_BUNDLE=true
 ERL_DED_FLAGS
 
-dnl ----------------------------------------------------------------------
-dnl Enable -fsanitize= flags.
-dnl ----------------------------------------------------------------------
-
-m4_define(DEFAULT_SANITIZERS, [address,undefined])
-AC_ARG_ENABLE(
-    sanitizers,
-    AS_HELP_STRING(
-        [--enable-sanitizers@<:@=comma-separated list of sanitizers@:>@],
-	    [Default=DEFAULT_SANITIZERS]),
-[
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=DEFAULT_SANITIZERS" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-])
-
 # ---------------------------------------------------------------------------
 # XXX
 # ---------------------------------------------------------------------------

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -747,7 +747,6 @@ ac_user_opts='
 enable_option_checking
 enable_megaco_reentrant_flex_scanner
 enable_megaco_flex_scanner_lineno
-enable_sanitizers
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1382,8 +1381,6 @@ Optional Features:
   --disable-megaco-reentrant-flex-scanner  disable reentrant megaco flex scanner
   --enable-megaco-flex-scanner-lineno  enable megaco flex scanner lineno
   --disable-megaco-flex-scanner-lineno  disable megaco flex scanner lineno
-  --enable-sanitizers[=comma-separated list of sanitizers]
-                          Default=address,undefined
 
 Some influential environment variables:
   CC          C compiler command
@@ -4428,23 +4425,6 @@ printf "%s\n" "no" >&6; }
 fi
 
 fi
-
-
-
-# Check whether --enable-sanitizers was given.
-if test ${enable_sanitizers+y}
-then :
-  enableval=$enable_sanitizers;
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=address,undefined" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-
-fi
-
 
 ac_header= ac_cache=
 for ac_item in $ac_header_c_list

--- a/lib/megaco/configure.ac
+++ b/lib/megaco/configure.ac
@@ -162,26 +162,6 @@ if test "x$GCC" = xyes; then
   LM_TRY_ENABLE_CFLAG([-Werror=return-type], [CFLAGS])
 fi
 
-dnl ----------------------------------------------------------------------
-dnl Enable -fsanitize= flags.
-dnl ----------------------------------------------------------------------
-
-m4_define(DEFAULT_SANITIZERS, [address,undefined])
-AC_ARG_ENABLE(
-    sanitizers,
-    AS_HELP_STRING(
-        [--enable-sanitizers@<:@=comma-separated list of sanitizers@:>@],
-	    [Default=DEFAULT_SANITIZERS]),
-[
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=DEFAULT_SANITIZERS" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-])
-
 ERL_DED
 
 AC_CHECK_PROG(PERL, perl, perl, no_perl)

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -723,7 +723,6 @@ ac_subst_files=''
 ac_user_opts='
 enable_option_checking
 with_odbc
-enable_sanitizers
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1349,13 +1348,6 @@ fi
 if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
-
-Optional Features:
-  --disable-option-checking  ignore unrecognized --enable/--with options
-  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
-  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-sanitizers[=comma-separated list of sanitizers]
-                          Default=address,undefined
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -5894,23 +5886,6 @@ fi
 
 
 fi
-
-
-
-# Check whether --enable-sanitizers was given.
-if test ${enable_sanitizers+y}
-then :
-  enableval=$enable_sanitizers;
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=address,undefined" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-
-fi
-
 
 ac_config_files="$ac_config_files c_src/$host/Makefile:c_src/Makefile.in"
 

--- a/lib/odbc/configure.ac
+++ b/lib/odbc/configure.ac
@@ -256,25 +256,5 @@ AS_IF([test "x$GCC" = xyes],
     LM_TRY_ENABLE_CFLAG([-Werror=return-type], [CFLAGS])
   ])
 
-dnl ----------------------------------------------------------------------
-dnl Enable -fsanitize= flags.
-dnl ----------------------------------------------------------------------
-
-m4_define(DEFAULT_SANITIZERS, [address,undefined])
-AC_ARG_ENABLE(
-    sanitizers,
-    AS_HELP_STRING(
-        [--enable-sanitizers@<:@=comma-separated list of sanitizers@:>@],
-	    [Default=DEFAULT_SANITIZERS]),
-[
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=DEFAULT_SANITIZERS" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-])
-
 AC_CONFIG_FILES([c_src/$host/Makefile:c_src/Makefile.in])
 AC_OUTPUT

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -758,7 +758,6 @@ with_wxdir
 with_wx_config
 with_wx_prefix
 with_wx_exec_prefix
-enable_sanitizers
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1388,13 +1387,6 @@ fi
 if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
-
-Optional Features:
-  --disable-option-checking  ignore unrecognized --enable/--with options
-  --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
-  --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-sanitizers[=comma-separated list of sanitizers]
-                          Default=address,undefined
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -7171,24 +7163,6 @@ fi
 
 
 fi
-
-
-
-# Check whether --enable-sanitizers was given.
-if test ${enable_sanitizers+y}
-then :
-  enableval=$enable_sanitizers;
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=address,undefined" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-CXXFLAGS="$CXXFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-
-fi
-
 
 #############################################################################
 

--- a/lib/wx/configure.ac
+++ b/lib/wx/configure.ac
@@ -712,27 +712,6 @@ AS_IF([test "x$GCC" = xyes],
     LM_TRY_ENABLE_CFLAG([-Werror=return-type], [CXXFLAGS])
   ])
 
-dnl ----------------------------------------------------------------------
-dnl Enable -fsanitize= flags.
-dnl ----------------------------------------------------------------------
-
-m4_define(DEFAULT_SANITIZERS, [address,undefined])
-AC_ARG_ENABLE(
-    sanitizers,
-    AS_HELP_STRING(
-        [--enable-sanitizers@<:@=comma-separated list of sanitizers@:>@],
-	    [Default=DEFAULT_SANITIZERS]),
-[
-case "$enableval" in
-    no) sanitizers= ;;
-    yes) sanitizers="-fsanitize=DEFAULT_SANITIZERS" ;;
-    *) sanitizers="-fsanitize=$enableval" ;;
-esac
-CFLAGS="$CFLAGS $sanitizers"
-CXXFLAGS="$CXXFLAGS $sanitizers"
-LDFLAGS="$LDFLAGS $sanitizers"
-])
-
 #############################################################################
 
 dnl 

--- a/make/configure
+++ b/make/configure
@@ -795,7 +795,6 @@ enable_m64_build
 enable_m32_build
 enable_pie
 with_libatomic_ops
-enable_sanitizers
 enable_silent_rules
 '
       ac_precious_vars='build_alias
@@ -1497,8 +1496,6 @@ Optional Features:
   --enable-m32-build      build 32bit binaries using the -m32 flag to (g)cc
   --enable-pie            build position independent executables
   --disable-pie           do no build position independent executables
-  --enable-sanitizers[=comma-separated list of sanitizers]
-                          Default=address,undefined
   --enable-silent-rules   less verbose build output (undo: "make V=1")
   --disable-silent-rules  verbose build output (undo: "make V=0")
 
@@ -5724,14 +5721,6 @@ fi
 if test ${with_libatomic_ops+y}
 then :
   withval=$with_libatomic_ops;
-fi
-
-
-
-# Check whether --enable-sanitizers was given.
-if test ${enable_sanitizers+y}
-then :
-  enableval=$enable_sanitizers;
 fi
 
 

--- a/make/configure.ac
+++ b/make/configure.ac
@@ -338,12 +338,6 @@ AC_ARG_WITH(libatomic_ops,
 	    AS_HELP_STRING([--with-libatomic_ops=PATH],
 			   [specify and prefer usage of libatomic_ops in the ethread library]))
 
-m4_define(DEFAULT_SANITIZERS, [address,undefined])
-AC_ARG_ENABLE(sanitizers,
-    AS_HELP_STRING(
-        [--enable-sanitizers@<:@=comma-separated list of sanitizers@:>@],
-	    [Default=DEFAULT_SANITIZERS]))
-
 AC_ARG_ENABLE([silent-rules], [dnl
 AS_HELP_STRING(
   [--enable-silent-rules],


### PR DESCRIPTION
- An untested broken feature.
- Can easily be enabled by setting CFLAGS and LDFLAGS.
- Address sanitizer for the emulator has better support by the `asan` build target.

Fix #7031