### PR TITLE
erts: check for sys/auxv.h

### DIFF
--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -1655,7 +1655,7 @@ AC_CHECK_HEADERS(fcntl.h limits.h unistd.h syslog.h dlfcn.h ieeefp.h \
                  sys/socket.h sys/sockio.h sys/socketio.h \
                  net/errno.h malloc.h arpa/nameser.h libdlpi.h \
 		 pty.h util.h libutil.h utmp.h langinfo.h poll.h sdkddkver.h \
-                 elf.h)
+                 elf.h sys/auxv.h)
 
 AC_CHECK_MEMBERS([struct ifreq.ifr_hwaddr], [], [],
 	[#ifdef __WIN32__

--- a/erts/emulator/asmjit/core/cpuinfo.cpp
+++ b/erts/emulator/asmjit/core/cpuinfo.cpp
@@ -15,7 +15,9 @@
 
 // Required by `getauxval()` on Linux.
 #if defined(__linux__)
+#if defined(HAVE_SYS_AUXV_H)
   #include <sys/auxv.h>
+#endif
 #endif
 
 //! Required to detect CPU and features on Apple platforms.


### PR DESCRIPTION
Fixes build with uClibc-based toolchains.