### PR TITLE
Use <c>...</c> (in xml docs) instead of `...`

### DIFF
--- a/lib/stdlib/doc/src/proc_lib.xml
+++ b/lib/stdlib/doc/src/proc_lib.xml
@@ -458,7 +458,7 @@ init(Parent) ->
         <note>
           <p>
             If the started process gets killed or crashes with a reason
-            that is not `normal`, the process link will kill the calling
+            that is not <c>normal</c>, the process link will kill the calling
             process so this function does not return,
             unless the calling process traps exits.
             For example, if this function times out it will kill

--- a/system/doc/reference_manual/expressions.xml
+++ b/system/doc/reference_manual/expressions.xml
@@ -566,7 +566,7 @@ end]]></code>
 
     <p>Finally, let us assume that <c>a()</c> returns
     <c>-1</c>. Because <c>true = A >= 0</c> uses the match operator
-    `=`, a <c>{badmatch,false}</c> run-time error occurs when the
+    <c>=</c>, a <c>{badmatch,false}</c> run-time error occurs when the
     expression fails to match the pattern.</p>
 
     <p>The example can be written in a less succient way using nested

--- a/system/doc/reference_manual/typespec.xml
+++ b/system/doc/reference_manual/typespec.xml
@@ -91,14 +91,14 @@
     </p>
     <p>
       To facilitate <url href="https://en.wikipedia.org/wiki/Gradual_typing">
-      gradual typing</url> of Erlang, the type `dynamic()` is provided.
+      gradual typing</url> of Erlang, the type <c>dynamic()</c> is provided.
       It is similar to
       <url href="https://docs.python.org/3/library/typing.html#the-any-type">Any</url>
       in Python,
       <url href="https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#any">any</url>
       in TypeScript and
       <url href="https://docs.hhvm.com/hack/built-in-types/dynamic">dynamic</url>
-      in Hack. `any()` and `dynamic()` interact with
+      in Hack. <c>any()</c> and <c>dynamic()</c> interact with
       <url href="https://learnyousomeerlang.com/dialyzer#success-typing">success typing</url>
       the same way, so Dialyzer doesn't distinguish between them.
     </p>


### PR DESCRIPTION
The former renders proper HTML, the latter renders actual backticks.

References:

* https://www.erlang.org/doc/reference_manual/typespec.html: search for \`dynamic()\`
* https://www.erlang.org/doc/reference_manual/expressions.html: search for \`=\`
* https://www.erlang.org/doc/man/proc_lib.html: search for \`normal\`