### PR TITLE
Fix longstanding errors in the compiler's alias analysis pass

### DIFF
--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -740,14 +740,10 @@ aa_bif(Dst, element, [#b_literal{},Tuple], SS, _AAS) ->
     aa_set_aliased([Dst,Tuple], SS);
 aa_bif(Dst, element, [#b_var{},Tuple], SS, _AAS) ->
     aa_set_aliased([Dst,Tuple], SS);
-aa_bif(Dst, hd, Args, SS, AAS) ->
-    %% If we extract a value and the aggregate dies and wasn't aliased,
-    %% we should not consider this an aliasing operation.
-    aa_alias_if_args_dont_die(Args, Dst, SS, AAS);
-aa_bif(Dst, tl, Args, SS, AAS) ->
-    %% If we extract a value and the aggregate dies and wasn't aliased,
-    %% we should not consider this an aliasing operation.
-    aa_alias_if_args_dont_die(Args, Dst, SS, AAS);
+aa_bif(Dst, hd, [Pair], SS, _AAS) ->
+    aa_pair_extraction(Dst, Pair, hd, SS);
+aa_bif(Dst, tl, [Pair], SS, _AAS) ->
+    aa_pair_extraction(Dst, Pair, tl, SS);
 aa_bif(Dst, map_get, [_Key,Map], SS, AAS) ->
     aa_map_extraction(Dst, Map, SS, AAS);
 aa_bif(Dst, Bif, Args, SS, _AAS) ->

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -32,6 +32,8 @@
 -include("beam_ssa_opt.hrl").
 -include("beam_types.hrl").
 
+%% Uncomment the following to get trace printouts.
+
 %% -define(DEBUG, true).
 
 -ifdef(DEBUG).
@@ -42,13 +44,40 @@
 -define(DP(FMT), skip).
 -endif.
 
+%% Uncomment the following to get trace printouts when states are
+%% merged.
+
+%% -define(TRACE_MERGE, true).
+
+-ifdef(TRACE_MERGE).
+-define(TM_DP(FMT, ARGS), io:format(FMT, ARGS)).
+-define(TM_DP(FMT), io:format(FMT)).
+-else.
+-define(TM_DP(FMT, ARGS), skip).
+-define(TM_DP(FMT), skip).
+-endif.
+
+%% Uncomment the following to check that all invariants for the state
+%% hold when a state are and has been updated. These checks are
+%% expensive and not enabled by default.
+
+%% -define(EXTRA_ASSERTS, true).
+
+-ifdef(EXTRA_ASSERTS).
+-define(aa_assert_ss(SS), aa_assert_ss(SS)).
+-define(ASSERT(Assert), Assert).
+-else.
+-define(aa_assert_ss(SS), SS).
+-define(ASSERT(Assert), skip).
+-endif.
+
 -type call_args_status_map() :: #{ #b_local{} => ['aliased' | 'unique'] }.
 
 %% Alias analysis state
 -record(aas, {
               caller :: func_id() | 'undefined',
               call_args = #{} :: call_args_status_map(),
-              alias_map = #{},
+              alias_map = #{} :: alias_map(),
               func_db :: func_info_db(),
               kills :: kills_map(),
               st_map :: st_map(),
@@ -66,11 +95,30 @@
 
 -type kills_map() :: #{ func_id() => kill_set() }.
 
+-type alias_map() :: #{ func_id() => lbl2ss() }.
+
+-type lbl2ss() :: #{ beam_ssa:label() => sharing_state() }.
+
 %% Record holding the liveness information for a code location.
 -record(liveness_st, {
                       in = sets:new([{version,2}]) :: sets:set(#b_var{}),
                       out = sets:new([{version,2}]) :: sets:set(#b_var{})
                      }).
+
+%% The sharing state for a variable.
+-record(vas, {
+              status :: 'unique' | 'aliased' | 'as_parent',
+              parents = [] :: ordsets:ordset(#b_var{}),
+              child = none :: #b_var{} | 'none',
+              extracted = [] :: ordsets:ordset(#b_var{}),
+              tuple_elems = [] :: ordsets:ordset({non_neg_integer(),#b_var{}}),
+              pair_elems = none :: 'none'
+                                 | {'hd',#b_var{}}
+                                 | {'tl',#b_var{}}
+                                 | {'both',#b_var{},#b_var{}}
+             }).
+
+-type sharing_state() :: #{ #b_var{} => #vas{} }.
 
 %%%
 %%% Optimization pass which calculates the alias status of values and
@@ -251,16 +299,33 @@ kills_is([], _, KillsMap, _) ->
 %%% can be reached by other means than the boxed pointer in the
 %%% variable.
 %%%
+%%% For this pass, a data structure called a Sharing State (in the
+%%% code the variable holding it is usually called SS) is used to
+%%% describe the alias status of SSA variables. The Sharing State
+%%% maintains information about:
+%%%
+%%% * Whether a variable is unique or aliased.
+%%%
+%%% * For variables which are unique and derived from other variables
+%%%   (that is, contained in or contains another term), it makes it
+%%%   possible to identify the variable for the contained/containing
+%%%   term. This includes information making it possible to avoid
+%%%   false aliasing when a tuple is deconstructed although
+%%%   technically, the variable holding tuple itself aliases its
+%%%   elements until all elements are extracted.
+%%%
 %%% The alias analysis is performed by traversing the functions in the
-%%% module and their code. For each operation the uniqueness and alias
-%%% status are updated. The unique/aliased status is maintained in a
-%%% map which maps a variable to a either a status or another
-%%% variable. Thus constructing equivalent sets in the same way a
-%%% Kotzmann and Mössenböck.
+%%% module and their code. The basic blocks of a function are
+%%% traversed in reverse post order. When the end of a block is
+%%% reached, the current sharing state is propagated to the block's
+%%% successors by merging the sharing state of all the successor
+%%% block's predecessors' sharing states.
 %%%
-%%% When the analysis finishes each instruction is annotated with
-%%% information about which of its arguments are unique or aliased.
-%%%
+%%% When all blocks have been visited and the sharing states at the
+%%% end of each block are known, information about aliased variables
+%%% are propagated along the edges of the execution graph during a
+%%% post order traversal of the basic blocks.
+
 -spec aa([func_id()], kills_map(), st_map(), func_info_db()) ->
           {st_map(), func_info_db()}.
 
@@ -314,13 +379,13 @@ aa_fixpoint([F|Fs], Order, OldAliasMap, OldCallArgs, AAS0=#aas{st_map=StMap},
     #b_local{name=#b_literal{val=_N},arity=_A} = F,
     AAS1 = AAS0#aas{caller=F},
     ?DP("-= ~p/~p =-~n", [_N, _A]),
-    {OptSt,AAS2} = aa_fun(F, map_get(F, StMap), AAS1),
-    AAS = AAS2#aas{st_map=StMap#{F => OptSt}},
+    AAS = aa_fun(F, map_get(F, StMap), AAS1),
     aa_fixpoint(Fs, Order, OldAliasMap, OldCallArgs, AAS, Limit);
-aa_fixpoint([], _Order, OldAliasMap, OldCallArgs,
+aa_fixpoint([], Order, OldAliasMap, OldCallArgs,
             #aas{alias_map=OldAliasMap,call_args=OldCallArgs,
-                 func_db=FuncDb,st_map=StMap}, _) ->
-    ?DP("**** End of iteration ~p ****~n"),
+                 func_db=FuncDb}=AAS, _Limit) ->
+    ?DP("**** End of iteration ~p ****~n", [_Limit]),
+    {StMap,_} = aa_update_annotations(Order, AAS),
     {StMap, FuncDb};
 aa_fixpoint([], _, _, _, #aas{func_db=FuncDb,orig_st_map=StMap}, 0) ->
     ?DP("**** End of iteration, too many iterations ****~n"),
@@ -334,7 +399,7 @@ aa_fixpoint([], Order, _OldAliasMap, _OldCallArgs,
     aa_fixpoint(NewOrder, Order, AliasMap, CallArgs,
                 AAS#aas{repeats=sets:new([{version,2}])}, Limit - 1).
 
-aa_fun(F, #opt_st{ssa=Linear0,args=Args}=St,
+aa_fun(F, #opt_st{ssa=Linear0,args=Args},
        AAS0=#aas{alias_map=AliasMap0,call_args=CallArgs0,
                  func_db=FuncDb,repeats=Repeats0}) ->
     %% Initially assume all formal parameters are unique for a
@@ -345,8 +410,8 @@ aa_fun(F, #opt_st{ssa=Linear0,args=Args}=St,
     SS0 = foldl(fun({Var, Status}, Acc) ->
                         aa_new_ssa_var(Var, Status, Acc)
                 end, #{}, ArgsStatus),
-    ?DP("@@ Args: ~p~n", [ArgsStatus]),
-    {Linear1,SS,#aas{call_args=CallArgs}=AAS} = aa_blocks(Linear0, SS0, AAS0),
+    ?DP("Args: ~p~n", [ArgsStatus]),
+    {SS,#aas{call_args=CallArgs}=AAS} = aa_blocks(Linear0, #{0=>SS0}, AAS0),
     ?DP("SS:~n~p~n~n", [SS]),
 
     AliasMap = AliasMap0#{ F => SS },
@@ -361,18 +426,19 @@ aa_fun(F, #opt_st{ssa=Linear0,args=Args}=St,
                   false ->
                       Repeats0
               end,
-    {St#opt_st{ssa=Linear1}, AAS#aas{alias_map=AliasMap,repeats=Repeats}}.
+    AAS#aas{alias_map=AliasMap,repeats=Repeats}.
 
 %% Main entry point for the alias analysis
-aa_blocks([{L,#b_blk{is=Is0,last=T0}=Blk}|Bs0], SS0, AAS0) ->
-    {Is,SS1,AAS1} = aa_is(Is0, SS0, [], AAS0),
-    {T,SS2} = aa_terminator(T0, SS1, AAS1),
-    {Bs,SS,AAS} = aa_blocks(Bs0, SS2, AAS1),
-    {[{L,Blk#b_blk{is=Is,last=T}}|Bs],SS,AAS};
-aa_blocks([], SS, AAS) ->
-    {[],SS, AAS}.
+aa_blocks([{L,#b_blk{is=Is0,last=T0}}|Bs0], Lbl2SS0, AAS0) ->
+    #{L:=SS0} = Lbl2SS0,
+    {SS1,AAS1} = aa_is(Is0, L, SS0, AAS0),
+    Lbl2SS1 = aa_terminator(T0, SS1, L, Lbl2SS0),
+    aa_blocks(Bs0, Lbl2SS1, AAS1);
+aa_blocks([], Lbl2SS, AAS) ->
+    {Lbl2SS,AAS}.
 
-aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, Acc, AAS0) ->
+aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is],
+      ThisBlock, SS0, AAS0) ->
     SS1 = aa_new_ssa_var(Dst, unique, SS0),
     {SS, AAS} =
         case Op of
@@ -386,7 +452,7 @@ aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, Acc, AAS0) ->
                         case aa_all_dies([Arg], Dst, AAS0) of
                             true ->
                                 %% Inherit the status of the argument
-                                {aa_join(Dst, Arg, SS1), AAS0};
+                                {aa_derive_from(Dst, Arg, SS1), AAS0};
                             false ->
                                 %% We alias with the surviving arg
                                 {aa_set_aliased([Dst|Args], SS1), AAS0}
@@ -414,10 +480,10 @@ aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, Acc, AAS0) ->
                 aa_call(Dst, Args, Anno0, SS1, AAS0);
             'catch_end' ->
                 [_Tag,Arg] = Args,
-                {aa_join(Dst, Arg, SS1), AAS0};
+                {aa_derive_from(Dst, Arg, SS1), AAS0};
             extract ->
                 [Arg,_] = Args,
-                {aa_join(Dst, Arg, SS1), AAS0};
+                {aa_derive_from(Dst, Arg, SS1), AAS0};
             get_hd ->
                 [Arg] = Args,
                 {aa_pair_extraction(Dst, Arg, hd, SS1), AAS0};
@@ -497,18 +563,22 @@ aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, Acc, AAS0) ->
             _ ->
                 exit({unknown_instruction, I})
         end,
-    aa_is(Is, SS, [aa_update_annotation(I, SS1, AAS)|Acc], AAS);
-aa_is([], SS, Acc, AAS) ->
-    {reverse(Acc), SS, AAS}.
+    aa_is(Is, ThisBlock, SS, AAS);
+aa_is([], _, SS, AAS) ->
+    {SS, AAS}.
 
-aa_terminator(T=#b_br{anno=Anno0}, SS0, AAS) ->
-    Anno = aa_update_annotation(Anno0, SS0, AAS),
-    {T#b_br{anno=Anno}, SS0};
-aa_terminator(T=#b_ret{arg=Arg,anno=Anno0}, SS0, AAS) ->
+aa_terminator(#b_br{succ=S,fail=S},
+              SS, ThisBlock, Lbl2SS) ->
+    aa_set_block_exit_ss(ThisBlock, SS, aa_add_block_entry_ss([S], SS, Lbl2SS));
+aa_terminator(#b_br{succ=S,fail=F},
+              SS, ThisBlock, Lbl2SS) ->
+    aa_set_block_exit_ss(ThisBlock, SS,
+                         aa_add_block_entry_ss([S,F], SS, Lbl2SS));
+aa_terminator(#b_ret{arg=Arg,anno=Anno0}, SS, ThisBlock, Lbl2SS0) ->
     Type = maps:get(result_type, Anno0, any),
-    Status0 = aa_get_status(Arg, SS0),
+    Status0 = aa_get_status(Arg, SS),
     ?DP("Returned ~p:~p:~p~n", [Arg, Status0, Type]),
-    Type2Status0 = maps:get(returns, SS0, #{}),
+    Type2Status0 = maps:get(returns, Lbl2SS0, #{}),
     Status = case Type2Status0 of
                  #{ Type := OtherStatus } ->
                      aa_meet(Status0, OtherStatus);
@@ -516,68 +586,285 @@ aa_terminator(T=#b_ret{arg=Arg,anno=Anno0}, SS0, AAS) ->
                      Status0
              end,
     Type2Status = Type2Status0#{ Type => Status },
-    ?DP("new status map: ~p~n", [Type2Status]),
-    SS = SS0#{ returns => Type2Status},
-    {aa_update_annotation(T, SS, AAS), SS};
-aa_terminator(T=#b_switch{anno=Anno0}, SS0, AAS) ->
-    Anno = aa_update_annotation(Anno0, SS0, AAS),
-    {T#b_switch{anno=Anno}, SS0}.
+    ?DP("New status map: ~p~n", [Type2Status]),
+    Lbl2SS = Lbl2SS0#{ returns => Type2Status},
+    aa_set_block_exit_ss(ThisBlock, SS, Lbl2SS);
+aa_terminator(#b_switch{fail=F,list=Ls},
+              SS, ThisBlock, Lbl2SS0) ->
+    Lbl2SS = aa_add_block_entry_ss([F|[L || {_,L} <- Ls]], SS, Lbl2SS0),
+    aa_set_block_exit_ss(ThisBlock, SS, Lbl2SS).
 
-%% Add a new ssa variable to the alias state and set its status.
-aa_new_ssa_var(Var, Status, State) ->
-    false = maps:get(Var, State, false), % Assertion
-    State#{Var => {status, Status}}.
+%% Store the updated SS for the point where execution leaves the
+%% block.
+aa_set_block_exit_ss(ThisBlockLbl, SS, Lbl2SS) ->
+    Lbl2SS#{ThisBlockLbl=>SS}.
 
-aa_get_representative(Var, State) ->
-    %% TODO: Consider path compression
-    case State of
-        #{ Var := {status, _} } ->
-            Var;
-        #{ Var := Parent } ->
-            aa_get_representative(Parent, State)
+%% Extend the SS valid on entry to the blocks in the list with NewSS.
+aa_add_block_entry_ss([L|BlockLabels], NewSS, Lbl2SS) ->
+    aa_add_block_entry_ss(BlockLabels, NewSS, aa_merge_ss(L, NewSS, Lbl2SS));
+aa_add_block_entry_ss([], _, Lbl2SS) ->
+    Lbl2SS.
+
+%% Merge two sharing states when traversing the execution graph
+%% reverse post order.
+aa_merge_ss(BlockLbl, NewSS, Lbl2SS)
+  when is_map_key(BlockLbl, Lbl2SS) ->
+    #{BlockLbl:=OrigSS} = Lbl2SS,
+    NewSize = maps:size(NewSS),
+    OrigSize = maps:size(OrigSS),
+    _ = ?aa_assert_ss(OrigSS),
+    _ = ?aa_assert_ss(NewSS),
+
+    %% Always merge the smaller state into the larger.
+    Tmp = if NewSize < OrigSize ->
+                  ?TM_DP("merging block ~p~n~p.~n~p.~n",
+                         [BlockLbl, OrigSS, NewSS]),
+                  aa_merge_continue(OrigSS, NewSS, maps:keys(NewSS), [], []);
+             true ->
+                  ?TM_DP("merging block ~p~n~p.~n~p.~n",
+                         [BlockLbl, NewSS, OrigSS]),
+                  aa_merge_continue(NewSS, OrigSS, maps:keys(OrigSS), [], [])
+          end,
+    Lbl2SS#{BlockLbl=>Tmp};
+aa_merge_ss(BlockLbl, NewSS, Lbl2SS) ->
+    Lbl2SS#{BlockLbl=>NewSS}.
+
+aa_merge_continue(A, B, [V|Vars], ParentFixups, AliasFixups) ->
+    #{V:=BVas} = B,
+    case A of
+        #{V:=AVas} ->
+            ?TM_DP("merge ~p~n", [V]),
+            aa_merge_1(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups);
+        #{} ->
+            ?TM_DP("not in dest ~p~n", [V]),
+            %% V isn't in A, nothing to merge, add it.
+            aa_merge_continue(A#{V=>BVas}, B, Vars, ParentFixups, AliasFixups)
+    end;
+aa_merge_continue(A0, _, [], ParentFixups, AliasFixups) ->
+    A = aa_merge_parent_fixups(A0, ParentFixups),
+    ?aa_assert_ss(aa_merge_alias_fixups(A, AliasFixups)).
+
+aa_merge_1(_V, Vas, Vas, A, B, Vars, ParentFixups, AliasFixups) ->
+    %% They are both the same, no change.
+    ?TM_DP("same~n"),
+    aa_merge_continue(A, B, Vars, ParentFixups, AliasFixups);
+aa_merge_1(_V, #vas{status=aliased}, BVas, A, B, Vars,
+           ParentFixups, AliasFixups) ->
+    %% V is aliased in A, anything related to B becomes aliased.
+    ?TM_DP("force aliasB of ~p~n", [aa_related(BVas)]),
+    aa_merge_continue(A, B, Vars, ParentFixups,
+                      aa_related(BVas)++AliasFixups);
+aa_merge_1(V, AVas, #vas{status=aliased}, A, B, Vars,
+           ParentFixups, AliasFixups) ->
+    %% V is aliased in B, anything related to A becomes aliased.
+    ?TM_DP("force aliasA of ~p~n", [aa_related(AVas)]),
+    aa_merge_continue(A#{V=>#vas{status=aliased}}, B, Vars,
+                      ParentFixups,
+                      aa_related(AVas)++AliasFixups);
+aa_merge_1(V, #vas{status=S}=AVas, #vas{status=S}=BVas, A, B, Vars,
+           ParentFixups, AliasFixups)
+  when S == unique ; S == as_parent ->
+    aa_merge_child(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups).
+
+aa_merge_child(V, #vas{child=Child}=AVas, #vas{child=Child}=BVas,
+               A, B, Vars, ParentFixups, AliasFixups) ->
+    ?TM_DP("child ~p, same~n", [Child]),
+    aa_merge_tuple(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups);
+aa_merge_child(V, #vas{child=none}=AVas, #vas{child=Child}=BVas,
+               A, B, Vars, ParentFixups, AliasFixups) ->
+    %% BVas has aquired a derivation from a Phi, no conflict, but the
+    %% A side has to be updated with new parent information.
+    ?TM_DP("new child in B, ~p~n", [Child]),
+    aa_merge_tuple(V, AVas#vas{child=Child}, BVas, A#{V=>BVas},
+                   B, Vars, [{Child,V}|ParentFixups], AliasFixups);
+aa_merge_child(V, AVas, #vas{child=none}=BVas, A, B, Vars,
+               ParentFixups, AliasFixups) ->
+    %% AVas has aquired a derivation from a Phi, no conflict, no
+    %% update of the state necessary.
+    ?TM_DP("no child in B~n"),
+    aa_merge_tuple(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups);
+aa_merge_child(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups) ->
+    %% Different children, this leads to aliasing.
+    ?TM_DP("different children, force alias of ~p~n",
+           [aa_related(AVas)++aa_related(BVas)]),
+    aa_merge_continue(
+      A#{V=>#vas{status=aliased}}, B, Vars,
+      ParentFixups,
+      aa_related(AVas)++aa_related(BVas)++AliasFixups).
+
+aa_merge_tuple(V, #vas{tuple_elems=Es}=AVas, #vas{tuple_elems=Es}=BVas,
+               A, B, Vars, ParentFixups, AliasFixups) ->
+    %% The same tuple elements are extracted, no conflict.
+    ?TM_DP("same tuple elements~n"),
+    aa_merge_pair(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups);
+aa_merge_tuple(V, #vas{tuple_elems=AEs}=AVas, #vas{tuple_elems=BEs}=BVas,
+               A, B, Vars, ParentFixups, AliasFixups) ->
+    %% This won't lead to aliasing if all elements are unique.
+    case aa_non_aliasing_tuple_elements(AEs++BEs) of
+        true ->
+            %% No aliasing, the elements are unique
+            ?TM_DP("different tuple elements, no aliasing~n"),
+            Elements = ordsets:union(AEs, BEs),
+            Vas = AVas#vas{tuple_elems=Elements},
+            aa_merge_pair(V, Vas, BVas, A#{V=>Vas}, B, Vars,
+                          ParentFixups, AliasFixups);
+        false ->
+            %% Aliasing occurred.
+            ?TM_DP("aliasing tuple elements, force ~p~n",
+                   aa_related(AVas)++aa_related(BVas)),
+            aa_merge_continue(A#{V=>#vas{status=aliased}}, B, Vars,
+                              ParentFixups,
+                              aa_related(AVas)++aa_related(BVas)++AliasFixups)
     end.
 
+aa_merge_pair(V, #vas{pair_elems=Es}=AVas, #vas{pair_elems=Es}=BVas,
+              A, B, Vars, ParentFixups, AliasFixups) ->
+    %% The same pair elements are extracted, no conflict.
+    ?TM_DP("same pairs~n"),
+    aa_merge_extracted(V, AVas, BVas, A, B, Vars, ParentFixups, AliasFixups);
+aa_merge_pair(V, #vas{pair_elems=AEs}=AVas, #vas{pair_elems=BEs}=BVas,
+              A, B, Vars, ParentFixups, AliasFixups) ->
+    R = case {AEs,BEs} of
+            {{hd,H},{tl,T}} ->
+                {both,H,T};
+            {{tl,T},{hd,H}} ->
+                {both,H,T};
+            {E,none} ->
+                E;
+            {none,E} ->
+                E;
+            _ ->
+                alias
+        end,
+    case R of
+        alias ->
+            ?TM_DP("aliasing pair elements: ~p~n", [R]),
+            aa_merge_continue(A#{V=>#vas{status=aliased}}, B, Vars,
+                              ParentFixups,
+                              aa_related(AVas)++aa_related(BVas)++AliasFixups);
+        Pair ->
+            ?TM_DP("different pair elements, no aliasing~n"),
+            Vas = AVas#vas{pair_elems=Pair},
+            aa_merge_extracted(V, Vas, BVas, A#{V=>Vas},
+                               B, Vars, ParentFixups, AliasFixups)
+    end.
+
+aa_merge_extracted(V, #vas{extracted=AEs}=AVas, #vas{extracted=BEs},
+                   A, B, Vars, ParentFixups, AliasFixups) ->
+    Extracted = ordsets:union(AEs, BEs),
+    aa_merge_continue(A#{V=>AVas#vas{extracted=Extracted}}, B, Vars,
+                      ParentFixups, AliasFixups).
+
+aa_related(#vas{parents=Ps,child=Child,extracted=Ex}) ->
+    case Child of none ->
+            [];
+        Child ->
+            [Child]
+    end ++ Ps ++ Ex.
+
+aa_non_aliasing_tuple_elements(Elems) ->
+    aa_non_aliasing_tuple_elements(Elems, #{}).
+
+aa_non_aliasing_tuple_elements([{I,V}|Es], Seen) ->
+    case Seen of
+        #{I:=X} when X =/= V ->
+            false;
+        #{} ->
+            aa_non_aliasing_tuple_elements(Es, Seen#{I=>V})
+    end;
+aa_non_aliasing_tuple_elements([], _) ->
+    true.
+
+aa_merge_alias_fixups(SS, Fixups) ->
+    ?TM_DP("fixup: Forcing aliasing ~p~n", [Fixups]),
+    aa_set_status_1(Fixups, none, SS).
+
+aa_merge_parent_fixups(SS0, [{Child,Parent}|Fixups]) ->
+    ?TM_DP("fixup: Forcing parents ~p->~p~n", [Child,Parent]),
+    #{Child:=#vas{parents=Parents}=Vas} = SS0,
+    SS = SS0#{Child=>Vas#vas{parents=ordsets:add_element(Parent, Parents)}},
+    aa_merge_parent_fixups(SS, Fixups);
+aa_merge_parent_fixups(SS, []) ->
+    ?TM_DP("Parent fixups executed~n"),
+    SS.
+
+%% Merge two sharing states when traversing the execution graph post
+%% order. The only thing the successor merging needs to to is to check
+%% if variables in the original SS have become aliased.
+aa_merge_ss_successor(BlockLbl, NewSS, Lbl2SS) ->
+    #{BlockLbl:=OrigSS} = Lbl2SS,
+    Lbl2SS#{BlockLbl=>aa_merge_ss_successor(OrigSS, NewSS)}.
+
+aa_merge_ss_successor(Orig, New) ->
+    maps:fold(fun(V, Vas, Acc) ->
+                      case New of
+                          #{V:=Vas} ->
+                              %% Nothing has changed for V.
+                              Acc;
+                          #{V:=#vas{status=aliased}} ->
+                              aa_set_aliased(V, Acc);
+                          #{} ->
+                              %% V did not exist in New.
+                              Acc
+                      end
+              end, Orig, Orig).
+
+%% Add a new ssa variable to the sharing state and set its status.
+aa_new_ssa_var(Var, Status, State) ->
+    ?ASSERT(false = maps:get(Var, State, false)),
+    State#{Var=>#vas{status=Status}}.
+
 aa_get_status(V=#b_var{}, State) ->
-    Repr = aa_get_representative(V, State),
     case State of
-        #{{tuple_element,Repr}:=_} ->
-            aliased;
-        #{{pair,Repr}:=_} ->
-            aliased;
-        #{Repr:={status,S}} ->
-            S
+        #{V:=#vas{status=as_parent,parents=Ps}} ->
+            aa_get_status(Ps, State);
+        #{V:=#vas{status=Status}} ->
+            Status
     end;
 aa_get_status(#b_literal{}, _State) ->
-    unique.
+    unique;
+aa_get_status([V=#b_var{}], State) ->
+    aa_get_status(V, State);
+aa_get_status([V=#b_var{}|Parents], State) ->
+    aa_meet(aa_get_status(V, State), aa_get_status(Parents, State)).
+
 
 %% aa_get_status but for instructions extracting values from pairs and
 %% tuples.
 aa_get_element_extraction_status(V=#b_var{}, State) ->
-    Repr = aa_get_representative(V, State),
     case State of
-        #{{tuple_element,Repr}:=_,Repr:={status,unique}} ->
+        #{V:=#vas{status=aliased}} ->
+            aliased;
+        #{V:=#vas{tuple_elems=Elems}} when Elems =/= [] ->
             unique;
-        #{{pair,Repr}:=_,Repr:={status,unique}} ->
-            unique;
-        #{Repr:={status,S}} ->
-            S
+        #{V:=#vas{pair_elems=Elems}} when Elems =/= none ->
+            unique
     end;
 aa_get_element_extraction_status(#b_literal{}, _State) ->
     unique.
 
-aa_set_status(V=#b_var{}, Status, State0) ->
-    Repr = aa_get_representative(V, State0),
-    ?DP("SET_STATUS: ~p(~p): ~p~n", [V,Repr,Status]),
-    State = State0#{Repr=>{status,Status}},
+aa_set_status(V=#b_var{}, aliased, State) ->
+    %% io:format("Setting ~p to aliased.~n", [V]),
     case State of
-        #{{extracted,Repr}:=Extracts} when Status =:= aliased ->
-            ?DP("  EXTRACTS: ~p~n", [Extracts]),
-            foldl(fun(E, StateAcc) ->
-                          aa_set_status(E, Status, StateAcc)
-                  end, State, Extracts);
-        _ ->
-            State
+        #{V:=#vas{status=unique,parents=[]}} ->
+            %% This is the initial value.
+            aa_set_status_1(V, none, State);
+        #{V:=#vas{status=aliased}} ->
+            %% No change
+            State;
+        #{V:=#vas{parents=Parents}} ->
+            %% V is derived from another value, so the status has to
+            %% be propagated to the parent(s).
+            aa_set_status(Parents, aliased, State)
     end;
+aa_set_status(_V=#b_var{}, unique, State) ->
+    ?ASSERT(true = case State of
+                       #{_V:=#vas{status=unique}} -> true;
+                       #{_V:=#vas{parents=Parents}} ->
+                           [unique = aa_get_status(P, State) || P <- Parents],
+                           true
+                   end),
+    State;
 aa_set_status(#b_literal{}, _Status, State) ->
     State;
 aa_set_status([X|T], Status, State) ->
@@ -585,7 +872,110 @@ aa_set_status([X|T], Status, State) ->
 aa_set_status([], _, State) ->
     State.
 
-aa_update_annotation(I=#b_set{args=[Tuple,Idx],op=get_tuple_element}, SS, AAS) ->
+%% Propagate the aliased status to the children.
+aa_set_status_1(#b_var{}=V, Parent, State0) ->
+    %% io:format("aa_set_status_1: ~p, parent:~p~n~p.~n", [V,Parent,State0]),
+    #{V:=#vas{child=Child,extracted=Extracted,parents=Parents}} = State0,
+    State = State0#{V=>#vas{status=aliased}},
+    Work = case Child of
+               none ->
+                   [];
+               _ ->
+                   [Child]
+           end ++ ordsets:del_element(Parent, Parents) ++ Extracted,
+    aa_set_status_1(Work, V, State);
+aa_set_status_1([#b_var{}=V|Rest], Parent, State) ->
+    aa_set_status_1(Rest, Parent, aa_set_status_1(V, Parent, State));
+aa_set_status_1([], _Parent, State) ->
+    State.
+
+%% aa_remove_parent(_V, none, State) ->
+%%     State;
+%% aa_remove_parent(V, Parent, State) ->
+%%     #{V:=#vas{parents=Parents0}=Vas} = State,
+%%     State#{V=>Vas#vas{parents=ordsets:del_element(Parent, Parents0)}}.
+
+aa_derive_from(Dst, [Parent|Parents], State0) ->
+    aa_derive_from(Dst, Parents, aa_derive_from(Dst, Parent, State0));
+aa_derive_from(_Dst, [], State0) ->
+    State0;
+aa_derive_from(#b_var{}, #b_literal{}, State) ->
+    State;
+aa_derive_from(#b_var{}=Dst, #b_var{}=Parent, State) ->
+    %% io:format("Deriving ~p from ~p~n~p.~n", [Dst,Parent,State]),
+    case State of
+        #{Dst:=#vas{status=aliased}} ->
+            %% io:format("Derive 1~n"),
+            %% Nothing to do, already aliased. This can happen when
+            %% handling Phis, no propagation to the parent should be
+            %% done.
+            ?aa_assert_ss(State);
+        #{Parent:=#vas{status=aliased}} ->
+            %% io:format("Derive 2~n"),
+            %% The parent is aliased, the child will become aliased.
+            ?aa_assert_ss(aa_set_aliased(Dst, State));
+        #{Parent:=#vas{child=Child}} when Child =/= none ->
+            %% io:format("Derive 3~n"),
+            %% There already is a child, this will alias both Dst and Parent.
+            ?aa_assert_ss(aa_set_aliased([Dst,Parent], State));
+        #{Parent:=#vas{child=none,tuple_elems=Elems}} when Elems =/= [] ->
+            %% io:format("Derive 4 ~p~n", [[Dst,Parent]]),
+            %% There already is a child, this will alias both Dst and Parent.
+            ?aa_assert_ss(aa_set_aliased([Dst,Parent], State));
+        #{Parent:=#vas{child=none,pair_elems=Elems}} when Elems =/= none ->
+            %% io:format("Derive 5~n"),
+            %% There already is a child, this will alias both Dst and Parent.
+            ?aa_assert_ss(aa_set_aliased([Dst,Parent], State));
+        #{Dst:=#vas{parents=Parents}=ChildVas0,
+          Parent:=#vas{child=none}=ParentVas0} ->
+            %% io:format("Derive 6~n"),
+            %% Inherit the status of the parent.
+            ChildVas =
+                ChildVas0#vas{parents=ordsets:add_element(Parent, Parents),
+                              status=as_parent},
+            ParentVas = ParentVas0#vas{child=Dst},
+            ?aa_assert_ss(State#{Dst=>ChildVas,Parent=>ParentVas})
+    end.
+
+aa_update_annotations(Funs, #aas{alias_map=AliasMap0,st_map=StMap0}=AAS) ->
+    foldl(fun(F, {StMapAcc,AliasMapAcc}) ->
+                  #{F:=Lbl2SS0} = AliasMapAcc,
+                  #{F:=OptSt0} = StMapAcc,
+                  {OptSt,Lbl2SS} =
+                      aa_update_fun_annotation(OptSt0, Lbl2SS0,
+                                               AAS#aas{caller=F}),
+                  {StMapAcc#{F=>OptSt},AliasMapAcc#{F=>Lbl2SS}}
+          end, {StMap0,AliasMap0}, Funs).
+
+aa_update_fun_annotation(#opt_st{ssa=SSA0}=OptSt0, Lbl2SS0, AAS) ->
+    %% Propagate alias information from successor to predecessor by
+    %% traversing the code post-order.
+    {SSA,Lbl2SS} = aa_update_annotation_blocks(reverse(SSA0), [], Lbl2SS0, AAS),
+    {OptSt0#opt_st{ssa=SSA},Lbl2SS}.
+
+aa_update_annotation_blocks([{Lbl, Block0}|Blocks], Acc, Lbl2SS0, AAS) ->
+    Successors = beam_ssa:successors(Block0),
+    Lbl2SS = foldl(fun(?EXCEPTION_BLOCK, Lbl2SSAcc) ->
+                           %% What happens in the exception block
+                           %% can't influence anything in any of the
+                           %% parents.
+                           Lbl2SSAcc;
+                      (Successor, Lbl2SSAcc) ->
+                           #{Successor:=OtherSS} = Lbl2SSAcc,
+                           aa_merge_ss_successor(Lbl, OtherSS, Lbl2SSAcc)
+                   end, Lbl2SS0, Successors),
+    #{Lbl:=SS} = Lbl2SS,
+    Block = aa_update_annotation_block(Block0, SS, AAS),
+    aa_update_annotation_blocks(Blocks, [{Lbl,Block}|Acc], Lbl2SS, AAS);
+aa_update_annotation_blocks([], Acc, Lbl2SS, _AAS) ->
+    {Acc,Lbl2SS}.
+
+aa_update_annotation_block(#b_blk{is=Linear,last=Last}=Blk, SS, AAS) ->
+    Blk#b_blk{is=[aa_update_annotation(I, SS, AAS) || I <- Linear],
+              last=aa_update_annotation(Last, SS, AAS)}.
+
+aa_update_annotation(I=#b_set{args=[Tuple,Idx],op=get_tuple_element},
+                     SS, AAS) ->
     Args = [{Tuple,aa_get_element_extraction_status(Tuple, SS)},
             {Idx,aa_get_status(Idx, SS)}],
     aa_update_annotation1(Args, I, AAS);
@@ -644,7 +1034,7 @@ aa_update_annotation1(ArgsStatus,
                    %% kill map during the private-append pass.
                    #aas{caller=Caller,kills=KillsMap} = AAS,
                    #b_set{dst=Dst} = I,
-                   KillMap = map_get(Caller, KillsMap),
+                   KillMap = maps:get(Caller, KillsMap),
                    Dies = sets:is_element(Var, map_get(Dst, KillMap)),
                    Anno2#{first_fragment_dies => Dies};
                _ ->
@@ -663,48 +1053,21 @@ aa_update_annotation1(Status, I=#b_ret{arg=#b_var{}=V,anno=Anno0}, _AAS) ->
 aa_set_aliased(Args, SS) ->
     aa_set_status(Args, aliased, SS).
 
-aa_alias_all(SS0) ->
-    maps:map(fun(#b_var{}, _) ->
-                     {status,aliased};
-                (returns, Types) ->
-                     #{ T => aliased || T := _ <- Types};
-                (_, V) ->
-                     V
-             end, SS0).
-
-aa_join_ls(VarA, [#b_var{}=VarB|Vars], State) ->
-    aa_join_ls(VarB, Vars, aa_join(VarA, VarB, State));
-aa_join_ls(VarA, [_|Vars], State) ->
-    aa_join_ls(VarA, Vars, State);
-aa_join_ls(_, [], State) ->
-    State.
-
-aa_join(#b_var{}=VarA, #b_var{}=VarB, State) ->
-    ARepr = aa_get_representative(VarA, State),
-    BRepr = aa_get_representative(VarB, State),
-    ?DP("JOIN ~p(~p) ~p(~p)~n", [VarA,ARepr,VarB,BRepr]),
-    case {ARepr, BRepr} of
-        {Repr, Repr} ->
-            State;
-        _ ->
-            {status, A} = map_get(ARepr, State),
-            {status, B} = map_get(BRepr, State),
-            State#{ ARepr => {status, aa_meet(A, B)}, BRepr => ARepr }
-    end;
-aa_join(_, _, State) ->
-    State.
+aa_alias_all(SS) ->
+    aa_set_aliased(maps:keys(SS), SS).
 
 aa_register_extracted(Extracted, Aggregate, State) ->
-    E = aa_get_representative(Extracted, State),
-    A = aa_get_representative(Aggregate, State),
-    ?DP("REGISTER ~p(~p): ~p(~p)~n", [Aggregate,A,Extracted,E]),
-    Key = {extracted,A},
-    State#{Key=>ordsets:add_element(E, maps:get(Key, State, []))}.
+    ?DP("REGISTER ~p: ~p~n", [Aggregate,Extracted]),
+    #{Aggregate:=#vas{extracted=ExVars}=AggVas0,
+      Extracted:=#vas{parents=Parents}=ExVas0} = State,
+    AggVas = AggVas0#vas{extracted=ordsets:add_element(Extracted, ExVars)},
+    ExVas = ExVas0#vas{status=as_parent,
+                       parents=ordsets:add_element(Aggregate, Parents)},
+    State#{Aggregate=>AggVas, Extracted=>ExVas}.
 
-aa_meet(#b_var{}=Var, SetStatus, State) ->
-    Repr = aa_get_representative(Var, State),
-    {status, Status} = map_get(Repr, State),
-    State#{ Repr => {status, aa_meet(SetStatus, Status)} };
+aa_meet(#b_var{}=Var, OtherStatus, State) ->
+    Status = aa_get_status(Var, State),
+    aa_set_status(Var, aa_meet(OtherStatus, Status), State);
 aa_meet(#b_literal{}, _SetStatus, State) ->
     State;
 aa_meet([Var|Vars], [Status|Statuses], State) ->
@@ -789,7 +1152,7 @@ aa_construct_term(Dst, Values, SS, AAS) ->
     case aa_all_vars_unique(Values, SS)
         andalso aa_all_dies(Values, Dst, AAS) of
         true ->
-            aa_join_ls(Dst, Values, SS);
+            aa_derive_from(Dst, Values, SS);
         false ->
             aa_set_aliased([Dst|Values], SS)
     end.
@@ -831,7 +1194,7 @@ aa_bif(Dst, Bif, Args, SS, _AAS) ->
 
 aa_phi(Dst, Args0, SS) ->
     Args = [V || {V,_} <- Args0],
-    aa_join_ls(Dst, Args, SS).
+    aa_derive_from(Dst, Args, SS).
 
 aa_call(Dst, [#b_local{}=Callee|Args], Anno, SS0,
         #aas{alias_map=AliasMap,st_map=StMap}=AAS0) ->
@@ -839,9 +1202,11 @@ aa_call(Dst, [#b_local{}=Callee|Args], Anno, SS0,
     ?DP("A Call~n  callee: ~p/~p~n  args: ~p~n", [_N, _A, Args]),
     IsNif = is_nif(Callee, StMap),
     case AliasMap of
-        #{ Callee := CalleeSS } when not IsNif ->
+        #{Callee:=#{0:=CalleeSS}=Lbl2SS} when not IsNif ->
             ?DP("  The callee is known~n"),
             #opt_st{args=CalleeArgs} = map_get(Callee, StMap),
+            ?DP("  callee args: ~p~n", [CalleeArgs]),
+            ?DP("  caller args: ~p~n", [Args]),
             ?DP("  args in caller: ~p~n",
                 [[{Arg, aa_get_status(Arg, SS0)} || Arg <- Args]]),
             ArgStates = [ aa_get_status(Arg, CalleeSS) || Arg <- CalleeArgs],
@@ -850,7 +1215,8 @@ aa_call(Dst, [#b_local{}=Callee|Args], Anno, SS0,
             SS = aa_meet(Args, ArgStates, SS0),
             ?DP("  meet: ~p~n",
                 [[{Arg, aa_get_status(Arg, SS)} || Arg <- Args]]),
-            ReturnStatusByType = maps:get(returns, CalleeSS, #{}),
+            ?DP("  callee-ss ~p~n", [CalleeSS]),
+            ReturnStatusByType = maps:get(returns, Lbl2SS, #{}),
             ?DP("  status by type: ~p~n", [ReturnStatusByType]),
             ReturnedType = case Anno of
                                #{ result_type := ResultType } ->
@@ -893,57 +1259,65 @@ aa_get_call_args_status(Args, Callee, #aas{call_args=Info}) ->
     #{ Callee := Status } = Info,
     zip(Args, Status).
 
-aa_pair_extraction(Dst, #b_var{}=Pair, Element, SS0) ->
-    Repr = aa_get_representative(Pair, SS0),
-    #{Repr:={status,S}} = SS0,
-    case S of
-        unique ->
-            case SS0 of
-                #{{pair,Repr}:=both} ->
-                    %% Both elements have already been extracted
-                    aa_set_aliased([Dst,Repr], SS0);
-                #{{pair,Repr}:=Element} ->
-                    %% This element has already been extracted
-                    aa_set_aliased([Dst,Repr], SS0);
-                #{{pair,Repr}:=_Other} ->
-                    %% Both elements have now been extracted
-                    aa_register_extracted(Dst, Repr, SS0#{{pair,Repr}=>both});
-                _ ->
-                    %% Nothing has been extracted from this pair yet
-                    aa_register_extracted(Dst, Repr, SS0#{{pair,Repr}=>Element})
-            end;
-        aliased ->
-            aa_set_aliased(Dst, SS0)
+%% Pair extraction.
+aa_pair_extraction(Dst, #b_var{}=Pair, Element, SS) ->
+    case SS of
+        #{Pair:=#vas{status=aliased}} ->
+            %% The pair is aliased, so what is extracted will be aliased.
+            aa_set_aliased(Dst, SS);
+        #{Pair:=#vas{pair_elems={both,_,_}}} ->
+            %% Both elements have already been extracted.
+            aa_set_aliased([Dst,Pair], SS);
+        #{Pair:=#vas{pair_elems=none}=Vas} ->
+            %% Nothing has been extracted from this pair yet.
+            aa_register_extracted(
+              Dst, Pair,
+              SS#{Pair=>Vas#vas{pair_elems={Element,Dst}}});
+        #{Pair:=#vas{pair_elems={Element,_}}} ->
+            %% This element has already been extracted.
+            aa_set_aliased([Dst,Pair], SS);
+        #{Pair:=#vas{pair_elems={tl,T}}=Vas} when Element =:= hd ->
+            %% Both elements have now been extracted, but no aliasing.
+            aa_register_extracted(Dst, Pair,
+                                  SS#{Pair=>Vas#vas{pair_elems={both,Dst,T}}});
+        #{Pair:=#vas{pair_elems={hd,H}}=Vas} when Element =:= tl ->
+            %% Both elements have now been extracted, but no aliasing.
+            aa_register_extracted(Dst, Pair,
+                                  SS#{Pair=>Vas#vas{pair_elems={both,H,Dst}}})
     end;
 aa_pair_extraction(_Dst, #b_literal{}, _Element, SS) ->
     SS.
 
 aa_map_extraction(Dst, Map, SS, AAS) ->
-    aa_join(Dst, Map,
-            aa_alias_inherit_and_alias_if_arg_does_not_die(Dst, Map, SS, AAS)).
+    aa_derive_from(
+      Dst, Map,
+      aa_alias_inherit_and_alias_if_arg_does_not_die(Dst, Map, SS, AAS)).
 
-aa_tuple_extraction(Dst, #b_var{}=Tuple, #b_literal{val=I}, SS1) ->
-    Repr = aa_get_representative(Tuple, SS1),
-    #{Repr:={status,S}} = SS1,
-    case S of
-        unique ->
-            case SS1 of
-                #{{tuple_element,Repr}:=OrdSet0} ->
-                    case ordsets:is_element(I, OrdSet0) of
-                        true ->
-                            aa_set_aliased([Dst,Repr], SS1);
-                        false ->
-                            OrdSet = ordsets:add_element(I, OrdSet0),
-                            aa_register_extracted(
-                              Dst, Repr, SS1#{{tuple_element,Repr}=>OrdSet})
-                    end;
-                _ ->
-                    %% Nothing has been extracted from this tuple yet
+%% Extracting elements from a tuple.
+aa_tuple_extraction(Dst, #b_var{}=Tuple, #b_literal{val=I}, SS) ->
+    case SS of
+        #{Tuple:=#vas{status=aliased}} ->
+            %% The tuple is aliased, so what is extracted will be
+            %% aliased.
+            aa_set_aliased(Dst, SS);
+        #{Tuple:=#vas{child=Child}} when Child =/= none ->
+            %% Something has already been derived from the tuple.
+            aa_set_aliased([Dst,Tuple], SS);
+        #{Tuple:=#vas{tuple_elems=[]}=TupleVas} ->
+            %% Nothing has been extracted from this tuple yet.
+            aa_register_extracted(
+              Dst, Tuple, SS#{Tuple=>TupleVas#vas{tuple_elems=[{I,Dst}]}});
+        #{Tuple:=#vas{tuple_elems=Elems0}=TupleVas} ->
+            case [ Idx || {Idx,_} <- Elems0, I =:= Idx] of
+                [] ->
+                    %% This element has not been extracted.
+                    Elems = ordsets:add_element({I,Dst}, Elems0),
                     aa_register_extracted(
-                      Dst, Repr, SS1#{{tuple_element,Repr}=>[I]})
-            end;
-        aliased ->
-            aa_set_aliased(Dst, SS1)
+                      Dst, Tuple, SS#{Tuple=>TupleVas#vas{tuple_elems=Elems}});
+                _ ->
+                    %% This element is already extracted -> aliasing
+                    aa_set_aliased([Dst,Tuple], SS)
+            end
     end;
 aa_tuple_extraction(_, #b_literal{}, _, SS) ->
     SS.
@@ -1006,3 +1380,141 @@ aa_breadth_first([], [], _Seen, _FuncDb) ->
 aa_breadth_first([], Next, Seen, FuncDb) ->
     aa_breadth_first(Next, [], Seen, FuncDb).
 
+-ifdef(EXTRA_ASSERTS).
+
+-spec aa_assert_ss(sharing_state()) -> sharing_state().
+
+aa_assert_ss(SS) ->
+    try
+        maps:foreach(
+          fun(_V, #vas{status=aliased}=Vas) ->
+                  %% An aliased variable should not have extra info.
+                  [] = Vas#vas.parents,
+                  none = Vas#vas.child,
+                  [] = Vas#vas.extracted,
+                  [] = Vas#vas.tuple_elems,
+                  none = Vas#vas.pair_elems,
+                  ok;
+             (V, #vas{status=unique,child=Child,extracted=Es,
+                      tuple_elems=Ts,pair_elems=Pair}=Vas) ->
+                  [] = Vas#vas.parents,
+                  aa_assert_extracted(Es, Ts, Pair, V),
+                  aa_assert_parent_of(V, Child, SS),
+                  aa_assert_parent_of(V, Es, SS),
+                  aa_assert_pair(Pair, V, SS),
+                  aa_assert_tuple_elems(Ts, V, SS);
+             (V, #vas{status=as_parent,parents=Ps,child=Child,extracted=Es,
+                      tuple_elems=Ts,pair_elems=Pair}) ->
+                  aa_assert_not_aliased(
+                    Ps, SS,
+                    io_lib:format("as parent of ~p should not be aliased.",
+                                  [V])),
+                  aa_assert_extracted(Es, Ts, Pair, V),
+                  aa_assert_parent_of(Ps, V, SS),
+                  aa_assert_parent_of(V, Child, SS),
+                  aa_assert_parent_of(V, Es, SS),
+                  aa_assert_pair(Pair, V, SS),
+                  aa_assert_tuple_elems(Ts, V, SS)
+          end, SS)
+    of
+        _ -> SS
+    catch {assertion_failure, V, Desc} ->
+            io:format("Malformed SS~n~p~n~p ~s~n", [SS, V, Desc]),
+            exit(assertion_failure)
+    end.
+
+%% Check that V is a parent of Child
+aa_assert_parent_of(_V, none, _SS) ->
+    ok;
+aa_assert_parent_of(#b_var{}=V, #b_var{}=Child, SS) ->
+    case SS of
+        #{Child:=#vas{status=as_parent,parents=Ps}} ->
+            case ordsets:is_element(V, Ps) of
+                true ->
+                    ok;
+                false ->
+                    throw({assertion_failure, V,
+                           io_lib:format(
+                             "child ~p does not have ~p as parent",
+                             [Child, V])})
+            end;
+        #{} ->
+            throw({assertion_failure, V,
+                   io_lib:format(
+                     "child ~p does not have status as_parent", [Child])})
+    end;
+aa_assert_parent_of(#b_var{}=V, [P|Ps], SS) ->
+    aa_assert_parent_of(V, P, SS),
+    aa_assert_parent_of(V, Ps, SS);
+aa_assert_parent_of([V|Vs], Child, SS) ->
+    aa_assert_parent_of(V, Child, SS),
+    aa_assert_parent_of(Vs, Child, SS);
+aa_assert_parent_of(_, [], _) ->
+    true;
+aa_assert_parent_of([], _, _) ->
+    true.
+
+aa_assert_pair(none, _V, _SS) ->
+    ok;
+aa_assert_pair({Elem,X}, V, SS) when Elem =:= hd; Elem =:= tl ->
+    case SS of
+        #{X:=#vas{status=as_parent}} ->
+            aa_assert_parent_of(V, X, SS);
+        #{} ->
+            throw({assertion_failure, V,
+                   io_lib:format("extracted pair and ~p does not"
+                                 " have status as_parent", [X])})
+    end;
+aa_assert_pair({both,X,Y}, V, SS) ->
+    case SS of
+        #{X:=#vas{status=as_parent},
+          Y:=#vas{status=as_parent}} ->
+            aa_assert_parent_of(V, X, SS),
+            aa_assert_parent_of(V, Y, SS);
+        #{} ->
+            throw({assertion_failure, V,
+                   io_lib:format("extracted pairs ~p and ~p do not"
+                                 " have status as_parent", [X, Y])})
+    end.
+
+aa_assert_tuple_elems([{_,X}|Ts], V, SS) ->
+    case SS of
+        #{X:=#vas{status=as_parent}} ->
+            aa_assert_parent_of(V, X, SS),
+            aa_assert_tuple_elems(Ts, V, SS);
+        #{} ->
+            throw({assertion_failure, V,
+                   io_lib:format(
+                     "child ~p does not have status as_parent", [X])})
+    end;
+aa_assert_tuple_elems([], _, _) ->
+    ok.
+
+aa_assert_extracted(Es, Ts, Pair, Var) ->
+    Actual = ordsets:union(ordsets:from_list([V || {_,V} <- Ts]),
+                           ordsets:from_list(case Pair of
+                                                 none -> [];
+                                                 {_, X} -> [X];
+                                                 {both,X,Y} -> [X,Y]
+                                             end)),
+    case Es of
+        Actual ->
+            true;
+        _ ->
+            throw({assertion_failure, Var,
+                   "has inconsistent extracted set"})
+    end.
+
+aa_assert_not_aliased([V|Vs], SS, Desc) ->
+    #{V:=#vas{status=S}} = SS,
+
+    case S of
+        unique -> ok;
+        as_parent -> ok;
+        _ ->
+            throw({assertion_failure, V, Desc})
+    end,
+    aa_assert_not_aliased(Vs, SS, Desc);
+aa_assert_not_aliased([], _SS, _) ->
+    true.
+-endif.

--- a/lib/compiler/src/beam_ssa_private_append.erl
+++ b/lib/compiler/src/beam_ssa_private_append.erl
@@ -330,7 +330,12 @@ track_put_tuple(FieldVars, {tuple_element,Idx,Element},
             DefSt = add_literal(Fun, {opargs,Dst,Idx,Lit,Element}, DefSt0),
             track_value_in_fun(Work, Fun, GlobalWork,
                                Defs, ValuesInFun, DefSt)
-    end.
+    end;
+track_put_tuple(_FieldVars, {hd,_},
+                Work, Fun, _Dst, GlobalWork,
+                Defs, ValuesInFun, DefSt) ->
+    track_value_in_fun(Work, Fun, GlobalWork,
+                       Defs, ValuesInFun, DefSt).
 
 track_put_list([Hd,_Tl], {hd,Element},
                Work, Fun, Dst, GlobalWork,
@@ -349,7 +354,10 @@ track_put_list([Hd,_Tl], {hd,Element},
         #b_literal{val=Lit} ->
             DefSt = add_literal(Fun, {opargs,Dst,0,Lit,Element}, DefSt0),
             track_value_in_fun(Work, Fun, GlobalWork, Defs, ValuesInFun, DefSt)
-    end.
+    end;
+track_put_list([_Hd,_Tl], {tuple_element,_,_}, Work, Fun, _Dst, GlobalWork,
+               Defs, ValuesInFun, DefSt) ->
+    track_value_in_fun(Work, Fun, GlobalWork, Defs, ValuesInFun, DefSt).
 
 %% Find all calls to Callee and produce a work-list containing all
 %% values which are used as the Idx:th argument.
@@ -546,7 +554,9 @@ merge_arg_patches([{Idx,Lit,P0},{Idx,Lit,P1}|Patches]) ->
             {{tuple_element,I0,E0},{tuple_element,I1,E1}} ->
                 {tuple_elements,[{I0,E0},{I1,E1}]};
             {{tuple_elements,Es},{tuple_element,I,E}} ->
-                {tuple_elements,[{I,E}|Es]}
+                {tuple_elements,[{I,E}|Es]};
+            {_,_} ->
+                [P0|merge_arg_patches([P1|Patches])]
         end,
     merge_arg_patches([{Idx,Lit,P}|Patches]);
 merge_arg_patches([P|Patches]) ->
@@ -594,12 +604,16 @@ patch_literal_term([H0|T0], {hd,Element}, Cnt0) ->
     {Dst,Cnt} = new_var(Cnt1),
     I = #b_set{op=put_list,dst=Dst,args=[H,T]},
     {Dst, [I|Extra], Cnt};
+patch_literal_term([_|_]=Pair, Elems, Cnt) when is_list(Elems) ->
+    [Elem] = [E || {hd,_}=E <- Elems],
+    patch_literal_term(Pair, Elem, Cnt);
 patch_literal_term(Lit, [], Cnt) ->
     {#b_literal{val=Lit}, [], Cnt}.
 
-patch_literal_tuple(Tuple, Elements, Cnt) ->
+patch_literal_tuple(Tuple, Elements0, Cnt) ->
     ?DP("Will patch literal tuple~n  tuple:~p~n  elements: ~p~n",
-              [Tuple,Elements]),
+        [Tuple,Elements0]),
+    Elements = [ E || {tuple_element,_,_}=E <- Elements0],
     patch_literal_tuple(erlang:tuple_to_list(Tuple), Elements, [], [], 0, Cnt).
 
 patch_literal_tuple([Lit|LitElements], [{tuple_element,Idx,Element}|Elements],

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -70,8 +70,11 @@
          aliased_map_lookup_instr/1,
          aliased_tuple_element_bif/1,
          aliased_tuple_element_bif/2,
-         aliased_tuple_element_bif_bad_idx/0,
-         aliased_tuple_element_instr/1]).
+         aliased_tuple_element_instr/1,
+         aliased_pair_hd_bif/1,
+         aliased_pair_tl_bif/1,
+         aliased_pair_hd_instr/1,
+         aliased_pair_tl_instr/1]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -721,7 +724,36 @@ aliased_tuple_element_bif(T, I) ->
 %ssa% ret(X) {aliased => [X]}.
     element(I, T).
 
-%% Check that alias analysis doesn't crash when element is given a
-%% literal non-integer index. Test case found by Robin Morisset.
-aliased_tuple_element_bif_bad_idx() ->
-    erlang:element(ok, length(erlang:pre_loaded())).
+%% Check that as the pair is aliased, the extracted value should also
+%% be aliased.
+aliased_pair_hd_bif(Ls) ->
+%ssa% (Ls) when post_ssa_opt ->
+%ssa% X = bif:hd(Ls),
+%ssa% ret(X) {aliased => [X]}.
+    hd(Ls).
+
+%% Check that as the pair is aliased, the extracted value should also
+%% be aliased.
+aliased_pair_tl_bif(Ls) ->
+%ssa% (Ls) when post_ssa_opt ->
+%ssa% X = bif:tl(Ls),
+%ssa% ret(X) {aliased => [X]}.
+    tl(Ls).
+
+%% Check that as the pair is aliased, the extracted value should also
+%% be aliased.
+aliased_pair_hd_instr(Ls) ->
+%ssa% (Ls) when post_ssa_opt ->
+%ssa% X = get_hd(Ls),
+%ssa% ret(X) {aliased => [X]}.
+    [X|_] = Ls,
+    X.
+
+%% Check that as the pair is aliased, the extracted value should also
+%% be aliased.
+aliased_pair_tl_instr(Ls) ->
+%ssa% (Ls) when post_ssa_opt ->
+%ssa% X = get_tl(Ls),
+%ssa% ret(X) {aliased => [X]}.
+    [_|X] = Ls,
+    X.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -65,7 +65,9 @@
          stacktrace1/0,
          in_cons/0,
          make_fun/0,
-         gh6925/0]).
+         gh6925/0,
+         aliased_map_lookup_bif/1,
+         aliased_map_lookup_instr/1]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -672,3 +674,20 @@ gh6925() ->
     A = << <<"x">> || true >>,
     B = <<A/binary, "z">>,
     {A, B}.
+
+%% Check that as the map is aliased, the extracted value should also
+%% be aliased.
+aliased_map_lookup_bif(M) ->
+%ssa% (M) when post_ssa_opt ->
+%ssa% X = bif:map_get(a, M),
+%ssa% ret(X) {aliased => [X]}.
+    map_get(a, M).
+
+%% Check that as the map is aliased, the extracted value should also
+%% be aliased.
+aliased_map_lookup_instr(M) ->
+%ssa% (M) when post_ssa_opt ->
+%ssa% X = get_map_element(M, a),
+%ssa% ret(X) {aliased => [X]}.
+    #{a:=X} = M,
+    X.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -67,7 +67,11 @@
          make_fun/0,
          gh6925/0,
          aliased_map_lookup_bif/1,
-         aliased_map_lookup_instr/1]).
+         aliased_map_lookup_instr/1,
+         aliased_tuple_element_bif/1,
+         aliased_tuple_element_bif/2,
+         aliased_tuple_element_bif_bad_idx/0,
+         aliased_tuple_element_instr/1]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -691,3 +695,33 @@ aliased_map_lookup_instr(M) ->
 %ssa% ret(X) {aliased => [X]}.
     #{a:=X} = M,
     X.
+
+%% Check that as the tuple is aliased, the extracted value should also
+%% be aliased.
+aliased_tuple_element_bif(T) ->
+%ssa% (T) when post_ssa_opt ->
+%ssa% X = bif:element(1, T),
+%ssa% ret(X) {aliased => [X]}.
+    element(1, T).
+
+%% Check that as the tuple is aliased, the extracted value should also
+%% be aliased.
+aliased_tuple_element_instr(T) ->
+%ssa% (T) when post_ssa_opt ->
+%ssa% X = get_tuple_element(T, 0),
+%ssa% ret(X) {aliased => [X]}.
+    {X} = T,
+    X.
+
+%% Check that alias analysis doesn't crash when element is given a
+%% non-constant index.
+aliased_tuple_element_bif(T, I) ->
+%ssa% (T, I) when post_ssa_opt ->
+%ssa% X = bif:element(I, T),
+%ssa% ret(X) {aliased => [X]}.
+    element(I, T).
+
+%% Check that alias analysis doesn't crash when element is given a
+%% literal non-integer index. Test case found by Robin Morisset.
+aliased_tuple_element_bif_bad_idx() ->
+    erlang:element(ok, length(erlang:pre_loaded())).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -315,31 +315,30 @@ transformable11([_|T], Acc)->
 transformable11([], Acc) ->
     Acc.
 
-% Broken, type analysis can't handle the list
 transformable12a(L) ->
-%ssa% xfail (_) when post_ssa_opt ->
+%ssa% (_) when post_ssa_opt ->
 %ssa% A = bs_init_writable(_),
 %ssa% B = put_tuple(A),
 %ssa% _ = call(fun transformable12/2, _, B).
     transformable12(L, {<<>>}).
 
 transformable12b(L) ->
-%ssa% xfail (_) when post_ssa_opt ->
+%ssa% (_) when post_ssa_opt ->
 %ssa% A = bs_init_writable(_),
-%ssa% B = put_list(A, '_'),
+%ssa% B = put_list(A, _),
 %ssa% _ = call(fun transformable12/2, _, B).
     transformable12(L, [<<>>]).
 
 %% The type analysis can't handle the list yet
 transformable12([H|T], {Acc}) ->
-%ssa% xfail (_, Arg1) when post_ssa_opt ->
+%ssa% (_, Arg1) when post_ssa_opt ->
 %ssa% A = get_hd(Arg1),
 %ssa% B = bs_create_bin(private_append, _, A, ...),
 %ssa% C = put_list(B, _),
 %ssa% _ = call(fun transformable12/2, _, C),
 %ssa% D = get_tuple_element(Arg1, 0),
 %ssa% E = bs_create_bin(private_append, _, D, ...),
-%ssa% F = put_tuple('E'),
+%ssa% F = put_tuple(E),
 %ssa% _ = call(fun transformable12/2, _, F).
     transformable12([H|T], {<<Acc/binary,H:8>>});
 transformable12([H|T], [Acc]) ->


### PR DESCRIPTION
This is a set of patches which fixes a number of errors in the compiler's alias analysis pass which have been there since the code was first merged. [The final commit](https://github.com/erlang/otp/commit/1ed37c62c6ffa6d28dac6b4a471218b18124b359) is unfortunately large, but I have been unable to create a smaller patch, which doesn't disable previously working and correct test cases.

