### PR TITLE
Add clause to handle user types named product.

### DIFF
--- a/lib/dialyzer/src/erl_types.erl
+++ b/lib/dialyzer/src/erl_types.erl
@@ -4410,6 +4410,11 @@ from_form({type, _Anno, 'fun', [{type, _, product, Domain}, Range]},
   {Dom1, L1, C1} = list_from_form(Domain, S, D, L, C),
   {Ran1, L2, C2} = from_form(Range, S, D, L1, C1),
   {t_fun(Dom1, Ran1), L2, C2};
+from_form({type, _Anno, 'fun', [{user_type, _, product, Domain}, Range]},
+          S, D, L, C) ->
+  {Dom1, L1, C1} = list_from_form(Domain, S, D, L, C),
+  {Ran1, L2, C2} = from_form(Range, S, D, L1, C1),
+  {t_fun(Dom1, Ran1), L2, C2};
 from_form({type, _Anno, identifier, []}, _S, _D, L, C) ->
   {t_identifier(), L, C};
 from_form({type, _Anno, integer, []}, _S, _D, L, C) ->
@@ -5069,6 +5074,9 @@ t_form_to_string({type, _Anno, 'fun', []}) -> "fun()";
 t_form_to_string({type, _Anno, 'fun', [{type, _, any}, Range]}) ->
   "fun(...) -> " ++ t_form_to_string(Range);
 t_form_to_string({type, _Anno, 'fun', [{type, _, product, Domain}, Range]}) ->
+  "fun((" ++ flat_join(t_form_to_string_list(Domain), ",") ++ ") -> "
+    ++ t_form_to_string(Range) ++ ")";
+t_form_to_string({type, _Anno, 'fun', [{user_type, _, product, Domain}, Range]}) ->
   "fun((" ++ flat_join(t_form_to_string_list(Domain), ",") ++ ") -> "
     ++ t_form_to_string(Range) ++ ")";
 t_form_to_string({type, _Anno, iodata, []}) -> "iodata()";

--- a/lib/dialyzer/test/abstract_SUITE.erl
+++ b/lib/dialyzer/test/abstract_SUITE.erl
@@ -82,7 +82,15 @@ generated_case(Config) when is_list(Config) ->
 		    {clause,[{location,7},{generated,true}],[{var,7,'_'}],[],
 		     [{call,7,{remote,7,{var,7,'Arg'},{atom,7,fn}},[]}]}]}]}]}],
 	     Config, [], []),
-    %% Location is a line (no column):
+    [] = test([{attribute,1,file,{"product_type.erl",1}},
+                  {attribute,1,module,product_type},
+                  {attribute,3,export,[{product_type_fun,0}]},
+                  {attribute,5,type,{product,{type,{5,20},any,[]},[]}},
+                  {attribute,7,spec,
+                   {{product_type_fun,0},
+                    [{type,7,'fun',[{type,7,product,[]},{user_type,7,product,[]}]}]}},
+                  {function,8,product_type_fun,0,[{clause,7,[],[],[{atom,9,ok}]}]},
+                  {eof,10}], Config, [], []),
     "fileName.erl:3: Function bar/0 has no local return\n" =
         dialyzer:format_warning(W),
     ok.


### PR DESCRIPTION
Resolves #7584

Add clause to handle user types named product.

Prior to OTP 26 `erl_types:t_from_form/6` could expect to take
in a form with the following shape :
`{type, _Anno, 'fun', [{type, _, product, Domain}, Range]}`

This changed in OTP 26 to : `{type, _Anno, 'fun', [{user_type, _, product, Domain}, Range]}`

Per the change we'd end up falling through to
`from_form({user_type, _Anno, Name, Args}, S, D, L, C) ...`
and in turn call `type_from_form/6`.

`type_form_form/6` would deduce that there was another record that could
be unfolded, and we'd hit `type_from_form1/11`.

The call would end up looking like :

```erlang
type_from_form1(fun,[{user_type,{7,11},product,[]},{user_type,{7,17},product,[]}],2, ...)
```

where as before the call would look like :

```erlang
type_from_form1(product,[],0, ...)
```

In the end the we'd try to look up the type `fun` with an arity of 2, which would result in the following failure:

`Unable to find type 'fun'/2`

This commit adds a clause much like the previous clause to handle this case.
In addition a supporting clause for `erl_types:t_form_to_string/1` was added.