### PR TITLE
kernel, stdlib, ssh: fix multiline editing bugs

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -522,6 +522,8 @@ get_chars_apply(Pbs, M, F, Xa, Drv, Shell, Buf, State0, LineCont, Encoding) ->
         {stop,Result,eof} ->
             {ok,Result,eof};
         {stop,Result,Rest} ->
+            %% Prompt was valid expression, clear the prompt in user_drv
+            send_drv_reqs(Drv, [new_prompt]),
             _ = case {M,F} of
                     {io_lib, get_until} ->
                         save_line_buffer(string:trim(Line, both)++"\n", get_lines(new_stack(get(line_buffer))));
@@ -696,12 +698,12 @@ get_line1({Expand, Before, Cs0, Cont,Rs}, Drv, Shell, Ls0, Encoding)
                                      _ ->
                                          %% If there are more results than fit on
                                          %% screen we expand above
-                                         send_drv_reqs(Drv, [{put_chars_keep_state, unicode, NlMatchStr},redraw_prompt]),
+                                         send_drv_reqs(Drv, [{put_chars, unicode, NlMatchStr}]),
                                          [$\e, $l | Cs1]
                                  end
                          end;
                      false ->
-                         send_drv(Drv, {put_chars_keep_state, unicode, NlMatchStr}),
+                         send_drv(Drv, {put_chars, unicode, NlMatchStr}),
                          [$\e, $l | Cs1]
                  end
          end,
@@ -772,7 +774,7 @@ get_line1({What,{line,Prompt,{_,{RevCmd0,_},_},search},_Rs},
                              send_drv(Drv, beep),
                              put(search_result, []),
                              send_drv(Drv, delete_line),
-                             send_drv(Drv, {put_chars, unicode, unicode:characters_to_binary(Prompt++Cmd)}),
+                             send_drv(Drv, {insert_chars, unicode, unicode:characters_to_binary(Prompt++Cmd)}),
                              {Ls2, {[],{RevCmd, []},[]}};
                          {Line, Ls2} -> % found. Complete the output edlin couldn't have done.
                              Lines = string:split(string:to_graphemes(Line), "\n", all),
@@ -784,7 +786,7 @@ get_line1({What,{line,Prompt,{_,{RevCmd0,_},_},search},_Rs},
                                       end,
                              put(search_result, Lines),
                              send_drv(Drv, delete_line),
-                             send_drv(Drv, {put_chars, unicode, unicode:characters_to_binary(Prompt++Cmd)}),
+                             send_drv(Drv, {insert_chars, unicode, unicode:characters_to_binary(Prompt++Cmd)}),
                              send_drv(Drv, {put_expand_no_trim, unicode, unicode:characters_to_binary(Output)}),
                              {Ls2, {[],{RevCmd, []},[]}}
                      end,
@@ -854,7 +856,7 @@ get_line_echo_off1({Chars,Rest}, _Drv, _Shell) ->
     {done,lists:reverse(Chars),case Rest of done -> []; _ -> Rest end}.
 
 get_chars_echo_off(Pbs, Drv, Shell) ->
-    send_drv_reqs(Drv, [{put_chars, unicode,Pbs}]),
+    send_drv_reqs(Drv, [{insert_chars, unicode,Pbs}]),
     get_chars_echo_off1(Drv, Shell).
 
 get_chars_echo_off1(Drv, Shell) ->
@@ -1027,7 +1029,7 @@ get_password1({Chars,[]}, Drv, Shell) ->
 	    exit(R)
     end;
 get_password1({Chars,Rest},Drv,_Shell) ->
-    send_drv_reqs(Drv,[{put_chars, unicode, "\n"}]),
+    send_drv_reqs(Drv,[{insert_chars, unicode, "\n"}]),
     {done,lists:reverse(Chars),case Rest of done -> []; _ -> Rest end}.
 
 edit_password([],Chars) ->

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -555,7 +555,7 @@ handle_request(State, {redraw_prompt, Pbs, Pbs2, {LB, {Bef, Aft}, LA}}) ->
     Text = Pbs ++ lists:flatten(lists:join("\n"++Pbs2, lists:reverse(LB)++[CL|LA])),
     Moves = if LA /= [] ->
                     [Last|_] = lists:reverse(LA),
-                    {move_combo, -logical(Last), length(LA), logical(Bef)};
+                    {move_combo, -logical(Last), -length(LA), logical(Bef)};
                true ->
                     {move, -logical(Aft)}
             end,

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -542,6 +542,8 @@ handle_request(State = #state{ options = #{ tty := false } }, Request) ->
             {Binary, State};
         {putc, Binary} ->
             {encode(Binary, State#state.unicode), State};
+        {insert, Binary} ->
+            {encode(Binary, State#state.unicode), State};
         beep ->
             {<<7>>, State};
         _Ignore ->

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -46,15 +46,14 @@
         %%   `{DrvPid :: pid(), set_unicode_state, SupportedUnicode :: boolean()}`
         {Sender :: pid(), set_unicode_state, boolean()}.
 -type request() ::
-        %% Put characters at current cursor position,
-        %% overwriting any characters it encounters.
+        %% Put characters above the prompt
         {put_chars, unicode, binary()} |
         %% Same as put_chars/3, but sends Reply to From when the characters are
         %% guaranteed to have been written to the terminal
         {put_chars_sync, unicode, binary(), {From :: pid(), Reply :: term()}} |
         %% Put text in expansion area
-        {put_expand} |
-        {put_expand_no_trim} |
+        {put_expand, unicode, binary()} |
+        {put_expand_no_trim,  unicode, binary()} |
         %% Move the cursor X characters left or right (negative is left)
         {move_rel, -32768..32767} |
         %% Move the cursor Y rows up or down (negative is up)
@@ -64,6 +63,9 @@
         %% Insert characters at current cursor position moving any
         %% characters after the cursor.
         {insert_chars, unicode, binary()} |
+        %% Put characters at current cursor position,
+        %% overwriting any characters it encounters.
+        {insert_chars_over, unicode, binary()} |
         %% Delete X chars before or after the cursor adjusting any test remaining
         %% to the right of the cursor.
         {delete_chars, -32768..32767} |
@@ -785,8 +787,6 @@ io_request(delete_after_cursor, TTY) ->
     write(prim_tty:handle_request(TTY, delete_after_cursor));
 io_request(delete_line, TTY) ->
     write(prim_tty:handle_request(TTY, delete_line));
-io_request({put_chars_keep_state, unicode, Chars}, TTY) ->
-    write(prim_tty:handle_request(TTY, {putc_keep_state, unicode:characters_to_binary(Chars)}));
 io_request({put_chars, unicode, Chars}, TTY) ->
     write(prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars)}));
 io_request({put_chars_sync, unicode, Chars, Reply}, TTY) ->
@@ -809,6 +809,8 @@ io_request({move_combo, V1, R, V2}, TTY) ->
     write(prim_tty:handle_request(TTY, {move_combo, V1, R, V2}));
 io_request({insert_chars, unicode, Chars}, TTY) ->
     write(prim_tty:handle_request(TTY, {insert, unicode:characters_to_binary(Chars)}));
+io_request({insert_chars_over, unicode, Chars}, TTY) ->
+    write(prim_tty:handle_request(TTY, {insert_over, unicode:characters_to_binary(Chars)}));
 io_request({delete_chars, N}, TTY) ->
     write(prim_tty:handle_request(TTY, {delete, N}));
 io_request(clear, TTY) ->

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -56,6 +56,7 @@
          shell_expand_location_above/1,
          shell_expand_location_below/1,
          shell_update_window_unicode_wrap/1,
+         shell_receive_standard_out/1,
          shell_standard_error_nlcr/1, shell_clear/1,
          remsh_basic/1, remsh_error/1, remsh_longnames/1, remsh_no_epmd/1,
          remsh_expand_compatibility_25/1, remsh_expand_compatibility_later_version/1,
@@ -128,6 +129,7 @@ groups() ->
        shell_transpose, shell_search, shell_insert,
        shell_update_window, shell_small_window_multiline_navigation, shell_huge_input,
        shell_support_ansi_input,
+       shell_receive_standard_out,
        shell_standard_error_nlcr,
        shell_expand_location_above,
        shell_expand_location_below,
@@ -929,7 +931,17 @@ shell_huge_input(Config) ->
     after
         stop_tty(Term)
     end.
-
+shell_receive_standard_out(Config) ->
+    Term = start_tty(Config),
+    try
+        send_tty(Term,"my_fun(5) -> ok; my_fun(N) -> receive after 100 -> io:format(\"~p\\n\", [N]), my_fun(N+1) end.\n"),
+        send_tty(Term, "spawn(shell_default, my_fun, [0]). ABC\n"),
+        timer:sleep(1000),
+        check_content(Term, "3\\s+4\\s+.+>\\sABC\\s+..\\s"),
+        ok
+    after
+        stop_tty(Term)
+    end.
 %% Test that the shell works when invalid utf-8 (aka latin1) is sent to it
 shell_invalid_unicode(Config) ->
     Term = start_tty(Config),
@@ -1071,8 +1083,8 @@ shell_expand_location_below(Config) ->
         send_stdin(Term, "\t"),
         %% The expansion does not fit on screen, verify that
         %% expand above mode is used
-        check_content(fun() -> get_content(Term, "-S -7") end,
-                      "3> long_module:" ++ FunctionName ++ "\nfunctions"),
+        check_content(fun() -> get_content(Term, "-S -5") end,
+                      "\nfunctions\n"),
         check_content(Term, "3> long_module:" ++ FunctionName ++ "$"),
 
         %% We resize the terminal to make everything fit and test that

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -456,10 +456,12 @@ shell_multiline_navigation(Config) ->
              check_location(Term, {0,0}),
              send_tty(Term,"C-h"), % Backspace
              check_location(Term, {-1,width("ccc}")}),
+             send_tty(Term, "C-Up"),
+             send_tty(Term, "End"),
              send_tty(Term,"Left"),
              send_tty(Term,"M-Enter"),
-             send_tty(Term,"Right"),
-             check_location(Term, {0,1}),
+             check_content(Term, ".. ,"),
+             check_location(Term, {-1,0}),
              send_tty(Term,"M-c"),
              check_location(Term, {-3,0}),
              send_tty(Term,"{'"++U++"',\n\n\nworks}.\n")
@@ -913,6 +915,8 @@ shell_small_window_multiline_navigation(Config) ->
         check_content(Term,"is_element"),
         check_content(Term,"is_empty"),
         check_location(Term, {-4, 9}),
+        send_tty(Term, "M-Enter"),
+        check_location(Term, {-1, 0}),
         ok
     after
         stop_tty(Term)

--- a/lib/ssh/test/ssh_basic_SUITE.erl
+++ b/lib/ssh/test/ssh_basic_SUITE.erl
@@ -1584,7 +1584,8 @@ new_do_shell(IO, N, Ops=[{Order,Arg}|More]) ->
 		    ct:log("Matched echo ~ts",[RecStr]),
 		    new_do_shell(IO, N, More);
 		false ->
-		    ct:fail("*** Expected ~p, but got ~p",[string:strip(ExpStr),RecStr])
+		    ct:log("*** Expected ~p, but got ~p",[string:strip(ExpStr),RecStr]),
+            new_do_shell(IO, N, Ops)
 	    end
     after 30000 ->
 	    ct:log("Message queue of ~p:~n~p",

--- a/lib/ssh/test/ssh_test_lib.erl
+++ b/lib/ssh/test/ssh_test_lib.erl
@@ -484,7 +484,7 @@ receive_exec_result(Msgs) when is_list(Msgs) ->
                             receive_exec_result(Msgs);
                         Other ->
                             ct:log("~p:~p unexpected Other ~p", [?MODULE,?FUNCTION_NAME,Other]),
-                            {unexpected_msg, Other}
+                            receive_exec_result(Msgs)
                     end
             end
     after 


### PR DESCRIPTION
Output stdout while editing a prompt in the shell, output appears above the prompt.
Support multiline editing when interacting with the erlang ssh daemon.
Plus a couple of other minor bugs.

Fixes the issues seen in #7312, #7263, #7318