### PR TITLE
compiler: Fix crash in beam_ssa_private_append

### DIFF
--- a/lib/compiler/src/beam_ssa_private_append.erl
+++ b/lib/compiler/src/beam_ssa_private_append.erl
@@ -262,10 +262,10 @@ track_value_in_fun([{#b_var{}=V,Element}|Rest], Fun, Work0, Defs,
                                                    Element, DefSt0),
                     track_value_in_fun(ToExplore ++ Rest, Fun, Work0,
                                        Defs, ValuesInFun, DefSt);
-                {put_tuple,_,_} ->
+                {put_tuple,_,_} when Element =/= self ->
                     track_put_tuple(Args, Element, Rest, Fun, V, Work0,
                                     Defs, ValuesInFun, DefSt0);
-                {put_list,_,_} ->
+                {put_list,_,_} when Element =/= self ->
                     track_put_list(Args, Element, Rest, Fun, V, Work0,
                                    Defs, ValuesInFun, DefSt0);
                 {_,_,_} ->


### PR DESCRIPTION
The beam_ssa_private_append pass can crash, if it, during initial value tracking, ends up in operations which do not create bit strings. This can happen as the initial value tracking in beam_ssa_private_append doesn't consider types. As the decision to apply the private append transform is using type information, tracking values into not type-compatible execution paths is harmless.

This patch changes the beam_ssa_private_append pass to simply stop tracking a value when it is known that the type is not compatible.

You run Erlfuzz over multiple week-ends without finding any issues, as soon as your branch gets merged, Erlfuzz delivers overnight :)