### PR TITLE
Reduce repeated work in concurrent code loading situations

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -187,10 +187,10 @@ ensure_loaded(Mod) when is_atom(Mod) ->
     case erlang:module_loaded(Mod) of
         true -> {module, Mod};
         false ->
-            case get_object_code(Mod) of
-                error -> call({sync_ensure_on_load, Mod});
-                {Mod,Binary,File} ->
-                    load_module(Mod, File, Binary, false, true)
+            case call({get_object_code_for_loading, Mod}) of
+                {module, Mod} -> {module, Mod};
+                {error, What} -> {error, What};
+                {Mod,Binary,File,Ref} -> load_module(Mod, File, Binary, false, Ref)
             end
     end.
 


### PR DESCRIPTION
With changes in #6736 significant work when code loading was moved away from the code server and shifted into the requesting process. However, there could be a lot of repeated work, especially on system startup, if a lot of similar processes are started, all trying to load the same module at the same time, overwhelming the code server with `get_object_code` requests.

In this change, we add additional synchronisation to `ensure_loaded` that makes sure only one process at a time tries to load the module. In the added test showcasing the worst-case scenario of long load path and many concurrent requests, this changes the runtime (on my local machine) from 8s+ to around 200ms.

Furthermore, the special sync operation can be merged with this and save one round-trip to the code server.

Fixes #7479