### PR TITLE
Export additional crypto types

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -159,17 +159,27 @@
        ensure_engine_loaded_nif/2
       ]).
 
--export_type([ %% A minimum exported: only what public_key needs.
-               dh_private/0,
-               dh_public/0,
-               dss_digest_type/0,
-               ec_named_curve/0,
-               ecdsa_digest_type/0,
-               pk_encrypt_decrypt_opts/0,
-               pk_sign_verify_opts/0,
-               rsa_digest_type/0,
-               sha1/0,
-               sha2/0
+-export_type([
+              blake2/0,
+              compatibility_only_hash/0,
+              dh_private/0,
+              dh_public/0,
+              dss_digest_type/0,
+              ec_named_curve/0,
+              ecdsa_digest_type/0,
+              pk_encrypt_decrypt_opts/0,
+              pk_sign_verify_opts/0,
+              sha1/0,
+              sha2/0,
+              sha3/0,
+              cipher/0,
+              cipher_aead/0,
+              cipher_iv/0,
+              cipher_no_iv/0,
+              cmac_cipher_algorithm/0,
+              hash_algorithm/0,
+              hmac_hash_algorithm/0,
+              rsa_digest_type/0
              ]).
 
 -export_type([engine_ref/0,


### PR DESCRIPTION
New dialyzer default in OTP-26 made it clear that in https://github.com/rabbitmq/credentials-obfuscation/ we are relying on some types from the crypto module that are not exported (specifically: `crypto:cipher_iv` and `crypto:hash_algorithm`), so our pipeline fails with OTP-26.

Would you be ok with exporting them? In this PR I included a few more as they seem at the same "level" as some of the currently exported ones and the ones we would like to be exported. 

There's a comment saying `A minimum exported: only what public_key needs.` but no justification why `public_key` gets special treatment. ;)  These types (and many more) are documented in https://www.erlang.org/doc/man/crypto.html

Thanks,