### PR TITLE
inets: start ssl and dependencies by default 

### DIFF
--- a/lib/inets/src/inets_app/inets.erl
+++ b/lib/inets/src/inets_app/inets.erl
@@ -47,11 +47,12 @@
 %% Description: Starts the inets application. Default type
 %% is temporary. see application(3)
 %%--------------------------------------------------------------------
-start() -> 
-    application:start(inets).
+start() ->
+    application:ensure_all_started([inets, ssl]).
 
-start(Type) -> 
-    application:start(inets, Type).
+start(Type) ->
+    application:start(inets, Type),
+    application:ensure_all_started(ssl).
 
 
 %%--------------------------------------------------------------------
@@ -92,7 +93,7 @@ start(Service, ServiceConfig, How) ->
 %%
 %% Description: Stops the inets application.
 %%--------------------------------------------------------------------
-stop() -> 
+stop() ->
     application:stop(inets).
 
 

--- a/lib/inets/src/inets_app/inets.erl
+++ b/lib/inets/src/inets_app/inets.erl
@@ -48,12 +48,11 @@
 %% is temporary. see application(3)
 %%--------------------------------------------------------------------
 start() ->
-    application:ensure_all_started([inets, ssl]).
+    application:start(inets, temporary).
 
 start(Type) ->
-    application:start(inets, Type),
-    application:ensure_all_started(ssl).
-
+    application:ensure_all_started(ssl),
+    application:start(inets, Type).
 
 %%--------------------------------------------------------------------
 %% Function: start(Service, ServiceConfig [, How]) -> {ok, Pid} | 


### PR DESCRIPTION
With this PR, the inets app starts the ssl and its dependencies by default.
This is a good standard nowadays, preventing redirects from http to https to break, so that it is easier to start and one does not need to start ssl and crypto manually.

Closes https://github.com/erlang/otp/issues/7580