### PR TITLE
erlc: Fix compiler server args on windows

### DIFF
--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -748,8 +748,10 @@ call_compile_server(char** argv)
     ei_x_encode_atom(&args, "command_line");
     argc = 0;
     while (argv[argc]) {
+        char *arg;
         ei_x_encode_list_header(&args, 1);
-        ei_x_encode_binary(&args, possibly_unquote(argv[argc]), strlen(argv[argc]));
+        arg = possibly_unquote(argv[argc]);
+        ei_x_encode_binary(&args, arg, strlen(arg));
         argc++;
     }
     ei_x_encode_empty_list(&args); /* End of command_line */


### PR DESCRIPTION
String could be wrong length if arg was quoted and changed.