### PR TITLE
ssl:negotiated_protocol can return {error,closed}

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -999,7 +999,7 @@ peercert(#sslsocket{pid = {_Listen, #config{}}}) ->
 -spec negotiated_protocol(SslSocket) -> {ok, Protocol} | {error, Reason} when
       SslSocket :: sslsocket(),
       Protocol :: binary(),
-      Reason :: protocol_not_negotiated.
+      Reason :: protocol_not_negotiated | closed.
 %%
 %% Description: Returns the protocol that has been negotiated. If no
 %% protocol has been negotiated will return {error, protocol_not_negotiated}


### PR DESCRIPTION
The function ssl_gen_statem:call/2 will return `{error,closed}` when the process is not alive.

https://github.com/erlang/otp/blob/master/lib/ssl/src/ssl_gen_statem.erl#L1318-L1329

Related: https://github.com/ninenines/gun/issues/313