### PR TITLE
dialyzer: Expand Dialyzer config file options

### DIFF
--- a/lib/dialyzer/doc/src/dialyzer.xml
+++ b/lib/dialyzer/doc/src/dialyzer.xml
@@ -507,6 +507,32 @@ dialyzer --plts plt_1 ... plt_n -- files_to_analyze</code>
     <p>Currently the only option used is the
     <seeerl marker="#error_location"><c>error_location</c></seeerl> option.
     </p>
+
+    <p><em>Dialyzer configuration file:</em></p>
+
+    <p>Dialyzer's configuration file may also be used to augment the default
+       options and those given directly to the Dialyzer command. It is commonly
+       used to avoid repeating options which would otherwise need to be given
+       explicitly to Dialyzer on every invocation.
+    </p>
+
+    <p>The location of the configuration file can be set via the
+      <c>DIALYZER_CONFIG</c> environment variable, and defaults to
+        within the <c>user_config</c> from <seemfa marker="stdlib:filename#basedir/3">
+        <c>filename:basedir/3</c></seemfa>.
+    </p>
+
+    <p>An example configuration file's contents might be:</p>
+
+    <code type="none">
+      {incremental,
+        {default_apps,[stdlib,kernel,erts]},
+        {default_warning_apps,[stdlib]}
+      }.
+      {warnings, [no_improper_lists]}.
+      {add_pathsa,["/users/samwise/potatoes/ebin"]}.
+      {add_pathsz,["/users/smeagol/fish/ebin"]}.
+    </code>
   </section>
 
   <section>

--- a/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
@@ -504,10 +504,11 @@ expand_files(Analysis = #analysis{files = Files, start_from = StartFrom}) ->
   case expand_files(Files, Ext, []) of
     [] ->
       Msg = "No " ++ Ext ++ " files to analyze" ++
-	case StartFrom of
-	  byte_code -> " (no --src specified?)";
-	  src_code -> ""
-	end,
+        case StartFrom of
+          byte_code -> " (no --src specified?)";
+          src_code -> ""
+        end ++
+        "\nConsider setting some default apps in your dialyzer.config file",
       exit({error, Msg});
     NewFiles ->
       Analysis#analysis{files = NewFiles}

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -577,6 +577,8 @@ Note:
     the syntax of defines and includes is the same as that used by \"erlc\".
 
 " ++ warning_options_msg() ++ "
+" ++ configuration_file_msg() ++ "
+
 The exit status of the command line version is:
   0 - No problems were encountered during the analysis and no
       warnings were emitted.
@@ -653,4 +655,30 @@ They are primarily intended to be used with the -dialyzer attribute:
      Suppress warnings about functions whose specification includes types that the function cannot return.
   -Wno_missing_return
      Suppress warnings about functions that return values that are not part of the specification.
+".
+
+configuration_file_msg() ->
+    "Configuration file:
+     Dialyzer's configuration file may also be used to augment the default
+     options and those given directly to the Dialyzer command. It is commonly
+     used to avoid repeating options which would otherwise need to be given
+     explicitly to Dialyzer on every invocation.
+
+     The location of the configuration file can be set via the
+     DIALYZER_CONFIG environment variable, and defaults to
+     within the user_config location given by filename:basedir/3.
+
+     On your system, the location is currently configured as:
+       " ++ dialyzer_options:get_default_config_filename() ++
+     "
+
+     An example configuration file's contents might be:
+
+       {incremental,
+         {default_apps,[stdlib,kernel,erts]},
+         {default_warning_apps,[stdlib]}
+       }.
+       {warnings, [no_improper_lists]}.
+       {add_pathsa,[\"/users/samwise/potatoes/ebin\"]}.
+       {add_pathsz,[\"/users/smeagol/fish/ebin\"]}.
 ".

--- a/lib/dialyzer/test/incremental_SUITE_data/extra_modules/ebin/.gitignore
+++ b/lib/dialyzer/test/incremental_SUITE_data/extra_modules/ebin/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file, to force the directory to stick around
+# for the tests to later make use of
+!.gitignore

--- a/lib/dialyzer/test/incremental_SUITE_data/extra_modules/src/extra_module.erl
+++ b/lib/dialyzer/test/incremental_SUITE_data/extra_modules/src/extra_module.erl
@@ -1,0 +1,14 @@
+-module(extra_module).
+
+-export([start/2,stop/1,f/1]).
+
+start(StartType, StartArgs) ->
+  error.
+
+stop(State) ->
+  error.
+
+% Purposely broken to generate a warning if the module is loaded and analysed
+-spec f(atom()) -> string().
+f(N) when is_integer(N) ->
+  [N + 1|3].

--- a/lib/dialyzer/test/incremental_SUITE_data/extra_modules/src/extra_modules.app.src
+++ b/lib/dialyzer/test/incremental_SUITE_data/extra_modules/src/extra_modules.app.src
@@ -1,0 +1,8 @@
+{application, extra_modules,
+ [{description, "An app with some extra modules"},
+  {vsn, "1"},
+  {modules, [extra_module]},
+  {registered, []},
+  {applications, [kernel, stdlib]},
+  {mod, {extra_module,[]}}
+ ]}.


### PR DESCRIPTION
The Dialyzer config file previously allowed setting fallback modules to analyse and report warnings for in the absence of explicitly given modules in the arguments.

This change extends the config file to include warnings to toggle and modifications to the beginning and end of the path, allowing users to factor these out of their command line arguments.

This change also fixes apps being in default_warning_apps without being in default_apps causing an inconsistency. Now all warning apps are implicitly added to the apps to analyze.

An example Dialyzer config that makes use of the new options:

```erlang
  {incremental,
    {default_apps,[stdlib,kernel,erts]},
    {default_warning_apps,[stdlib]}
  }.
  {warnings, [no_improper_lists]}.
  {add_pathsa,["/users/samwise/potatoes/ebin"]}.
  {add_pathsz,["/users/smeagol/fish/ebin"]}.
```

This config expresses that:
 - If no apps/warnings apps are given explicitly, analyse stdlib, kernel and erts, and report warnings for stdlib only.
 - Set the no_improper_lists option to suppress warnings about improper list construction
 - Add /users/samwise/potatoes/ebin to the start of the path, and /users/smeagol/fish/ebin to the end of it

This change should make incremental mode suitable as the default analysis mode for Dialyzer in OTP 27 and beyond.