### PR TITLE
Handle feature attribute in epp_dodger

### DIFF
--- a/lib/edoc/test/edoc_SUITE.erl
+++ b/lib/edoc/test/edoc_SUITE.erl
@@ -24,13 +24,14 @@
 
 %% Test cases
 -export([app/1,appup/1,build_std/1,build_map_module/1,otp_12008/1,
-         build_app/1, otp_14285/1, infer_module_app_test/1]).
+         build_app/1, otp_14285/1, infer_module_app_test/1,
+         module_with_feature/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [app,appup,build_std,build_map_module,otp_12008, build_app, otp_14285,
-     infer_module_app_test].
+     infer_module_app_test, module_with_feature].
 
 groups() -> 
     [].
@@ -159,3 +160,13 @@ infer_module_app_test_({M, Beam}) ->
 	    R2 = filelib:is_regular(BeamPath2),
 	    R1 orelse R2
     end.
+
+module_with_feature(Config) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    Source = filename:join(DataDir, "module_with_feature.erl"),
+    DodgerOpts = [{dir, PrivDir}],
+    ok = edoc:files([Source], DodgerOpts),
+    PreprocessOpts = [{preprocess, true}, {dir, PrivDir}],
+    ok = edoc:files([Source], PreprocessOpts),
+    ok.

--- a/lib/edoc/test/edoc_SUITE_data/module_with_feature.erl
+++ b/lib/edoc/test/edoc_SUITE_data/module_with_feature.erl
@@ -1,0 +1,2 @@
+-module(module_with_feature).
+-feature(maybe_expr, enable).

--- a/lib/syntax_tools/src/epp_dodger.erl
+++ b/lib/syntax_tools/src/epp_dodger.erl
@@ -517,6 +517,8 @@ quickscan_form([{'-', _Anno}, {'else', AnnoA} | _Ts]) ->
     kill_form(AnnoA);
 quickscan_form([{'-', _Anno}, {atom, AnnoA, endif} | _Ts]) ->
     kill_form(AnnoA);
+quickscan_form([{'-', _Anno}, {atom, AnnoA, feature} | _Ts]) ->
+   kill_form(AnnoA);
 quickscan_form([{'-', Anno}, {'?', _}, {Type, _, _}=N | [{'(', _} | _]=Ts])
   when Type =:= atom; Type =:= var ->
     %% minus, macro and open parenthesis at start of form - assume that


### PR DESCRIPTION
* Handle the `feature` attribute in `epp_dodger` (by killing the form)
* Add a testcase (failing before the change, passing after)

Testplan:

```
export ERL_TOP=`pwd`
./otp_build setup -a
make syntax_tools
make edoc_test ARGS="-suite edoc_SUITE -case module_with_feature"
```

Fixes #7175 .