### PR TITLE
Fix typo for maybe expression abstract form

### DIFF
--- a/erts/doc/src/absform.xml
+++ b/erts/doc/src/absform.xml
@@ -449,7 +449,7 @@
       <item>
         <p>If E is a maybe expression <c>maybe B else Ec_1 ; ... ; Ec_k end</c>,
           where <c>B</c> is a body and each <c>Ec_i</c> is an else clause then Rep(E) =
-          <c>{'maybe',ANNO,Rep(B),{'else',ANNO,[Rep(Ec_1), ..., Rep(Tc_k)]}}</c>.</p>
+          <c>{'maybe',ANNO,Rep(B),{'else',ANNO,[Rep(Ec_1), ..., Rep(Ec_k)]}}</c>.</p>
       </item>
       <item>
         <p>If E is nil, <c>[]</c>, then Rep(E) = <c>{nil,ANNO}</c>.</p>


### PR DESCRIPTION
The term `Tc_k` was not introduced, and I think `Ec_k` was intended.