### PR TITLE
[dialyzer] Simplify ets usage

### DIFF
--- a/lib/dialyzer/src/dialyzer_cplt.erl
+++ b/lib/dialyzer/src/dialyzer_cplt.erl
@@ -490,9 +490,8 @@ tab_merge('$end_of_table', T1, T2) ->
       tab_merge(Key, T1, T2)
   end;
 tab_merge(K1, T1, T2) ->
-  Vs = ets:lookup(T1, K1),
   NextK1 = ets:next(T1, K1),
-  true = ets:delete(T1, K1),
+  Vs = ets:take(T1, K1),
   true = ets:insert(T2, Vs),
   tab_merge(NextK1, T1, T2).
 

--- a/lib/dialyzer/src/dialyzer_plt.erl
+++ b/lib/dialyzer/src/dialyzer_plt.erl
@@ -371,9 +371,8 @@ tab_merge('$end_of_table', T1, T2) ->
       tab_merge(Key, T1, T2)
   end;
 tab_merge(K1, T1, T2) ->
-  Vs = ets:lookup(T1, K1),
   NextK1 = ets:next(T1, K1),
-  true = ets:delete(T1, K1),
+  Vs = ets:take(T1, K1),
   true = ets:insert(T2, Vs),
   tab_merge(NextK1, T1, T2).
 

--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -1179,9 +1179,8 @@ ets_take('$end_of_table', T, F, A) ->
     Key -> ets_take(Key, T, F, A)
   end;
 ets_take(Key, T, F, A) ->
-  Vs = ets:lookup(T, Key),
   Key1 = ets:next(T, Key),
-  true = ets:delete(T, Key),
+  Vs = ets:take(T, Key),
   ets_take(Key1, T, F, F(Vs, A)).
 
 -spec parallelism() -> integer().


### PR DESCRIPTION
This simplifies ets:lookup + ets:delete into ets:take calls. Removing one call to ets should be beneficial in terms of performance.