### PR TITLE
dialyzer: Add dry-run mode

### DIFF
--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -158,6 +158,7 @@
                        | {'warnings', [warn_option()]}
                        | {'get_warnings', boolean()}
                        | {'use_spec', boolean()}
+                       | {'dry_run', boolean()}
                        | {'filename_opt', filename_opt()}
                        | {'callgraph_file', file:filename()}
                        | {'mod_deps_file', file:filename()}
@@ -240,6 +241,7 @@
 		  check_plt       = true           :: boolean(),
                   error_location  = ?ERROR_LOCATION :: error_location(),
                   metrics_file       = none	   :: none | file:filename(),
+                  dry_run         = false	   :: boolean(),
 		  module_lookup_file = none	   :: none | file:filename(),
                   solvers         = []             :: [solver()]}).
 

--- a/lib/dialyzer/src/dialyzer_cl_parse.erl
+++ b/lib/dialyzer/src/dialyzer_cl_parse.erl
@@ -222,6 +222,11 @@ cli() ->
                         "modules considered, how many modules were changed since the PLT was "
                         "last updated, how many modules needed to be analyzed) to a file. This "
                         "can be useful for tracking and debugging Dialyzer's incrementality.">>},
+            #{name => dry_run, long => "-dry_run", type => boolean,
+                help => <<"Perform initial setup stages, including reading the PLT and checking "
+                          "which modules will need to be analysed, then exit before running the full "
+                          "analysis. Useful for checking the expected size of the analysis, etc. "
+                          "Only valid in incremental mode.">>},
             #{name => warning_files_rec, long => "-warning_apps", type => {custom, fun parse_app/1},
                 nargs => list, action => extend,
                 help => <<"By default, warnings will be reported to all applications given by "

--- a/lib/dialyzer/src/dialyzer_options.erl
+++ b/lib/dialyzer/src/dialyzer_options.erl
@@ -104,6 +104,7 @@ postprocess_opts(Opts = #options{}) ->
     end,
   check_file_existence(Opts1),
   check_metrics_file_validity(Opts1),
+  check_dry_run_validity(Opts1),
   check_module_lookup_file_validity(Opts1),
   Opts2 = check_output_plt(Opts1),
   check_init_plt_kind(Opts2),
@@ -118,6 +119,13 @@ check_metrics_file_validity(#options{analysis_type = _NotIncremental, metrics_fi
   ok;
 check_metrics_file_validity(#options{analysis_type = _NotIncremental, metrics_file = FileName}) ->
   bad_option("A metrics filename may only be given when in incremental mode", {metrics_file, FileName}).
+
+check_dry_run_validity(#options{analysis_type = incremental}) ->
+  ok;
+check_dry_run_validity(#options{analysis_type = _NotIncremental, dry_run = false}) ->
+  ok;
+check_dry_run_validity(#options{analysis_type = _NotIncremental, dry_run = true}) ->
+  bad_option("The dry_run flag may only be given when in incremental mode", {dry_run, true}).
 
 check_module_lookup_file_validity(#options{analysis_type = incremental, module_lookup_file = none}) ->
   ok;
@@ -337,6 +345,8 @@ build_options([{OptionName, Value} = Term|Rest], Options) ->
     metrics_file ->
       assert_filename(Value),
       build_options(Rest, Options#options{metrics_file = Value});
+    dry_run when is_boolean(Value) ->
+      build_options(Rest, Options#options{dry_run = Value});
     module_lookup_file ->
       assert_filename(Value),
       build_options(Rest, Options#options{module_lookup_file = Value});


### PR DESCRIPTION
For big incremental analyses, it can be useful to "dry-run" Dialyzer in order to determine how many modules Dialyzer expects to need to analyse. This allows for determining whether or not a full analysis run is needed, and what sort of resources it might require. In principle, this information could then be used for automatically running Dialyzer on an appropriately sized worker.