### PR TITLE
common test: Synchronize capture start and stop

### DIFF
--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -1863,22 +1863,14 @@ log(Msg) ->
     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% capture_start() -> ok
-%% capture_stop() -> ok
-%%
-%% Starts/stops capturing all output from io:format, and similar. Capturing
-%% output doesn't stop output from happening. It just makes it possible
-%% to retrieve the output using capture_get/0.
-%% Starting and stopping capture doesn't affect already captured output.
-%% All output is stored as messages in the message queue until retrieved
+%% @see test_server_gl:capture_start/2
 
 capture_start() ->
-    group_leader() ! {capture,self()},
-    ok.
+    test_server_gl:capture_start(group_leader(), self()).
 
+%% @see test_server_gl:capture_stop/1
 capture_stop() ->
-    group_leader() ! {capture,false},
-    ok.
+    test_server_gl:capture_stop(group_leader()).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% capture_get() -> Output

--- a/lib/common_test/src/test_server_gl.erl
+++ b/lib/common_test/src/test_server_gl.erl
@@ -25,7 +25,8 @@
 
 -module(test_server_gl).
 -export([start_link/1,stop/1,set_minor_fd/3,unset_minor_fd/1,
-	 get_tc_supervisor/1,print/4,set_props/2]).
+	 get_tc_supervisor/1,print/4,set_props/2,
+	 capture_start/2, capture_stop/1]).
 
 -export([init/1,handle_call/3,handle_cast/2,handle_info/2,terminate/2]).
 
@@ -88,6 +89,24 @@ set_minor_fd(GL, Fd, MFA) ->
 unset_minor_fd(GL) ->
     req(GL, unset_minor_fd).
 
+%% capture_start(GL, Who)
+%%  GL = Pid for the group leader process
+%%  Who = Process that wants to start capturing output
+%%
+%% capture_stop(GL)
+%%  GL = Pid for the group leader process
+%%
+%% Starts/stops capturing all output from io:format, and similar. Capturing
+%% output doesn't stop output from happening. It just makes it possible
+%% to retrieve the output using capture_get/0.
+%% Starting and stopping capture doesn't affect already captured output.
+%% All output is stored as messages in the message queue until retrieved.
+
+capture_start(GL, Who) ->
+    req(GL, {capture, Who}).
+
+capture_stop(GL) ->
+    req(GL, {capture, false}).
 
 %% get_tc_supervisor(GL)
 %%  GL = Pid for the group leader process
@@ -165,7 +184,13 @@ handle_call({set_props,PropList}, _From, St) ->
     {reply,ok,do_set_props(PropList, St)};
 handle_call({print,Detail,Msg,Printer}, {From,_}, St) ->
     output(Detail, Msg, Printer, From, St),
-    {reply,ok,St}.
+    {reply,ok,St};
+handle_call({capture, Who}, {_From, _}, St) ->
+    Cap = case Who of
+	      false -> none;
+	      Pid when is_pid(Pid) -> Pid
+	  end,
+    {reply, ok, St#st{capture=Cap}}.
 
 handle_cast(stop, St) ->
     {stop,normal,St}.
@@ -185,12 +210,6 @@ handle_info({'DOWN',Ref,process,_,_}, #st{tsio_monitor=Ref}=St) ->
     {stop,normal,St};
 handle_info({permit_io,Pid}, #st{permit_io=P}=St) ->
     {noreply,St#st{permit_io=gb_sets:add(Pid, P)}};
-handle_info({capture,Cap0}, St) ->
-    Cap = case Cap0 of
-	      false -> none;
-	      Pid when is_pid(Cap0) -> Pid
-	  end,
-    {noreply,St#st{capture=Cap}};
 handle_info({io_request,From,ReplyAs,Req}=IoReq, St) ->
     _ = try io_req(Req, From, St) of
 	passthrough ->

--- a/lib/tools/test/cover_SUITE.erl
+++ b/lib/tools/test/cover_SUITE.erl
@@ -864,7 +864,6 @@ export_import(Config) when is_list(Config) ->
     %% warning is written when data is deleted for imported module.
     test_server:capture_start(),
     {ok,f} = cover:compile(f),
-    timer:sleep(10), % capture needs some time
     [Text3] = test_server:capture_get(),
     "WARNING: Deleting data for module f imported from" ++ _ = lists:flatten(Text3),
     test_server:capture_stop(),


### PR DESCRIPTION
Wait on the reply by the test server group leader to ensure that by the time we continue running the test case all output is captured.