### PR TITLE
Compile escripts by default

### DIFF
--- a/erts/doc/src/escript_cmd.xml
+++ b/erts/doc/src/escript_cmd.xml
@@ -185,15 +185,16 @@ halt(1).</pre>
           <c>127</c>.</p>
         <p>Both the module declaration and the export declaration of
           the <c>main/1</c> function are optional.</p>
-        <p>By default, the script will be interpreted. You can force
-          it to be compiled by including the following line somewhere
-          in the script file:</p>
+        <p>By default, the script will be compiled by the Erlang compiler.</p>
+        <p>It is possible to force it to be interpreted by including
+        the following line somewhere in the script file:</p>
         <pre>
--mode(compile).</pre>
-        <p>Execution of interpreted code is slower than compiled code.
-          If much of the execution takes place in interpreted code, it
-          can be worthwhile to compile it, although the compilation
-          itself takes a little while.</p>
+-mode(interpret).</pre>
+        <p>Execution of interpreted code is slower than compiled code,
+        and some language constructs will not work, but there is no
+        requirement for the Erlang compiler application to be available.</p>
+        <change><p>Before the Erlang/OTP 27 the script would be
+        interpreted by default.</p></change>
         <p>As mentioned earlier, a script can
           contains precompiled <c>beam</c> code. In a precompiled
           script, the interpretation of the script header is

--- a/lib/stdlib/src/escript.erl
+++ b/lib/stdlib/src/escript.erl
@@ -431,7 +431,7 @@ do_parse_file(Type, File, Fd, StartLine, HeaderSz, CheckOnly) ->
 initial_state(File) ->
     #state{file = File,
 	   n_errors = 0,
-	   mode = interpret,
+	   mode = compile,
 	   exports_main = false,
 	   has_records = false}.
 

--- a/lib/stdlib/test/escript_SUITE.erl
+++ b/lib/stdlib/test/escript_SUITE.erl
@@ -89,25 +89,28 @@ basic(Config) when is_list(Config) ->
     run(Config, Dir, "factorial_compile_main 7",
 	<<"factorial 7 = 5040\nExitCode:0">>),
     run(Config, Dir, "factorial_warning 20",
-	[data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
-		    "factorial 20 = 2432902008176640000\nExitCode:0">>]),
-    run_with_opts(Config, Dir, "-s", "factorial_warning",
-		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
-                              "%   12| bar() ->\n"
-                              "%     | ^\n\n"
-                              "ExitCode:0">>]),
-    run_with_opts(Config, Dir, "-s -i", "factorial_warning",
-		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
-                              "%   12| bar() ->\n"
-                              "%     | ^\n\n"
-                              "ExitCode:0">>]),
-    run_with_opts(Config, Dir, "-c -s", "factorial_warning",
-		  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
-                              "%   12| bar() ->\n"
-                              "%     | ^\n\n"
-                              "ExitCode:0">>]),
+        [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
+                    "%   12| bar() ->\n"
+                    "%     | ^\n\n"
+                    "factorial 20 = 2432902008176640000\n"
+                    "ExitCode:0">>]),
+    run_with_opts(Config, Dir, "-i", "factorial_warning 20",
+                  [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
+                              "factorial 20 = 2432902008176640000\nExitCode:0">>]),
+    Warnings = [data_dir,<<"factorial_warning:12:1: Warning: function bar/0 is unused\n"
+                           "%   12| bar() ->\n"
+                           "%     | ^\n\n"
+                           "ExitCode:0">>],
+    run_with_opts(Config, Dir, "-s", "factorial_warning", Warnings),
+    run_with_opts(Config, Dir, "-s -i", "factorial_warning", Warnings),
+    run_with_opts(Config, Dir, "-c -s", "factorial_warning", Warnings),
     run(Config, Dir, "filesize "++filename:join(proplists:get_value(data_dir, Config),"filesize"),
-	[data_dir,<<"filesize:11:1: Warning: function id/1 is unused\n324\nExitCode:0">>]),
+	[data_dir,<<"filesize:11:1: Warning: function id/1 is unused\n"
+                    "%   11| id(I) -> I.\n"
+                    "%     | ^\n"
+                    "\n"
+                    "324\n"
+                    "ExitCode:0">>]),
     run(Config, Dir, "test_script_name",
 	[data_dir,<<"test_script_name\nExitCode:0">>]),
     run(Config, Dir, "tail_rec 1000",
@@ -128,18 +131,19 @@ errors(Config) when is_list(Config) ->
 	[data_dir,<<"compile_error:5:12: syntax error before: '*'\n">>,
 	 data_dir,<<"compile_error:8:9: syntax error before: blarf\n">>,
 	 <<"escript: There were compilation errors.\nExitCode:127">>]),
-    run(Config, Dir, "lint_error",
-	[data_dir,<<"lint_error:6:1: function main/1 already defined\n">>,
-	 data_dir,"lint_error:8:10: variable 'ExitCode' is unbound\n",
-	 <<"escript: There were compilation errors.\nExitCode:127">>]),
-    run_with_opts(Config, Dir, "-s", "lint_error",
-		  [data_dir,<<"lint_error:6:1: function main/1 already defined\n"
-                              "%    6| main(Args) ->\n"
-                              "%     | ^\n\n">>,
-		   data_dir,("lint_error:8:10: variable 'ExitCode' is unbound\n"
-                             "%    8|     halt(ExitCode).\n"
-                             "%     |          ^\n\n"),
-		   <<"escript: There were compilation errors.\nExitCode:127">>]),
+    CompileErrors = [data_dir,<<"lint_error:6:1: function main/1 already defined\n"
+                                "%    6| main(Args) ->\n"
+                                "%     | ^\n\n">>,
+                     data_dir,("lint_error:8:10: variable 'ExitCode' is unbound\n"
+                               "%    8|     halt(ExitCode).\n"
+                               "%     |          ^\n\n"),
+                     <<"escript: There were compilation errors.\nExitCode:127">>],
+    run(Config, Dir, "lint_error", CompileErrors),
+    run_with_opts(Config, Dir, "-i", "lint_error",
+                  [data_dir,<<"lint_error:6:1: function main/1 already defined\n">>,
+                   data_dir,"lint_error:8:10: variable 'ExitCode' is unbound\n",
+                   <<"escript: There were compilation errors.\nExitCode:127">>]),
+    run_with_opts(Config, Dir, "-s", "lint_error", CompileErrors),
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
The current default when running an escript is to interpret it using the `erl_eval` module. In the ancient times when escript was invented that made sense. Interpretation would be slower and some language constructs would not work, but execution could start immediately without waiting for the compiler to finish.

Nowadays with faster computers it makes less sense.

Therefore, in Erlang/OTP 27, change the default to compile the escript. That will require the escript to be executed by an Erlang system that includes the Erlang compiler.