### PR TITLE
diameter:  remove optional call to deprecated fn and update appup

### DIFF
--- a/erts/test/otp_SUITE.erl
+++ b/erts/test/otp_SUITE.erl
@@ -542,7 +542,7 @@ ignore_undefs() ->
                 %% The following functions are optional dependencies for diameter
                 #{{dbg,ctp,0} => true,
                   {dbg,p,2} => true,
-                  {dbg,stop_clear,0} => true,
+                  {dbg,stop,0} => true,
                   {dbg,trace_port,2} => true,
                   {dbg,tracer,2} => true,
                   {erl_prettypr,format,1} => true,

--- a/lib/diameter/src/diameter.appup.src
+++ b/lib/diameter/src/diameter.appup.src
@@ -69,8 +69,9 @@
   {"2.2.4",   [{restart_application, diameter}]},  %% 23.3.4
   {"2.2.5",   [{restart_application, diameter}]},  %% 24.3
   {"2.2.6",   [{restart_application, diameter}]},  %% 25.0
-  {"2.2.7",   [{restart_application, diameter}]}   %% 25.1
- ],
+  {"2.2.7",   [{restart_application, diameter}]},  %% 25.1
+  {"2.3",     [{restart_application, diameter}]}
+],
  [
   {"0.9",     [{restart_application, diameter}]},
   {"0.10",    [{restart_application, diameter}]},
@@ -120,6 +121,7 @@
   {"2.2.4",   [{restart_application, diameter}]},
   {"2.2.5",   [{restart_application, diameter}]},
   {"2.2.6",   [{restart_application, diameter}]},
-  {"2.2.7",   [{restart_application, diameter}]}
+  {"2.2.7",   [{restart_application, diameter}]},
+  {"2.3",     [{restart_application, diameter}]}
  ]
 }.


### PR DESCRIPTION
`diameter` should not call or rely on the deprecated function `dbg:stop_clear/0`.

The main reason is that `dbg:stop_clear/0` is simply an alias to `dbg:stop/0`. Thus, `dbg:stop_clear/0` was marked as deprecated in a previous pull request GH-6903 (commit
`861be72c5a1261ee1694ee468540256f6db11e87`), and these are the remains that I forgot to update.