### PR TITLE
Update erl_nif.xml

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -2342,7 +2342,7 @@ enif_inspect_iovec(env, max_elements, term, &amp;tail, &amp;iovec);
 
     <func>
       <name since="OTP R14B"><ret>ERL_NIF_TERM</ret>
-        <nametext>enif_make_pid(ErlNifEnv* env, const ErlNifPid* pid)</nametext>
+        <nametext>enif_make_pid(ErlNifEnv* env, ErlNifPid* pid)</nametext>
       </name>
       <fsummary>Make a pid term.</fsummary>
       <desc>


### PR DESCRIPTION
this function appears to have the "incorrect" const-correctness (it *should* be const * but the .h file *appears* to make it not const), but I could be misreading `erl_nif_api_funcs.h`.  This change to documentation reflects the reality of the code (unless the header file is to be changed to give it const correctness).