### PR TITLE
Remove incorrect compatibility section from `gb_sets` docs

### DIFF
--- a/lib/stdlib/doc/src/gb_sets.xml
+++ b/lib/stdlib/doc/src/gb_sets.xml
@@ -68,48 +68,10 @@
 
   <section>
     <title>Compatibility</title>
-    <p>The following functions in this module also exist and provides
-      the same functionality in the
-      <seeerl marker="sets"><c>sets(3)</c></seeerl> and
-      <seeerl marker="ordsets"><c>ordsets(3)</c></seeerl>
-      modules. That is, by only changing the module name for each call,
-      you can try out different set representations.</p>
-    <list type="bulleted">
-      <item><seemfa marker="#add_element/2"><c>add_element/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#del_element/2"><c>del_element/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#filter/2"><c>filter/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#fold/3"><c>fold/3</c></seemfa>
-      </item>
-      <item><seemfa marker="#from_list/1"><c>from_list/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#intersection/1"><c>intersection/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#intersection/2"><c>intersection/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#is_element/2"><c>is_element/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#is_empty/1"><c>is_empty/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#is_set/1"><c>is_set/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#is_subset/2"><c>is_subset/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#new/0"><c>new/0</c></seemfa>
-      </item>
-      <item><seemfa marker="#size/1"><c>size/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#subtract/2"><c>subtract/2</c></seemfa>
-      </item>
-      <item><seemfa marker="#to_list/1"><c>to_list/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#union/1"><c>union/1</c></seemfa>
-      </item>
-      <item><seemfa marker="#union/2"><c>union/2</c></seemfa>
-      </item>
-    </list>
+    <p>See the <seeerl marker="sets#compatibility">Compatibility Section
+      in the <c>sets(3)</c> module</seeerl> for information about
+      the compatibility of the different implementations of sets in the
+      Standard Library.</p>
   </section>
 
   <datatypes>

--- a/lib/stdlib/doc/src/ordsets.xml
+++ b/lib/stdlib/doc/src/ordsets.xml
@@ -48,6 +48,11 @@
       that while <c>sets</c> considers two elements as different if they
       do not match (<c>=:=</c>), this module considers two elements as
       different if and only if they do not compare equal (<c>==</c>).</p>
+
+    <p>See the <seeerl marker="sets#compatibility">Compatibility Section
+      in the <c>sets(3)</c> module</seeerl> for more information about
+      the compatibility of the different implementations of sets in the
+      Standard Library.</p>
   </description>
 
   <datatypes>

--- a/lib/stdlib/doc/src/sets.xml
+++ b/lib/stdlib/doc/src/sets.xml
@@ -69,6 +69,71 @@
 
   </description>
 
+  <section>
+    <title>Compatibility</title>
+    <p>The following functions in this module also exist and provide
+      the same functionality in the
+      <seeerl marker="gb_sets"><c>gb_sets(3)</c></seeerl> and
+      <seeerl marker="ordsets"><c>ordsets(3)</c></seeerl>
+      modules. That is, by only changing the module name for each call,
+      you can try out different set representations.</p>
+    <list type="bulleted">
+      <item><seemfa marker="#add_element/2"><c>add_element/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#del_element/2"><c>del_element/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#filter/2"><c>filter/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#fold/3"><c>fold/3</c></seemfa>
+      </item>
+      <item><seemfa marker="#from_list/1"><c>from_list/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#intersection/1"><c>intersection/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#intersection/2"><c>intersection/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#is_element/2"><c>is_element/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#is_empty/1"><c>is_empty/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#is_set/1"><c>is_set/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#is_subset/2"><c>is_subset/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#new/0"><c>new/0</c></seemfa>
+      </item>
+      <item><seemfa marker="#size/1"><c>size/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#subtract/2"><c>subtract/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#to_list/1"><c>to_list/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#union/1"><c>union/1</c></seemfa>
+      </item>
+      <item><seemfa marker="#union/2"><c>union/2</c></seemfa>
+      </item>
+    </list>
+    <note>
+      <p>
+        While the three set implementations offer the same <em>functionality</em>
+        with respect to the aforementioned functions, their overall <em>behavior</em>
+        may differ. As mentioned, this module considers elements as different if
+        and only if they do not match (<c>=:=</c>), while both
+        <seeerl marker="ordsets"><c>ordsets</c></seeerl> and
+        <seeerl marker="gb_sets"><c>gb_sets</c></seeerl> consider elements as
+        different if and only if they do not compare equal (<c>==</c>).
+      </p>
+      <p><em>Example:</em></p>
+      <pre>
+1> <input>sets:is_element(1.0, sets:from_list([1])).</input>
+false
+2> <input>ordsets:is_element(1.0, ordsets:from_list([1])).</input>
+true
+2> <input>gb_sets:is_element(1.0, gb_sets:from_list([1])).</input>
+true</pre>
+    </note>
+  </section>
+
   <datatypes>
     <datatype>
       <name name="set" n_vars="1"/>


### PR DESCRIPTION
The paragraph is misleading, if not outright wrong.

The listed functions are fully compatible with those in the `ordsets` module, that much is true, at least AFAICS.

They are also present and provide the same _functionality_ as those in the `sets` module, but the results may be different since `sets` considers two elements as different iff they do not match (`=:=`), while `gb_sets` and `ordsets` consider two elements as different iff they do not compare equal (`==`).

Examples:
```erlang
1> gb_sets:to_list(gb_sets:from_list([1, 1.0])).
[1]
2> sets:to_list(sets:from_list([1, 1.0])).
[1.0, 1]
3> gb_sets:is_element(1.0, gb_sets:from_list([1])).
true
4> sets:is_element(1.0, sets:from_list([1])).
false
...
```

So, one can _not_ simply swap out the module name `sets` for `gb_sets`/`ordsets` or vice versa.

I see no big value in the paragraph itself, especially with version 2 `sets` becoming the preferred set representation. So instead of correcting the paragraph, making it clumsy and verbose, I think it is best to remove it altogether. Also, none of the other two set modules does have them.