### PR TITLE
erts: Shrink and optimize funs (again)

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -1725,8 +1725,9 @@ call_fun(Process* p,    /* Current process. */
     code_ix = erts_active_code_ix();
     code_ptr = (funp->entry.disp)->addresses[code_ix];
 
-    if (ERTS_LIKELY(code_ptr != beam_unloaded_fun && funp->arity == arity)) {
-        for (int i = 0, num_free = funp->num_free; i < num_free; i++) {
+    if (ERTS_LIKELY(code_ptr != beam_unloaded_fun &&
+                    fun_arity(funp) == arity)) {
+        for (int i = 0, num_free = fun_num_free(funp); i < num_free; i++) {
             reg[i + arity] = funp->env[i];
         }
 
@@ -1765,7 +1766,7 @@ call_fun(Process* p,    /* Current process. */
             }
         }
 
-        if (funp->arity != arity) {
+        if (fun_arity(funp) != arity) {
             /* There is a fun defined, but the call has the wrong arity. */
             Eterm *hp = HAlloc(p, 3);
             p->freason = EXC_BADARITY;
@@ -1865,7 +1866,7 @@ is_function2(Eterm Term, Uint arity)
 {
     if (is_any_fun(Term)) {
         ErlFunThing *funp = (ErlFunThing*)fun_val(Term);
-        return funp->arity == arity;
+        return fun_arity(funp) == arity;
     }
 
     return 0;

--- a/erts/emulator/beam/copy.c
+++ b/erts/emulator/beam/copy.c
@@ -142,16 +142,16 @@ Uint size_object_x(Eterm obj, erts_literal_area_t *litopt)
                         const ErlFunThing* funp = (ErlFunThing*)fun_val(obj);
 
                         ASSERT(ERL_FUN_SIZE == (1 + thing_arityval(hdr)));
-                        sum += ERL_FUN_SIZE + funp->num_free;
+                        sum += ERL_FUN_SIZE + fun_num_free(funp);
 
-                        for (int i = 1; i < funp->num_free; i++) {
+                        for (int i = 1; i < fun_num_free(funp); i++) {
                             obj = funp->env[i];
                             if (!IS_CONST(obj)) {
                                 ESTACK_PUSH(s, obj);
                             }
                         }
 
-                        if (funp->num_free > 0) {
+                        if (fun_num_free(funp) > 0) {
                             obj = funp->env[0];
                             break;
                         }
@@ -396,9 +396,9 @@ Uint size_shared(Eterm obj)
                 const ErlFunThing* funp = (ErlFunThing *) ptr;
 
                 ASSERT(ERL_FUN_SIZE == (1 + thing_arityval(hdr)));
-                sum += ERL_FUN_SIZE + funp->num_free;
+                sum += ERL_FUN_SIZE + fun_num_free(funp);
 
-                for (int i = 0; i < funp->num_free; i++) {
+                for (int i = 0; i < fun_num_free(funp); i++) {
                     obj = funp->env[i];
                     if (!IS_CONST(obj)) {
                         EQUEUE_PUT(s, obj);
@@ -558,7 +558,7 @@ cleanup:
 	    case FUN_SUBTAG: {
                 const ErlFunThing *funp = (ErlFunThing *) ptr;
 
-                for (int i = 0; i < funp->num_free; i++) {
+                for (int i = 0; i < fun_num_free(funp); i++) {
                     obj = funp->env[i];
                     if (!IS_CONST(obj)) {
                         EQUEUE_PUT_UNCHECKED(s, obj);
@@ -873,12 +873,12 @@ Eterm copy_struct_x(Eterm obj, Uint sz, Eterm** hpp, ErlOffHeap* off_heap,
 
                     *dst_fun = *src_fun;
 
-                    for (int i = 0; i < src_fun->num_free; i++) {
+                    for (int i = 0; i < fun_num_free(dst_fun); i++) {
                         dst_fun->env[i] = src_fun->env[i];
                     }
 
                     ASSERT(&htop[ERL_FUN_SIZE] == &dst_fun->env[0]);
-                    htop = &dst_fun->env[dst_fun->num_free];
+                    htop = &dst_fun->env[fun_num_free(dst_fun)];
                     *argp = make_fun(dst_fun);
 
                     if (is_local_fun(dst_fun)) {
@@ -1266,9 +1266,9 @@ Uint copy_shared_calculate(Eterm obj, erts_shcopy_t *info)
                 const ErlFunThing* funp = (ErlFunThing *) ptr;
 
                 ASSERT(ERL_FUN_SIZE == (1 + thing_arityval(hdr)));
-                sum += ERL_FUN_SIZE + funp->num_free;
+                sum += ERL_FUN_SIZE + fun_num_free(funp);
 
-                for (int i = 0; i < funp->num_free; i++) {
+                for (int i = 0; i < fun_num_free(funp); i++) {
                     obj = funp->env[i];
                     if (!IS_CONST(obj)) {
                         EQUEUE_PUT(s, obj);
@@ -1610,7 +1610,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                  * restore it. */
                 dst_fun->thing_word = hdr;
 
-                for (int i = 0; i < src_fun->num_free; i++) {
+                for (int i = 0; i < fun_num_free(dst_fun); i++) {
                     obj = src_fun->env[i];
 
                     if (!IS_CONST(obj)) {
@@ -1622,7 +1622,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                 }
 
                 ASSERT(&hp[ERL_FUN_SIZE] == &dst_fun->env[0]);
-                hp = &dst_fun->env[dst_fun->num_free];
+                hp = &dst_fun->env[fun_num_free(dst_fun)];
                 *resp = make_fun(dst_fun);
 
                 if (is_local_fun(dst_fun)) {
@@ -1839,7 +1839,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                             const ErlFunThing* funp = (ErlFunThing *) hscan;
                             ASSERT(ERL_FUN_SIZE == (1 + thing_arityval(*hscan)));
                             hscan += ERL_FUN_SIZE;
-                            remaining = funp->num_free;
+                            remaining = fun_num_free(funp);
                             break;
 			}
 			case MAP_SUBTAG:

--- a/erts/emulator/beam/emu/emu_load.c
+++ b/erts/emulator/beam/emu/emu_load.c
@@ -665,14 +665,14 @@ void beam_load_finalize_code(LoaderState* stp, struct erl_module_instance* inst_
                 literal = beamfile_get_literal(&stp->beam,
                                                stp->lambda_literals[i]);
                 funp = (ErlFunThing *)fun_val(literal);
-                ASSERT(funp->external == 1);
 
                 funp->entry.fun = fun_entry;
 
                 funp->next = literal_area->off_heap;
                 literal_area->off_heap = (struct erl_off_heap_header *)funp;
 
-                funp->external = 0;
+                ASSERT(funp->thing_word & (1 << FUN_HEADER_EXTERNAL_OFFS));
+                funp->thing_word &= ~(1 << FUN_HEADER_EXTERNAL_OFFS);
 
                 erts_refc_inc(&fun_entry->refc, 2);
             }

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -3702,7 +3702,7 @@ fun_info_2(BIF_ALIST_2)
         break;
     case am_env:
         {
-            Uint num_free = funp->num_free;
+            Uint num_free = fun_num_free(funp);
             int i;
 
             hp = HAlloc(p, 3 + 2 * num_free);
@@ -3724,7 +3724,7 @@ fun_info_2(BIF_ALIST_2)
         hp = HAlloc(p, 3);
         break;
     case am_arity:
-        val = make_small(funp->arity);
+        val = make_small(fun_arity(funp));
         hp = HAlloc(p, 3);
         break;
     case am_name:
@@ -3763,7 +3763,7 @@ fun_info_mfa_1(BIF_ALIST_1)
                 BIF_RET(TUPLE3(hp,
                                funp->entry.fun->module,
                                NIL,
-                               make_small(funp->arity)));
+                               make_small(fun_arity(funp))));
             }
         } else {
             ASSERT(is_external_fun(funp) && funp->next == NULL);
@@ -3773,7 +3773,7 @@ fun_info_mfa_1(BIF_ALIST_1)
         BIF_RET(TUPLE3(hp,
                        mfa->module,
                        mfa->function,
-                       make_small(funp->arity)));
+                       make_small(fun_arity(funp))));
     }
 
     BIF_ERROR(p, BADARG);

--- a/erts/emulator/beam/erl_bif_op.c
+++ b/erts/emulator/beam/erl_bif_op.c
@@ -254,7 +254,7 @@ Eterm erl_is_function(Process* p, Eterm arg1, Eterm arg2)
     if (is_any_fun(arg1)) {
 	ErlFunThing* funp = (ErlFunThing *) fun_val(arg1);
 
-	if (funp->arity == (Uint) arity) {
+	if (fun_arity(funp) == (Uint) arity) {
 	    BIF_RET(am_true);
 	}
     }

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -82,7 +82,7 @@ ERTS_GLB_INLINE Eterm* move_boxed(Eterm *ERTS_RESTRICT ptr, Eterm hdr, Eterm **h
         if (is_flatmap_header(hdr)) nelts+=flatmap_get_size(ptr) + 1;
         else nelts += hashmap_bitcount(MAP_HEADER_VAL(hdr));
     break;
-    case FUN_SUBTAG: nelts+=((ErlFunThing*)(ptr))->num_free; break;
+    case FUN_SUBTAG: nelts+=fun_num_free((ErlFunThing*)(ptr)); break;
     }
     gval    = make_boxed(htop);
     *orig   = gval;

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -729,7 +729,7 @@ dump_externally(fmtfn_t to, void *to_arg, Eterm term)
 	 * The crashdump_viewer does not allow inspection of them anyway.
 	 */
 	ErlFunThing* funp = (ErlFunThing *) fun_val(term);
-	Uint num_free = funp->num_free;
+	Uint num_free = fun_num_free(funp);
 	Uint i;
 
 	for (i = 0; i < num_free; i++) {
@@ -1035,7 +1035,7 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
             size = 1 + header_arity(w);
             switch (w & _HEADER_SUBTAG_MASK) {
             case FUN_SUBTAG:
-                ASSERT(((ErlFunThing*)(htop))->num_free == 0);
+                ASSERT(fun_num_free((ErlFunThing*)(htop)) == 0);
                 break;
             case MAP_SUBTAG:
                 if (is_flatmap_header(w)) {

--- a/erts/emulator/beam/erl_term.c
+++ b/erts/emulator/beam/erl_term.c
@@ -144,7 +144,7 @@ ET_DEFINE_CHECKED(struct erl_node_*,external_port_node,Wterm,is_external_port);
 ET_DEFINE_CHECKED(Uint,external_ref_data_words,Wterm,is_external_ref);
 ET_DEFINE_CHECKED(Uint32*,external_ref_data,Wterm,is_external_ref);
 ET_DEFINE_CHECKED(struct erl_node_*,external_ref_node,Eterm,is_external_ref);
-ET_DEFINE_CHECKED(Uint,external_thing_data_words,ExternalThing*,is_thing_ptr);
+ET_DEFINE_CHECKED(Uint,external_thing_data_words,const ExternalThing*,is_thing_ptr);
 
 ET_DEFINE_CHECKED(Eterm,make_cp,ErtsCodePtr,_is_legal_cp);
 ET_DEFINE_CHECKED(ErtsCodePtr,cp_val,Eterm,is_CP);

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -299,8 +299,10 @@ _ET_DECLARE_CHECKED(Uint,atom_val,Eterm)
 /* header (arityval or thing) access methods */
 #define _make_header(sz,tag) ((Uint)(((Uint)(sz) << _HEADER_ARITY_OFFS) + (tag)))
 #define is_header(x)	(((x) & _TAG_PRIMARY_MASK) == TAG_PRIMARY_HEADER)
-#define _unchecked_header_arity(x) \
-    (is_map_header(x) ? MAP_HEADER_ARITY(x) : ((x) >> _HEADER_ARITY_OFFS))
+#define _unchecked_header_arity(x)                                            \
+    (is_map_header(x) ? MAP_HEADER_ARITY(x) :                                 \
+     (is_fun_header(x) ? (ERL_FUN_SIZE - 1) :                                 \
+      ((x) >> _HEADER_ARITY_OFFS)))
 _ET_DECLARE_CHECKED(Uint,header_arity,Eterm)
 #define header_arity(x)	_ET_APPLY(header_arity,(x))
 
@@ -386,9 +388,35 @@ _ET_DECLARE_CHECKED(Eterm*,binary_val,Wterm)
 /* process binaries stuff (special case of binaries) */
 #define HEADER_PROC_BIN	_make_header(PROC_BIN_SIZE-1,_TAG_HEADER_REFC_BIN)
 
-/* fun objects */
-#define HEADER_FUN              _make_header(ERL_FUN_SIZE-1,_TAG_HEADER_FUN)
-#define is_fun_header(x)        ((x) == HEADER_FUN)
+/* Fun objects.
+ *
+ * This has a special tag scheme to make the representation as compact as
+ * possible. For normal headers, we have:
+ *
+ *     aaaaaaaaaaaaaaaa aaaaaaaaaatttt00       arity:26, tag:4
+ *
+ * Since the arity and number of free variables are both limited to 255, and we
+ * only need one bit to signify whether the fun is local or external, we can
+ * fit all of that information in the header word.
+ *
+ *     0000000effffffff aaaaaaaa00010100       external:1, free:8, arity:8
+ *
+ * Note that the lowest byte contains only the function subtag, and the next
+ * byte after that contains only the arity. This lets us combine the type
+ * and/or arity check into a single comparison without masking, by using 8- or
+ * 16-bit operations on the header word. */
+
+#define FUN_HEADER_ARITY_OFFS (_HEADER_ARITY_OFFS + 2)
+#define FUN_HEADER_NUM_FREE_OFFS (FUN_HEADER_ARITY_OFFS + 8)
+#define FUN_HEADER_EXTERNAL_OFFS (FUN_HEADER_NUM_FREE_OFFS + 8)
+
+#define MAKE_FUN_HEADER(Arity, NumFree, External)                             \
+    (_TAG_HEADER_FUN |                                                        \
+     (((Arity)) << FUN_HEADER_ARITY_OFFS) |                                   \
+     (((NumFree)) << FUN_HEADER_NUM_FREE_OFFS) |                              \
+     ((!!(External)) << FUN_HEADER_EXTERNAL_OFFS))
+
+#define is_fun_header(x)        (((x) & _HEADER_SUBTAG_MASK) == FUN_SUBTAG)
 #define make_fun(x)             make_boxed((Eterm*)(x))
 #define is_any_fun(x)           (is_boxed((x)) && is_fun_header(*boxed_val((x))))
 #define is_not_any_fun(x)       (!is_any_fun((x)))

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -390,7 +390,7 @@ _ET_DECLARE_CHECKED(Eterm*,binary_val,Wterm)
 
 /* Fun objects.
  *
- * This has a special tag scheme to make the representation as compact as
+ * These have a special tag scheme to make the representation as compact as
  * possible. For normal headers, we have:
  *
  *     aaaaaaaaaaaaaaaa aaaaaaaaaatttt00       arity:26, tag:4

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -1168,7 +1168,7 @@ _ET_DECLARE_CHECKED(Eterm*,external_val,Wterm)
 
 #define _unchecked_external_thing_data_words(thing) \
     (_unchecked_thing_arityval((thing)->header) + (1 - EXTERNAL_THING_HEAD_SIZE))
-_ET_DECLARE_CHECKED(Uint,external_thing_data_words,ExternalThing*)
+_ET_DECLARE_CHECKED(Uint,external_thing_data_words,const ExternalThing*)
 #define external_thing_data_words(thing) _ET_APPLY(external_thing_data_words,(thing))
 
 #define _unchecked_external_data_words(x) \

--- a/erts/emulator/beam/erl_term_hashing.c
+++ b/erts/emulator/beam/erl_term_hashing.c
@@ -231,7 +231,7 @@ tail_recur:
             if (is_local_fun(funp)) {
 
                 ErlFunEntry* fe = funp->entry.fun;
-                Uint num_free = funp->num_free;
+                Uint num_free = fun_num_free(funp);
 
                 hash = hash * FUNNY_NUMBER10 + num_free;
                 hash = hash*FUNNY_NUMBER1 +
@@ -1160,7 +1160,7 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
                 if (is_local_fun(funp)) {
                     ErlFunEntry* fe = funp->entry.fun;
                     ErtsMakeHash2Context_FUN_SUBTAG ctx = {
-                        .num_free = funp->num_free,
+                        .num_free = fun_num_free(funp),
                         .bptr = NULL};
 
                     UINT32_HASH_2
@@ -1901,7 +1901,7 @@ make_internal_hash(Eterm term, erts_ihash_t salt)
 
                 if (is_local_fun(funp)) {
                     const ErlFunEntry *fe = funp->entry.fun;
-                    Uint num_free = funp->num_free;
+                    Uint num_free = fun_num_free(funp);
 
                     IHASH_MIX_ALPHA_2F32(IHASH_TYPE_LOCAL_FUN, num_free);
                     IHASH_MIX_BETA_2F32(fe->index, fe->old_uniq);

--- a/erts/emulator/beam/generators.tab
+++ b/erts/emulator/beam/generators.tab
@@ -318,12 +318,9 @@ MakeLiteralLambda(Op, Index, DstType, DstVal) {
          * created by the user. We also disable deduplication to prevent it
          * from colliding with other placeholder lambdas of the same arity. */
         funp = (ErlFunThing*)tmp_hp;
-        funp->thing_word = HEADER_FUN;
+        funp->thing_word = MAKE_FUN_HEADER(entry->arity, 0, 1);
         funp->entry.exp = NULL;
         funp->next = NULL;
-        funp->arity = entry->arity;
-        funp->num_free = 0;
-        funp->external = 1;
 
         literal = beamfile_add_literal(&S->beam, make_fun(tmp_hp), 0);
         S->lambda_literals[$Index] = literal;

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1091,8 +1091,7 @@ protected:
     arm::Mem emit_fixed_apply(const ArgWord &arity, bool includeI);
 
     arm::Gp emit_call_fun(bool skip_box_test = false,
-                          bool skip_fun_test = false,
-                          bool skip_arity_test = false);
+                          bool skip_header_test = false);
 
     void emit_is_boxed(Label Fail, arm::Gp Src) {
         BeamAssembler::emit_is_boxed(Fail, Src);

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -997,14 +997,14 @@ void beam_load_finalize_code(LoaderState *stp,
                 literal = beamfile_get_literal(&stp->beam,
                                                stp->lambda_literals[i]);
                 funp = (ErlFunThing *)fun_val(literal);
-                ASSERT(funp->external == 1);
 
                 funp->entry.fun = fun_entry;
 
                 funp->next = literal_area->off_heap;
                 literal_area->off_heap = (struct erl_off_heap_header *)funp;
 
-                funp->external = 0;
+                ASSERT(funp->thing_word & (1 << FUN_HEADER_EXTERNAL_OFFS));
+                funp->thing_word &= ~(1 << FUN_HEADER_EXTERNAL_OFFS);
 
                 erts_refc_inc(&fun_entry->refc, 2);
             }

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1196,8 +1196,7 @@ protected:
     x86::Mem emit_fixed_apply(const ArgWord &arity, bool includeI);
 
     x86::Gp emit_call_fun(bool skip_box_test = false,
-                          bool skip_fun_test = false,
-                          bool skip_arity_test = false);
+                          bool skip_header_test = false);
 
     void emit_is_boxed(Label Fail, x86::Gp Src, Distance dist = dLong) {
         BeamAssembler::emit_is_boxed(Fail, Src, dist);

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -22,7 +22,7 @@
 
 /* Calls to functions that are being purged (but haven't finished) land here.
  *
- * ARG3 = arity
+ * ARG3 = lower 16 bits of expected header, containing FUN_SUBTAG and arity
  * ARG4 = fun thing
  * ARG5 = current PC */
 void BeamGlobalAssembler::emit_unloaded_fun() {
@@ -36,7 +36,8 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    /* ARG3 and ARG4 have already been set. */
+    a.shr(ARG3, imm(FUN_HEADER_ARITY_OFFS));
+    /* ARG4 has already been set. */
     runtime_call<4>(beam_jit_handle_unloaded_fun);
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eReductions |
@@ -60,18 +61,17 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
 
 /* Handles errors for `call_fun`.
  *
- * ARG3 = arity
+ * ARG3 = lower 16 bits of expected header, containing FUN_SUBTAG and arity
  * ARG4 = fun thing
  * ARG5 = current PC */
 void BeamGlobalAssembler::emit_handle_call_fun_error() {
     Label bad_arity = a.newLabel(), bad_fun = a.newLabel();
 
     emit_enter_frame();
-
     emit_is_boxed(bad_fun, ARG4);
 
     x86::Gp fun_thing = emit_ptr_val(RET, ARG4);
-    a.cmp(emit_boxed_val(fun_thing), imm(HEADER_FUN));
+    a.cmp(emit_boxed_val(fun_thing, 0, sizeof(byte)), imm(FUN_SUBTAG));
     a.short_().je(bad_arity);
 
     a.bind(bad_fun);
@@ -97,7 +97,7 @@ void BeamGlobalAssembler::emit_handle_call_fun_error() {
 
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
-        /* ARG3 is already set. */
+        a.shr(ARG3, imm(FUN_HEADER_ARITY_OFFS));
         runtime_call<3>(beam_jit_build_argument_list);
 
         emit_leave_runtime<Update::eHeapAlloc>();
@@ -285,6 +285,11 @@ void BeamGlobalAssembler::emit_apply_fun_shared() {
 
     a.bind(finished);
 
+    /* Make the lower 16 bits of ARG3 equal those of the header word of all
+     * funs with the same arity. */
+    a.shl(ARG3, imm(FUN_HEADER_ARITY_OFFS));
+    a.or_(ARG3, imm(FUN_SUBTAG));
+
     emit_leave_frame();
     a.ret();
 }
@@ -311,62 +316,48 @@ void BeamModuleAssembler::emit_i_apply_fun_only() {
 }
 
 /* Assumes that:
- *   ARG3 = arity
+ *   ARG3 = lower 16 bits of expected header, containing FUN_SUBTAG and arity
  *   ARG4 = fun thing */
 x86::Gp BeamModuleAssembler::emit_call_fun(bool skip_box_test,
-                                           bool skip_fun_test,
-                                           bool skip_arity_test) {
-    const bool never_fails = skip_box_test && skip_fun_test && skip_arity_test;
+                                           bool skip_header_test) {
+    const bool can_fail = !(skip_box_test && skip_header_test);
     Label next = a.newLabel();
 
     /* Speculatively strip the literal tag when needed. */
     x86::Gp fun_thing = emit_ptr_val(RET, ARG4);
 
-    if (!never_fails) {
-        /* Load the error fragment into ARG2 so we can CMOV ourselves there on
+    if (can_fail) {
+        /* Load the error fragment into ARG1 so that we'll land there on any
          * error. */
-        a.mov(ARG2, ga->get_handle_call_fun_error());
+        a.mov(ARG1, ga->get_handle_call_fun_error());
     }
 
     /* The `handle_call_fun_error` and `unloaded_fun` fragments expect current
-     * PC in ARG5. */
+     * PC in ARG5. Note that the latter requires that we do this even if we
+     * know the call never fails. */
     a.lea(ARG5, x86::qword_ptr(next));
 
-    if (!skip_box_test) {
+    if (skip_box_test) {
+        comment("skipped box test since source is always boxed");
+    } else {
         /* As emit_is_boxed(), but explicitly sets ZF so we can rely on that
          * for error checking in `next`. */
         a.test(ARG4d, imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_BOXED));
         a.short_().jne(next);
-    } else {
-        comment("skipped box test since source is always boxed");
     }
 
-    if (skip_fun_test) {
-        comment("skipped fun test since source is always a fun when boxed");
+    if (skip_header_test) {
+        comment("skipped fun/arity test since source is always a fun of the "
+                "right arity when boxed");
     } else {
-        a.cmp(emit_boxed_val(fun_thing), imm(HEADER_FUN));
+        a.cmp(emit_boxed_val(fun_thing, 0, sizeof(Uint16)), ARG3.r16());
         a.short_().jne(next);
-    }
-
-    if (skip_arity_test) {
-        comment("skipped arity test since source always has right arity");
-    } else {
-        a.cmp(emit_boxed_val(fun_thing,
-                             offsetof(ErlFunThing, arity),
-                             sizeof(byte)),
-              ARG3.r8());
     }
 
     a.mov(RET, emit_boxed_val(fun_thing, offsetof(ErlFunThing, entry)));
     a.mov(ARG1, emit_setup_dispatchable_call(RET));
 
     a.bind(next);
-
-    if (!never_fails) {
-        /* Assumes that ZF is set on success and clear on error, overwriting
-         * our destination with the error fragment's address. */
-        a.cmovne(ARG1, ARG2);
-    }
 
     return ARG1;
 }
@@ -377,12 +368,15 @@ void BeamModuleAssembler::emit_i_call_fun2(const ArgVal &Tag,
     mov_arg(ARG4, Func);
 
     if (Tag.isImmed()) {
-        mov_imm(ARG3, Arity.get());
+        /* Make the lower 16 bits of ARG3 equal those of the header word of all
+         * funs with the same arity. */
+        mov_imm(ARG3, MAKE_FUN_HEADER(Arity.get(), 0, 0) & 0xFFFF);
 
-        auto target = emit_call_fun(
-                always_one_of<BeamTypeId::AlwaysBoxed>(Func),
-                masked_types<BeamTypeId::MaybeBoxed>(Func) == BeamTypeId::Fun,
-                Tag.as<ArgImmed>().get() == am_safe);
+        ASSERT(Tag.as<ArgImmed>().get() != am_safe ||
+               exact_type<BeamTypeId::Fun>(Func));
+        auto target =
+                emit_call_fun(always_one_of<BeamTypeId::AlwaysBoxed>(Func),
+                              Tag.as<ArgImmed>().get() == am_safe);
 
         erlang_call(target, ARG6);
     } else {
@@ -398,12 +392,15 @@ void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
     mov_arg(ARG4, Func);
 
     if (Tag.isImmed()) {
-        mov_imm(ARG3, Arity.get());
+        /* Make the lower 16 bits of ARG3 equal those of the header word of all
+         * funs with the same arity. */
+        mov_imm(ARG3, MAKE_FUN_HEADER(Arity.get(), 0, 0) & 0xFFFF);
 
-        auto target = emit_call_fun(
-                always_one_of<BeamTypeId::AlwaysBoxed>(Func),
-                masked_types<BeamTypeId::MaybeBoxed>(Func) == BeamTypeId::Fun,
-                Tag.as<ArgImmed>().get() == am_safe);
+        ASSERT(Tag.as<ArgImmed>().get() != am_safe ||
+               exact_type<BeamTypeId::Fun>(Func));
+        auto target =
+                emit_call_fun(always_one_of<BeamTypeId::AlwaysBoxed>(Func),
+                              Tag.as<ArgImmed>().get() == am_safe);
 
         emit_deallocate(Deallocate);
         emit_leave_frame();

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -1220,6 +1220,10 @@ tailrecur_ne:
                     f1 = (ErlFunThing *) fun_val(a);
                     f2 = (ErlFunThing *) fun_val(b);
 
+                    if (f1->thing_word != f2->thing_word) {
+                        goto not_equal;
+                    }
+
                     if (is_local_fun(f1) && is_local_fun(f2)) {
                         ErlFunEntry *fe1, *fe2;
 
@@ -1228,12 +1232,11 @@ tailrecur_ne:
 
                         if (fe1->module != fe2->module ||
                             fe1->index != fe2->index ||
-                            fe1->old_uniq != fe2->old_uniq ||
-                            f1->num_free != f2->num_free) {
+                            fe1->old_uniq != fe2->old_uniq) {
                             goto not_equal;
                         }
 
-                        if ((sz = f1->num_free) == 0) {
+                        if ((sz = fun_num_free(f1)) == 0) {
                             goto pop_next;
                         }
 
@@ -2057,13 +2060,14 @@ tailrecur_ne:
                             RETURN_NEQ(diff);
                         }
 
-                        diff = f1->num_free - f2->num_free;
+                        diff = fun_num_free(f1) - fun_num_free(f2);
                         if (diff != 0) {
                             RETURN_NEQ(diff);
                         }
 
-                        i = f1->num_free;
+                        i = fun_num_free(f1);
                         if (i == 0) goto pop_next;
+
                         aa = f1->env;
                         bb = f2->env;
                         goto term_array;

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -82,7 +82,7 @@ test_size(Config) when is_list(Config) ->
 
     %% Fun environment size = 0 (the smallest fun possible)
     SimplestFun = fun() -> ok end,
-    FunSz0 = 4,
+    FunSz0 = 3,
     FunSz0 = do_test_size(SimplestFun),
 
     %% Fun environment size = 1

--- a/erts/emulator/test/trace_call_memory_SUITE.erl
+++ b/erts/emulator/test/trace_call_memory_SUITE.erl
@@ -308,8 +308,8 @@ spawn_memory_lambda(Config) when is_list(Config) ->
     MRef = monitor(process, Pid),
     receive {'DOWN', MRef, process, Pid, _} -> ok end,
     1 = erlang:trace(self(), false, [all]),
-    %% 16-elements list translates into 34-words for spawn, and 6 more words for apply itself
-    {call_memory, [{Pid, 1, 39}]} = erlang:trace_info({erlang, apply, 2}, call_memory).
+    %% 16-elements list translates into 34-words for spawn, and 4 more words for apply itself
+    {call_memory, [{Pid, 1, 38}]} = erlang:trace_info({erlang, apply, 2}, call_memory).
 
 spawn_memory_internal(Array) ->
     Array.


### PR DESCRIPTION
This PR shrinks funs by one word through packing the arity, number of free variables, and whether it's external or not into the header word.

As an added bonus, we can now combine function type tests with arity tests, further reducing fun call overhead.