### PR TITLE
erts: Fix warning about set but unused variable

### DIFF
--- a/erts/emulator/beam/hash.c
+++ b/erts/emulator/beam/hash.c
@@ -64,6 +64,7 @@ void hash_get_info(HashInfo *hi, Hash *h)
         }
     }
     ASSERT(objects == h->nobjs);
+    (void)objects;
 
     hi->name  = h->name;
     hi->size  = hash_get_slots(h);


### PR DESCRIPTION
When assertions are disabled, `offset` is set but not used and Clang warns about it. Add a `(void)object` after the assert to silence the warning.