### PR TITLE
Make multiline prompt invert-colored spaces.

### DIFF
--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -941,7 +941,8 @@ shell_receive_standard_out(Config) ->
         send_tty(Term,"my_fun(5) -> ok; my_fun(N) -> receive after 100 -> io:format(\"~p\\n\", [N]), my_fun(N+1) end.\n"),
         send_tty(Term, "spawn(shell_default, my_fun, [0]). ABC\n"),
         timer:sleep(1000),
-        check_content(Term, "3\\s+4\\s+.+>\\sABC\\s+..\\s"),
+        check_location(Term, {0, 0}), %% Check that we are at the same location relative to the start.
+        check_content(Term, "3\\s+4\\s+.+>\\sABC"),
         ok
     after
         stop_tty(Term)

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -334,7 +334,7 @@ do_op({insert,C}, {LB,{[Bef|Bef0], Aft},LA}, Rs) ->
 %% search mode), we can use the Bef and Aft variables to hold each
 %% part of the line. Bef takes charge of "(search)`$TERMS" and Aft
 %% takes charge of "': $RESULT".
-%% 
+%%
 %% Since multiline support the search mode prompt always looks like:
 %% search: $TERMS
 %%   $ResultLine1
@@ -668,7 +668,8 @@ redraw_line({line, Pbs, L,_}) ->
     redraw(Pbs, L, []).
 
 multi_line_prompt(Pbs) ->
-    lists:duplicate(max(0,prim_tty:npwcwidthstring(Pbs)-3), $ )++".. ".
+    lists:duplicate(max(0,prim_tty:npwcwidthstring(Pbs)-3), $ )
+    ++ "\e[7m  \e[27m ". % <invert>  </invert>
 
 redraw(Pbs, {_,{_,_},_}=L, Rs) ->
     [{redraw_prompt, Pbs, multi_line_prompt(Pbs), L} |Rs].


### PR DESCRIPTION
This way it is syntactically correct, as opposed to '..'.

Fixes https://github.com/erlang/otp/issues/7558

I got only one failure in stdlib tests, which was in ssh, and seemed unrelated.
Maybe i missed where it was tested still somehow, or there were no tests.

![Screenshot from 2023-08-16 10-20-28](https://github.com/erlang/otp/assets/3988878/69dcf5ef-84d9-42ad-97c0-9ae6c48d97dc)
