### PR TITLE
compiler: Don't apply beam_ssa_type to unreachable functions

### DIFF
--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -1490,6 +1490,13 @@ will_succeed_1(_V0, _V1)
 will_succeed_1(_, _) ->
     b.
 
+%% GH-7478 and GH-7509: The beam_ssa_type pass would crash when
+%% insisting on optimizing a function the pass had concluded was
+%% unreachable.
+gh_7478(_V0) ->
+    <<0 || erlang:yield() and ([0 || _ <- _V0] =< 9223372036854775807),
+           <<>> <= ok >>.
+
 %%%
 %%% Common utilities.
 %%%


### PR DESCRIPTION
The `beam_ssa_type:opt_continue/4` pass requires that type information is available for all arguments or else it will crash with a back trace similar to this:

```
Sub pass ssa_opt_type_continue
Function: '-f3/1-lc$^0/1-3-'/1
test362604.erl: internal error in pass beam_ssa_opt: exception error: no function clause matching beam_types:join([])
  in function  beam_ssa_type:join_arg_types/3 (beam_ssa_type.erl, line 449)
  in call from beam_ssa_type:opt_continue/4 (beam_ssa_type.erl, line 432)
  in call from beam_ssa_opt:ssa_opt_type_continue/1 (beam_ssa_opt.erl, line 449)
  in call from compile:run_sub_passes_1/3 (compile.erl, line 424)
  in call from beam_ssa_opt:phase/4 (beam_ssa_opt.erl, line 116)
  in call from beam_ssa_opt:fixpoint/6 (beam_ssa_opt.erl, line 99)
  in call from beam_ssa_opt:run_phases/3 (beam_ssa_opt.erl, line 85)
```

If type analysis during `beam_ssa_type:opt_start/2` concludes that a function is never called, type information for the callee will never be recorded, thus leaving no type information for the arguments in the function's entry in the function database, leading to the crash above.

Although naively unreachable functions are pruned when the list of functions is first traversed in `beam_ssa_type:opt_start/2`, it doesn't handle they case when type inference concludes that a function is never called. This patch extends `beam_ssa_type:opt_start/2` to, when all functions have been processed, prune non-exported functions for which `#func_info.arg_types` is just a list of empty dictionaries.  That a function of zero arity is always considered reachable, is harmless as it won't crash opt_continue/4.

Closes #7509
Closes #7478