### PR TITLE
Avoid optimization that beam_validator might consider unsafe

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -274,7 +274,7 @@ expand_opt(r23, Os) ->
                               no_recv_opt, no_init_yregs |
                               expand_opt(r24, Os)]);
 expand_opt(r24, Os) ->
-    expand_opt(no_type_opt, [no_bs_create_bin, no_ssa_opt_ranges |
+    expand_opt(no_type_opt, [no_badrecord, no_bs_create_bin, no_ssa_opt_ranges |
                              expand_opt(r25, Os)]);
 expand_opt(r25, Os) ->
     [no_ssa_opt_update_tuple, no_bs_match, no_min_max_bifs | Os];


### PR DESCRIPTION
Eliminating a repeated `=:=` test can result in code that `beam_validator` doesn't consider safe. This pull request makes the optimization keep `=:=` if it seems to be significant, that is, if one or both operands will gain type information from it.
    
That makes it possible to compile code from #6599 such as:
    
        f(X, X) when is_integer(X) ->
            ok;
        f(Y, Y = #{}) ->
            Y#{ok := ok}.
    
(Six other examples from #6599 can now also be compiled.)
    
Running `scripts/diffable` shows that this fix prevented the optimization in 14 modules (out of about 1000).
    
Closes #6599 (the examples that were not fixed by this PR will be transferred to a new issue)