### PR TITLE
More precise specs for some functions in the `binary` module

### DIFF
--- a/lib/stdlib/doc/src/binary.xml
+++ b/lib/stdlib/doc/src/binary.xml
@@ -149,11 +149,12 @@
       only one element. The order of alternatives in a pattern is
       not significant.</p>
 
-      <p>The list of binaries used for search alternatives must be flat and
-      proper.</p>
+      <p>The list of binaries used for search alternatives must be flat,
+      proper and non-empty.</p>
 
-      <p>If <c><anno>Pattern</anno></c> is not a binary or a flat proper list of
-      binaries with length &gt; 0, a <c>badarg</c> exception is raised.</p>
+      <p>If <c><anno>Pattern</anno></c> is not a binary or a flat proper
+      non-empty list of binaries with length &gt; 0, a <c>badarg</c>
+      exception is raised.</p>
       </desc>
     </func>
 
@@ -324,8 +325,8 @@
 2> binary:longest_common_prefix([&lt;&lt;"erlang"&gt;&gt;, &lt;&lt;"perl"&gt;&gt;]).
 0</code>
 
-      <p>If <c><anno>Binaries</anno></c> is not a flat list of binaries, a
-      <c>badarg</c> exception is raised.</p>
+      <p>If <c><anno>Binaries</anno></c> is not a flat non-empty list of
+      binaries, a <c>badarg</c> exception is raised.</p>
       </desc>
     </func>
 
@@ -345,8 +346,8 @@
 2> binary:longest_common_suffix([&lt;&lt;"erlang"&gt;&gt;, &lt;&lt;"perl"&gt;&gt;]).
 0</code>
 
-      <p>If <c>Binaries</c> is not a flat list of binaries, a <c>badarg</c>
-      exception is raised.</p>
+      <p>If <c>Binaries</c> is not a flat non-empty list of binaries, a
+      <c>badarg</c> exception is raised.</p>
       </desc>
     </func>
 

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -108,7 +108,8 @@ bin_to_list(Subject, Pos, Len) ->
     badarg_with_info([Subject, Pos, Len]).
 
 -spec compile_pattern(Pattern) -> cp() when
-      Pattern :: binary() | [binary()].
+      Pattern :: PatternBinary | [PatternBinary,...],
+      PatternBinary :: nonempty_binary().
 
 compile_pattern(_) ->
     erlang:nif_error(undef).
@@ -173,20 +174,21 @@ list_to_bin(_) ->
     erlang:nif_error(undef).
 
 -spec longest_common_prefix(Binaries) -> non_neg_integer() when
-      Binaries :: [binary()].
+      Binaries :: [binary(),...].
 
 longest_common_prefix(_) ->
     erlang:nif_error(undef).
 
 -spec longest_common_suffix(Binaries) -> non_neg_integer() when
-      Binaries :: [binary()].
+      Binaries :: [binary(),...].
 
 longest_common_suffix(_) ->
     erlang:nif_error(undef).
 
 -spec match(Subject, Pattern) -> Found | nomatch when
       Subject :: binary(),
-      Pattern :: binary() | [binary()] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Found :: part().
 
 match(_, _) ->
@@ -194,7 +196,8 @@ match(_, _) ->
 
 -spec match(Subject, Pattern, Options) -> Found | nomatch when
       Subject :: binary(),
-      Pattern :: binary() | [binary()] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Found :: part(),
       Options :: [Option],
       Option :: {scope, part()}.
@@ -204,7 +207,8 @@ match(_, _, _) ->
 
 -spec matches(Subject, Pattern) -> Found when
       Subject :: binary(),
-      Pattern :: binary() | [binary()] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Found :: [part()].
 
 matches(_, _) ->
@@ -212,7 +216,8 @@ matches(_, _) ->
 
 -spec matches(Subject, Pattern, Options) -> Found when
       Subject :: binary(),
-      Pattern :: binary() | [binary()] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Found :: [part()],
       Options :: [Option],
       Option :: {scope, part()}.
@@ -243,7 +248,8 @@ referenced_byte_size(_) ->
 
 -spec split(Subject, Pattern) -> Parts when
       Subject :: binary(),
-      Pattern :: binary() | [binary()] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Parts :: [binary()].
 
 split(_, _) ->
@@ -251,7 +257,8 @@ split(_, _) ->
 
 -spec split(Subject, Pattern, Options) -> Parts when
       Subject :: binary(),
-      Pattern :: binary() | [binary()] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Options :: [Option],
       Option :: {scope, part()} | trim | global | trim_all,
       Parts :: [binary()].
@@ -267,7 +274,8 @@ split(_, _, _) ->
 
 -spec replace(Subject, Pattern, Replacement) -> Result when
       Subject :: binary(),
-      Pattern :: binary() | [ binary() ] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Replacement :: binary(),
       Result :: binary().
 
@@ -281,7 +289,8 @@ replace(H,N,R) ->
 
 -spec replace(Subject, Pattern, Replacement, Options) -> Result when
       Subject :: binary(),
-      Pattern :: binary() | [ binary() ] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      PatternBinary :: nonempty_binary(),
       Replacement :: binary(),
       Options :: [Option],
       Option :: global | {scope, part()} | {insert_replaced, InsPos},


### PR DESCRIPTION
In the `binary` module, the functions `longest_common_prefix/1` and `longest_common_suffix/1` expect the given list of binaries to be non-empty. This is not reflected in the specs of or documentation for those functions.

Also, the functions ` compile_pattern/1`, `match/2,3`, `matches/2,3`, `replace/3,4` and `split/2,3`, if the pattern is given as a list of binaries, expect that list to be non-empty. This is not reflected in the specs of or documentation for those functions.
Also, for those functions, any binary given as pattern must be non-empty. This is mentioned in the documentation, but not reflected in the specs.