### PR TITLE
erts: Remove buggy optimization in fun purging

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -1948,21 +1948,14 @@ BIF_RETTYPE erts_internal_purge_module_2(BIF_ALIST_2)
                 purge_state.module = BIF_ARG_1;
                 erts_mtx_unlock(&purge_state.mtx);
 
-                /* Because fun calls always land in the latest instance, there
-                 * is no need to set up purge markers if there's current code
-                 * for this module. */
-                if (!modp->curr.code_hdr) {
-                    /* Set up "pending purge" markers for the funs in this
-                     * module. Processes trying to call these funs will be
-                     * suspended _before_ calling them, which will then either
-                     * crash or succeed when resumed after the purge finishes
-                     * or is aborted.
-                     *
-                     * This guarantees that we won't get any more direct
-                     * references into the code while checking for such
-                     * funs. */
-                    erts_fun_purge_prepare(&modp->old);
-                }
+                /* Set up "pending purge" markers for the funs in this module.
+                 * Processes trying to call these funs will be suspended
+                 * _before_ calling them, which will then either crash or
+                 * succeed when resumed after the purge finishes or is aborted.
+                 *
+                 * This guarantees that we won't get any more direct references
+                 * into the code while checking for such funs. */
+                erts_fun_purge_prepare(&modp->old);
 
                 res = am_true;
             }

--- a/erts/emulator/test/code_SUITE.erl
+++ b/erts/emulator/test/code_SUITE.erl
@@ -26,6 +26,7 @@
          call_purged_fun_code_gone/1,
          call_purged_fun_code_reload/1,
          call_purged_fun_code_there/1,
+         call_purged_fun_code_altered/1,
          multi_proc_purge/1, t_check_old_code/1,
          external_fun/1,get_chunk/1,module_md5/1,
          constant_pools/1,constant_refc_binaries/1,
@@ -47,6 +48,7 @@ all() ->
      bad_beam_file, literal_leak,
      call_purged_fun_code_gone,
      call_purged_fun_code_reload, call_purged_fun_code_there,
+     call_purged_fun_code_altered,
      multi_proc_purge, t_check_old_code, external_fun, get_chunk,
      module_md5,
      constant_pools, constant_refc_binaries, fake_literals,
@@ -250,6 +252,18 @@ call_purged_fun_code_there_test(Config) when is_list(Config) ->
     call_purged_fun_test(Priv, Data, code_there),
     ok.
 
+%% GH-7288: calling a fun defined by a module that had been purged after
+%% loading a different version of the same module (and therefore did not
+%% inherit the old fun entries) could cause the emulator to crash.
+call_purged_fun_code_altered(Config) when is_list(Config) ->
+    run_sys_proc_test(fun call_purged_fun_code_altered_test/1, Config).
+
+call_purged_fun_code_altered_test(Config) when is_list(Config) ->
+    Priv = proplists:get_value(priv_dir, Config),
+    Data = proplists:get_value(data_dir, Config),
+    call_purged_fun_test(Priv, Data, code_altered),
+    ok.
+
 call_purged_fun_test(Priv, Data, Type) ->
     SrcFile = filename:join(Data, "call_purged_fun_tester.erl"),
     ObjFile = filename:join(Priv, "call_purged_fun_tester.beam"),
@@ -257,7 +271,6 @@ call_purged_fun_test(Priv, Data, Type) ->
     {module,Mod} = code:load_binary(Mod, ObjFile, Code),
 
     call_purged_fun_tester:do(Priv, Data, Type, []).
-
 
 multi_proc_purge(Config) when is_list(Config) ->
     run_sys_proc_test(fun multi_proc_purge_test/1, Config).

--- a/erts/emulator/test/code_SUITE_data/call_purged_fun.erl
+++ b/erts/emulator/test/code_SUITE_data/call_purged_fun.erl
@@ -1,0 +1,32 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2023-2023. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+-module(call_purged_fun).
+
+-export([make_fun/1, make_fun2/0]).
+
+make_fun(A) ->
+    fun(X) -> A + X end.
+
+make_fun2() ->
+    fun (F1,F2) ->
+	    F1(),
+	    F2()
+    end.

--- a/erts/emulator/test/code_SUITE_data/call_purged_fun_altered.erl
+++ b/erts/emulator/test/code_SUITE_data/call_purged_fun_altered.erl
@@ -1,0 +1,37 @@
+%%
+%% %CopyrightBegin%
+%% 
+%% Copyright Ericsson AB 2023-2023. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+
+-module(call_purged_fun).
+
+-export([make_fun/1, make_fun2/0, dummy/1]).
+
+make_fun(A) ->
+    fun(X) -> A + X end.
+
+make_fun2() ->
+    fun (F1,F2) ->
+	    F1(),
+	    F2()
+    end.
+
+%% Dummy function that ensures the module MD5 is different from the alpha
+%% version, keeping us from inheriting its fun entries.
+dummy(I) ->
+    I.


### PR DESCRIPTION
Calling a fun defined by a module that had been purged after loading a different version of the same module (and therefore did not inherit the old fun entries) could cause the emulator to crash.

We could retain the optimization by comparing the MD5 of the old and current instances, but it didn't give much so it's better to just get rid of it.

Fixes #7288