### PR TITLE
Add stacktrace in max heap size log

### DIFF
--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -163,9 +163,6 @@ static char erts_system_version[] = ("Erlang/OTP " ERLANG_OTP_RELEASE
 static Eterm
 current_function(Process* p, ErtsHeapFactory *hfact, Process* rp,
                  int full_info, Uint reserve_size, int flags);
-static Eterm
-current_stacktrace(Process* p, ErtsHeapFactory *hfact, Process* rp,
-                   Uint reserve_size, int flags);
 
 Eterm
 erts_bld_bin_list(Uint **hpp, Uint *szp, ErlOffHeap* oh, Eterm tail)
@@ -1506,7 +1503,7 @@ process_info_aux(Process *c_p,
 	break;
 
     case ERTS_PI_IX_CURRENT_STACKTRACE:
-	res = current_stacktrace(c_p, hfact, rp, reserve_size, flags);
+	res = erts_current_stacktrace(c_p, hfact, rp, reserve_size, flags);
 	break;
 
     case ERTS_PI_IX_INITIAL_CALL:
@@ -2214,8 +2211,8 @@ current_function(Process *c_p, ErtsHeapFactory *hfact, Process* rp,
     return res;
 }
 
-static Eterm
-current_stacktrace(Process *p, ErtsHeapFactory *hfact, Process* rp,
+Eterm
+erts_current_stacktrace(Process *p, ErtsHeapFactory *hfact, Process* rp,
                    Uint reserve_size, int flags)
 {
     Uint sz;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3725,6 +3725,7 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             int alive = erts_is_alive;
             erts_dsprintf_buf_t *dsbufp = erts_create_logger_dsbuf();
             Eterm *o_hp, *hp, args = NIL;
+            ErtsHeapFactory hfact;
 
             /* Build the format message */
             erts_dsprintf(dsbufp, "     Process:            ~p ");
@@ -3737,9 +3738,13 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             erts_dsprintf(dsbufp, "     Error Logger:       ~p~n");
             erts_dsprintf(dsbufp, "     Message Queue Len:  ~p~n");
             erts_dsprintf(dsbufp, "     GC Info:            ~p~n");
+            erts_dsprintf(dsbufp, "     Stacktrace:         ~p~n");
 
             /* Build the args in reverse order */
-            o_hp = hp = erts_alloc(ERTS_ALC_T_TMP, 2*(alive ? 8 : 7) * sizeof(Eterm));
+            o_hp = hp = erts_alloc(ERTS_ALC_T_TMP, 2*(alive ? 9 : 8) * sizeof(Eterm));
+            erts_factory_proc_init(&hfact, p);
+            args = CONS(hp, erts_current_stacktrace(p, &hfact, p, 0 ,0), args); hp += 2;
+            erts_factory_close(&hfact);
             args = CONS(hp, msg, args); hp += 2;
             args = CONS(hp, make_small((p)->sig_inq.len), args); hp += 2;
             args = CONS(hp, am_true, args); hp += 2;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3743,7 +3743,10 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             /* Build the args in reverse order */
             o_hp = hp = erts_alloc(ERTS_ALC_T_TMP, 2*(alive ? 9 : 8) * sizeof(Eterm));
             erts_factory_proc_init(&hfact, p);
-            args = CONS(hp, erts_current_stacktrace(p, &hfact, p, 0 ,0), args); hp += 2;
+            args = CONS(hp, erts_build_stacktrace(&hfact, p, 0,
+                                                  erts_backtrace_depth, 1),
+                        args);
+            hp += 2;
             erts_factory_close(&hfact);
             args = CONS(hp, msg, args); hp += 2;
             args = CONS(hp, make_small((p)->sig_inq.len), args); hp += 2;

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3724,7 +3724,7 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
         if (max_heap_flags & MAX_HEAP_SIZE_LOG) {
             int alive = erts_is_alive;
             erts_dsprintf_buf_t *dsbufp = erts_create_logger_dsbuf();
-            Eterm *o_hp, *hp, args = NIL;
+            Eterm *hp, args = NIL, stacktrace;
             ErtsHeapFactory hfact;
 
             /* Build the format message */
@@ -3741,13 +3741,11 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
             erts_dsprintf(dsbufp, "     Stacktrace:         ~p~n");
 
             /* Build the args in reverse order */
-            o_hp = hp = erts_alloc(ERTS_ALC_T_TMP, 2*(alive ? 9 : 8) * sizeof(Eterm));
-            erts_factory_proc_init(&hfact, p);
-            args = CONS(hp, erts_build_stacktrace(&hfact, p, 0,
-                                                  erts_backtrace_depth, 1),
-                        args);
-            hp += 2;
-            erts_factory_close(&hfact);
+            erts_factory_tmp_init(&hfact, NULL, 0, ERTS_ALC_T_TMP);
+            stacktrace = erts_build_stacktrace(&hfact, p, 0,
+                                               erts_backtrace_depth, 1);
+            hp = erts_produce_heap(&hfact, 2*(alive ? 9 : 8), 0);
+            args = CONS(hp, stacktrace, args); hp += 2;
             args = CONS(hp, msg, args); hp += 2;
             args = CONS(hp, make_small((p)->sig_inq.len), args); hp += 2;
             args = CONS(hp, am_true, args); hp += 2;
@@ -3758,9 +3756,10 @@ reached_max_heap_size(Process *p, Uint total_heap_size,
                 args = CONS(hp, erts_this_node->sysname, args); hp += 2;
             }
             args = CONS(hp, p->common.id, args); hp += 2;
+            ASSERT(hp == hfact.hp);
 
             erts_send_error_term_to_logger(p->group_leader, dsbufp, args);
-            erts_free(ERTS_ALC_T_TMP, o_hp);
+            erts_factory_close(&hfact);
         }
 
         if (IS_TRACED_FL(p, F_TRACE_GC))

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -2940,3 +2940,7 @@ float erts_sched_local_random_float(Uint additional_seed)
 void erts_halt(int code);
 extern erts_atomic32_t erts_halt_progress;
 extern int erts_halt_code;
+
+extern Eterm
+erts_current_stacktrace(Process* p, ErtsHeapFactory *hfact, Process* rp,
+                        Uint reserve_size, int flags);

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -2942,5 +2942,5 @@ extern erts_atomic32_t erts_halt_progress;
 extern int erts_halt_code;
 
 extern Eterm
-erts_current_stacktrace(Process* p, ErtsHeapFactory *hfact, Process* rp,
-                        Uint reserve_size, int flags);
+erts_build_stacktrace(ErtsHeapFactory *hfact, Process* rp,
+                      Uint reserve_size, int max_depth, int include_i);


### PR DESCRIPTION
This commit externs the current_stacktrace function and use it in erl_gc when doing max heap event log. This is especially useful when debugging a process that has been killed by the heap limit.

I'm not sure if this is the right way doing it, but here is how it will look like:

```
./bin/erl +hmax 1000000
Erlang/OTP 27 [DEVELOPMENT] [erts-14.0.2] [source-05c52ba036] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]

Eshell V14.0.2 (press Ctrl+G to abort, type help(). for help)
1> lists:seq(1,1000000).
=ERROR REPORT==== 25-Aug-2023::14:41:56.256793 ===
     Process:            <0.85.0>
     Context:            maximum heap size reached
     Max Heap Size:      1000000
     Total Heap Size:    1029719
     Kill:               true
     Error Logger:       true
     Message Queue Len:  0
     GC Info:            [{old_heap_block_size,318187},
                          {heap_block_size,711488},
                          {mbuf_size,0},
                          {recent_size,150168},
                          {stack_size,26},
                          {old_heap_size,196624},
                          {heap_size,196616},
                          {bin_vheap_size,0},
                          {bin_vheap_block_size,46422},
                          {bin_old_vheap_size,8},
                          {bin_old_vheap_block_size,46422}]
     Stacktrace:         [{erl_eval,do_apply,7,
                                    [{file,"erl_eval.erl"},{line,750}]},
                          {shell,exprs,7,[{file,"shell.erl"},{line,780}]},
                          {shell,eval_exprs,7,[{file,"shell.erl"},{line,736}]},
                          {shell,eval_loop,4,[{file,"shell.erl"},{line,721}]}]

** exception exit: killed
2>
```