### PR TITLE
Refine types for `min/2` and `max/2`

### DIFF
--- a/lib/compiler/src/beam_bounds.erl
+++ b/lib/compiler/src/beam_bounds.erl
@@ -222,19 +222,13 @@ bounds('bsl', R1, R2) ->
             any
     end;
 bounds(max, R1, R2) ->
-    case {R1,R2} of
-        {{A,B},{C,D}} ->
-            normalize({inf_max(A, C),inf_max(B, D)});
-        {_,_} ->
-            any
-    end;
+    {A,B} = expand(R1),
+    {C,D} = expand(R2),
+    normalize({inf_max(A, C),inf_max(B, D)});
 bounds(min, R1, R2) ->
-    case {R1,R2} of
-        {{A,B},{C,D}} ->
-            normalize({inf_min(A, C),inf_min(B, D)});
-        {_,_} ->
-            any
-    end.
+    {A,B} = expand(R1),
+    {C,D} = expand(R2),
+    normalize({inf_min(A, C),inf_min(B, D)}).
 
 -spec relop(relop(), range(), range()) -> bool_result().
 
@@ -510,6 +504,9 @@ infer_relop_types_1('>', {A,B}, {C,D}) ->
 %%% Atoms are greater than all integers. Therefore, we don't
 %%% need any special handling of '+inf'.
 %%%
+
+expand(any) -> {'-inf','+inf'};
+expand({_,_}=R) -> R.
 
 normalize({'-inf','-inf'}) ->
     {'-inf',-1};

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -287,6 +287,10 @@ min_bounds(_Config) ->
     {1,100} = min_bounds({1,100}, {100,'+inf'}),
     {100,200} = min_bounds({150,200}, {100,'+inf'}),
 
+    {'-inf',10} = min_bounds({1,10}, any),
+    any = min_bounds({1,'+inf'}, any),
+    {'-inf',777} = min_bounds(any, {'-inf',777}),
+
     ok.
 
 min_bounds(R1, R2) ->
@@ -308,6 +312,10 @@ max_bounds(_Config) ->
     {100,'+inf'} = max_bounds({1,99}, {100,'+inf'}),
     {100,'+inf'} = max_bounds({1,100}, {100,'+inf'}),
     {150,'+inf'} = max_bounds({150,200}, {100,'+inf'}),
+
+    {1,'+inf'} = max_bounds({1,99}, any),
+    {10,'+inf'} = max_bounds({10,'+inf'}, any),
+    any = max_bounds({'-inf',70}, any),
 
     ok.
 

--- a/lib/compiler/test/bif_SUITE.erl
+++ b/lib/compiler/test/bif_SUITE.erl
@@ -45,6 +45,7 @@ groups() ->
       ]}].
 
 init_per_suite(Config) ->
+    _ = id(Config),
     test_lib:recompile(?MODULE),
     Config.
 
@@ -208,6 +209,36 @@ min_max(_Config) ->
     true = bool_max_true(True, False),
     true = bool_max_true(True, True),
 
+    11 = min_increment(100),
+    11 = min_increment(10),
+    10 = min_increment(9),
+    1 = min_increment(0),
+    0 = min_increment(-1),
+    11 = min_increment(a),
+
+    {42,42} = max_number(id(42)),
+    {42,42.0} = max_number(id(42.0)),
+    {-1,1} = max_number(id(-1)),
+    {-1,1} = max_number(id(-1.0)),
+
+    100 = int_clamped_add(-1),
+    100 = int_clamped_add(0),
+    105 = int_clamped_add(5),
+    110 = int_clamped_add(10),
+    110 = int_clamped_add(11),
+
+    100 = num_clamped_add(-1),
+    100 = num_clamped_add(0),
+    105 = num_clamped_add(5),
+    110 = num_clamped_add(10),
+    110 = num_clamped_add(11),
+
+    105 = num_clamped_add(5),
+    105.0 = num_clamped_add(5.0),
+    110 = num_clamped_add(a),
+    110 = num_clamped_add({a,b,c}),
+    110 = num_clamped_add({a,b,c}),
+
     ok.
 
 %% GH-7170: The following functions would cause a crash in
@@ -222,8 +253,27 @@ bool_min_true(A, B) when is_boolean(A), is_boolean(B) ->
 bool_max_false(A, B) when is_boolean(A), is_boolean(B) ->
     false = max(A, B).
 
-bool_max_true(A, B) when is_boolean(A), is_boolean(B) ->
-    true = max(A, B).
+bool_max_true(A, B) when is_boolean(B) ->
+    true = max(A, B),
+    if
+        is_boolean(A) ->
+            true = max(A, B)
+    end.
+
+max_number(A) ->
+    Res = {trunc(A), max(A, 1)},
+    Res = {trunc(A), max(1, A)}.
+
+min_increment(A) ->
+    Res = min(10, A) + 1,
+    Res = min(A, 10) + 1,
+    Res = min(id(A), 10) + 1.
+
+int_clamped_add(A) when is_integer(A) ->
+    min(max(A, 0), 10) + 100.
+
+num_clamped_add(A) ->
+    min(max(A, 0), 10) + 100.
 
 %%%
 %%% Common utilities.


### PR DESCRIPTION
For this example:

    clamped_add(A) when is_integer(A) ->
        min(max(A, 0), 10) + 100.

the compiler will now be able to infer the range 1 through 10 for the `A` variable when it is used by the plus operator:

    {gc_bif,'+',{f,0},1,[{tr,{x,0},{t_integer,{0,10}}},{integer,100}],{x,0}}.