### PR TITLE
Export documented and exposed type erl_syntax:annotation_or_location/0

### DIFF
--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -377,7 +377,7 @@
 	 data/1,
 	 is_tree/1]).
 
--export_type([forms/0, syntaxTree/0, syntaxTreeAttributes/0, padding/0]).
+-export_type([forms/0, syntaxTree/0, syntaxTreeAttributes/0, padding/0, annotation_or_location/0]).
 
 %% =====================================================================
 %% IMPLEMENTATION NOTES:


### PR DESCRIPTION
Exposed (and documented) at https://www.erlang.org/doc/man/erl_syntax#data-types.