### PR TITLE
Alias fix

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -370,6 +370,7 @@ demonitor(Process *c_p, Eterm ref, Eterm *multip)
                                                    NIL,
                                                    THE_NON_VALUE);
        amdp->origin.flags = mon->flags & ERTS_ML_STATE_ALIAS_MASK;
+       mon->flags &= ~ERTS_ML_STATE_ALIAS_MASK;
        erts_monitor_tree_replace(&ERTS_P_MONITORS(c_p), mon, &amdp->origin);
        break;
    }

--- a/erts/emulator/beam/erl_bif_unique.c
+++ b/erts/emulator/beam/erl_bif_unique.c
@@ -591,14 +591,15 @@ erts_pid_ref_delete(Eterm ref)
 	erts_rwmtx_rwlock(&tblp->rwmtx);
 
 	tep = hash_remove(&tblp->hash, &tmpl);
-	ASSERT(tep);
 
 	erts_rwmtx_rwunlock(&tblp->rwmtx);
 
-	if (tblp != &pid_ref_table[0].u.table)
-	    erts_free(ERTS_ALC_T_PREF_NSCHED_ENT, (void *) tep);
-	else
-	    erts_free(ERTS_ALC_T_PREF_ENT, (void *) tep);
+        if (tep) {
+            if (tblp != &pid_ref_table[0].u.table)
+                erts_free(ERTS_ALC_T_PREF_NSCHED_ENT, (void *) tep);
+            else
+                erts_free(ERTS_ALC_T_PREF_ENT, (void *) tep);
+        }
     }
 }
 

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -5628,6 +5628,7 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
                                                mdp->ref, c_p->common.id,
                                                NIL, NIL, THE_NON_VALUE);
                     amdp->origin.flags = ERTS_ML_STATE_ALIAS_UNALIAS;
+                    omon->flags &= ~ERTS_ML_STATE_ALIAS_MASK;
                     erts_monitor_tree_replace(&ERTS_P_MONITORS(c_p),
                                               omon,
                                               &amdp->origin);

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -96,6 +96,8 @@
          monitor_alias/1,
          spawn_monitor_alias/1,
          alias_process_exit/1,
+         demonitor_aliasmonitor/1,
+         down_aliasmonitor/1,
          monitor_tag/1]).
 
 -export([prio_server/2, prio_client/2, init/1, handle_event/2]).
@@ -183,7 +185,8 @@ groups() ->
        gc_request_when_gc_disabled, gc_request_blast_when_gc_disabled,
        otp_16436, otp_16642]},
      {alias, [],
-      [alias_bif, monitor_alias, spawn_monitor_alias, alias_process_exit]}].
+      [alias_bif, monitor_alias, spawn_monitor_alias, alias_process_exit,
+       demonitor_aliasmonitor, down_aliasmonitor]}].
 
 init_per_suite(Config) ->
     A0 = case application:start(sasl) of
@@ -5015,6 +5018,51 @@ alias_process_exit(Config) when is_list(Config) ->
     exit(P, kill),
     false = is_process_alive(P),
     check_pid_ref_table_size(PRTSz),
+    ok.
+
+demonitor_aliasmonitor(Config) when is_list(Config) ->
+    {ok, Peer, Node} = ?CT_PEER(),
+    Fun = fun () ->
+                  receive
+                      {alias, Alias} ->
+                          Alias ! {alias_reply, Alias, self()}
+                  end
+          end,
+    LPid = spawn(Fun),
+    RPid = spawn(Node, Fun),
+    AliasMonitor = erlang:monitor(process, LPid, [{alias, explicit_unalias}]),
+    erlang:demonitor(AliasMonitor),
+    LPid ! {alias, AliasMonitor},
+    receive {alias_reply, AliasMonitor, LPid} -> ok end,
+    %% Demonitor signal has been received and cleaned up. Cleanup of
+    %% it erroneously removed it from the alias table which caused
+    %% remote use of the alias to stop working...
+    RPid ! {alias, AliasMonitor},
+    receive {alias_reply, AliasMonitor, RPid} -> ok end,
+    exit(LPid, kill),
+    peer:stop(Peer),
+    false = is_process_alive(LPid),
+    ok.
+
+down_aliasmonitor(Config) when is_list(Config) ->
+    {ok, Peer, Node} = ?CT_PEER(),
+    LPid = spawn(fun () -> receive infinty -> ok end end),
+    RPid = spawn(Node,
+                 fun () ->
+                         receive
+                             {alias, Alias} ->
+                                 Alias ! {alias_reply, Alias, self()}
+                         end
+                 end),
+    AliasMonitor = erlang:monitor(process, LPid, [{alias, explicit_unalias}]),
+    exit(LPid, bye),
+    receive {'DOWN', AliasMonitor, process, LPid, bye} -> ok end,
+    %% Down signal has been received and cleaned up. Cleanup of
+    %% it erroneously removed it from the alias table which caused
+    %% remote use of the alias to stop working...
+    RPid ! {alias, AliasMonitor},
+    receive {alias_reply, AliasMonitor, RPid} -> ok end,
+    peer:stop(Peer),
     ok.
 
 monitor_tag(Config) when is_list(Config) ->


### PR DESCRIPTION
Aliases created in combination with a monitor using the `{alias, explicit_unalias}` option stopped working from remote nodes when a `'DOWN'` signal had been received due to the monitor or if the monitor was removed using the `erlang:demonitor()` BIF.

This bug was introduced in OTP 24.3.4.10 and OTP 25.3.