### PR TITLE
erts/instrument: Extend allocation tags with per-process/port and code tracking

### DIFF
--- a/erts/doc/src/erts_alloc.xml
+++ b/erts/doc/src/erts_alloc.xml
@@ -576,7 +576,7 @@
             <seeerl marker="runtime_tools:instrument"><c>instrument</c></seeerl>
             module to inspect this information.</p>
 
-          <p>The runtime overhead is one word per allocation when enabled. This
+          <p>The runtime overhead is two words per allocation when enabled. This
             may change at any time in the future.</p>
 
           <p>The default is <c>true</c> for <c>binary_alloc</c> and

--- a/erts/emulator/beam/erl_alloc.types
+++ b/erts/emulator/beam/erl_alloc.types
@@ -289,7 +289,7 @@ type    MAP_TRAP        SHORT_LIVED     PROCESSES       map_bif_trap_state
 
 type	ENVIRONMENT	SYSTEM		SYSTEM		environment
 
-type	PERSISTENT_TERM	LONG_LIVED	CODE		persisten_term
+type	PERSISTENT_TERM	LONG_LIVED	CODE		persistent_term
 type	PERSISTENT_LOCK_Q SHORT_LIVED	SYSTEM		persistent_lock_q
 type	PERSISTENT_TERM_TMP SHORT_LIVED	SYSTEM		persistent_term_tmp_table
 

--- a/erts/emulator/beam/erl_alloc_util.h
+++ b/erts/emulator/beam/erl_alloc_util.h
@@ -179,6 +179,8 @@ typedef struct {
 
 #endif
 
+extern int erts_alcu_enable_code_atags;
+
 void *	erts_alcu_alloc(ErtsAlcType_t, void *, Uint);
 void *	erts_alcu_realloc(ErtsAlcType_t, void *, void *, Uint);
 void *	erts_alcu_realloc_mv(ErtsAlcType_t, void *, void *, Uint);
@@ -244,7 +246,8 @@ int erts_alcu_try_set_dyn_param(Allctr_t*, Eterm param, Uint value);
  * for. */
 int erts_alcu_gather_alloc_histograms(struct process *p, int allocator_num,
                                       int sched_id, int hist_width,
-                                      UWord hist_start, Eterm ref);
+                                      UWord hist_start, int flags,
+                                      Eterm ref);
 
 /* Gathers per-carrier info from the given allocator number (ERTS_ALC_A_*) and
  * scheduler id. An id of 0 means the global instance will be used.
@@ -253,7 +256,8 @@ int erts_alcu_gather_alloc_histograms(struct process *p, int allocator_num,
  * for. */
 int erts_alcu_gather_carrier_info(struct process *p, int allocator_num,
                                   int sched_id, int hist_width,
-                                  UWord hist_start, Eterm ref);
+                                  UWord hist_start, int flags,
+                                  Eterm ref);
 
 struct alcu_blockscan;
 

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -5346,16 +5346,19 @@ erts_get_ethread_info(Process *c_p)
 
 static BIF_RETTYPE
 gather_histograms_helper(Process * c_p, Eterm arg_tuple,
-                         int gather(Process *, int, int, int, UWord, Eterm))
+                         int gather(Process *, int, int, int, UWord, int, Eterm))
 {
     SWord hist_start, hist_width, aux_work_tid;
     int msg_count, alloc_num;
     Eterm *args;
+    int flags;
 
-    /* This is an internal BIF, so the error checking is mostly left to erlang
-     * code. */
+    /* This is an internal BIF so the error checking is mostly left to erlang
+     * code, we'll just make sure we won't crash the emulator outright. */
+    if (!is_tuple_arity(arg_tuple, 6)) {
+        BIF_ERROR(c_p, BADARG);
+    }
 
-    ASSERT(is_tuple_arity(arg_tuple, 5));
     args = tuple_val(arg_tuple);
 
     for (alloc_num = ERTS_ALC_A_MIN; alloc_num <= ERTS_ALC_A_MAX; alloc_num++) {
@@ -5371,12 +5374,14 @@ gather_histograms_helper(Process * c_p, Eterm arg_tuple,
     aux_work_tid = signed_val(args[2]);
     hist_width = signed_val(args[3]);
     hist_start = signed_val(args[4]);
+    flags = signed_val(args[5]);
 
     if (aux_work_tid < 0 || erts_no_aux_work_threads <= aux_work_tid) {
         BIF_ERROR(c_p, BADARG);
     }
 
-    msg_count = gather(c_p, alloc_num, aux_work_tid, hist_width, hist_start, args[5]);
+    msg_count = gather(c_p, alloc_num, aux_work_tid, hist_width, hist_start,
+                       flags, args[6]);
 
     BIF_RET(make_small(msg_count));
 }

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -639,6 +639,12 @@ void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
     a.mov(XREG0, ARG1);
 
     emit_leave_erlang_frame();
+
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.str(a64::x30, arm::Mem(c_p, offsetof(Process, i)));
+    }
+
     a.ret(a64::x30);
 
     a.bind(check_trap);
@@ -881,6 +887,11 @@ void BeamGlobalAssembler::emit_dispatch_nif(void) {
 
 void BeamGlobalAssembler::emit_call_nif_yield_helper() {
     Label yield = a.newLabel();
+
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.str(ARG3, arm::Mem(c_p, offsetof(Process, i)));
+    }
 
     a.subs(FCALLS, FCALLS, imm(1));
     a.b_le(yield);

--- a/erts/emulator/beam/jit/arm/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/instr_call.cpp
@@ -41,6 +41,11 @@ void BeamModuleAssembler::emit_return() {
     emit_validate(ArgVal(ArgVal::Word, 1));
 #endif
 
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.str(a64::x30, arm::Mem(c_p, offsetof(Process, i)));
+    }
+
     /* The reduction test is kept in module code because moving it to a shared
      * fragment caused major performance regressions in dialyzer. */
     a.subs(FCALLS, FCALLS, imm(1));

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -2481,7 +2481,8 @@ void BeamModuleAssembler::emit_raw_raise() {
 }
 
 #define TEST_YIELD_RETURN_OFFSET                                               \
-    (BEAM_ASM_FUNC_PROLOGUE_SIZE + sizeof(Uint32[3]))
+    (BEAM_ASM_FUNC_PROLOGUE_SIZE + sizeof(Uint32[3]) +                         \
+     (erts_alcu_enable_code_atags ? sizeof(Uint32) : 0))
 
 /* ARG3 = current_label */
 void BeamGlobalAssembler::emit_i_test_yield_shared() {
@@ -2502,6 +2503,16 @@ void BeamModuleAssembler::emit_i_test_yield() {
            BEAM_ASM_FUNC_PROLOGUE_SIZE);
 
     a.adr(ARG3, current_label);
+
+    if (erts_alcu_enable_code_atags) {
+        /* The point-of-origin allocation tags are vastly improved when the
+         * instruction pointer is updated frequently. This has a relatively low
+         * impact on performance but there's little point in doing this unless
+         * the user has requested it -- it's an undocumented feature for
+         * now. */
+        a.str(ARG3, arm::Mem(c_p, offsetof(Process, i)));
+    }
+
     a.subs(FCALLS, FCALLS, imm(1));
     a.b_le(resolve_fragment(ga->get_i_test_yield_shared(), disp1MB));
 

--- a/erts/emulator/beam/jit/x86/instr_bif.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bif.cpp
@@ -692,10 +692,21 @@ void BeamGlobalAssembler::emit_bif_nif_epilogue(void) {
     emit_leave_frame();
 
 #ifdef NATIVE_ERLANG_STACK
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.mov(RET, x86::qword_ptr(E));
+        a.mov(x86::qword_ptr(c_p, offsetof(Process, i)), RET);
+    }
+
     a.ret();
 #else
     a.mov(RET, getCPRef());
     a.mov(getCPRef(), imm(NIL));
+
+    if (erts_alcu_enable_code_atags) {
+        a.mov(x86::qword_ptr(c_p, offsetof(Process, i)), RET);
+    }
+
     a.jmp(RET);
 #endif
 
@@ -953,6 +964,11 @@ void BeamGlobalAssembler::emit_dispatch_nif(void) {
 
 void BeamGlobalAssembler::emit_call_nif_yield_helper() {
     Label yield = a.newLabel();
+
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+        a.mov(x86::qword_ptr(c_p, offsetof(Process, i)), ARG3);
+    }
 
     a.dec(FCALLS);
     a.short_().jl(yield);

--- a/erts/emulator/beam/jit/x86/instr_call.cpp
+++ b/erts/emulator/beam/jit/x86/instr_call.cpp
@@ -51,6 +51,14 @@ void BeamModuleAssembler::emit_return() {
     a.mov(getCPRef(), imm(NIL));
 #endif
 
+    if (erts_alcu_enable_code_atags) {
+        /* See emit_i_test_yield. */
+#if defined(NATIVE_ERLANG_STACK)
+        a.mov(ARG3, x86::qword_ptr(E));
+#endif
+        a.mov(x86::qword_ptr(c_p, offsetof(Process, i)), ARG3);
+    }
+
     /* The reduction test is kept in module code because moving it to a shared
      * fragment caused major performance regressions in dialyzer. */
     a.dec(FCALLS);

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -2486,8 +2486,9 @@ void BeamModuleAssembler::emit_raw_raise() {
 }
 
 #define TEST_YIELD_RETURN_OFFSET                                               \
-    (BEAM_ASM_FUNC_PROLOGUE_SIZE + 16 +                                        \
-     (erts_frame_layout == ERTS_FRAME_LAYOUT_FP_RA ? 4 : 0))
+    (BEAM_ASM_FUNC_PROLOGUE_SIZE + 16u +                                       \
+     (erts_frame_layout == ERTS_FRAME_LAYOUT_FP_RA ? 4u : 0u) +                \
+     (erts_alcu_enable_code_atags ? 8u : 0u))
 
 /* ARG3 = return address, current_label + TEST_YIELD_RETURN_OFFSET */
 void BeamGlobalAssembler::emit_i_test_yield_shared() {
@@ -2510,8 +2511,19 @@ void BeamModuleAssembler::emit_i_test_yield() {
     emit_enter_frame();
 
     a.lea(ARG3, x86::qword_ptr(current_label, TEST_YIELD_RETURN_OFFSET));
+
+    if (erts_alcu_enable_code_atags) {
+        /* The point-of-origin allocation tags are vastly improved when the
+         * instruction pointer is updated frequently. This has a relatively low
+         * impact on performance but there's little point in doing this unless
+         * the user has requested it -- it's an undocumented feature for
+         * now. */
+        a.mov(x86::qword_ptr(c_p, offsetof(Process, i)), ARG3);
+    }
+
     a.dec(FCALLS);
     a.long_().jle(resolve_fragment(ga->get_i_test_yield_shared()));
+    a.align(AlignMode::kCode, 4);
 
     ASSERT((a.offset() - code.labelOffsetFromBase(current_label)) ==
            TEST_YIELD_RETURN_OFFSET);

--- a/lib/runtime_tools/doc/src/instrument.xml
+++ b/lib/runtime_tools/doc/src/instrument.xml
@@ -54,8 +54,8 @@
            that returned the histogram, and the last interval has no upper
            bound.</p>
         <p>For example, the histogram below has 40 (<c>message</c>) blocks
-           between 256-512 bytes in size, 78 blocks between 512-1024 bytes,2
-           blocks between 1-2KB, and 2 blocks between 2-4KB.</p>
+           between 128-256 bytes in size, 78 blocks between 256-512 bytes,2
+           blocks between 512-1024 bytes, and 2 blocks between 1-2KB.</p>
         <code type="none"><![CDATA[
 > instrument:allocations(#{ histogram_start => 128, histogram_width => 15 }).
 {ok, {128, 0, #{ message => {0,40,78,2,2,0,0,0,0,0,0,0,0,0,0}, ... } }}
@@ -78,6 +78,9 @@
           the responsiveness of the system, <c><anno>UnscannedSize</anno></c>
           is the number of bytes that had to be skipped.</p>
        </desc>
+    </datatype>
+    <datatype>
+      <name name="allocation_origin"/>
     </datatype>
     <datatype>
       <name name="carrier_info_list"/>
@@ -154,6 +157,12 @@
           <item>
             <p>The number of intervals in the allocated block size histograms.
               Defaults to 18.</p>
+          </item>
+          <tag><c>flags</c></tag>
+          <item>
+            <p>Controls how to group the output, for example showing
+              allocations on a per-process basis (when possible) rather than
+              only a NIF/driver-basis. Defaults to <c>[]</c>.</p>
           </item>
         </taglist>
         <p><em>Example:</em></p>

--- a/lib/runtime_tools/test/instrument_SUITE.erl
+++ b/lib/runtime_tools/test/instrument_SUITE.erl
@@ -65,9 +65,16 @@ allocations_test(Args, Plain, PerAlloc) ->
                                [fun instrument:allocations/1, PerAlloc]),
                  ok = rpc:call(Node, ?MODULE, test_format,
                                [#{ histogram_start => 512,
-                                   histogram_width => 4 },
+                                   histogram_width => 4,
+                                   flags => [] },
                                 fun instrument:allocations/1,
                                 fun verify_allocations_output/2]),
+                ok = rpc:call(Node, ?MODULE, test_format,
+                              [#{ histogram_start => 512,
+                                  histogram_width => 4,
+                                  flags => [per_process, per_port] },
+                               fun instrument:allocations/1,
+                               fun verify_allocations_output/2]),
                  ok = rpc:call(Node, ?MODULE, test_abort,
                                [fun erts_internal:gather_alloc_histograms/1])
              end).
@@ -113,10 +120,23 @@ verify_allocations_output(#{}, {ok, {_, _, Allocs}}) when Allocs =:= #{} ->
 verify_allocations_output(#{}, {error, not_enabled}) ->
     ok;
 verify_allocations_output(#{ histogram_start := HistStart,
-                             histogram_width := HistWidth },
+                             histogram_width := HistWidth,
+                             flags := Flags },
                     {ok, {HistStart, _UnscannedBytes, ByOrigin}}) ->
     AllHistograms = lists:flatten([maps:values(ByType) ||
                                    ByType <- maps:values(ByOrigin)]),
+
+    Origins = maps:keys(ByOrigin),
+
+    PerProcess = lists:member(per_process, Flags),
+    PerProcess = lists:any(fun(K) -> is_pid(K) end, Origins),
+
+    PerPort = lists:member(per_port, Flags),
+    PerPort = lists:any(fun(K) -> is_port(K) end, Origins),
+
+    true = lists:all(fun(K) ->
+                             is_pid(K) or is_port(K) or is_atom(K)
+                     end, Origins),
 
     %% Do the histograms look alright?
     HistogramSet = ordsets:from_list(AllHistograms),
@@ -277,7 +297,7 @@ test_abort(Gather) ->
     spawn_opt(fun() ->
                       [begin
                            Ref2 = make_ref(),
-                           [Gather({Type, SchedId, 1, 1, Ref2}) ||
+                           [Gather({Type, SchedId, 1, 1, 0, Ref2}) ||
                                Type <- erlang:system_info(alloc_util_allocators),
                                SchedId <- lists:seq(0, erlang:system_info(schedulers))]
                        end || _ <- lists:seq(1,100)],


### PR DESCRIPTION
This PR extends the allocation tagging feature with support for tracking allocations on a per-process/port level, as well as another mode (disabling the former) that tracks them on a per-MFA level when the JIT is enabled.

```
$ erl +Muatags true
1> instrument:allocations(#{ flags => [per_process] }).
{ok,{128,0,
     #{
       %% Registered processes are shown under their registered name
       init =>
           #{binary => {0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             link => {6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             proc => {0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             reg_proc => {1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             fun_tab => {0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0},
             atom_entry => {1084,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             module_entry => {0,112,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             fun_entry => {0,54,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             module_tab => {0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0},
             export_tab => {0,0,0,0,0,0,0,6,0,0,0,0,0,0,0,0,0,0},
             export_entry => {0,280,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             heap => {0,0,0,0,2,0,1,0,0,0,0,0,0,0,0,0,0,0},
             old_heap => {0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0},
             nif_internal => {0,5,6,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             driver_mutex => {2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},

      %% Unregistered processes are shown with their plain pids
      <0.85.0> =>
           #{binary => {0,0,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             link => {4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             proc => {0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             proc_dict => {1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             process_specific_data =>
                 {1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             atom_entry => {234,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             export_entry => {0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             heap => {0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0},
             old_heap => {0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0},
             db_tab => {0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             db_stack => {0,0,0,2,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             magic_indirection => {3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},

       %% snip
       }}

# This is only available with the JIT. Skipping the per_mfa option
# will display everything on a per-module basis instead, which is
# far less chatty.
$ erl +Muatags code
1> instrument:allocations(#{ flags => [per_mfa] }).
{ok,{128,0,
     #{
       {code,where_is_file,4} =>
           #{heap => {0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0}},
       {beam_lib,chunk_to_data,6} =>
           #{atom_entry => {47,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},
       {prim_socket,on_load,1} =>
           #{proc => {0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             atom_entry => {343,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             heap => {0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0},
             nif_internal => {0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             driver_mutex => {2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},
       {prim_tty,tty_select,3} =>
           #{message => {0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             monitor_extended => {0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             enif_select_data_state =>
                 {2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},
       {gen,register_name,1} =>
           #{reg_proc => {14,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
             reg_tab => {0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},
       {user_sup,wait_for_user_p,1} =>
           #{link => {2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},
       {application_controller,maybe_load_application,2} =>
           #{old_heap => {0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0}},
       {inet_db,init_timer,0} =>
           #{bif_timer => {0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}},

       %% snip
       }}
```