### PR TITLE
Drop support in the compiler for OTP 22/23

### DIFF
--- a/erts/emulator/test/erts_test_utils.erl
+++ b/erts/emulator/test/erts_test_utils.erl
@@ -19,7 +19,7 @@
 %%
 
 -module(erts_test_utils).
--compile(r22).
+-compile(r24).
 
 %%
 %% THIS MODULE IS ALSO USED BY *OTHER* APPLICATIONS TEST CODE

--- a/erts/test/upgrade_SUITE.erl
+++ b/erts/test/upgrade_SUITE.erl
@@ -20,7 +20,7 @@
 
 -compile(export_all).
 
--compile(r22).
+-compile(r24).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("kernel/include/file.hrl").

--- a/lib/common_test/src/test_server_node.erl
+++ b/lib/common_test/src/test_server_node.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 -module(test_server_node).
--compile(r22).
+-compile(r24).
 
 %% Test Controller interface
 -export([is_release_available/1, find_release/1]).

--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -110,7 +110,6 @@ swap_opt_end(_, _, _, _) -> no.
 
 is_unused(X, [{call,A,_}|_]) when A =< X -> true;
 is_unused(X, [{call_ext,A,_}|_]) when A =< X -> true;
-is_unused(X, [{make_fun2,_,_,_,A}|_]) when A =< X -> true;
 is_unused(X, [{move,Src,Dst}|Is]) ->
     case {Src,Dst} of
         {{x,X},_} -> false;

--- a/lib/compiler/src/beam_core_to_ssa.erl
+++ b/lib/compiler/src/beam_core_to_ssa.erl
@@ -66,7 +66,7 @@
                 map/2,mapfoldl/3,member/2,
                 keyfind/3,keysort/2,last/1,
                 partition/2,reverse/1,reverse/2,
-                seq/2,sort/1,sort/2,splitwith/2,
+                sort/1,sort/2,splitwith/2,
                 zip/2]).
 -import(ordsets, [add_element/2,del_element/2,intersection/2,
                   subtract/2,union/2,union/1]).
@@ -148,8 +148,6 @@ get_anno(#cg_select{anno=Anno}) -> Anno.
                funs=[],                         %Fun functions
                free=#{},                        %Free variables
                ws=[]   :: [warning()],          %Warnings.
-               no_make_fun3 :: boolean(),
-               no_shared_fun_wrappers=false :: boolean(),
                no_min_max_bifs=false :: boolean()
               }).
 
@@ -159,14 +157,9 @@ get_anno(#cg_select{anno=Anno}) -> Anno.
 module(#c_module{name=#c_literal{val=Mod},exports=Es,attrs=As,defs=Fs}, Options) ->
     Kas = attributes(As),
     Kes = map(fun (#c_var{name={_,_}=Fname}) -> Fname end, Es),
-    NoSharedFunWrappers = proplists:get_bool(no_shared_fun_wrappers,
-                                             Options),
     NoMinMaxBifs = proplists:get_bool(no_min_max_bifs, Options),
-    NoMakeFun3 = proplists:get_bool(no_make_fun3, Options),
     St0 = #kern{module=Mod,
-                no_shared_fun_wrappers=NoSharedFunWrappers,
-                no_min_max_bifs=NoMinMaxBifs,
-                no_make_fun3=NoMakeFun3},
+                no_min_max_bifs=NoMinMaxBifs},
     {Kfs,St} = mapfoldl(fun function/2, St0, Fs),
     Body = Kfs ++ St#kern.funs,
     Code = #b_module{name=Mod,exports=Kes,attributes=Kas,body=Body},
@@ -281,21 +274,9 @@ gexpr_test_add(Ke, St0) ->
 %% expr(Cexpr, Sub, State) -> {Kexpr,[PreKexpr],State}.
 %%  Convert a Core expression, flattening it at the same time.
 
-expr(#c_var{anno=A,name={Name0,Arity}}=Fname, Sub, St) ->
-    case St#kern.no_shared_fun_wrappers of
-        false ->
-            Name = get_fsub(Name0, Arity, Sub),
-            {#b_local{name=#b_literal{val=Name},arity=Arity},[],St};
-        true ->
-            %% For backward compatibility with OTP 22 and earlier,
-            %% use the pre-generated name for the fun wrapper.
-            %% There will be one wrapper function for each occurrence
-            %% of `fun F/A`.
-            Vs = [#c_var{name=list_to_atom("V" ++ integer_to_list(V))} ||
-                     V <- seq(1, Arity)],
-            Fun = #c_fun{anno=A,vars=Vs,body=#c_apply{anno=A,op=Fname,args=Vs}},
-            expr(Fun, Sub, St)
-    end;
+expr(#c_var{name={Name0,Arity}}, Sub, St) ->
+    Name = get_fsub(Name0, Arity, Sub),
+    {#b_local{name=#b_literal{val=Name},arity=Arity},[],St};
 expr(#c_var{name=V}, Sub, St) ->
     {#b_var{name=get_vsub(V, Sub)},[],St};
 expr(#c_literal{val=V}, _Sub, St) ->
@@ -2140,11 +2121,7 @@ uexpr(Atomic, {break,[Dst]}, St0) ->
 
 make_fun(Rs, Local, FreeVars, St0) ->
     {[Dst],St1} = ensure_return_vars(Rs, St0),
-    Op = case St1 of
-             #kern{no_make_fun3=false} -> make_fun;
-             #kern{no_make_fun3=true} -> old_make_fun
-         end,
-    {#b_set{op=Op,dst=Dst,args=[Local|FreeVars]},St1}.
+    {#b_set{op=make_fun,dst=Dst,args=[Local|FreeVars]},St1}.
 
 add_local_function(_, #kern{funs=ignore}=St) ->
     St;

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -117,7 +117,6 @@
                    'landingpad' |
                    'make_fun' | 'match_fail' | 'new_try_tag' |
                    'nif_start' |
-                   'old_make_fun' |
                    'peek_message' | 'phi' | 'put_list' | 'put_map' | 'put_tuple' |
                    'raw_raise' |
                    'recv_marker_bind' |
@@ -187,7 +186,6 @@ clobbers_xregs(#b_set{op=Op}) ->
         build_stacktrace -> true;
         call -> true;
         landingpad -> true;
-        old_make_fun -> true;
         peek_message -> true;
         raw_raise -> true;
         wait_timeout -> true;

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -417,9 +417,6 @@ aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, Acc, AAS0) ->
             make_fun ->
                 [Callee|Env] = Args,
                 aa_make_fun(Dst, Callee, Env, SS1, AAS0);
-            old_make_fun ->
-                [Callee|Env] = Args,
-                aa_make_fun(Dst, Callee, Env, SS1, AAS0);
             peek_message ->
                 {aa_set_aliased(Dst, SS1), AAS0};
             phi ->

--- a/lib/compiler/src/beam_utils.erl
+++ b/lib/compiler/src/beam_utils.erl
@@ -95,8 +95,6 @@ replace_labels_1([{call,Ar,{f,Lbl}}|Is], Acc, D, Fb) ->
     replace_labels_1(Is, [{call,Ar,{f,label(Lbl, D, Fb)}}|Acc], D, Fb);
 replace_labels_1([{call_fun2,{f,Lbl},Ar,Func}|Is], Acc, D, Fb) ->
     replace_labels_1(Is, [{call_fun2,{f,label(Lbl, D, Fb)},Ar,Func}|Acc], D, Fb);
-replace_labels_1([{make_fun2,{f,Lbl},U1,U2,U3}|Is], Acc, D, Fb) ->
-    replace_labels_1(Is, [{make_fun2,{f,label(Lbl, D, Fb)},U1,U2,U3}|Acc], D, Fb);
 replace_labels_1([{make_fun3,{f,Lbl},U1,U2,U3,U4}|Is], Acc, D, Fb) ->
     replace_labels_1(Is, [{make_fun3,{f,label(Lbl, D, Fb)},U1,U2,U3,U4}|Acc], D, Fb);
 replace_labels_1([{bs_create_bin,{f,Lbl},Alloc,Live,Unit,Dst,{list,List}}|Is], Acc, D, Fb)

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -704,19 +704,6 @@ vi({call_fun,Live}, Vst) ->
                                          Fun, SuccVst0),
                    validate_body_call('fun', Live+1, SuccVst)
            end);
-vi({make_fun2,{f,Lbl},_,_,NumFree}, #vst{ft=Ft}=Vst0) ->
-    #{ name := Name, arity := TotalArity } = map_get(Lbl, Ft),
-    Arity = TotalArity - NumFree,
-
-    true = Arity >= 0,                          %Assertion.
-
-    Vst = prune_x_regs(NumFree, Vst0),
-    verify_call_args(make_fun, NumFree, Vst),
-    verify_y_init(Vst),
-
-    Type = #t_fun{target={Name,TotalArity},arity=Arity},
-
-    create_term(Type, make_fun, [], {x,0}, Vst);
 vi({make_fun3,{f,Lbl},_,_,Dst,{list,Env}}, #vst{ft=Ft}=Vst0) ->
     _ = [assert_term(E, Vst0) || E <- Env],
     NumFree = length(Env),

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -262,24 +262,11 @@ expand_opt(report, Os) ->
     [report_errors,report_warnings|Os];
 expand_opt(return, Os) ->
     [return_errors,return_warnings|Os];
-expand_opt(no_bsm4, Os) ->
-    %% bsm4 instructions are only used when type optimization has determined
-    %% that a match instruction won't fail.
-    expand_opt(no_type_opt, Os);
-expand_opt(r22, Os) ->
-    expand_opt(r23, [no_bs_create_bin, no_shared_fun_wrappers,
-                     no_swap | expand_opt(no_bsm4, Os)]);
-expand_opt(r23, Os) ->
-    expand_opt(no_make_fun3, [no_bs_create_bin, no_ssa_opt_float,
-                              no_recv_opt, no_init_yregs |
-                              expand_opt(r24, Os)]);
 expand_opt(r24, Os) ->
     expand_opt(no_type_opt, [no_badrecord, no_bs_create_bin, no_ssa_opt_ranges |
                              expand_opt(r25, Os)]);
 expand_opt(r25, Os) ->
     [no_ssa_opt_update_tuple, no_bs_match, no_min_max_bifs | Os];
-expand_opt(no_make_fun3, Os) ->
-    [no_make_fun3, no_fun_opt | Os];
 expand_opt({debug_info_key,_}=O, Os) ->
     [encrypt_debug_info,O|Os];
 expand_opt(no_type_opt=O, Os) ->
@@ -1506,10 +1493,16 @@ is_obsolete(r18) -> true;
 is_obsolete(r19) -> true;
 is_obsolete(r20) -> true;
 is_obsolete(r21) -> true;
+is_obsolete(r22) -> true;
+is_obsolete(r23) -> true;
 is_obsolete(no_bsm3) -> true;
 is_obsolete(no_get_hd_tl) -> true;
 is_obsolete(no_put_tuple2) -> true;
 is_obsolete(no_utf8_atoms) -> true;
+is_obsolete(no_swap) -> true;
+is_obsolete(no_init_yregs) -> true;
+is_obsolete(no_shared_fun_wrappers) -> true;
+is_obsolete(no_make_fun3) -> true;
 is_obsolete(_) -> false.
 
 core(Forms, #compile{options=Opts}=St) ->

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -854,12 +854,8 @@ expr({'catch',L,E0}, St0) ->
     Lanno = lineno_anno(L, St1),
     {#icatch{anno=#a{anno=Lanno},body=Eps ++ [E1]},[],St1};
 expr({'fun',L,{function,F,A}}, St0) ->
-    %% Generate a new name for eta conversion of local funs (`fun local/123`)
-    %% in case `no_shared_fun_wrappers` is given.
-    {Fname,St1} = new_fun_name(St0),
-    Lanno = full_anno(L, St1),
-    Id = {0,0,Fname},
-    {#c_var{anno=Lanno++[{id,Id}],name={F,A}},[],St1};
+    Lanno = full_anno(L, St0),
+    {#c_var{anno=Lanno,name={F,A}},[],St0};
 expr({'fun',L,{function,M,F,A}}, St0) ->
     {As,Aps,St1} = safe_list([M,F,A], St0),
     Lanno = full_anno(L, St1),

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -111,10 +111,6 @@ INLINE= \
 	receive \
 	record
 
-R23= \
-        fun \
-	bs_match
-
 R24= \
 	bs_construct \
 	bs_utf \
@@ -148,8 +144,6 @@ NO_CORE_SSA_OPT_MODULES= $(NO_OPT:%=%_no_copt_ssa_SUITE)
 NO_CORE_SSA_OPT_ERL_FILES= $(NO_CORE_SSA_OPT_MODULES:%=%.erl)
 INLINE_MODULES= $(INLINE:%=%_inline_SUITE)
 INLINE_ERL_FILES= $(INLINE_MODULES:%=%.erl)
-R23_MODULES= $(R23:%=%_r23_SUITE)
-R23_ERL_FILES= $(R23_MODULES:%=%.erl)
 R24_MODULES= $(R24:%=%_r24_SUITE)
 R24_ERL_FILES= $(R24_MODULES:%=%.erl)
 R25_MODULES= $(R25:%=%_r25_SUITE)
@@ -195,8 +189,7 @@ DISABLE_SSA_OPT = +no_bool_opt +no_share_opt +no_bsm_opt +no_fun_opt +no_ssa_opt
 
 make_emakefile: $(NO_OPT_ERL_FILES) $(POST_OPT_ERL_FILES) $(NO_SSA_OPT_ERL_FILES) \
   $(NO_CORE_OPT_ERL_FILES) $(NO_CORE_SSA_OPT_ERL_FILES) \
-  $(INLINE_ERL_FILES) $(R23_ERL_FILES) \
-  $(NO_MOD_OPT_ERL_FILES) $(NO_TYPE_OPT_ERL_FILES) \
+  $(INLINE_ERL_FILES) $(NO_MOD_OPT_ERL_FILES) $(NO_TYPE_OPT_ERL_FILES) \
   $(DIALYZER_ERL_FILES) $(R24_ERL_FILES) $(R25_ERL_FILES)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) $(MODULES) \
 	  > $(EMAKEFILE)
@@ -212,8 +205,6 @@ make_emakefile: $(NO_OPT_ERL_FILES) $(POST_OPT_ERL_FILES) $(NO_SSA_OPT_ERL_FILES
 	  -o$(EBIN) $(NO_CORE_SSA_OPT_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +inline $(ERL_COMPILE_FLAGS) \
 	  -o$(EBIN) $(INLINE_MODULES) >> $(EMAKEFILE)
-	$(ERL_TOP)/make/make_emakefile +r23 $(ERL_COMPILE_FLAGS) \
-	  -o$(EBIN) $(R23_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +r24 $(ERL_COMPILE_FLAGS) \
 	  -o$(EBIN) $(R24_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +r25 $(ERL_COMPILE_FLAGS) \
@@ -290,7 +281,6 @@ release_tests_spec: make_emakefile
 		$(EMAKEFILE) $(ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(NO_OPT_ERL_FILES) $(POST_OPT_ERL_FILES) \
 		$(INLINE_ERL_FILES) \
-	        $(R23_ERL_FILES) \
 	        $(R24_ERL_FILES) \
 	        $(R25_ERL_FILES) \
 		$(NO_CORE_OPT_ERL_FILES) \

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -180,7 +180,9 @@ file_1(Config) when is_list(Config) ->
     error = compile:file(filename:join(DataDir, "bad_core_tokens"), [from_core,report]),
 
     %% Cover handling of obsolete options.
-    ObsoleteOptions = [r18,r19,r20,r21,no_bsm3,no_get_hd_tl,no_put_tuple2,no_utf8_atoms],
+    ObsoleteOptions = [r18,r19,r20,r21,r22,r23,
+                       no_bsm3,no_get_hd_tl,no_put_tuple2,no_utf8_atoms,
+                       no_swap,no_init_yregs,no_shared_fun_wrappers,no_make_fun3],
     _ = [begin
              {error,[{_Simple,
                       [{none,compile,{obsolete_option,Opt}}]}],
@@ -1664,47 +1666,41 @@ bc_options(Config) ->
 
     DataDir = proplists:get_value(data_dir, Config),
 
-    L = [{101, small_float, [no_shared_fun_wrappers,no_line_info]},
-         {125, small_float, [no_shared_fun_wrappers,
-                             no_line_info,
+    L = [{171, small_float, [no_line_info,
                              no_ssa_opt_float,
                              no_type_opt]},
+         {171, small_float, [no_line_info]},
+         {171, small_float, []},
+         {171, small_float, [r24]},
+         {171, small_float, [r25]},
 
-         {153, small_float, [no_shared_fun_wrappers]},
-
-         {164, small_maps, [no_init_yregs,no_shared_fun_wrappers,no_type_opt]},
-         {164, small_maps, [r22]},
-         {164, big, [r22]},
-         {164, funs, [r22]},
-         {164, funs, [no_init_yregs,no_shared_fun_wrappers,
-                      no_ssa_opt_record,
-                      no_line_info,no_stack_trimming,
-                      no_make_fun3,no_type_opt]},
-
-         {168, small, [r22]},
-         {168, small, [no_init_yregs,no_shared_fun_wrappers,
-                       no_ssa_opt_record,no_make_fun3,
-                       no_ssa_opt_float,no_line_info,no_type_opt,
+         {172, small, [no_ssa_opt_record,
+                       no_ssa_opt_float,
+                       no_line_info,
+                       no_type_opt,
                        no_bs_match]},
-         {169, small, [r23]},
+         {172, small, [r24]},
 
-         {169, big, [no_init_yregs,no_shared_fun_wrappers,
-                     no_ssa_opt_record,
-                     no_line_info,no_stack_trimming,
-                     no_make_fun3,no_type_opt]},
-         {169, big, [r23]},
-
-         {169, small_maps, [no_init_yregs,no_type_opt]},
-
-         {171, big, [no_init_yregs,no_shared_fun_wrappers,
-                     no_ssa_opt_record,
-                     no_ssa_opt_float,no_line_info,
-                     no_type_opt]},
-         {171, funs, [no_init_yregs,no_shared_fun_wrappers,
-                      no_ssa_opt_record,
+         {172, funs, [no_ssa_opt_record,
                       no_ssa_opt_float,no_line_info,
                       no_type_opt]},
+         {172, funs, [no_ssa_opt_record,
+                      no_line_info,
+                      no_stack_trimming,
+                      no_type_opt]},
+         {172, funs, [r24]},
 
+         {172, small_maps, [r24]},
+         {172, small_maps, [no_type_opt]},
+
+         {172, big, [no_ssa_opt_record,
+                     no_ssa_opt_float,
+                     no_line_info,
+                     no_type_opt]},
+         {172, big, [r24]},
+
+         {178, small, [r25]},
+         {178, big, [r25]},
          {178, funs, []},
          {178, big, []}
         ],

--- a/lib/compiler/test/property_test/compile_prop.erl
+++ b/lib/compiler/test/property_test/compile_prop.erl
@@ -82,7 +82,9 @@ spawn_compile(Forms, Options) ->
 compiler_variants() ->
     [
      [ssalint,clint0,clint],
-     [r22,ssalint],
+     [r24,ssalint],
+     [r25,ssalint],
+     [r26,ssalint],
      [no_type_opt,ssalint],
      [no_module_opt,ssalint],
      [no_copt,ssalint,clint0],

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -90,23 +90,21 @@ opt_opts(Mod) ->
                      ({feature,_,enable}) -> true;
                      ({feature,_,disable}) -> true;
                      (inline) -> true;
+                     (no_badrecord) -> true;
                      (no_bs_create_bin) -> true;
                      (no_bsm_opt) -> true;
                      (no_bs_match) -> true;
                      (no_copt) -> true;
                      (no_fun_opt) -> true;
-                     (no_init_yregs) -> true;
-                     (no_make_fun3) -> true;
+                     (no_min_max_bifs) -> true;
                      (no_module_opt) -> true;
                      (no_postopt) -> true;
                      (no_recv_opt) -> true;
                      (no_share_opt) -> true;
-                     (no_shared_fun_wrappers) -> true;
                      (no_ssa_opt_float) -> true;
                      (no_ssa_opt_ranges) -> true;
                      (no_ssa_opt) -> true;
                      (no_stack_trimming) -> true;
-                     (no_swap) -> true;
                      (no_type_opt) -> true;
                      (_) -> false
                 end, Opts).

--- a/lib/kernel/test/global_SUITE.erl
+++ b/lib/kernel/test/global_SUITE.erl
@@ -19,7 +19,7 @@
 %%
 -module(global_SUITE).
 
--compile(r23). % many_nodes()
+-compile(r24). % many_nodes()
 
 -export([all/0, suite/0, groups/0, 
 	 init_per_suite/1, end_per_suite/1,

--- a/lib/kernel/test/kernel_SUITE.erl
+++ b/lib/kernel/test/kernel_SUITE.erl
@@ -23,7 +23,7 @@
 -module(kernel_SUITE).
 -include_lib("common_test/include/ct.hrl").
 
--compile(r22).
+-compile(r24).
 
 %% Test server specific exports
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 

--- a/lib/observer/test/crashdump_helper.erl
+++ b/lib/observer/test/crashdump_helper.erl
@@ -25,7 +25,7 @@
          dump_persistent_terms/0,
          create_persistent_terms/0,
          dump_global_literals/0]).
--compile(r22).
+-compile(r24).
 -include_lib("common_test/include/ct.hrl").
 
 n1_proc(N2,Creator) ->

--- a/lib/sasl/test/sasl_SUITE.erl
+++ b/lib/sasl/test/sasl_SUITE.erl
@@ -32,7 +32,7 @@
 	 log_file/1,
 	 utc_log/1]).
 
--compile(r22).
+-compile(r24).
 
 all() -> 
     [log_mf_h_env, log_file, app_test, appup_test, utc_log].

--- a/lib/stdlib/test/stdlib_SUITE.erl
+++ b/lib/stdlib/test/stdlib_SUITE.erl
@@ -27,7 +27,7 @@
          init_per_testcase/2, end_per_testcase/2,
          app_test/1, appup_test/1, assert_test/1]).
 
--compile(r22).
+-compile(r24).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 


### PR DESCRIPTION
The compiler has undocumented options for generating code for older releases, so that we can test that the runtime system can load code compiled for a previous release.

Remove the support for generating code that can be loaded on OTP 22/23. The support in the runtime system for loading code compiled for OTP 22/23 will be dropped in a separate pull request.