### PR TITLE
Make ets:tab2file always truncate file

### DIFF
--- a/lib/kernel/doc/src/disk_log.xml
+++ b/lib/kernel/doc/src/disk_log.xml
@@ -780,8 +780,8 @@
               no automatic repair is attempted. Instead, the
               tuple <c>{error, {need_repair, <anno>Log</anno>}}</c> is returned if an
               attempt is made to open a corrupt log file. 
-              If <c>truncate</c> is specified, the log file becomes
-              truncated, creating an empty log. Defaults to
+              If <c>truncate</c> is specified, the log file becomes truncated,
+	      creating an empty log, regardless of previous content. Defaults to
               <c>true</c>, which has no effect on logs opened in 
               read-only mode.
               </p>

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -812,7 +812,8 @@ tab2file(Table, File, Options) ->
 	    _ -> throw(eaccess)
 	end,
 	Name = make_ref(),
-	case disk_log:open([{name, Name}, {file, File}]) of
+	case disk_log:open([{name, Name}, {file, File},
+                            {repair, truncate}]) of
 	    {ok, Name} ->
 		ok;
 	    {error, Reason} ->


### PR DESCRIPTION
to avoid `{repaired, ...}` returned from disk_log:open if raced by concurrent file creator.

Fix #7162.
