### PR TITLE
compiler: Refine too strict assert in beam_ssa_pp:format_tuple_set_1/1

### DIFF
--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -427,5 +427,5 @@ format_tuple_set(RecordSet) ->
                 " | ").
 
 format_tuple_set_1({{Arity,Key},#t_tuple{size=Arity,elements=Elems}=Tuple}) ->
-    Key = map_get(1, Elems), % Assertion
+    false = none =:= beam_types:meet(Key, map_get(1, Elems)), % Assertion
     format_type(Tuple).


### PR DESCRIPTION
The assertion in `beam_ssa_pp:format_tuple_set_1/1` is not always true, as the type stored in the `Elems` map doesn't need to be exactly the same type as `Key`, they just have to be compatible.

The assert can be triggered by running `./scripts/diffable --asm --co 'dssaopt' $TMPDIR`.