### PR TITLE
Document loading httpd mime_types from file

### DIFF
--- a/lib/inets/doc/src/httpd.xml
+++ b/lib/inets/doc/src/httpd.xml
@@ -280,7 +280,13 @@
           1590. File suffixes are mapped to MIME types before file delivery.
           The mapping between file suffixes and MIME types can be specified
 	  in the property list.</p>
-	<p>Default is [{"html","text/html"},{"htm","text/html"}].</p>
+        <p>Mime types can also be read from a file. The file should contain
+          lines in the form <c>MediaType [Extensions...]</c>, such as
+          <c>text/html html htm</c>. To configure this, specify
+          the path to it, such as <c>{mime_types, "/etc/mime.types"}</c>.</p>
+        <p>If unset, <c>conf/mime.types</c> under <c>server_root</c>
+          will be used if it exists, otherwise, the default is
+          <c>[{"html","text/html"},{"htm","text/html"}]</c>.</p>
       </item>
 
       <tag><marker id="prop_mime_type"></marker>{mime_type, string()}</tag>


### PR DESCRIPTION
Re-reading this, a possible improvement could be trying to load mime types from `/etc/mime.types` as a fallback if it exists, as this seems to be the default location at least on Debian.

https://github.com/erlang/otp/blob/646be911ba326bfffd04042297389ebcb7753fa4/lib/inets/src/http_server/httpd_conf.erl#L347-L371