### PR TITLE
Fix heap allocation for matching out short bitstrings

### DIFF
--- a/erts/emulator/beam/emu/generators.tab
+++ b/erts/emulator/beam/emu/generators.tab
@@ -1100,7 +1100,7 @@ gen.bs_match(Fail, Ctx, N, List) {
             ASSERT(List[src+3].type == TAG_u);
             ASSERT(List[src+4].type == TAG_u);
             size = List[src+3].val * List[src+4].val;
-            words_needed = heap_bin_size((size + 7) / 8);
+            words_needed = erts_extracted_binary_size(size);
             break;
         case am_integer:
             ASSERT(List[src+3].type == TAG_u);

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -2288,6 +2288,22 @@ erts_copy_bits(byte* src,	/* Base pointer to source. */
     }
 }
 
+/*
+ * Calculate sufficient heap space for a binary extracted by
+ * erts_extract_sub_binary().
+ */
+Uint erts_extracted_binary_size(Uint bit_size)
+{
+    Uint byte_size = BYTE_OFFSET(bit_size);
+    ERTS_CT_ASSERT(ERL_SUB_BIN_SIZE <= ERL_ONHEAP_BIN_LIMIT);
+
+    if (BIT_OFFSET(bit_size) == 0 && byte_size <= ERL_ONHEAP_BIN_LIMIT) {
+        return heap_bin_size(byte_size);
+    } else {
+        return ERL_SUB_BIN_SIZE;
+    }
+}
+
 Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
                               Uint bit_offset, Uint bit_size)
 {

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -196,16 +196,27 @@ void erts_copy_bits(byte* src, size_t soffs, int sdir,
 		    byte* dst, size_t doffs,int ddir, size_t n);
 int erts_cmp_bits(byte* a_ptr, size_t a_offs, byte* b_ptr, size_t b_offs, size_t size); 
 
+/*
+ * Calculate the heap space for a binary extracted by
+ * erts_extract_sub_binary().
+ */
+Uint erts_extracted_binary_size(Uint bit_size);
 
 /* Extracts a region from base_bin as a sub-binary or heap binary, whichever
  * is the most appropriate.
  *
- * The caller must ensure that there's enough free space at *hp */
+ * The caller must ensure that there's enough free space at *hp by using
+ * erts_extracted_binary_size().
+ * */
 Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
                               Uint bit_offset, Uint num_bits);
 
-/* Pessimistic estimate of the words required for erts_extract_sub_binary */
-#define EXTRACT_SUB_BIN_HEAP_NEED (heap_bin_size(ERL_ONHEAP_BIN_LIMIT))
+/*
+ * Conservative estimate of the number of words required for
+ * erts_extract_sub_binary() when the number of bits is unknown.
+ */
+#define EXTRACT_SUB_BIN_HEAP_NEED \
+    (MAX(ERL_SUB_BIN_SIZE, heap_bin_size(ERL_ONHEAP_BIN_LIMIT)))
 
 /*
  * Flags for bs_create_bin / bs_get_* / bs_put_* / bs_init* instructions.

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -3700,7 +3700,7 @@ static std::vector<BsmSegment> opt_bsm_segments(
             }
             break;
         case BsmSegment::action::GET_BINARY:
-            heap_need += heap_bin_size((seg.size + 7) / 8);
+            heap_need += erts_extracted_binary_size(seg.size);
             break;
         case BsmSegment::action::GET_TAIL:
             heap_need += EXTRACT_SUB_BIN_HEAP_NEED;

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -3829,7 +3829,7 @@ static std::vector<BsmSegment> opt_bsm_segments(
             }
             break;
         case BsmSegment::action::GET_BINARY:
-            heap_need += heap_bin_size((seg.size + 7) / 8);
+            heap_need += erts_extracted_binary_size(seg.size);
             break;
         case BsmSegment::action::GET_TAIL:
             heap_need += EXTRACT_SUB_BIN_HEAP_NEED;


### PR DESCRIPTION
The runtime system could underestimate the amount of heap space needed for matching out short bitstrings with a size not divisble by 8. That could lead to the runtime system terminating with an "Overrun heap and stack" error.

Fixes #7292