### PR TITLE
Always consider 'maybe' and 'else' as keywords in epp_dodger

### DIFF
--- a/lib/edoc/test/edoc_SUITE.erl
+++ b/lib/edoc/test/edoc_SUITE.erl
@@ -25,7 +25,7 @@
 %% Test cases
 -export([app/1,appup/1,build_std/1,build_map_module/1,otp_12008/1,
          build_app/1, otp_14285/1, infer_module_app_test/1,
-         module_with_feature/1]).
+         module_with_feature/1, module_with_maybe/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -165,6 +165,16 @@ module_with_feature(Config) ->
     DataDir = ?config(data_dir, Config),
     PrivDir = ?config(priv_dir, Config),
     Source = filename:join(DataDir, "module_with_feature.erl"),
+    DodgerOpts = [{dir, PrivDir}],
+    ok = edoc:files([Source], DodgerOpts),
+    PreprocessOpts = [{preprocess, true}, {dir, PrivDir}],
+    ok = edoc:files([Source], PreprocessOpts),
+    ok.
+
+module_with_maybe(Config) ->
+    DataDir = ?config(data_dir, Config),
+    PrivDir = ?config(priv_dir, Config),
+    Source = filename:join(DataDir, "module_with_maybe.erl"),
     DodgerOpts = [{dir, PrivDir}],
     ok = edoc:files([Source], DodgerOpts),
     PreprocessOpts = [{preprocess, true}, {dir, PrivDir}],

--- a/lib/syntax_tools/src/epp_dodger.erl
+++ b/lib/syntax_tools/src/epp_dodger.erl
@@ -434,8 +434,7 @@ parse_form(Dev, L0, Parser, Options) ->
     %% This as the *potential* to read options for enabling/disabling
     %% features for the parsing of the file.
     {ok, {_Ftrs, ResWordFun}} =
-        erl_features:keyword_fun(Options,
-                                 fun erl_scan:f_reserved_word/1),
+        erl_features:keyword_fun(Options, fun reserved_word/1),
 
     case io:scan_erl_form(Dev, "", L0, [{reserved_word_fun,ResWordFun}]) of
         {ok, Ts, L1} ->
@@ -932,3 +931,11 @@ errormsg(String) ->
 
 
 %% =====================================================================
+
+%% See #7266: The dodger currently does not process feature attributes
+%% correctly, so temporarily consider the `else` and `maybe` atoms
+%% always as keywords
+-spec reserved_word(Atom :: atom()) -> boolean().
+reserved_word('else') -> true;
+reserved_word('maybe') -> true;
+reserved_word(Atom) -> erl_scan:f_reserved_word(Atom).


### PR DESCRIPTION
This PR adds a testcase that highlights the issue in #7266 and provides a temporary fix. A proper solution would be to process the feature attributes in the dodger.