### PR TITLE
JIT: Avoid mixing AVX and SSE instructions

### DIFF
--- a/erts/emulator/beam/jit/x86/instr_map.cpp
+++ b/erts/emulator/beam/jit/x86/instr_map.cpp
@@ -300,8 +300,8 @@ void BeamModuleAssembler::emit_i_new_small_map_lit(const ArgRegister &Dst,
 
             comment("(initializing two elements at once)");
             dst_ptr0.setSize(16);
-            a.movups(x86::xmm0, src_ptr);
-            a.movups(dst_ptr0, x86::xmm0);
+            vmovups(x86::xmm0, src_ptr);
+            vmovups(dst_ptr0, x86::xmm0);
             break;
         }
         case ArgVal::reverse_consecutive: {


### PR DESCRIPTION
Mixing AVX and SSE instructions results in performance penalities on many CPUs.

Therefore, if AVX is available, the JIT will always emit AVX instructions instead of SSE instructions (for example, `vmovups` instead of `movups`). The JIT will also emit a `vzeroupper` instruction before calling any BIFs or helper routines in the runtime system to avoid a costly state change in case the runtime system uses SSE instructions.