### PR TITLE
ssl: Improve format_error/1

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2752,16 +2752,34 @@ do_format_error(closed) ->
     "TLS connection is closed";
 do_format_error({tls_alert, {_, Description}}) ->
     Description;
-do_format_error({options,{FileType, File, Reason}}) when FileType == cacertfile;
-						      FileType == certfile;
-                                                         FileType == keyfile;
-						      FileType == dhfile ->
+do_format_error({options,{FileType, File, Reason}})
+  when FileType == cacertfile;
+       FileType == certfile;
+       FileType == keyfile;
+       FileType == dhfile ->
     Error = file_error_format(Reason),
     file_desc(FileType) ++ File ++ ": " ++ Error;
 do_format_error ({options, {socket_options, Option, Error}}) ->
     lists:flatten(io_lib:format("Invalid transport socket option ~p: ~s", [Option, do_format_error(Error)]));
 do_format_error({options, {socket_options, Option}}) ->
     lists:flatten(io_lib:format("Invalid socket option: ~p", [Option]));
+do_format_error({options, incompatible, Opts}) ->
+    lists:flatten(io_lib:format("Options (or their values) can not be combined: ~p", [Opts]));
+do_format_error({option, Reason, Opts}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, Reason]));
+do_format_error({options, Reason, Opts}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, Reason]));
+do_format_error({options, {missing_version=R, Opts}}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, R]));
+do_format_error({options, {option_not_a_key_value_tuple=R, Opts}}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, R]));
+do_format_error({options, {no_supported_algorithms=R, Opts}}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, R]));
+do_format_error({options, {no_supported_signature_schemes=R, Opts}}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, R]));
+do_format_error({options, {insufficient_crypto_support=R, Opts}}) ->
+    lists:flatten(io_lib:format("Invalid option ~w ~w", [Opts, R]));
+
 do_format_error({options, Options}) ->
     lists:flatten(io_lib:format("Invalid TLS option: ~p", [Options]));
 


### PR DESCRIPTION
Convert more (and new) option tuples to error strings.

Fixes #7247 