### PR TITLE
Eliminate make warning about ignored old recipe

### DIFF
--- a/lib/compiler/Makefile
+++ b/lib/compiler/Makefile
@@ -38,6 +38,7 @@ include $(ERL_TOP)/make/otp_subdir.mk
 
 DIA_PLT_APPS=crypto
 
+NO_TEST_TARGET:=1 # Avoid warning about ignoring old recipe for target 'test'
 include $(ERL_TOP)/make/app_targets.mk
 
 # Enable feature maybe_expr in runtime when running tests

--- a/lib/stdlib/Makefile
+++ b/lib/stdlib/Makefile
@@ -39,6 +39,7 @@ include $(ERL_TOP)/make/otp_subdir.mk
 DIA_PLT_APPS=compiler crypto
 TEST_NEEDS_RELEASE=true
 
+NO_TEST_TARGET:=1 # Avoid warning about ignoring old recipe for target 'test'
 include $(ERL_TOP)/make/app_targets.mk
 
 # Enable feature maybe_expr in runtime when running tests.

--- a/make/app_targets.mk
+++ b/make/app_targets.mk
@@ -22,9 +22,11 @@ APPLICATION ?= $(basename $(notdir $(PWD)))
 
 .PHONY: test info gclean dialyzer dialyzer_plt dclean
 
+ifndef NO_TEST_TARGET
 test:
 	TEST_NEEDS_RELEASE=$(TEST_NEEDS_RELEASE) TYPE=$(TYPE) \
 	  $(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
+endif
 
 info:
 	@echo "$(APPLICATION)_VSN:   $(VSN)"


### PR DESCRIPTION
The makefiles for lib/compiler/ and lib/stdlib/ both include $(ERL_TOP)/make/app_targets.mk and defines their own `test` target. As this leads to warnings about:

  Makefile:48: warning: overriding recipe for target 'test'
  $ERL_TOP/make/app_targets.mk:26:warning: ignoring old recipe for target 'test'

which are annoying as even a clean build produces warnings, this patch conditionally avoids defining the default target in app_targets.mk when included from lib/compiler/Makefile and lib/stdlib/Makefile.