### PR TITLE
Export documented and exposed type beam_lib:beam/0

### DIFF
--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -53,6 +53,7 @@
 -export_type([attrib_entry/0, compinfo_entry/0, labeled_entry/0, label/0]).
 -export_type([chunkid/0]).
 -export_type([chnk_rsn/0]).
+-export_type([beam/0]).
 
 -import(lists, [append/1, delete/2, foreach/2, keysort/2, 
 		member/2, reverse/1, sort/1, splitwith/2]).


### PR DESCRIPTION
From https://www.erlang.org/doc/man/beam_lib.html#type-beam, used e.g. by [`katana-code`](https://github.com/inaka/katana-code/blob/main/src/ktn_code.erl#L37C22-L37C37).