### PR TITLE
inets: httpd avoid function_clause during startup

### DIFF
--- a/lib/inets/src/http_server/httpd_manager.erl
+++ b/lib/inets/src/http_server/httpd_manager.erl
@@ -454,8 +454,18 @@ report_error(State,String) ->
 call(ServerRef, Request) ->
     try gen_server:call(ServerRef, Request, infinity) 
     catch
-	exit:_ ->
-	    {error, closed} 
+	exit:Reason:Stacktrace ->
+            String =
+                lists:flatten(
+                  io_lib:format(
+                    "Request"
+                    "~n   ~p"
+                    "~nto manager (~p) from ~p failed:"
+                    "~n   ~p"
+                    "~n   ~p",
+                    [Request, ServerRef, self(), Reason, Stacktrace])),
+            error_logger:warning_report(String),
+	    {error, Reason}
     end.
 
 count_children(Sup) ->


### PR DESCRIPTION
- avoid function_clause httpd_request:body_data/2
- happening when httpd is stopped during TLS negotiation
- in such cases Manager process is killed and then continue_init fails