### PR TITLE
asn1: Fix warning about mismatched allocation function

### DIFF
--- a/lib/asn1/c_src/asn1_erl_nif.c
+++ b/lib/asn1/c_src/asn1_erl_nif.c
@@ -1167,7 +1167,7 @@ static mem_chunk_t *ber_new_chunk(unsigned int length) {
     new->next = NULL;
     new->top = enif_alloc(sizeof(char) * length);
     if (new->top == NULL) {
-	free(new);
+	enif_free(new);
 	return NULL;
     }
     new->curr = new->top + length - 1;


### PR DESCRIPTION
As enif_alloc is, in applicable cases, declared with the malloc attribute, recent GCCs complain that: "‘free’ called on pointer returned from a mismatched allocation function". Avoid the warning by freeing the new chunk using enif_free().