### PR TITLE
dialyzer: Handle definition of type product/0

### DIFF
--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -581,6 +581,13 @@ massage_forms([H | T], Defs) ->
 massage_forms([], _Defs) ->
   [].
 
+massage_type({type, Loc, 'fun',
+              [{type, ArgsLoc, product, ArgTypes}, Ret0]},
+             Defs) ->
+  %% We must make sure that we keep the built-in `product` type here.
+  Args = {type, ArgsLoc, product, massage_type_list(ArgTypes, Defs)},
+  Ret = massage_type(Ret0, Defs),
+  {type, Loc, 'fun', [Args, Ret]};
 massage_type({type, Loc, Name, Args0}, Defs) when is_list(Args0) ->
   case sets:is_element({Name, length(Args0)}, Defs) of
     true ->

--- a/lib/dialyzer/test/small_SUITE_data/src/test_product_app.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/test_product_app.erl
@@ -1,0 +1,13 @@
+-module(test_product_app).
+-export([zero/0, one/1]).
+
+-type mfa() :: integer().
+-type product() :: binary().
+
+-spec zero() -> any().
+zero() ->
+    ok.
+
+-spec one(mfa()) -> mfa().
+one(I) when is_integer(I) ->
+    I * 42.


### PR DESCRIPTION
Analyzing a module that defines the type `product/0` could crash Dialyzer. This bug was introduced in 4d08fc95830b650d.

Fixes #7584