### PR TITLE
Document that NaN, +Inf, -Inf are not valid Erlang terms.

### DIFF
--- a/system/doc/reference_manual/data_types.xml
+++ b/system/doc/reference_manual/data_types.xml
@@ -132,6 +132,9 @@ exactly as floats.</p>
         then you should use a library that handles that or work in cents instead of euros so
         that you do not need decimal fractions.
       </p>
+      <p>Please also note that Erlang's floats do not exactly match IEEE 754 floats, in that neither Inf nor NaN are supported in Erlang.
+        Any operation that would result in NaN, +Inf, or -Inf, will instead raise a <c>badarith</c> exception.
+      </p>
     </section>
   </section>
 
@@ -568,4 +571,3 @@ hello
 7.0</pre>
   </section>
 </chapter>
-


### PR DESCRIPTION
The only documentation I managed to find about those values in Erlang is an 11 years-old mailing list message by Sverker:
http://erlang.org/pipermail/erlang-questions/2012-February/064728.html.

This commit just copies that information into the official documentation.