### PR TITLE
Fix Dialyzer failures in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -582,6 +582,7 @@ jobs:
             -e TEST_NEEDS_RELEASE=true -e "RELEASE_ROOT=/buildroot/otp/Erlang ∅⊤℞" \
             -e EXTRA_ARGS="-ct_hooks cth_surefire [{path,\"/buildroot/otp/$DIR/make_test_dir/${{ matrix.type }}_junit.xml\"}]" \
             -v "$PWD/make_test_dir:/buildroot/otp/$DIR/make_test_dir" \
+            -v "$PWD/scripts:/buildroot/otp/scripts" \
             otp "make TYPE=${TYPE} && make ${APP}_test TYPE=${TYPE}"
           ## Rename os_mon to debug for debug build
           if [ "$APP" != "${{ matrix.type }}" ]; then


### PR DESCRIPTION
Dialyzer failed in CI during testing because we'd run the tests in a Docker image which uses the output of a build of OTP, but that build doesn't include the `scripts/` directory (which contains the script for running Dialyzer) from the main Git repository. This change mirrors that directory into the Docker image used for testing so that it can be run there.

Tested by running the GitHub Actions on my own fork.