### PR TITLE
ssl: Improve error information when middlebox assert fails

### DIFF
--- a/lib/ssl/src/tls_client_connection_1_3.erl
+++ b/lib/ssl/src/tls_client_connection_1_3.erl
@@ -316,6 +316,10 @@ hello_middlebox_assert(enter, _, State) ->
     {keep_state, State};
 hello_middlebox_assert(internal, #change_cipher_spec{}, State) ->
     tls_gen_connection:next_event(wait_ee, no_record, State);
+hello_middlebox_assert(internal = Type, #encrypted_extensions{} = Msg,  #state{ssl_options = #{log_level := Level}} = State) ->
+    ssl_logger:log(warning, Level, #{description => "Failed to assert middlebox server message",
+                                     reason => [{missing, #change_cipher_spec{}}]}, ?LOCATION),
+    ssl_gen_statem:handle_common_event(Type, Msg, ?FUNCTION_NAME, State);
 hello_middlebox_assert(info, Msg, State) ->
     tls_gen_connection:handle_info(Msg, ?FUNCTION_NAME, State);
 hello_middlebox_assert(Type, Msg, State) ->
@@ -331,8 +335,10 @@ hello_retry_middlebox_assert(enter, _, State) ->
     {keep_state, State};
 hello_retry_middlebox_assert(internal, #change_cipher_spec{}, State) ->
     tls_gen_connection:next_event(wait_sh, no_record, State);
-hello_retry_middlebox_assert(internal, #server_hello{}, State) ->
-    tls_gen_connection:next_event(?FUNCTION_NAME, no_record, State, [postpone]);
+hello_retry_middlebox_assert(internal = Type, #server_hello{} = Msg, #state{ssl_options = #{log_level := Level}} = State) ->
+    ssl_logger:log(warning, Level, #{description => "Failed to assert middlebox server message",
+                                     reason => [{missing, #change_cipher_spec{}}]}, ?LOCATION),
+    ssl_gen_statem:handle_common_event(Type, Msg, ?FUNCTION_NAME, State);
 hello_retry_middlebox_assert(info, Msg, State) ->
     tls_gen_connection:handle_info(Msg, ?FUNCTION_NAME, State);
 hello_retry_middlebox_assert(Type, Msg, State) ->


### PR DESCRIPTION
To make it more obvious what the problem is. 