### PR TITLE
argparse: Make formatting of argument descriptions less ambiguous

### DIFF
--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -1252,17 +1252,21 @@ format_description(#{help := {_Short, Desc}} = Opt) ->
                 String
         end, Desc
     );
-%% default format: "desc", "desc (type)", "desc (default)", "desc (type, default)"
+%% default format:
+%%     "desc"
+%%     "desc (type)"
+%%     "desc, default: abc"
+%%     "desc (type), default: abc"
 format_description(#{name := Name} = Opt) ->
     NameStr = maps:get(help, Opt, io_lib:format("~ts", [Name])),
     case {NameStr, format_type(Opt), format_default(Opt)} of
         {"", "", Type} -> Type;
         {"", Default, ""} -> Default;
         {Desc, "", ""} -> Desc;
-        {Desc, "", Default} -> [Desc, " (", Default, ")"];
+        {Desc, "", Default} -> [Desc, " , default: ", Default];
         {Desc, Type, ""} -> [Desc, " (", Type, ")"];
-        {"", Type, Default} -> [Type, ", ", Default];
-        {Desc, Type, Default} -> [Desc, " (", Type, ", ", Default, ")"]
+        {"", Type, Default} -> [Type, ", default: ", Default];
+        {Desc, Type, Default} -> [Desc, " (", Type, "), default: ", Default]
     end.
 
 %% option formatting helpers

--- a/lib/stdlib/test/argparse_SUITE.erl
+++ b/lib/stdlib/test/argparse_SUITE.erl
@@ -399,7 +399,7 @@ unicode(Config) when is_list(Config) ->
     Prog = [prog()],
     ?assertEqual({ok, Expected, Prog, Cmd}, argparse:parse([], Cmd)), %% default
     ?assertEqual({ok, Expected, Prog, Cmd}, argparse:parse(["★"], Cmd)), %% specified in the command line
-    ?assertEqual("Usage:\n  " ++ prog() ++ " <text>\n\nArguments:\n  text åäö (binary, ★)\n",
+    ?assertEqual("Usage:\n  " ++ prog() ++ " <text>\n\nArguments:\n  text åäö (binary), default: ★\n",
         unicode:characters_to_list(argparse:help(Cmd))),
     %% test command name and argument name in unicode
     Uni = #{commands => #{"åäö" => #{help => "öФ"}}, handler => optional,
@@ -775,7 +775,7 @@ usage(Config) when is_list(Config) ->
         "  -v           verbosity level\n"
         "  -i           interval set (int >= 1)\n"
         "  --req        required optional, right?\n"
-        "  --float      floating-point long form argument (float, 3.14)\n",
+        "  --float      floating-point long form argument (float), default: 3.14\n",
     ?assertEqual(Usage, unicode:characters_to_list(argparse:help(Cmd,
         #{progname => "erl", command => ["start"]}))),
     FullCmd = "Usage:\n  erl"
@@ -790,7 +790,7 @@ usage(Config) when is_list(Config) ->
         "  -v          verbosity level\n"
         "  -i          interval set (int >= 1)\n"
         "  --req       required optional, right?\n"
-        "  --float     floating-point long form argument (float, 3.14)\n",
+        "  --float     floating-point long form argument (float), default: 3.14\n",
     ?assertEqual(FullCmd, unicode:characters_to_list(argparse:help(Cmd,
         #{progname => erl}))),
     CrawlerStatus = "Usage:\n  erl status crawler [-rfv] [---extra <extra>] [--force] [-i <interval>]\n"
@@ -799,7 +799,7 @@ usage(Config) when is_list(Config) ->
         "  -f, --force force\n  -v          verbosity level\n"
         "  -i          interval set (int >= 1)\n"
         "  --req       required optional, right?\n"
-        "  --float     floating-point long form argument (float, 3.14)\n",
+        "  --float     floating-point long form argument (float), default: 3.14\n",
     ?assertEqual(CrawlerStatus, unicode:characters_to_list(argparse:help(Cmd,
         #{progname => "erl", command => ["status", "crawler"]}))),
     ok.


### PR DESCRIPTION
Currently, the default value is rather ambiguous for choice types, being presented as:

`choice: a, b, c, d, a`

Where it's not entirely clear that the last value, `a`, is the default. This PR attempts to fix that.