### PR TITLE
Update `perf` workflow for OTP26

### DIFF
--- a/erts/emulator/internal_doc/BeamAsm.md
+++ b/erts/emulator/internal_doc/BeamAsm.md
@@ -385,8 +385,9 @@ not need the symbols in the executable.
 Using the same data we can also produce a graph where the scheduler profile data
 has been merged by using `sed`:
 
-    ## Strip [0-9]+_ from all scheduler names
-    sed -e 's/^[0-9]\+_//' out.folded > out.folded_sched
+    ## Strip [0-9]+_ and/or _[0-9]+ from all scheduler names
+    ## scheduler names changed in OTP26, hence two expressions
+    sed -e 's/^[0-9]\+_//' -e 's/^erts_\([^_]\+\)_[0-9]\+/erts_\1/' out.folded > out.folded_sched
     ## Create the svg
     flamegraph.pl out.folded_sched > out_sched.svg
 


### PR DESCRIPTION
Scheduler names changed in OTP26, so we need a different `sed` expresion to merge data from all schedulers. The example is now compatible with versions prior to OTP26 and OTP26+