### PR TITLE
Replace OTPROOT with ERL_ROOTDIR in documentation

### DIFF
--- a/erts/doc/src/erl_prim_loader.xml
+++ b/erts/doc/src/erl_prim_loader.xml
@@ -58,7 +58,7 @@
           <c><anno>Bin</anno></c> is the contents of the file as a binary.</p>
         <p><c><anno>Filename</anno></c> can also be a file in an archive,
           for example,
-          <c>$OTPROOT/lib/</c><c>mnesia-4.4.7.ez/mnesia-4.4.7/ebin/</c><c>mnesia.beam</c>.
+          <c>$ERL_ROOTDIR/lib/</c><c>mnesia-4.4.7.ez/mnesia-4.4.7/ebin/</c><c>mnesia.beam</c>.
           For information about archive files, see
           <seeerl marker="kernel:code"><c>code(3)</c></seeerl>.</p>
       </desc>
@@ -85,7 +85,7 @@
           not sorted.</p>
         <p><c><anno>Dir</anno></c> can also be a directory in an archive,
           for example,
-          <c>$OTPROOT/lib/</c><c>mnesia-4.4.7.ez/mnesia-4.4.7/ebin</c>.
+          <c>$ERL_ROOTDIR/lib/</c><c>mnesia-4.4.7.ez/mnesia-4.4.7/ebin</c>.
           For information about archive files, see
           <seeerl marker="kernel:code"><c>code(3)</c></seeerl>.</p>
       </desc>
@@ -107,7 +107,7 @@
           <seeerl marker="kernel:file"><c>file(3)</c></seeerl>.</p>
         <p><c><anno>Filename</anno></c> can also be a file in an archive,
           for example,
-          <c>$OTPROOT/lib/</c><c>mnesia-4.4.7.ez/mnesia-4.4.7/ebin/</c><c>mnesia</c>.
+          <c>$ERL_ROOTDIR/lib/</c><c>mnesia-4.4.7.ez/mnesia-4.4.7/ebin/</c><c>mnesia</c>.
           For information about archive files, see
           <seeerl marker="kernel:code"><c>code(3)</c></seeerl>.</p>
       </desc>

--- a/lib/erl_docgen/priv/bin/xml_from_edoc.escript
+++ b/lib/erl_docgen/priv/bin/xml_from_edoc.escript
@@ -83,8 +83,8 @@ module(File, Args) ->
 		    {includes,    Args#args.includes},
 		    {preprocess,  Args#args.preprocess},
 		    {sort_functions, Args#args.sort_functions},
-		    
-		    {app_default, "OTPROOT"},
+
+		    {app_default, "ERL_ROOTDIR"},
 		    {file_suffix, Args#args.suffix},
 		    {dir,         Args#args.dir},
 		    {layout,      Args#args.layout}],
@@ -105,7 +105,7 @@ users_guide(File, Args) ->
             Enc = epp:read_encoding(File, [{in_comment_only, false}]),
             Encoding = [{encoding, Enc} || Enc =/= none],
 	    Opts = [{def,         Args#args.def},
-		    {app_default, "OTPROOT"},
+		    {app_default, "ERL_ROOTDIR"},
 		    {file_suffix, Args#args.suffix},
 		    {layout,      Args#args.layout}] ++ Encoding,
 	    

--- a/lib/erl_docgen/src/docgen_edoc_xml_cb.erl
+++ b/lib/erl_docgen/src/docgen_edoc_xml_cb.erl
@@ -457,7 +457,7 @@ otp_xmlify_e(E) ->
 %% In the case of a seealso/url, the href part is checked, making
 %% sure a .xml/.html file extension is removed.
 %% Also, references to other applications //App has a href attribute
-%% value "OTPROOT/..." (due to app_default being set to "OTPROOT")
+%% value "ERL_ROOTDIR/..." (due to app_default being set to "ERL_ROOTDIR")
 %% , in this case both href attribute and content must be
 %% formatted correctly according to requirements.
 otp_xmlify_a(A) ->
@@ -493,7 +493,7 @@ otp_xmlify_a_href("http:"++_ = URL, Es0) -> % external URL
     {URL, Es0};
 otp_xmlify_a_href("https:"++_ = URL, Es0) -> % external URL
     {URL, Es0};
-otp_xmlify_a_href("OTPROOT"++AppRef, Es0) -> % <.. marker="App:FileRef
+otp_xmlify_a_href("ERL_ROOTDIR"++AppRef, Es0) -> % <.. marker="App:FileRef
     [AppS, "doc", FileRef1] = split(AppRef, "/"),
     FileRef = AppS++":"++otp_xmlify_a_fileref(FileRef1, AppS),
     [#xmlText{value=Str0} = T] = Es0,
@@ -547,7 +547,7 @@ otp_xmlify_a_fileref(FileRef1, AppS) ->
 	    if
 		%% Ignore file extension in file reference if it either
 		%% is ".xml" or if it is ".html" but AppS/=this, that
-		%% is, we're resolving an OTPROOT file reference
+		%% is, we're resolving an ERL_ROOTDIR file reference
 		Ext=="xml";
 		Ext=="html", AppS/=this ->
 		    File++"#"++Marker;

--- a/lib/erl_interface/doc/src/ei_users_guide.xml
+++ b/lib/erl_interface/doc/src/ei_users_guide.xml
@@ -102,12 +102,12 @@ Eshell V4.7.4  (abort with ^G)
       <c>-I</c> argument on the command line, or add it to
       the <c>CFLAGS</c> definition in your
       <c>Makefile</c>. The correct value for this path is
-      <c>$OTPROOT/lib/erl_interface-$EIVSN/include</c>,
+      <c>$ERL_ROOTDIR/lib/erl_interface-$EIVSN/include</c>,
       where:</p>
 
     <list type="bulleted">
       <item>
-        <p><c>$OTPROOT</c> is the path reported by
+        <p><c>$ERL_ROOTDIR</c> is the path reported by
           <c>code:root_dir/0</c> in the example above.</p>
       </item>
       <item>
@@ -125,7 +125,7 @@ $ cc -c -I/usr/local/otp/lib/erl_interface-3.2.3/include myprog.c    ]]></code>
 
     <list type="bulleted">
       <item>Specify the path to <c>libei.a</c> with
-        <c>-L$OTPROOT/lib/erl_interface-3.2.3/lib</c>.</item>
+        <c>-L$ERL_ROOTDIR/lib/erl_interface-3.2.3/lib</c>.</item>
       <item>Specify the name of the library with <c>-lei</c>.</item>
     </list>
 

--- a/lib/erl_interface/doc/src/notes_history.xml
+++ b/lib/erl_interface/doc/src/notes_history.xml
@@ -355,9 +355,9 @@ int ei_x_encode_bignum(ei_x_buff *x, mpz_t obj);
             need to make changes to the Makefiles used to build
             applications based on Erl_Interface. In particular,
             header and library files are no longer in
-            <c><![CDATA[$(OTPROOT)/usr/]]></c>. The <c><![CDATA[include]]></c> and <c><![CDATA[lib]]></c>
+            <c><![CDATA[$(ERL_ROOTDIR)/usr/]]></c>. The <c><![CDATA[include]]></c> and <c><![CDATA[lib]]></c>
             directories are now located in the directory
-            <c><![CDATA[$(OTPROOT)/lib/erl_interface-3.1]]></c> (i.e.
+            <c><![CDATA[$(ERL_ROOTDIR)/lib/erl_interface-3.1]]></c> (i.e.
             the directory name is now version specific).</p>
           <p>Own Id: OTP-3082</p>
         </item>

--- a/lib/jinterface/doc/src/jinterface_users_guide.xml
+++ b/lib/jinterface/doc/src/jinterface_users_guide.xml
@@ -443,7 +443,7 @@ Eshell V4.9.1.2  (abort with ^G)
       This is done by specifying an appropriate <c>-classpath</c>
       argument on the command line, or by adding it to the <c>CLASSPATH</c>
       definition in your <c>Makefile</c>. The correct value for this path is
-      <c>$OTPROOT/lib/jinterface</c><em>Vsn</em><c>/priv/OtpErlang.jar</c>, where <c>$OTPROOT</c> 
+      <c>$ERL_ROOTDIR/lib/jinterface</c><em>Vsn</em><c>/priv/OtpErlang.jar</c>, where <c>$ERL_ROOTDIR</c>
       is the path reported by <c>code:root_dir/0</c> in the above example and <em>Vsn</em> is the version of Jinterface, for example <c>jinterface-1.2</c></p>
     <code type="none">
 $ javac -classpath ".:/usr/local/otp/lib/jinterface-1.2/priv/OtpErlang.jar" 

--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -74,7 +74,7 @@
       module.</p>
     <p>Initially, the code path consists of the current working
       directory and all Erlang object code directories under library
-      directory <c>$OTPROOT/lib</c>, where <c>$OTPROOT</c> is
+      directory <c>$ERL_ROOTDIR/lib</c>, where <c>$ERL_ROOTDIR</c> is
       the installation directory of Erlang/OTP, <c>code:root_dir()</c>.
       Directories can be named <c>Name[-Vsn]</c> and the code server,
       by default, chooses the directory with the highest version number
@@ -156,14 +156,14 @@ zip:create("mnesia-4.4.7.ez",
      the archive.</p>
 
     <p>Normally the top directory of an application is located
-     in library directory <c>$OTPROOT/lib</c> or in a directory
+     in library directory <c>$ERL_ROOTDIR/lib</c> or in a directory
      referred to by environment variable <c>ERL_LIBS</c>. At
      startup, when the initial code path is computed, the code server
      also looks for archive files in these directories and
      possibly adds <c>ebin</c> directories in archives to the code path. The
      code path then contains paths to directories that look like
-     <c>$OTPROOT/lib/mnesia.ez/mnesia/ebin</c> or
-     <c>$OTPROOT/lib/mnesia-4.4.7.ez/mnesia-4.4.7/ebin</c>.</p>
+     <c>$ERL_ROOTDIR/lib/mnesia.ez/mnesia/ebin</c> or
+     <c>$ERL_ROOTDIR/lib/mnesia-4.4.7.ez/mnesia-4.4.7/ebin</c>.</p>
 
     <p>The code server uses module <c>erl_prim_loader</c> in ERTS
      (possibly through <c>erl_boot_server</c>) to read code files from
@@ -214,9 +214,9 @@ zip:create("mnesia-4.4.7.ez",
     <p>When the choice of directories in the code path is
      <c>strict</c>, the directory that ends up in the code path is
      exactly the stated one. This means that if, for example, the
-     directory <c>$OTPROOT/lib/mnesia-4.4.7/ebin</c> is explicitly
+     directory <c>$ERL_ROOTDIR/lib/mnesia-4.4.7/ebin</c> is explicitly
      added to the code path, the code server does not load files from
-     <c>$OTPROOT/lib/mnesia-4.4.7.ez/mnesia-4.4.7/ebin</c>.</p>
+     <c>$ERL_ROOTDIR/lib/mnesia-4.4.7.ez/mnesia-4.4.7/ebin</c>.</p>
 
     <p>This behavior can be controlled through command-line flag
      <c>-code_path_choice Choice</c>. If the flag is set to <c>relaxed</c>,
@@ -876,8 +876,8 @@ rpc:call(Node, code, load_binary, [Module, Filename, Binary]),
       <name name="lib_dir" arity="0" since=""/>
       <fsummary>Library directory of Erlang/OTP.</fsummary>
       <desc>
-        <p>Returns the library directory, <c>$OTPROOT/lib</c>, where
-          <c>$OTPROOT</c> is the root directory of Erlang/OTP.</p>
+        <p>Returns the library directory, <c>$ERL_ROOTDIR/lib</c>, where
+          <c>$ERL_ROOTDIR</c> is the root directory of Erlang/OTP.</p>
 	<p><em>Example:</em></p>
         <pre>
 > <input>code:lib_dir().</input>
@@ -890,7 +890,7 @@ rpc:call(Node, code, load_binary, [Module, Filename, Binary]),
       <desc>
         <p>Returns the path
           for the "library directory", the top directory, for an
-          application <c><anno>Name</anno></c> located under <c>$OTPROOT/lib</c> or
+          application <c><anno>Name</anno></c> located under <c>$ERL_ROOTDIR/lib</c> or
           on a directory referred to with environment variable <c>ERL_LIBS</c>.</p>
         <p>If a regular directory called <c><anno>Name</anno></c> or
           <c><anno>Name</anno>-Vsn</c> exists in the code path with an <c>ebin</c>
@@ -909,7 +909,7 @@ rpc:call(Node, code, load_binary, [Module, Filename, Binary]),
 > <input>code:lib_dir(mnesia).</input>
 "/usr/local/otp/lib/mnesia-4.2.2"</pre>
         <p>Returns <c>{error, bad_name}</c> if <c><anno>Name</anno></c>
-	 is not the name of an application under <c>$OTPROOT/lib</c> or
+	 is not the name of an application under <c>$ERL_ROOTDIR/lib</c> or
 	 on a directory referred to through environment variable <c>ERL_LIBS</c>.
 	 Fails with an exception if <c>Name</c> has the wrong type.</p>
 

--- a/system/doc/tutorial/cnode.xmlsrc
+++ b/system/doc/tutorial/cnode.xmlsrc
@@ -236,13 +236,13 @@ unix> <input>gcc -o cclient \\ </input>
 <input>-lerl_interface -lei -lsocket -lnsl</input></pre>
      <p>In Erlang/OTP R5B and later versions of OTP, the
       <c>include</c> and <c>lib</c> directories are situated under
-      <c>OTPROOT/lib/erl_interface-VSN</c>, where <c>OTPROOT</c> is
+      <c>ERL_ROOTDIR/lib/erl_interface-VSN</c>, where <c>ERL_ROOTDIR</c> is
       the root directory of the OTP installation
       (<c>/usr/local/otp</c> in the recent example) and <c>VSN</c> is
       the version of the Erl_Interface application (3.2.1 in the
       recent example).</p>
     <p>In R4B and earlier versions of OTP, <c>include</c> and
-      <c>lib</c> are situated under <c>OTPROOT/usr</c>.</p>
+      <c>lib</c> are situated under <c>ERL_ROOTDIR/usr</c>.</p>
     <p><em>Step 2.</em> Compile the Erlang code:</p>
     <pre>
 unix> <input>erl -compile complex3 complex4</input></pre>

--- a/system/doc/tutorial/erl_interface.xmlsrc
+++ b/system/doc/tutorial/erl_interface.xmlsrc
@@ -106,13 +106,13 @@ unix> <input>gcc -o extprg -I/usr/local/otp/lib/erl_interface-3.9.2/include \ </
 <input>      complex.c erl_comm.c ei.c -lei -lpthread</input></pre>
     <p>In Erlang/OTP R5B and later versions of OTP, the <c>include</c>
       and <c>lib</c> directories are situated under
-      <c>OTPROOT/lib/erl_interface-VSN</c>, where <c>OTPROOT</c> is
+      <c>ERL_ROOTDIR/lib/erl_interface-VSN</c>, where <c>ERL_ROOTDIR</c> is
       the root directory of the OTP installation
       (<c>/usr/local/otp</c> in the recent example) and <c>VSN</c> is
       the version of the Erl_interface application (3.2.1 in the
       recent example).</p>
     <p>In R4B and earlier versions of OTP, <c>include</c> and <c>lib</c>
-      are situated under <c>OTPROOT/usr</c>.</p>
+      are situated under <c>ERL_ROOTDIR/usr</c>.</p>
     <p><em>Step 2.</em> Start Erlang and compile the Erlang code:</p>
     <pre>
 unix> <input>erl</input>


### PR DESCRIPTION
I was reading [documentation](https://www.erlang.org/doc/man/code.html#code-path) and found that it mentions `OTPROOT`, but `erl` actually [uses](https://github.com/erlang/otp/blob/91b9369f320ae04de0bcff07cd0d4e5ba9a34414/erts/etc/unix/erl.src.src#L39) `ERL_ROOTDIR`.