### PR TITLE
os_mon: Fix failing port_close

### DIFF
--- a/lib/os_mon/src/cpu_sup.erl
+++ b/lib/os_mon/src/cpu_sup.erl
@@ -613,8 +613,8 @@ port_server_loop(Port, Timeout) ->
 
 	% Close port and this server
 	{Pid, ?quit} ->
-	    port_command(Port, ?quit),
-	    port_close(Port),
+            Port ! {self(), {command, ?quit}},
+	    Port ! {self(), close},
 	    Pid ! {self(), {data, quit}},
 	    ok;
 

--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -653,7 +653,7 @@ start_portprogram() ->
 
 port_shutdown(Port) ->
     Port ! {self(), {command, [?EXIT]}},
-    port_close(Port).
+    Port ! {self(), close}.
 
 %% The connected process loops are a bit awkward (several different
 %% functions doing almost the same thing) as


### PR DESCRIPTION
Use asynchronous close message to not fail on already closed port.