### PR TITLE
ct: various doc fixes

### DIFF
--- a/lib/common_test/doc/src/ct_suite.xml
+++ b/lib/common_test/doc/src/ct_suite.xml
@@ -85,7 +85,9 @@
       <fsummary>Returns the list of all test case groups and test cases
 	in the module.</fsummary>
       <type>
-	<v><seetype marker="#ct_test_def">ct_test_def()</seetype> = TestCase | {group, GroupName} | {group, GroupName, Properties} | {group, GroupName, Properties, SubGroups}</v>
+	<v><seetype marker="#ct_test_def">ct_test_def()</seetype> = TestCase |
+        {group, GroupName} | {group, GroupName, Properties} | {group, GroupName,
+        Properties, SubGroups} | {testcase, TestCase, TestCaseRepeatType}</v>
 	<v>TestCase = <seetype marker="#ct_testname">ct_testname()</seetype></v>
 	<v>GroupName = <seetype marker="#ct_groupname">ct_groupname()</seetype></v>
 	<v>Properties = [parallel | sequence | Shuffle | {RepeatType, N}] | default</v>
@@ -93,6 +95,7 @@
 	<v>Shuffle = shuffle | {shuffle, Seed}</v>
 	<v>Seed = {integer(), integer(), integer()}</v>
 	<v>RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail | repeat_until_any_ok | repeat_until_any_fail</v>
+        <v>TestCaseRepeatType = [{repeat, N} | {repeat_until_ok, N} | {repeat_until_fail, N}]</v>
 	<v>N = integer() | forever</v>
 	<v>Reason = term()</v>
       </type>
@@ -135,11 +138,12 @@
         <v><seetype marker="#ct_group_def">ct_group_def()</seetype> = {GroupName, Properties, GroupsAndTestCases}</v>
         <v>GroupName = <seetype marker="#ct_groupname">ct_groupname()</seetype></v>
         <v>Properties = [parallel | sequence | Shuffle | {RepeatType, N}]</v>
-        <v>GroupsAndTestCases = [Group | {group, GroupName} | TestCase]</v>
+        <v>GroupsAndTestCases = [Group | {group, GroupName} | TestCase | {testcase, TestCase, TestCaseRepeatType}]</v>
         <v>TestCase = <seetype marker="#ct_testname">ct_testname()</seetype></v>
         <v>Shuffle = shuffle | {shuffle, Seed}</v>
         <v>Seed = {integer(), integer(), integer()}</v>
         <v>RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail | repeat_until_any_ok | repeat_until_any_fail</v>
+        <v>TestCaseRepeatType = [{repeat, N} | {repeat_until_ok, N} | {repeat_until_fail, N}]</v>
         <v>N = integer() | forever</v>
       </type>
 

--- a/lib/common_test/doc/src/run_test_chapter.xml
+++ b/lib/common_test/doc/src/run_test_chapter.xml
@@ -763,7 +763,7 @@
 	finally function <c>end_per_group</c>. Also, if particular
 	test cases in a group are specified, <c>init_per_group</c>
 	and <c>end_per_group</c>, for the group in question, are
-	called. If a group defined (in <c>Suite:group/0</c>) as
+	called. If a group defined (in <c>Suite:groups/0</c>) as
 	a subgroup of another group, is specified (or if particular test
 	cases of a subgroup are), <c>Common Test</c> calls the configuration
 	functions for the top-level groups and for the subgroup

--- a/lib/common_test/doc/src/write_test_chapter.xml
+++ b/lib/common_test/doc/src/write_test_chapter.xml
@@ -515,14 +515,14 @@
       <c>{group,GroupName,Properties,SubGroups}</c>
       Where, <c>SubGroups</c> is a list of tuples, <c>{GroupName,Properties}</c> or
       <c>{GroupName,Properties,SubGroups}</c> representing the subgroups.
-      Any subgroups defined in <c>group/0</c> for a group, that are not specified
+      Any subgroups defined in <c>groups/0</c> for a group, that are not specified
       in the <c>SubGroups</c> list, executes with their predefined
       properties.</p>
 
     <p><em>Example:</em></p>
     <pre>
- groups() -> {tests1, [], [{tests2, [], [t2a,t2b]},
-                           {tests3, [], [t31,t3b]}]}.</pre>
+ groups() -> [{tests1, [], [{tests2, [], [t2a,t2b]},
+                           {tests3, [], [t31,t3b]}]}].</pre>
     <p>To execute group <c>tests1</c> twice with different properties for <c>tests2</c>
       each time:</p>
     <pre>

--- a/lib/common_test/src/ct_suite.erl
+++ b/lib/common_test/src/ct_suite.erl
@@ -47,9 +47,9 @@
             {group, ct_groupname(), ct_group_props_ref()} |
             {group, ct_groupname(), ct_group_props_ref(), ct_subgroups_def()}.
 -type ct_testcase_ref() :: {testcase, ct_testname(), ct_testcase_repeat_prop()}.
--type ct_testcase_repeat_prop() :: {repeat, ct_test_repeat()} |
+-type ct_testcase_repeat_prop() :: [{repeat, ct_test_repeat()} |
             {repeat_until_ok, ct_test_repeat()} |
-            {repeat_until_fail, ct_test_repeat()}.
+            {repeat_until_fail, ct_test_repeat()}].
 -type ct_info() :: {timetrap, ct_info_timetrap()} |
             {require, ct_info_required()} |
             {require, Name :: atom(), ct_info_required()} |


### PR DESCRIPTION
- fix typo group/0 -> groups/1
- in groups example, wrap result term in a list
- add testcase tuple in type specs for all/0 and groups/0