### PR TITLE
Document squashing of smaller changes in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ If you want to change the setting only for the Erlang mode, you can use a hook l
 ### After you have submitted your pull request
 
 * Follow the discussion following your pull request, answer questions, discuss and implement
-changes requested by reviewers.
+changes requested by reviewers. Smaller changes should be squashed into their associated commits.
 
 * If your pull requests introduces new public functions, they need to be tagged with the
 OTP release in which they _will_ appear in the `since` tag in the functions' documentation.


### PR DESCRIPTION
Via https://github.com/erlang/otp/pull/7293#issuecomment-1568293651, I figured this may be valuable to have in the contributing docs as well.