### PR TITLE
Add map/filtermap functions to `sets`, `ordsets` and `gb_sets`

### DIFF
--- a/lib/stdlib/doc/src/gb_sets.xml
+++ b/lib/stdlib/doc/src/gb_sets.xml
@@ -178,6 +178,15 @@
     </func>
 
     <func>
+      <name name="filtermap" arity="2" since="OTP @OTP-18622@"/>
+      <fsummary>Filter and map set elements.</fsummary>
+      <desc>
+        <p>Filters and maps elements in <c><anno>Set1</anno></c> using function
+          <c><anno>Fun</anno></c>.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="fold" arity="3" since=""/>
       <fsummary>Fold over set elements.</fsummary>
       <desc>
@@ -332,6 +341,15 @@
       <desc>
         <p>Returns the largest element in <c><anno>Set</anno></c>. Assumes that
           <c><anno>Set</anno></c> is not empty.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="map" arity="2" since="OTP @OTP-18622@"/>
+      <fsummary>Map set elements.</fsummary>
+      <desc>
+        <p>Maps elements in <c><anno>Set1</anno></c> using mapping function
+          <c><anno>Fun</anno></c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/ordsets.xml
+++ b/lib/stdlib/doc/src/ordsets.xml
@@ -92,6 +92,15 @@
     </func>
 
     <func>
+      <name name="filtermap" arity="2" since="OTP @OTP-18622@"/>
+      <fsummary>Filter and map set elements.</fsummary>
+      <desc>
+        <p>Filters and maps elements in <c><anno>Ordset1</anno></c> with function
+          <c><anno>Fun</anno></c>.</p>
+      </desc>
+    </func>
+
+    <func>
       <name name="fold" arity="3" since=""/>
       <fsummary>Fold over set elements.</fsummary>
       <desc>
@@ -173,6 +182,15 @@
         <p>Returns <c>true</c> when every element of <c><anno>Ordset1</anno></c>
           is also a member of <c><anno>Ordset2</anno></c>, otherwise
           <c>false</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="map" arity="2" since="OTP @OTP-18622@"/>
+      <fsummary>Map set elements.</fsummary>
+      <desc>
+        <p>Maps elements in <c><anno>Ordset1</anno></c> with mapping function
+          <c><anno>Fun</anno></c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/sets.xml
+++ b/lib/stdlib/doc/src/sets.xml
@@ -84,6 +84,8 @@
       </item>
       <item><seemfa marker="#filter/2"><c>filter/2</c></seemfa>
       </item>
+      <item><seemfa marker="#filtermap/2"><c>filtermap/2</c></seemfa>
+      </item>
       <item><seemfa marker="#fold/3"><c>fold/3</c></seemfa>
       </item>
       <item><seemfa marker="#from_list/1"><c>from_list/1</c></seemfa>
@@ -99,6 +101,8 @@
       <item><seemfa marker="#is_set/1"><c>is_set/1</c></seemfa>
       </item>
       <item><seemfa marker="#is_subset/2"><c>is_subset/2</c></seemfa>
+      </item>
+      <item><seemfa marker="#map/2"><c>map/2</c></seemfa>
       </item>
       <item><seemfa marker="#new/0"><c>new/0</c></seemfa>
       </item>
@@ -170,6 +174,15 @@ true</pre>
       <desc>
         <p>Filters elements in <c><anno>Set1</anno></c> with boolean function
           <c><anno>Pred</anno></c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="filtermap" arity="2" since="OTP @OTP-18622@"/>
+      <fsummary>Filter and map set elements.</fsummary>
+      <desc>
+        <p>Filters and maps elements in <c><anno>Set1</anno></c> with function
+          <c><anno>Fun</anno></c>.</p>
       </desc>
     </func>
 
@@ -264,6 +277,15 @@ true</pre>
       <desc>
         <p>Returns <c>true</c> when every element of <c><anno>Set1</anno></c> is
           also a member of <c><anno>Set2</anno></c>, otherwise <c>false</c>.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name name="map" arity="2" since="OTP @OTP-18622@"/>
+      <fsummary>Map set elements.</fsummary>
+      <desc>
+        <p>Maps elements in <c><anno>Set1</anno></c> with mapping function
+          <c><anno>Fun</anno></c>.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/ordsets.erl
+++ b/lib/stdlib/src/ordsets.erl
@@ -24,7 +24,7 @@
 -export([union/2,union/1,intersection/2,intersection/1]).
 -export([is_disjoint/2]).
 -export([subtract/2,is_subset/2]).
--export([fold/3,filter/2]).
+-export([fold/3,filter/2,map/2,filtermap/2]).
 
 -export_type([ordset/1]).
 
@@ -262,3 +262,24 @@ fold(F, Acc, Set) ->
 
 filter(F, Set) ->
     lists:filter(F, Set).
+
+%% map(Fun, OrdSet) -> OrdSet.
+%%  Map OrdSet with Fun.
+
+-spec map(Fun, Ordset1) -> Ordset2 when
+    Fun :: fun((Element1 :: T1) -> Element2 :: T2),
+    Ordset1 :: ordset(T1),
+    Ordset2 :: ordset(T2).
+
+map(F, Set) ->
+    from_list(lists:map(F, Set)).
+
+%% filtermap(Fun, OrdSet) -> OrdSet.
+%%  Filter and map Ordset with Fun.
+-spec filtermap(Fun, Ordset1) -> Ordset2 when
+      Fun :: fun((Element1 :: T1) -> boolean | ({true, Element2 :: T2})),
+      Ordset1 :: ordset(T1),
+      Ordset2 :: ordset(T1 | T2).
+
+filtermap(F, Set) ->
+    from_list(lists:filtermap(F, Set)).

--- a/lib/stdlib/test/sets_SUITE.erl
+++ b/lib/stdlib/test/sets_SUITE.erl
@@ -28,8 +28,8 @@
 	 init_per_testcase/2,end_per_testcase/2,
 	 create/1,add_element/1,del_element/1,
 	 subtract/1,intersection/1,union/1,is_subset/1,
-	 is_disjoint/1,is_set/1,is_empty/1,fold/1,filter/1,
-	 take_smallest/1,take_largest/1, iterate/1]).
+	 is_disjoint/1,is_set/1,is_empty/1,fold/1,filter/1, map/1,
+	 filtermap/1, take_smallest/1,take_largest/1, iterate/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -47,8 +47,9 @@ suite() ->
 
 all() -> 
     [create, add_element, del_element, subtract,
-     intersection, union, is_subset, is_set, fold, filter,
-     take_smallest, take_largest, iterate, is_empty, is_disjoint].
+     intersection, union, is_subset, is_set, fold, filter, map,
+     filtermap, take_smallest, take_largest, iterate, is_empty,
+     is_disjoint].
 
 groups() -> 
     [].
@@ -392,6 +393,32 @@ filter_1(List, M) ->
     M(equal, {M(from_list, lists:filter(IsNumber, List)),
 	      M(filter, {IsNumber,S})}),
     M(filter, {fun(X) -> is_atom(X) end,S}).
+
+map(Config) when is_list(Config) ->
+    test_all([{0,69},{126,130},{254,259},{510,513},{1023,1025},{7999,8000}],
+	     fun map_1/2).
+
+map_1(List, M) ->
+    S = M(from_list, List),
+    ToTuple = fun(X) -> {X} end,
+    M(equal, {M(from_list, lists:map(ToTuple, List)),
+	      M(map, {ToTuple, S})}),
+    M(map, {fun(_) -> x end, S}).
+
+filtermap(Config) when is_list(Config) ->
+    test_all([{0,69},{126,130},{254,259},{510,513},{1023,1025},{7999,8000}],
+	     fun filtermap_1/2).
+
+filtermap_1(List, M) ->
+    S = M(from_list, List),
+    FMFun = fun
+                (X) when is_float(X) -> false;
+		(X) when is_integer(X) -> true;
+		(X) -> {true, {X}}
+            end,
+    M(equal, {M(from_list, lists:filtermap(FMFun, List)),
+	      M(filtermap, {FMFun, S})}),
+    M(empty, []).
 
 %%%
 %%% Test specifics for gb_sets.

--- a/lib/stdlib/test/sets_test_lib.erl
+++ b/lib/stdlib/test/sets_test_lib.erl
@@ -31,6 +31,7 @@ new(Mod, Eq, New, FromList) ->
 	(empty, []) -> New();
 	(equal, {S1,S2}) -> Eq(S1, S2);
 	(filter, {F,S}) -> filter(Mod, F, S);
+	(filtermap, {F,S}) -> filtermap(Mod, F, S);
 	(fold, {F,A,S}) -> fold(Mod, F, A, S);
 	(from_list, L) -> FromList(L);
 	(intersection, {S1,S2}) -> intersection(Mod, Eq, S1, S2);
@@ -41,6 +42,7 @@ new(Mod, Eq, New, FromList) ->
 	(is_subset, {S,Set}) -> is_subset(Mod, Eq, S, Set);
         (iterator, S) -> Mod:iterator(S);
         (iterator_from, {Start, S}) -> Mod:iterator_from(Start, S);
+	(map, {F, S}) -> map(Mod, F, S);
 	(module, []) -> Mod;
         (next, I) -> Mod:next(I);
 	(singleton, E) -> singleton(Mod, FromList, E);
@@ -121,3 +123,11 @@ fold(Mod, F, A, S) ->
 filter(Mod, F, S) ->
     true = Mod:is_set(S),
     Mod:filter(F, S).
+
+map(Mod, F, S) ->
+    true = Mod:is_set(S),
+    Mod:map(F, S).
+
+filtermap(Mod, F, S) ->
+    true = Mod:is_set(S),
+    Mod:filtermap(F, S).


### PR DESCRIPTION
This PR provides mapping functionality for sets (`sets`, `ordsets` and `gb_sets`).

Often when I deal with sets, I have the need to map one to another. Currently, this is only possible by folding or by converting to a list, mapping over that, and converting back to a set.