### PR TITLE
Remove Vanilla Drivers

### DIFF
--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -1,7 +1,7 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 2001-2022. All Rights Reserved.
+ * Copyright Ericsson AB 2001-2023. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -786,7 +786,6 @@ static Port *
 open_port(Process* p, Eterm name, Eterm settings, int *err_typep, int *err_nump)
 {
     int merged_environment = 0;
-    Sint i;
     Eterm option;
     Uint arity;
     Eterm* tp;
@@ -1021,24 +1020,6 @@ open_port(Process* p, Eterm name, Eterm settings, int *err_typep, int *err_nump)
     /*
      * Parse the first argument and start the appropriate driver.
      */
-
-    if (is_atom(name) || (i = is_string(name))) {
-	/* a vanilla port */
-	if (is_atom(name)) {
-	    name_buf = (char *) erts_alloc(ERTS_ALC_T_TMP,
-					   atom_tab(atom_val(name))->len+1);
-	    sys_memcpy((void *) name_buf,
-		       (void *) atom_tab(atom_val(name))->name, 
-		       atom_tab(atom_val(name))->len);
-	    name_buf[atom_tab(atom_val(name))->len] = '\0';
-	} else {
-	    name_buf = (char *) erts_alloc(ERTS_ALC_T_TMP, i + 1);
-	    if (intlist_to_buf(name, name_buf, i) != i)
-		erts_exit(ERTS_ERROR_EXIT, "%s:%d: Internal error\n", __FILE__, __LINE__);
-	    name_buf[i] = '\0';
-	}
-	driver = &vanilla_driver;
-    } else {   
 	if (is_not_tuple(name)) {
 	    goto badarg;		/* Not a process or fd port */
 	}
@@ -1091,7 +1072,6 @@ open_port(Process* p, Eterm name, Eterm settings, int *err_typep, int *err_nump)
 	} else {
 	    goto badarg;
 	}
-    }
 
     if ((driver != &spawn_driver && opts.argv != NULL) ||
 	(driver == &spawn_driver && 

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1708,7 +1708,6 @@ extern void erts_match_prog_foreach_offheap(Binary *b,
 #define MATCH_SET_EXCEPTION_TRACE (0x4) /* exception trace requested */
 #define MATCH_SET_RX_TRACE (MATCH_SET_RETURN_TRACE|MATCH_SET_EXCEPTION_TRACE)
 
-extern erts_driver_t vanilla_driver;
 extern erts_driver_t spawn_driver;
 extern erts_driver_t forker_driver;
 extern erts_driver_t fd_driver;

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -57,7 +57,6 @@
 #include "erl_global_literals.h"
 
 extern ErlDrvEntry fd_driver_entry;
-extern ErlDrvEntry vanilla_driver_entry;
 extern ErlDrvEntry spawn_driver_entry;
 #ifndef __WIN32__
 extern ErlDrvEntry forker_driver_entry;
@@ -77,7 +76,6 @@ const ErlDrvTermData driver_term_nil = (ErlDrvTermData)NIL;
 
 const Port erts_invalid_port = {{ERTS_INVALID_PORT}};
 
-erts_driver_t vanilla_driver;
 erts_driver_t spawn_driver;
 #ifndef __WIN32__
 erts_driver_t forker_driver;
@@ -610,7 +608,7 @@ erts_open_driver(erts_driver_t* driver,	/* Pointer to driver. */
     }
 
     if (opts->port_watermarks_set && driver != &spawn_driver
-        && driver != &fd_driver && driver != &vanilla_driver) {
+        && driver != &fd_driver) {
 	erts_rwmtx_runlock(&erts_driver_list_lock);
 	ERTS_OPEN_DRIVER_RET(NULL, -3, BADARG);
     }
@@ -3007,7 +3005,6 @@ void erts_init_io(int port_tab_size,
     erts_rwmtx_rwlock(&erts_driver_list_lock);
 
     init_driver(&fd_driver, &fd_driver_entry, NULL);
-    init_driver(&vanilla_driver, &vanilla_driver_entry, NULL);
     init_driver(&spawn_driver, &spawn_driver_entry, NULL);
 #ifndef __WIN32__
     init_driver(&forker_driver, &forker_driver_entry, NULL);
@@ -3068,7 +3065,6 @@ static void lcnt_enable_port_lock_count(Port *prt, int enable)
 void erts_lcnt_update_driver_locks(int enable) {
     erts_driver_t *driver;
 
-    lcnt_enable_driver_lock_count(&vanilla_driver, enable);
     lcnt_enable_driver_lock_count(&spawn_driver, enable);
 #ifndef __WIN32__
     lcnt_enable_driver_lock_count(&forker_driver, enable);
@@ -5159,8 +5155,6 @@ print_port_info(Port *p, fmtfn_t to, void *arg)
 
     if (p->drv_ptr == &fd_driver) {
 	erts_print(to, arg, "Port is UNIX fd not opened by emulator: %s\n", p->name);
-    } else if (p->drv_ptr == &vanilla_driver) {
-	erts_print(to, arg, "Port is a file: %s\n",p->name);
     } else if (p->drv_ptr == &spawn_driver) {
 	erts_print(to, arg, "Port controls external process: %s\n",p->name);
 #ifndef __WIN32__

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -1,7 +1,7 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 1996-2020. All Rights Reserved.
+ * Copyright Ericsson AB 1996-2023. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,10 +198,6 @@ static ErlDrvData spawn_start(ErlDrvPort, char*, SysDriverOpts*);
 static ErlDrvSSizeT spawn_control(ErlDrvData, unsigned int, char *,
                                   ErlDrvSizeT, char **, ErlDrvSizeT);
 
-/* II.II Vanilla prototypes */
-static ErlDrvData vanilla_start(ErlDrvPort, char*, SysDriverOpts*);
-
-
 /* II.III FD prototypes */
 static ErlDrvData fd_start(ErlDrvPort, char*, SysDriverOpts*);
 static void fd_async(void *);
@@ -271,33 +267,6 @@ struct erl_drv_entry fd_driver_entry = {
     outputv,
     fd_ready_async, /* ready_async */
     fd_flush, /* flush */
-    NULL, /* call */
-    NULL, /* event */
-    ERL_DRV_EXTENDED_MARKER,
-    ERL_DRV_EXTENDED_MAJOR_VERSION,
-    ERL_DRV_EXTENDED_MINOR_VERSION,
-    0, /* ERL_DRV_FLAGs */
-    NULL, /* handle2 */
-    NULL, /* process_exit */
-    stop_select
-};
-
-/* III.III The vanilla driver */
-struct erl_drv_entry vanilla_driver_entry = {
-    NULL,
-    vanilla_start,
-    stop,
-    output,
-    ready_input,
-    ready_output,
-    "vanilla",
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    NULL, /* flush */
     NULL, /* call */
     NULL, /* event */
     ERL_DRV_EXTENDED_MARKER,
@@ -1059,30 +1028,6 @@ static void fd_flush(ErlDrvData ev)
         dd->terminating = 1;
 }
 
-static ErlDrvData vanilla_start(ErlDrvPort port_num, char* name,
-				SysDriverOpts* opts)
-{
-    int flags, fd;
-    ErlDrvData res;
-
-    flags = (opts->read_write == DO_READ ? O_RDONLY :
-	     opts->read_write == DO_WRITE ? O_WRONLY|O_CREAT|O_TRUNC :
-	     O_RDWR|O_CREAT);
-    if ((fd = open(name, flags, 0666)) < 0)
-	return ERL_DRV_ERROR_GENERAL;
-    if (fd >= sys_max_files()) {
-	close(fd);
-	return ERL_DRV_ERROR_GENERAL;
-    }
-    SET_NONBLOCKING(fd);
-
-    res = (ErlDrvData)(long)create_driver_data(port_num, fd, fd,
-                                               opts->packet_bytes,
-                                               opts->read_write, 0, -1, 0,
-                                               opts);
-    return res;
-}
-
 /* Note that driver_data[fd].ifd == fd if the port was opened for reading, */
 /* otherwise (i.e. write only) driver_data[fd].ofd = fd.  */
 
@@ -1186,7 +1131,7 @@ static void outputv(ErlDrvData e, ErlIOVec* ev)
     /* return 0;*/
 }
 
-/* Used by spawn_driver and vanilla driver */
+/* Used by spawn_driver */
 static void output(ErlDrvData e, char* buf, ErlDrvSizeT len)
 {
     ErtsSysDriverData *dd = (ErtsSysDriverData*)e;

--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -409,7 +409,7 @@ int* pBuild;			/* Pointer to build number. */
 
 /* I. Common stuff */
 
-/* II. The spawn/fd/vanilla drivers */
+/* II. The spawn/fd drivers */
 
 /*
  * Definitions for driver flags.
@@ -469,7 +469,7 @@ static AsyncIo* fd_driver_input = NULL;
 static BOOL (WINAPI *fpSetHandleInformation)(HANDLE,DWORD,DWORD);
 
 /*
- * This data is used by the spawn and vanilla drivers.
+ * This data is used by the spawn drivers.
  * There will be one entry for each port, even if the input
  * and output HANDLES are different.  Since handles are not
  * guaranteed to be small numbers in Win32, we cannot index
@@ -504,7 +504,6 @@ struct driver_data {
 /* Driver interfaces */
 static ErlDrvData spawn_start(ErlDrvPort, char*, SysDriverOpts*);
 static ErlDrvData fd_start(ErlDrvPort, char*, SysDriverOpts*);
-static ErlDrvData vanilla_start(ErlDrvPort, char*, SysDriverOpts*);
 static int spawn_init(void);
 static int fd_init(void);
 static void fd_stop(ErlDrvData);
@@ -560,32 +559,6 @@ struct erl_drv_entry fd_driver_entry = {
     ready_input,
     ready_output,
     "fd",
-    NULL, /* finish */
-    NULL, /* handle */
-    NULL, /* control */
-    NULL, /* timeout */
-    NULL, /* outputv */
-    NULL, /* ready_async */
-    NULL, /* flush */
-    NULL, /* call */
-    NULL, /* event */
-    ERL_DRV_EXTENDED_MARKER,
-    ERL_DRV_EXTENDED_MAJOR_VERSION,
-    ERL_DRV_EXTENDED_MINOR_VERSION,
-    0,	/* ERL_DRV_FLAGs */
-    NULL,
-    NULL, /* process_exit */
-    stop_select
-};
-
-struct erl_drv_entry vanilla_driver_entry = {
-    null_func,
-    vanilla_start,
-    stop,
-    output,
-    ready_input,
-    ready_output,
-    "vanilla",
     NULL, /* finish */
     NULL, /* handle */
     NULL, /* control */
@@ -2229,44 +2202,6 @@ static void fd_stop(ErlDrvData data)
 	       && !(dp->out.flags & DF_THREAD_FLUSHED));
   }    
 
-}
-
-static ErlDrvData
-vanilla_start(ErlDrvPort port_num, char* name, SysDriverOpts* opts)
-{
-    HANDLE ofd,ifd;
-    DriverData* dp;
-    DWORD access;		/* Access mode: GENERIC_READ, GENERIC_WRITE. */
-    DWORD crFlags;
-    HANDLE this_process = GetCurrentProcess();
-
-    access = 0;
-    if (opts->read_write == DO_READ)
-	access |= GENERIC_READ;
-    if (opts->read_write == DO_WRITE)
-	access |= GENERIC_WRITE;
-
-    if (opts->read_write == DO_READ)
-	crFlags = OPEN_EXISTING;
-    else if (opts->read_write == DO_WRITE)
-	crFlags = CREATE_ALWAYS;
-    else
-	crFlags = OPEN_ALWAYS;
-
-    if ((dp = new_driver_data(port_num, opts->packet_bytes, 2, FALSE)) == NULL)
-	return ERL_DRV_ERROR_GENERAL;
-    ofd = CreateFile(name, access, FILE_SHARE_READ | FILE_SHARE_WRITE,
-		    NULL, crFlags, FILE_ATTRIBUTE_NORMAL, NULL);
-    if (!DuplicateHandle(this_process, (HANDLE) ofd,	
-			 this_process, &ifd, 0,
-			 FALSE, DUPLICATE_SAME_ACCESS)) {
-	CloseHandle(ofd);
-	ofd = INVALID_HANDLE_VALUE;
-    }
-    if (ofd == INVALID_HANDLE_VALUE)
-	return ERL_DRV_ERROR_GENERAL;
-    return set_driver_data(dp, ifd, ofd, opts->read_write,
-                           0, opts);
 }
 
 static void

--- a/erts/emulator/test/binary_SUITE.erl
+++ b/erts/emulator/test/binary_SUITE.erl
@@ -1566,11 +1566,6 @@ ordering(Config) when is_list(Config) ->
     true = B1 > fun() -> 1 end,
     true = B1 > fun erlang:send/2,
 
-    Path = proplists:get_value(priv_dir, Config),
-    AFile = filename:join(Path, "vanilla_file"),
-    Port = open_port(AFile, [out]),
-    true = B1 > Port,
-
     true = B1 >= 0,
     true = B1 >= 39827491247298471289473333333333333333333333333333,
     true = B1 >= -3489274937438742190467869234328742398347,
@@ -1583,7 +1578,6 @@ ordering(Config) when is_list(Config) ->
     true = B1 >= xxx,
     true = B1 >= fun() -> 1 end,
     true = B1 >= fun erlang:send/2,
-    true = B1 >= Port,
 
     ok.
 

--- a/erts/emulator/test/fun_SUITE.erl
+++ b/erts/emulator/test/fun_SUITE.erl
@@ -25,7 +25,7 @@
 	 bad_apply/1,bad_fun_call/1,badarity/1,ext_badarity/1,
          bad_arglist/1,
 	 equality/1,ordering/1,
-	 fun_to_port/1,t_phash/1,t_phash2/1,md5/1,
+	 t_phash/1,t_phash2/1,md5/1,
 	 refc/1,refc_ets/1,refc_dist/1,
 	 const_propagation/1,t_arity/1,t_is_function2/1,
 	 t_fun_info/1,t_fun_info_mfa/1,t_fun_to_list/1]).
@@ -42,7 +42,7 @@ suite() ->
 all() ->
     [bad_apply, bad_fun_call, badarity, ext_badarity,
      bad_arglist,
-     equality, ordering, fun_to_port, t_phash,
+     equality, ordering, t_phash,
      t_phash2, md5, refc, refc_ets, refc_dist,
      const_propagation, t_arity, t_is_function2, t_fun_info,
      t_fun_info_mfa,t_fun_to_list].
@@ -340,30 +340,6 @@ ordering(Config) when is_list(Config) ->
     false = FF1 >= B,
     false = B =< FF2,
 
-    %% Create a port and ref.
-
-    Path = proplists:get_value(priv_dir, Config),
-    AFile = filename:join(Path, "vanilla_file"),
-    P = open_port(AFile, [out]),
-    R = make_ref(),
-
-    %% Compare funs with ports and refs.
-
-    true = R < F3,
-    true = F3 > R,
-    true = F3 < P,
-    true = P > F3,
-
-    true = R =< F3,
-    true = F3 >= R,
-    true = F3 =< P,
-    true = P >= F3,
-
-    false = R > F3,
-    false = F3 < R,
-    false = F3 > P,
-    false = P < F3,
-
     %% Compare funs with conses and nils.
 
     true = F1 < [a],
@@ -401,27 +377,6 @@ ordering(Config) when is_list(Config) ->
 
 make_fun(X, Y) ->
     fun(A) -> A*X+Y end.
-
-%% Try sending funs to ports (should fail).
-fun_to_port(Config) when is_list(Config) ->
-    fun_to_port(Config, xxx),
-    fun_to_port(Config, fun() -> 42 end),
-    fun_to_port(Config, [fun() -> 43 end]),
-    fun_to_port(Config, [1,fun() -> 44 end]),
-    fun_to_port(Config, [0,1|fun() -> 45 end]),
-    B64K = build_io_list(65536),
-    fun_to_port(Config, [B64K,fun() -> 45 end]),
-    fun_to_port(Config, [B64K|fun() -> 45 end]),
-    ok.
-
-fun_to_port(Config, IoList) ->
-    Path = proplists:get_value(priv_dir, Config),
-    AFile = filename:join(Path, "vanilla_file"),
-    Port = open_port(AFile, [out]),
-    case catch port_command(Port, IoList) of
-	{'EXIT',{badarg,_}} -> ok;
-	Other -> ct:fail({unexpected_retval,Other})
-    end.
 
 build_io_list(0) -> [];
 build_io_list(1) -> [7];

--- a/erts/emulator/test/port_SUITE.erl
+++ b/erts/emulator/test/port_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1997-2022. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2023. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -34,13 +34,10 @@
 %%         external program. That is not true. It might very well be
 %%         a linked-in program (the notion of 'linked-in driver' is
 %%         silly, since any driver is 'linked-in').
-%%	  [Spawn of external program is tested.]
-%%
-%%       Atom
-%%         Read all contents of Atom, or write to it.
+%%	       [Spawn of external program is tested.]
 %%
 %%       {fd, In, Out}
-%%       Open file descriptors In and Out. [Not tested]
+%%         Open file descriptors In and Out. [Not tested]
 %%
 %%   PortSettings can be
 %%
@@ -77,6 +74,7 @@
 -export([all/0, suite/0, groups/0, init_per_testcase/2, end_per_testcase/2,
          init_per_suite/1, end_per_suite/1]).
 -export([
+    badarg_port_with_atom/1,
     bad_args/1,
     bad_env/1,
     bad_packet/1,
@@ -112,8 +110,6 @@
     mul_basic/1,
     mul_slow_writes/1,
     name1/1,
-    open_input_file_port/1,
-    open_output_file_port/1,
     otp_3906/1,
     otp_4389/1,
     otp_5112/1,
@@ -174,9 +170,8 @@ all() ->
     [otp_6224, {group, stream}, basic_ping, slow_writes,
      bad_packet, bad_port_messages, {group, options},
      {group, multiple_packets}, parallell, dying_port, dropped_commands,
-     port_program_with_path, open_input_file_port,
-     open_output_file_port, name1, env, huge_env, bad_env, cd,
-     cd_relative, pipe_limit_env, bad_args,
+     port_program_with_path, name1, env, huge_env, bad_env, cd,
+     cd_relative, pipe_limit_env, bad_args, badarg_port_with_atom,
      exit_status, iter_max_ports, count_fds, t_exit, {group, tps}, line,
      stderr_to_stdout, otp_3906, otp_4389, win_massive,
      mix_up_ports, otp_5112, otp_5119,
@@ -660,45 +655,19 @@ port_program_with_path(Config) when is_list(Config) ->
     end,
     ok.
 
-
-%% Tests that files can be read using open_port(Filename, [in]).
-%% This used to fail on Windows.
-open_input_file_port(Config) when is_list(Config) ->
+%% Tests that ports can no longer be opened using atoms
+badarg_port_with_atom(Config) when is_list(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
-
-    %% Create a file with the file driver and read it back using
-    %% open_port/2.
-
-    MyFile1 = filename:join(PrivDir, "my_input_file"),
-    FileData1 = "An input file",
-    ok = file:write_file(MyFile1, FileData1),
-    case open_port(MyFile1, [in]) of
-        InputPort when is_port(InputPort) ->
-            receive
-                {InputPort, {data, FileData1}} ->
-                    ok
-            end
+    File = filename:join(PrivDir, "port_file"),
+    case catch open_port(File, [eof]) of
+        {'EXIT', {badarg, _}} ->
+            ok
     end,
-    ok.
 
-%% Tests that files can be written using open_port(Filename, [out]).
-open_output_file_port(Config) when is_list(Config) ->
-    ct:timetrap({minutes, 2}),
-    PrivDir = proplists:get_value(priv_dir, Config),
-
-    %% Create a file with open_port/2 and read it back with
-    %% the file driver.
-
-    MyFile2 = filename:join(PrivDir, "my_output_file"),
-    FileData2_0 = "A file created ",
-    FileData2_1 = "with open_port/2.\n",
-    FileData2 = FileData2_0 ++ FileData2_1,
-    OutputPort = open_port(MyFile2, [out]),
-    OutputPort ! {self(), {command, FileData2_0}},
-    OutputPort ! {self(), {command, FileData2_1}},
-    OutputPort ! {self(), close},
-    {ok, Bin} = file:read_file(MyFile2),
-    FileData2 = binary_to_list(Bin),
+    case catch open_port(atom_port, [eof]) of
+        {'EXIT', {badarg, _}} ->
+            ok
+    end,
     ok.
 
 %% Tests that all appropriate fd's have been closed in the port program
@@ -2552,7 +2521,7 @@ close_deaf_port(Config) when is_list(Config) ->
     ct:timetrap({minutes, 2}),
     DataDir = proplists:get_value(data_dir, Config),
     DeadPort = os:find_executable("dead_port", DataDir),
-    Port = open_port({spawn,DeadPort++" 60"},[]),
+    Port = open_port({spawn, DeadPort++" 60"},[]),
     erlang:port_command(Port,"Hello, can you hear me!?!?"),
     port_close(Port),
 


### PR DESCRIPTION
This PR removes all code related to Vanilla Drivers port creation, add tests to validate that both Atoms and Strings as 1st argument on `open_port/2` should raise badarg error.

The changes in this PR resolves #6725 so that ports could only be used with tuple args and file manipulation as the way vanilla drivers used to do should be accomplished through [File module](https://www.erlang.org/doc/man/file.html)