### PR TITLE
Remove archives fallback

### DIFF
--- a/lib/kernel/doc/src/code.xml
+++ b/lib/kernel/doc/src/code.xml
@@ -174,34 +174,6 @@ zip:create("mnesia-4.4.7.ez",
      would list the contents of a directory inside an archive.
      See <seeerl marker="erts:erl_prim_loader"><c>erl_prim_loader(3)</c></seeerl>.</p>
 
-    <p>An application archive file and a regular application directory
-     can coexist. This can be useful when it is needed to have
-     parts of the application as regular files. A typical case is the
-     <c>priv</c> directory, which must reside as a regular directory
-     to link in drivers dynamically and start port programs.
-     For other applications that do not need this, directory
-     <c>priv</c> can reside in the archive and the files
-     under the directory <c>priv</c> can be read through
-     <c>erl_prim_loader</c>.</p>
-
-    <p>When a directory is added to the code path and
-     when the entire code path is (re)set, the code server
-     decides which subdirectories in an application that are to be
-     read from the archive and which that are to be read as regular
-     files. If directories are added or removed afterwards, the file
-     access can fail if the code path is not updated (possibly to the
-     same path as before, to trigger the directory resolution
-     update).</p>
-
-     <p>For each directory on the second level in the application archive
-     (<c>ebin</c>, <c>priv</c>, <c>src</c>, and so on), the code server first
-     chooses the regular directory if it exists and second from the
-     archive. Function <c>code:lib_dir/2</c> returns the path to the
-     subdirectory. For example, <c>code:lib_dir(megaco,ebin)</c> can return
-     <c>/otp/root/lib/megaco-3.9.1.1.ez/megaco-3.9.1.1/ebin</c> while
-     <c>code:lib_dir(megaco,priv)</c> can return
-     <c>/otp/root/lib/megaco-3.9.1.1/priv</c>.</p>
-
     <p>When an <c>escript</c> file contains an archive, there are
      no restrictions on the name of the <c>escript</c> and no restrictions
      on how many applications that can be stored in the embedded

--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -807,7 +807,7 @@ create_namedb(Path, Root) ->
     init_namedb(lists:reverse(Path), Db),
 
     case lookup_name("erts", Db) of
-        {ok, _, _, _} ->
+        {ok, _} ->
             %% erts is part of code path
             ok;
         false ->
@@ -855,33 +855,8 @@ insert_name(Name, Dir, Db) ->
     do_insert_name(Name, AppDir, Db).
 
 do_insert_name(Name, AppDir, Db) ->
-    {Base, SubDirs} = archive_subdirs(AppDir),
-    ets:insert(Db, {Name, AppDir, Base, SubDirs}),
+    ets:insert(Db, {Name, AppDir}),
     true.
-
-archive_subdirs(AppDir) ->
-    Base = filename:basename(AppDir),
-    Dirs = case split_base(Base) of
-	       {Name, _} -> [Name, Base];
-	    _ -> [Base]
-	end,
-    Ext = archive_extension(),
-    try_archive_subdirs(AppDir ++ Ext, Base, Dirs).
-
-try_archive_subdirs(Archive, Base, [Dir | Dirs]) ->
-    ArchiveDir = filename:append(Archive, Dir),
-    case erl_prim_loader:list_dir(ArchiveDir) of
-	{ok, Files} ->
-	    IsDir = fun(RelFile) ->
-			    File = filename:append(ArchiveDir, RelFile),
-			    is_dir(File)
-		    end,
-	    {Dir, lists:filter(IsDir, Files)};
-	_ ->
-	    try_archive_subdirs(Archive, Base, Dirs)
-    end;
-try_archive_subdirs(_Archive, Base, []) ->
-    {Base, []}.
 
 %%
 %% Delete a directory from Path.
@@ -972,21 +947,7 @@ del_ebin(Dir) ->
     filename:join(del_ebin_1(filename:split(Dir))).
 
 del_ebin_1([Parent,App,"ebin"]) ->
-    case filename:basename(Parent) of
-	[] ->
-	    %% Parent is the root directory
-	    [Parent,App];
-	_ ->
-	    Ext = archive_extension(),
-	    case filename:basename(Parent, Ext) of
-		Parent ->
-		    %% Plain directory.
-		    [Parent,App];
-		Archive ->
-		    %% Archive.
-		    [Archive]
-	    end
-    end;
+    [Parent,App];
 del_ebin_1(Path = [_App,"ebin"]) ->
     del_ebin_1(filename:split(absname(filename:join(Path))));
 del_ebin_1(["ebin"]) ->
@@ -1014,7 +975,7 @@ delete_name_dir(Dir, Db) ->
 	Name ->
 	    Dir0 = del_ebin(Dir),
 	    case lookup_name(Name, Db) of
-		{ok, Dir0, _Base, _SubDirs} ->
+		{ok, Dir0} ->
 		    ets:delete(Db, Name), 
 		    true;
 		_ -> false
@@ -1023,7 +984,7 @@ delete_name_dir(Dir, Db) ->
 
 lookup_name(Name, Db) ->
     case ets:lookup(Db, Name) of
-	[{Name, Dir, Base, SubDirs}] -> {ok, Dir, Base, SubDirs};
+	[{Name, Dir}] -> {ok, Dir};
 	_ -> false
     end.
 
@@ -1036,28 +997,19 @@ do_dir(Root,root_dir,_) ->
     Root;
 do_dir(_Root,compiler_dir,NameDb) ->
     case lookup_name("compiler", NameDb) of
-	{ok, Dir, _Base, _SubDirs} -> Dir;
+	{ok, Dir} -> Dir;
 	_  -> ""
     end;
 do_dir(_Root,{lib_dir,Name},NameDb) ->
     case catch lookup_name(to_list(Name), NameDb) of
-	{ok, Dir, _Base, _SubDirs} -> Dir;
+	{ok, Dir} -> Dir;
 	_         -> {error, bad_name}
     end;
 do_dir(_Root,{lib_dir,Name,SubDir0},NameDb) ->
     SubDir = atom_to_list(SubDir0),
     case catch lookup_name(to_list(Name), NameDb) of
-	{ok, Dir, Base, SubDirs} ->
-	    case lists:member(SubDir, SubDirs) of
-		true ->
-		    %% Subdir is in archive
-		    filename:join([Dir ++ archive_extension(),
-				   Base,
-				   SubDir]);
-		false ->
-		    %% Subdir is regular directory
-		    filename:join([Dir, SubDir])
-	    end;
+	{ok, Dir} ->
+	    filename:join([Dir, SubDir]);
 	_  -> 
 	    {error, bad_name}
     end;

--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -1206,12 +1206,6 @@ do_code_archive(Config, Root, StripVsn) when is_list(Config) ->
     {ok, _} = zip:create(Archive, [Base],
 			       [{compress, []}, {cwd, PrivDir}]),
 
-    %% Create a directory and a file outside of the archive.
-    OtherFile = filename:join([RootDir,VsnBase,"other","other.txt"]),
-    OtherContents = ?MODULE:module_info(md5),
-    filelib:ensure_dir(OtherFile),
-    ok = file:write_file(OtherFile, OtherContents),
-
     %% Set up ERL_LIBS and start a peer node.
     {ok, Peer, Node} = ?CT_PEER(["-env", "ERL_LIBS", RootDir]),
     CodePath = rpc:call(Node, code, get_path, []),
@@ -1227,7 +1221,7 @@ do_code_archive(Config, Root, StripVsn) when is_list(Config) ->
     %% Get the lib dir for the app.
     AppLibDir = rpc:call(Node, code, lib_dir, [App]),
     io:format("AppLibDir: ~p\n", [AppLibDir]),
-    AppLibDir = filename:join(RootDir, VsnBase),
+    AppLibDir = filename:join(Archive, Base),
 
     %% Access the app priv dir
     AppPrivDir = rpc:call(Node, code, priv_dir, [App]),
@@ -1235,13 +1229,6 @@ do_code_archive(Config, Root, StripVsn) when is_list(Config) ->
     io:format("AppPrivFile: ~p\n", [AppPrivFile]),
     {ok, _Bin, _} =
 	rpc:call(Node, erl_prim_loader, get_file, [AppPrivFile]),
-
-    %% Read back the other text file.
-    OtherDirPath = rpc:call(Node, code, lib_dir, [App,other]),
-    OtherFilePath = filename:join(OtherDirPath, "other.txt"),
-    io:format("OtherFilePath: ~p\n", [OtherFilePath]),
-    {ok, OtherContents, _} =
-	rpc:call(Node, erl_prim_loader, get_file, [OtherFilePath]),
 
     %% Use the app
     Tab = code_archive_tab,


### PR DESCRIPTION
Archives have a feature where both the archive directory and the application directory can co-exist and the contents of the archive will be read as a fallback. This pull request removes this feature as it is implicit behaviour and has a direct impact on each code path added to the code server with two additional file system lookups per code path.

Instead, the correct path must be given to -pa/-pz, and everything will continue to work as before. This pull request does not change anything in relation to escripts.

Revival of #6693. Follow up of #7117.