### PR TITLE
docs: Add --print-external-links to `otp_html_check`, fix some dead links

### DIFF
--- a/HOWTO/DTRACE.md
+++ b/HOWTO/DTRACE.md
@@ -52,5 +52,5 @@ DTrace probe specifications
 Probe specifications can be found in `erts/emulator/beam/erlang_dtrace.d`, and
 a few example scripts can be found under `lib/runtime_tools/examples/`.
 
-   [1]: http://www.erlang.org/euc/08/
+   [1]: https://erlang.org/euc/08/
    [$ERL_TOP/HOWTO/SYSTEMTAP.md]: SYSTEMTAP.md

--- a/lib/common_test/doc/src/run_test_chapter.xml
+++ b/lib/common_test/doc/src/run_test_chapter.xml
@@ -1272,8 +1272,8 @@
 	    performed through JavaScript code, automatically inserted into the HTML 
 	    log files. <c>Common Test</c> uses the <url href="http://jquery.com">jQuery</url> 
 	    library and the
-	    <url href="http://tablesorter.com">tablesorter</url> plugin, 
-	    with customized sorting functions, for this implementation.</p>
+	    <url href="https://mottie.github.io/tablesorter/docs/">tablesorter</url>
+	    plugin, with customized sorting functions, for this implementation.</p>
 	</section>
 
 	<section>

--- a/lib/inets/doc/src/mod_alias.xml
+++ b/lib/inets/doc/src/mod_alias.xml
@@ -75,7 +75,7 @@
         <marker id="path"></marker>
         <p><c>path/3</c> returns the file <c>Path</c> in the
 	<c>RequestURI</c> (see 
-	<url href="http://www.rfc-base.org/rfc-1945.html">RFC 1945</url>). 
+	<url href="https://www.ietf.org/rfc/rfc1945.txt">RFC 1945</url>).
 	If the interaction data <c>{real_name,{Path,AfterPath}}</c> 
 	has been exported by <c>mod_alias</c>,
 	<c>Path</c> is returned. If no interaction data has been

--- a/lib/megaco/doc/src/megaco_intro.xml
+++ b/lib/megaco/doc/src/megaco_intro.xml
@@ -120,16 +120,16 @@
       Megaco/H.248 and about the Erlang/OTP development system:</p>
     <list type="bulleted">
       <item>
-        <p><url href="http://www.erlang.org/project/megaco/standard/rfc3525.txt">version 1, RFC 3525</url></p>
+        <p><url href="https://www.erlang.org/doc/standard/rfc3525.txt">version 1, RFC 3525</url></p>
       </item>
       <item>
         <p><url href="http://www.ietf.org/rfc/rfc3015.txt">old version 1, RFC 3015</url></p>
       </item>
       <item>
-        <p><url href="http://www.erlang.org/project/megaco/standard/H.248.1-Corr1-200403.doc">Version 2 Corrigendum 1</url></p>
+        <p><url href="https://web.archive.org/web/20100704020645/http://www.erlang.org/project/megaco/standard/H.248.1-Corr1-200403.doc">Version 2 Corrigendum 1</url></p>
       </item>
       <item>
-        <p><url href="http://www.erlang.org/project/megaco/standard/draft-ietf-megaco-h248v2-04.txt">version 2, draft-ietf-megaco-h248v2-04</url></p>
+        <p><url href="https://web.archive.org/web/20100620185420/http://erlang.org/project/megaco/standard/draft-ietf-megaco-h248v2-04.txt">version 2, draft-ietf-megaco-h248v2-04</url></p>
       </item>
       <item>
         <p><url href="http://www.itu.int/">H.248.1 version 3</url></p>

--- a/lib/public_key/doc/src/public_key_app.xml
+++ b/lib/public_key/doc/src/public_key_app.xml
@@ -47,7 +47,7 @@
       <item>Supports <url href="http://csrc.nist.gov/publications/fips/fips186-3/fips_186-3.pdf"> DSS</url> - 
       Digital Signature Standard (DSA - Digital Signature Algorithm)</item>
       <item>Supports 
-      <url href="http://www.emc.com/emc-plus/rsa-labs/standards-initiatives/pkcs-3-diffie-hellman-key-agreement-standar.htm"> PKCS-3 </url> - 
+      <url href="https://web.archive.org/web/20170417091930/https://www.emc.com/emc-plus/rsa-labs/standards-initiatives/pkcs-3-diffie-hellman-key-agreement-standar.htm"> PKCS-3 </url> -
       Diffie-Hellman Key Agreement Standard </item>
       <item>Supports <url href="http://www.ietf.org/rfc/rfc2898.txt"> PKCS-5</url> - 
       Password-Based Cryptography Standard </item>

--- a/scripts/otp_html_check
+++ b/scripts/otp_html_check
@@ -60,9 +60,9 @@ my %anchor_defs;		# <a name="..."> in the form "$page#$anchor"
 
 @ARGV or usage("No base directory given");
 my $base = shift @ARGV;
-my @print_external_links = 0;
+my $print_external_links = 0;
 if ($base eq "--print-external-links") {
-    @print_external_links = 1;
+    $print_external_links = 1;
     $base = shift @ARGV;
 }
 -d $base or usage("Not a directory: $base");
@@ -284,7 +284,10 @@ sub normalize_link {
 
     # mailto: http: .....
     if ($link =~ /^\w{3,10}:/i) {
-        if ((@print_external_links)
+        # Exclude "Edit on GitHub" links. These would make up
+        # the majority of the output and there's likely little
+        # value in checking them.
+        if (($print_external_links)
             && ($link !~ /github\.com\/erlang\/otp/) 
             && ($link =~ /^http/)) {
                 push(@external_links, [$page, $link]);
@@ -421,16 +424,13 @@ if (keys %anchor_refs) {
     }
 }
 
-if (@print_external_links) {
+if ($print_external_links) {
   print "\n**** External links (excluding github.com/erlang/otp)\n\n";
 
   while (@external_links) {
     my $page_and_link = shift @external_links;
     my ($page, $link) = @$page_and_link;
     if ($link =~ /^\w{3,10}:/i) {
-      # Exclude "Edit on GitHub" links. These would make up
-      # the majority of the output and there's likely little
-      # value in checking them.
       print "$page -> $link\n";
     }
   }

--- a/scripts/otp_html_check
+++ b/scripts/otp_html_check
@@ -38,6 +38,7 @@ my @indexes =			# The order to try URL expansion
 my $html_ext = 'shtml|html|htm'; # HTML pages ends in these
 
 my @links;			# Set of [page,link] we want to check
+my @external_links;	        # Set of [page,link] for external links
 my @exclude;			# Pages/dir/prefix to exclude
 my %pages;			# Set of all files found in the file system
 				# limited by the script arguments.
@@ -59,6 +60,11 @@ my %anchor_defs;		# <a name="..."> in the form "$page#$anchor"
 
 @ARGV or usage("No base directory given");
 my $base = shift @ARGV;
+my @print_external_links = 0;
+if ($base eq "--print-external-links") {
+    @print_external_links = 1;
+    $base = shift @ARGV;
+}
 -d $base or usage("Not a directory: $base");
 $base =~ m&^/& or usage("Has to be absolute path: $base");
 $base =~ s&/+$&&;		# Remove ending slash if any
@@ -276,7 +282,15 @@ sub normalize_link {
 	$link = "$dir/$mod";
     }
 
-    return $link if $link =~ /^\w{3,10}:/i; # mailto: http: .....
+    # mailto: http: .....
+    if ($link =~ /^\w{3,10}:/i) {
+        if ((@print_external_links)
+            && ($link !~ /github\.com\/erlang\/otp/) 
+            && ($link =~ /^http/)) {
+                push(@external_links, [$page, $link]);
+        }
+        return $link;
+    }
 
     $link =~ s/%([\da-fA-F]{2})/chr(hex($1))/eg; # Translate hex to char
 
@@ -407,6 +421,21 @@ if (keys %anchor_refs) {
     }
 }
 
+if (@print_external_links) {
+  print "\n**** External links (excluding github.com/erlang/otp)\n\n";
+
+  while (@external_links) {
+    my $page_and_link = shift @external_links;
+    my ($page, $link) = @$page_and_link;
+    if ($link =~ /^\w{3,10}:/i) {
+      # Exclude "Edit on GitHub" links. These would make up
+      # the majority of the output and there's likely little
+      # value in checking them.
+      print "$page -> $link\n";
+    }
+  }
+}
+
 if (keys %missing || keys %anchor_refs) {
     exit 1;
 }
@@ -417,13 +446,16 @@ if (keys %missing || keys %anchor_refs) {
 sub usage {
   print STDERR "ERROR: ",join("\n",@_),"\n" if @_;
   print <<HERE;
-Usage: $0 BaseDirectory URL [ URLs... ] [ -- ExcludeURLs... ]
+Usage: $0 [ --print-external-links ] BaseDirectory URL [ URLs... ] [ -- ExcludeURLs... ]
 
 This script try to find out what files are used and not of your
 HTML documents, graphic files etc. It doesn't use HTTP, i.e. you
 work off-line, so this script may fail to find a link. Javascripts
 and other extensions also makes it very hard. But for many sites
 it work very well.
+
+If --print-external-links is given, the script will print any links that it
+finds to external sites, excluding links to the Erlang/OTP GitHub repository.
 
 The base directory given has to start with a slash.
 


### PR DESCRIPTION
The new flag for `otp_html_check` can be used for checking external references for validity. A few dead links that have been found were fixed.