### PR TITLE
Test BEAM files without type information

### DIFF
--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -159,6 +159,14 @@ R25= \
 	bs_match_misc \
 	bs_utf
 
+STRIPPED_TYPES= \
+	bs_bincomp \
+	bs_construct \
+	bs_match_bin \
+	bs_match_int \
+	bs_match_tail \
+	bs_match_misc \
+	bs_utf
 
 NATIVE= hibernate
 
@@ -170,6 +178,9 @@ NATIVE_ERL_FILES= $(NATIVE_MODULES:%=%.erl)
 
 R25_MODULES= $(R25:%=%_r25_SUITE)
 R25_ERL_FILES= $(R25_MODULES:%=%.erl)
+
+STRIPPED_TYPES_MODULES= $(STRIPPED_TYPES:%=%_stripped_types_SUITE)
+STRIPPED_TYPES_ERL_FILES= $(STRIPPED_TYPES_MODULES:%=%.erl)
 
 ERL_FILES= $(MODULES:%=%.erl)
 
@@ -203,7 +214,7 @@ ERL_COMPILE_FLAGS := $(filter-out +deterministic,$($(ERL_COMPILE_FLAGS)))
 # ----------------------------------------------------
 
 make_emakefile: $(NO_OPT_ERL_FILES) $(NATIVE_ERL_FILES) \
-  $(KERNEL_ERL_FILES) $(R25_ERL_FILES)
+  $(KERNEL_ERL_FILES) $(R25_ERL_FILES) $(STRIPPED_TYPES_ERL_FILES)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) +compressed -o$(EBIN) \
 	$(MODULES) $(KERNEL_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +no_copt +no_postopt +no_ssa_opt +no_bsm_opt \
@@ -212,6 +223,8 @@ make_emakefile: $(NO_OPT_ERL_FILES) $(NATIVE_ERL_FILES) \
 	-o$(EBIN) $(NATIVE_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +r25 \
         $(ERL_COMPILE_FLAGS) -o$(EBIN) $(R25_MODULES) >> $(EMAKEFILE)
+	$(ERL_TOP)/make/make_emakefile +strip_types \
+        $(ERL_COMPILE_FLAGS) -o$(EBIN) $(STRIPPED_TYPES_MODULES) >> $(EMAKEFILE)
 
 
 tests debug opt: make_emakefile
@@ -239,6 +252,9 @@ targets: $(TARGET_FILES)
 %_r25_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
+%_stripped_types_SUITE.erl: %_SUITE.erl
+	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
+
 # ----------------------------------------------------
 # Release Target
 # ---------------------------------------------------- 
@@ -254,6 +270,7 @@ release_tests_spec: make_emakefile
 	$(INSTALL_DATA) $(NATIVE_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(KERNEL_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(R25_ERL_FILES) "$(RELSYSDIR)"
+	$(INSTALL_DATA) $(STRIPPED_TYPES_ERL_FILES) "$(RELSYSDIR)"
 	chmod -R u+w "$(RELSYSDIR)"
 	tar cf - *_SUITE_data property_test | (cd "$(RELSYSDIR)"; tar xf -)
 

--- a/erts/emulator/test/bs_match_int_SUITE.erl
+++ b/erts/emulator/test/bs_match_int_SUITE.erl
@@ -846,6 +846,8 @@ match_huge_int(Config) when is_list(Config) ->
         bs_match_int_SUITE ->
             do_match_huge_int();
         bs_match_int_r25_SUITE ->
+            do_match_huge_int();
+        bs_match_int_stripped_types_SUITE ->
             do_match_huge_int()
     end.
 

--- a/erts/emulator/test/bs_utf_SUITE.erl
+++ b/erts/emulator/test/bs_utf_SUITE.erl
@@ -490,7 +490,8 @@ get_data_dir(Config) ->
     Data = proplists:get_value(data_dir, Config),
     Opts = [{return,list}],
     Suffixes = ["_no_opt_SUITE",
-                "_r25_SUITE"],
+                "_r25_SUITE",
+                "_stripped_types_SUITE"],
     lists:foldl(fun(Suffix, Acc) ->
                         Opts = [{return,list}],
                         re:replace(Acc, Suffix, "_SUITE", Opts)

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -934,7 +934,8 @@ asm_passes() ->
        {iff,'S',{listing,"S"}},
        {iff,'to_asm',{done,"S"}}]},
      ?pass(beam_validator_weak),
-     ?pass(beam_asm)
+     ?pass(beam_asm),
+     {iff,strip_types,?pass(beam_strip_types)}
      | binary_passes()].
 
 binary_passes() ->
@@ -1697,6 +1698,13 @@ beam_asm(Code0, #compile{ifile=File,extra_chunks=ExtraChunks,options=CompilerOpt
 	{error,Es} ->
 	    {error,St#compile{errors=St#compile.errors ++ [{File,Es}]}}
     end.
+
+beam_strip_types(Beam0, #compile{}=St) ->
+    {ok,_Module,Chunks0} = beam_lib:all_chunks(Beam0),
+    Chunks = [{Tag,Contents} || {Tag,Contents} <- Chunks0,
+                                Tag =/= "Type"],
+    {ok,Beam} = beam_lib:build_module(Chunks),
+    {ok,Beam,St}.
 
 compile_info(File, CompilerOpts, Opts) ->
     IsSlim = member(slim, CompilerOpts),


### PR DESCRIPTION
Normally, all BEAM files created by OTP 25 and later have a "Type" chunk that contains type information. `beam_lib:strip/1` will not discard the "Type" chunk, but build/release scripts that do their own custom stripping could accidentally delete the chunk.

Make sure to test that loading and executing BEAM files without type information works. Since there was an overrun-heap-and-stack bug (reported in #7292, fixed in #7581) when using the bit syntax, the bit syntax test suites seems to be appropriate to clone to new BEAM files without types.