### PR TITLE
beam_ssa_private_append: Fix crash on oddly structured code

### DIFF
--- a/lib/compiler/src/beam_ssa_private_append.erl
+++ b/lib/compiler/src/beam_ssa_private_append.erl
@@ -565,6 +565,8 @@ patch_literal_term(<<>>, self, Cnt0) ->
     {V,Cnt} = new_var(Cnt0),
     I = #b_set{op=bs_init_writable,dst=V,args=[#b_literal{val=256}]},
     {V, [I], Cnt};
+patch_literal_term(Lit, self, Cnt) ->
+    {#b_literal{val=Lit}, [], Cnt};
 patch_literal_term([H0|T0], {hd,Element}, Cnt0) ->
     {H,Extra,Cnt1} = patch_literal_term(H0, Element, Cnt0),
     {T,[],Cnt1} = patch_literal_term(T0, [], Cnt1),


### PR DESCRIPTION
The private append pass didn't expect to append anything to literals other than `<<>>`. Rare interactions with the type or bool passes could sneak in things like atoms in unexpected places, crashing the pass.

@frej 