### PR TITLE
[dialyzer] Tolerate is_function/2 with invalid arity

### DIFF
--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -1998,7 +1998,7 @@ handle_guard_is_function(Guard, Map, Env, Eval, State) ->
 	case t_number_vals(ArityType, State#state.opaques) of
 	  unknown -> t_fun();
 	  Vals ->
-	    t_sup([t_fun(lists:duplicate(X, t_any()), t_any()) || X <- Vals])
+	    t_sup([t_fun(lists:duplicate(X, t_any()), t_any()) || X <- Vals, X >= 0, X =< 255])
 	end,
       FunType = t_inf(FunType0, FunTypeConstr, Opaques),
       case t_is_none(FunType) of

--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -1368,7 +1368,7 @@ get_bif_constr({erlang, is_function, 2}, Dst, [Fun, Arity], _State) ->
 		   ArityType = lookup_type(Arity, Map),
 		   case t_number_vals(ArityType) of
 		     unknown -> t_fun();
-		     Vals -> t_sup([t_fun(X, t_any()) || X <- Vals])
+		     Vals -> t_sup([t_fun(X, t_any()) || X <- Vals, X >= 0, X =< 255])
 		   end;
 		 false -> t_any()
 	       end

--- a/lib/dialyzer/test/small_SUITE_data/src/guards.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/guards.erl
@@ -145,6 +145,14 @@ t17(X) when #{x => X} ->
 t18(X) when <<X>> ->
     ok.
 
+%% Should give a warning, see https://github.com/erlang/otp/issues/7181
+t19() when is_function(ok, -9223372036854775808) ->
+    never.
+
+% Could give a warning, see the same link
+t20(X) ->
+    (is_function(ok, 9223372036854775807) andalso X) bor X.
+
 %% Coverage
 
 cover1() when 1 < 2; 1 > 2 ->


### PR DESCRIPTION
Fixes #7181.

Functions in Erlang have a max arity of 255 (see
https://www.erlang.org/doc/reference_manual/typespec.html), so `is_function(Foo, 999)` will always fail, and obviously no function can have negative arity so `is_function(Foo, -100)` will also always fail.

This patch just teaches dialyzer to deal with such obviously wrong code in a more graceful manner (i.e. without crashing).

I've tried putting the tests in a reasonable place, but there might be a better file for them to live in.