### PR TITLE
Fix deadlock when setting encoding on Windows

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -2915,8 +2915,23 @@ uncompiled code with the same arity are mapped to the same list by
           groups have a <em>group leader</em>. All I/O from the group
           is channeled to the group leader. When a new process is
           spawned, it gets the same group leader as the spawning
-          process. Initially, at system startup, <c>init</c> is both
-          its own group leader and the group leader of all processes.</p>
+          process.</p>
+        <p>Initially, at system startup, <c>init</c> is both
+          its own group leader and the group leader of all processes.
+          During the boot of a system the group leader for processes
+          will be changed depending on the need of the system. Some examples
+          where this is done are:</p>
+        <list type="bulleted">
+          <item>When an application is started, the top supervisor of that
+            application will have its group leader set to the application
+            master. See <seemfa marker="kernel:application#start/2"><c>
+            application:start/2</c></seemfa> for more details.</item>
+          <item>When running tests, both <seeapp marker="common_test:index"><c>common_test</c></seeapp> and
+            <seeerl marker="eunit:eunit"><c>eunit</c></seeerl> set the
+            group leader in order to capture any I/O from the testcase.</item>
+          <item>The <seeerl marker="stdlib:shell">interactive shell</seeerl>
+            sets the group leader to intercept I/O.</item>
+        </list>
       </desc>
     </func>
 

--- a/erts/doc/src/escript_cmd.xml
+++ b/erts/doc/src/escript_cmd.xml
@@ -119,10 +119,8 @@ $ <input>escript factorial 5</input></pre>
             I/O-server, however, must be set explicitly as follows:</p>
           <code>
 io:setopts([{encoding, latin1}])</code>
-          <p>The default encoding of the I/O-server for <c>standard_io</c>
-            is <c>unicode</c> if its supported, as the script runs in a
-            non-interactive terminal.
-            (see section
+          <p>The default encoding of the I/O-server for <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>
+            is <c>unicode</c> if its supported. (see section
             <seeguide marker="stdlib:unicode_usage#unicode_options_summary">
             Summary of Options</seeguide>) in the STDLIB User's Guide.</p>
         </note>

--- a/lib/common_test/doc/src/run_test_chapter.xml
+++ b/lib/common_test/doc/src/run_test_chapter.xml
@@ -1169,7 +1169,7 @@
 	<item>A confirmation when the test run is complete.</item>
 	<item>Some special information, such as error reports, progress
 	  reports, and printouts written with <c>erlang:display/1</c>, or <c>io:format/3</c>
-	  specifically addressed to a receiver other than <c>standard_io</c>
+	  specifically addressed to a receiver other than <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>
 	  (for example, the default group leader process <c>user</c>).</item>
       </list>
 

--- a/lib/erl_docgen/priv/bin/validate_links.escript
+++ b/lib/erl_docgen/priv/bin/validate_links.escript
@@ -256,13 +256,18 @@ validate_link(Filename, "seemfa", Line, Link, CachedFiles) ->
     end;
 validate_link(Filename, LinkType = "seetype", Line, Link, CachedFiles) ->
     {App,Mod,Type} = ParsedLink = parse_link(Filename, maps:get(m2a,CachedFiles), Link),
-    Types = maps:get(datatypes,maps:get({App,Mod},CachedFiles)),
-    case lists:member(Type, Types) of
-        false ->
+    case maps:find({App,Mod},CachedFiles) of
+        error ->
             fail(Line, "Could not find documentation for ~s when "
                  "resolving link",[App ++ ":" ++ Mod ++ "#" ++ Type]);
-        _ ->
-            validate_type(Line,LinkType,read_link(Line, ParsedLink, CachedFiles))
+        {ok, AppData} ->
+            case lists:member(Type, maps:get(datatypes,AppData)) of
+                false ->
+                    fail(Line, "Could not find documentation for ~s when "
+                         "resolving link",[App ++ ":" ++ Mod ++ "#" ++ Type]);
+                _ ->
+                    validate_type(Line,LinkType,read_link(Line, ParsedLink, CachedFiles))
+            end
     end;
 validate_link({"jinterface","jinterface_users_guide"},"seefile",_, _, _) ->
     %% Skip links to java documentation

--- a/lib/kernel/doc/src/file.xml
+++ b/lib/kernel/doc/src/file.xml
@@ -1374,8 +1374,8 @@ f.txt:  {person, "kalle", 25}.
 	  read from the file, while the position in the file can be moved much more than
 	  this number when reading a Unicode file.</p>
 	  <p>Also, if <c>encoding</c> is set to something else than <c>latin1</c>,
-	  the <c>read/3</c> call fails if the data contains characters larger than 255,
-	  which is why module <seeerl marker="stdlib:io"><c>io(3)</c></seeerl>
+	  the <c>read/2</c> call fails if the data contains characters larger than 255,
+	  which is why <seemfa marker="stdlib:io#get_chars/3"><c>io:get_chars/3</c></seemfa>
 	  is to be preferred when reading such a file.</p>
 	  <p>The function returns:</p>
         <taglist>
@@ -1628,7 +1628,7 @@ f.txt:  {person, "kalle", 25}.
 	  raw line-oriented reading.</p>
 	  <p>If <c>encoding</c> is set to something else than <c>latin1</c>, the
 	  <c>read_line/1</c> call fails if the data contains characters larger than 255,
-	  why module <seeerl marker="stdlib:io"><c>io(3)</c></seeerl> is to be
+	  why <seemfa marker="stdlib:io#get_line/2"><c>io:get_line/2</c></seemfa> is to be
 	  preferred when reading such a file.</p>
 	  <p>The function returns:</p>
         <taglist>
@@ -1978,7 +1978,10 @@ f.txt:  {person, "kalle", 25}.
 	  <p>If the file is opened with <c>encoding</c> set to something else than
 	  <c>latin1</c>, each byte written can result in many bytes being written to
 	  the file, as the byte range 0..255 can represent anything between one and
-	  four bytes depending on value and UTF encoding type.</p>
+	  four bytes depending on value and UTF encoding type. If you want to write
+          <seetype marker="stdlib:unicode#chardata"><c>unicode:chardata()</c></seetype>
+          to the <c><anno>IoDevice</anno></c> you should use <seemfa marker="stdlib:io#put_chars/2">
+          <c>io:put_chars/2</c></seemfa> instead.</p>
         <p>Typical error reasons:</p>
         <taglist>
           <tag><c>ebadf</c></tag>

--- a/lib/kernel/doc/src/kernel_app.xml
+++ b/lib/kernel/doc/src/kernel_app.xml
@@ -614,13 +614,13 @@ MaxT = NetTickTime + NetTickTime / NetTickIntensity</code>
 	</p>
 
       </item>
-    <tag><marker id="standard_io_encoding"/><c>standard_io_encoding = Encoding</c></tag>
+      <tag><marker id="standard_io_encoding"/><c>standard_io_encoding = Encoding</c></tag>
       <item>
         <p>Set whether bytes sent or received via standard_io should be interpreted as unicode or latin1.
-        By default input and output is interpreted as Unicode if it is supported on the host. With this flag
-        you may configure the encoding on startup.</p>
+          By default input and output is interpreted as Unicode if it is supported on the host. With this flag
+          you may configure the encoding on startup.</p>
         <p>This works similarly to <seemfa marker="stdlib:io#setopts/2"><c>io:setopts(standard_io, {encoding, Encoding})</c></seemfa>
-        but is applied before any bytes on standard_io may have been read.</p>
+          but is applied before any bytes on standard_io may have been read.</p>
         <p>Encoding is one of:</p>
         <taglist>
           <tag><c>unicode</c></tag>
@@ -631,8 +631,10 @@ MaxT = NetTickTime + NetTickTime / NetTickIntensity</code>
           <item><p>Anything other than unicode or latin1 will be ignored and the system will
             configure the encoding by itself, typically unicode on modern systems.</p></item>
         </taglist>
+        <p>See <seeguide marker="stdlib:unicode_usage#escripts-and-non-interactive-i-o">
+        Escripts and non-interactive I/O in Unicode Usage in Erlang</seeguide> for more details.</p>
       </item>
-          </taglist>
+    </taglist>
   </section>
 
   <section>

--- a/lib/kernel/doc/src/logger_chapter.xml
+++ b/lib/kernel/doc/src/logger_chapter.xml
@@ -829,7 +829,7 @@ logger:debug(#{got => connection_request, id => Id, state => State},
 	configuration file that configures Logger according to the
 	description.</p>
       <p>Modify the default handler to print to a file instead of
-	<c>standard_io</c>:</p>
+	<seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>:</p>
       <code>
 [{kernel,
   [{logger,

--- a/lib/kernel/doc/src/logger_std_h.xml
+++ b/lib/kernel/doc/src/logger_std_h.xml
@@ -38,8 +38,8 @@
   <description>
     <p>This is the standard handler for Logger.
       Multiple instances of this handler can be added to
-      Logger, and each instance prints logs to <c>standard_io</c>,
-      <c>standard_error</c>, or to file.</p>
+      Logger, and each instance prints logs to <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>,
+      <seetype marker="stdlib:io#standard_error"><c>standard_error</c></seetype>, or to file.</p>
     <p>The handler has an overload protection mechanism that keeps the handler
       process and the Kernel application alive during high loads of log 
       events. How overload protection works, and how to configure it, is
@@ -55,12 +55,14 @@
        is stored in a sub map with the key <c>config</c>, and can contain the
        following parameters:</p>
     <taglist>
-      <tag><marker id="type"/><c>type = standard_io | standard_error | file | {device, io:device()}</c></tag>
+      <tag><marker id="type"/><c>type = </c><seetype marker="stdlib:io#standard_io"><c>io:standard_io()</c></seetype><c>
+        | </c><seetype marker="stdlib:io#standard_error"><c>io:standard_error()</c></seetype><c> | file
+        | {device, </c><seetype marker="stdlib:io#device"><c>io:device()</c></seetype><c>}</c></tag>
       <item>
 	<p>Specifies the log destination.</p>
 	<p>The value is set when the handler is added, and it cannot
 	  be changed in runtime.</p>
-	<p>Defaults to <c>standard_io</c>, unless
+	<p>Defaults to <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>, unless
 	  parameter <seeerl marker="#file"><c>file</c></seeerl> is
 	  given, in which case it defaults to <c>file</c>.</p>
       </item>
@@ -182,7 +184,7 @@ logger:add_handler(my_standard_h, logger_std_h,
                                  filesync_repeat_interval => 1000}}).
     </code>
     <p>To set the default handler, that starts initially with
-    the Kernel application, to log to file instead of <c>standard_io</c>,
+    the Kernel application, to log to file instead of <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>,
     change the Kernel default logger configuration. Example:</p>
     <code type="none">
 erl -kernel logger '[{handler,default,logger_std_h,

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -582,7 +582,7 @@ allocate(#file_descriptor{module = Module} = Handle, Offset, Length) ->
     Module:allocate(Handle, Offset, Length).
 
 -spec read(IoDevice, Number) -> {ok, Data} | eof | {error, Reason} when
-      IoDevice :: io_device() | atom(),
+      IoDevice :: io_device() | io:device(),
       Number :: non_neg_integer(),
       Data :: string() | binary(),
       Reason :: posix()
@@ -604,7 +604,7 @@ read(_, _) ->
     {error, badarg}.
 
 -spec read_line(IoDevice) -> {ok, Data} | eof | {error, Reason} when
-      IoDevice :: io_device() | atom(),
+      IoDevice :: io_device() | io:device(),
       Data :: string() | binary(),
       Reason :: posix()
               | badarg
@@ -668,7 +668,7 @@ pread(_, _, _) ->
     {error, badarg}.
 
 -spec write(IoDevice, Bytes) -> ok | {error, Reason} when
-      IoDevice :: io_device() | atom(),
+      IoDevice :: io_device() | io:device(),
       Bytes :: iodata(),
       Reason :: posix() | badarg | terminated.
 

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -567,9 +567,9 @@ handle_request(State = #state{ options = #{ tty := false } }, Request) ->
         {putc_raw, Binary} ->
             {Binary, State};
         {putc, Binary} ->
-            {encode(Binary, State#state.unicode), State};
+            {encode(Binary, State#state.unicode, false), State};
         {insert, Binary} ->
-            {encode(Binary, State#state.unicode), State};
+            {encode(Binary, State#state.unicode, false), State};
         beep ->
             {<<7>>, State};
         _Ignore ->
@@ -636,7 +636,8 @@ handle_request(State = #state{ unicode = U }, {putc, Binary}) ->
     %% print above the prompt if we have a prompt.
     %% otherwise print on the current line.
     case {State#state.lines_before,{State#state.buffer_before, State#state.buffer_after}, State#state.lines_after} of
-        {[],{[],[]},[]} -> {PutBuffer, _} = insert_buf(State, Binary),
+        {[],{[],[]},[]} ->
+            {PutBuffer, _} = insert_buf(State, Binary),
             {[encode(PutBuffer, U)], State};
         _ ->
             {Delete, DeletedState} = handle_request(State, delete_line),
@@ -644,8 +645,6 @@ handle_request(State = #state{ unicode = U }, {putc, Binary}) ->
             {Redraw, _} = handle_request(State, redraw_prompt_pre_deleted),
             {[Delete, encode(PutBuffer, U), Redraw], State}
     end;
-handle_request(State, {putc_raw, Binary}) ->
-    handle_request(State, {putc, unicode:characters_to_binary(Binary, latin1)});
 handle_request(State = #state{}, delete_after_cursor) ->
     {[State#state.delete_after_cursor],
      State#state{buffer_after = [],
@@ -1038,7 +1037,7 @@ npwcwidth(Char, true) ->
         C -> C
     end;
 npwcwidth(Char, false) ->
-    byte_size(char_to_latin1(Char)).
+    byte_size(char_to_latin1(Char, true)).
 
 
 %% Return the xn fix for the current cursor position.
@@ -1193,11 +1192,11 @@ ansi_sgr(<<$m, _Rest/binary>>, Size) ->
     {ok, Size + 1};
 ansi_sgr(<<_/binary>>, _) -> none.
 
--spec to_latin1(erlang:binary()) -> erlang:iovec().
-to_latin1(Bin) ->
+-spec to_latin1(erlang:binary(), TTY :: boolean()) -> erlang:iovec().
+to_latin1(Bin, TTY) ->
     case is_usascii(Bin) of
         true -> [Bin];
-        false -> lists:flatten([binary_to_latin1(Bin)])
+        false -> lists:flatten([binary_to_latin1(Bin, TTY)])
     end.
 
 is_usascii(<<Char/utf8,T/binary>>) when Char < 128 ->
@@ -1207,19 +1206,21 @@ is_usascii(<<>>) ->
 is_usascii(_) ->
     false.
 
-binary_to_latin1(Buffer) ->
-    [char_to_latin1(CP) || CP <- unicode:characters_to_list(Buffer)].
-char_to_latin1(UnicodeChar) when UnicodeChar >= 512 ->
+binary_to_latin1(Buffer, TTY) ->
+    [char_to_latin1(CP, TTY) || CP <- unicode:characters_to_list(Buffer)].
+char_to_latin1(UnicodeChar, _) when UnicodeChar >= 512 ->
     <<"\\x{",(integer_to_binary(UnicodeChar, 16))/binary,"}">>;
-char_to_latin1(UnicodeChar) when UnicodeChar >= 128 ->
+char_to_latin1(UnicodeChar, true) when UnicodeChar >= 128 ->
     <<"\\",(integer_to_binary(UnicodeChar, 8))/binary>>;
-char_to_latin1(UnicodeChar) ->
+char_to_latin1(UnicodeChar, _) ->
     <<UnicodeChar>>.
 
-encode(UnicodeChars, true) ->
+encode(UnicodeChars, Unicode) ->
+    encode(UnicodeChars, Unicode, true).
+encode(UnicodeChars, true, _) ->
     unicode:characters_to_binary(UnicodeChars);
-encode(UnicodeChars, false) ->
-    to_latin1(unicode:characters_to_binary(UnicodeChars)).
+encode(UnicodeChars, false, TTY) ->
+    to_latin1(unicode:characters_to_binary(UnicodeChars), TTY).
 
 %% Using get_position adds about 10ms of latency
 %% get_position(#state{ position = false }) ->

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -793,10 +793,6 @@ io_request({put_chars_sync, unicode, Chars, Reply}, TTY) ->
     {Output, NewTTY} = prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars)}),
     {ok, MonitorRef} = prim_tty:write(NewTTY, Output, self()),
     {Reply, MonitorRef, NewTTY};
-io_request({put_chars_sync, latin1, Chars, Reply}, TTY) ->
-    {Output, NewTTY} = prim_tty:handle_request(TTY, {putc_raw, Chars}),
-    {ok, MonitorRef} = prim_tty:write(NewTTY, Output, self()),
-    {Reply, MonitorRef, NewTTY};
 io_request({put_expand, unicode, Chars}, TTY) ->
     write(prim_tty:handle_request(TTY, {expand_with_trim, unicode:characters_to_binary(Chars)}));
 io_request({put_expand_no_trim, unicode, Chars}, TTY) ->

--- a/lib/stdlib/doc/src/io.xml
+++ b/lib/stdlib/doc/src/io.xml
@@ -41,7 +41,7 @@
      protocols. Normally, it is a <c>IoDevice</c> returned by
      <seemfa marker="kernel:file#open/2"><c>file:open/2</c></seemfa>.
      If no <seetype marker="#device"><c>IoDevice</c></seetype> is given,
-     <c>standard_io</c> is used.</p>
+     <seetype marker="#standard_io"><c>standard_io</c></seetype> is used.</p>
 
     <p>For a description of the I/O protocols, see section
       <seeguide marker="io_protocol">The Erlang I/O Protocol</seeguide>
@@ -71,12 +71,74 @@
     <datatype>
       <name name="device"/>
       <desc>
-        <p>An I/O device, either <c>standard_io</c>, <c>standard_error</c>, a
-          registered name, or a pid handling I/O protocols (returned from
+        <p>An I/O device, either <c>standard_io</c>, <c>standard_error</c>, <c>user</c>,
+          a registered name, or a pid handling I/O protocols (returned from
           <seemfa marker="kernel:file#open/2"><c>file:open/2</c></seemfa>).</p>
-        <p>For more information about the built-in devices see
-          <seeerl marker="#standard-input-output">Standard Input/Output</seeerl>
-          and <seeerl marker="#standard-error">Standard Error</seeerl>.
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="standard_io"/>
+      <desc>
+        <p>All Erlang processes have a default standard I/O device. This
+          device is used when no <c>IoDevice</c> argument is specified in
+          the function calls in this module. However, it is sometimes desirable to
+          use an explicit <c>IoDevice</c> argument that refers to the
+          default I/O device. This is the case with functions that can
+          access either a file or the default I/O device. The atom
+          <c>standard_io</c> has this special meaning. The following example
+          illustrates this:
+        </p>
+
+        <pre>
+27> <input>io:read('enter>').</input>
+enter><input>foo.</input>
+{ok,foo}
+28> <input>io:read(standard_io, 'enter>').</input>
+enter><input>bar.</input>
+{ok,bar}</pre>
+
+         <p>By default all I/O sent to <c>standard_io</c> will en up in the
+           <seetype marker="#user"><c>user</c></seetype> I/O device of the node
+           that spawned the calling process.
+        </p>
+
+        <p><c>standard_io</c> is an alias for <seemfa marker="erts:erlang#group_leader/0"><c>
+          group_leader/0</c></seemfa>, so in order to change where the default input/output
+          requests are sent you can change the group leader for the current process using
+          <seemfa marker="erts:erlang#group_leader/2"><c>
+            group_leader(NewGroupLeader, self())</c></seemfa>.
+        </p>
+
+      </desc>
+    </datatype>
+    <datatype>
+      <name name="standard_error"/>
+      <desc>
+        <p>The I/O device <c>standard_error</c> can be used to direct
+          output to whatever the current operating system considers a suitable
+          I/O device for error output. This can be useful when standard output is
+          redirected. Example on a Unix-like operating system:
+        </p>
+
+        <pre>
+$ <input>erl -noinput -eval 'io:format(standard_error,"Error: ~s~n",["error 11"]),'\</input>
+<input>'init:stop().' > /dev/null</input>
+Error: error 11</pre>
+        </desc>
+    </datatype>
+    <datatype>
+      <name name="user"/>
+      <desc>
+        <p>An I/O device that can be used to interact with the node local
+          <c>stdout</c> and <c>stdin</c>. This can be either a terminal,
+          a pipe, a file, or a combination. You can use <seemfa marker="#getopts/0">
+          <c>getopts/0</c></seemfa> to get more information about the
+          I/O device.
+        </p>
+        <p>See <seeguide marker="unicode_usage#the-interactive-shell">The Interactive Shell</seeguide>
+          and <seeguide marker="unicode_usage#escripts-and-non-interactive-i-o">Escripts and non-interactive I/O</seeguide>
+          in the Using Unicode In Erlang User's Guide for details on how Unicode
+          is handled by <c>user</c>.
         </p>
       </desc>
     </datatype>
@@ -743,7 +805,10 @@ enter><input>:</input>   <input>alan</input>   <input>:</input>   <input>joe</in
               the data can represent codepoints &gt; 255 (the
               <c>latin1</c> range). If the I/O server is set to deliver
               binaries, they are encoded in UTF-8 (regardless of whether
-              the I/O device supports Unicode).</p>
+              the I/O device supports Unicode). If you want the data to
+              be returned as a latin1 encoded binary you should use
+              <seemfa marker="kernel:file#read/2"><c>file:read/2</c></seemfa>
+              instead.</p>
           </item>
           <tag><c>eof</c></tag>
           <item>
@@ -775,7 +840,10 @@ enter><input>:</input>   <input>alan</input>   <input>:</input>   <input>joe</in
               the data can represent codepoints &gt; 255 (the
               <c>latin1</c> range). If the I/O server is set to deliver
               binaries, they are encoded in UTF-8 (regardless of if
-              the I/O device supports Unicode).</p>
+              the I/O device supports Unicode). If you want the data to
+              be returned as a latin1 encoded binary you should use
+              <seemfa marker="kernel:file#read_line/1"><c>file:read_line/1</c></seemfa>
+              instead.</p>
           </item>
           <tag><c>eof</c></tag>
           <item>
@@ -816,8 +884,11 @@ enter><input>:</input>   <input>alan</input>   <input>:</input>   <input>joe</in
       <p>This example is, as can be seen, run in an environment where the
         terminal supports Unicode input and output.</p>
       <p>The <c>terminal</c> option is read only and indicates whether
-        the output stream is a terminal or not.
-        See <seemfa marker="#setopts/1"><c>setopts/1</c></seemfa> for a description
+        the output stream is a terminal or not. When it is a terminal,
+        most systems that Erlang runs on allows the use of
+        <url href="https://en.wikipedia.org/wiki/ANSI_escape_code">ANSI escape codes</url>
+        to control what the terminal outputs.</p>
+      <p>See <seemfa marker="#setopts/1"><c>setopts/1</c></seemfa> for a description
         of the other options.</p>
       </desc>
     </func>
@@ -965,7 +1036,10 @@ enter><input>abc("hey".</input>
       <fsummary>Write a list of characters.</fsummary>
       <desc>
         <p>Writes the characters of <c><anno>CharData</anno></c> to the I/O
-          server (<c><anno>IoDevice</anno></c>).</p>
+          server (<c><anno>IoDevice</anno></c>). If you want to write latin1 encoded
+          bytes to the I/O server you should use
+          <seemfa marker="kernel:file#write/2"><c>file:write/2</c></seemfa>
+          instead.</p>
       </desc>
     </func>
 
@@ -1214,15 +1288,19 @@ fun("") -> {yes, "quit", []};
             <note><p>
               Prior to OTP 26.0, when Erlang was started with the
               <c>-oldshell</c> or <c>-noshell</c> flags (for example, in an
-              <c>escript</c>), the default encoding for <c>standard_io</c> was
-              set to <c>latin1</c>, meaning that any characters &gt; codepoint
-              255 were escaped and that input was expected to be plain 8-bit
-              ISO Latin-1. As of OTP 26.0, <c>standard_io</c> always defaults
+              <c>escript</c>), the default encoding for <seetype marker="#standard_io">
+              <c>standard_io</c></seetype> was set to <c>latin1</c>, meaning
+              that any characters &gt; codepoint 255 were escaped and that input
+              was expected to be plain 8-bit ISO Latin-1. As of OTP 26.0,
+              <seetype marker="#standard_io"><c>standard_io</c></seetype> always defaults
               to <c>unicode</c> if its supported, otherwise <c>latin1</c>.
             </p><p>
-              If you want to send raw bytes on <c>standard_io</c>, you now
-              always need to explicitly set the encoding to <c>latin1</c>;
+              If you want to send raw bytes on <seetype marker="#standard_io"><c>standard_io</c></seetype>,
+              you now always need to explicitly set the encoding to <c>latin1</c>;
               otherwise, code points 128-255 will be converted to UTF-8.
+              This is best done by setting the kernel configuration parameter
+              <seeapp marker="kernel:kernel_app#standard_io_encoding">standard_io_encoding</seeapp>
+              to <c>latin1</c>.
             </p></note>
             <p>Files can also be set in <c>{encoding, unicode}</c>, meaning
               that data is written and read as UTF-8. More encodings are
@@ -1260,49 +1338,6 @@ fun("") -> {yes, "quit", []};
       </desc>
     </func>
   </funcs>
-
-  <section>
-    <title>Standard Input/Output</title>
-    <p>All Erlang processes have a default standard I/O device. This
-      device is used when no <c>IoDevice</c> argument is specified in
-      the function calls in this module. However, it is sometimes desirable to
-      use an explicit <c>IoDevice</c> argument that refers to the
-      default I/O device. This is the case with functions that can
-      access either a file or the default I/O device. The atom
-      <c>standard_io</c> has this special meaning. The following example
-      illustrates this:</p>
-
-    <pre>
-27> <input>io:read('enter>').</input>
-enter><input>foo.</input>
-{ok,foo}
-28> <input>io:read(standard_io, 'enter>').</input>
-enter><input>bar.</input>
-{ok,bar}</pre>
-
-    <p><c>standard_io</c> is an alias for <seemfa marker="erts:erlang#group_leader/0"><c>
-      group_leader/0</c></seemfa>, so in order to change where the default input/output
-      requests are sent you can change the group leader for the current process using
-      <seemfa marker="erts:erlang#group_leader/2"><c>
-      group_leader(NewGroupLeader, self()).</c></seemfa></p>
-
-    <p>There is always a process registered under the name of
-      <c>user</c>. This can be used for sending output to the user.</p>
-  </section>
-
- <section>
-    <title>Standard Error</title>
-    <p>In certain situations, especially when the standard output is
-      redirected, access to an I/O server specific for error messages can be
-      convenient. The I/O device <c>standard_error</c> can be used to direct
-      output to whatever the current operating system considers a suitable
-      I/O device for error output. Example on a Unix-like operating system:</p>
-
-<pre>
-$ <input>erl -noshell -noinput -eval 'io:format(standard_error,"Error: ~s~n",["error 11"]),'\</input>
-<input>'init:stop().' > /dev/null</input>
-Error: error 11</pre>
-  </section>
 
   <section>
     <title>Error Information</title>

--- a/lib/stdlib/doc/src/peer.xml
+++ b/lib/stdlib/doc/src/peer.xml
@@ -311,7 +311,7 @@ build_image(Dir) ->
           <tag><c>detached</c></tag>
           <item>
             <p>Defines whether to pass the <c>-detached</c> flag to the started peer.
-              This option cannot be set to <c>false</c> using the standard_io alternative
+              This option cannot be set to <c>false</c> using the <c>standard_io</c> alternative
               connection type. Default is <c>true</c>.
             </p>
           </item>

--- a/lib/stdlib/doc/src/sys.xml
+++ b/lib/stdlib/doc/src/sys.xml
@@ -470,7 +470,7 @@
         <p>If <c><anno>Flag</anno></c> is <c>get</c>, a list of all logged
           events is returned.</p>
         <p>If <c><anno>Flag</anno></c> is <c>print</c>, the logged events
-          are printed to <c>standard_io</c>.</p>
+          are printed to <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>.</p>
         <p>The events are formatted with a function that is defined by the
           process that generated the event (with a call to
           <seemfa marker="#handle_debug/4">
@@ -675,9 +675,9 @@
       <name name="trace" arity="3" since=""/>
       <fsummary>Print all system events on <c>standard_io</c>.</fsummary>
       <desc>
-        <p>Prints all system events on <c>standard_io</c>. The events are
-          formatted with a function that is defined by the process that
-          generated the event (with a call to
+        <p>Prints all system events on <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>.
+          The events are formatted with a function that is defined by
+          the process that generated the event (with a call to
           <seemfa marker="#handle_debug/4"><c>handle_debug/4</c></seemfa>).
         </p>
       </desc>

--- a/lib/stdlib/doc/src/unicode_usage.xml
+++ b/lib/stdlib/doc/src/unicode_usage.xml
@@ -611,9 +611,7 @@ ok</pre>
 
   <section>
     <title>The Interactive Shell</title>
-    <p>The interactive Erlang shell, when started to a terminal or started
-      using command <c>werl</c> on Windows, can support Unicode input and
-      output.</p>
+    <p>The interactive Erlang shell can support Unicode input and output.</p>
 
     <p>On Windows, proper operation requires that a suitable font is
       installed and selected for the Erlang application to use. If no suitable
@@ -716,7 +714,49 @@ Eshell V5.10.1  (abort with ^G)
 2> <input>Юникод.</input>
 * 1: illegal character
 2> </pre>
-  </section> 
+  </section>
+
+  <section>
+    <title>Escripts and non-interactive I/O</title>
+    <p>When Erlang is started without an interactive shell (<c>-noshell</c>,
+      <c>-noinput</c> or as an escript) the unicode support is identified using
+      environment variables just as for <seeguide marker="#the-interactive-shell">
+      interactive shells</seeguide>. Working with unicode in non-interactive
+      sessions works just the same as for interactive sessions.
+    </p>
+    <p>In some situations you may need to be able to read and write raw bytes
+      from <seeerl marker="stdlib:io#standard-input-output"><c>standard_io</c></seeerl>.
+      If that is the case, then you want to set
+      the <seeapp marker="kernel:kernel_app#standard_io_encoding">standard_io_encoding</seeapp>
+      configuration parameter to <c>latin1</c> and use the <seeerl marker="kernel:file"><c>file</c></seeerl>
+      API to read and write data (as explained in <seeguide marker="#unicode-data-in-files">Unicode Data in Files</seeguide>).
+    </p>
+    <p>In the example below we first read the character <c>ξ</c> from <c>standard_io</c>
+      and then print the <seetype marker="unicode:charlist">charlist()</seetype>
+      represented by it.
+    </p>
+<pre>
+#!/usr/bin/env escript
+%%! -kernel standard_io_encoding latin1
+
+main(_) ->
+  {ok, Char} = file:read_line(standard_io),
+  ok = file:write(standard_io, string:trim(Char)),
+  ok = file:write(standard_io, io_lib:format(": ~w~n",[string:trim(Char)])),
+  ok.
+</pre>
+<pre>
+$ escript test.es
+<input>ξ</input>
+ξ: [206,190]
+</pre>
+    <p><c>ξ</c> would normally be represented as the integer 958, but since we are
+      using bytewise encoding (<c>latin1</c>), it is represented by 206 and 190,
+      which is the utf-8 bytes representing <c>ξ</c>. When we echo those bytes back
+      to standard_io, the terminal will see the bytes as utf-8 and show the
+      correct value even though in Erlang we never knew that it was indeed a unicode
+      string.</p>
+  </section>
 
   <section>
     <marker id="unicode_file_names"/>
@@ -1214,12 +1254,14 @@ ok
         </p>
       </item>
       <tag><seemfa marker="stdlib:io#setopts/1"><c>io:setopts/1,2</c></seemfa>
-        and flags <c>-oldshell</c>/<c>-noshell</c></tag>
+        and <seeapp marker="kernel:kernel_app#standard_io_encoding">
+        <c>standard_io_encoding</c></seeapp></tag>
       <item>
-        <p>When Erlang is started with <c>-oldshell</c> or <c>-noshell</c>, the
-          I/O server for <c>standard_io</c> is by default set to bytewise
-          encoding, while an interactive shell defaults to what the
-          environment variables says.</p>
+        <p>When Erlang is started the I/O server for <c>standard_io</c> is by
+          default set to what the environment variables says. You can override
+          the default by setting the kernel configuration parameter
+          <seeapp marker="kernel:kernel_app#standard_io_encoding">
+          <c>standard_io_encoding</c></seeapp> to the desired encoding.</p>
         <p>You can set the encoding of a file or other I/O server with function
           <seemfa marker="stdlib:io#setopts/1"><c>io:setopts/2</c></seemfa>.
           This can also be set when opening a file. Setting the terminal (or
@@ -1227,6 +1269,11 @@ ok
           <c>{encoding,utf8}</c> implies that UTF-8 encoded characters are
           written to the device, regardless of how Erlang was started or the
           user's environment.</p>
+        <note>If you use <seemfa marker="stdlib:io#setopts/1"><c>io:setopts/2</c></seemfa>
+          to change the encoding of <c>standard_io</c> the I/O server may already have
+          read some data using the default encoding. To avoid this you should set
+          the encoding using <seeapp marker="kernel:kernel_app#standard_io_encoding">
+          <c>standard_io_encoding</c></seeapp>.</note>
         <p>Opening files with option <c>encoding</c> is convenient when
           writing or reading text files in a known encoding.</p>
         <p>You can retrieve the <c>encoding</c> setting for an I/O server with

--- a/lib/stdlib/doc/src/unicode_usage.xml
+++ b/lib/stdlib/doc/src/unicode_usage.xml
@@ -725,14 +725,14 @@ Eshell V5.10.1  (abort with ^G)
       sessions works just the same as for interactive sessions.
     </p>
     <p>In some situations you may need to be able to read and write raw bytes
-      from <seeerl marker="stdlib:io#standard-input-output"><c>standard_io</c></seeerl>.
+      from <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>.
       If that is the case, then you want to set
       the <seeapp marker="kernel:kernel_app#standard_io_encoding">standard_io_encoding</seeapp>
       configuration parameter to <c>latin1</c> and use the <seeerl marker="kernel:file"><c>file</c></seeerl>
       API to read and write data (as explained in <seeguide marker="#unicode-data-in-files">Unicode Data in Files</seeguide>).
     </p>
-    <p>In the example below we first read the character <c>ξ</c> from <c>standard_io</c>
-      and then print the <seetype marker="unicode:charlist">charlist()</seetype>
+    <p>In the example below we first read the character <c>ξ</c> from <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>
+      and then print the <seetype marker="unicode#charlist">charlist()</seetype>
       represented by it.
     </p>
 <pre>
@@ -753,7 +753,8 @@ $ escript test.es
     <p><c>ξ</c> would normally be represented as the integer 958, but since we are
       using bytewise encoding (<c>latin1</c>), it is represented by 206 and 190,
       which is the utf-8 bytes representing <c>ξ</c>. When we echo those bytes back
-      to standard_io, the terminal will see the bytes as utf-8 and show the
+      to <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>,
+      the terminal will see the bytes as utf-8 and show the
       correct value even though in Erlang we never knew that it was indeed a unicode
       string.</p>
   </section>
@@ -1257,23 +1258,24 @@ ok
         and <seeapp marker="kernel:kernel_app#standard_io_encoding">
         <c>standard_io_encoding</c></seeapp></tag>
       <item>
-        <p>When Erlang is started the I/O server for <c>standard_io</c> is by
-          default set to what the environment variables says. You can override
-          the default by setting the kernel configuration parameter
+        <p>When Erlang is started the encoding for <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype> is by
+          default set to what the <seeguide marker="#the-interactive-shell">locale settings indicate</seeguide>.
+          You can override the default by setting the kernel configuration parameter
           <seeapp marker="kernel:kernel_app#standard_io_encoding">
           <c>standard_io_encoding</c></seeapp> to the desired encoding.</p>
         <p>You can set the encoding of a file or other I/O server with function
           <seemfa marker="stdlib:io#setopts/1"><c>io:setopts/2</c></seemfa>.
           This can also be set when opening a file. Setting the terminal (or
-          other <c>standard_io</c> server) unconditionally to option
-          <c>{encoding,utf8}</c> implies that UTF-8 encoded characters are
-          written to the device, regardless of how Erlang was started or the
-          user's environment.</p>
-        <note>If you use <seemfa marker="stdlib:io#setopts/1"><c>io:setopts/2</c></seemfa>
-          to change the encoding of <c>standard_io</c> the I/O server may already have
+          other <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype> server)
+          unconditionally to option <c>{encoding,utf8}</c> implies that UTF-8
+          encoded characters are written to the device, regardless of how Erlang
+          was started or the user's environment.</p>
+        <note><p>If you use <seemfa marker="stdlib:io#setopts/1"><c>io:setopts/2</c></seemfa>
+          to change the encoding of <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype>
+          the I/O server may already have
           read some data using the default encoding. To avoid this you should set
           the encoding using <seeapp marker="kernel:kernel_app#standard_io_encoding">
-          <c>standard_io_encoding</c></seeapp>.</note>
+          <c>standard_io_encoding</c></seeapp>.</p></note>
         <p>Opening files with option <c>encoding</c> is convenient when
           writing or reading text files in a known encoding.</p>
         <p>You can retrieve the <c>encoding</c> setting for an I/O server with
@@ -1404,7 +1406,8 @@ ok</pre>
         terminal: "oldshell" or "noshell") or whatever is suitable to show the
         character properly (for an interactive terminal: the regular shell).</p>
 
-      <p>So, you can always send Unicode data to the <c>standard_io</c> device.
+      <p>So, you can always send Unicode data to the
+        <seetype marker="stdlib:io#standard_io"><c>standard_io</c></seetype> device.
         Files, however, accept only Unicode code points beyond ISO Latin-1 if
         <c>encoding</c> is set to something else than <c>latin1</c>.</p>
     </section>

--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -36,11 +36,15 @@
 %% Implemented in native code
 -export([printable_range/0]).
 
--export_type([device/0, format/0, server_no_data/0]).
+-export_type([device/0, format/0, server_no_data/0,
+              standard_io/0, standard_error/0, user/0]).
 
 %%-------------------------------------------------------------------------
 
--type device() :: atom() | pid().
+-type standard_io() :: standard_io.
+-type standard_error() :: standard_error.
+-type user() :: user.
+-type device() :: atom() | pid() | standard_io() | standard_error() | user().
 -type prompt() :: atom() | unicode:chardata().
 
 %% ErrorDescription is whatever the I/O-server sends.


### PR DESCRIPTION
This PR fixes a bug when calling `io:setopts([{encoding,unicode}])` on Windows and also cleans up and documents how to bytewise encoded data should be handled by standard_io.

closes #7459