### PR TITLE
Fix shell:start_interactive/1 spec

### DIFF
--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -58,11 +58,11 @@ non_local_allowed(_,_,State) ->
 -spec start_interactive() -> ok | {error, already_started}.
 start_interactive() ->
     user_drv:start_shell().
--spec start_interactive(noshell | mfa()) ->
+-spec start_interactive(noshell | {module(), atom(), [term()]}) ->
           ok | {error, already_started};
                        ({remote, string()}) ->
           ok | {error, already_started | noconnection};
-                       ({node(), mfa()} | {remote, string(), mfa()}) ->
+                       ({node(), {module(), atom(), [term()]}} | {remote, string(), {module(), atom(), [term()]}}) ->
           ok | {error, already_started | noconnection | badfile | nofile | on_load_failure}.
 start_interactive({Node, {M, F, A}}) ->
     user_drv:start_shell(#{ initial_shell => {Node, M, F ,A} });


### PR DESCRIPTION
See also https://github.com/erlang/otp/pull/7063 and https://github.com/erlang/otp/blob/acedc250f06f02d534ba21b8ab1d84b3b830c50b/lib/kernel/src/user_drv.erl#L110-L113 (there `unicode:charlist()` is used instead of `string()` but I don't know what's more correct)