### PR TITLE
Amends enif_release_resource documentation.

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -3040,6 +3040,10 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
           References made by <seecref marker="#enif_make_resource">
           <c>enif_make_resource</c></seecref>
           can only be removed by the garbage collector.</p>
+        <p> You may call this function only after the resource object has been
+          bound to a term using <seecref marker="#enif_make_resource><c>
+              enif_make_resource</c></seecref>; calling it beforehand is undefined
+              behaviour.
 	<p>There are no guarantees exactly when the destructor of an
 	  unreferenced resource is called. It could be called directly by
 	  <c>enif_release_resource</c> but it could also be scheduled to be

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -3043,7 +3043,7 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
         <p> You may call this function only after the resource object has been
           bound to a term using <seecref marker="#enif_make_resource><c>
               enif_make_resource</c></seecref>; calling it beforehand is undefined
-              behaviour.
+              behaviour.</p>
 	<p>There are no guarantees exactly when the destructor of an
 	  unreferenced resource is called. It could be called directly by
 	  <c>enif_release_resource</c> but it could also be scheduled to be

--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -3041,7 +3041,7 @@ enif_map_iterator_destroy(env, &amp;iter);</code>
           <c>enif_make_resource</c></seecref>
           can only be removed by the garbage collector.</p>
         <p> You may call this function only after the resource object has been
-          bound to a term using <seecref marker="#enif_make_resource><c>
+          bound to a term using <seecref marker="#enif_make_resource"><c>
               enif_make_resource</c></seecref>; calling it beforehand is undefined
               behaviour.</p>
 	<p>There are no guarantees exactly when the destructor of an


### PR DESCRIPTION
Adds extra clarification on ordering for resource release operations.  If you do it in the wrong order, there is a high likelihood of causing segfault.