### PR TITLE
inets: Document sending status with mod_esi

### DIFF
--- a/lib/inets/doc/src/mod_esi.xml
+++ b/lib/inets/doc/src/mod_esi.xml
@@ -150,7 +150,14 @@
 	that is, <c>"\r\n\r\n",</c> the server assumes that no HTTP
 	header fields will be generated.</p>
 
-	<p><c>Env</c> environment data of the request see description above.</p>
+	<p>To set the response status code, the special <c>status</c> response
+	header can be sent. For instance, to acknowledge creation of a resource
+	and annotate the response content type with JSON, one could respond with
+	the following headers:</p>
+
+	<code type="erl">"status: 201 Created\r\n content-type: application/json\r\n\r\n"</code>
+
+	<p><c>Env</c> environment data of the request, see description above.</p>
 		
 	<p><c>Input</c> is query data of a GET request or the body of
 	a PUT or POST request. The default behavior (legacy reasons)


### PR DESCRIPTION
I think this was previously undocumented because of its roots in CGI (https://stackoverflow.com/questions/25800385/how-to-send-response-headers-and-status-from-cgi-scripts), but I figured it would be nice to explicitly mention it in the docs regardless.
A test for this is already done as part of `httpd_SUITE:esi`, line 949:
```erl
    ok = http_status("GET /cgi-bin/erl/httpd_example:new_status_and_location ",
                     Config, [{statuscode, 201},
                              {header, "location"}]).
```
which calls `src/http_server/httpd_example.erl`, doing:
```erl
new_status_and_location(SessionID, Env, Input) ->
    mod_esi:deliver(SessionID, new_status_and_location(Env, Input)).

new_status_and_location(_Env,_Input) ->
  "status:201 Created\r\n Location: http://www.yahoo.com\r\n\r\n".
```