### PR TITLE
Fix a bug that prim_socket:cancel/3 could return `{error, select_sent|not_found}` while socket module expects `select_sent|not_found`

### DIFF
--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -10134,7 +10134,7 @@ ERL_NIF_TERM esock_cancel_mode_select(ErlNifEnv*       env,
             return esock_atom_ok;
         } else {
             /* Has already sent the message */
-            return esock_make_error(env, esock_atom_select_sent);
+            return esock_atom_select_sent;
         }
     } else {
         /* Stopped? */
@@ -10143,7 +10143,7 @@ ERL_NIF_TERM esock_cancel_mode_select(ErlNifEnv*       env,
                 "esock_cancel_mode_select {%d} -> failed: %d (0x%lX)"
                 "\r\n", descP->sock, selectRes, selectRes) );
 
-        return esock_make_error(env, esock_atom_not_found);
+        return esock_atom_not_found;
     }
 }
 #endif // #ifndef __WIN32__


### PR DESCRIPTION
The return value of `prim_socket:cancel/3` changed in https://github.com/erlang/otp/commit/640c4a52c806d5a080f7e327d53cb8c6f022b4b0 from `select_sent|not_found` to `{error, select_sent|not_found}`. 
However, `socket` module keeps expecting that `prim_socket:cancel/3` returns `select_sent|not_found` (without `{error, _}`) as following code:

```erlang
%% From: https://github.com/erlang/otp/blob/OTP-26.0/lib/kernel/src/socket.erl#L4595-L4603
cancel(SockRef, Op, Handle) ->                                                                                                                                                                                
    case prim_socket:cancel(SockRef, Op, Handle) of                                                                                                                                                                             
        select_sent ->                                                                                                                                                                                                          
            _ = flush_select_msg(SockRef, Handle),                                                                                                                                                                              
            _ = flush_abort_msg(SockRef, Handle),                                                                                                                                                                               
            ok;                                                                                                                                                                                                                 
        not_found ->                                                                                                                                                                                                            
            _ = flush_completion_msg(SockRef, Handle),                                                                                                                                                                          
            _ = flush_abort_msg(SockRef, Handle),                                                                                                                                                                               
            invalid;   
```

This is the cause of the process crash reported in #7165.
This PR fixes this problem by reverting the changes in priim_socket_nif.c. 
