### PR TITLE
asn1: Fix handling of SIZE constraints

### DIFF
--- a/lib/asn1/src/asn1ct_check.erl
+++ b/lib/asn1/src/asn1ct_check.erl
@@ -3559,6 +3559,20 @@ range_union_1([]) ->
 finish_constraints(Cs) ->
     finish_constraints_1(Cs, fun smart_collapse/1).
 
+finish_constraints_1([{element_set,{'SizeConstraint',
+                                    {element_set,Root,none}},
+                       {set,[]}=Set}|T],
+                     Collapse) ->
+    %% Rewrite:
+    %%
+    %%     (SIZE (Lower..Upper), ...)
+    %%
+    %% to:
+    %%
+    %%     (SIZE (Lower..Upper, ...))
+
+    C = {element_set,{'SizeConstraint',{element_set,Root,Set}},none},
+    finish_constraints_1([C|T], Collapse);
 finish_constraints_1([{element_set,{Tag,{element_set,_,_}=Set0},none}|T],
 		     Collapse0) ->
     Collapse = collapse_fun(Tag),

--- a/lib/asn1/test/asn1_SUITE_data/ConstraintEquivalence.asn1
+++ b/lib/asn1/test/asn1_SUITE_data/ConstraintEquivalence.asn1
@@ -106,6 +106,8 @@ BEGIN
  ExtConstrainedStringX04 ::= IA5String (SIZE (1|2), ..., SIZE (1|2|3|4|5))
  ExtConstrainedStringX05 ::= IA5String (SIZE (1|2, ...), ...,
                                         SIZE (1|2|3|4|5, ...))
+ -- The following syntax is not recommended, but should work.
+ ExtConstrainedStringX06 ::= IA5String (SIZE (1..2), ...)
 
  integer4 INTEGER ::= 4
  integer11 INTEGER ::= 11


### PR DESCRIPTION
A constraint such as:

    (SIZE (1..4), ...)

is supposed to be equivalent to:

    (SIZE (1..4, ...))

but the former variant was ignored by the ASN.1 compiler, causing the size to be incorrectly encoded and decoded by PER backends.