### PR TITLE
crypto: Fix segv crash after purge and reload of crypto on musl libc

### DIFF
--- a/lib/crypto/c_src/algorithms.c
+++ b/lib/crypto/c_src/algorithms.c
@@ -51,7 +51,6 @@ void init_rsa_opts_types(ErlNifEnv* env);
 
 void init_algorithms_types(ErlNifEnv* env)
 {
-    mtx_init_curve_types =  enif_mutex_create("init_curve_types");
 #ifdef HAS_3_0_API
 #else
     init_hash_types(env);
@@ -62,9 +61,21 @@ void init_algorithms_types(ErlNifEnv* env)
     /* ciphers and macs are initiated statically */
 }
 
-void cleanup_algorithms_types(ErlNifEnv* env)
+
+int create_curve_mutex(void)
 {
-    enif_mutex_destroy(mtx_init_curve_types);
+    if (!mtx_init_curve_types) {
+        mtx_init_curve_types =  enif_mutex_create("init_curve_types");
+    }
+    return !!mtx_init_curve_types;
+}
+
+void destroy_curve_mutex(void)
+{
+    if (mtx_init_curve_types) {
+        enif_mutex_destroy(mtx_init_curve_types);
+        mtx_init_curve_types = NULL;
+    }
 }
 
 /*================================================================

--- a/lib/crypto/c_src/algorithms.h
+++ b/lib/crypto/c_src/algorithms.h
@@ -23,8 +23,9 @@
 
 #include "common.h"
 
+int create_curve_mutex(void);
+void destroy_curve_mutex(void);
 void init_algorithms_types(ErlNifEnv* env);
-void cleanup_algorithms_types(ErlNifEnv* env);
 
 ERL_NIF_TERM hash_algorithms(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM pubkey_algorithms(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);

--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -214,6 +214,8 @@ static int initialize(ErlNifEnv* env, ERL_NIF_TERM load_info)
     if (!create_engine_mutex(env)) {
         return __LINE__;
     }
+    if (!create_curve_mutex())
+        return __LINE__;
 
 #ifdef HAS_3_0_API
     prov_cnt = 0;
@@ -329,7 +331,7 @@ static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
 static void unload(ErlNifEnv* env, void* priv_data)
 {
     if (--library_refc == 0) {
-        cleanup_algorithms_types(env);
+        destroy_curve_mutex();
         destroy_engine_mutex(env);
     }
 


### PR DESCRIPTION
Fixes #7436

Symptom: Different kind of segv crashes seen after crypto is loaded, purged and loaded again.

Problem:
dlclose on musl libc is a no-op.

Mutex 'mtx_init_curve_types' was destroyed by unload (called at module purge) and then not re-created at reload as static variable `library_initialized` in crypto.c was true because musl dlclose is a no-op and dlopen reuses the existing loaded crypto.so library with static variables intact.