### PR TITLE
ssl: Handle that inet:getopts may return {ok, []}

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -2050,6 +2050,8 @@ get_socket_opts(Connection, Transport, Socket, [Tag | Tags], SockOpts, Acc) ->
     case Connection:getopts(Transport, Socket, [Tag]) of
         {ok, [Opt]} ->
             get_socket_opts(Connection, Transport, Socket, Tags, SockOpts, [Opt | Acc]);
+        {ok, []} ->
+            get_socket_opts(Connection, Transport, Socket, Tags, SockOpts, Acc);
         {error, Reason} ->
             {error, {options, {socket_options, Tag, Reason}}}
     end;


### PR DESCRIPTION
If the standard C library call getsockopt(2) returns an error for an option - then no return value is created for that option. There is not check about the socket's state in the call chain; if the inet_drv port is still open, then the getsockopt(2) call is executed.
So it should be possible that inet:getsockopt(Port, [sndbuf]) (or recbuf), for a Port that is not dead yet but the underlying socket is closed, may return {ok,[]}.

Closes 7506