### PR TITLE
ft: increase default process limit

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -1131,7 +1131,7 @@ $ <input>erl \
 	however, be changed in the future. The actual value chosen can be
 	checked by calling
 	<seeerl marker="erlang#system_info_process_limit">erlang:system_info(process_limit)</seeerl>.</p>
-	<p>The default value is <c>262144</c></p>
+	<p>The default value is <c>1048576</c></p>
       </item>
       <tag><marker id="+Q"/><marker id="max_ports"/><c><![CDATA[+Q Number]]></c></tag>
       <item>

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -78,7 +78,7 @@ typedef struct process Process;
 #define ERTS_MAX_NO_OF_DIRTY_CPU_SCHEDULERS ERTS_MAX_NO_OF_SCHEDULERS
 #define ERTS_MAX_NO_OF_DIRTY_IO_SCHEDULERS ERTS_MAX_NO_OF_SCHEDULERS
 
-#define ERTS_DEFAULT_MAX_PROCESSES (1 << 18)
+#define ERTS_DEFAULT_MAX_PROCESSES (1 << 20)
 
 #define ERTS_HEAP_ALLOC(Type, Size)					\
      erts_alloc((Type), (Size))

--- a/erts/emulator/test/node_container_SUITE.erl
+++ b/erts/emulator/test/node_container_SUITE.erl
@@ -28,6 +28,7 @@
 -module(node_container_SUITE).
 -author('rickard.green@uab.ericsson.se').
 
+-include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1,
@@ -904,21 +905,29 @@ mkpidlist(N, Ps) -> mkpidlist(N-1, [spawn(fun () -> ok end)|Ps]).
 
 
 iter_max_procs(Config) when is_list(Config) ->
-    NoMoreTests = make_ref(),
-    erlang:send_after(10000, self(), NoMoreTests),
-
     %% Disable logging to avoid "Too many processes" log which can
     %% cause ct_logs to crash when trying to spawn "async print job".
-    #{level := LoggerLevel} = logger:get_primary_config(),
-    ok = logger:set_primary_config(level, none),
-    Res = try
-              R = chk_max_proc_line(),
-              R = chk_max_proc_line(),
-              done = chk_max_proc_line_until(NoMoreTests, R),
-              R
-          after
-              logger:set_primary_config(level, LoggerLevel)
+    {ok, Peer, Node} = ?CT_PEER(["+P", "2048", "-kernel", "logger_level", "none"]),
+    NoMoreTests = make_ref(),
+
+    Self = self(),
+    NcData = make_ref(),
+
+    %% Sleep to give all `peer` processes time to go down.
+    ct:sleep(500),
+
+    RPid = spawn_link(Node, fun () ->
+                                   erlang:send_after(10000, self(), NoMoreTests),
+                                   R = chk_max_proc_line(),
+                                   R = chk_max_proc_line(),
+                                   done = chk_max_proc_line_until(NoMoreTests, R),
+                                   Self ! {NcData, R}
+                            end),
+    Res = receive
+              {NcData, R} -> R
           end,
+    unlink(RPid),
+    stop_node(Peer, Node),
     Cmt = io_lib:format("max processes = ~p; "
                         "process line length = ~p",
                         [element(2, Res), element(1, Res)]),
@@ -959,7 +968,7 @@ chk_max_proc_line_until(NoMoreTests, Res) ->
         NoMoreTests ->
             done
     after 0 ->
-              Res = chk_max_proc_line(),
+              ?assertEqual(Res, chk_max_proc_line()),
               chk_max_proc_line_until(NoMoreTests, Res)
     end.
 
@@ -972,20 +981,20 @@ magic_ref(Config) when is_list(Config) ->
     MRef0 = MRef1,
     Me = self(),
     {Pid, Mon} = spawn_opt(fun () ->
-				   receive
-				       {Me, MRef} ->
-					   Me ! {self(), erts_debug:get_internal_state({magic_ref,MRef})}
-				   end
-			   end,
-			   [link, monitor]),
+                                   receive
+                                       {Me, MRef} ->
+                                           Me ! {self(), erts_debug:get_internal_state({magic_ref,MRef})}
+                                   end
+                           end,
+                           [link, monitor]),
     Pid ! {self(), MRef0},
     receive
-	{Pid, Info} ->
-	    {Addr0, 3, true} = Info
+        {Pid, Info} ->
+            {Addr0, 3, true} = Info
     end,
     receive
-	{'DOWN', Mon, process, Pid, _} ->
-	    ok
+        {'DOWN', Mon, process, Pid, _} ->
+            ok
     end,
     MaxTime = erlang:monotonic_time(millisecond) + 1000,
     %% The DOWN signal is sent before heap is cleaned up,

--- a/system/doc/efficiency_guide/advanced.xml
+++ b/system/doc/efficiency_guide/advanced.xml
@@ -155,7 +155,7 @@
       <row>
         <cell>Processes</cell>
         <cell>The maximum number of simultaneously alive Erlang processes
-	is by default 262,144. This limit can be configured at startup.
+	is by default 1,048,576. This limit can be configured at startup.
 	For more information, see the
 	<seecom marker="erts:erl#max_processes"><c>+P</c></seecom>
 	command-line flag in the


### PR DESCRIPTION
Increase the default process limit from quite conservative limit that wasn't
changed since ERTS 5.10.1 to value that is more applicable in 2023. It cause
about 9 MiB more memory to be consumed at startup, but with current machines it
shouldn't be much of an issue.
