### PR TITLE
stdlib: fix exported types in supervisor, gen_server, gen_event

### DIFF
--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -2794,7 +2794,7 @@ peer_name(Module, TestCase) ->
 %% Command line arguments passed
 -spec start_peer([string()] | peer:start_options() | #{ start_cover => boolean() },
                  atom() | string(), TestCase :: atom() | string()) ->
-    {ok, gen_statem:server_ref(), node()} | {error, term()}.
+    {ok, gen_statem:process_ref(), node()} | {error, term()}.
 start_peer(Args, Module, TestCase) when is_list(Args) ->
     start_peer(#{args => Args, name => peer_name(Module, TestCase)}, Module);
 
@@ -2808,7 +2808,7 @@ start_peer(Opts, Module, TestCase) ->
 -spec start_peer([string()] | peer:start_options() | #{ start_cover => boolean() },
                  atom() | string(), TestCase :: atom() | string(),
                  Release :: string(), OutDir :: file:filename()) ->
-          {ok, gen_statem:server_ref(), node()} | {error, term()} | not_available.
+          {ok, gen_statem:process_ref(), node()} | {error, term()} | not_available.
 start_peer(Args, Module, TestCase, Release, OutDir) when is_list(Args) ->
     start_peer(#{args => Args}, Module, TestCase, Release, OutDir);
 start_peer(Opts, Module, TestCase, Release, OutDir) ->

--- a/lib/dialyzer/test/small_SUITE_data/results/gencall
+++ b/lib/dialyzer/test/small_SUITE_data/results/gencall
@@ -1,6 +1,6 @@
 
 gencall.erl:10:3: Call to missing or unexported function gen_server:handle_cast/2
 gencall.erl:5:1: Function f/0 has no local return
-gencall.erl:6:34: The call gen_server:call(pid(),'request',{'not_a_timeout'}) breaks the contract (ServerRef::server_ref(),Request::term(),Timeout::timeout()) -> Reply::term()
+gencall.erl:6:34: The call gen_server:call(pid(),'request',{'not_a_timeout'}) breaks the contract (ServerRef::process_ref(),Request::term(),Timeout::timeout()) -> Reply::term()
 gencall.erl:7:3: Call to missing or unexported function ets:lookup/3
 gencall.erl:9:3: Call to missing or unexported function gencall:foo/0

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -142,8 +142,12 @@ gen_event:stop             ----->  Module:terminate/2
     </datatype>
 
     <datatype>
-      <name name="emgr_ref"/>
-    </datatype>    
+      <name name="sup_ref"/>
+    </datatype>
+
+    <datatype>
+      <name name="sup_name"/>
+    </datatype>
     
     <datatype>
       <name name="request_id"/>

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -142,7 +142,7 @@ gen_event:stop             ----->  Module:terminate/2
     </datatype>
 
     <datatype>
-      <name name="sup_ref"/>
+      <name name="process_ref"/>
     </datatype>
 
     <datatype>

--- a/lib/stdlib/doc/src/gen_event.xml
+++ b/lib/stdlib/doc/src/gen_event.xml
@@ -146,7 +146,7 @@ gen_event:stop             ----->  Module:terminate/2
     </datatype>
 
     <datatype>
-      <name name="sup_name"/>
+      <name name="process_name"/>
     </datatype>
     
     <datatype>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -133,19 +133,19 @@ gen_server:abcast     -----> Module:handle_cast/2
           <seemfa marker="#enter_loop/3"><c>enter_loop/3,4,5</c></seemfa>,
           and the type
 	  <seetype marker="#server_ref"><c>server_ref()</c></seetype>
-	  below.
+	  is an alias to <seetype marker="stdlib:supervisor#sup_name"><c>supervisor:sup_name()</c></seetype>.
         </p>
         <taglist>
-          <tag><c>{local,<anno>LocalName</anno>}</c></tag>
+          <tag><c>{local,LocalName}</c></tag>
           <item>
             <p>
               Register the <c>gen_server</c> locally
-              as <c><anno>LocalName</anno></c> using
+              as <c>LocalName</c> using
               <seemfa marker="erts:erlang#register/2">
                 <c>register/2</c></seemfa>.
             </p>
           </item>
-          <tag><c>{global,<anno>GlobalName</anno>}</c></tag>
+          <tag><c>{global,GlobalName}</c></tag>
           <item>
             <p>
               Register the <c>gen_server</c> process id
@@ -154,19 +154,19 @@ gen_server:abcast     -----> Module:handle_cast/2
                 <c>global:register_name/2</c></seemfa>.
             </p>
           </item>
-          <tag><c>{via,<anno>RegMod</anno>,<anno>ViaName</anno>}</c></tag>
+          <tag><c>{via,RegMod,ViaName}</c></tag>
           <item>
             <p>
               Register the <c>gen_server</c> process with the registry
-              represented by <c><anno>RegMod</anno></c>.
-              The <c><anno>RegMod</anno></c> callback is to export
+              represented by <c>RegMod</c>.
+              The <c>RegMod</c> callback is to export
               the functions <c>register_name/2</c>, <c>unregister_name/1</c>,
               <c>whereis_name/1</c>, and <c>send/2</c>, which are to behave
               like the corresponding functions in
               <seeerl marker="kernel:global"><c>global</c></seeerl>.
-              Thus, <c>{via,global,<anno>GlobalName</anno>}</c>
+              Thus, <c>{via,global,GlobalName}</c>
               is a valid reference equivalent to
-              <c>{global,<anno>GlobalName</anno>}</c>.
+              <c>{global,GlobalName}</c>.
             </p>
           </item>
         </taglist>
@@ -197,42 +197,42 @@ gen_server:abcast     -----> Module:handle_cast/2
               The <c>gen_server</c>'s process identifier.
             </p>
           </item>
-	  <tag><c><anno>LocalName</anno></c></tag>
+	  <tag><c>LocalName</c></tag>
 	  <item>
             <p>
               The <c>gen_server</c> is locally registered
-              as <c><anno>LocalName</anno></c> with
+              as <c>LocalName</c> with
               <seemfa marker="erts:erlang#register/2">
                 <c>register/2</c></seemfa>.
             </p>
           </item>
-	  <tag><c>{<anno>Name</anno>,<anno>Node</anno>}</c></tag>
+	  <tag><c>{Name,Node}</c></tag>
 	  <item>
             <p>
 	      The <c>gen_server</c> is locally registered
 	      on another node.
             </p>
 	  </item>
-	  <tag><c>{global,<anno>GlobalName</anno>}</c></tag>
+	  <tag><c>{global,GlobalName}</c></tag>
 	  <item>
             <p>
 	      The <c>gen_server</c> is globally registered in
 	      <seeerl marker="kernel:global"><c>global</c></seeerl>.
             </p>
 	  </item>
-	  <tag><c>{via,<anno>RegMod</anno>,<anno>ViaName</anno>}</c></tag>
+	  <tag><c>{via,RegMod,ViaName}</c></tag>
 	  <item>
             <p>
 	      The <c>gen_server</c> is registered in
 	      an alternative process registry.
-	      The registry callback module <c><anno>RegMod</anno></c>
+	      The registry callback module <c>RegMod</c>
 	      is to export functions
 	      <c>register_name/2</c>, <c>unregister_name/1</c>,
 	      <c>whereis_name/1</c>, and <c>send/2</c>,
 	      which are to behave like the corresponding functions in
 	      <seeerl marker="kernel:global"><c>global</c></seeerl>.
-	      Thus, <c>{via,global,<anno>GlobalName</anno>}</c>
-              is the same as <c>{global,<anno>GlobalName</anno>}</c>.
+	      Thus, <c>{via,global,GlobalName}</c>
+              is the same as <c>{global,GlobalName}</c>.
             </p>
 	  </item>
 	</taglist>
@@ -248,7 +248,7 @@ gen_server:abcast     -----> Module:handle_cast/2
 	  <seemfa marker="#start_link/3"><c>start_link/3,4</c></seemfa>.
 	</p>
         <taglist>
-          <tag><c>{timeout,<anno>Timeout</anno>}</c></tag>
+          <tag><c>{timeout,Timeout}</c></tag>
           <item>
             <p>
               How many milliseconds the <c>gen_server</c> process is allowed
@@ -257,11 +257,11 @@ gen_server:abcast     -----> Module:handle_cast/2
             </p>
           </item>
           <tag>
-            <c>{spawn_opt,<anno>SpawnOptions</anno>}</c>
+            <c>{spawn_opt,SpawnOptions}</c>
           </tag>
           <item>
             <p>
-              The <c><anno>SpawnOptions</anno></c> option list
+              The <c>SpawnOptions</c> option list
               is passed to the function used to spawn
               the <c>gen_server</c>; see
               <seemfa marker="erts:erlang#spawn_opt/2">
@@ -298,7 +298,7 @@ gen_server:abcast     -----> Module:handle_cast/2
 	  <seemfa marker="#start_link/3"><c>start_link/3,4</c></seemfa>.
 	</p>
 	<taglist>
-	  <tag><c>{hibernate_after,<anno>HibernateAfterTimeout</anno>}</c></tag>
+	  <tag><c>{hibernate_after,HibernateAfterTimeout}</c></tag>
 	  <item>
             <p>
 	      Specifies that the <c>gen_server</c> process awaits
@@ -309,10 +309,10 @@ gen_server:abcast     -----> Module:handle_cast/2
                 <c>proc_lib:hibernate/3</c></seemfa>).
             </p>
 	  </item>
-	  <tag><c>{debug,<anno>Dbgs</anno>}</c></tag>
+	  <tag><c>{debug,Dbgs}</c></tag>
 	  <item>
             <p>
-	      For every entry in <c><anno>Dbgs</anno></c>,
+	      For every entry in <c>Dbgs</c>,
 	      the corresponding function in
 	      <seeerl marker="sys"><c>sys(3)</c></seeerl> is called.
             </p>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -133,7 +133,7 @@ gen_server:abcast     -----> Module:handle_cast/2
           <seemfa marker="#enter_loop/3"><c>enter_loop/3,4,5</c></seemfa>,
           and the type
 	  <seetype marker="#server_ref"><c>server_ref()</c></seetype>
-	  is an alias to <seetype marker="stdlib:supervisor#sup_name"><c>supervisor:sup_name()</c></seetype>.
+	  is an alias to <seetype marker="stdlib:supervisor#sup_name"><c>supervisor:process_name()</c></seetype>.
         </p>
         <taglist>
           <tag><c>{local,LocalName}</c></tag>

--- a/lib/stdlib/doc/src/gen_server.xml
+++ b/lib/stdlib/doc/src/gen_server.xml
@@ -122,7 +122,7 @@ gen_server:abcast     -----> Module:handle_cast/2
 
   <datatypes>
     <datatype>
-      <name name="server_name"/>
+      <name name="process_name"/>
       <desc>
         <p>
           Name specification to use when starting a <c>gen_server</c>.
@@ -132,8 +132,8 @@ gen_server:abcast     -----> Module:handle_cast/2
           <seemfa marker="#start_monitor/3"><c>start_monitor/3,4</c></seemfa>,
           <seemfa marker="#enter_loop/3"><c>enter_loop/3,4,5</c></seemfa>,
           and the type
-	  <seetype marker="#server_ref"><c>server_ref()</c></seetype>
-	  is an alias to <seetype marker="stdlib:supervisor#sup_name"><c>supervisor:process_name()</c></seetype>.
+	  <seetype marker="#process_ref"><c>process_ref()</c></seetype>
+	  is an alias to <seetype marker="stdlib:supervisor#process_name"><c>supervisor:process_name()</c></seetype>.
         </p>
         <taglist>
           <tag><c>{local,LocalName}</c></tag>
@@ -174,7 +174,7 @@ gen_server:abcast     -----> Module:handle_cast/2
     </datatype>
 
     <datatype>
-      <name name="server_ref"/>
+      <name name="process_ref"/>
       <desc>
 	<p>
 	  Server specification to use when addressing
@@ -186,7 +186,7 @@ gen_server:abcast     -----> Module:handle_cast/2
 	  <seemfa marker="#wait_response/2"><c>wait_response/2</c></seemfa>,
 	  <seemfa marker="#stop/1"><c>stop/2,3</c></seemfa>
           and the type
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
 	  above.
 	</p>
 	<p>It can be:</p>
@@ -574,7 +574,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         </p>
         <p>
           See also <c><anno>ServerRef</anno></c>'s type
-          <seetype marker="#server_ref"><c>server_ref()</c></seetype>.
+          <seetype marker="#process_ref"><c>process_ref()</c></seetype>.
         </p>
         <p>
           <c><anno>Request</anno></c> is any term that is passed as the
@@ -703,7 +703,7 @@ gen_server:abcast     -----> Module:handle_cast/2
         </p>
         <p>
           See also <c><anno>ServerRef</anno></c>'s type
-          <seetype marker="#server_ref"><c>server_ref()</c></seetype>.
+          <seetype marker="#process_ref"><c>process_ref()</c></seetype>.
         </p>
         <p>
           <c><anno>Request</anno></c> is any term that is passed as
@@ -1211,7 +1211,7 @@ gen_server:abcast     -----> Module:handle_cast/2
 	</p>
         <p>
           See the type
-          <seetype marker="#server_ref"><c>server_ref()</c></seetype>
+          <seetype marker="#process_ref"><c>process_ref()</c></seetype>
           for the possible values for <c><anno>ServerRef</anno></c>.
         </p>
         <p>
@@ -1293,7 +1293,7 @@ gen_server:abcast     -----> Module:handle_cast/2
           Using the argument <c><anno>ServerName</anno></c>
           creates a <c>gen_server</c> with a registered name.
           See type
-          <seetype marker="#server_name"><c>server_name()</c></seetype>
+          <seetype marker="#process_name"><c>process_name()</c></seetype>
           for different name registrations.
           If no <c><anno>ServerName</anno></c> is provided,
           the <c>gen_server</c> process is not registered.

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -512,26 +512,26 @@ handle_event(_, _, State, Data) ->
 
   <datatypes>
     <datatype>
-      <name name="server_name"/>
+      <name name="process_name"/>
       <desc>
 	<p>
 	  Name specification to use when starting
 	  a <c>gen_statem</c> server. See
 	  <seemfa marker="#start_link/3"><c>start_link/3</c></seemfa>
 	  and
-	  <seetype marker="#server_ref"><c>server_ref()</c></seetype>
+	  <seetype marker="#process_ref"><c>process_ref()</c></seetype>
 	  below.
 	</p>
       </desc>
     </datatype>
     <datatype>
-      <name name="server_ref"/>
+      <name name="process_ref"/>
       <desc>
 	<p>
 	  Server specification to use when addressing
 	  a <c>gen_statem</c> server.
 	  See <seemfa marker="#call/2"><c>call/2</c></seemfa> and
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
 	  above.
 	</p>
 	<p>It can be:</p>
@@ -1761,7 +1761,7 @@ handle_event(_, _, State, Data) ->
       <desc>
         <p>
 	  Makes a synchronous call to the <c>gen_statem</c>
-	  <seetype marker="#server_ref"><c><anno>ServerRef</anno></c></seetype>
+	  <seetype marker="#process_ref"><c><anno>ServerRef</anno></c></seetype>
 	  by sending a request
 	  and waiting until its reply arrives.
 	  The <c>gen_statem</c> calls the
@@ -1825,7 +1825,7 @@ handle_event(_, _, State, Data) ->
       <desc>
 	<p>
 	  Sends an asynchronous event to the <c>gen_statem</c>
-	  <seetype marker="#server_ref"><c><anno>ServerRef</anno></c></seetype>
+	  <seetype marker="#process_ref"><c><anno>ServerRef</anno></c></seetype>
 	  and returns <c>ok</c> immediately,
 	  ignoring if the destination node or <c>gen_statem</c>
 	  does not exist.
@@ -1945,7 +1945,7 @@ handle_event(_, _, State, Data) ->
 	  The same as
 	  <seemfa marker="#enter_loop/6"><c>enter_loop/6</c></seemfa>
 	  with <c>Actions = []</c> except that no
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
 	  must have been registered.  This creates an anonymous server.
 	</p>
       </desc>
@@ -1960,7 +1960,7 @@ handle_event(_, _, State, Data) ->
 	  the same as
 	  <seemfa marker="#enter_loop/6"><c>enter_loop/6</c></seemfa>
 	  except that no
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
 	  must have been registered and
 	  <c>Actions = <anno>Server_or_Actions</anno></c>.
 	  This creates an anonymous server.
@@ -2005,11 +2005,11 @@ handle_event(_, _, State, Data) ->
 	  server is created just as when using 
 	  <seemfa marker="#start_link/3"><c>start[_link|_monitor]/3</c></seemfa>.
 	  If <c><anno>Server</anno></c> is a
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
 	  a named server is created just as when using
 	  <seemfa marker="#start_link/4"><c>start[_link|_monitor]/4</c></seemfa>.
 	  However, the
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
 	  name must have been registered accordingly
 	  <em>before</em> this function is called.
 	</p>
@@ -2027,7 +2027,7 @@ handle_event(_, _, State, Data) ->
 	  <seeerl marker="proc_lib"><c>proc_lib</c></seeerl>
 	  start function, or if it is not registered
 	  according to
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>.
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>.
 	</p>
       </desc>
     </func>
@@ -2401,11 +2401,11 @@ handle_event(_, _, State, Data) ->
 	</p>
 	<p>
 	  <c><anno>ServerName</anno></c> specifies the
-	  <seetype marker="#server_name"><c>server_name()</c></seetype>
-	  to register for the <c>gen_statem</c> process.
-	  If the <c>gen_statem</c> process is started with <c>start_link/3</c>,
-          no <c><anno>ServerName</anno></c> is provided and
-	  the <c>gen_statem</c> process is not registered.
+	  <seetype marker="#process_name"><c>process_name()</c></seetype>
+	  to register for the <c>gen_statem</c>.
+	  If the <c>gen_statem</c> is started with <c>start_link/3</c>,
+	  no <c><anno>ServerName</anno></c> is provided and
+	  the <c>gen_statem</c> is not registered.
 	</p>
         <p><c><anno>Module</anno></c> is the name of the callback module.</p>
         <p>
@@ -2603,7 +2603,7 @@ handle_event(_, _, State, Data) ->
       <desc>
 	<p>
 	  Orders the <c>gen_statem</c>
-	  <seetype marker="#server_ref"><c><anno>ServerRef</anno></c></seetype>
+	  <seetype marker="#process_ref"><c><anno>ServerRef</anno></c></seetype>
 	  to exit with the specified <c><anno>Reason</anno></c>
 	  and waits for it to terminate.
 	  The <c>gen_statem</c> calls

--- a/lib/stdlib/doc/src/gen_statem.xml
+++ b/lib/stdlib/doc/src/gen_statem.xml
@@ -628,7 +628,7 @@ handle_event(_, _, State, Data) ->
 	  <tag><c>debug</c></tag>
 	  <item>
 	    <p>
-	      For every entry in <c><anno>Dbgs</anno></c>,
+	      For every entry in <c>Dbgs</c>,
 	      the corresponding function in
 	      <seeerl marker="sys"><c>sys</c></seeerl> is called.
 	    </p>

--- a/lib/stdlib/doc/src/proc_lib.xml
+++ b/lib/stdlib/doc/src/proc_lib.xml
@@ -97,10 +97,10 @@
       <name name="dict_or_pid"/>
     </datatype>
     <datatype>
-      <name name="sup_name"/>
+      <name name="process_name"/>
     </datatype>
     <datatype>
-      <name name="sup_ref"/>
+      <name name="process_ref"/>
     </datatype>
     <datatype>
       <name name="option"/>

--- a/lib/stdlib/doc/src/proc_lib.xml
+++ b/lib/stdlib/doc/src/proc_lib.xml
@@ -96,6 +96,21 @@
     <datatype>
       <name name="dict_or_pid"/>
     </datatype>
+    <datatype>
+      <name name="sup_name"/>
+    </datatype>
+    <datatype>
+      <name name="sup_ref"/>
+    </datatype>
+    <datatype>
+      <name name="option"/>
+    </datatype>
+    <datatype>
+      <name name="enter_loop_opt"/>
+    </datatype>
+    <datatype>
+      <name name="debug"/>
+    </datatype>
   </datatypes>
 
   <funcs>

--- a/lib/stdlib/doc/src/supervisor.xml
+++ b/lib/stdlib/doc/src/supervisor.xml
@@ -402,10 +402,10 @@ child_spec() = #{id => child_id(),             % mandatory
         <seeerl marker="#sup_flags">above</seeerl>.</p></desc>
     </datatype>
     <datatype>
-      <name name="sup_ref"/>
+      <name name="process_ref"/>
     </datatype>
     <datatype>
-      <name name="sup_name"/>
+      <name name="process_name"/>
     </datatype>
     <datatype>
       <name name="worker"/>
@@ -609,7 +609,7 @@ child_spec() = #{id => child_id(),             % mandatory
       <fsummary>Create a supervisor process.</fsummary>
       <type name="startlink_ret"/>
       <type name="startlink_err"/>
-      <type name="sup_name"/>
+      <type name="process_name"/>
       <desc>
         <p>Creates a supervisor process as part of a supervision tree.
           For example, the function ensures that the supervisor is linked to

--- a/lib/stdlib/doc/src/supervisor.xml
+++ b/lib/stdlib/doc/src/supervisor.xml
@@ -405,6 +405,9 @@ child_spec() = #{id => child_id(),             % mandatory
       <name name="sup_ref"/>
     </datatype>
     <datatype>
+      <name name="sup_name"/>
+    </datatype>
+    <datatype>
       <name name="worker"/>
     </datatype>
   </datatypes>
@@ -631,14 +634,14 @@ child_spec() = #{id => child_id(),             % mandatory
           </item>
           <item>
             <p>If
-              <c><anno>SupName</anno>={via,<anno>Module</anno>,<anno>Name</anno>}</c>,
+              <c><anno>SupName</anno>={via,<anno>Module</anno>,Name}</c>,
               the supervisor is registered as <c>Name</c> using the registry
               represented by <c>Module</c>. The <c>Module</c> callback must
               export the functions <c>register_name/2</c>,
               <c>unregister_name/1</c>, and <c>send/2</c>, which must behave
               like the corresponding functions in
               <seeerl marker="kernel:global"><c>global</c></seeerl>. Thus,
-              <c>{via,global,<anno>Name</anno>}</c> is a valid reference.</p>
+              <c>{via,global,Name}</c> is a valid reference.</p>
           </item>
         </list>
         <p>If no name is provided, the supervisor is not registered.</p>

--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -54,9 +54,7 @@
               request_id_collection/0]).
 
 -type linkage()    :: 'monitor' | 'link' | 'nolink'.
--type emgr_name()  :: {'local', atom()}
-                    | {'global', term()}
-                    | {'via', Module :: module(), Name :: term()}.
+-type process_name()  :: proc_lib:process_name().
 
 -type start_ret()  :: {'ok', pid()}
                     | {'ok', {pid(), reference()}}
@@ -65,8 +63,7 @@
 
 -type option()     :: proc_lib:option().
 
--type server_ref() :: pid() | atom() | {atom(), node()}
-                    | {global, term()} | {via, module(), term()}.
+-type process_ref() :: proc_lib:process_ref().
 
 -opaque reply_tag() :: % As accepted by reply/2
           reference()
@@ -97,7 +94,7 @@
 %%    The 'already_started' is returned only if Name is given 
 %%-----------------------------------------------------------------
 
--spec start(module(), linkage(), emgr_name(), module(), term(), [option()]) ->
+-spec start(module(), linkage(), process_name(), module(), term(), [option()]) ->
 	start_ret().
 
 start(GenMod, LinkP, Name, Mod, Args, Options) ->
@@ -286,7 +283,7 @@ get_node(Process) ->
 	    node(Process)
     end.
 
--spec send_request(Name::server_ref(), Tag::term(), Request::term()) ->
+-spec send_request(Name::process_ref(), Tag::term(), Request::term()) ->
           request_id().
 send_request(Process, Tag, Request) when is_pid(Process) ->
     do_send_request(Process, Tag, Request);
@@ -300,7 +297,7 @@ send_request(Process, Tag, Request) ->
             Mref
     end.
 
--spec send_request(Name::server_ref(), Tag::term(), Request::term(),
+-spec send_request(Name::process_ref(), Tag::term(), Request::term(),
                    Label::term(), ReqIdCol::request_id_collection()) ->
           request_id_collection().
 send_request(Process, Tag, Request, Label, ReqIdCol) when is_map(ReqIdCol) ->
@@ -331,7 +328,7 @@ do_send_request(Process, Tag, Request) ->
 -spec wait_response(ReqId, Timeout) -> Result when
       ReqId :: request_id(),
       Timeout :: response_timeout(),
-      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), process_ref()}},
       Result :: Resp | 'timeout'.
 
 wait_response(ReqId, Timeout) ->
@@ -350,7 +347,7 @@ wait_response(ReqId, Timeout) ->
       ReqIdCol :: request_id_collection(),
       Timeout :: response_timeout(),
       Delete :: boolean(),
-      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), process_ref()}},
       Result :: {Resp, Label::term(), NewReqIdCol::request_id_collection()} |
                 'no_request' | 'timeout'.
 
@@ -373,7 +370,7 @@ wait_response(ReqIdCol, Timeout, Delete) when is_map(ReqIdCol),
 -spec receive_response(ReqId, Timeout) -> Result when
       ReqId :: request_id(),
       Timeout :: response_timeout(),
-      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), process_ref()}},
       Result :: Resp | 'timeout'.
 
 receive_response(ReqId, Timeout) ->
@@ -398,7 +395,7 @@ receive_response(ReqId, Timeout) ->
       ReqIdCol :: request_id_collection(),
       Timeout :: response_timeout(),
       Delete :: boolean(),
-      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), process_ref()}},
       Result :: {Resp, Label::term(), NewReqIdCol::request_id_collection()}
               | 'no_request' | 'timeout'.
 
@@ -427,9 +424,9 @@ receive_response(ReqIdCol, Timeout, Delete) when is_map(ReqIdCol),
 -spec check_response(Msg::term(), ReqIdOrReqIdCol) -> Result when
       ReqIdOrReqIdCol :: request_id() | request_id_collection(),
       ReqIdResp :: {reply, Reply::term()} |
-                   {error, {Reason::term(), server_ref()}},
+                   {error, {Reason::term(), process_ref()}},
       ReqIdColResp :: {{reply, Reply::term()}, Label::term()} |
-                             {{error, {Reason::term(), server_ref()}}, Label::term()},
+                             {{error, {Reason::term(), process_ref()}}, Label::term()},
       Result :: ReqIdResp | ReqIdColResp | 'no_reply'.
 
 check_response(Msg, ReqId) when is_reference(ReqId) ->
@@ -449,7 +446,7 @@ check_response(_, _) ->
       Msg :: term(),
       ReqIdCol :: request_id_collection(),
       Delete :: boolean(),
-      Resp :: {reply, Reply::term()} | {error, {Reason::term(), server_ref()}},
+      Resp :: {reply, Reply::term()} | {error, {Reason::term(), process_ref()}},
       Result :: {Resp, Label::term(), NewReqIdCol::request_id_collection()}
               | 'no_request' | 'no_reply'.
 

--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -63,10 +63,7 @@
                     | 'ignore'
                     | {'error', term()}.
 
--type option()     :: {'timeout', timeout()}
-		    | {'debug', [sys:debug_option()]}
-		    | {'hibernate_after', timeout()}
-		    | {'spawn_opt', [proc_lib:spawn_option()]}.
+-type option()     :: proc_lib:option().
 
 -type server_ref() :: pid() | atom() | {atom(), node()}
                     | {global, term()} | {via, module(), term()}.

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -63,7 +63,7 @@
 
 -export_type([handler/0, handler_args/0, add_handler_ret/0,
               del_handler_ret/0, request_id/0, request_id_collection/0,
-              response_timeout/0, format_status/0, sup_ref/0, sup_name/0]).
+              response_timeout/0, format_status/0, sup_ref/0, process_name/0]).
 
 -record(handler, {module             :: atom(),
 		  id = false,
@@ -142,9 +142,9 @@
 -type add_handler_ret()  :: ok | term() | {'EXIT',term()}.
 -type del_handler_ret()  :: ok | term() | {'EXIT',term()}.
 
--type sup_name() :: proc_lib:sup_name().
+-type process_name() :: proc_lib:process_name().
 -type option() :: proc_lib:option().
--type sup_ref()  :: proc_lib:sup_ref().
+-type sup_ref()  :: proc_lib:process_ref().
 -type start_ret() :: {'ok', pid()} | {'error', term()}.
 -type start_mon_ret() :: {'ok', {pid(),reference()}} | {'error', term()}.
 
@@ -180,13 +180,13 @@
 start() ->
     gen:start(?MODULE, nolink, ?NO_CALLBACK, [], []).
 
--spec start(sup_name() | [option()]) -> start_ret().
+-spec start(process_name() | [option()]) -> start_ret().
 start(Name) when is_tuple(Name) ->
     gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], []);
 start(Options) when is_list(Options) ->
     gen:start(?MODULE, nolink, ?NO_CALLBACK, [], Options).
 
--spec start(sup_name(), [option()]) -> start_ret().
+-spec start(process_name(), [option()]) -> start_ret().
 start(Name, Options) ->
     gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], Options).
 
@@ -194,13 +194,13 @@ start(Name, Options) ->
 start_link() ->
     gen:start(?MODULE, link, ?NO_CALLBACK, [], []).
 
--spec start_link(sup_name() | [option()]) -> start_ret().
+-spec start_link(process_name() | [option()]) -> start_ret().
 start_link(Name) when is_tuple(Name) ->
     gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], []);
 start_link(Options) when is_list(Options) ->
     gen:start(?MODULE, link, ?NO_CALLBACK, [], Options).
 
--spec start_link(sup_name(), [option()]) -> start_ret().
+-spec start_link(process_name(), [option()]) -> start_ret().
 start_link(Name, Options) ->
     gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], Options).
 
@@ -208,17 +208,17 @@ start_link(Name, Options) ->
 start_monitor() ->
     gen:start(?MODULE, monitor, ?NO_CALLBACK, [], []).
 
--spec start_monitor(sup_name() | [option()]) -> start_mon_ret().
+-spec start_monitor(process_name() | [option()]) -> start_mon_ret().
 start_monitor(Name) when is_tuple(Name) ->
     gen:start(?MODULE, monitor, Name, ?NO_CALLBACK, [], []);
 start_monitor(Options) when is_list(Options) ->
     gen:start(?MODULE, monitor, ?NO_CALLBACK, [], Options).
 
--spec start_monitor(sup_name(), [option()]) -> start_mon_ret().
+-spec start_monitor(process_name(), [option()]) -> start_mon_ret().
 start_monitor(Name, Options) ->
     gen:start(?MODULE, monitor, Name, ?NO_CALLBACK, [], Options).
 
-%% -spec init_it(pid(), 'self' | pid(), sup_name(), module(), [term()], [_]) ->
+%% -spec init_it(pid(), 'self' | pid(), process_name(), module(), [term()], [_]) ->
 init_it(Starter, self, Name, Mod, Args, Options) ->
     init_it(Starter, self(), Name, Mod, Args, Options);
 init_it(Starter, Parent, Name0, _, _, Options) ->

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -132,8 +132,8 @@
     format_status/0]).
 
 -export_type(
-   [server_name/0,
-    server_ref/0,
+   [process_name/0,
+    process_ref/0,
     start_opt/0,
     enter_loop_opt/0,
     start_ret/0,
@@ -246,11 +246,11 @@
 %%%          {error, Reason}
 %%% -----------------------------------------------------------------
 
--type server_name() :: % Duplicate of gen:emgr_name()
+-type process_name() :: % Duplicate of gen:emgr_name()
         proc_lib:process_name().
 
 % What gen:call/3,4 and gen:stop/1,3 accepts
--type server_ref() :: proc_lib:process_ref().
+-type process_ref() :: proc_lib:process_ref().
 
 % Duplicate of gen:option()
 -type start_opt() :: proc_lib:option().
@@ -281,7 +281,7 @@ start(Module, Args, Options) ->
     gen:start(?MODULE, nolink, Module, Args, Options).
 
 -spec start(
-	ServerName :: server_name(),
+	ServerName :: process_name(),
 	Module     :: module(),
         Args       :: term(),
         Options    :: [start_opt()]
@@ -302,7 +302,7 @@ start_link(Module, Args, Options) ->
     gen:start(?MODULE, link, Module, Args, Options).
 
 -spec start_link(
-	ServerName :: server_name(),
+	ServerName :: process_name(),
 	Module     :: module(),
         Args       :: term(),
         Options    :: [start_opt()]
@@ -323,7 +323,7 @@ start_monitor(Module, Args, Options) ->
     gen:start(?MODULE, monitor, Module, Args, Options).
 
 -spec start_monitor(
-	ServerName :: server_name(),
+	ServerName :: process_name(),
 	Module     :: module(),
         Args       :: term(),
         Options    :: [start_opt()]
@@ -341,14 +341,14 @@ start_monitor(ServerName, Module, Args, Options) ->
 %% -----------------------------------------------------------------
 
 -spec stop(
-        ServerRef :: server_ref()
+        ServerRef :: process_ref()
        ) -> ok.
 %%
 stop(ServerRef) ->
     gen:stop(ServerRef).
 
 -spec stop(
-	ServerRef :: server_ref(),
+	ServerRef :: process_ref(),
 	Reason    :: term(),
 	Timeout   :: timeout()
        ) -> ok.
@@ -365,7 +365,7 @@ stop(ServerRef, Reason, Timeout) ->
 %% ----------------------------------------------------------------- 
 
 -spec call(
-        ServerRef :: server_ref(),
+        ServerRef :: process_ref(),
         Request   :: term()
        ) ->
                   Reply :: term().
@@ -379,7 +379,7 @@ call(ServerRef, Request) ->
     end.
 
 -spec call(
-        ServerRef :: server_ref(),
+        ServerRef :: process_ref(),
         Request   :: term(),
         Timeout   :: timeout()
        ) ->
@@ -398,7 +398,7 @@ call(ServerRef, Request, Timeout) ->
 %% used with wait_response/2 or check_response/2 to fetch the
 %% result of the request.
 
--spec send_request(ServerRef::server_ref(), Request::term()) ->
+-spec send_request(ServerRef::process_ref(), Request::term()) ->
           ReqId::request_id().
 
 send_request(ServerRef, Request) ->
@@ -409,7 +409,7 @@ send_request(ServerRef, Request) ->
             error(badarg, [ServerRef, Request])
     end.
 
--spec send_request(ServerRef::server_ref(),
+-spec send_request(ServerRef::process_ref(),
                    Request::term(),
                    Label::term(),
                    ReqIdCollection::request_id_collection()) ->
@@ -427,7 +427,7 @@ send_request(ServerRef, Request, Label, ReqIdCol) ->
       ReqId :: request_id(),
       WaitTime :: response_timeout(),
       Response :: {reply, Reply::term()}
-                | {error, {Reason::term(), server_ref()}},
+                | {error, {Reason::term(), process_ref()}},
       Result :: Response | 'timeout'.
 
 wait_response(ReqId, WaitTime) ->
@@ -443,7 +443,7 @@ wait_response(ReqId, WaitTime) ->
       WaitTime :: response_timeout(),
       Delete :: boolean(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: {Response,
                  Label::term(),
                  NewReqIdCollection::request_id_collection()} |
@@ -462,7 +462,7 @@ wait_response(ReqIdCol, WaitTime, Delete) ->
       ReqId :: request_id(),
       Timeout :: response_timeout(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: Response | 'timeout'.
 
 receive_response(ReqId, Timeout) ->
@@ -478,7 +478,7 @@ receive_response(ReqId, Timeout) ->
       Timeout :: response_timeout(),
       Delete :: boolean(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: {Response,
                  Label::term(),
                  NewReqIdCollection::request_id_collection()} |
@@ -497,7 +497,7 @@ receive_response(ReqIdCol, Timeout, Delete) ->
       Msg :: term(),
       ReqId :: request_id(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: Response | 'no_reply'.
 
 check_response(Msg, ReqId) ->
@@ -513,7 +513,7 @@ check_response(Msg, ReqId) ->
       ReqIdCollection :: request_id_collection(),
       Delete :: boolean(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: {Response,
                  Label::term(),
                  NewReqIdCollection::request_id_collection()} |
@@ -570,7 +570,7 @@ reqids_to_list(ReqIdCollection) ->
 %% -----------------------------------------------------------------
 
 -spec cast(
-        ServerRef :: server_ref(),
+        ServerRef :: process_ref(),
         Request   :: term()
        ) ->
                   ok.
@@ -801,7 +801,7 @@ enter_loop(Mod, Options, State)
         Module     :: module(),
         Options    :: [enter_loop_opt()],
         State      :: term(),
-        ServerName :: server_name() | pid()
+        ServerName :: process_name() | pid()
        ) ->
                         no_return();
        (
@@ -848,7 +848,7 @@ enter_loop(Mod, Options, State, {continue, _}=Continue)
         Module     :: module(),
         Options    :: [enter_loop_opt()],
         State      :: term(),
-        ServerName :: server_name() | pid(),
+        ServerName :: process_name() | pid(),
         Timeout    :: timeout()
        ) ->
                         no_return();
@@ -856,7 +856,7 @@ enter_loop(Mod, Options, State, {continue, _}=Continue)
            Module     :: module(),
            Options    :: [enter_loop_opt()],
            State      :: term(),
-           ServerName :: server_name() | pid(),
+           ServerName :: process_name() | pid(),
            Hibernate  :: 'hibernate'
        ) ->
                         no_return();
@@ -864,7 +864,7 @@ enter_loop(Mod, Options, State, {continue, _}=Continue)
            Module     :: module(),
            Options    :: [enter_loop_opt()],
            State      :: term(),
-           ServerName :: server_name() | pid(),
+           ServerName :: process_name() | pid(),
            Cont       :: {'continue', term()}
        ) ->
                         no_return().

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -247,10 +247,10 @@
 %%% -----------------------------------------------------------------
 
 -type server_name() :: % Duplicate of gen:emgr_name()
-        proc_lib:sup_name().
+        proc_lib:process_name().
 
 % What gen:call/3,4 and gen:stop/1,3 accepts
--type server_ref() :: proc_lib:sup_ref().
+-type server_ref() :: proc_lib:process_ref().
 
 % Duplicate of gen:option()
 -type start_opt() :: proc_lib:option().

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -128,6 +128,7 @@
     reply_tag/0,
     request_id/0,
     request_id_collection/0,
+    response_timeout/0,
     format_status/0]).
 
 -export_type(
@@ -246,25 +247,16 @@
 %%% -----------------------------------------------------------------
 
 -type server_name() :: % Duplicate of gen:emgr_name()
-        {'local', LocalName :: atom()}
-      | {'global', GlobalName :: term()}
-      | {'via', RegMod :: module(), ViaName :: term()}.
+        proc_lib:sup_name().
 
--type server_ref() :: % What gen:call/3,4 and gen:stop/1,3 accepts
-        pid()
-      | (LocalName :: atom())
-      | {Name :: atom(), Node :: atom()}
-      | {'global', GlobalName :: term()}
-      | {'via', RegMod :: module(), ViaName :: term()}.
+% What gen:call/3,4 and gen:stop/1,3 accepts
+-type server_ref() :: proc_lib:sup_ref().
 
--type start_opt() :: % Duplicate of gen:option()
-        {'timeout', Timeout :: timeout()}
-      | {'spawn_opt', SpawnOptions :: [proc_lib:spawn_option()]}
-      | enter_loop_opt().
+% Duplicate of gen:option()
+-type start_opt() :: proc_lib:option().
 %%
--type enter_loop_opt() :: % Some gen:option()s works for enter_loop/*
-	{'hibernate_after', HibernateAfterTimeout :: timeout()}
-      | {'debug', Dbgs :: [sys:debug_option()]}.
+% Some gen:option()s works for enter_loop/*
+-type enter_loop_opt() :: proc_lib:enter_loop_opt().
 
 -type start_ret() :: % gen:start_ret() without monitor return
         {'ok', Pid :: pid()}

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -90,8 +90,8 @@
 
 %% Type exports for start_link & friends
 -export_type(
-   [server_name/0,
-    server_ref/0,
+   [process_name/0,
+    process_ref/0,
     start_opt/0,
     enter_loop_opt/0,
     start_ret/0,
@@ -546,10 +546,10 @@ event_type(Type) ->
 %%%==========================================================================
 %%% API
 
--type server_name() :: proc_lib:process_name().
+-type process_name() :: proc_lib:process_name().
 
 % What gen:call/3,4 and gen:stop/1,3 accepts
--type server_ref() :: proc_lib:process_ref().
+-type process_ref() :: proc_lib:process_ref().
 
 % Some gen:option()s works for enter_loop/*
 -type enter_loop_opt() :: proc_lib:enter_loop_opt().
@@ -574,7 +574,7 @@ start(Module, Args, Opts) ->
     gen:start(?MODULE, nolink, Module, Args, Opts).
 %%
 -spec start(
-	ServerName :: server_name(),
+	ServerName :: process_name(),
 	Module :: module(), Args :: term(), Opts :: [start_opt()]) ->
 		   start_ret().
 start(ServerName, Module, Args, Opts) ->
@@ -588,7 +588,7 @@ start_link(Module, Args, Opts) ->
     gen:start(?MODULE, link, Module, Args, Opts).
 %%
 -spec start_link(
-	ServerName :: server_name(),
+	ServerName :: process_name(),
 	Module :: module(), Args :: term(), Opts :: [start_opt()]) ->
 		   start_ret().
 start_link(ServerName, Module, Args, Opts) ->
@@ -602,26 +602,26 @@ start_monitor(Module, Args, Opts) ->
     gen:start(?MODULE, monitor, Module, Args, Opts).
 %%
 -spec start_monitor(
-	ServerName :: server_name(),
+	ServerName :: process_name(),
 	Module :: module(), Args :: term(), Opts :: [start_opt()]) ->
 		   start_mon_ret().
 start_monitor(ServerName, Module, Args, Opts) ->
     gen:start(?MODULE, monitor, ServerName, Module, Args, Opts).
 
 %% Stop a state machine
--spec stop(ServerRef :: server_ref()) -> ok.
+-spec stop(ServerRef :: process_ref()) -> ok.
 stop(ServerRef) ->
     gen:stop(ServerRef).
 %%
 -spec stop(
-	ServerRef :: server_ref(),
+	ServerRef :: process_ref(),
 	Reason :: term(),
 	Timeout :: timeout()) -> ok.
 stop(ServerRef, Reason, Timeout) ->
     gen:stop(ServerRef, Reason, Timeout).
 
 %% Send an event to a state machine that arrives with type 'event'
--spec cast(ServerRef :: server_ref(), Msg :: term()) -> ok.
+-spec cast(ServerRef :: process_ref(), Msg :: term()) -> ok.
 cast(ServerRef, Msg) when is_pid(ServerRef) ->
     send(ServerRef, wrap_cast(Msg));
 cast(ServerRef, Msg) when is_atom(ServerRef) ->
@@ -643,12 +643,12 @@ cast({Name,Node} = ServerRef, Msg) when is_atom(Name), is_atom(Node) ->
 
 %% Call a state machine (synchronous; a reply is expected) that
 %% arrives with type {call,From}
--spec call(ServerRef :: server_ref(), Request :: term()) -> Reply :: term().
+-spec call(ServerRef :: process_ref(), Request :: term()) -> Reply :: term().
 call(ServerRef, Request) ->
     call(ServerRef, Request, infinity).
 %%
 -spec call(
-	ServerRef :: server_ref(),
+	ServerRef :: process_ref(),
 	Request :: term(),
 	Timeout ::
 	  timeout() |
@@ -666,7 +666,7 @@ call(ServerRef, Request, {_, _} = Timeout) ->
 call(ServerRef, Request, Timeout) ->
     call(ServerRef, Request, Timeout, Timeout).
 
--spec send_request(ServerRef::server_ref(), Request::term()) ->
+-spec send_request(ServerRef::process_ref(), Request::term()) ->
         ReqId::request_id().
 send_request(Name, Request) ->
     try
@@ -676,7 +676,7 @@ send_request(Name, Request) ->
             error(badarg, [Name, Request])
     end.
 
--spec send_request(ServerRef::server_ref(),
+-spec send_request(ServerRef::process_ref(),
                    Request::term(),
                    Label::term(),
                    ReqIdCollection::request_id_collection()) ->
@@ -694,7 +694,7 @@ send_request(ServerRef, Request, Label, ReqIdCol) ->
 -spec wait_response(ReqId) -> Result when
       ReqId :: request_id(),
       Response :: {reply, Reply::term()}
-                | {error, {Reason::term(), server_ref()}},
+                | {error, {Reason::term(), process_ref()}},
       Result :: Response | 'timeout'.
 
 wait_response(ReqId) ->
@@ -704,7 +704,7 @@ wait_response(ReqId) ->
       ReqId :: request_id(),
       WaitTime :: response_timeout(),
       Response :: {reply, Reply::term()}
-                | {error, {Reason::term(), server_ref()}},
+                | {error, {Reason::term(), process_ref()}},
       Result :: Response | 'timeout'.
 
 wait_response(ReqId, WaitTime) ->
@@ -720,7 +720,7 @@ wait_response(ReqId, WaitTime) ->
       WaitTime :: response_timeout(),
       Delete :: boolean(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: {Response,
                  Label::term(),
                  NewReqIdCollection::request_id_collection()} |
@@ -738,7 +738,7 @@ wait_response(ReqIdCol, WaitTime, Delete) ->
 -spec receive_response(ReqId) -> Result when
       ReqId :: request_id(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: Response | 'timeout'.
 
 receive_response(ReqId) ->
@@ -748,7 +748,7 @@ receive_response(ReqId) ->
       ReqId :: request_id(),
       Timeout :: response_timeout(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: Response | 'timeout'.
 
 receive_response(ReqId, Timeout) ->
@@ -764,7 +764,7 @@ receive_response(ReqId, Timeout) ->
       Timeout :: response_timeout(),
       Delete :: boolean(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: {Response,
                  Label::term(),
                  NewReqIdCollection::request_id_collection()} |
@@ -783,7 +783,7 @@ receive_response(ReqIdCol, Timeout, Delete) ->
       Msg :: term(),
       ReqId :: request_id(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: Response | 'no_reply'.
 
 check_response(Msg, ReqId) ->
@@ -799,7 +799,7 @@ check_response(Msg, ReqId) ->
       ReqIdCollection :: request_id_collection(),
       Delete :: boolean(),
       Response :: {reply, Reply::term()} |
-                  {error, {Reason::term(), server_ref()}},
+                  {error, {Reason::term(), process_ref()}},
       Result :: {Response,
                  Label::term(),
                  NewReqIdCollection::request_id_collection()} |
@@ -878,7 +878,7 @@ enter_loop(Module, Opts, State, Data) ->
 	Module :: module(), Opts :: [enter_loop_opt()],
 	State :: state(), Data :: data(),
 	Server_or_Actions ::
-	  server_name() | pid() | [action()]) ->
+	  process_name() | pid() | [action()]) ->
 			no_return().
 enter_loop(Module, Opts, State, Data, Server_or_Actions) ->
     if
@@ -891,7 +891,7 @@ enter_loop(Module, Opts, State, Data, Server_or_Actions) ->
 -spec enter_loop(
 	Module :: module(), Opts :: [enter_loop_opt()],
 	State :: state(), Data :: data(),
-	Server :: server_name() | pid(),
+	Server :: process_name() | pid(),
 	Actions :: [action()] | action()) ->
 			no_return().
 enter_loop(Module, Opts, State, Data, Server, Actions) ->

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -124,7 +124,6 @@
         'timeout' | {'timeout', Name :: term()} | 'state_timeout'.
 
 -type event_content() :: term().
-
 -type callback_mode_result() ::
 	callback_mode() | [callback_mode() | state_enter()].
 -type callback_mode() :: 'state_functions' | 'handle_event_function'.
@@ -547,26 +546,15 @@ event_type(Type) ->
 %%%==========================================================================
 %%% API
 
--type server_name() :: % Duplicate of gen:emgr_name()
-        {'local', atom()}
-      | {'global', GlobalName :: term()}
-      | {'via', RegMod :: module(), Name :: term()}.
+-type server_name() :: proc_lib:sup_name().
 
--type server_ref() :: % What gen:call/3,4 and gen:stop/1,3 accepts
-        pid()
-      | (LocalName :: atom())
-      | {Name :: atom(), Node :: atom()}
-      | {'global', GlobalName :: term()}
-      | {'via', RegMod :: module(), ViaName :: term()}.
+% What gen:call/3,4 and gen:stop/1,3 accepts
+-type server_ref() :: proc_lib:sup_ref().
 
--type start_opt() :: % Duplicate of gen:option()
-        {'timeout', Time :: timeout()}
-      | {'spawn_opt', [proc_lib:spawn_option()]}
-      | enter_loop_opt().
-%%
--type enter_loop_opt() :: % Some gen:option()s works for enter_loop/*
-	{'hibernate_after', HibernateAfterTimeout :: timeout()}
-      | {'debug', Dbgs :: [sys:debug_option()]}.
+% Some gen:option()s works for enter_loop/*
+-type enter_loop_opt() :: proc_lib:enter_loop_opt().
+
+-type start_opt() :: proc_lib:option() | enter_loop_opt().
 
 -type start_ret() :: % gen:start_ret() without monitor return
         {'ok', pid()}
@@ -577,9 +565,6 @@ event_type(Type) ->
         {'ok', {pid(),reference()}}
       | 'ignore'
       | {'error', term()}.
-
-
-
 
 %% Start a state machine
 -spec start(

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -546,10 +546,10 @@ event_type(Type) ->
 %%%==========================================================================
 %%% API
 
--type server_name() :: proc_lib:sup_name().
+-type server_name() :: proc_lib:process_name().
 
 % What gen:call/3,4 and gen:stop/1,3 accepts
--type server_ref() :: proc_lib:sup_ref().
+-type server_ref() :: proc_lib:process_ref().
 
 % Some gen:option()s works for enter_loop/*
 -type enter_loop_opt() :: proc_lib:enter_loop_opt().

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -43,6 +43,8 @@
 -export_type([spawn_option/0]).
 -export_type([start_spawn_option/0]).
 
+-export_type([sup_name/0, sup_ref/0, option/0, debug/0, enter_loop_opt/0]).
+
 -include("logger.hrl").
 
 %%-----------------------------------------------------------------------------
@@ -80,6 +82,31 @@
 -type dict_or_pid()    :: pid()
                         | (ProcInfo :: [_])
                         | {X :: integer(), Y :: integer(), Z :: integer()}.
+
+%%-----------------------------------------------------------------------------
+%%-----------------------------------------------------------------------------
+
+-type sup_name()      :: {'local', Name :: atom()}
+                       | {'global', Name :: term()}
+                       | {'via', Module :: module(), Name :: any()}.
+
+-type sup_ref()       :: (Name :: atom())
+                       | {Name :: atom(), Node :: node()}
+                       | {'global', Name :: term()}
+                       | {'via', Module :: module(), Name :: any()}
+                       | pid().
+
+-type option() :: {'timeout', Timeout :: timeout()}
+                | {'debug', Dbgs :: [debug()]}
+                | {'spawn_opt', [proc_lib:start_spawn_option()]}
+                | enter_loop_opt().
+
+-type enter_loop_opt() ::   {'hibernate_after', HibernateAfterTimeout :: timeout()}
+                          | {'debug', Dbgs :: [sys:debug_option()]}.
+
+
+-type debug () :: 'trace' | 'log' | 'statistics' | 'debug'
+                | {'logfile', string()}.
 
 %%-----------------------------------------------------------------------------
 

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -43,7 +43,7 @@
 -export_type([spawn_option/0]).
 -export_type([start_spawn_option/0]).
 
--export_type([sup_name/0, sup_ref/0, option/0, debug/0, enter_loop_opt/0]).
+-export_type([process_name/0, process_ref/0, option/0, debug/0, enter_loop_opt/0]).
 
 -include("logger.hrl").
 
@@ -86,11 +86,11 @@
 %%-----------------------------------------------------------------------------
 %%-----------------------------------------------------------------------------
 
--type sup_name()      :: {'local', Name :: atom()}
+-type process_name()   :: {'local', Name :: atom()}
                        | {'global', Name :: term()}
                        | {'via', Module :: module(), Name :: any()}.
 
--type sup_ref()       :: (Name :: atom())
+-type process_ref()    :: (Name :: atom())
                        | {Name :: atom(), Node :: node()}
                        | {'global', Name :: term()}
                        | {'via', Module :: module(), Name :: any()}

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -71,8 +71,8 @@
 -type significant()   :: boolean().
 -type shutdown()      :: 'brutal_kill' | timeout().
 -type worker()        :: 'worker' | 'supervisor'.
--type sup_name()      :: proc_lib:sup_name().
--type sup_ref()       :: proc_lib:sup_ref().
+-type sup_name()      :: proc_lib:process_name().
+-type sup_ref()       :: proc_lib:process_ref().
 -type child_spec()    :: #{id := child_id(),             % mandatory
 			   start := mfargs(),            % mandatory
 			   restart => restart(),         % optional

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -58,7 +58,7 @@
 
 -export_type([sup_flags/0, child_spec/0, strategy/0,
               startchild_ret/0, startchild_err/0,
-              startlink_ret/0, startlink_err/0]).
+              startlink_ret/0, startlink_err/0, sup_name/0, sup_ref/0]).
 
 %%--------------------------------------------------------------------------
 
@@ -71,14 +71,8 @@
 -type significant()   :: boolean().
 -type shutdown()      :: 'brutal_kill' | timeout().
 -type worker()        :: 'worker' | 'supervisor'.
--type sup_name()      :: {'local', Name :: atom()}
-                       | {'global', Name :: term()}
-                       | {'via', Module :: module(), Name :: any()}.
--type sup_ref()       :: (Name :: atom())
-                       | {Name :: atom(), Node :: node()}
-                       | {'global', Name :: term()}
-                       | {'via', Module :: module(), Name :: any()}
-                       | pid().
+-type sup_name()      :: proc_lib:sup_name().
+-type sup_ref()       :: proc_lib:sup_ref().
 -type child_spec()    :: #{id := child_id(),             % mandatory
 			   start := mfargs(),            % mandatory
 			   restart => restart(),         % optional

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -58,7 +58,7 @@
 
 -export_type([sup_flags/0, child_spec/0, strategy/0,
               startchild_ret/0, startchild_err/0,
-              startlink_ret/0, startlink_err/0, sup_name/0, sup_ref/0]).
+              startlink_ret/0, startlink_err/0, process_name/0, process_ref/0]).
 
 %%--------------------------------------------------------------------------
 
@@ -71,8 +71,8 @@
 -type significant()   :: boolean().
 -type shutdown()      :: 'brutal_kill' | timeout().
 -type worker()        :: 'worker' | 'supervisor'.
--type sup_name()      :: proc_lib:process_name().
--type sup_ref()       :: proc_lib:process_ref().
+-type process_name()      :: proc_lib:process_name().
+-type process_ref()       :: proc_lib:process_ref().
 -type child_spec()    :: #{id := child_id(),             % mandatory
 			   start := mfargs(),            % mandatory
 			   restart => restart(),         % optional
@@ -170,7 +170,7 @@ start_link(Mod, Args) ->
     gen_server:start_link(supervisor, {self, Mod, Args}, []).
  
 -spec start_link(SupName, Module, Args) -> startlink_ret() when
-      SupName :: sup_name(),
+      SupName :: process_name(),
       Module :: module(),
       Args :: term().
 start_link(SupName, Mod, Args) ->
@@ -187,13 +187,13 @@ start_link(SupName, Mod, Args) ->
 			| {'error', startchild_err()}.
 
 -spec start_child(SupRef, ChildSpec) -> startchild_ret() when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       ChildSpec :: child_spec() | (List :: [term()]).
 start_child(Supervisor, ChildSpec) ->
     call(Supervisor, {start_child, ChildSpec}).
 
 -spec restart_child(SupRef, Id) -> Result when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       Id :: child_id(),
       Result :: {'ok', Child :: child()}
               | {'ok', Child :: child(), Info :: term()}
@@ -204,7 +204,7 @@ restart_child(Supervisor, Id) ->
     call(Supervisor, {restart_child, Id}).
 
 -spec delete_child(SupRef, Id) -> Result when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       Id :: child_id(),
       Result :: 'ok' | {'error', Error},
       Error :: 'running' | 'restarting' | 'not_found' | 'simple_one_for_one'.
@@ -219,7 +219,7 @@ delete_child(Supervisor, Id) ->
 %%-----------------------------------------------------------------
 
 -spec terminate_child(SupRef, Id) -> Result when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       Id :: pid() | child_id(),
       Result :: 'ok' | {'error', Error},
       Error :: 'not_found' | 'simple_one_for_one'.
@@ -227,7 +227,7 @@ terminate_child(Supervisor, Id) ->
     call(Supervisor, {terminate_child, Id}).
 
 -spec get_childspec(SupRef, Id) -> Result when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       Id :: pid() | child_id(),
       Result :: {'ok', child_spec()} | {'error', Error},
       Error :: 'not_found'.
@@ -235,7 +235,7 @@ get_childspec(Supervisor, Id) ->
     call(Supervisor, {get_childspec, Id}).
 
 -spec which_children(SupRef) -> [{Id,Child,Type,Modules}] when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       Id :: child_id() | undefined,
       Child :: child() | 'restarting',
       Type :: worker(),
@@ -244,7 +244,7 @@ which_children(Supervisor) ->
     call(Supervisor, which_children).
 
 -spec count_children(SupRef) -> PropListOfCounts when
-      SupRef :: sup_ref(),
+      SupRef :: process_ref(),
       PropListOfCounts :: [Count],
       Count :: {specs, ChildSpecCount :: non_neg_integer()}
              | {active, ActiveProcessCount :: non_neg_integer()}
@@ -308,7 +308,7 @@ get_callback_module(Pid) ->
 %%% 
 %%% ---------------------------------------------------
 
--type init_sup_name() :: sup_name() | 'self'.
+-type init_process_name() :: process_name() | 'self'.
 
 -type stop_rsn() :: {'shutdown', term()}
                   | {'bad_return', {module(),'init', term()}}
@@ -316,7 +316,7 @@ get_callback_module(Pid) ->
                   | {'start_spec', term()}
                   | {'supervisor_data', term()}.
 
--spec init({init_sup_name(), module(), [term()]}) ->
+-spec init({init_process_name(), module(), [term()]}) ->
         {'ok', state()} | 'ignore' | {'stop', stop_rsn()}.
 
 init({SupName, Mod, Args}) ->


### PR DESCRIPTION
Exports types mentioned in the documentation of supervisor, gen_server, and gen_event

Closes #6893 