### PR TITLE
compiler: Eliminate nondeterminism in beam_ssa_recv optimization

### DIFF
--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -740,7 +740,7 @@ plan_clears(UsageMap, Graph) ->
                           [] ->
                               Acc
                       end
-              end, #{}, UsageMap).
+              end, #{}, maps:iterator(UsageMap, ordered)).
 
 plan_clears_1([{From, To, branch} | Edges], ActiveRefs, UsageMap) ->
     %% Clear all references that are no longer active on the `To` block.


### PR DESCRIPTION
The beam_ssa_recv optimization builds a list of `recv_marker_clear` instructions to insert by using `maps:fold/3` in the function `beam_ssa_recv:plan_clears/2`. The fold iterates over `UsageMap` and concatenates the lists returned by `beam_ssa_recv:plan_clears_1/3`. As the iteration order of `maps:fold/3` is undefined, repeated runs on the same module can produce different results, as the SSA-variables holding the result of inserted `recv_marker_clear` instructions depend on the order they are created.

As a compiler developer interested in the effect of optimizations on the SSA-level (using for example, `erlc +dssaopt`) this produces many non-relevant changes in the SSA output. This patch forces the iteration order to be defined and makes the output for repeated compiler runs stable.