### PR TITLE
Add link to appup manpage in release handling doc

### DIFF
--- a/system/doc/design_principles/release_handling.xml
+++ b/system/doc/design_principles/release_handling.xml
@@ -416,8 +416,10 @@
     <item>Each <c>Instructions</c> is a list of release handling
     instructions.</item>
   </list>
-    <p>For information about the syntax and contents of the <c>.appup</c>
-      file, see the <c>appup(4)</c> manual page in SASL.</p>
+    <p><c>UpFromVsn</c> and <c>DownToVsn</c> can also be specified as regular
+      expressions. For more information about the syntax and contents of the
+      <c>.appup</c> file, see the <seefile marker="sasl:appup"><c>appup(4)</c>
+      manual page in SASL</seefile>.</p>
     <p><seeguide marker="appup_cookbook">Appup Cookbook</seeguide>
       includes examples of <c>.appup</c> files for typical upgrade/downgrade
       cases.</p>


### PR DESCRIPTION
Additionally, document that `UpFromVsn` and `DownToVsn` can also be a regular expression (explained in detail in the `appup` reference): the current document implies, to me, that previous versions must be a fixed string, whilst the appup file can deal with regular expressions as well.