### PR TITLE
erts: Modernize K&R-style functions

### DIFF
--- a/erts/emulator/beam/beam_file.c
+++ b/erts/emulator/beam/beam_file.c
@@ -1318,7 +1318,7 @@ int iff_read_chunk(IFF_File *iff, Uint id, IFF_Chunk *chunk)
     return read_beam_chunks(iff, 1, &id, chunk);
 }
 
-void beamfile_init() {
+void beamfile_init(void) {
     Eterm suffix;
     Eterm *hp;
 

--- a/erts/emulator/beam/code_ix.c
+++ b/erts/emulator/beam/code_ix.c
@@ -276,7 +276,7 @@ int erts_try_seize_code_stage_permission(Process* c_p)
     return try_seize_code_permission(&code_stage_permission, c_p, NULL, NULL);
 }
 
-void erts_release_code_stage_permission() {
+void erts_release_code_stage_permission(void) {
     release_code_permission(&code_stage_permission);
 }
 
@@ -304,7 +304,7 @@ int erts_try_seize_code_load_permission(Process* c_p) {
     return 0;
 }
 
-void erts_release_code_load_permission() {
+void erts_release_code_load_permission(void) {
     erts_release_code_mod_permission();
     erts_release_code_stage_permission();
 }
@@ -474,7 +474,7 @@ static void schedule_blocking_code_barriers(void *ignored) {
 }
 #endif
 
-void erts_blocking_code_barrier()
+void erts_blocking_code_barrier(void)
 {
 #ifdef DEBUG
     erts_debug_unrequire_code_barrier();
@@ -487,7 +487,7 @@ void erts_blocking_code_barrier()
 #endif
 }
 
-void erts_code_ix_finalize_wait() {
+void erts_code_ix_finalize_wait(void) {
 #ifdef CODE_IX_ISSUE_INSTRUCTION_BARRIERS
     if (erts_atomic32_read_nob(&outstanding_blocking_code_barriers) != 0) {
         ERTS_THR_INSTRUCTION_BARRIER;

--- a/erts/emulator/beam/erl_arith.c
+++ b/erts/emulator/beam/erl_arith.c
@@ -1310,6 +1310,6 @@ Eterm erts_bnot(Process* p, Eterm arg)
 } 
 
 /* Needed to remove compiler optimization */
-double erts_get_positive_zero_float() {
+double erts_get_positive_zero_float(void) {
     return 0.0f;
 }

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -5523,7 +5523,7 @@ erts_db_foreach_thr_prgr_offheap(void (*func)(ErlOffHeap *, void *),
 
 /* retrieve max number of ets tables */
 Uint
-erts_db_get_max_tabs()
+erts_db_get_max_tabs(void)
 {
     return db_max_tabs;
 }

--- a/erts/emulator/beam/erl_md5.c
+++ b/erts/emulator/beam/erl_md5.c
@@ -129,10 +129,9 @@ void MD5Init(MD5_CTX* context)
  * operation, processing another message block, and updating the
  * context.
  */
-void MD5Update (context, input, inputLen)
-    MD5_CTX *context;                                        /* context */
-    unsigned char *input;                                /* input block */
-    unsigned int inputLen;                     /* length of input block */
+void MD5Update (MD5_CTX *context,
+                unsigned char *input,  /* input block */
+                unsigned int inputLen) /* length of input block */
 {
     unsigned int i, index, partLen;
 
@@ -175,9 +174,8 @@ void MD5Update (context, input, inputLen)
  * MD5 finalization. Ends an MD5 message-digest operation, writing
   the message digest and zeroizing the context.
  */
-void MD5Final (digest, context)
-    unsigned char digest[16];                         /* message digest */
-    MD5_CTX *context;                                       /* context */
+void MD5Final (unsigned char digest[16], /* message digest */
+               MD5_CTX *context)         /* context */
 {
     unsigned char bits[8];
     unsigned int index, padLen;
@@ -213,9 +211,7 @@ void MD5Final (digest, context)
 /*
  * MD5 basic transformation. Transforms state based on block.
  */
-static void MD5Transform (state, block)
-    Uint32 state[4];
-    unsigned char block[64];
+static void MD5Transform (Uint32 state[4], unsigned char block[64])
 {
     Uint32 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
 
@@ -308,10 +304,7 @@ static void MD5Transform (state, block)
  * Encodes input (Uint32) into output (unsigned char). Assumes len is
  * a multiple of 4.
  */
-static void Encode (output, input, len)
-    unsigned char *output;
-    Uint32 *input;
-    unsigned int len;
+static void Encode (unsigned char *output, Uint32 *input, unsigned int len)
 {
     unsigned int i, j;
 
@@ -327,10 +320,7 @@ static void Encode (output, input, len)
  * Decodes input (unsigned char) into output (Uint32). Assumes len is
  * a multiple of 4.
  */
-static void Decode (output, input, len)
-    Uint32 *output;
-    unsigned char *input;
-    unsigned int len;
+static void Decode (Uint32 *output, unsigned char *input, unsigned int len)
 {
     unsigned int i, j;
 

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -5265,7 +5265,7 @@ erts_unload_nif(struct erl_module_nif* lib)
     deref_nifmod(lib);
 }	
 
-void erl_nif_init()
+void erl_nif_init(void)
 {
     ERTS_CT_ASSERT((offsetof(ErtsResource,data) % 8)
                    == ERTS_MAGIC_BIN_BYTES_TO_ALIGN);

--- a/erts/emulator/beam/erl_posix_str.c
+++ b/erts/emulator/beam/erl_posix_str.c
@@ -47,8 +47,7 @@
  */
 
 char *
-erl_errno_id(error)
-    int error;			/* Posix error number (as from errno). */
+erl_errno_id(int error /* Posix error number (as from errno). */)
 {
     switch (error) {
 #ifdef E2BIG

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -3079,7 +3079,7 @@ erts_tracer_update(ErtsTracer *tracer, const ErtsTracer new_tracer)
     }
 }
 
-static void init_tracer_nif()
+static void init_tracer_nif(void)
 {
     erts_rwmtx_opt_t rwmtx_opt = ERTS_RWMTX_OPT_DEFAULT_INITER;
     rwmtx_opt.type = ERTS_RWMTX_TYPE_EXTREMELY_FREQUENT_READ;
@@ -3092,7 +3092,7 @@ static void init_tracer_nif()
 
 }
 
-int erts_tracer_nif_clear()
+int erts_tracer_nif_clear(void)
 {
 
     erts_rwmtx_rlock(&tracer_mtx);

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -323,7 +323,7 @@ extern void** beam_ops;
 
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 ERTS_GLB_INLINE
-int erts_cp_size()
+int erts_cp_size(void)
 {
     if (erts_frame_layout == ERTS_FRAME_LAYOUT_RA) {
         return 1;

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -3126,8 +3126,7 @@ void erts_lcnt_update_port_locks(int enable) {
  * Parameters:
  * bufsiz - The (maximum) size of the line buffer.
  */
-LineBuf *allocate_linebuf(bufsiz)
-int bufsiz;
+LineBuf *allocate_linebuf(int bufsiz)
 {
     int ovsiz = (bufsiz < LINEBUF_INITIAL) ? bufsiz : LINEBUF_INITIAL;
     LineBuf *lb = (LineBuf *) erts_alloc(ERTS_ALC_T_LINEBUF,

--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -230,7 +230,7 @@ struct tpkt_head {
     unsigned char packet_length[2]; /* size incl header, big-endian (?) */
 };
 
-void packet_parser_init()
+void packet_parser_init(void)
 {
     static int done = 0;
     if (!done) {

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -3749,7 +3749,7 @@ erts_ptr_id(void *ptr)
     return ptr;
 }
 
-const void *erts_get_stacklimit() {
+const void *erts_get_stacklimit(void) {
     return ethr_get_stacklimit();
 }
 

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -4421,7 +4421,7 @@ static void inet_init_sctp(void) {
 }
 #endif /* HAVE_SCTP */
 
-static int inet_init()
+static int inet_init(void)
 {
     if (!sock_init())
 	goto error;
@@ -13875,7 +13875,7 @@ static udp_descriptor* sctp_inet_copy(udp_descriptor* desc, SOCKET s,
 
 
 #ifdef HAVE_UDP
-static int packet_inet_init()
+static int packet_inet_init(void)
 {
     sys_memzero((char *)&disassoc_sa, sizeof(disassoc_sa));
 #ifdef AF_UNSPEC
@@ -15060,8 +15060,7 @@ static MultiTimerData *add_multi_timer(tcp_descriptor *desc, ErlDrvPort port,
 -----------------------------------------------------------------------------*/
 
 static int
-save_subscriber(subs, subs_pid)
-subs_list *subs; ErlDrvTermData subs_pid;
+save_subscriber(subs_list *subs, ErlDrvTermData subs_pid)
 {
   subs_list *tmp;
 
@@ -15083,8 +15082,7 @@ subs_list *subs; ErlDrvTermData subs_pid;
 }
 
 static void
-free_subscribers(subs)
-subs_list *subs;
+free_subscribers(subs_list *subs)
 {
   subs_list *this;
   subs_list *next;

--- a/erts/emulator/nifs/common/socket_util.c
+++ b/erts/emulator/nifs/common/socket_util.c
@@ -2554,7 +2554,7 @@ MSG_FUNCS
  */
 
 extern
-ErlNifTime esock_timestamp()
+ErlNifTime esock_timestamp(void)
 {
     ErlNifTime monTime = enif_monotonic_time(ERL_NIF_USEC);
     ErlNifTime offTime = enif_time_offset(ERL_NIF_USEC);

--- a/erts/emulator/sys/unix/erl_unix_sys.h
+++ b/erts/emulator/sys/unix/erl_unix_sys.h
@@ -281,7 +281,7 @@ ERTS_GLB_INLINE ErtsSysPerfCounter erts_sys_perf_counter(void);
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
 ERTS_GLB_FORCE_INLINE ErtsSysPerfCounter
-erts_sys_perf_counter()
+erts_sys_perf_counter(void)
 {
     return (*erts_sys_time_data__.r.o.perf_counter)();
 }

--- a/erts/emulator/sys/unix/sys_env.c
+++ b/erts/emulator/sys/unix/sys_env.c
@@ -16,7 +16,7 @@ extern char **environ;
 
 static void import_initial_env(void);
 
-void erts_sys_env_init() {
+void erts_sys_env_init(void) {
     erts_rwmtx_init(&sysenv_rwmtx, "environ", NIL,
         ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
 
@@ -24,21 +24,21 @@ void erts_sys_env_init() {
     import_initial_env();
 }
 
-const erts_osenv_t *erts_sys_rlock_global_osenv() {
+const erts_osenv_t *erts_sys_rlock_global_osenv(void) {
     erts_rwmtx_rlock(&sysenv_rwmtx);
     return &sysenv_global_env;
 }
 
-erts_osenv_t *erts_sys_rwlock_global_osenv() {
+erts_osenv_t *erts_sys_rwlock_global_osenv(void) {
     erts_rwmtx_rwlock(&sysenv_rwmtx);
     return &sysenv_global_env;
 }
 
-void erts_sys_rwunlock_global_osenv() {
+void erts_sys_rwunlock_global_osenv(void) {
     erts_rwmtx_rwunlock(&sysenv_rwmtx);
 }
 
-void erts_sys_runlock_global_osenv() {
+void erts_sys_runlock_global_osenv(void) {
     erts_rwmtx_runlock(&sysenv_rwmtx);
 }
 

--- a/erts/emulator/utils/make_driver_tab
+++ b/erts/emulator/utils/make_driver_tab
@@ -107,7 +107,7 @@ foreach (@static_drivers) {
 }
 print "    {NULL}\n};\n";
 
-print "void erts_init_static_drivers() {\n";
+print "void erts_init_static_drivers(void) {\n";
 
 my $index = 0;
 foreach (@static_drivers) {

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -745,12 +745,7 @@ static unsigned int get_creation(Node* node)
 
 /* buf is actually one byte larger than bsize,
    giving place for null termination */
-static void do_request(g, fd, s, buf, bsize)
-     EpmdVars *g;
-     int fd;
-     Connection *s;
-     char *buf;
-     int bsize;
+static void do_request(EpmdVars *g, int fd, Connection *s, char *buf, int bsize)
 {
   char wbuf[OUTBUF_SIZE];	/* Buffer for writing */
   int i;

--- a/erts/etc/common/heart.c
+++ b/erts/etc/common/heart.c
@@ -354,8 +354,7 @@ int main(int argc, char **argv) {
  * message loop
  */
 static int
-message_loop(erlin_fd, erlout_fd)
-     int   erlin_fd, erlout_fd;
+message_loop(int erlin_fd, int erlout_fd)
 {
   int   i;
   time_t now, last_received;
@@ -776,8 +775,7 @@ int wait_until_close_write_or_env_tmo(int tmo) {
  * Sends an HEART_ACK.
  */
 static int
-notify_ack(fd)
-  int   fd;
+notify_ack(int fd)
 {
   struct msg m;
   
@@ -824,9 +822,7 @@ heart_cmd_reply(int fd, char *s)
  *  FIXME.
  */
 static int
-write_message(fd, mp)
-  int   fd;
-  struct msg *mp;
+write_message(int fd, struct msg *mp)
 {
   int len = ntohs(mp->len);
 
@@ -853,9 +849,7 @@ write_message(fd, mp)
  *  message.
  */
 static int
-read_message(fd, mp)
-  int   fd;
-  struct msg *mp;
+read_message(int fd, struct msg *mp)
 {
   int   rlen, i;
   unsigned char* tmp;
@@ -891,9 +885,7 @@ read_message(fd, mp)
  *  bytes read (i.e. len) , 0 if eof, or < 0 if error. len must be > 0.
  */
 static int
-read_fill(fd, buf, len)
-  int   fd, len;
-  char *buf;
+read_fill(int fd, char *buf, int len)
 {
   int   i, got = 0;
 
@@ -914,9 +906,7 @@ read_fill(fd, buf, len)
  *  0 if eof, or < 0 if error. len > maxlen > 0 must hold.
  */
 static int
-read_skip(fd, buf, maxlen, len)
-  int   fd, maxlen, len;
-  char *buf;
+read_skip(int fd, char *buf, int maxlen, int len)
 {
   int   i, got = 0;
   char  c;


### PR DESCRIPTION
Clang 16 now warns about functions using K&R syntax. Instead of juggling with compiler warning options, it is better to just bite the bullet and modernize the source code.