### PR TITLE
Add sign_fun config option (SSL)

### DIFF
--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -830,9 +830,6 @@ sign(DigestOrPlainText, DigestType, Key) ->
 sign(Digest, none, Key = #'DSAPrivateKey'{}, Options) when is_binary(Digest) ->
     %% Backwards compatible
     sign({digest, Digest}, sha, Key, Options);
-sign(DigestOrPlainText, DigestType, Key, SignAlgo) when is_atom(SignAlgo) ->
-    Options = signature_options(SignAlgo, DigestType),
-    sign(DigestOrPlainText, DigestType, Key, Options);
 sign(DigestOrPlainText, DigestType, Key, Options) ->
     case format_sign_key(Key) of
 	badarg ->
@@ -1495,18 +1492,6 @@ set_padding(Pad, Opts) ->
                                    T =/= rsa_padding,
                                    T =/= rsa_pad]
     ].
-
-signature_options(SignAlgo, HashAlgo) when SignAlgo =:= rsa_pss_rsae orelse
-                                           SignAlgo =:= rsa_pss_pss ->
-    pss_options(HashAlgo);
-signature_options(_, _) ->
-    [].
-
-pss_options(HashAlgo) ->
-    %% of the digest algorithm: rsa_pss_saltlen = -1
-    [{rsa_padding, rsa_pkcs1_pss_padding},
-     {rsa_pss_saltlen, -1},
-     {rsa_mgf1_md, HashAlgo}].
 
 format_pkix_sign_key({#'RSAPrivateKey'{} = Key, _}) ->
     %% Params are handled in option arg

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -832,14 +832,14 @@ sign(Digest, none, Key = #'DSAPrivateKey'{}, Options) when is_binary(Digest) ->
     sign({digest, Digest}, sha, Key, Options);
 sign(DigestOrPlainText, DigestType, Key, Options) ->
     case format_sign_key(Key) of
-	badarg ->
-	    erlang:error(badarg, [DigestOrPlainText, DigestType, Key, Options]);
-    {extern, {Mod, Fun}} ->
-        Mod:Fun(DigestOrPlainText, DigestType, Options);
-    {extern, Fun} when is_function(Fun) ->
-        Fun(DigestOrPlainText, DigestType, Options);
-	{Algorithm, CryptoKey} ->
-	    try crypto:sign(Algorithm, DigestType, DigestOrPlainText, CryptoKey, Options)
+	    badarg ->
+	        erlang:error(badarg, [DigestOrPlainText, DigestType, Key, Options]);
+        {extern, {Mod, Fun}} ->
+            Mod:Fun(DigestOrPlainText, DigestType, Options);
+        {extern, Fun} when is_function(Fun) ->
+            Fun(DigestOrPlainText, DigestType, Options);
+	    {Algorithm, CryptoKey} ->
+	        try crypto:sign(Algorithm, DigestType, DigestOrPlainText, CryptoKey, Options)
             catch %% Compatible with old error schema
                 error:{notsup,_,_} -> error(notsup);
                 error:{error,_,_} -> error(error);

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -658,9 +658,10 @@ encrypt_decrypt_sign_fun() ->
 encrypt_decrypt_sign_fun(Config) when is_list(Config) ->
     {PrivateKey, _DerKey} = erl_make_certs:gen_rsa(64),
     #'RSAPrivateKey'{modulus=Mod, publicExponent=Exp} = PrivateKey,
-    EncryptFun = fun (PlainText, Options) ->
-        public_key:encrypt_private(PlainText, PrivateKey, Options)
-    end,
+    EncryptFun =
+        fun (PlainText, Options) ->
+                public_key:encrypt_private(PlainText, PrivateKey, Options)
+        end,
     CustomPrivKey = #{sign_fun => EncryptFun},
     PublicKey = #'RSAPublicKey'{modulus=Mod, publicExponent=Exp},
     Msg = list_to_binary(lists:duplicate(5, "Foo bar 100")),
@@ -753,8 +754,8 @@ custom_sign_fun_verify(Config) when is_list(Config) ->
     #'RSAPrivateKey'{modulus=Mod, publicExponent=Exp} = PrivateRSA,
     PublicRSA = #'RSAPublicKey'{modulus=Mod, publicExponent=Exp},
     SignFun = fun (Msg, HashAlgo, Options) ->
-        public_key:sign(Msg, HashAlgo, PrivateRSA, Options)
-    end,
+                      public_key:sign(Msg, HashAlgo, PrivateRSA, Options)
+              end,
     CustomKey = #{algorithm => rsa, sign_fun => SignFun},
 
     Msg = list_to_binary(lists:duplicate(5, "Foo bar 100")),

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -77,12 +77,16 @@
          cert_pem/1,
          encrypt_decrypt/0,
          encrypt_decrypt/1,
+         encrypt_decrypt_sign_fun/0,
+         encrypt_decrypt_sign_fun/1,
          rsa_sign_verify/0,
          rsa_sign_verify/1,
          rsa_pss_sign_verify/0,
          rsa_pss_sign_verify/1,
          dsa_sign_verify/0,
          dsa_sign_verify/1,
+         custom_sign_fun_verify/0,
+         custom_sign_fun_verify/1,
          pkix/0,
          pkix/1,
          pkix_countryname/0,
@@ -147,6 +151,7 @@ all() ->
      appup,
      {group, pem_decode_encode},
      encrypt_decrypt,
+     encrypt_decrypt_sign_fun,
      {group, sign_verify},
      pkix, 
      pkix_countryname, 
@@ -181,7 +186,7 @@ groups() ->
 			      ec_pem_encode_generated, gen_ec_param_prime_field,
 			      gen_ec_param_char_2_field]},
      {sign_verify, [], [rsa_sign_verify, rsa_pss_sign_verify, dsa_sign_verify,
-                        eddsa_sign_verify_24_compat]}
+                        eddsa_sign_verify_24_compat, custom_sign_fun_verify]}
     ].
 %%-------------------------------------------------------------------
 init_per_suite(Config) ->
@@ -646,6 +651,22 @@ encrypt_decrypt(Config) when is_list(Config) ->
     RsaEncrypted2 = public_key:encrypt_public(Msg, PublicKey),
     Msg = public_key:decrypt_private(RsaEncrypted2, PrivateKey),
     ok.
+
+%%--------------------------------------------------------------------
+encrypt_decrypt_sign_fun() ->
+    [{doc, "Test public_key:encrypt_private with user provided sign_fun"}].
+encrypt_decrypt_sign_fun(Config) when is_list(Config) ->
+    {PrivateKey, _DerKey} = erl_make_certs:gen_rsa(64),
+    #'RSAPrivateKey'{modulus=Mod, publicExponent=Exp} = PrivateKey,
+    EncryptFun = fun (PlainText, Options) ->
+            public_key:encrypt_private(PlainText, PrivateKey, Options)
+        end,
+    CustomPrivKey = #{sign_fun => EncryptFun},
+    PublicKey = #'RSAPublicKey'{modulus=Mod, publicExponent=Exp},
+    Msg = list_to_binary(lists:duplicate(5, "Foo bar 100")),
+    RsaEncrypted = public_key:encrypt_private(Msg, CustomPrivKey),
+    Msg = public_key:decrypt_public(RsaEncrypted, PublicKey),
+    ok.
        
 %%--------------------------------------------------------------------
 rsa_sign_verify() ->
@@ -722,6 +743,28 @@ dsa_sign_verify(Config) when is_list(Config) ->
 			      {DSAPublicKey, DSAParams}), 
     false = public_key:verify(Digest, none, <<1:8, DigestSign/binary>>, 
 			      {DSAPublicKey, DSAParams}).
+%%--------------------------------------------------------------------
+
+custom_sign_fun_verify() ->
+    [{doc, "Checks that public_key:sign correctly calls the `sign_fun`"}].
+custom_sign_fun_verify(Config) when is_list(Config) ->
+    {_, CaKey} = erl_make_certs:make_cert([{key, rsa}]),
+    PrivateRSA = public_key:pem_entry_decode(CaKey),
+    #'RSAPrivateKey'{modulus=Mod, publicExponent=Exp} = PrivateRSA,
+    PublicRSA = #'RSAPublicKey'{modulus=Mod, publicExponent=Exp},
+    SignFun = fun (Msg, HashAlgo, Options) ->
+            public_key:sign(Msg, HashAlgo, PrivateRSA, Options)
+        end,
+    CustomKey = #{algorithm => rsa, sign_fun => SignFun},
+
+    Msg = list_to_binary(lists:duplicate(5, "Foo bar 100")),
+    RSASign = public_key:sign(Msg, sha, CustomKey),
+    true = public_key:verify(Msg, sha, RSASign, PublicRSA),
+    false = public_key:verify(<<1:8, Msg/binary>>, sha, RSASign, PublicRSA),
+    false = public_key:verify(Msg, sha, <<1:8, RSASign/binary>>, PublicRSA),
+
+    RSASign1 = public_key:sign(Msg, md5, CustomKey),
+    true = public_key:verify(Msg, md5, RSASign1, PublicRSA).
 
 %%--------------------------------------------------------------------
 pkix() ->

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -659,8 +659,8 @@ encrypt_decrypt_sign_fun(Config) when is_list(Config) ->
     {PrivateKey, _DerKey} = erl_make_certs:gen_rsa(64),
     #'RSAPrivateKey'{modulus=Mod, publicExponent=Exp} = PrivateKey,
     EncryptFun = fun (PlainText, Options) ->
-            public_key:encrypt_private(PlainText, PrivateKey, Options)
-        end,
+        public_key:encrypt_private(PlainText, PrivateKey, Options)
+    end,
     CustomPrivKey = #{sign_fun => EncryptFun},
     PublicKey = #'RSAPublicKey'{modulus=Mod, publicExponent=Exp},
     Msg = list_to_binary(lists:duplicate(5, "Foo bar 100")),
@@ -753,8 +753,8 @@ custom_sign_fun_verify(Config) when is_list(Config) ->
     #'RSAPrivateKey'{modulus=Mod, publicExponent=Exp} = PrivateRSA,
     PublicRSA = #'RSAPublicKey'{modulus=Mod, publicExponent=Exp},
     SignFun = fun (Msg, HashAlgo, Options) ->
-            public_key:sign(Msg, HashAlgo, PrivateRSA, Options)
-        end,
+        public_key:sign(Msg, HashAlgo, PrivateRSA, Options)
+    end,
     CustomKey = #{algorithm => rsa, sign_fun => SignFun},
 
     Msg = list_to_binary(lists:duplicate(5, "Foo bar 100")),

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -614,7 +614,27 @@ version.
       ROOT-CA, and so on. The default value is 10.</p>
       </desc>
     </datatype>
-    
+
+    <datatype>
+      <name name="custom_sign"/>
+      <desc><p>The signature fun is to be defined as follows:</p>
+      <code>
+fun(SSL_Verision :: {Major, Minor},
+    Msg :: binary(),
+    HashAlgo :: hash(),
+    Key :: key(),
+    SignAlgo :: sign_algo()) ->
+	Signed :: binary()
+	    </code>
+      <p> The signature fun is called during the tls handshake to use the provided Key to sign the ssl message.
+      By using this option it is possible to completly controll how the signature is done.
+      This comes particularly usefull in cases where the private key is not available to the ssl application.
+      You can use this to implement you own signature or delegate it to other entities or devices.</p>
+      <p> For example: if your private key is stored in a Secure Element, like a TPM or any HSM device,
+      you can use this feature to call your specific drivers to sign the ssl handshake.</p>
+      </desc>
+    </datatype>
+
     <datatype>
       <name name="custom_verify"/>
       <desc>

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -351,7 +351,9 @@
                                      #{algorithm := rsa | dss | ecdsa, 
                                        engine := crypto:engine_ref(), 
                                        key_id := crypto:key_id(), 
-                                       password => crypto:password()}. % exported
+                                       password => crypto:password()} |
+                                     #{algorithm := rsa | dss | ecdsa, 
+                                       sign_fun := custom_sign()}. % exported
 -type key_pem()                   :: file:filename().
 -type key_pem_password()          :: iodata() | fun(() -> iodata()).
 -type certs_keys()                :: [cert_key_conf()].
@@ -369,6 +371,7 @@
 -type keep_secrets()              :: boolean().
 -type secure_renegotiation()      :: boolean(). 
 -type allowed_cert_chain_length() :: integer().
+-type custom_sign()               :: SignFun :: fun() | {Module :: atom(), Fun :: atom()}.
 
 -type custom_verify()               ::  {Verifyfun :: fun(), InitialUserState :: any()}.
 -type crl_check()                :: boolean() | peer | best_effort.
@@ -1891,6 +1894,8 @@ check_cert_key(UserOpts, CertKeys, LogLevel) ->
                            KF == 'ECPrivateKey'; KF == 'PrivateKeyInfo' ->
                         CertKeys0#{key => Key};
                     {_, #{engine := _, key_id := _, algorithm := _} = Key} ->
+                        CertKeys0#{key => Key};
+                    {_, #{sign_fun := _, algorithm := _} = Key} ->
                         CertKeys0#{key => Key};
                     {new, Err1} ->
                         option_error(key, Err1)

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -348,11 +348,11 @@
 -type cert_pem()                  :: file:filename().
 -type key()                       :: {'RSAPrivateKey'| 'DSAPrivateKey' | 'ECPrivateKey' |'PrivateKeyInfo', 
                                            public_key:der_encoded()} | 
-                                     #{algorithm := rsa | rsa_pss_rsae | rsa_pss_pss | dss | ecdsa,
+                                     #{algorithm := rsa | dss | ecdsa, 
                                        engine := crypto:engine_ref(), 
                                        key_id := crypto:key_id(), 
                                        password => crypto:password()} |
-                                     #{algorithm := rsa | rsa_pss_rsae | rsa_pss_pss | dss | ecdsa,
+                                     #{algorithm := rsa | dss | ecdsa, 
                                        sign_fun := custom_sign()}. % exported
 -type key_pem()                   :: file:filename().
 -type key_pem_password()          :: iodata() | fun(() -> iodata()).

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -348,11 +348,11 @@
 -type cert_pem()                  :: file:filename().
 -type key()                       :: {'RSAPrivateKey'| 'DSAPrivateKey' | 'ECPrivateKey' |'PrivateKeyInfo', 
                                            public_key:der_encoded()} | 
-                                     #{algorithm := rsa | dss | ecdsa, 
+                                     #{algorithm := rsa | rsa_pss_rsae | rsa_pss_pss | dss | ecdsa,
                                        engine := crypto:engine_ref(), 
                                        key_id := crypto:key_id(), 
                                        password => crypto:password()} |
-                                     #{algorithm := rsa | dss | ecdsa, 
+                                     #{algorithm := rsa | rsa_pss_rsae | rsa_pss_pss | dss | ecdsa,
                                        sign_fun := custom_sign()}. % exported
 -type key_pem()                   :: file:filename().
 -type key_pem_password()          :: iodata() | fun(() -> iodata()).

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -341,16 +341,16 @@ available_cert_key_pairs(CertKeyGroups) ->
     %% To be able to find possible TLS session pre TLS-1.3
     %% that may be reused. At this point the version is
     %% not negotiated.
-    RevAlgos = [dsa, rsa, rsa_pss_rsae, rsa_pss_pss, ecdsa],
+    RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []).
 
 %% Create the prioritized list of cert key pairs that
 %% are availble for use in the negotiated version
 available_cert_key_pairs(CertKeyGroups, ?TLS_1_3) ->
-    RevAlgos = [rsa, rsa_pss_rsae, rsa_pss_pss, ecdsa, eddsa],
+    RevAlgos = [rsa, rsa_pss_pss, ecdsa, eddsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
 available_cert_key_pairs(CertKeyGroups, ?TLS_1_2) ->
-     RevAlgos = [dsa, rsa, rsa_pss_rsae, rsa_pss_pss, ecdsa],
+     RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
 available_cert_key_pairs(CertKeyGroups, Version)
   when ?TLS_LT(Version, ?TLS_1_2) ->

--- a/lib/ssl/src/ssl_certificate.erl
+++ b/lib/ssl/src/ssl_certificate.erl
@@ -341,16 +341,16 @@ available_cert_key_pairs(CertKeyGroups) ->
     %% To be able to find possible TLS session pre TLS-1.3
     %% that may be reused. At this point the version is
     %% not negotiated.
-    RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
+    RevAlgos = [dsa, rsa, rsa_pss_rsae, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []).
 
 %% Create the prioritized list of cert key pairs that
 %% are availble for use in the negotiated version
 available_cert_key_pairs(CertKeyGroups, ?TLS_1_3) ->
-    RevAlgos = [rsa, rsa_pss_pss, ecdsa, eddsa],
+    RevAlgos = [rsa, rsa_pss_rsae, rsa_pss_pss, ecdsa, eddsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
 available_cert_key_pairs(CertKeyGroups, ?TLS_1_2) ->
-     RevAlgos = [dsa, rsa, rsa_pss_pss, ecdsa],
+     RevAlgos = [dsa, rsa, rsa_pss_rsae, rsa_pss_pss, ecdsa],
     cert_key_group_to_list(RevAlgos, CertKeyGroups, []);
 available_cert_key_pairs(CertKeyGroups, Version)
   when ?TLS_LT(Version, ?TLS_1_2) ->

--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -61,7 +61,6 @@ group_pairs([#{certs := []}]) ->
     #{eddsa => [],
       ecdsa => [],
       rsa_pss_pss => [],
-      rsa_pss_rsae => [],
       rsa => [],
       dsa => []
      };
@@ -69,7 +68,6 @@ group_pairs(Pairs) ->
     group_pairs(Pairs, #{eddsa => [],
                          ecdsa => [],
                          rsa_pss_pss => [],
-                         rsa_pss_rsae => [],
                          rsa => [],
                          dsa => []
                         }).
@@ -102,13 +100,11 @@ group_pairs([], Group) ->
 prioritize_groups(#{eddsa := EDDSA,
                     ecdsa := ECDSA,
                     rsa_pss_pss := RSAPSS,
-                    rsa_pss_rsae := RSAPSSRSAE,
                     rsa := RSA,
                     dsa := DSA} = CertKeyGroups) ->
     CertKeyGroups#{eddsa => prio_eddsa(EDDSA),
                    ecdsa => prio_ecdsa(ECDSA),
                    rsa_pss_pss => prio_rsa_pss(RSAPSS),
-                   rsa_pss_rsae => prio_rsa_pss(RSAPSSRSAE),
                    rsa => prio_rsa(RSA),
                    dsa => prio_dsa(DSA)}.
 

--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -87,6 +87,9 @@ group_pairs([#{private_key := #'DSAPrivateKey'{}} = Pair | Rest], #{dsa := DSA} 
 group_pairs([#{private_key := #{algorithm := dss, engine := _}} = Pair | Rest], Group) ->
     Pairs = maps:get(dsa, Group),
     group_pairs(Rest, Group#{dsa => [Pair | Pairs]});
+group_pairs([#{private_key := #{algorithm := Alg, sign_fun := _}} = Pair | Rest], Group) ->
+    Pairs = maps:get(Alg, Group),
+    group_pairs(Rest, Group#{Alg => [Pair | Pairs]});
 group_pairs([#{private_key := #{algorithm := Alg, engine := _}} = Pair | Rest], Group) ->
     Pairs = maps:get(Alg, Group),
     group_pairs(Rest, Group#{Alg => [Pair | Pairs]});
@@ -107,16 +110,23 @@ prioritize_groups(#{eddsa := EDDSA,
 
 prio_eddsa(EDDSA) ->
     %% Engine not supported yet
-    using_curve({namedCurve, ?'id-Ed25519'}, EDDSA, []) ++ using_curve({namedCurve, ?'id-Ed448'}, EDDSA, []).
+    SignFunPairs = [Pair || Pair = #{private_key := #{sign_fun := _}} <- EDDSA],
+    SignFunPairs
+        ++ using_curve({namedCurve, ?'id-Ed25519'}, EDDSA, [])
+        ++ using_curve({namedCurve, ?'id-Ed448'}, EDDSA, []).
 
 prio_ecdsa(ECDSA) ->
     EnginePairs = [Pair || Pair = #{private_key := #{engine := _}} <- ECDSA],
+    SignFunPairs = [Pair || Pair = #{private_key := #{sign_fun := _}} <- ECDSA],
     Curves = tls_v1:ecc_curves(all),
-    EnginePairs ++ lists:foldr(fun(Curve, AccIn) ->
-                                       CurveOid = pubkey_cert_records:namedCurves(Curve),
-                                       Pairs = using_curve({namedCurve, CurveOid}, ECDSA -- EnginePairs, []),
-                                       Pairs ++ AccIn
-                               end, [], Curves).
+    EnginePairs
+        ++ SignFunPairs 
+        ++ lists:foldr(
+            fun(Curve, AccIn) ->
+                CurveOid = pubkey_cert_records:namedCurves(Curve),
+                Pairs = using_curve({namedCurve, CurveOid}, ECDSA -- EnginePairs -- SignFunPairs, []),
+                Pairs ++ AccIn
+             end, [], Curves).
 using_curve(_, [], Acc) ->
     lists:reverse(Acc);
 using_curve(Curve, [#{private_key := #'ECPrivateKey'{parameters = Curve}} = Pair | Rest], Acc) ->
@@ -265,6 +275,8 @@ init_certificate_file(CertFile, PemCache, Role) ->
             file_error(CertFile, {certfile, Reason})
     end.
 
+init_private_key(#{algorithm := _, sign_fun := _SignFun} = Key, _, _) ->
+    Key;
 init_private_key(#{algorithm := Alg} = Key, _, _PemCache)
   when Alg =:= ecdsa; Alg =:= rsa; Alg =:= dss ->
     case maps:is_key(engine, Key) andalso maps:is_key(key_id, Key) of

--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -61,6 +61,7 @@ group_pairs([#{certs := []}]) ->
     #{eddsa => [],
       ecdsa => [],
       rsa_pss_pss => [],
+      rsa_pss_rsae => [],
       rsa => [],
       dsa => []
      };
@@ -68,6 +69,7 @@ group_pairs(Pairs) ->
     group_pairs(Pairs, #{eddsa => [],
                          ecdsa => [],
                          rsa_pss_pss => [],
+                         rsa_pss_rsae => [],
                          rsa => [],
                          dsa => []
                         }).
@@ -100,11 +102,13 @@ group_pairs([], Group) ->
 prioritize_groups(#{eddsa := EDDSA,
                     ecdsa := ECDSA,
                     rsa_pss_pss := RSAPSS,
+                    rsa_pss_rsae := RSAPSSRSAE,
                     rsa := RSA,
                     dsa := DSA} = CertKeyGroups) ->
     CertKeyGroups#{eddsa => prio_eddsa(EDDSA),
                    ecdsa => prio_ecdsa(ECDSA),
                    rsa_pss_pss => prio_rsa_pss(RSAPSS),
+                   rsa_pss_rsae => prio_rsa_pss(RSAPSSRSAE),
                    rsa => prio_rsa(RSA),
                    dsa => prio_dsa(DSA)}.
 

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2150,22 +2150,13 @@ digitally_signed(Version, Msg, HashAlgo, PrivateKey, SignAlgo) ->
 
 do_digitally_signed(Version, Msg, HashAlgo, {#'RSAPrivateKey'{} = Key,
                                              #'RSASSA-PSS-params'{}}, SignAlgo) when ?TLS_GTE(Version, ?TLS_1_2) ->
-    Options = signature_options(SignAlgo, HashAlgo),
-    public_key:sign(Msg, HashAlgo, Key, Options);
+    public_key:sign(Msg, HashAlgo, Key, SignAlgo);
 do_digitally_signed(Version, {digest, Digest}, _HashAlgo, Key, rsa) when ?TLS_LTE(Version, ?TLS_1_1) ->
     public_key:encrypt_private(Digest, Key);
 do_digitally_signed(Version, {digest, _} = Msg, HashAlgo, Key, _) when ?TLS_LTE(Version, ?TLS_1_1) ->
     public_key:sign(Msg, HashAlgo, Key);
 do_digitally_signed(_, Msg, HashAlgo, Key, SignAlgo) ->
-    Options = signature_options(SignAlgo, HashAlgo),
-    public_key:sign(Msg, HashAlgo, Key, Options).
-
-    
-signature_options(SignAlgo, HashAlgo) when SignAlgo =:= rsa_pss_rsae orelse
-                                           SignAlgo =:= rsa_pss_pss ->
-    pss_options(HashAlgo);
-signature_options(_, _) ->
-    [].
+    public_key:sign(Msg, HashAlgo, Key, SignAlgo).
 
 verify_options(SignAlgo, HashAlgo, _KeyParams)
   when SignAlgo =:= rsa_pss_rsae orelse

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2148,6 +2148,12 @@ digitally_signed(Version, Msg, HashAlgo, PrivateKey, SignAlgo) ->
 	    throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, bad_key(PrivateKey)))
     end.
 
+do_digitally_signed(Version, Msg, HashAlgo, #{algorithm := _KeyAlg, 
+                                              sign_fun := Sign} = Key, SignAlgo) when is_function(Sign) ->
+    Sign(Version, Msg, HashAlgo, Key, SignAlgo);
+do_digitally_signed(Version, Msg, HashAlgo, #{algorithm := _KeyAlg,
+                                              sign_fun := {Mod, Fun}} = Key, SignAlgo) ->
+    Mod:Fun(Version, Msg, HashAlgo, Key, SignAlgo);
 do_digitally_signed(Version, Msg, HashAlgo, {#'RSAPrivateKey'{} = Key,
                                              #'RSASSA-PSS-params'{}}, SignAlgo) when ?TLS_GTE(Version, ?TLS_1_2) ->
     Options = signature_options(SignAlgo, HashAlgo),

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -2150,13 +2150,22 @@ digitally_signed(Version, Msg, HashAlgo, PrivateKey, SignAlgo) ->
 
 do_digitally_signed(Version, Msg, HashAlgo, {#'RSAPrivateKey'{} = Key,
                                              #'RSASSA-PSS-params'{}}, SignAlgo) when ?TLS_GTE(Version, ?TLS_1_2) ->
-    public_key:sign(Msg, HashAlgo, Key, SignAlgo);
+    Options = signature_options(SignAlgo, HashAlgo),
+    public_key:sign(Msg, HashAlgo, Key, Options);
 do_digitally_signed(Version, {digest, Digest}, _HashAlgo, Key, rsa) when ?TLS_LTE(Version, ?TLS_1_1) ->
     public_key:encrypt_private(Digest, Key);
 do_digitally_signed(Version, {digest, _} = Msg, HashAlgo, Key, _) when ?TLS_LTE(Version, ?TLS_1_1) ->
     public_key:sign(Msg, HashAlgo, Key);
 do_digitally_signed(_, Msg, HashAlgo, Key, SignAlgo) ->
-    public_key:sign(Msg, HashAlgo, Key, SignAlgo).
+    Options = signature_options(SignAlgo, HashAlgo),
+    public_key:sign(Msg, HashAlgo, Key, Options).
+
+    
+signature_options(SignAlgo, HashAlgo) when SignAlgo =:= rsa_pss_rsae orelse
+                                           SignAlgo =:= rsa_pss_pss ->
+    pss_options(HashAlgo);
+signature_options(_, _) ->
+    [].
 
 verify_options(SignAlgo, HashAlgo, _KeyParams)
   when SignAlgo =:= rsa_pss_rsae orelse

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -42,7 +42,9 @@
 -export([no_auth/0,
          no_auth/1,
          auth/0,
-         auth/1,
+         auth/1,         
+         client_auth_custom_sign/0,
+         client_auth_custom_sign/1,
          client_auth_empty_cert_accepted/0,
          client_auth_empty_cert_accepted/1,
          client_auth_empty_cert_rejected/0,
@@ -227,7 +229,8 @@ tls_1_2_rsa_tests() ->
 all_version_tests() ->
     [
      no_auth,
-     auth,
+     auth,      
+     client_auth_custom_sign,
      client_auth_empty_cert_accepted,
      client_auth_empty_cert_rejected,
      client_auth_use_partial_chain,
@@ -458,6 +461,11 @@ auth() ->
     ssl_cert_tests:auth().
 auth(Config) ->
     ssl_cert_tests:auth(Config).
+%%--------------------------------------------------------------------
+client_auth_custom_sign() ->
+    ssl_cert_tests:client_auth_custom_sign().
+client_auth_custom_sign(Config) ->
+    ssl_cert_tests:client_auth_custom_sign(Config).
 %%--------------------------------------------------------------------
 client_auth_empty_cert_accepted() ->
     ssl_cert_tests:client_auth_empty_cert_accepted().

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -107,7 +107,7 @@ client_auth_custom_sign(Config) when is_list(Config) ->
     % 'rsa_pss_rsae' is not an expected config value here, 
     % using rsa or rsa_pss_pss instad seams to work,
     % Not sure how to modify SSL to add it in the acceptable key pair groups...
-    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa_pss_pss; _ -> KeyAlg end,
+    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa; _ -> KeyAlg end,
     Version = proplists:get_value(version,Config),
     ClientOpts0 =  case Version of
                       'tlsv1.3' ->

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -104,10 +104,7 @@ client_auth_custom_sign() ->
 
 client_auth_custom_sign(Config) when is_list(Config) ->
     KeyAlg =  proplists:get_value(cert_key_alg, Config),
-    % 'rsa_pss_rsae' is not an expected config value here, 
-    % using rsa or rsa_pss_pss instad seams to work,
-    % Not sure how to modify SSL to add it in the acceptable key pair groups...
-    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa_pss_pss; _ -> KeyAlg end,
+    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa; _ -> KeyAlg end,
     Version = proplists:get_value(version,Config),
     ClientOpts0 =  case Version of
                       'tlsv1.3' ->

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -104,6 +104,10 @@ client_auth_custom_sign() ->
 
 client_auth_custom_sign(Config) when is_list(Config) ->
     KeyAlg =  proplists:get_value(cert_key_alg, Config),
+    % 'rsa_pss_rsae' is not an expected config value here, 
+    % using rsa or rsa_pss_pss instad seams to work,
+    % Not sure how to modify SSL to add it in the acceptable key pair groups...
+    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa_pss_pss; _ -> KeyAlg end,
     Version = proplists:get_value(version,Config),
     ClientOpts0 =  case Version of
                       'tlsv1.3' ->
@@ -117,7 +121,7 @@ client_auth_custom_sign(Config) when is_list(Config) ->
     ClientKey = ssl_test_lib:public_key(public_key:pem_entry_decode(ClientKeyEntry)),
     ClientSignFun = choose_sign_fun(ClientKey, Version),
 
-    ClientCustomKey = {key, #{algorithm => KeyAlg, sign_fun => ClientSignFun}},
+    ClientCustomKey = {key, #{algorithm => CompatibleKeyAlg, sign_fun => ClientSignFun}},
     ClientOpts = [ ClientCustomKey | proplists:delete(key, proplists:delete(keyfile, ClientOpts0))],
 
     ServerOpts0 = ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config),
@@ -126,7 +130,7 @@ client_auth_custom_sign(Config) when is_list(Config) ->
     ServerKey = ssl_test_lib:public_key(public_key:pem_entry_decode(ServerKeyEntry)),
     ServerSignFun = choose_sign_fun(ServerKey, Version),
 
-    ServerCustomKey = {key, #{algorithm => KeyAlg, sign_fun => ServerSignFun}},
+    ServerCustomKey = {key, #{algorithm => CompatibleKeyAlg, sign_fun => ServerSignFun}},
     ServerOpts = [ ServerCustomKey, {verify, verify_peer} | ServerOpts0],
 
     ssl_test_lib:basic_test(ClientOpts, ServerOpts, Config).

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -107,7 +107,7 @@ client_auth_custom_sign(Config) when is_list(Config) ->
     % 'rsa_pss_rsae' is not an expected config value here, 
     % using rsa or rsa_pss_pss instad seams to work,
     % Not sure how to modify SSL to add it in the acceptable key pair groups...
-    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa; _ -> KeyAlg end,
+    CompatibleKeyAlg = case KeyAlg of rsa_pss_rsae -> rsa_pss_pss; _ -> KeyAlg end,
     Version = proplists:get_value(version,Config),
     ClientOpts0 =  case Version of
                       'tlsv1.3' ->


### PR DESCRIPTION
# sign_fun 
This option allows the user to define a function tasked to sign an ssl message. This enables to delegate the private key signature to sources like: Secure Elements.

Users are free to program such function the way they think is best, allowing them to support any private key storage
or to delegate signature to any external service or device.
## How to use
The tls settings try to be similar to what is already in place to support crypto engines.
For this reason is necessary to provide a proper `algorithm` atom along side with the `sign_fun`
```erlang
    TLS_Options = [
        {cacertfile, "my.CA.pem"},
        {certfile, "me.pem"},
        {verify, verify_peer},
        {key, #{
            algorithm => rsa, % any of the supported key types for Key-Cert pairs
            sign_fun => {Module, Fun} % or fun()
        }}
    ]
```

## Tests

I implemented a testcase (`client_auth_custom_sign`) in the `ssl_cert_SUITE` which tests this feature with various combinations of key types both on the client and on the server. This test is just to prove that the feature is working, not sure where and what to add to the test suites.
To make all key-cert combos work, I had to adapt few functions that manipulate the configuration to correctly process the new config option. I kept the changes to the minimum, given my limited knowledge about the code-base.

## Use-cases

### GRiSP

At Stritzinger, we use it in a slightly old version to enable our GRiSP board to use the OTP SSL app, while storing the private key in a secured element.
https://github.com/grisp/grisp_cryptoauth/blob/5b9ca3cfaf5a1d07baaed2bd4f00bceba9501a2d/src/grisp_cryptoauth.erl#L94

We came up with this idea since we noticed that the PKCS11 crypto engine doesn't cover all use cases for HSMs. We faced few technical difficulties, like loading shared libs.

Currently we have to patch OTP to include such feature in our boards, but we would like to see this part of the lib since we believe it would be a great addition.

### Braid

Recently we also published an open source project that uses this feature in combination with erlang distribution.

Here where it is used to sign ssl for `erlang distribution`:
Where is set: https://github.com/stritzinger/braidnode/blob/main/priv/ssl_dist_opts.rel
Where is implemented: https://github.com/stritzinger/braidnode/blob/main/src/braidnode_crypto.erl

In this last case we do not use a secure element but instead, we detached the key storage on another service that holds the key and signs for us.
