### PR TITLE
Add notes about two upcoming incompatibilities

### DIFF
--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -53,6 +53,7 @@
     </section>
 
     <section>
+      <marker id="maybe_expr"/>
       <title>Feature maybe_expr will be enabled by default</title>
       <p>
 	As of OTP 27, the <c>maybe_expr</c> feature will be approved
@@ -118,6 +119,41 @@
         slower, and thus more can be gained by explicitly compiling
         the regular expression before matching with it.</p></item>
       </list>
+    </section>
+
+    <section>
+      <marker id="float_matching"/>
+      <title>0.0 and -0.0 will no longer be exactly equal</title>
+
+      <p>Currently, the floating point numbers <c>0.0</c> and <c>-0.0</c>
+      have distinct internal representations. That can be seen if they are
+      converted to binaries:</p>
+      <pre>
+1&gt; <input>&lt;&lt;0.0/float&gt;&gt;.</input>
+&lt;&lt;0,0,0,0,0,0,0,0&gt;&gt;
+2&gt; <input>&lt;&lt;-0.0/float&gt;>.</input>
+&lt;&lt;128,0,0,0,0,0,0,0>></pre>
+
+      <p>However, when they are matched against each other or compared
+      using the <c>=:=</c> operator, they are considered to be
+      equal. Thus, <c>0.0 =:= -0.0</c> currently returns
+      <c>true</c>.</p>
+
+      <p>In Erlang/OTP 27, <c>0.0 =:= -0.0</c> will return <c>false</c>, and matching
+      <c>0.0</c> against <c>-0.0</c> will fail. When used as map keys, <c>0.0</c> and
+      <c>-0.0</c> will be considered to be distinct.</p>
+
+      <p>The <c>==</c> operator will continue to return <c>true</c>
+      for <c>0.0 == -0.0</c>.</p>
+
+      <p>To help to find code that might need to be revised, in OTP 27
+      there will be a new compiler warning when matching against
+      <c>0.0</c> or comparing to that value using the <c>=:=</c>
+      operator. The warning can be suppressed by matching against
+      <c>+0.0</c> instead of <c>0.0</c>.</p>
+
+      <p>We plan to introduce the same warning in OTP 26.1, but by default it
+      will be disabled.</p>
     </section>
   </section>
 

--- a/system/doc/general_info/upcoming_incompatibilities.xml
+++ b/system/doc/general_info/upcoming_incompatibilities.xml
@@ -155,6 +155,30 @@
       <p>We plan to introduce the same warning in OTP 26.1, but by default it
       will be disabled.</p>
     </section>
+
+    <section>
+      <marker id="singleton_typevars"/>
+      <title>Singleton type variables will become a compile-time error</title>
+
+      <p>Before Erlang/OTP 26, the compiler would silenty accept the
+      following spec:</p>
+
+      <pre>
+-spec f(Opts) -> term() when
+    Opts :: {ok, Unknown} | {error, Unknown}.
+f(_) -> error.</pre>
+
+    <p>In OTP 26, the compiler emits a warning pointing out that the type variable
+    <c>Unknown</c> is unbound:</p>
+
+    <pre>
+t.erl:6:18: Warning: type variable 'Unknown' is only used once (is unbound)
+%    6|     Opts :: {ok, Unknown} | {error, Unknown}.
+%     |                  ^</pre>
+
+    <p>In OTP 27, that warning will become an error.</p>
+    </section>
+
   </section>
 
   <section>


### PR DESCRIPTION
Add notes about the following incompatibilities:

* In OTP 27, `+0.0 =:= -0.0` will return false.
* Having unbound type variables in a union will become an error.