### PR TITLE
Handle empty target host name

### DIFF
--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -1513,7 +1513,7 @@ getaddrs_tm({A,B,C,D,E,F,G,H} = IP, Fam, _) ->
 getaddrs_tm(Address, Family, Timer) when is_atom(Address) ->
     getaddrs_tm(atom_to_list(Address), Family, Timer);
 getaddrs_tm(Address, Family, Timer) ->
-    case inet_parse:visible_string(Address) andalso Address =/= "" of
+    case inet_parse:visible_string(Address) of
 	false ->
 	    {error,einval};
 	true ->

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -1513,7 +1513,7 @@ getaddrs_tm({A,B,C,D,E,F,G,H} = IP, Fam, _) ->
 getaddrs_tm(Address, Family, Timer) when is_atom(Address) ->
     getaddrs_tm(atom_to_list(Address), Family, Timer);
 getaddrs_tm(Address, Family, Timer) ->
-    case inet_parse:visible_string(Address) of
+    case inet_parse:visible_string(Address) andalso Address =/= "" of
 	false ->
 	    {error,einval};
 	true ->

--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -498,7 +498,7 @@ res_check_option(nameservers, NSs) ->
 res_check_option(alt_nameservers, NSs) ->
     res_check_list(NSs, fun res_check_ns/1);
 res_check_option(domain, Dom) ->
-    Dom =:= "" orelse inet_parse:visible_string(Dom);
+    inet_parse:visible_string(Dom);
 res_check_option(lookup, Methods) ->
     try lists_subtract(Methods, valid_lookup()) of
 	[] -> true;
@@ -550,7 +550,6 @@ res_check_ns({{A,B,C,D}, Port})
   when ?ip(A,B,C,D), Port band 65535 =:= Port -> true;
 res_check_ns(_) -> false.
 
-res_check_search("") -> true;
 res_check_search(Dom) -> inet_parse:visible_string(Dom).
 
 socks_option(server)  -> db_get(socks5_server);
@@ -1044,7 +1043,7 @@ handle_call(Request, From, #state{db=Db}=State) ->
 	    end;
 
 	{set_hostname, Name} ->
-	    case inet_parse:visible_string(Name) of
+	    case inet_parse:visible_string(Name) andalso Name =/= "" of
 		true ->
 		    ets:insert(Db, {hostname, Name}),
 		    {reply, ok, State};

--- a/lib/kernel/src/inet_parse.erl
+++ b/lib/kernel/src/inet_parse.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -386,14 +386,9 @@ port_proto([$/ | Proto], Port) when Port =/= 0 ->
 %% Check if a String is a string with visible characters #21..#7E
 %% visible_string(String) -> Bool
 %%
-visible_string([H|T]) ->
-    is_vis1([H|T]);
-visible_string(_) ->
-    false.
-
-is_vis1([C | Cs]) when C >= 16#21, C =< 16#7e -> is_vis1(Cs);
-is_vis1([]) -> true;
-is_vis1(_) -> false.
+visible_string([C | Cs]) when C >= 16#21, C =< 16#7e -> visible_string(Cs);
+visible_string([]) -> true;
+visible_string(_) -> false.
 
 %%
 %% Check if a String is a domain name according to RFC XXX.

--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -490,7 +490,7 @@ getbyname(Name, Type, Timeout) ->
 getbyname_tm(Name, Type, Timer) when is_list(Name) ->
     case type_p(Type) of
 	true ->
-	    case inet_parse:visible_string(Name) andalso Name =/= "" of
+	    case inet_parse:visible_string(Name) of
 		false ->
                     {error, formerr};
 		true ->
@@ -573,12 +573,13 @@ res_getby_search(Name, [Dom | Ds], _Reason, Type, Timer) ->
     QueryName =
         %% Join Name and Dom with a single dot.
         %% Allow Dom to be "." or "", but not to lead with ".".
-        %% Do not allow Name to be "".
         if
-            Name =/= "" andalso (Dom =:= "." orelse Dom =:= "") ->
+            Dom =:= "."; Dom =:= "" ->
                 Name;
-            Name =/= "" andalso hd(Dom) =/= $. ->
-                Name++"."++Dom;
+            Name =/= "", hd(Dom) =/= $. ->
+                Name ++ "." ++ Dom;
+            Name =:= "", hd(Dom) =/= $. ->
+                Dom;
             true ->
                 erlang:error({if_clause, Name, Dom})
         end,

--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -490,7 +490,7 @@ getbyname(Name, Type, Timeout) ->
 getbyname_tm(Name, Type, Timer) when is_list(Name) ->
     case type_p(Type) of
 	true ->
-	    case inet_parse:visible_string(Name) of
+	    case inet_parse:visible_string(Name) andalso Name =/= "" of
 		false ->
                     {error, formerr};
 		true ->

--- a/lib/kernel/test/gen_sctp_SUITE.erl
+++ b/lib/kernel/test/gen_sctp_SUITE.erl
@@ -771,8 +771,11 @@ api_listen(Config) when is_list(Config) ->
     {ok,Sb} = gen_sctp:open(Pb),
     {ok,Sa} = gen_sctp:open(),
 
-    {error, nxdomain} = gen_sctp:connect(Sa, "", 65535, []),
-    {error, nxdomain} = gen_sctp:connect(Sa, '', 65535, []),
+    element(1, os:type()) =:= unix andalso
+        begin
+            {error, nxdomain} = gen_sctp:connect(Sa, "", 65535, []),
+            {error, nxdomain} = gen_sctp:connect(Sa, '', 65535, [])
+        end,
     {error, nxdomain} = gen_sctp:connect(Sa, ".", 65535, []),
     {error, nxdomain} = gen_sctp:connect(Sa, '.', 65535, []),
 

--- a/lib/kernel/test/gen_sctp_SUITE.erl
+++ b/lib/kernel/test/gen_sctp_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2007-2022. All Rights Reserved.
+%% Copyright Ericsson AB 2007-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 %% limitations under the License.
 %%
 %% %CopyrightEnd%
-%% 
+%%
 -module(gen_sctp_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
@@ -770,6 +770,12 @@ api_listen(Config) when is_list(Config) ->
 
     {ok,Sb} = gen_sctp:open(Pb),
     {ok,Sa} = gen_sctp:open(),
+
+    {error, nxdomain} = gen_sctp:connect(Sa, "", 65535, []),
+    {error, nxdomain} = gen_sctp:connect(Sa, '', 65535, []),
+    {error, nxdomain} = gen_sctp:connect(Sa, ".", 65535, []),
+    {error, nxdomain} = gen_sctp:connect(Sa, '.', 65535, []),
+
     case gen_sctp:connect(Sa, localhost, Pb, []) of
 	{error,econnrefused} ->
 	    {ok,{Localhost,

--- a/lib/kernel/test/gen_tcp_api_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_api_SUITE.erl
@@ -355,8 +355,11 @@ t_connect_bad(Config) when is_list(Config) ->
     NonExistingPort = 45638,		% Not in use, I hope.
     t_connect_bad(Config, localhost, NonExistingPort, "port not in use"),
     t_connect_bad(Config, "non-existing-host-xxx", 7, "non-existing host"),
-    t_connect_bad(Config, "",                      7, "empty host string"),
-    t_connect_bad(Config, '',                      7, "empty host atom"),
+    element(1, os:type()) =:= unix andalso
+        begin
+            t_connect_bad(Config, "",              7, "empty host string"),
+            t_connect_bad(Config, '',              7, "empty host atom")
+        end,
     t_connect_bad(Config, ".",                     7, "root domain string"),
     t_connect_bad(Config, '.',                     7, "root domain atom").
 

--- a/lib/kernel/test/gen_tcp_api_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_api_SUITE.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
-%% Copyright Ericsson AB 1998-2022. All Rights Reserved.
-%% 
+%%
+%% Copyright Ericsson AB 1998-2023. All Rights Reserved.
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(gen_tcp_api_SUITE).
@@ -353,15 +353,19 @@ t_connect_src_port(Config) when is_list(Config) ->
 %% invalid things.
 t_connect_bad(Config) when is_list(Config) ->
     NonExistingPort = 45638,		% Not in use, I hope.
-    {error, Reason1} = gen_tcp:connect(localhost, NonExistingPort, 
-                                       ?INET_BACKEND_OPTS(Config)),
-    io:format("Error for connection attempt to port not in use: ~p",
-	      [Reason1]),
+    t_connect_bad(Config, localhost, NonExistingPort, "port not in use"),
+    t_connect_bad(Config, "non-existing-host-xxx", 7, "non-existing host"),
+    t_connect_bad(Config, "",                      7, "empty host string"),
+    t_connect_bad(Config, '',                      7, "empty host atom"),
+    t_connect_bad(Config, ".",                     7, "root domain string"),
+    t_connect_bad(Config, '.',                     7, "root domain atom").
 
-    {error, Reason2} = gen_tcp:connect("non-existing-host-xxx", 7,
-                                       ?INET_BACKEND_OPTS(Config)),
-    io:format("Error for connection attempt to non-existing host: ~p",
-	      [Reason2]),
+t_connect_bad(Config, Host, Port, Descr) ->
+    {error, Reason} =
+        gen_tcp:connect(Host, Port,?INET_BACKEND_OPTS(Config)),
+    io:format(
+      "Error for connection attempt to " ++ Descr ++ ": ~p~n",
+      [Reason]),
     ok.
 
 

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -348,8 +348,11 @@ send_to_empty(Config) when is_list(Config) ->
 
 do_send_to_empty(Config) ->
     {ok, Sock} = ?OPEN(Config, 0),
-    {error, nxdomain} = gen_udp:send(Sock, "", ?CLOSED_PORT, "xXx"),
-    {error, nxdomain} = gen_udp:send(Sock, '', ?CLOSED_PORT, "xXx"),
+    element(1, os:type()) =:= unix andalso
+        begin
+            {error, nxdomain} = gen_udp:send(Sock, "", ?CLOSED_PORT, "xXx"),
+            {error, nxdomain} = gen_udp:send(Sock, '', ?CLOSED_PORT, "xXx")
+        end,
     {error, nxdomain} = gen_udp:send(Sock, ".", ?CLOSED_PORT, "xXx"),
     {error, nxdomain} = gen_udp:send(Sock, '.', ?CLOSED_PORT, "xXx"),
     ok.

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
-%% Copyright Ericsson AB 1998-2022. All Rights Reserved.
-%% 
+%%
+%% Copyright Ericsson AB 1998-2023. All Rights Reserved.
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 
@@ -37,7 +37,7 @@
          init_per_testcase/2, end_per_testcase/2]).
 
 -export([
-	 send_to_closed/1, active_n/1,
+	 send_to_closed/1, send_to_empty/1, active_n/1,
 	 buffer_size/1, binary_passive_recv/1, max_buffer_size/1, bad_address/1,
 	 read_packets/1, recv_poll_after_active_once/1,
          open_fd/1, connect/1, reconnect/1, implicit_inet6/1,
@@ -118,6 +118,7 @@ inet_backend_socket_cases() ->
 all_cases() ->
     [
      send_to_closed,
+     send_to_empty,
      buffer_size,
      binary_passive_recv,
      max_buffer_size,
@@ -338,6 +339,20 @@ do_send_to_closed(Config) ->
     ok.
 
 
+
+%%-------------------------------------------------------------
+%% Send to the empty host name
+
+send_to_empty(Config) when is_list(Config) ->
+    ?TC_TRY(?FUNCTION_NAME, fun() -> do_send_to_empty(Config) end).
+
+do_send_to_empty(Config) ->
+    {ok, Sock} = ?OPEN(Config, 0),
+    {error, nxdomain} = gen_udp:send(Sock, "", ?CLOSED_PORT, "xXx"),
+    {error, nxdomain} = gen_udp:send(Sock, '', ?CLOSED_PORT, "xXx"),
+    {error, nxdomain} = gen_udp:send(Sock, ".", ?CLOSED_PORT, "xXx"),
+    {error, nxdomain} = gen_udp:send(Sock, '.', ?CLOSED_PORT, "xXx"),
+    ok.
 
 %%-------------------------------------------------------------
 %% Test that the UDP socket buffer sizes are settable
@@ -1744,6 +1759,11 @@ do_connect(Config) when is_list(Config) ->
     ?P("sleep some"),
     ct:sleep({seconds, 5}),
 
+    ?P("try some doomed connect targets: ~p", [P1]),
+    {error, nxdomain} = gen_udp:connect(S2, "", ?CLOSED_PORT),
+    {error, nxdomain} = gen_udp:connect(S2, '', ?CLOSED_PORT),
+    {error, nxdomain} = gen_udp:connect(S2, ".", ?CLOSED_PORT),
+    {error, nxdomain} = gen_udp:connect(S2, '.', ?CLOSED_PORT),
     ?P("try connect second socket to: ~p, ~p", [Addr, P1]),
     ok = gen_udp:connect(S2, Addr, P1),
     ?P("try send on second socket"),

--- a/lib/kernel/test/inet_SUITE.erl
+++ b/lib/kernel/test/inet_SUITE.erl
@@ -369,8 +369,11 @@ do_gethostbyname(Config) when is_list(Config) ->
 
 
 t_gethostbyname_empty(Config) when is_list(Config) ->
-    {error,nxdomain} = inet:gethostbyname(""),
-    {error,nxdomain} = inet:gethostbyname(''),
+    element(1, os:type()) =:= unix andalso
+        begin
+            {error,nxdomain} = inet:gethostbyname(""),
+            {error,nxdomain} = inet:gethostbyname('')
+        end,
     {error,nxdomain} = inet:gethostbyname("."),
     {error,nxdomain} = inet:gethostbyname('.'),
     ok.

--- a/lib/kernel/test/inet_SUITE.erl
+++ b/lib/kernel/test/inet_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 
 	 t_gethostbyaddr/0, t_gethostbyaddr/1,
 	 t_getaddr/0, t_getaddr/1,
-	 t_gethostbyname/0, t_gethostbyname/1,
+	 t_gethostbyname/0, t_gethostbyname/1, t_gethostbyname_empty/1,
 	 t_gethostbyaddr_v6/0, t_gethostbyaddr_v6/1,
 	 t_getaddr_v6/0, t_getaddr_v6/1,
 	 t_gethostbyname_v6/0, t_gethostbyname_v6/1,
@@ -70,7 +70,7 @@ suite() ->
 
 all() -> 
     [
-     t_gethostbyaddr, t_gethostbyname, t_getaddr,
+     t_gethostbyaddr, t_gethostbyname, t_gethostbyname_empty, t_getaddr,
      t_gethostbyaddr_v6, t_gethostbyname_v6, t_getaddr_v6,
      ipv4_to_ipv6, host_and_addr, is_ip_address, {group, parse},
      t_gethostnative, gethostnative_parallell, cname_loop,
@@ -366,6 +366,15 @@ do_gethostbyname(Config) when is_list(Config) ->
     {error,nxdomain} = inet:gethostbyname(DName),
     {error,nxdomain} = inet:gethostbyname(IP_46_Str),
     ok.
+
+
+t_gethostbyname_empty(Config) when is_list(Config) ->
+    {error,nxdomain} = inet:gethostbyname(""),
+    {error,nxdomain} = inet:gethostbyname(''),
+    {error,nxdomain} = inet:gethostbyname("."),
+    {error,nxdomain} = inet:gethostbyname('.'),
+    ok.
+
 
 t_gethostbyname_v6() -> required(v6).
 %% Test the inet:gethostbyname/1 inet6 function.


### PR DESCRIPTION
This PR changes the internal function `inet_parse:visible_string/1` to allow an empty string.

Then it changes an empty target host name to be passed through to the resolver backend, and changes the `inet_res` backend to handle the empty host name in a reasonable way.

It seems the `inet_res` backend was the only one that was not prepared for an empty host name.

The changes in this PR solves #6353 so that `gen_tcp:connect("", Port, Opts)` instead of crashing will return, as indicated by the function's type spec.  Most probably `{error, nxdomain}`, but it depends on the current resolver domain configuration.