### PR TITLE
erts: Fix warning about bitwise operations on booleans

### DIFF
--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -4884,7 +4884,7 @@ BIF_RETTYPE setnode_2(BIF_ALIST_2)
     erts_thr_progress_block();
 
     success = (!ERTS_PROC_IS_EXITING(net_kernel)
-               & !ERTS_PROC_GET_DIST_ENTRY(net_kernel));
+               && !ERTS_PROC_GET_DIST_ENTRY(net_kernel));
     if (success) {
         inc_no_nodes();
         erts_set_this_node(BIF_ARG_1, (Uint32) creation);

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -2922,7 +2922,7 @@ void erts_nif_demonitored(ErtsResource* resource)
     ASSERT(resource->type->fn.down);
 
     erts_mtx_lock(&rmp->lock);
-    free_me = ((rmon_refc_dec_read(rmp) == 0) & !!rmon_is_dying(rmp));
+    free_me = ((rmon_refc_dec_read(rmp) == 0) && !!rmon_is_dying(rmp));
     erts_mtx_unlock(&rmp->lock);
 
     if (free_me)

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -7397,7 +7397,7 @@ static ERTS_INLINE int
 have_dirty_work(void)
 {
     return !(ERTS_EMPTY_RUNQ(ERTS_DIRTY_CPU_RUNQ)
-             | ERTS_EMPTY_RUNQ(ERTS_DIRTY_IO_RUNQ));
+             || ERTS_EMPTY_RUNQ(ERTS_DIRTY_IO_RUNQ));
 }
 
 #define ERTS_MSB_NONE_PRIO_BIT PORT_BIT


### PR DESCRIPTION
Clang 16 warns when `&` and `|` are used on boolean operands.