### PR TITLE
List optional applications for wx apps

### DIFF
--- a/lib/debugger/src/debugger.app.src
+++ b/lib/debugger/src/debugger.app.src
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 1997-2021. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 {application, debugger,
@@ -47,6 +47,7 @@
 	     int
 	    ]},
   {registered, [dbg_iserver, dbg_wx_mon, dbg_wx_winman]},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, compiler]},
+  {optional_applications, [compiler, wx]},
   {runtime_dependencies, ["wx-2.0","stdlib-3.15","kernel-8.0","erts-12.0",
 			  "compiler-8.0"]}]}.

--- a/lib/et/src/et.app.src
+++ b/lib/et/src/et.app.src
@@ -31,7 +31,8 @@
     et_wx_viewer
    ]},
   {registered, [et_collector]},
-  {applications, [stdlib, kernel]},
+  {applications, [stdlib, kernel, runtime_tools]},
+  {optional_applications, [wx, runtime_tools]},
   {env, []},
   {runtime_dependencies, ["wx-1.2","stdlib-3.4","runtime_tools-1.10",
 			  "kernel-5.3","erts-9.0"]}

--- a/lib/observer/src/observer.app.src
+++ b/lib/observer/src/observer.app.src
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 2002-2023. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 {application, observer,
@@ -65,7 +65,8 @@
 	       ttb,
 	       ttb_et]},
     {registered, []},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, runtime_tools, et]},
+    {optional_applications, [wx, runtime_tools, et]},
     {env, []},
     {runtime_dependencies, ["wx-2.3","stdlib-5.0","runtime_tools-1.19",
 			    "kernel-9.0","et-1.5","erts-14.0"]}]}.

--- a/lib/reltool/src/reltool.app.src
+++ b/lib/reltool/src/reltool.app.src
@@ -34,10 +34,11 @@
     reltool_utils
    ]},
   {registered, []},
-  {applications, [stdlib, kernel]},
+  {applications, [stdlib, kernel, wx, tools, sasl]},
+  {optional_applications, [wx, tools, sasl]},
   {env, []},
   {runtime_dependencies,
    ["wx-2.3","tools-2.6.14",
-    "stdlib-5.0","stdlib-5.0","sasl-4.2.1",
+    "stdlib-5.0","sasl-4.2.1",
     "kernel-9.0","erts-14.0"]}
  ]}.


### PR DESCRIPTION
Erlang/OTP 24 added support for optional applications,
this pull request lists them to some apps in order to
exercise the tooling.

If no bugs are found, we could list the optional applications
for more apps in the future.