### PR TITLE
Fix is_record/3 for unreasonable tuple sizes

### DIFF
--- a/lib/compiler/test/record_SUITE.erl
+++ b/lib/compiler/test/record_SUITE.erl
@@ -52,6 +52,7 @@ groups() ->
 
 
 init_per_suite(Config) ->
+    _ = id(Config),                  %Make return value unpredicatble.
     test_lib:recompile(?MODULE),
     Config.
 
@@ -393,6 +394,28 @@ record_test_3(Config) when is_list(Config) ->
 
     true = is_record(Rec, Good, Size) orelse error,
     error = is_record(Rec, Bad, Size) orelse error,
+
+    %% GH-7298: Zero size.
+    TupleA = id({a}),
+
+    false = is_record(TupleA, a, 0),
+    false = is_record(Bad, a, 0),
+
+    ZeroF = fun(A) when is_record(A, a, 0) -> ok;
+               (_) -> error
+            end,
+    error = ZeroF(TupleA),
+    error = ZeroF(Bad),
+
+    %% GH-7317: Huge tuple size used to take forever to compile.
+    false = is_record(TupleA, a, 10_000_000),
+    false = is_record(Bad, a, 10_000_000),
+
+    HugeF = fun(A) when is_record(A, a, 10_000_000) -> ok;
+               (_) -> error
+            end,
+    error = HugeF(TupleA),
+    error = HugeF(Bad),
 
     ok.
 


### PR DESCRIPTION
Calling `is_record/3` with a zero tuple size would crash the compiler. For example:

    foo(A) -> is_record(A, a, 0).

Using the same kind of expression in a guard would generate incorrect code that could succeed. For example, given:

    bar(A) when is_record(A, a, 0) -> ok.

the call `bar({a})` would succeed.

The compiler would run out of memory or never finish compiling a call to `is_record/3` with a huge tuple size. Example:

    foobar(A) when is_record(A, a, 10000000) -> A.

Closes #7298
Closes #7317