### PR TITLE
Speed up alias analysis 

### DIFF
--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -257,8 +257,6 @@ killsets_blk_live_outs([], _, _, _, Acc) ->
     Acc.
 
 %%%
-
-%%%
 %%% Perform an alias analysis of the given functions, alias
 %%% information is added as annotations on the SSA code.
 %%%

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -1226,6 +1226,12 @@ aa_call(Dst, [#b_local{}=Callee|Args], Anno, SS0,
             %% the status of any variables
             {SS0, AAS0}
     end;
+aa_call(_Dst, [#b_remote{mod=#b_literal{val=erlang},
+                         name=#b_literal{val=exit},
+                         arity=1}|_], _Anno, SS, AAS) ->
+    %% The function will never return, so nothing that happens after
+    %% this can influence the aliasing status.
+    {SS, AAS};
 aa_call(Dst, [_Callee|Args], _Anno, SS, AAS) ->
     %% This is either a call to a fun or to an external function,
     %% assume that all arguments and the result escape.

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -2101,7 +2101,7 @@ annotations_pp(Config) when is_list(Config) ->
     10 = length(Uniques),
 
     Aliased = get_annotations("  %% Aliased:", Lines),
-    17 = length(Aliased),
+    13 = length(Aliased),
 
     ok = file:del_dir_r(TargetDir),
     ok.


### PR DESCRIPTION
Combined with improved kill-set calculation (85454714956f54679ae75ef49d10d7992e31b9e2) and an improved data
structure for describing the alias status of variables (c389665cc991fb8a9d123fe34dc95c12bdf1263f), this patch series provides a substantial reduction of the time required for alias analysis. For the set of modules compiled by `scripts/diffable` the time spent in alias analysis is reduced by approximately 55%. For the [example](https://github.com/erlang/otp/issues/7432) in Issue #7432, provided by José Valim, which has a large number of variables, the reduction is even more dramatic. The time spent in the alias analysis pass is reduced by 97%.
