### PR TITLE
Use generator for existing atoms in `lists` property tests

### DIFF
--- a/lib/stdlib/test/lists_property_test_SUITE.erl
+++ b/lib/stdlib/test/lists_property_test_SUITE.erl
@@ -112,7 +112,6 @@ init_per_suite(Config) ->
     ct_property_test:init_per_suite(Config).
 
 end_per_suite(Config) ->
-    persistent_term:erase({lists_prop, random_atoms}),
     Config.
 
 do_proptest(Prop, Config) ->


### PR DESCRIPTION
The `atom()` generator of PropEr creates atoms from random strings, and is thereby prone to exhaust the atom limit. By extension, so are the generators containing the `atom()` generator, such as `any()` or `list()`.

The `lists` property test suite exhausted the atom limit at around 80 (of 107) properties, and we had to find a workaround by pre-generating a limited set of random atoms, store them in `persistent_term`, and a generator that subsequently took atoms only from this set instead of generating new ones.

This PR changes the custom atom generator again to not pre-generate anything but pick from the set of already existing atoms. This has the following benefits over the current version:
* no need to generate and store (and remember to delete) anything, as everything is already there
* by using existing atoms, there is a greater likelihood of hitting anything than by simply random ones, as they at least have been written down at least _somewhere_

Unfortunately, there is no official way of getting at the existing atoms, so this has to rely on an obscure "trick" that somebody figured out at some point. For OTP-internal tests like this one, I think it is justifiable, though.