### PR TITLE
Default -code_path_choice to strict

### DIFF
--- a/erts/doc/src/init.xml
+++ b/erts/doc/src/init.xml
@@ -243,8 +243,7 @@
       <p>The support for loading of code from archive files is
         experimental. The only purpose of releasing it before it is ready
 	is to obtain early feedback. The file format, semantics,
-	interfaces, and so on, can  be changed in a future release. The
-        <c>-code_path_choice</c> flag is also experimental.</p>
+	interfaces, and so on, can  be changed in a future release.</p>
     </warning>
 
     <p>The <c>init</c> module interprets the following command-line flags:</p>
@@ -271,13 +270,8 @@
               and an <c>ebin</c> directory in an archive file.</p>
           </item>
         </list>
-        <p>This flag is particular
-          useful when you want to elaborate with code loading from
-          archives without editing the <c>boot script</c>. For more
-          information about interpretation of boot scripts, see
-          <seefile marker="sasl:script"><c>script(4)</c></seefile>.
-          The flag has also a similar effect on how the code server works; see
-          <seeerl marker="kernel:code"><c>code(3)</c></seeerl>.</p>
+            <p>It defaults to <c>strict</c> from OTP 27 and this option
+              is scheduled for removal in OTP 28.</p>
       </item>
       <tag><c>-epmd_module Module</c></tag>
       <item>

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -303,7 +303,7 @@ code_path_choice() ->
 	{ok,[["relaxed"]]} ->
 	    relaxed;
 	_Else ->
-	    relaxed
+	    strict
     end.
 
 boot(Start,Flags,Args) ->

--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -233,7 +233,8 @@ zip:create("mnesia-4.4.7.ez",
      script</c> can be <c>strict</c> or <c>relaxed</c>. It is
      particularly useful to set the flag to <c>relaxed</c> when
      elaborating with code loading from archives without editing the
-     <c>boot script</c>. The default is <c>relaxed</c>. See <seeerl
+     <c>boot script</c>. The default has changed to <c>strict</c>
+     in OTP 27 and the option is scheduled for removal in OTP 28. See <seeerl
      marker="erts:init"><c>erts:init(3)</c></seeerl>.</p></section>
 
   <section>


### PR DESCRIPTION
This option requires traversing the loadpaths
several times and doing multiple filesystem
lookups during boot.

This was previously scheduled for Erlang/OTP 26
but it was postponed as there was a need for a longer
deprecation cycle.

Revival of #6683. Follow up of #7117.

PS: Please remember to update the bootscripts on merge. :)