### PR TITLE
ssl: Add signature_algs/2

### DIFF
--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -477,12 +477,10 @@
 {sha384, ecdsa},
 {sha384, rsa},
 {sha256, ecdsa},
-{sha256, rsa},
-{sha224, ecdsa},
-{sha224, rsa}
+{sha256, rsa}
 ]</code>
 
-<p>Support for {md5, rsa} was removed from the the TLS-1.2 default in ssl-8.0 (OTP-22) and support for SHA1 {sha, _} was removed in ssl-11.0 (OTP-26) </p>
+<p>Support for {md5, rsa} was removed from the the TLS-1.2 default in ssl-8.0 (OTP-22) and support for SHA1 {sha, _}  and SHA224 {sha224, _} was removed in ssl-11.0 (OTP-26) </p>
 
  <p><c> rsa_pss_schemes =</c></p>
  <code>
@@ -521,10 +519,10 @@ rsa_pss_schemes()
  <p>EDDSA was made highest priority in ssl-10.8 (OTP-25) </p>
 
 <p>TLS-1.3 default is</p>
-<code>Default_TLS_13_Schemes ++ Legacy_TLS_13_Schemes </code>
+<code>Default_TLS_13_Schemes</code>
 
 <p>If both TLS-1.3 and TLS-1.2 are supported the default will be</p>
-<code>Default_TLS_13_Schemes ++ Default_TLS_12_Alg_Pairs </code>
+<code>Default_TLS_13_Schemes ++ TLS_13_Legacy_Schemes ++ Default_TLS_12_Alg_Pairs (not represented in TLS_13_Legacy_Schemes) </code>
 
 <p>so appropriate algorithms can be chosen for the negotiated
 version.
@@ -2173,6 +2171,60 @@ fun(srp, Username :: binary(), UserState :: term()) ->
         <p>To be able to handle that the peer has done a shutdown on
           the write side, option <c>{exit_on_close, false}</c>
           is useful.</p>
+      </desc>
+    </func>
+
+    <func>
+      <name since="OTP @OTP-18572@" name="signature_algs" arity="2" />
+      <fsummary>Returns a list of signature algorithms/schemes </fsummary>
+      <desc>
+        <p>Lists all possible signature algorithms corresponding to
+        <c>Description</c> that are available. The
+        <c>exclusive</c> option will exclusively list
+        algorithms/schemes for that protocol version, whereas the
+        <c>default</c> and <c>all</c> options lists the combined list to support the
+        range of protocols from (D)TLS-1.2, the first version to support
+        configuration of the signature algorithms, to <c>Version</c>.</p>
+
+      <p> Example: <c>
+
+      1&gt; ssl:signature_algs(default, 'tlsv1.3').
+      [eddsa_ed25519,eddsa_ed448,ecdsa_secp521r1_sha512,
+      ecdsa_secp384r1_sha384,ecdsa_secp256r1_sha256,
+      rsa_pss_pss_sha512,rsa_pss_pss_sha384,rsa_pss_pss_sha256,
+      rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,rsa_pss_rsae_sha256,
+      rsa_pkcs1_sha512,rsa_pkcs1_sha384,rsa_pkcs1_sha256,
+      {sha512,ecdsa},
+      {sha384,ecdsa},
+      {sha256,ecdsa}]
+
+      2&gt;ssl:signature_algs(all, 'tlsv1.3').
+      [eddsa_ed25519,eddsa_ed448,ecdsa_secp521r1_sha512,
+      ecdsa_secp384r1_sha384,ecdsa_secp256r1_sha256,
+      rsa_pss_pss_sha512,rsa_pss_pss_sha384,rsa_pss_pss_sha256,
+      rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,rsa_pss_rsae_sha256,
+      rsa_pkcs1_sha512,rsa_pkcs1_sha384,rsa_pkcs1_sha256,
+      {sha512,ecdsa},
+      {sha384,ecdsa},
+      {sha256,ecdsa},
+      {sha224,ecdsa},
+      {sha224,rsa},
+      {sha,rsa},
+      {sha,dsa}]
+
+      3&gt; ssl:signature_algs(exclusive, 'tlsv1.3').
+      [eddsa_ed25519,eddsa_ed448,ecdsa_secp521r1_sha512,
+      ecdsa_secp384r1_sha384,ecdsa_secp256r1_sha256,
+      rsa_pss_pss_sha512,rsa_pss_pss_sha384,rsa_pss_pss_sha256,
+      rsa_pss_rsae_sha512,rsa_pss_rsae_sha384,rsa_pss_rsae_sha256]
+      </c></p>
+      
+	<note><p>Some TLS-1-3 scheme names overlap with TLS-1.2
+	algorithm-tuple-pair-names and then TLS-1.3 names will be
+	used, for example <c>rsa_pkcs1_sha256</c> instead of
+	<c>{sha256, rsa}</c> these are legacy algorithms in TLS-1.3
+	that apply only to certificate signatures in this version of
+	the protocol.</p></note>
       </desc>
     </func>
     

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -81,6 +81,7 @@
          filter_cipher_suites/2,
          prepend_cipher_suites/2, 
          append_cipher_suites/2,
+         signature_algs/2,
          eccs/0, 
          eccs/1, 
          versions/0, 
@@ -183,12 +184,11 @@
 -type hash()                     :: sha2() |
                                     legacy_hash(). % exported
 
--type sha2()                    ::  sha224 |
-                                    sha256 |
-                                    sha384 |
-                                    sha512.
+-type sha2()                    :: sha256 |
+                                   sha384 |
+                                   sha512.
 
--type legacy_hash()             :: sha | md5.
+-type legacy_hash()             :: sha224 | sha | md5.
 
 -type sign_algo()               :: rsa | dsa | ecdsa | eddsa. % exported
 
@@ -1104,6 +1104,41 @@ append_cipher_suites([First | _] = Deferred, Suites0) when is_map(First)->
 append_cipher_suites(Filters, Suites) ->
     Deferred = filter_cipher_suites(Suites, Filters), 
     (Suites -- Deferred) ++  Deferred.
+
+%%--------------------------------------------------------------------
+-spec signature_algs(Description, Version) -> [signature_algs()] when
+      Description :: default | all | exclusive,
+      Version :: protocol_version().
+
+%% Description: Returns possible signature algorithms/schemes
+%% for TLS/DTLS version
+%%--------------------------------------------------------------------
+
+signature_algs(default, 'tlsv1.3') ->
+    tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.3'), 
+                                   tls_record:protocol_version_name('tlsv1.2')]);
+signature_algs(default, 'tlsv1.2') ->
+    tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.2')]);
+signature_algs(all, 'tlsv1.3') ->
+   tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.3'), 
+                                  tls_record:protocol_version_name('tlsv1.2')]) ++ 
+        tls_v1:legacy_signature_algs_pre_13();
+signature_algs(all, 'tlsv1.2') ->
+    tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.2')]) ++ 
+        tls_v1:legacy_signature_algs_pre_13();
+signature_algs(exclusive, 'tlsv1.3') ->
+    tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.3')]);
+signature_algs(exclusive, 'tlsv1.2') ->
+    Algs = tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.2')]),
+    Algs ++ tls_v1:legacy_signature_algs_pre_13();
+signature_algs(Description, 'dtlsv1.2') ->
+    signature_algs(Description, 'tlsv1.2');
+signature_algs(Description, Version) when Description == default;
+                                          Description == all;
+                                          Description == exclusive->
+    {error, {signature_algs_not_supported_in_protocol_version, Version}};
+signature_algs(Description,_) ->
+    {error, {badarg, Description}}.
 
 %%--------------------------------------------------------------------
 -spec eccs() -> NamedCurves when

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -55,6 +55,7 @@
          oid_to_enum/1,
          enum_to_oid/1,
          default_signature_algs/1,
+         legacy_signature_algs_pre_13/0,
          signature_algs/2,
          signature_schemes/2,
          rsa_schemes/0,
@@ -883,9 +884,10 @@ signature_algs(?TLS_1_2, HashSigns) ->
     lists:reverse(Supported).
 
 default_signature_algs([?TLS_1_3]) ->
-    default_signature_schemes(?TLS_1_3) ++ legacy_signature_schemes(?TLS_1_3);
+    default_signature_schemes(?TLS_1_3);
 default_signature_algs([?TLS_1_3, ?TLS_1_2 | _]) ->
-    default_signature_schemes(?TLS_1_3) ++ default_pre_1_3_signature_algs_only();
+    default_signature_schemes(?TLS_1_3) ++ legacy_signature_schemes(?TLS_1_3) 
+        ++ default_pre_1_3_signature_algs_only();
 default_signature_algs([?TLS_1_2 = Version |_]) ->
     Default = [%% SHA2 ++ PSS
                {sha512, ecdsa},
@@ -899,9 +901,7 @@ default_signature_algs([?TLS_1_2 = Version |_]) ->
                {sha256, ecdsa},
                rsa_pss_pss_sha256,
                rsa_pss_rsae_sha256,
-               {sha256, rsa},
-               {sha224, ecdsa},
-               {sha224, rsa}
+               {sha256, rsa}
               ],
     signature_algs(Version, Default);
 default_signature_algs(_) ->
@@ -910,15 +910,13 @@ default_signature_algs(_) ->
 default_pre_1_3_signature_algs_only() ->
     Default = [%% SHA2
                {sha512, ecdsa},
-               {sha512, rsa},
                {sha384, ecdsa},
-               {sha384, rsa},
-               {sha256, ecdsa},
-               {sha256, rsa},
-               {sha224, ecdsa},
-               {sha224, rsa}
+               {sha256, ecdsa}
               ],
     signature_algs(?TLS_1_2, Default).
+
+legacy_signature_algs_pre_13() ->
+    [{sha224, ecdsa}, {sha224, rsa}, {sha, rsa}, {sha, dsa}].
 
 signature_schemes(Version, [_|_] =SignatureSchemes) when is_tuple(Version)
                                                          andalso ?TLS_GTE(Version, ?TLS_1_2) ->

--- a/lib/ssl/test/ssl_reject_SUITE.erl
+++ b/lib/ssl/test/ssl_reject_SUITE.erl
@@ -184,9 +184,12 @@ accept_sslv3_record_hello(Config) when is_list(Config) ->
 
     Allversions = all_versions(),
 
+    AllSigAlgs = ssl:signature_algs(all, 'tlsv1.3'),
+
     Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
                                         {from, self()},
-                                        {options, [{versions, Allversions} | ServerOpts]}]),
+                                        {options, [{versions, Allversions}, 
+                                                   {signature_algs, AllSigAlgs} | ServerOpts]}]),
     Port = ssl_test_lib:inet_port(Server),
 
     %% TLS-1.X Hello with SSL-3.0 record version


### PR DESCRIPTION
To make it easier to configure signature algorithms with algorithms that are moved from the default add the API function signature_algs/2 that lists possible values.

Also adjust signature algorithms according to TLS-1.3 RFC. That is TLS-1.3 legacy algorithms are the TLS-1.2 algorithms to be supported in TLS-1.2-TLS-1.3 combination. sha224 is also considered legacy.