### PR TITLE
inets: Speed up test suite by ~ 2 minutes

### DIFF
--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -1554,8 +1554,8 @@ inet_opts(Config) when is_list(Config) ->
     httpc:set_options(ConnOptions),
 
     Request  = {url(group_name(Config), "/dummy.html", Config), []},
-    Timeout      = timer:seconds(1),
-    ConnTimeout  = Timeout + timer:seconds(1),
+    Timeout      = timer:seconds(5),
+    ConnTimeout  = Timeout + timer:seconds(5),
     HttpOptions = [{timeout, Timeout}, {connect_timeout, ConnTimeout}, ?SSL_NO_VERIFY],
     Options0     = [{socket_opts, [{tos,    87},
 				   {recbuf, 16#FFFF},

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -68,7 +68,7 @@ all() ->
 
 groups() ->
     [
-     {http, [], real_requests()},
+     {http, [parallel], real_requests()},
      {http_ipv6, [], [request_options]},
      %% process_leak_on_keepalive is depending on stream_fun_server_close
      %% and it shall be the last test case in the suite otherwise cookie
@@ -81,7 +81,7 @@ groups() ->
      {https, [], [def_ssl_opt | real_requests()]},
      {sim_https, [], only_simulated()},
      {misc, [parallel], misc()},
-     {sim_mixed, [], sim_mixed()}
+     {sim_mixed, [parallel], sim_mixed()}
     ].
 
 real_requests()->

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -1381,9 +1381,7 @@ security(Config) ->
     Node = proplists:get_value(node, Config),
     ServerRoot = proplists:get_value(server_root, Config),
 
-    global:register_name(mod_security_test, self()),   % Receive events
-
-    ct:sleep(5000),
+    yes = global:register_name(mod_security_test, self()),   % Receive events
 
     OpenDir = filename:join([ServerRoot, "htdocs", "open"]),
 

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -395,7 +395,7 @@ end_per_testcase(Case, Config) ->
 
 
 dbg(Case, Config, Status) ->
-    Cases = [esi_put],
+    Cases = [],
     case lists:member(Case, Cases) of
 	true ->
 	    case Status of

--- a/lib/inets/test/httpd_basic_SUITE.erl
+++ b/lib/inets/test/httpd_basic_SUITE.erl
@@ -34,21 +34,20 @@ suite() -> [{ct_hooks,[ts_install_cth]},
 	    {timetrap, {seconds, 30}}].
 
 all() -> 
-    [uri_too_long_414, 
-     header_too_long_413,
-     entity_too_long,
-     http_0_9_not_supported,
-     erl_script_nocache_opt,
-     script_nocache,
-     escaped_url_in_error_body,
-     script_timeout,
-     slowdose,
-     keep_alive_timeout,
-     invalid_rfc1123_date
-    ].
+    [{group, httpd_basic}].
 
 groups() -> 
-    [].
+    [{httpd_basic, [parallel], [uri_too_long_414,
+                                header_too_long_413,
+                                entity_too_long,
+                                http_0_9_not_supported,
+                                erl_script_nocache_opt,
+                                script_nocache,
+                                escaped_url_in_error_body,
+                                script_timeout,
+                                slowdose,
+                                keep_alive_timeout,
+                                invalid_rfc1123_date]}].
 
 init_per_group(_GroupName, Config) ->
     Config.

--- a/lib/inets/test/inets_SUITE.erl
+++ b/lib/inets/test/inets_SUITE.erl
@@ -84,10 +84,6 @@ end_per_suite(_Config) ->
 %% Note: This function is free to add any key/value pairs to the Config
 %% variable, but should NOT alter/remove any existing entries.
 %%--------------------------------------------------------------------
-init_per_testcase(httpd_reload, Config) ->
-    inets:stop(),
-    ct:timetrap({seconds, 40}),
-    Config;
 init_per_testcase(_Case, Config) ->
     inets:stop(),
     Config.

--- a/lib/inets/test/inets_SUITE.erl
+++ b/lib/inets/test/inets_SUITE.erl
@@ -262,26 +262,20 @@ httpd_reload(Config) when is_list(Config) ->
 		 {bind_address,  "localhost"}],
 
     ok = inets:start(),
-    ct:sleep(5000),
 
     {ok, Pid0} = inets:start(httpd, [{port, 0}, 
 				     {ipfamily, inet} | HttpdConf]),
-    ct:sleep(5000),
 
     [{port, Port0}] = httpd:info(Pid0, [port]),         
-    ct:sleep(5000),
 
     [{document_root, PrivDir}] =  httpd:info(Pid0, [document_root]),
-    ct:sleep(5000),
 
     ok = httpd:reload_config([{port, Port0}, {ipfamily, inet},
 			      {server_name, "httpd_test"}, 
 			      {server_root, PrivDir},
 			      {document_root, DataDir}, 
 			      {bind_address, "localhost"}], non_disturbing),
-    ct:sleep(5000),    
     [{document_root, DataDir}] =  httpd:info(Pid0, [document_root]),
-    ct:sleep(5000),    
 
     ok = httpd:reload_config([{port, Port0}, {ipfamily, inet},
 			      {server_name, "httpd_test"}, 

--- a/lib/inets/test/inets_socketwrap_SUITE.erl
+++ b/lib/inets/test/inets_socketwrap_SUITE.erl
@@ -79,7 +79,7 @@ start_httpd_fd(Config) when is_list(Config) ->
 	    case open_port({spawn_executable, Wrapper},
                            [stderr_to_stdout,{args,Args}]) of
 	    	Port when is_port(Port) ->
-		    wait_node_up(Node, 10),
+		    wait_node_up(Node, 200),
 		    ct:pal("~p", [rpc:call(Node, init, get_argument, [httpd_80])]),
 		    ok  = rpc:call(Node, inets, start, []),
 		    {ok, Pid} = rpc:call(Node, inets, start, [httpd, HttpdConf]),
@@ -117,6 +117,6 @@ wait_node_up(Node, N) ->
 	pong ->
 	    ok;
 	pang ->
-	    ct:sleep(5000),
+	    ct:sleep(250),
 	    wait_node_up(Node, N-1)
     end.


### PR DESCRIPTION
Improve inets test suite runtime from 560s to 435s on my fast local machine, from 595s to 486s on my slow local machine, and from 10m47s to 8m49s on GitHub actions in my fork.
 
The following was done:
- Some testcases that supported it were just migrated to `parallel` directly
- Global state in tests is either isolated out of parallel groups or only taken when needed (ETS tables, httpc profiles)
- Removed or reduced naptime in some tests depending on shared resources
- Removed debug tracing from `esi_put`, this seemed to hang the tests when running in GH Actions

I've tried to keep the individual changes cleanly separated, let me know if they should be squashed.