### PR TITLE
Document performance reduction with QLC string handles

### DIFF
--- a/lib/stdlib/doc/src/qlc.xml
+++ b/lib/stdlib/doc/src/qlc.xml
@@ -1247,6 +1247,11 @@ ets:match_spec_run(
           <anno>Options</anno>, erl_eval:new_bindings())</c>.</p>
         <p>This function is probably mainly useful when called from
           outside of Erlang, for example from a driver written in C.</p>
+        <note>
+          <p>Query handles created this way may have worse
+            performance than when created directly via
+            <seemfa marker="#q/1"><c>q/1,2</c></seemfa>.</p>
+        </note>
       </desc>
     </func>
 


### PR DESCRIPTION
`qlc:string_to_handle` seems to have worse performance than `qlc:q` with the same input query, presumably because the parse transform is not optimizing `qlc:string_to_handle`.

Benchmarks that showcase this behaviour can be found here: https://elixirforum.com/t/performance-discrepancies-with-using-qlc-queries-written-in-erlang-and-elixir/