### PR TITLE
diameter: updates deprecation function

### DIFF
--- a/erts/test/otp_SUITE.erl
+++ b/erts/test/otp_SUITE.erl
@@ -542,7 +542,7 @@ ignore_undefs() ->
                 %% The following functions are optional dependencies for diameter
                 #{{dbg,ctp,0} => true,
                   {dbg,p,2} => true,
-                  {dbg,stop_clear,0} => true,
+                  {dbg,stop,0} => true,
                   {dbg,trace_port,2} => true,
                   {dbg,tracer,2} => true,
                   {erl_prettypr,format,1} => true,


### PR DESCRIPTION
`diameter` should not call nor rely on the deprecated function `dbg:stop_clear/0`. 

the main reason is that `dbg:stop_clear/0` is simply an alias to `dbg:stop/0`. thus, `dbg:stop_clear/0` was marked as deprecated in a previous pull request GH-6903 (commit `861be72c5a1261ee1694ee468540256f6db11e87`), and these are the remains that I forgot to update.