### PR TITLE
Add matchspec BIFs maps_put and maps_remove

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -416,6 +416,8 @@ atom Lt='<'
 atom machine
 atom magic_ref
 atom major
+atom maps_put
+atom maps_remove
 atom match
 atom match_limit
 atom match_limit_recursion

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -697,6 +697,18 @@ static DMCGuardBif guard_tab[] =
         DBIF_ALL
     },
     {
+        am_maps_put,
+        &maps_put_3,
+        3,
+        DBIF_TABLE_BODY
+    },
+    {
+        am_maps_remove,
+        &maps_remove_2,
+        2,
+        DBIF_TABLE_BODY
+    },
+    {
         am_is_map_key,
         &is_map_key_2,
         2,

--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -1020,6 +1020,8 @@ action_function(trace,3) -> true;
 action_function(caller_line,0) -> true;
 action_function(current_stacktrace,0) -> true;
 action_function(current_stacktrace,1) -> true;
+action_function(maps_put,3) -> true;
+action_function(maps_remove,2) -> true;
 action_function(_,_) -> false.
 
 bool_operator('and',2) ->


### PR DESCRIPTION
corresponding to maps:put/3 and maps:remove/2.

This is a quick attempt to fix #7309.

The map syntax to update keys cannot simply be used as `Map#{key => value}` would be translated by fun2ms to something like `'$1'#{key => value}` which is not valid Erlang syntax. Instead use the match spec syntax to call BIFs.

```
1> T = ets:new(x,[]).

2> ets:insert(T, {key, #{a=>1, b=>2}}).

3> MS = ets:fun2ms(fun({Key, Map}) when is_map(Map) -> {Key, maps_put(c, 3, Map)} end).
[{{'$1','$2'},
  [{is_map,'$2'}],
  [{{'$1',{maps_put,c,3,'$2'}}}]}]

4> ets:select_replace(T, MS).
1
5> ets:tab2list(T).
[{key,#{c => 3,a => 1,b => 2}}]
```

ToDo: Test and documentation.