### PR TITLE
Socket NIF recv buffer allocation issue

### DIFF
--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -647,7 +647,7 @@ GLOBAL_ERROR_REASON_ATOM_DEFS;
 #define GET_MAP_VAL(E, M, K, V)     enif_get_map_value((E), (M), (K), (V))
 
 #define ALLOC_BIN(SZ, BP)         enif_alloc_binary((SZ), (BP))
-#define REALLOC_BIN(SZ, BP)       enif_realloc_binary((SZ), (BP))
+#define REALLOC_BIN(BP, SZ)       enif_realloc_binary((BP), (SZ))
 #define FREE_BIN(BP)              enif_release_binary((BP))
 
 #define FREE_IOVEC(IV)            enif_free_iovec((IV))

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -2816,21 +2816,10 @@ ERL_NIF_TERM recvfrom_check_result(ErlNifEnv*       env,
                               fromAddrP, fromAddrLen,
                               &eSockAddr);
 
-        if (read == bufP->size) {
-
-            data = MKBIN(env, bufP);
-
-        } else {
-
-            /* +++ We got a chunk of data but +++
-             * +++ since we did not fill the  +++
-             * +++ buffer, we must split it   +++
-             * +++ into a sub-binary.         +++
-             */
-
-            data = MKBIN(env, bufP);
-            data = MKSBIN(env, data, 0, read);
+        if (read != bufP->size) {
+            ESOCK_ASSERT( REALLOC_BIN(bufP, read) );
         }
+        data = MKBIN(env, bufP);
 
         ESOCK_CNT_INC(env, descP, sockRef, esock_atom_read_pkg,
                       &descP->readPkgCnt, 1);
@@ -7066,8 +7055,8 @@ ERL_NIF_TERM recv_check_partial_done(ErlNifEnv*       env,
     /* This transfers "ownership" of the *allocated* binary to an
      * erlang term (no need for an explicit free).
      */
+    ESOCK_ASSERT( REALLOC_BIN(bufP, read) );
     data = MKBIN(env, bufP);
-    data = MKSBIN(env, data, 0, read);
 
     SSDBG( descP,
            ("UNIX-ESSIO", "recv_check_partial_done(%T) {%d} -> [%ld] done\r\n",
@@ -7116,8 +7105,8 @@ ERL_NIF_TERM recv_check_partial_part(ErlNifEnv*       env,
         ERL_NIF_TERM data;
 
         descP->readState |= ESOCK_STATE_SELECTED;
+        ESOCK_ASSERT( REALLOC_BIN(bufP, read) );
 	data = MKBIN(env, bufP);
-	data = MKSBIN(env, data, 0, read);
 	res  = MKT2(env, esock_atom_select, data);
     }
 

--- a/lib/kernel/doc/src/socket.xml
+++ b/lib/kernel/doc/src/socket.xml
@@ -534,25 +534,63 @@
 	      BufSize&nbsp;::&nbsp;(default&nbsp;|&nbsp;integer()>0)}
 	    </c>
 	    - Receive buffer size.
-	    The value <c>default</c> is only valid to <em>set</em>.
-	    <c>N</c> specifies the number of read attempts to do
-	    in a tight loop before assuming no more data is pending.
+            <p>
+	      The value <c>default</c> is only valid to <em>set</em>.
+            </p>
+            <p>
+	      <c>N</c> specifies the number of read attempts to do
+	      in a tight loop before assuming no more data is pending.
+            </p>
+            <p>
+              This is the allocation size for the receive buffer
+              used when calling the OS protocol stack's receive API,
+              when no specific size (size 0) is requested.
+              When the receive function returns the receive buffer
+              is reallocated to the actually received size.
+              If the data is copied or shrinked in place is up to
+              the allocator, and can to some extent be configured
+              in the Erlang VM.
+            </p>
+            <p>
+              The similar socket option; <c>{socket,rcvbuf}</c>
+              is a related option for the OS' protocol stack
+              that on Unix corresponds to <c>SOL_SOCKET,SO_RCVBUF</c>.
+            </p>
 	  </item>
 	  <tag><c>rcvctrlbuf</c></tag>
 	  <item>
 	    <c>
 	      BufSize&nbsp;::&nbsp;(default&nbsp;|&nbsp;integer()>0)
 	    </c>
-	    - Buffer size for received ancillary messages.
-	    The value <c>default</c> is only valid to <em>set</em>.
+	    - Allocation size for the ancillary data buffer used
+            when calling the OS protocol stack's receive API.
+            <p>
+	      The value <c>default</c> is only valid to <em>set</em>.
+            </p>
 	  </item>
 	  <tag><c>sndctrlbuf</c></tag>
 	  <item>
 	    <c>
 	      BufSize&nbsp;::&nbsp;(default&nbsp;|&nbsp;integer()>0)
 	    </c>
-	    - Buffer size for sent ancillary messages.
-	    The value <c>default</c> is only valid to <em>set</em>.
+	    - Allocation size for the ancillary data buffer used
+            when calling the OS protocol stack's
+            <seemfa marker="#sendmsg/2">sendmsg</seemfa>
+            API.
+            <p>
+	      The value <c>default</c> is only valid to <em>set</em>.
+            </p>
+            <p>
+              It is the user's responsibility to set a buffer size
+              that has room for the encoded ancillary data
+              in the message to send.
+            </p>
+            <p>
+              See <seemfa marker="#sendmsg/2">sendmsg</seemfa> and
+              also the <c>ctrl</c> field of the
+              <seetype marker="#msg_send"><c>msg_send()</c></seetype>
+              type.
+            </p>
 	  </item>
 	  <tag><c>fd</c></tag>
 	  <item>


### PR DESCRIPTION
This fixes #6152, at least the original OOM problem, by always reallocating the receive buffer binary.  It is thereby up to the VM allocators to copy data or not, and they are somewhat configurable.

Perhaps not the final solution, but a better default behaviour, I hope...