### PR TITLE
Eliminate the temporary buffer for binary construction

### DIFF
--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -2642,11 +2642,6 @@ erts_allocated_areas(fmtfn_t *print_to_p, void *print_to_arg, void *proc)
     i++;
 
     values[i].arity = 2;
-    values[i].name = "bits_bufs_size";
-    values[i].ui[0] = erts_bits_bufs_size();
-    i++;
-
-    values[i].arity = 2;
     values[i].name = "bif_timer";
     values[i].ui[0] = erts_bif_timer_memory_size();
     i++;

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -51,12 +51,6 @@ typedef struct erl_bin_match_buffer {
 
 struct erl_bits_state {
     /*
-     * Temporary buffer sometimes used by erts_new_bs_put_integer().
-     */
-    byte *byte_buf_;
-    Uint byte_buf_len_;
-
-    /*
      * Pointer to the beginning of the current binary.
      */
     byte* erts_current_bin_;
@@ -127,11 +121,6 @@ typedef struct erl_bin_match_struct{
     }											    \
   }  while (0)
 
-void erts_init_bits(void);	/* Initialization once. */
-void erts_bits_init_state(ERL_BITS_PROTO_0);
-void erts_bits_destroy_state(ERL_BITS_PROTO_0);
-
-
 /*
  * NBYTES(x) returns the number of bytes needed to store x bits.
  */
@@ -177,7 +166,6 @@ int erts_new_bs_put_binary_all(Process *c_p, Eterm Bin, Uint unit);
 Eterm erts_new_bs_put_float(Process *c_p, Eterm Float, Uint num_bits, int flags);
 void erts_new_bs_put_string(ERL_BITS_PROTO_2(byte* iptr, Uint num_bytes));
 
-Uint erts_bits_bufs_size(void);
 Uint32 erts_bs_get_unaligned_uint32(ErlBinMatchBuffer* mb);
 Eterm erts_bs_get_utf8(ErlBinMatchBuffer* mb);
 Eterm erts_bs_get_utf16(ErlBinMatchBuffer* mb, Uint flags);

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -343,7 +343,6 @@ erl_init(int ncpu,
     BIN_VH_MIN_SIZE = erts_next_heap_size(BIN_VH_MIN_SIZE, 0);
 
     erts_init_trace();
-    erts_init_bits();
     erts_code_ix_init();
     erts_init_fun_table();
     init_atom_table();

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -5889,8 +5889,6 @@ init_scheduler_registers(ErtsSchedulerData* esdp) {
         registers =
             erts_alloc_permanent_cache_aligned(ERTS_ALC_T_BEAM_REGISTER,
                                                sizeof(ErtsSchedulerRegisters));
-
-        erts_bits_init_state(&registers->aux_regs.d.erl_bits_state);
     }
 
     esdp->registers = registers;

--- a/erts/emulator/beam/jit/arm/process_main.cpp
+++ b/erts/emulator/beam/jit/arm/process_main.cpp
@@ -72,9 +72,6 @@ void BeamGlobalAssembler::emit_process_main() {
 
     a.mov(scheduler_registers, a64::sp);
 
-    load_erl_bits_state(ARG1);
-    runtime_call<1>(erts_bits_init_state);
-
     /* Save the initial SP of the thread so that we can verify that it
      * doesn't grow. */
 #ifdef JIT_HARD_DEBUG

--- a/erts/emulator/beam/jit/x86/process_main.cpp
+++ b/erts/emulator/beam/jit/x86/process_main.cpp
@@ -75,9 +75,6 @@ void BeamGlobalAssembler::emit_process_main() {
           x86::qword_ptr(x86::rsp,
                          offsetof(ErtsSchedulerRegisters, x_reg_array.d)));
 
-    load_erl_bits_state(ARG1);
-    runtime_call<1>(erts_bits_init_state);
-
 #if defined(DEBUG) && defined(NATIVE_ERLANG_STACK)
     /* Save stack bounds so they can be tested without clobbering anything. */
     runtime_call<0>(erts_get_stacklimit);

--- a/erts/emulator/valgrind/suppress.patched.3.6.0
+++ b/erts/emulator/valgrind/suppress.patched.3.6.0
@@ -280,21 +280,6 @@ obj:*/ssleay.*
 }
 
 {
-erts_bits_init_state; Why is this needed?
-Memcheck:Leak
-PossiblyLost
-fun:malloc
-fun:erts_sys_alloc
-...
-fun:erts_alloc
-fun:erts_bits_init_state
-fun:erts_init_scheduling
-fun:erl_init
-fun:erl_start
-fun:main
-}
-
-{
 Prebuilt constant terms in os_info_init
 Memcheck:Leak
 PossiblyLost


### PR DESCRIPTION
In the old non-SMP emulator there was one global temporary buffer. In the SMP emulator, there is one per scheduler thread, which reduces the possibility for reuse and potentially wastes memory.

As well as saving some memory, the rewritten operations are also slightly faster.