### PR TITLE
Reword warning around `process_flag/2`

### DIFF
--- a/lib/stdlib/test/shell_docs_SUITE_data/unknown_erlang_process_flag_2_func.txt
+++ b/lib/stdlib/test/shell_docs_SUITE_data/unknown_erlang_process_flag_2_func.txt
@@ -63,8 +63,8 @@
   [;1m                      when Module :: atom(), OldModule :: atom().[0m
 
   Used by a process to redefine the error handler for undefined
-  function calls and undefined registered processes. Inexperienced
-  users are not to use this flag, as code auto-loading depends on
+  function calls and undefined registered processes. Use this flag
+  with substantial caution, as code auto-loading depends on
   the correct operation of the error handling module.
 
   Returns the old value of the flag.


### PR DESCRIPTION
Tweak wording to be a bit friendlier