### PR TITLE
Add catch for port_close in memsup and cpu_sup

### DIFF
--- a/lib/os_mon/src/cpu_sup.erl
+++ b/lib/os_mon/src/cpu_sup.erl
@@ -614,7 +614,12 @@ port_server_loop(Port, Timeout) ->
 	% Close port and this server
 	{Pid, ?quit} ->
 	    port_command(Port, ?quit),
-	    port_close(Port),
+	    try
+	        port_close(Port)
+	    catch
+	        error:badarg ->
+	            true
+	    end,
 	    Pid ! {self(), {data, quit}},
 	    ok;
 

--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -653,7 +653,12 @@ start_portprogram() ->
 
 port_shutdown(Port) ->
     Port ! {self(), {command, [?EXIT]}},
-    port_close(Port).
+    try
+        port_close(Port)
+    catch
+        error:badarg ->
+            true
+    end.
 
 %% The connected process loops are a bit awkward (several different
 %% functions doing almost the same thing) as


### PR DESCRIPTION
EXIT/quit command was sent to port before port_close(Port).
When racing happens the Port could close itself before the port_close call.
Which results in following error

```
2023/04/26 20:02:41.034428 <0.9837.4> === error: Error in process <0.9837.4> with exit value:
{badarg,[{erlang,port_close,
                 [#Port<0.32648>],
                 [{error_info,#{module => erl_erts_errors}}]}]}
```
which the process is (ignore the current_function, it was logged before crash)
```
 [{current_function,{memsup,port_idle,1}},
  {initial_call,{erlang,apply,2}},
  {status,waiting},
  {message_queue_len,0},
  {links,[<0.9836.4>,#Port<0.32648>]},
  {dictionary,[]},
  {trap_exit,true},
  {error_handler,error_handler},
  {priority,normal},
  {group_leader,<0.9832.4>},
  {total_heap_size,3268},
  {heap_size,2586},
  {stack_size,4},
  {reductions,38437},
  {garbage_collection,[{max_heap_size,#{error_logger => true,kill => true,size => 536870911}},
                       {min_bin_vheap_size,46422},
                       {min_heap_size,233},
                       {fullsweep_after,65535},
                       {minor_gcs,98}]},
  {suspending,[]}],
```