### PR TITLE
Add more illumos/SunOS cacert directories

### DIFF
--- a/lib/public_key/src/pubkey_os_cacerts.erl
+++ b/lib/public_key/src/pubkey_os_cacerts.erl
@@ -62,7 +62,7 @@ load() ->
         {unix, netbsd} ->
             load_from_file(bsd_paths());
         {unix, sunos} ->
-            load_from_files(sunos_path());
+            load_from_files(sunos_paths());
         {win32, _} ->
             load_win32();
 	{unix, darwin} ->
@@ -169,8 +169,11 @@ bsd_paths() ->
      "/etc/openssl/certs/ca-certificates.crt"
     ].
 
-sunos_path() ->
-    "/etc/certs/CA/".
+sunos_paths() ->
+    ["/etc/certs/CA/", %% Oracle Solaris, some older illumos distros
+     "/etc/ssl/cacert.pem", %% OmniOS
+     "/opt/local/etc/openssl/certs/ca-certificates.crt" %% SmartOS and pkgsrc
+    ].
 
 run_cmd(Cmd, Args) ->
     Opts = [binary, exit_status, stderr_to_stdout],


### PR DESCRIPTION
While attempting to install Pleroma on OmniOS r151046 using `mix deps.get`, I ran into an obscure error message about cacerts:

$ mix deps.get
!!! RUNNING IN LOCALHOST DEV MODE! !!!
FEDERATION WON'T WORK UNTIL YOU CONFIGURE A dev.secret.exs
Could not find Hex, which is needed to build dependency :phoenix
Shall I install Hex? (if running non-interactively, use "mix local.hex --force") [Yn] y
warning: failed to load system certificates. SSL peer verification will be skipped but downloads are still verified with a checksum

18:44:33.251 [error] Task #PID<0.115.0> started from #PID<0.100.0> terminating
** (MatchError) no match of right hand side value: {:error, :no_cacerts_found}
    (public_key 1.14) pubkey_os_cacerts.erl:38: :pubkey_os_cacerts.get/0
    (inets 9.0) httpc.erl:476: :httpc.ssl_verify_host_options/1
    (inets 9.0) httpc.erl:1012: :httpc.http_options_default/0
    (inets 9.0) httpc.erl:927: :httpc.http_options/1
    (inets 9.0) httpc.erl:771: :httpc.handle_request/9
    (mix 1.14.5) lib/mix/utils.ex:688: Mix.Utils.read_httpc/1
    (mix 1.14.5) lib/mix/utils.ex:579: anonymous fn/2 in Mix.Utils.read_path/2
    (elixir 1.14.5) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2

After testing myself, digging around and looking at pubkey_os_cacerts.erl, and symlinking files in /etc/certs/CA/ to fix the error, I was able to determine that Erlang isn't aware of the other directories illumos distributions now use as under SunOS it's only coded to look in one directory. This change adds in two other directories that both OmniOS and SmartOS are known to use.