### PR TITLE
kernel: support sending byte stream on standard in

### DIFF
--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -614,7 +614,25 @@ MaxT = NetTickTime + NetTickTime / NetTickIntensity</code>
 	</p>
 
       </item>
-    </taglist>
+    <tag><marker id="standard_io_encoding"/><c>standard_io_encoding = Encoding</c></tag>
+      <item>
+        <p>Set whether bytes sent or received via standard_io should be interpreted as unicode or latin1.
+        By default input and output is interpreted as Unicode if it is supported on the host. With this flag
+        you may configure the encoding on startup.</p>
+        <p>This works similarly to <seemfa marker="stdlib:io#setopts/2"><c>io:setopts(standard_io, {encoding, Encoding})</c></seemfa>
+        but is applied before any bytes on standard_io may have been read.</p>
+        <p>Encoding is one of:</p>
+        <taglist>
+          <tag><c>utf8</c></tag>
+          <item><p>Configure standard_io to use unicode mode.</p></item>
+          <tag><c>latin1</c></tag>
+          <item><p>Configure standard_io to use latin1 mode.</p></item>
+          <tag><c>_</c></tag>
+          <item><p>Anything other then utf8 or latin1 will be ignored and the system will
+            configure the encoding by itself, typically utf8 on modern systems.</p></item>
+        </taglist>
+      </item>
+          </taglist>
   </section>
 
   <section>

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -218,7 +218,7 @@ init(UserOptions) when is_map(UserOptions) ->
     {ok, TTY} = tty_create(),
 
     %% Initialize the locale to see if we support utf-8 or not
-    UnicodeMode =
+    UnicodeSupported =
         case setlocale(TTY) of
             primitive ->
                 lists:any(
@@ -228,6 +228,11 @@ init(UserOptions) when is_map(UserOptions) ->
             UnicodeLocale when is_boolean(UnicodeLocale) ->
                 UnicodeLocale
         end,
+    IOEncoding = application:get_env(kernel, standard_io_encoding, default),
+    UnicodeMode = if IOEncoding =:= latin1 -> false;
+       IOEncoding =:= utf8 -> true;
+       true -> UnicodeSupported
+    end,
     {ok, ANSI_RE_MP} = re:compile(?ANSI_REGEXP, [unicode]),
     init_term(#state{ tty = TTY, unicode = UnicodeMode, options = Options, ansi_regexp = ANSI_RE_MP }).
 init_term(State = #state{ tty = TTY, options = Options }) ->


### PR DESCRIPTION
Fixes issue in: #7230

Adds a flag "-kernel standard_io_encoding" that configures encoding before standard_io is being read.