### PR TITLE
stdlib: make the shell multiline prompt configurable

### DIFF
--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -46,7 +46,8 @@
          shell_history_custom/1, shell_history_custom_errors/1,
 	 job_control_remote_noshell/1,ctrl_keys/1,
          get_columns_and_rows_escript/1,
-         shell_navigation/1, shell_multiline_navigation/1, shell_xnfix/1, shell_delete/1,
+         shell_navigation/1, shell_multiline_navigation/1, shell_multiline_prompt/1,
+         shell_xnfix/1, shell_delete/1,
          shell_transpose/1, shell_search/1, shell_insert/1,
          shell_update_window/1, shell_small_window_multiline_navigation/1, shell_huge_input/1,
          shell_invalid_unicode/1, shell_support_ansi_input/1,
@@ -125,7 +126,8 @@ groups() ->
       ]},
      {tty_latin1,[],[{group,tty_tests}]},
      {tty_tests, [parallel],
-      [shell_navigation, shell_multiline_navigation, shell_xnfix, shell_delete,
+      [shell_navigation, shell_multiline_navigation, shell_multiline_prompt,
+       shell_xnfix, shell_delete,
        shell_transpose, shell_search, shell_insert,
        shell_update_window, shell_small_window_multiline_navigation, shell_huge_input,
        shell_support_ansi_input,
@@ -470,6 +472,39 @@ shell_multiline_navigation(Config) ->
     after
         stop_tty(Term)
     end.
+
+shell_multiline_prompt(Config) ->
+    Term1 = start_tty([{args,["-stdlib","shell_multiline_prompt","{edlin,inverted_space_prompt}"]}|Config]),
+    Term2 = start_tty([{args,["-stdlib","shell_multiline_prompt","\"...> \""]}|Config]),
+    Term3 = start_tty([{args,["-stdlib","shell_multiline_prompt","edlin"]}|Config]),
+
+    try
+        check_location(Term1, {0, 0}),
+        send_tty(Term1,"\na"),
+        check_location(Term1, {0, 1}),
+        check_content(Term1, "   a"),
+        ok
+    after
+        stop_tty(Term1)
+    end,
+    try
+        check_location(Term2, {0, 0}),
+        send_tty(Term2,"\na"),
+        check_location(Term2, {0, 1}),
+        check_content(Term2, "...> a"),
+        ok
+    after
+        stop_tty(Term2)
+    end,
+    try
+        send_tty(Term3,"\na"),
+        check_location(Term3, {0, 1}),
+        check_content(Term3, ".. a"),
+        ok
+    after
+        stop_tty(Term3)
+    end.
+
 shell_clear(Config) ->
 
     Term = start_tty(Config),

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -28,7 +28,7 @@
 -export([current_line/1, current_chars/1]).
 
 -export([edit_line1/2]).
-
+-export([inverted_space_prompt/1]).
 -import(lists, [reverse/1, reverse/2]).
 
 -export([over_word/3]).
@@ -668,8 +668,29 @@ redraw_line({line, Pbs, L,_}) ->
     redraw(Pbs, L, []).
 
 multi_line_prompt(Pbs) ->
-    lists:duplicate(max(0,prim_tty:npwcwidthstring(Pbs)-3), $ )
-    ++ "\e[7m  \e[27m ". % <invert>  </invert>
+    case application:get_env(stdlib, shell_multiline_prompt, default) of
+        default -> %% Default multiline prompt
+            default_multiline_prompt(Pbs);
+        {M,F} when is_atom(M), is_atom(F) ->
+            case catch apply(M,F,[Pbs]) of
+                Prompt when is_list(Prompt) -> Prompt;
+                _ ->
+                    application:set_env(stdlib, shell_multiline_prompt, default),
+                    io:format("Invalid call: ~p:~p/1~n", [M,F]),
+                    default_multiline_prompt(Pbs)
+            end;
+        Prompt when is_list(Prompt) ->
+            lists:duplicate(max(0,prim_tty:npwcwidthstring(Pbs) - prim_tty:npwcwidthstring(Prompt)), $\s) ++ Prompt;
+        Prompt ->
+            application:set_env(stdlib, shell_multiline_prompt, default),
+            io:format("Invalid multiline prompt: ~p~n", [Prompt]),
+            default_multiline_prompt(Pbs)
+    end.
+
+default_multiline_prompt(Pbs) ->
+    lists:duplicate(max(0,prim_tty:npwcwidthstring(Pbs) - 3), $\s) ++ ".. ".
+inverted_space_prompt(Pbs) ->
+    "\e[7m" ++ lists:duplicate(prim_tty:npwcwidthstring(Pbs) - 1, $\s) ++ "\e[27m ".
 
 redraw(Pbs, {_,{_,_},_}=L, Rs) ->
     [{redraw_prompt, Pbs, multi_line_prompt(Pbs), L} |Rs].


### PR DESCRIPTION
The default multiline prompt will be "..".
But this can be configurable via environment variable: -stdlib shell_multiline_prompt TERM
where TERM can be:
  a string `-stdlib shell_multiline_prompt \"...>\"`.
  a module and function tuple `-stdlib shell_multiline_prompt {M,F}`,
  which takes the main prompt as only argument, returning a string prompt.
    e.g. `{edlin,inverted_space_prompt}`.

Also modifies valid multiline expressions that are submitted so that they no longer have the multiline prompt infront in scrollback.

Related issue: #7558 