### PR TITLE
compiler: Fix bug in `nif_start` insertion

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -4101,7 +4101,12 @@ insert_nif_start([VF={V,F=#c_fun{body=Body}}|Funs]) ->
         #c_case{} ->
             NifStart = #c_primop{name=#c_literal{val=nif_start},args=[]},
             [{V,F#c_fun{body=#c_seq{arg=NifStart,body=Body}}}
-            |insert_nif_start(Funs)]
+            |insert_nif_start(Funs)];
+        #c_letrec{defs=Defs,body=LetrecBody0}=LR0 ->
+            NifStart = #c_primop{name=#c_literal{val=nif_start},args=[]},
+            LetrecBody = #c_seq{arg=NifStart,body=LetrecBody0},
+            LR = LR0#c_letrec{defs=insert_nif_start(Defs), body=LetrecBody},
+            [{V,F#c_fun{body=LR}}|insert_nif_start(Funs)]
     end;
 insert_nif_start([]) ->
     [].

--- a/lib/compiler/test/core_SUITE_data/nif.erl
+++ b/lib/compiler/test/core_SUITE_data/nif.erl
@@ -1,6 +1,6 @@
 -module(nif).
 
--export([init/1, start/1]).
+-export([init/1, start/1, bug0/1]).
 
 -ifdef(WITH_ATTRIBUTE).
 -nifs([start/1]).
@@ -15,3 +15,8 @@ init(_File) ->
 -endif.
 
 start(_) -> erlang:nif_error(not_loaded).
+
+%% This used to crash the compiler in the v3_core pass as
+%% insert_nif_start/1 did not support letrecs.
+bug0(<<HL:32/signed-integer-big-unit:1, _:HL/binary, _/binary>>) ->
+    <<>>.


### PR DESCRIPTION
Commit 724da95cd04d2bc1d6cb89d1988b58b2096d59cd extended the v3_core-pass to make all functions start with a `nif_start` instruction when the `nifs` attribute isn't present in the module but a call to `erlang:load_nif/2` is. The `nif_start` instruction is used as a flag, allowing later compiler passes to easily identify a NIF.

The initial implementation assumed that a function body could only be a `#c_seq{}` or a `#c_case{}` and never a `#c_letrec{}`. This patch extends the v3_core-pass to handle function bodies consisting of a `#c_letrec{}`. Credits for discovering a test case triggering this omission goes to Matthew Pope.

Closes #7409