### PR TITLE
[RFC] Allow dist input_handler to be added if the dist control is an internal port

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -1927,16 +1927,22 @@ end</code>
 	  channel.
 	</p>
 	<note><p>
-	  Only the process registered as distribution
-	  controller for the distribution channel identified by
-	  <c><anno>DHandle</anno></c> is allowed to call this
-	  function.
+          When the distribution controller for the distribution
+          channel identified by <c><anno>DHandle</anno></c> is a
+          process, it is the only process allowed to call this
+          function.
+          This function is also allowed to be called when the
+          distribution controller for the distribution channel
+          identified by <c><anno>DHandle</anno></c> is a port.
+          The data received by the port should in this case be delivered to
+          the process identified by <c><anno>InputHandler</anno></c>
+          which in turn should call
+          <seemfa marker="erlang#dist_ctrl_put_data/2"><c>erlang:dist_ctrl_put_data/2</c></seemfa>.
 	</p></note>
 	<p>
 	  This function is used when implementing an alternative
-	  distribution carrier using processes as distribution
-	  controllers. <c><anno>DHandle</anno></c> is retrieved
-	  via the callback
+	  distribution carrier. <c><anno>DHandle</anno></c> is
+	  retrieved via the callback
 	  <seeguide marker="erts:alt_dist#hs_data_f_handshake_complete"><c>f_handshake_complete</c></seeguide>.
 	  More information can be found in the documentation of
 	  <seeguide marker="erts:alt_dist#distribution_module">ERTS
@@ -1967,9 +1973,8 @@ end</code>
 	</p></note>
 	<p>
 	  This function is used when implementing an alternative
-	  distribution carrier using processes as distribution
-	  controllers. <c><anno>DHandle</anno></c> is retrieved
-	  via the callback
+	  distribution carrier. <c><anno>DHandle</anno></c> is
+	  retrieved via the callback
 	  <seeguide marker="erts:alt_dist#hs_data_f_handshake_complete"><c>f_handshake_complete</c></seeguide>.
 	  More information can be found in the documentation of
 	  <seeguide marker="erts:alt_dist#distribution_module">ERTS

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -4386,13 +4386,13 @@ dist_get_stat_1(BIF_ALIST_1)
 BIF_RETTYPE
 dist_ctrl_input_handler_2(BIF_ALIST_2)
 {
-    DistEntry *dep = ERTS_PROC_GET_DIST_ENTRY(BIF_P);
     Uint32 conn_id;
+    DistEntry *dep = erts_dhandle_to_dist_entry(BIF_ARG_1, &conn_id);
 
     if (!dep)
         BIF_ERROR(BIF_P, EXC_NOTSUP);
 
-    if (erts_dhandle_to_dist_entry(BIF_ARG_1, &conn_id) != dep)
+    if ((ERTS_PROC_GET_DIST_ENTRY(BIF_P) != dep) && !is_internal_port(dep->cid))
         BIF_ERROR(BIF_P, BADARG);
 
     if (is_not_internal_pid(BIF_ARG_2))

--- a/lib/ssl/test/ssl_dist_bench_SUITE.erl
+++ b/lib/ssl/test/ssl_dist_bench_SUITE.erl
@@ -77,6 +77,7 @@ groups() ->
      {cryptcookie_socket_ktls, categories()},
      {dist_cryptcookie_inet,   categories()},
      {cryptcookie_inet_ktls,   categories()},
+     {cryptcookie_inet_ktls_ih, categories()},
      %%
      %% categories()
      {setup, [{repeat, 1}],
@@ -110,7 +111,8 @@ cryptcookie_backends() ->
     [{group, dist_cryptcookie_socket},
      {group, cryptcookie_socket_ktls},
      {group, dist_cryptcookie_inet},
-     {group, cryptcookie_inet_ktls}].
+     {group, cryptcookie_inet_ktls},
+     {group, cryptcookie_inet_ktls_ih}].
 
 categories() ->
     [{group, setup},
@@ -290,7 +292,22 @@ init_per_group(cryptcookie_inet_ktls, Config) ->
         ok ->
             [{ssl_dist, false}, {ssl_dist_prefix, "Crypto-Inet-kTLS"},
              {ssl_dist_args,
-              "-proto_dist inet_epmd -inet_epmd cryptcookie_inet_ktls"}
+              "-proto_dist inet_epmd -inet_epmd cryptcookie_inet_ktls "
+              "-inet_ktls port"}
+            | Config];
+        Problem ->
+            {skip, Problem}
+    catch
+        Class : Reason : Stacktrace ->
+            {fail, {Class, Reason, Stacktrace}}
+    end;
+init_per_group(cryptcookie_inet_ktls_ih, Config) ->
+    try inet_epmd_cryptcookie_inet_ktls:supported() of
+        ok ->
+            [{ssl_dist, false}, {ssl_dist_prefix, "Crypto-Inet-kTLS-IH"},
+             {ssl_dist_args,
+              "-proto_dist inet_epmd -inet_epmd cryptcookie_inet_ktls "
+              "-inet_ktls input_handler"}
             | Config];
         Problem ->
             {skip, Problem}


### PR DESCRIPTION
Currently dist input_handler can only be set if dist control is a pid. However, in some case we might want to intercept incoming traffic and do some security check. Allowing dist input_handler to be added in port case would let us achieve this without sacrificing performance while using kTLS in dist. This change won't have impact on any current usage of input_handler.

After this change, if we set socket option to {deliver, term} after handshake, all data will be send to the port owner, and port owner can make dist_ctrl_put_data after validation.

We can also make it work for {deliver, port} socket option, but need a bit more change in driver_output2 in io.c