### PR TITLE
erts: Use C99-style flexible array for environment in ErlFunThing

### DIFF
--- a/erts/emulator/beam/erl_fun.h
+++ b/erts/emulator/beam/erl_fun.h
@@ -74,14 +74,15 @@ typedef struct erl_fun_thing {
 
     /* -- The following may be compound Erlang terms ---------------------- */
     Eterm creator;          /* Pid of creator process (contains node). */
-    Eterm env[1];           /* Environment (free variables). */
+    Eterm env[];            /* Environment (free variables). */
 } ErlFunThing;
 
 #define is_local_fun(FunThing) ((FunThing)->creator != am_external)
 #define is_external_fun(FunThing) ((FunThing)->creator == am_external)
 
-/* ERL_FUN_SIZE does _not_ include space for the environment */
-#define ERL_FUN_SIZE ((sizeof(ErlFunThing)/sizeof(Eterm))-1)
+/* ERL_FUN_SIZE does _not_ include space for the environment which is a
+ * C99-style flexible array */
+#define ERL_FUN_SIZE ((sizeof(ErlFunThing)/sizeof(Eterm)))
 
 ErlFunThing *erts_new_export_fun_thing(Eterm **hpp, Export *exp, int arity);
 ErlFunThing *erts_new_local_fun_thing(Process *p,


### PR DESCRIPTION
Consider the code fragment from erts/emulator/beam/erl_math.c below:

```
Eterm tmp_hp[ERL_FUN_SIZE];
ErlFunThing *funp;

funp = (ErlFunThing*)tmp_hp;
funp->thing_word = HEADER_FUN;
funp->entry.exp = NULL;
```

As `ErlFunThing` is not using a C99-style flexible array, GCC 12 is smart enough to figure out that `sizeof(*funp)` is larger than sizeof(tmp_hp) as ERL_FUN_SIZE subtracts the word used for the 1-sized environment array in `ErlFunThing`. The difference in size leads to multiple warnings in the style of: `array subscript ErlFunThing {aka struct erl_fun_thing}[0] is partly outside array bounds of Eterm[5]`.

We can avoid the warning by converting the `env`-field in `ErlFunThing` to a flexible array and then remove the `-1` from the definition of `ERL_FUN_SIZE`.

The runtime is already using C99-style flexible arrays for microstate accounting, in `erl_lock_count.h` and a comment in `erts/emulator/beam/erl_math.c` documents a requirement for a C99-capable compiler. Hopefully this is enough to not inadvertently break compilation with older compilers.