### PR TITLE
Return error if ssl is not started

### DIFF
--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -101,7 +101,7 @@ handle_sender_options(ErlDist, SpawnOpts) ->
 start_connection_tree(User, IsErlDist, SenderOpts, Role, ReceiverOpts) ->
     StartConnectionTree =
         fun() ->
-                case start_dyn_connection_sup(IsErlDist) of
+                try start_dyn_connection_sup(IsErlDist) of
                     {ok, DynSup} ->
                         case tls_dyn_connection_sup:start_child(DynSup, sender, SenderOpts) of
                             {ok, Sender} ->
@@ -119,6 +119,11 @@ start_connection_tree(User, IsErlDist, SenderOpts, Role, ReceiverOpts) ->
                         end;
                     {error, Error} ->
                         User ! {self(), Error}
+                catch exit:{noproc, _} ->
+                        User ! {self(), {error, ssl_not_started}};
+                      _:Reason:ST ->  %% Don't hang signal internal error
+                        ?SSL_LOG(notice, internal_error, [{error, Reason}, {stacktrace, ST}]),
+                        User ! {self(), {error, internal_error}}
                 end
         end,
     spawn(StartConnectionTree).

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -177,6 +177,8 @@
          server_options_negative_dependency_role/1,
          invalid_options_tls13/0,
          invalid_options_tls13/1,
+         ssl_not_started/0,
+         ssl_not_started/1,
          cookie/0,
          cookie/1,
 	 warn_verify_none/0,
@@ -315,6 +317,7 @@ gen_api_tests() ->
      options_not_proplist,
      invalid_options,
      cb_info,
+     ssl_not_started,
      log_alert,
      getstat,
      warn_verify_none,
@@ -2637,6 +2640,23 @@ invalid_options_tls13(Config) when is_list(Config) ->
                   end
           end,
     [Fun(Option, ErrorMsg, Type) || {Option, ErrorMsg, Type} <- TestOpts].
+
+
+ssl_not_started() ->
+    [{doc, "Test that an error is returned if ssl is not started"}].
+ssl_not_started(Config) when is_list(Config) ->
+    application:stop(ssl),
+    Protocol = proplists:get_value(protocol, Config, tls),
+    Version = proplists:get_value(version, Config),
+    Opts = [{verify, verify_none},
+            {versions, [Version]},
+            {protocol, Protocol}],
+    try
+        {error, ssl_not_started} = ssl:connect("localhost", 22, Opts)
+    after
+        ssl:start()
+    end,
+    ok.
 
 cookie() ->
     [{doc, "Test cookie extension in TLS 1.3"}].


### PR DESCRIPTION
It hanged since the supervisor re-write, need to catch errors when use spawn on the startup function.

Fixes #7297