### PR TITLE
kernel: support sending raw byte data over stdout

### DIFF
--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -164,6 +164,7 @@
                       sig => boolean()
                     }.
 -type request() ::
+        {putc_raw, binary()} |
         {putc, unicode:unicode_binary()} |
         {expand, unicode:unicode_binary()} |
         {insert, unicode:unicode_binary()} |
@@ -525,6 +526,8 @@ writer_loop(TTY, WriterRef) ->
 -spec handle_request(state(), request()) -> {erlang:iovec(), state()}.
 handle_request(State = #state{ options = #{ tty := false } }, Request) ->
     case Request of
+        {putc_raw, Binary} ->
+            {Binary, State};
         {putc, Binary} ->
             {encode(Binary, State#state.unicode), State};
         beep ->
@@ -565,6 +568,8 @@ handle_request(State = #state{ unicode = U }, {putc, Binary}) ->
             {_, _, _, NewBA} = split(NewLength - OldLength, NewState#state.buffer_after, U),
             {encode(PutBuffer, U), NewState#state{ buffer_after = NewBA }}
     end;
+handle_request(State, {putc_raw, Binary}) ->
+    handle_request(State, {putc, unicode:characters_to_binary(Binary, latin1)});
 handle_request(State = #state{ unicode = U }, {delete, N}) when N > 0 ->
     {_DelNum, DelCols, _, NewBA} = split(N, State#state.buffer_after, U),
     BBCols = cols(State#state.buffer_before, U),

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -765,6 +765,10 @@ io_request({put_chars_sync, unicode, Chars, Reply}, TTY) ->
     {Output, NewTTY} = prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars)}),
     {ok, MonitorRef} = prim_tty:write(NewTTY, Output, self()),
     {Reply, MonitorRef, NewTTY};
+io_request({put_chars_sync, latin1, Chars, Reply}, TTY) ->
+    {Output, NewTTY} = prim_tty:handle_request(TTY, {putc_raw, Chars}),
+    {ok, MonitorRef} = prim_tty:write(NewTTY, Output, self()),
+    {Reply, MonitorRef, NewTTY};
 io_request({put_expand, unicode, Chars}, TTY) ->
     write(prim_tty:handle_request(TTY, {expand, unicode:characters_to_binary(Chars)}));
 io_request({move_rel, N}, TTY) ->

--- a/lib/stdlib/test/io_proto_SUITE.erl
+++ b/lib/stdlib/test/io_proto_SUITE.erl
@@ -25,7 +25,7 @@
 -export([setopts_getopts/1,unicode_options/1,unicode_options_gen/1, 
 	 binary_options/1, read_modes_gl/1,
 	 read_modes_ogl/1, broken_unicode/1,eof_on_pipe/1,
-         unicode_prompt/1, shell_slogan/1, raw_stdout/1]).
+         unicode_prompt/1, shell_slogan/1, raw_stdout/1, raw_stdout_isatty/1]).
 
 
 -export([io_server_proxy/1,start_io_server_proxy/0, proxy_getall/1, 
@@ -53,7 +53,7 @@ all() ->
     [setopts_getopts, unicode_options, unicode_options_gen,
      binary_options, read_modes_gl, read_modes_ogl,
      broken_unicode, eof_on_pipe, unicode_prompt,
-     shell_slogan, raw_stdout].
+     shell_slogan, raw_stdout, raw_stdout_isatty].
 
 groups() -> 
     [].
@@ -1124,8 +1124,14 @@ write_raw_to_stdout() ->
             io:format(standard_error, "~p~p~p", [Class, Reason, StackTrace]),
             halt(17)
     end.
-    
 
+raw_stdout_isatty(Config) when is_list(Config) ->
+    rtnode:run(
+        [{putline,"io:setopts(group_leader(), [{encoding, latin1}])."},
+         {putline,"file:write(group_leader(),[90, 127, 128, 255, 131, 90, 10])."},%
+         {expect, "\\QZ^?\\200\\377\\203Z\\E"}
+        ],[]),
+        ok.
 %%
 %% Test I/O-server
 %%

--- a/lib/stdlib/test/io_proto_SUITE.erl
+++ b/lib/stdlib/test/io_proto_SUITE.erl
@@ -25,7 +25,7 @@
 -export([setopts_getopts/1,unicode_options/1,unicode_options_gen/1, 
 	 binary_options/1, read_modes_gl/1,
 	 read_modes_ogl/1, broken_unicode/1,eof_on_pipe/1,
-         unicode_prompt/1, shell_slogan/1]).
+         unicode_prompt/1, shell_slogan/1, raw_stdout/1]).
 
 
 -export([io_server_proxy/1,start_io_server_proxy/0, proxy_getall/1, 
@@ -34,6 +34,8 @@
 -export([answering_machine1/3, answering_machine2/3]).
 
 -export([uprompt/1, slogan/0, session_slogan/0]).
+
+-export([write_raw_to_stdout/0]).
 
 %%-define(debug, true).
 
@@ -51,7 +53,7 @@ all() ->
     [setopts_getopts, unicode_options, unicode_options_gen,
      binary_options, read_modes_gl, read_modes_ogl,
      broken_unicode, eof_on_pipe, unicode_prompt,
-     shell_slogan].
+     shell_slogan, raw_stdout].
 
 groups() -> 
     [].
@@ -1090,6 +1092,39 @@ eof_on_pipe(Config) when is_list(Config) ->
 	{_,_} ->
 	    {skipped,"Only on linux"}
     end.
+
+raw_stdout(Config) when is_list(Config) ->
+    Cmd = lists:append(
+            [ct:get_progname(),
+             " -noshell -noinput",
+             " -pa ", filename:dirname(code:which(?MODULE)),
+             " -s ", atom_to_list(?MODULE), " write_raw_to_stdout"]),
+    ct:log("~p~n", [Cmd]),
+    Port = open_port({spawn, Cmd}, [stream, eof]),
+    Expected = lists:seq(0,255),
+    Expected = get_all_port_data(Port, []),
+    Port ! {self(), close},
+    ok.
+
+get_all_port_data(Port, Acc) ->
+    receive
+        {Port, {data, Data}} ->
+            get_all_port_data(Port, [Acc|Data]);
+        {Port, eof} ->
+            lists:flatten(Acc)
+    end.
+
+write_raw_to_stdout() ->
+    try
+        ok = io:setopts(standard_io, [{encoding, latin1}]),
+        ok = file:write(standard_io, lists:seq(0,255)),
+        halt(0)
+    catch
+        Class:Reason:StackTrace ->
+            io:format(standard_error, "~p~p~p", [Class, Reason, StackTrace]),
+            halt(17)
+    end.
+    
 
 %%
 %% Test I/O-server


### PR DESCRIPTION
After rewriting the shell, group.erl converts everything to Unicode. However, this is problematic if you want to send raw byte data over stdout which may contain Erlang terms converted to binary that you want to convert back to Erlang term after data transfer. If io:setopts(_, {encoding, latin1}) is set, group.erl will just send the data directly to user_drv.erl which will send the data to prim_tty.erl without converting it to Unicode. Fixes #7132.