### PR TITLE
Fix/httpc stand alone cookies

### DIFF
--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -2229,11 +2229,11 @@ esi_post(Sid, _Env, _Input) ->
     mod_esi:deliver(Sid, ["OK"]).
 
 start_apps(https) ->
-    inets_test_lib:start_apps([crypto, public_key, ssl]);
+    inets_test_lib:start_apps([asn1, crypto, public_key, ssl]);
 start_apps(sim_https) ->
-    inets_test_lib:start_apps([crypto, public_key, ssl]);
+    inets_test_lib:start_apps([asn1, crypto, public_key, ssl]);
 start_apps(sim_mixed) ->
-    inets_test_lib:start_apps([crypto, public_key, ssl]);
+    inets_test_lib:start_apps([asn1, crypto, public_key, ssl]);
 start_apps(_) ->
     ok.
 

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -2022,7 +2022,7 @@ start_apps(Group) when  Group == https_basic;
                         Group == https_not_sup;
                         Group == https_alert
 			->
-    inets_test_lib:start_apps([inets, asn1, crypto, public_key, ssl]);
+    inets_test_lib:start_apps([asn1, crypto, public_key, ssl, inets]);
 start_apps(Group) when  Group == http_basic;
 			Group == http_limit;
 			Group == http_custom;

--- a/lib/inets/test/inets_test_lib.erl
+++ b/lib/inets/test/inets_test_lib.erl
@@ -562,7 +562,7 @@ timestamp() ->
 start_apps(Apps) ->
     lists:foreach(fun(App) ->
 			  application:stop(App),
-			  application:start(App)
+			  ok = application:start(App)
 		  end, Apps).
 stop_apps(Apps) ->
     lists:foreach(fun(App) ->


### PR DESCRIPTION
I spotted that `stand_alone` `httpc` doesn't track session cookies (at least when started without `data_dir`). I went with PR rather than issue because I included testcase `cookie_stand_alone` (based on `cookie` and `cookie_profile` testcases) that proves the claim. I spent few hours trying to work out why this issue happens, but with little success. Hoping to get some advice from OTP team before going further. I made sure that `cookies` are enabled and checked that `<profile>__handler_db`, `<profile>__session_db` and `<profile>__session_cookie_db` ETS tables exist at runtime. session_db seems to be working, but session_cookie always stays empty. Set-cookie headers are 100% correct because it works when `httpc` is started under `inets` supervision tree.

In the first commit, changes to the `handle_http_msg/3` and `check_cookie/1` must be made because if `ct:fail/1` gets called from there it just blocks the testcase until timetrap triggered so I changed the mechanism to return HTTP 401 when there is no cookie.

Second commit contains a small improvements which I think should be done for tests to work as intended.