### PR TITLE
stdlib: custom keybindings for the shell

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -576,23 +576,19 @@ get_line(Chars, Pbs, Cont, Drv, Shell, Encoding) ->
 get_line1({done, Cont, Rest, Rs}, Drv, _Shell, _Ls, _Encoding) ->
     send_drv_reqs(Drv, Rs),
     {done, Cont, Rest};
-get_line1({undefined,{_A, Mode, Char}, _Cs, Cont, Rs}, Drv, Shell, Ls0, Encoding)
-  when Mode =:= none, Char =:= $\^O;
-       Mode =:= meta, Char =:= $o ->
+get_line1({open_editor, _Cs, Cont, Rs}, Drv, Shell, Ls0, Encoding) ->
     send_drv_reqs(Drv, Rs),
     Buffer = edlin:current_line(Cont),
     send_drv(Drv, {open_editor, Buffer}),
     receive
-        {Drv, {editor_data, Cs}} ->
+        {Drv, {editor_data, Cs1}} ->
             send_drv_reqs(Drv, edlin:erase_line()),
             {more_chars,NewCont,NewRs} = edlin:start(edlin:prompt(Cont)),
             send_drv_reqs(Drv, NewRs),
-            get_line1(edlin:edit_line(Cs, NewCont), Drv, Shell, Ls0, Encoding)
+            get_line1(edlin:edit_line(Cs1, NewCont), Drv, Shell, Ls0, Encoding)
     end;
 %% Move Up, Down in History: Ctrl+P, Ctrl+N
-get_line1({undefined,{_A,Mode,Char},Cs,Cont,Rs}, Drv, Shell, Ls0, Encoding)
-  when Mode =:= none, Char =:= $\^P;
-       Mode =:= meta_left_sq_bracket, Char =:= $A ->
+get_line1({history_up,Cs,Cont,Rs}, Drv, Shell, Ls0, Encoding) ->
     send_drv_reqs(Drv, Rs),
     case up_stack(save_line(Ls0, edlin:current_line(Cont))) of
         {none,_Ls} ->
@@ -609,9 +605,7 @@ get_line1({undefined,{_A,Mode,Char},Cs,Cont,Rs}, Drv, Shell, Ls0, Encoding)
                 Ncont),
               Drv, Shell, Ls, Encoding)
     end;
-get_line1({undefined,{_A,Mode,Char},Cs,Cont,Rs}, Drv, Shell, Ls0, Encoding)
-  when Mode =:= none, Char =:= $\^N;
-       Mode =:= meta_left_sq_bracket, Char =:= $B ->
+get_line1({history_down,Cs,Cont,Rs}, Drv, Shell, Ls0, Encoding) ->
     send_drv_reqs(Drv, Rs),
     case down_stack(save_line(Ls0, edlin:current_line(Cont))) of
         {none,_Ls} ->
@@ -639,14 +633,13 @@ get_line1({undefined,{_A,Mode,Char},Cs,Cont,Rs}, Drv, Shell, Ls0, Encoding)
 %% new modes: search, search_quit, search_found. These are added to
 %% the regular ones (none, meta_left_sq_bracket) and handle special
 %% cases of history search.
-get_line1({undefined,{_A,Mode,Char},Cs,Cont,Rs}, Drv, Shell, Ls, Encoding)
-  when Mode =:= none, Char =:= $\^R ->
+get_line1({search,Cs,Cont,Rs}, Drv, Shell, Ls, Encoding) ->
     send_drv_reqs(Drv, Rs),
     %% drop current line, move to search mode. We store the current
     %% prompt ('N>') and substitute it with the search prompt.
     put(search_quit_prompt, Cont),
     Pbs = prompt_bytes("\033[;1;4msearch:\033[0m ", Encoding),
-    {more_chars,Ncont,_Nrs} = edlin:start(Pbs, search),
+    {more_chars,Ncont,_Nrs} = edlin:start(Pbs, {search,none}),
     get_line1(edlin:edit_line1(Cs, Ncont), Drv, Shell, Ls, Encoding);
 get_line1({Expand, Before, Cs0, Cont,Rs}, Drv, Shell, Ls0, Encoding)
   when Expand =:= expand; Expand =:= expand_full ->
@@ -703,15 +696,10 @@ get_line1({Expand, Before, Cs0, Cont,Rs}, Drv, Shell, Ls0, Encoding)
                  end
          end,
     get_line1(edlin:edit_line(Cs, Cont), Drv, Shell, Ls0, Encoding);
-get_line1({undefined, {_, search_quit, _}, _Cs, _Cont={line, P, Line, none}, Rs}, Drv, Shell, Ls, Encoding) ->
-    get_line1({more_chars, {line, P, Line, search_quit}, Rs}, Drv, Shell, Ls, Encoding);
-get_line1({undefined,_Char,Cs,Cont,Rs}, Drv, Shell, Ls, Encoding) ->
-    send_drv_reqs(Drv, Rs),
-    send_drv(Drv, beep),
-    get_line1(edlin:edit_line(Cs, Cont), Drv, Shell, Ls, Encoding);
+
 %% The search item was found and accepted (new line entered on the exact
 %% result found)
-get_line1({_What,{line,_,_Drv,search_found},Rs}, Drv, Shell, Ls0, Encoding) ->
+get_line1({search_found,_Cs,_,Rs}, Drv, Shell, Ls0, Encoding) ->
     SearchResult = get(search_result),
     LineCont = case SearchResult of
                    [] -> {[],{[],[]},[]};
@@ -721,14 +709,12 @@ get_line1({_What,{line,_,_Drv,search_found},Rs}, Drv, Shell, Ls0, Encoding) ->
     Prompt = edlin:prompt(get(search_quit_prompt)),
     send_drv_reqs(Drv, Rs),
     send_drv_reqs(Drv, edlin:erase_line()),
-    send_drv_reqs(Drv, edlin:redraw_line({line, Prompt, LineCont, none})),
+    send_drv_reqs(Drv, edlin:redraw_line({line, Prompt, LineCont, {none,none}})),
     put(search_result, []),
-    %% TODO, do even need to save it, won't it be saved by handling {done...}?
-    Ls = save_line(new_stack(get_lines(Ls0)), edlin:current_line({line, edlin:prompt(get(search_quit_prompt)), LineCont, none})),
-    get_line1({done, LineCont, "\n", Rs}, Drv, Shell, Ls, Encoding);
+    get_line1({done, LineCont, "\n", Rs}, Drv, Shell, Ls0, Encoding);
 %% The search mode has been exited, but the user wants to remain in line
 %% editing mode wherever that was, but editing the search result.
-get_line1({What,{line,_,_,search_quit},Rs}, Drv, Shell, Ls, Encoding) ->
+get_line1({search_quit,_Cs,_,Rs}, Drv, Shell, Ls, Encoding) ->
     %% Load back the old prompt with the correct line number.
     case edlin:prompt(get(search_quit_prompt)) of
         Prompt -> % redraw the line and keep going with the same stack position
@@ -738,20 +724,20 @@ get_line1({What,{line,_,_,search_quit},Rs}, Drv, Shell, Ls, Encoding) ->
                     _  -> [Last|LB] = lists:reverse(SearchResult),
                           {LB, {lists:reverse(Last), []}, []}
                 end,
-            NCont = {line,Prompt,L,none},
+            NCont = {line,Prompt,L,{none,none}},
             put(search_result, []),
             send_drv_reqs(Drv, [delete_line|Rs]),
             send_drv_reqs(Drv, edlin:redraw_line(NCont)),
-            get_line1({What, NCont ,[]}, Drv, Shell, pad_stack(Ls), Encoding)
+            get_line1({more_chars, NCont ,[]}, Drv, Shell, pad_stack(Ls), Encoding)
     end;
-get_line1({What,_Cont={line,_,_,search_cancel},Rs}, Drv, Shell, Ls, Encoding) ->
+get_line1({search_cancel,_Cs,_,Rs}, Drv, Shell, Ls, Encoding) ->
     NCont = get(search_quit_prompt),
     put(search_result, []),
     send_drv_reqs(Drv, [delete_line|Rs]),
     send_drv_reqs(Drv, edlin:redraw_line(NCont)),
-    get_line1({What, NCont, []}, Drv, Shell, Ls, Encoding);
+    get_line1({more_chars, NCont, []}, Drv, Shell, Ls, Encoding);
 %% Search mode is entered.
-get_line1({What,{line,Prompt,{_,{RevCmd0,_},_},search},_Rs},
+get_line1({What,{line,Prompt,{_,{RevCmd0,_},_},{search, none}},_Rs},
           Drv, Shell, Ls0, Encoding) ->
     %% Figure out search direction. ^S and ^R are returned through edlin
     %% whenever we received a search while being already in search mode.
@@ -785,7 +771,7 @@ get_line1({What,{line,Prompt,{_,{RevCmd0,_},_},search},_Rs},
                              send_drv(Drv, {put_expand_no_trim, unicode, unicode:characters_to_binary(Output)}),
                              {Ls2, {[],{RevCmd, []},[]}}
                      end,
-    Cont = {line,Prompt,NewStack,search},
+    Cont = {line,Prompt,NewStack,{search, none}},
     more_data(What, Cont, Drv, Shell, Ls, Encoding);
 get_line1({What,Cont0,Rs}, Drv, Shell, Ls, Encoding) ->
     send_drv_reqs(Drv, Rs),
@@ -797,7 +783,8 @@ more_data(What, Cont0, Drv, Shell, Ls, Encoding) ->
             send_drv_reqs(Drv, edlin:redraw_line(Cont0)),
             more_data(What, Cont0, Drv, Shell, Ls, Encoding);
         {Drv,{data,Cs}} ->
-            get_line1(edlin:edit_line(cast(Cs, list), Cont0),
+            Res = edlin:edit_line(cast(Cs, list), Cont0),
+            get_line1(Res,
                       Drv, Shell, Ls, Encoding);
         {Drv,eof} ->
             get_line1(edlin:edit_line(eof, Cont0), Drv, Shell, Ls, Encoding);

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -1178,7 +1178,7 @@ insert_buf(State, Bin, LineAcc, Acc) ->
 %% This function replicates this regex pattern <<"^[\e",194,155,"]\\[[0-9;:]*m">>
 %% calling re:run/2 nif on compiled regex_pattern was significantly
 %% slower than this implementation.
-ansi_sgr(<<N, $[, Rest/binary>>=Bin) when N =:= $\e; N =:= 194; N =:= 155 ->
+ansi_sgr(<<N, $[, Rest/binary>> = Bin) when N =:= $\e; N =:= 194; N =:= 155 ->
     case ansi_sgr(Rest, 2) of
         {ok, Size} ->
             <<Result:Size/binary, Bin1/binary>> = Bin,

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -638,10 +638,6 @@ switch_loop(info,{ReadHandle,{data,Cs}}, {Cont, #state{ read = ReadHandle } = St
         {done,{[Line],_,_},_Rest, Rs} ->
             {keep_state, State#state{ tty = io_requests(Rs, State#state.tty) },
              {next_event, internal, {line, Line}}};
-        {undefined,_Char,MoreCs,NewCont,Rs} ->
-            {keep_state,
-             {NewCont, State#state{ tty = io_requests(Rs ++ [beep], State#state.tty)}},
-             {next_event, info, {ReadHandle,{data,MoreCs}}}};
         {more_chars,NewCont,Rs} ->
             {keep_state,
              {NewCont, State#state{ tty = io_requests(Rs, State#state.tty)}}};

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -63,6 +63,7 @@
          external_editor/1, external_editor_visual/1,
          external_editor_unicode/1, shell_ignore_pager_commands/1]).
 
+-export([test_invalid_keymap/1, test_valid_keymap/1]).
 %% Exports for custom shell history module
 -export([load/0, add/1]).
 %% For custom prompt testing
@@ -107,6 +108,7 @@ groups() ->
      {tty,[],
       [{group,tty_unicode},
        {group,tty_latin1},
+       test_invalid_keymap, test_valid_keymap,
        shell_suspend,
        shell_full_queue,
        external_editor,
@@ -1173,7 +1175,46 @@ shell_ignore_pager_commands(Config) ->
                 ok
             end
     end.
+test_valid_keymap(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir,Config),
+    Term = setup_tty([{args, ["-kernel", "shell_keymap", "\"" ++ DataDir ++ "valid_keymap.toml\""]} | Config]),
+    try
+        check_not_in_content(Term, "Invalid key"),
+        check_not_in_content(Term, "Invalid function"),
+        send_tty(Term, "asdf"),
+        send_tty(Term, "C-u"),
+        check_content(Term, ">$"),
+        ok
+    after
+        stop_tty(Term),
+        ok
+    end.
 
+test_invalid_keymap(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir,Config),
+    Term1 = setup_tty([{args, ["-kernel", "shell_keymap", "\"" ++ DataDir ++ "nope.toml\""]} | Config]),
+    try
+        check_content(Term1, "Invalid keymap file:"),
+        send_tty(Term1, "asdf"),
+        send_tty(Term1, "C-u"),
+        check_content(Term1, ">$"),
+        ok
+    after
+        stop_tty(Term1),
+        ok
+    end,
+    Term2 = setup_tty([{args, ["-kernel", "shell_keymap", "\"" ++ DataDir ++ "invalid_keymap.toml\""]} | Config]),
+    try
+        check_content(Term2, "Invalid key"),
+        check_content(Term2, "Invalid function"),
+        send_tty(Term2, "asdf"),
+        send_tty(Term2, "C-u"),
+        check_content(Term2, ">$"),
+        ok
+    after
+        stop_tty(Term2),
+        ok
+    end.
 external_editor(Config) ->
     case os:find_executable("nano") of
         false -> {skip, "nano is not installed"};
@@ -1684,6 +1725,33 @@ get_window_size(Term) ->
     [Row, Col] = string:lexemes(string:trim(RowAndCol,both)," "),
     {list_to_integer(Row), list_to_integer(Col)}.
 
+check_not_in_content(Term, NegativeMatch) ->
+    check_not_in_content(Term, NegativeMatch, #{}, 5).
+check_not_in_content(Term, NegativeMatch, Opts, Attempt) ->
+    Opts = #{},
+    OrigContent = case Term of
+        #tmux{} -> get_content(Term);
+        Fun when is_function(Fun,0) -> Fun()
+    end,
+    Content = case maps:find(replace, Opts) of
+                {ok, {RE,Repl} } ->
+                    re:replace(OrigContent, RE, Repl, [global]);
+                error ->
+                    OrigContent
+                end,
+    case re:run(string:trim(Content, both), lists:flatten(NegativeMatch), [unicode]) of
+        {match,_} ->
+            io:format("Failed, found '~ts' in ~n'~ts'~n",
+            [unicode:characters_to_binary(NegativeMatch), Content]),
+            io:format("Failed, found '~w' in ~n'~w'~n",
+                        [unicode:characters_to_binary(NegativeMatch), Content]),
+            ct:fail(match);
+        _ when Attempt =:= 0 ->
+            ok;
+        _ ->
+            timer:sleep(500),
+            check_not_in_content(Term, NegativeMatch, Opts, Attempt - 1)
+    end.
 check_content(Term, Match) ->
     check_content(Term, Match, #{}).
 check_content(Term, Match, Opts) when is_map(Opts) ->

--- a/lib/kernel/test/interactive_shell_SUITE_data/invalid_keymap.toml
+++ b/lib/kernel/test/interactive_shell_SUITE_data/invalid_keymap.toml
@@ -1,0 +1,6 @@
+^C^C: clear
+# undo not implemented
+^Z: undo
+a: clear
+asdf: clear
+^[OP: clear

--- a/lib/kernel/test/interactive_shell_SUITE_data/valid_keymap.toml
+++ b/lib/kernel/test/interactive_shell_SUITE_data/valid_keymap.toml
@@ -1,0 +1,157 @@
+## Default Keymap template
+# This is a keymap that corresponds to what was previously
+# configured in edlin, now moved to edlin_key.erl.
+#
+
+## Enter
+\n: new_line_finish
+\r: new_line_finish
+### Alt-Enter or Esc + Enter
+^[\n: new_line
+^[\r: new_line
+
+## Tab ^I
+\t: tab_expand
+
+## Ctrl-alpha keys 0-31
+^A: beginning_of_line
+^B: backward_char
+#^C: sig_term_menu    # cannot be changed, yet
+^D: forward_delete_char
+^E: end_of_line
+^F: forward_char
+#^G: jcl_menu         # cannot be changed, yet
+^H: backward_delete_word
+#^I: tab_expand       # same as \t
+#^J: new_line_finish  # same as \n
+^K: kill_line
+^L: clear
+#^M: new_line_finish  # same as \r
+^N: history_down
+^O: open_editor
+^P: history_up
+^Q: none
+^R: search
+^S: none
+^T: transpose_char
+^U: backward_kill_line
+^V: none
+^W: backward_kill_word
+^X: none
+^Y: yank
+#^Z: sig_stop       # cannot be changed, yet
+#^[: meta           # cannot be changed
+^]: auto_blink
+^@: none
+^\: none
+^^: none
+^_: none
+
+# test f1-f12
+^[OP: clear
+^[[1;5P: clear
+^[[15~: clear
+^[[15;5~: clear
+
+# Alt-alpha_key or Esc + alpha_key, can distinguish case
+#^[A:
+^[B: backward_word
+^[b: backward_word
+#^[C:
+^[D: kill_word
+^[d: kill_word
+#^[E:
+^[F: forward_word
+^[f: forward_word
+#^[G:
+#^[H:
+#^[I:
+#^[J:
+#^[K:
+^[L: redraw_line
+^[l: redraw_line
+#^[M:
+#^[N:
+^[o: open_editor
+#^[P:
+#^[Q:
+#^[R:
+#^[S:
+^[T: transpose_word
+^[t: transpose_word
+#^[U:
+#^[V:
+#^[W:
+#^[X:
+#^[Y:
+#^[Z:
+^[<: beginning_of_expression
+^[>: end_of_expression
+
+
+# Deletion keys
+## Backspace
+^?: backward_delete_char
+## Ctrl+Backspace
+^[^?: backward_kill_word
+## Del
+^[[3~: forward_delete_char
+^[[3;5~: forward_delete_word
+
+# Navigation keys
+## Home
+^[[H: beginning_of_line
+^[OH: beginning_of_line
+
+## End
+^[[F: end_of_line
+^[OF: end_of_line
+
+# Arrow keys
+## Up
+^[OA: backward_line
+^[[A: backward_line
+^[[1;3A: history_up
+^[[1;5A: history_up
+^[[1;4A: beginning_of_expression
+
+## Down
+^[OB: forward_line
+^[[B: forward_line
+^[[1;3B: history_down
+^[[1;5B: history_down
+^[[1;4B: end_of_expression
+
+## Left
+^[OD: backward_char
+^[[D: backward_char
+^[[3D: backward_word
+^[[1;3D: backward_word
+^[[5D: backward_word
+^[[1;5D: backward_word
+
+## Right
+^[OC: forward_char
+^[[C: forward_char
+^[[3C: forward_word
+^[[1;3C: forward_word
+^[[5C: forward_word
+^[[1;5C: forward_word
+
+# By default, if there is a key that is not mapped in the keymap, map it to none
+default: none
+
+[search]
+^R: skip_up
+^S: skip_down
+^Q: search_cancel
+^[c: search_cancel
+\n: search_found
+\r: search_found
+^H: backward_delete_char
+^?: backward_delete_char
+default: search_quit
+
+[tab_expand]
+\t: tab_expand_full
+default: tab_expand_quit

--- a/lib/stdlib/doc/src/Makefile
+++ b/lib/stdlib/doc/src/Makefile
@@ -44,6 +44,7 @@ XML_REF3_FILES = \
 	dict.xml \
 	digraph.xml \
 	digraph_utils.xml \
+	edlin.xml \
 	edlin_expand.xml \
 	epp.xml \
 	erl_anno.xml \

--- a/lib/stdlib/doc/src/edlin.xml
+++ b/lib/stdlib/doc/src/edlin.xml
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE erlref SYSTEM "erlref.dtd">
+
+<erlref>
+  <header>
+    <copyright>
+      <year>1996</year><year>2023</year>
+      <holder>Ericsson AB. All Rights Reserved.</holder>
+    </copyright>
+    <legalnotice>
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+ 
+          http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+    </legalnotice>
+
+    <title>edlin</title>
+    <prepared></prepared>
+    <docno></docno>
+    <date></date>
+    <rev></rev>
+  </header>
+  <module since="OTP 26.0">edlin</module>
+  <modulesummary>Line and input interpretter for the erlang shell.</modulesummary>
+  <description>
+    <p>This module reads input, handles any escape sequences that have been configured via edlin_key
+    and outputs action requests. The action requests are handled either by modules <c>group</c> or the <c>user_drv</c>.
+    </p>
+  </description>
+  <section>
+    <title>Actions</title>
+    <p>The commands below are the built-in action requests for switching input modes on the normal
+    shell or navigating, or manipulating the line feed. The line feed supports multiple lines.
+    </p>
+    <taglist>
+      <tag><c>auto_blink</c></tag>
+      <item>
+        <p>Automatically close the closest matching opening parenthesis.</p>
+      </item>
+      <tag><c>backward_char</c></tag>
+      <item>
+        <p>Move backward one character.</p>
+      </item>
+      <tag><c>backward_delete_char</c></tag>
+      <item>
+        <p>Delete the character behind the cursor.</p>
+      </item>
+      <tag><c>backward_delete_word</c></tag>
+      <item>
+        <p>Delete the word behind the cursor.</p>
+      </item>
+      <tag><c>backward_kill_line</c></tag>
+      <item>
+        <p>Delete all characters from the cursor to the beginning of the line and save them in the kill buffer.</p>
+      </item>
+      <tag><c>backward_kill_word</c></tag>
+      <item>
+        <p>Delete the word behind the cursor and save it in the kill buffer.</p>
+      </item>
+      <tag><c>backward_line</c></tag>
+      <item>
+        <p>Move backward one line.</p>
+      </item>
+      <tag><c>backward_word</c></tag>
+      <item>
+        <p>Move backward one word.</p>
+      </item>
+      <tag><c>beginning_of_expression</c></tag>
+      <item>
+        <p>Move to the beginning of the expression.</p>
+      </item>
+      <tag><c>beginning_of_line</c></tag>
+      <item>
+        <p>Move to the beginning of the line.</p>
+      </item>
+      <tag><c>clear</c></tag>
+      <item>
+        <p>Clear the screen.</p>
+      </item>
+      <tag><c>clear_line</c></tag>
+      <item>
+        <p>Clear the current expression.</p>
+      </item>
+      <tag><c>end_of_expression</c></tag>
+      <item>
+        <p>Move to the end of the expression.</p>
+      </item>
+      <tag><c>end_of_line</c></tag>
+      <item>
+        <p>Move to the end of the line.</p>
+      </item>
+      <tag><c>forward_char</c></tag>
+      <item>
+        <p>Move forward one character.</p>
+      </item>
+      <tag><c>forward_delete_char</c></tag>
+      <item>
+        <p>Delete the character under the cursor.</p>
+      </item>
+      <tag><c>forward_line</c></tag>
+      <item>
+        <p>Move forward one line.</p>
+      </item>
+      <tag><c>forward_word</c></tag>
+      <item>
+        <p>Move forward one word.</p>
+      </item>
+      <tag><c>history_down</c></tag>
+      <item>
+        <p>Move to the next item in the history.</p>
+      </item>
+      <tag><c>history_up</c></tag>
+      <item>
+        <p>Move to the previous item in the history.</p>
+      </item>
+      <tag><c>kill_line</c></tag>
+      <item>
+        <p>Delete all characters from the cursor to the end of the line and save them in the kill buffer.</p>
+      </item>
+      <tag><c>kill_word</c></tag>
+      <item>
+        <p>Delete the word under the cursor and save it in the kill buffer.</p>
+      </item>
+      <tag><c>new_line_finish</c></tag>
+      <item>
+        <p>Add a newline at the end of the line and try to evaluate the current expression.</p>
+      </item>
+      <tag><c>newline</c></tag>
+      <item>
+        <p>Add a newline at the cursor position.</p>
+      </item>
+      <tag><c>open_editor</c></tag>
+      <item>
+        <p>Open the current line in an editor e.g. EDITOR="code -w" opens a buffer in vs code.
+        Note that you need to pass a flag to the editor so that it signals the shell when you close
+        the buffer.</p>
+      </item>
+      <tag><c>redraw_line</c></tag>
+      <item>
+        <p>Redraw the current line.</p>
+      </item>
+      <tag><c>search_cancel</c></tag>
+      <item>
+        <p>Cancel the current search.</p>
+      </item>
+      <tag><c>search_found</c></tag>
+      <item>
+        <p>Accept the current search result and submit it.</p>
+      </item>
+      <tag><c>search_quit</c></tag>
+      <item>
+        <p>Accept the current search result, but edit it before submitting.</p>
+      </item>
+      <tag><c>search</c></tag>
+      <item>
+        <p>Enter search mode, search the history.</p>
+      </item>
+      <tag><c>search_down</c></tag>
+      <item>
+        <p>Skip to the next line in the history that matches the current search expression.</p>
+      </item>
+      <tag><c>search_up</c></tag>
+      <item>
+        <p>Skip to the previous line in the history that matches the current search expression.</p>
+      </item>
+      <tag><c>tab_expand_full</c></tag>
+      <item>
+        <p>Output all possible tab completions.</p>
+      </item>
+      <tag><c>tab_expand_quit</c></tag>
+      <item>
+        <p>Go back to normal mode.</p>
+      </item>
+      <tag><c>tab_expand</c></tag>
+      <item>
+        <p>Autocomplete the current word, or show 5 lines of possible completions.</p>
+      </item>
+      <tag><c>transpose_char</c></tag>
+      <item>
+        <p>Swap the character behind the cursor with the one in front of it.</p>
+      </item>
+      <tag><c>transpose_word</c></tag>
+      <item>
+        <p>Swap the word behind the cursor with the one in front of it.</p>
+      </item>
+      <tag><c>yank</c></tag>
+      <item>
+        <p>Insert the contents of the kill buffer at the cursor position.</p>
+      </item>
+    </taglist>
+  </section>
+</erlref>

--- a/lib/stdlib/doc/src/ref_man.xml
+++ b/lib/stdlib/doc/src/ref_man.xml
@@ -44,6 +44,7 @@
   <xi:include href="dict.xml"/>
   <xi:include href="digraph.xml"/>
   <xi:include href="digraph_utils.xml"/>
+  <xi:include href="edlin.xml"/>
   <xi:include href="edlin_expand.xml"/>
   <xi:include href="epp.xml"/>
   <xi:include href="erl_anno.xml"/>

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -57,6 +57,7 @@ MODULES= \
 	digraph \
 	digraph_utils \
 	edlin \
+	edlin_key \
 	edlin_context \
 	edlin_expand \
 	edlin_type_suggestion \

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -22,7 +22,7 @@
 %% A simple Emacs-like line editor.
 %% About Latin-1 characters: see the beginning of erl_scan.erl.
 
--export([init/0,init/1,start/1,start/2,edit_line/2,prefix_arg/1]).
+-export([init/0,init/1,start/1,start/2,edit_line/2]).
 -export([erase_line/0,erase_inp/1,redraw_line/1]).
 -export([length_before/1,length_after/1,prompt/1]).
 -export([current_line/1, current_chars/1]).
@@ -35,27 +35,29 @@
 
 
 %% A Continuation has the structure:
-%%	{line,Prompt,CurrentLine,EditPrefix}
+%%	{line,Prompt,{LinesBefore,{ColumnsBefore, ColumnsAfter},LinesAfter},{ShellMode, EscapePrefix}}
 
 %% init()
 %%  Initialise the line editor. This must be done once per process using
 %%  the editor.
 
 init() ->
+    put(key_map, edlin_key:get_key_map()),
     put(kill_buffer, []).
 
 init(Pid) ->
+    init(),
     %% copy the kill_buffer from the process Pid
     CopiedKillBuf =
-	case erlang:process_info(Pid, dictionary) of
-	    {dictionary,Dict} ->
-		case proplists:get_value(kill_buffer, Dict) of
-		    undefined -> [];
-		    Buf       -> Buf
-		end;
-	    undefined ->
-		[]
-	end,
+        case erlang:process_info(Pid, dictionary) of
+	        {dictionary,Dict} ->
+		            case proplists:get_value(kill_buffer, Dict) of
+		                    undefined -> [];
+		                    Buf       -> Buf
+		            end;
+	        undefined ->
+		            []
+	    end,
     put(kill_buffer, CopiedKillBuf).
 
 %% start(Prompt)
@@ -64,250 +66,146 @@ init(Pid) ->
 %%	{done,Line,Rest,Requests}
 %%	{more_chars,Cont,Requests}
 %%	{blink,Cont,Requests}
-%%	{undefined,Char,Rest,Cont,Requests}
 
 start(Pbs) ->
-    start(Pbs, none).
+    start(Pbs, {none,none}).
 
 %% Only two modes used: 'none' and 'search'. Other modes can be
 %% handled inline through specific character handling.
 start(Pbs, {_,{_,_},_}=Cont) ->
-    {more_chars,{line,Pbs,Cont,none},redraw(Pbs, Cont, [])};
+    {more_chars,{line,Pbs,Cont,{none,none}},redraw(Pbs, Cont, [])};
 
-start(Pbs, Mode) ->
-    {more_chars,{line,Pbs,{[],{[],[]},[]},Mode},[new_prompt, {insert_chars,unicode,Pbs}]}.
+start(Pbs, EditState) ->
+    {more_chars,{line,Pbs,{[],{[],[]},[]},EditState},[new_prompt, {insert_chars,unicode,Pbs}]}.
 
 edit_line(Cs, {line,P,L,{blink,N_Rs}}) ->
-    edit(Cs, P, L, none, N_Rs);
+    edit(Cs, P, L, {none, none}, N_Rs);
 edit_line(Cs, {line,P,L,M}) ->
     edit(Cs, P, L, M, []).
 
 edit_line1(Cs, {line,P,L,{blink,N_Rs}}) ->
-    edit(Cs, P, L, none, N_Rs);
-edit_line1(Cs, {line,P,{B,{[],[]},A},none}) ->
+    edit(Cs, P, L, {none, none}, N_Rs);
+edit_line1(Cs, {line,P,{B,{[],[]},A},{none,none}}) ->
     [CurrentLine|Lines] = [string:to_graphemes(Line) || Line <- reverse(string:split(Cs, "\n",all))],
     Cont = {Lines ++ B,{reverse(CurrentLine),[]},A},
     Rs = redraw(P, Cont, []),
-    {more_chars, {line,P,Cont,none},[delete_line|Rs]};
+    {more_chars, {line,P,Cont,{none,none}},[delete_line|Rs]};
 edit_line1(Cs, {line,P,L,M}) ->
     edit(Cs, P, L, M, []).
 
 edit([C|Cs], P, Line, {blink,_}, [_|Rs]) ->	%Remove blink here
-    edit([C|Cs], P, Line, none, Rs);
-edit([C|Cs], P, {LB, {Bef,Aft}, LA}=MultiLine, Prefix, Rs0) ->
-    case key_map(C, Prefix) of
-        meta ->
-            edit(Cs, P, MultiLine, meta, Rs0);
-        meta_o ->
-            edit(Cs, P, MultiLine, meta_o, Rs0);
-        meta_csi ->
-            edit(Cs, P, MultiLine, meta_csi, Rs0);
-        meta_meta ->
-            edit(Cs, P, MultiLine, meta_meta, Rs0);
-        {csi, _} = Csi ->
-            edit(Cs, P, MultiLine, Csi, Rs0);
-        meta_left_sq_bracket ->
-            edit(Cs, P, MultiLine, meta_left_sq_bracket, Rs0);
-        search_meta ->
-            edit(Cs, P, MultiLine, search_meta, Rs0);
-        search_meta_left_sq_bracket ->
-            edit(Cs, P, MultiLine, search_meta_left_sq_bracket, Rs0);
-        ctlx ->
-            edit(Cs, P, MultiLine, ctlx, Rs0);
-        new_line ->
-            MultiLine1 = {[lists:reverse(Bef)|LB],{[],Aft},LA},
-            edit(Cs, P, MultiLine1, none, reverse(redraw(P, MultiLine1, Rs0)));
-        new_line_finish ->
-            % Move to end
-            {{LB1,{Bef1,[]},[]}, Rs1} = do_op(end_of_expression, MultiLine, Rs0),
-            {done, {[lists:reverse(Bef1)|LB1],{[],[]},[]}, Cs, reverse(Rs1, [{insert_chars, unicode, "\n"}])};
-        redraw_line ->
-            Rs1 = erase_line(Rs0),
-            Rs = redraw(P, MultiLine, Rs1),
-            edit(Cs, P, MultiLine, none, Rs);
-        clear ->
-            Rs = redraw(P, MultiLine, [clear|Rs0]),
-            edit(Cs, P, MultiLine, none, Rs);
-        tab_expand ->
-            {expand, chars_before(MultiLine), Cs,
-            {line, P, MultiLine, tab_expand},
-            reverse(Rs0)};
-        tab_expand_full ->
-            {expand_full, chars_before(MultiLine), Cs,
-	        {line, P, MultiLine, tab_expand},
-	        reverse(Rs0)};
-        {undefined,C} ->
-            {undefined,{none,Prefix,C},Cs,{line,P,MultiLine,none},
-            reverse(Rs0)};
-        Op ->
-            case do_op(Op, MultiLine, Rs0) of
-                {blink,N,MultiLine1,Rs} ->
-                    edit(Cs, P, MultiLine1, {blink,N}, Rs);
-                {redraw, MultiLine1, Rs} ->
-                    edit(Cs, P, MultiLine1, none, redraw(P, MultiLine1, Rs));
-                {MultiLine1, Rs, Mode} -> % allow custom modes from do_op
-                    edit(Cs, P, MultiLine1, Mode, Rs);
-                {MultiLine1,Rs} ->
-                    edit(Cs, P, MultiLine1, none, Rs)
-            end
-    end;
+    edit([C|Cs], P, Line, {none,none}, Rs);
 edit([], P, L, {blink,N}, Rs) ->
     {blink,{line,P,L, {blink,N}},reverse(Rs)};
-edit([], P, L, Prefix, Rs) ->
-    {more_chars,{line,P,L,Prefix},reverse(Rs)};
+edit([], P, L, EditState, Rs) ->
+    {more_chars,{line,P,L,EditState},reverse(Rs)};
 edit(eof, _, {_,{Bef,Aft0},LA} = L, _, Rs) ->
     Aft1 = case LA of
         [Last|_] -> Last;
         _ -> Aft0
     end,
-    {done,L,[],reverse(Rs, [{move_combo,-cp_len(Bef), length(LA), cp_len(Aft1)}])}.
-
-%% %% Assumes that arg is a string
-%% %% Horizontal whitespace only.
-%% whitespace_only([]) ->
-%%     true;
-%% whitespace_only([C|Rest]) ->
-%%     case C of
-%% 	$\s ->
-%% 	    whitespace_only(Rest);
-%% 	$\t ->
-%% 	    whitespace_only(Rest);
-%% 	_ ->
-%% 	    false
-%%     end.
-
-%% prefix_arg(Argument)
-%%  Take a prefix argument and return its numeric value.
-
-prefix_arg(none) -> 1;
-prefix_arg({ctlu,N}) -> N;
-prefix_arg(N) -> N.
-
-%% key_map(Char, Prefix)
-%%  Map a character and a prefix to an action.
-
-key_map(A, _) when is_atom(A) -> A;             % so we can push keywords
-key_map($\^A, none) -> beginning_of_line;
-key_map($\^B, none) -> backward_char;
-key_map($\^D, none) -> forward_delete_char;
-key_map($\^E, none) -> end_of_line;
-key_map($\^F, none) -> forward_char;
-key_map($\^H, none) -> backward_delete_char;
-key_map($\t, none) -> tab_expand;
-key_map($\t, tab_expand) -> tab_expand_full;
-key_map(C, tab_expand) -> key_map(C, none);
-key_map($\^K, none) -> kill_line;
-key_map($\^L, none) -> clear;
-key_map($\n, none) -> new_line_finish;
-key_map($\r, none) -> new_line_finish;
-key_map($\^T, none) -> transpose_char;
-key_map($\^U, none) -> ctlu;
-key_map($\^], none) -> auto_blink;
-key_map($\^X, none) -> ctlx;
-key_map($\^Y, none) -> yank;
-key_map($\^W, none) -> backward_kill_word;
-key_map($\e, none) -> meta;
-key_map($), Prefix) when Prefix =/= meta,
-                         Prefix =/= search,
-                         Prefix =/= search_meta -> {blink,$),$(};
-key_map($}, Prefix) when Prefix =/= meta,
-                         Prefix =/= search,
-                         Prefix =/= search_meta -> {blink,$},${};
-key_map($], Prefix) when Prefix =/= meta,
-                         Prefix =/= search,
-                         Prefix =/= search_meta -> {blink,$],$[};
-key_map($B, meta) -> backward_word;
-key_map($D, meta) -> kill_word;
-key_map($F, meta) -> forward_word;
-key_map($L, meta) -> redraw_line;
-key_map($T, meta) -> transpose_word;
-key_map($Y, meta) -> yank_pop;
-key_map($b, meta) -> backward_word;
-key_map($c, meta) -> clear_line;
-key_map($d, meta) -> kill_word;
-key_map($f, meta) -> forward_word;
-key_map($l, meta) -> redraw_line;
-key_map($t, meta) -> transpose_word;
-key_map($y, meta) -> yank_pop;
-key_map($<, meta) -> beginning_of_expression;
-key_map($>, meta) -> end_of_expression;
-key_map($\n, meta) -> new_line;
-key_map($\r, meta) -> new_line;
-key_map($O, meta) -> meta_o;
-key_map($H, meta_o) -> beginning_of_line;
-key_map($F, meta_o) -> end_of_line;
-key_map($\177, none) -> backward_delete_char;
-key_map($\177, meta) -> backward_kill_word;
-key_map($[, meta) -> meta_left_sq_bracket;
-key_map($H, meta_left_sq_bracket) -> beginning_of_line;
-key_map($F, meta_left_sq_bracket) -> end_of_line;
-key_map($D, meta_left_sq_bracket) -> backward_char;
-key_map($C, meta_left_sq_bracket) -> forward_char;
-% support a few <CTRL/ALT>+<CURSOR> combinations...
-%  - forward:  \e\e[C, \e[5C, \e[1;5C
-%  - backward: \e\e[D, \e[5D, \e[1;5D
-key_map($\e, meta) -> meta_meta;
-key_map($[, meta_meta) -> meta_csi;
-key_map($C, meta_csi) -> forward_word;
-key_map($D, meta_csi) -> backward_word;
-key_map($1, meta_left_sq_bracket) -> {csi, "1"};
-key_map($3, meta_left_sq_bracket) -> {csi, "3"};
-key_map($C, {csi, "3"}) -> forward_word;
-key_map($D, {csi, "3"})  -> backward_word;
-key_map($~, {csi, "3"}) -> forward_delete_char;
-key_map($5, meta_left_sq_bracket) -> {csi, "5"};
-key_map($C, {csi, "5"}) -> forward_word;
-key_map($D, {csi, "5"})  -> backward_word;
-key_map($;, {csi, "1"}) -> {csi, "1;"};
-key_map($3, {csi, "1;"}) -> {csi, "1;3"};
-key_map($C, {csi, "1;3"}) -> forward_word;
-key_map($D, {csi, "1;3"}) -> backward_word;
-key_map($A, {csi, "1;3"}) -> backward_line;
-key_map($B, {csi, "1;3"}) -> forward_line;
-key_map($4, {csi, "1;"}) -> {csi, "1;4"};
-key_map($A, {csi, "1;4"}) -> beginning_of_expression;
-key_map($B, {csi, "1;4"}) -> end_of_expression;
-key_map($5, {csi, "1;"}) -> {csi, "1;5"};
-key_map($C, {csi, "1;5"}) -> forward_word;
-key_map($D, {csi, "1;5"}) -> backward_word;
-key_map($A, {csi, "1;5"}) -> backward_line;
-key_map($B, {csi, "1;5"}) -> forward_line;
-
-
-
-
-
-key_map(C, none) when C >= $\s ->
-    {insert,C};
-%% for search, we need smarter line handling and so
-%% we cheat a bit on the dispatching, and allow to
-%% return a mode.
-key_map($\^H, search) -> {search, backward_delete_char};
-key_map($\177, search) -> {search, backward_delete_char};
-key_map($\^R, search) -> {search, skip_up};
-key_map($\^S, search) -> {search, skip_down};
-key_map($\n, search) -> {search, search_found};
-key_map($\r, search) -> {search, search_found};
-key_map($\^A, search) -> {search, search_quit};
-key_map($\^B, search) -> {search, search_quit};
-key_map($\^D, search) -> {search, search_quit};
-key_map($\^E, search) -> {search, search_quit};
-key_map($\^F, search) -> {search, search_quit};
-key_map($\t,  search) -> {search, search_quit};
-key_map($\^L, search) -> {search, search_quit};
-key_map($\^T, search) -> {search, search_quit};
-key_map($\^U, search) -> {search, search_quit};
-key_map($\^], search) -> {search, search_quit};
-key_map($\^X, search) -> {search, search_quit};
-key_map($\^Y, search) -> {search, search_quit};
-key_map($\e,  search) -> search_meta;
-key_map($c, search_meta) -> {search, search_cancel};
-key_map($C, search_meta) -> {search, search_cancel};
-key_map($[,  search_meta) -> search_meta_left_sq_bracket;
-key_map(_, search_meta) -> {search, search_quit};
-key_map(_C, search_meta_left_sq_bracket) -> {search, search_quit};
-key_map(C, search) -> {insert_search,C};
-key_map(C, _) -> {undefined,C}.
+    {done,L,[],reverse(Rs, [{move_combo,-cp_len(Bef), length(LA), cp_len(Aft1)}])};
+edit(Buf, P, {LB, {Bef,Aft}, LA}=MultiLine, {ShellMode, EscapePrefix}, Rs0) ->
+    case edlin_key:get_valid_escape_key(Buf, EscapePrefix) of
+        {escape_prefix, EscapePrefix1} ->
+            case ShellMode of
+                tab_expand -> edit(Buf, P, MultiLine, {none, none}, Rs0);
+                _ -> edit([], P, MultiLine, {ShellMode, EscapePrefix1}, Rs0)
+            end;
+        {invalid, _I, Rest} ->
+            edit(Rest, P, MultiLine, {ShellMode, none}, Rs0);
+        {insert, C1, Cs2} ->
+            %% If its a printable character
+            %% we could in theory override it in the keymap,
+            %% but lets not for now.
+            Op = case ShellMode of
+                none when C1 =:= $) ->
+                    {blink,$),$(};
+                none when C1 =:= $] ->
+                    {blink,$],$[};
+                none when C1 =:= $} ->
+                    {blink,$},${};
+                none -> {insert, C1};
+                search when $\s =< C1 ->{insert_search, C1};
+                search -> search_quit;
+                tab_expand -> tab_expand_quit
+            end,
+            case Op of
+                tab_expand_quit ->
+                    edit(Buf, P, MultiLine, {none,none}, Rs0);
+                search_quit ->
+                    {search_quit,Cs2,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                _ ->
+                    case do_op(Op, MultiLine, Rs0) of
+                        {blink,N,MultiLine1,Rs} ->
+                            edit(Cs2, P, MultiLine1, {blink,N}, Rs);
+                        {redraw, MultiLine1, Rs} ->
+                            edit(Cs2, P, MultiLine1, {ShellMode, none}, redraw(P, MultiLine1, Rs));
+                        {MultiLine1,Rs} ->
+                            edit(Cs2, P, MultiLine1, {ShellMode, none}, Rs)
+                    end
+            end;
+        {key, Key, Cs} ->
+            KeyMap = get(key_map),
+            Value = case maps:find(Key, maps:get(ShellMode, KeyMap)) of
+                error ->
+                    %% Default handling for shell modes
+                    case maps:find(default, maps:get(ShellMode, KeyMap)) of
+                        error -> none;
+                        {ok, Value0} -> Value0
+                    end;
+                {ok, Value0} -> Value0
+            end,
+            case Value of
+                none -> edit(Cs, P, MultiLine, {none,none}, Rs0);
+                search -> {search,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                search_found -> {search_found,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                search_cancel -> {search_cancel,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                search_quit -> {search_quit,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                open_editor -> {open_editor,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                history_up -> {history_up,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                history_down -> {history_down,Cs,{line,P,MultiLine,{none, none}},reverse(Rs0)};
+                new_line ->
+                    MultiLine1 = {[lists:reverse(Bef)|LB],{[],Aft},LA},
+                    edit(Cs, P, MultiLine1, {none, none}, reverse(redraw(P, MultiLine1, Rs0)));
+                new_line_finish ->
+                    % Move to end
+                    {{LB1,{Bef1,[]},[]}, Rs1} = do_op(end_of_expression, MultiLine, Rs0),
+                    {done, {[lists:reverse(Bef1)|LB1],{[],[]},[]}, Cs, reverse(Rs1, [{insert_chars, unicode, "\n"}])};
+                redraw_line ->
+                    Rs1 = erase_line(Rs0),
+                    Rs = redraw(P, MultiLine, Rs1),
+                    edit(Cs, P, MultiLine, {none, none}, Rs);
+                clear ->
+                    Rs = redraw(P, MultiLine, [clear|Rs0]),
+                    edit(Cs, P, MultiLine, {none, none}, Rs);
+                tab_expand ->
+                    {expand, chars_before(MultiLine), Cs,
+                     {line, P, MultiLine, {tab_expand, none}},
+                     reverse(Rs0)};
+                tab_expand_full ->
+                    {expand_full, chars_before(MultiLine), Cs,
+                     {line, P, MultiLine, {tab_expand, none}},
+                     reverse(Rs0)};
+                tab_expand_quit ->
+                    %% When exiting tab expand mode, we want to evaluate the key in normal mode
+                    edit(Buf, P, MultiLine, {none,none}, Rs0);
+                Op ->
+                    Op1 = case ShellMode of
+                        search ->
+                            {search, Op};
+                        _ -> Op
+                    end,
+                    case do_op(Op1, MultiLine, Rs0) of
+                        {blink,N,MultiLine1,Rs} ->
+                            edit(Cs, P, MultiLine1, {blink,N}, Rs);
+                        {redraw, MultiLine1, Rs} ->
+                            edit(Cs, P, MultiLine1, {none, none}, redraw(P, MultiLine1, Rs));
+                        {MultiLine1,Rs} ->
+                            edit(Cs, P, MultiLine1, {ShellMode, none}, Rs)
+                    end
+            end
+    end.
 
 %% do_op(Action, Before, After, Requests)
 %% Before and After are of lists of type string:grapheme_cluster()
@@ -341,7 +239,7 @@ do_op({insert,C}, {LB,{[Bef|Bef0], Aft},LA}, Rs) ->
 %%   $ResultLine2
 do_op({insert_search, C}, {LB,{Bef, []},LA}, Rs) ->
     {{LB, {[C|Bef],[]}, LA},
-     [{insert_chars, unicode, [C]}, delete_after_cursor | Rs], search};
+     [{insert_chars, unicode, [C]}, delete_after_cursor | Rs]};
 do_op({insert_search, C}, {LB,{Bef, _Aft},LA}, Rs) ->
     {{LB, {[C|Bef],[]}, LA},
      [{insert_chars, unicode, [C]}, delete_after_cursor | Rs],
@@ -349,26 +247,17 @@ do_op({insert_search, C}, {LB,{Bef, _Aft},LA}, Rs) ->
 do_op({search, backward_delete_char}, {LB,{[_|Bef], Aft},LA}, Rs) ->
     Offset= cp_len(Aft)+1,
     {{LB, {Bef,Aft}, LA},
-     [{insert_chars, unicode, Aft}, {delete_chars,-Offset}|Rs],
-     search};
+     [{insert_chars, unicode, Aft}, {delete_chars,-Offset}|Rs]};
 do_op({search, backward_delete_char}, {LB,{[], Aft},LA}, Rs) ->
-    {{LB, {[],Aft}, LA}, [{insert_chars, unicode, Aft}, {delete_chars,-cp_len(Aft)}|Rs], search};
+    {{LB, {[],Aft}, LA}, [{insert_chars, unicode, Aft}, {delete_chars,-cp_len(Aft)}|Rs]};
 do_op({search, skip_up}, {_,{Bef, Aft},_}, Rs) ->
     Offset= cp_len(Aft),
     {{[],{[$\^R|Bef],Aft},[]}, % we insert ^R as a flag to whoever called us
-     [{insert_chars, unicode, Aft}, {delete_chars,-Offset}|Rs],
-     search};
+     [{insert_chars, unicode, Aft}, {delete_chars,-Offset}|Rs]};
 do_op({search, skip_down}, {_,{Bef, Aft},_LA}, Rs) ->
     Offset= cp_len(Aft),
     {{[],{[$\^S|Bef],Aft},[]}, % we insert ^S as a flag to whoever called us
-     [{insert_chars, unicode, Aft}, {delete_chars,-Offset}|Rs],
-     search};
-do_op({search, search_found}, {_,{_Bef, Aft},LA}, Rs) ->
-    {{[],{[],Aft},LA}, Rs, search_found};
-do_op({search, search_quit}, {_,{_Bef, Aft},LA}, Rs) ->
-    {{[],{[],Aft},LA}, Rs, search_quit};
-do_op({search, search_cancel}, _, Rs) ->
-    {{[],{[],[]},[]}, Rs, search_cancel};
+     [{insert_chars, unicode, Aft}, {delete_chars,-Offset}|Rs]};
 %% do blink after $$
 do_op({blink,C,M}, {_,{[$$,$$|_], _},_} = MultiLine, Rs) ->
     blink(over_paren(chars_before(MultiLine), C, M), C, MultiLine, Rs);
@@ -389,12 +278,87 @@ do_op(backward_delete_char, {[PrevLine|LB],{[], Aft},LA}, Rs) ->
     {redraw, NewLine,Rs};
 do_op(backward_delete_char, {LB,{[GC|Bef], Aft},LA}, Rs) ->
     {{LB, {Bef,Aft}, LA},[{delete_chars,-gc_len(GC)}|Rs]};
+do_op(forward_delete_word, {LB,{Bef, []},[NextLine|LA]}, Rs) ->
+    NewLine = {LB, {Bef, NextLine}, LA},
+    {redraw, NewLine, Rs};
+do_op(forward_delete_word, {LB,{Bef, Aft0},LA}, Rs) ->
+    {Aft1,Kill0,N0} = over_non_word(Aft0, [], 0),
+    {Aft,Kill,N} = over_word(Aft1, Kill0, N0),
+    put(kill_buffer, reverse(Kill)),
+    {{LB, {Bef,Aft}, LA},[{delete_chars,N}|Rs]};
+do_op(backward_delete_word, {[PrevLine|LB],{[], Aft},LA}, Rs) ->
+    NewLine = {LB, {lists:reverse(PrevLine), Aft}, LA},
+    {redraw, NewLine,Rs};
+do_op(backward_delete_word, {LB,{Bef0, Aft},LA}, Rs) ->
+    {Bef1,Kill0,N0} = over_non_word(Bef0, [], 0),
+    {Bef,Kill,N} = over_word(Bef1, Kill0, N0),
+    put(kill_buffer, Kill),
+    {{LB,{Bef,Aft},LA},[{delete_chars,-N}|Rs]};
+do_op(forward_delete_word2, {LB,{Bef, []},[NextLine|LA]}, Rs) ->
+    NewLine = {LB, {Bef, NextLine}, LA},
+    {redraw, NewLine, Rs};
+do_op(forward_delete_word2, {LB,{Bef, Aft0},LA}, Rs) ->
+    {Aft1,Kill0,N0} = over_non_word(Aft0, [], 0),
+    {Aft,Kill,N} = case N0 of
+        0 -> over_word(Aft1, Kill0, N0);
+        _ -> {Aft1,Kill0,N0}
+    end,
+    put(kill_buffer, reverse(Kill)),
+    {{LB, {Bef,Aft}, LA},[{delete_chars,N}|Rs]};
+do_op(backward_delete_word2, {[PrevLine|LB],{[], Aft},LA}, Rs) ->
+    NewLine = {LB, {lists:reverse(PrevLine), Aft}, LA},
+    {redraw, NewLine,Rs};
+do_op(backward_delete_word2, {LB,{Bef0, Aft},LA}, Rs) ->
+    {Bef1,Kill0,N0} = over_non_word(Bef0, [], 0),
+    {Bef,Kill,N} = case N0 of
+        0 -> over_word(Bef1, Kill0, N0);
+        _ -> {Bef1,Kill0,N0}
+    end,
+    put(kill_buffer, Kill),
+    {{LB,{Bef,Aft},LA},[{delete_chars,-N}|Rs]};
 do_op(transpose_char, {LB,{[C1,C2|Bef], []},LA}, Rs) ->
     Len = gc_len(C1)+gc_len(C2),
     {{LB, {[C2,C1|Bef],[]}, LA},[{insert_chars_over, unicode,[C1,C2]},{move_rel,-Len}|Rs]};
 do_op(transpose_char, {LB,{[C2|Bef], [C1|Aft]},LA}, Rs) ->
     Len = gc_len(C2),
     {{LB, {[C2,C1|Bef],Aft}, LA},[{insert_chars_over, unicode,[C1,C2]},{move_rel,-Len}|Rs]};
+do_op(transpose_word, {LB,{Bef0, Aft},LA}, Rs) ->
+    {Bef1,Word2,N0} = over_word(Bef0, [], 0),
+    {Bef2,NonWord,N1} = over_non_word(Bef1, [], N0),
+    {Bef3,Word1,N2} = over_word(Bef2, [], N1),
+    TransposedWords = Word2++NonWord++Word1,
+    {{LB, {reverse(TransposedWords)++Bef3,Aft}, LA},[{insert_chars_over, unicode, TransposedWords}, {move_rel, -N2}|Rs]};
+do_op(transpose_word2, {LB,{Bef0, Aft0},LA}, Rs) ->
+    {Aft1,Word2A,N0} = over_word(Aft0, [], 0),
+    {Bef, TransposedWords, Aft, N} = case N0 of
+        0 -> {Aft2,NonWord,N1} = over_non_word(Aft1, [], 0),
+            case N1 of
+                0 ->
+                    {Bef1,Word2B,B0} = over_word(Bef0, [], 0),
+                    {Bef2,NonWordB,B1} = over_non_word(Bef1, [], B0),
+                    {Bef3,Word1,B2} = over_word(Bef2, [], B1),
+                    {Bef3, Word2B++NonWordB++Word1, Aft0, B2};
+                _ ->
+                    {Aft3,Word2,N2} = over_word(Aft2, [], N1),
+                    case N2 of
+                        0 ->
+                            {Bef1,Word2B,B0} = over_word(Bef0, [], 0),
+                            {Bef2,NonWordB,B1} = over_non_word(Bef1, [], B0),
+                            {Bef3,Word1,B2} = over_word(Bef2, [], B1),
+                            {Bef3, Word2B++NonWordB++Word1, Aft0, B2};
+                        _ ->
+                            {Bef1, NonWord2, B0} = over_non_word(Bef0, [], 0),
+                            {Bef2, Word1, B1} = over_word(Bef1, [], B0),
+                            {Bef2, reverse(Word2) ++NonWord2 ++ reverse(NonWord) ++Word1, Aft3, B1}
+                    end
+            end;
+        _ ->
+            {Bef1,Word2B,B0} = over_word(Bef0, [], 0),
+            {Bef2,NonWord,B1} = over_non_word(Bef1, [], B0),
+            {Bef3,Word1,B2} = over_word(Bef2, [], B1),
+            {Bef3, Word2B++reverse(Word2A)++NonWord++Word1, Aft1, B2}
+    end,
+    {{LB, {reverse(TransposedWords)++Bef, Aft}, LA},[{insert_chars_over, unicode, TransposedWords}, {move_rel, -N}|Rs]};
 do_op(kill_word, {LB,{Bef, Aft0},LA}, Rs) ->
     {Aft1,Kill0,N0} = over_non_word(Aft0, [], 0),
     {Aft,Kill,N} = over_word(Aft1, Kill0, N0),
@@ -403,6 +367,22 @@ do_op(kill_word, {LB,{Bef, Aft0},LA}, Rs) ->
 do_op(backward_kill_word, {LB,{Bef0, Aft},LA}, Rs) ->
     {Bef1,Kill0,N0} = over_non_word(Bef0, [], 0),
     {Bef,Kill,N} = over_word(Bef1, Kill0, N0),
+    put(kill_buffer, Kill),
+    {{LB,{Bef,Aft},LA},[{delete_chars,-N}|Rs]};
+do_op(kill_word2, {LB,{Bef, Aft0},LA}, Rs) ->
+    {Aft1,Kill0,N0} = over_non_word(Aft0, [], 0),
+    {Aft,Kill,N} = case N0 of
+        0 -> over_word(Aft1, Kill0, N0);
+        _ -> {Aft1,Kill0,N0}
+    end,
+    put(kill_buffer, reverse(Kill)),
+    {{LB, {Bef,Aft}, LA},[{delete_chars,N}|Rs]};
+do_op(backward_kill_word2, {LB,{Bef0, Aft},LA}, Rs) ->
+    {Bef1,Kill0,N0} = over_non_word(Bef0, [], 0),
+    {Bef,Kill,N} = case N0 of
+        0 -> over_word(Bef1, Kill0, N0);
+        _ -> {Bef1,Kill0,N0}
+    end,
     put(kill_buffer, Kill),
     {{LB,{Bef,Aft},LA},[{delete_chars,-N}|Rs]};
 do_op(kill_line, {LB, {Bef, Aft}, LA}, Rs) ->
@@ -450,6 +430,24 @@ do_op(backward_word, {LB,{Bef0, Aft0},LA}, Rs) ->
     {Bef1,Aft1,N0} = over_non_word(Bef0, Aft0, 0),
     {Bef,Aft,N} = over_word(Bef1, Aft1, N0),
     {{LB, {Bef,Aft}, LA},[{move_rel,-N}|Rs]};
+do_op(forward_word2, {LB,{Bef0, []},[NextLine|LA]}, Rs) ->
+    {{[reverse(Bef0)|LB], {[], NextLine}, LA},[{move_combo, -cp_len(Bef0), 1, 0}|Rs]};
+do_op(forward_word2, {LB,{Bef0, Aft0},LA}, Rs) ->
+    {Aft1,Bef1,N0} = over_non_word(Aft0, Bef0, 0),
+    {Aft, Bef, N} = case N0 of
+        0 -> over_word(Aft1, Bef1, 0);
+        _ -> {Aft1, Bef1, N0}
+    end,
+    {{LB, {Bef,Aft}, LA},[{move_rel,N}|Rs]};
+do_op(backward_word2, {[PrevLine|LB],{[], Aft0},LA}, Rs) ->
+    {{LB, {reverse(PrevLine), []}, [Aft0|LA]},[{move_combo, 0, -1, cp_len(PrevLine)}|Rs]};
+do_op(backward_word2, {LB,{Bef0, Aft0},LA}, Rs) ->
+    {Bef1,Aft1,N0} = over_non_word(Bef0, Aft0, 0),
+    {Bef,Aft,N} = case N0 of
+        0 -> over_word(Bef1, Aft1, N0);
+        _ -> {Bef1, Aft1, N0}
+    end,
+    {{LB, {Bef,Aft}, LA},[{move_rel,-N}|Rs]};
 do_op(beginning_of_expression, {[],{[], Aft},LA}, Rs) ->
     {{[], {[],Aft}, LA},Rs};
 do_op(beginning_of_expression, {LB,{Bef, Aft},LA}, Rs) ->
@@ -468,7 +466,7 @@ do_op(end_of_line, {LB,{Bef, [_|_]=Aft},LA}, Rs) ->
     {{LB, {reverse(Aft, Bef),[]}, LA},[{move_rel,cp_len(Aft)}|Rs]};
 do_op(end_of_line, {LB,{Bef, []},LA}, Rs) ->
     {{LB, {Bef,[]}, LA},Rs};
-do_op(ctlu, {LB,{Bef, Aft},LA}, Rs) ->
+do_op(backward_kill_line, {LB,{Bef, Aft},LA}, Rs) ->
     put(kill_buffer, reverse(Bef)),
     {{LB, {[], Aft}, LA}, [{delete_chars, -cp_len(Bef)} | Rs]};
 do_op(beep, {LB,{Bef, Aft},LA}, Rs) ->

--- a/lib/stdlib/src/edlin_key.erl
+++ b/lib/stdlib/src/edlin_key.erl
@@ -1,0 +1,411 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2017-2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(edlin_key).
+-export([get_key_map/0, get_valid_escape_key/2]).
+-import(lists, [reverse/1, reverse/2]).
+get_key_map() ->
+    KeyMapFile = application:get_env(kernel, shell_keymap, none),
+    case KeyMapFile of
+        none -> key_map();
+        _ -> process_lines(KeyMapFile)
+    end.
+
+
+%% Incase we are receiving partial input, we need to wait for the rest of the input.
+%% We return a mode whenever we are waiting for more input.
+get_valid_escape_key([], {csi, [_]=Acc}=_Mode) ->
+    %% we allow \e[1, \e[2... to be a valid escape sequences
+    %% note that this blocks <Esc>[1;... inputed one character at a time 
+    {key, "\e["++Acc, []};
+get_valid_escape_key([], Res) ->
+    case Res of
+        {Atom, Acc, Rest} ->
+            case Atom of
+                finished -> {key, Acc, Rest};
+                invalid -> {invalid, Acc, Rest}
+            end;
+        {Atom, Acc} ->
+            case Atom of
+                finished -> {key, Acc, []};
+                invalid -> {invalid, Acc, []};
+                csi -> {mode, {csi, Acc}}
+            end;
+        meta -> {escape_prefix, meta};
+        meta_o -> {key,"\eO", []};
+        meta_meta -> {escape_prefix, meta_meta};
+        meta_csi -> {escape_prefix, meta_csi};
+        meta_left_sq_bracket -> {escape_prefix, meta_left_sq_bracket}
+    end;
+get_valid_escape_key([C|Rest], none) ->
+    case C of
+        $\e -> get_valid_escape_key(Rest,meta);
+        C when $\^@ =< C, C =< $\^_; C =:= $\^? -> {key, [C], Rest};
+        _ -> {insert, C, Rest}
+    end;
+get_valid_escape_key([C|Rest], meta) ->
+    case C of
+        $\e -> get_valid_escape_key(Rest, meta_meta);
+        $O -> get_valid_escape_key(Rest, meta_o);
+        $[ -> get_valid_escape_key(Rest, meta_left_sq_bracket);
+        _ when $! =< C, C =< $~ -> get_valid_escape_key(Rest, {finished, "\e"++[C]});
+        _ when $\^@ =< C, C =< $\^_; C=:= $\^? -> get_valid_escape_key(Rest, {finished, "\e"++[C]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\e"++[C]})
+    end;
+get_valid_escape_key([C|Rest], meta_meta) ->
+    case C of
+        $[ -> get_valid_escape_key(Rest, meta_csi);
+        _ when $! =< C, C =< $~ -> get_valid_escape_key(Rest, {finished, "\e\e"++[C]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\e\e"++[C]})
+    end;
+get_valid_escape_key([C|Rest], meta_o) ->
+    case C of
+        _ when $! =< C, C =< $~ -> get_valid_escape_key(Rest, {finished, "\eO"++[C]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\eO"++[C]})
+    end;
+get_valid_escape_key([C|Rest], meta_csi) ->
+    case C of
+        _ when $! =< C, C =< $~ -> get_valid_escape_key(Rest, {finished, "\e\e["++[C]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\e["++[C]})
+    end;
+get_valid_escape_key([C|Rest], meta_left_sq_bracket) ->
+    case C of
+        _ when $0 =< C, C =< $9 -> get_valid_escape_key(Rest, {csi, [C]});
+        _ when $a =< C, C =< $z; $A =< C, C =< $Z -> get_valid_escape_key(Rest, {finished, "\e["++[C]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\e["++[C]})
+    end;
+get_valid_escape_key([C|Rest], {csi, [$;|Acc]}) ->
+    case C of
+        _ when $0 =< C, C =< $9 -> get_valid_escape_key(Rest, {csi, [C,$;|Acc]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\e["++reverse([$;|Acc])++[C]})
+    end;
+get_valid_escape_key([C|Rest], {csi, Acc}) ->
+    case C of
+        $~ -> get_valid_escape_key(Rest, {finished, "\e["++reverse([$~|Acc])});
+        $; -> get_valid_escape_key(Rest, {csi, [$;|Acc]});
+        _ when $0 =< C, C =< $9 -> get_valid_escape_key(Rest, {csi, [C|Acc]});
+        $m -> {invalid, "\e["++reverse([$m|Acc]), [$m|Rest]};
+        _ when $! =< C, C =< $~ -> get_valid_escape_key(Rest, {finished, "\e["++reverse([C|Acc])})
+    end;
+get_valid_escape_key([C|Rest], {finished, Acc}) ->
+    case C of
+        $~ -> get_valid_escape_key([], {finished, Acc++[C], Rest});
+        _ -> get_valid_escape_key([], {finished, Acc, [C|Rest]})
+    end;
+get_valid_escape_key(Rest, {invalid, Acc}) ->
+    {invalid, Acc, Rest};
+get_valid_escape_key(Rest, Acc) ->
+    {invalid, Acc, Rest}.
+
+process_lines(Filename) ->
+    try
+        {ok, Device} = file:open(Filename, [read]),
+        process_lines(Device, none, key_map(),1)
+    catch _:_ ->
+        io:format(standard_error, "Invalid keymap file: ~p~n", [Filename]),
+        key_map()
+    end.
+process_lines(Device, ShellMode, KeyMap,N) ->
+    case io:get_line(Device, '') of
+        eof  ->
+            _ = file:close(Device),
+            KeyMap;
+        Line ->
+            case process_line(Line, N) of
+                skip -> process_lines(Device, ShellMode, KeyMap, N+1);
+                {shell_mode, ShellMode1} ->
+                    process_lines(Device, ShellMode1, KeyMap, N+1);
+                {Key, Function} ->
+                        KeyMap1 = try
+                            Key1 = convert_escape(Key),
+                            %% Test that the key is a valid escape key, unless its the default atom
+                            _ = case Key1 of
+                                default -> skip;
+                                _ -> {key, Key1, []} = get_valid_escape_key(Key1, none)
+                            end,
+                            ShellModeKeyMap = maps:get(ShellMode, KeyMap),
+                            ShellModeKeyMap1 = ShellModeKeyMap#{
+                                Key1 => list_to_atom(Function)
+                            },
+                            KeyMap#{ShellMode => ShellModeKeyMap1}
+                        catch
+                            _:_ ->
+                                io:format(standard_error, "Invalid key ~p in entry ~w:~p~n", [Key,N,Line]),
+                                KeyMap
+                        end,
+                        process_lines(Device, ShellMode, KeyMap1, N+1)
+            end
+    end.
+process_line([$#|_],_) ->
+    skip;
+process_line(Line,N) ->
+    Entry1 = case string:split(string:trim(Line), " #", leading) of
+        [Entry] -> Entry;
+        [Entry, _Comment] -> Entry
+    end,
+    case string:split(string:trim(Entry1), ": ", all) of
+        [Key, Function] ->
+            try
+                case lists:member(list_to_atom(Function),valid_functions()) of
+                    true -> {Key, Function};
+                    false ->
+                        io:format(standard_error, "Invalid function ~p in entry ~w:~p~n", [Function, N, Line]),
+                        skip
+                end
+            catch _:_ ->
+                io:format(standard_error, "Invalid function ~p in entry ~w:~p~n", [Function, N, Line]),
+                skip
+            end;
+        ["[search]"] -> {shell_mode, search};
+        ["[tab_expand]"] -> {shell_mode, tab_expand};
+        _ -> skip
+    end.
+convert_escape("default") -> default;
+convert_escape([$\\, $n | Rest]) ->
+    [$\n | convert_escape(Rest)];
+convert_escape([$\\, $r | Rest]) ->
+    [$\r | convert_escape(Rest)];
+convert_escape([$\\, $t | Rest]) ->
+    [$\t | convert_escape(Rest)];
+convert_escape([$^, $[ | Rest]) ->
+    [$\e | convert_escape(Rest)];
+convert_escape([$^, $? | Rest]) ->
+    [$\^? | convert_escape(Rest)];
+convert_escape([$^, C | Rest]) ->
+    [C - $@ | convert_escape(Rest)];
+convert_escape(Same) ->
+    Same.
+
+
+%% Default Keymap for erl shell.
+%% This is a keymap that corresponds to what was previously
+%% configured in edlin.erl.
+%% They are now in a map of maps that supports multiple shell modes,
+%% none (normal), search, expand.
+%%
+%% See below for unused keys.
+%%
+
+key_map() -> #{
+        none => normal_map(),
+        search => #{
+            "\^R" => skip_up,
+            "\^S" => skip_down,
+            "\^[C" => search_cancel,
+            "\^[c" => search_cancel,
+            "\n" => search_found,
+            "\r" => search_found,
+            "\^H" => backward_delete_char,
+            "\^?" => backward_delete_char,
+            default => search_quit
+            %% # everything else should exit search mode and edit the search result (search_quit),
+        },
+        tab_expand => #{
+            "\t" => tab_expand_full,
+            default => tab_expand_quit %% go to normal mode and evaluate key input again
+        }
+    }.
+
+normal_map() ->
+    #{
+        %% Enter
+        "\n" => new_line_finish,
+        "\r" => new_line_finish,
+        %%% Alt-Enter or Esc + Enter
+        "\^[\n" => new_line,
+        "\^[\r" => new_line,
+        %% Tab ^I
+        "\t" => tab_expand,
+
+        %% Ctrl-alpha_key, can not distinguish case
+        "\^A" => beginning_of_line,
+        "\^B" => backward_char,
+        %%"\^C" => sig_term_menu, currently handled by user_drv.erl
+        "\^D" => forward_delete_char,
+        "\^E" => end_of_line,
+        "\^F" => forward_char,
+        %%"\^G" => jcl_menu, currently handled by user_drv.erl
+        "\^H" => backward_delete_word,
+        %%"\^I" => tab_expand, same as \t
+        %%"\^J" => new_line_finish, same as \n
+        "\^K" => kill_line,
+        "\^L" => clear,
+        %%"\^M" => new_line_finish, same as \r
+        "\^N" => history_down,
+        "\^O" => open_editor,
+        "\^P" => history_up,
+        "\^R" => search,
+        "\^T" => transpose_char,
+        "\^U" => backward_kill_line,
+        "\^W" => backward_kill_word,
+        %%"\^X" => ,
+        "\^Y" => yank,
+        %%"\^Z" => sig_stop, currently not handled by edlin.erl
+        "\^]" => auto_blink, % ctrl+5 seems to do the same thing,
+
+        %%# Alt-alpha_key or Esc + alpha_key, can distinguish case,
+        "\^[B" => backward_word,
+        "\^[b" => backward_word,
+        "\^[c" => clear_line,
+        "\^[D" => kill_word,
+        "\^[d" => kill_word,
+        "\^[F" => forward_word,
+        "\^[f" => forward_word,
+        "\^[L" => redraw_line,
+        "\^[l" => redraw_line,
+        "\^[o" => open_editor,
+        "\^[T" => transpose_word2,
+        "\^[t" => transpose_word2,
+        "\^[<" => beginning_of_expression,
+        "\^[>" => end_of_expression,
+
+        %% # Deletion keys
+        %% ## Backspace
+        "\^?" => backward_delete_char,
+        %% ## Ctrl+Backspace
+        "\^[\^?" => backward_kill_word,
+        %% ## Del
+        "\^[[3~" => forward_delete_char,
+        "\^[[3;5~" => forward_delete_word,
+
+        %% # Navigation keys
+        %% ## Home
+        "\^[[H" => beginning_of_line,
+        "\^[OH" => beginning_of_line,
+
+        %% ## End
+        "\^[[F" => end_of_line,
+        "\^[OF" => end_of_line,
+
+        %% # Arrow keys
+        %% ## Up
+        "\^[OA" => history_up,
+        "\^[[A" => history_up,
+        "\^[[1;3A" => backward_line,
+        "\^[[1;5A" => backward_line,
+        "\^[[1;4A" => beginning_of_expression,
+
+        %% ## Down
+        "\^[OB" => history_down,
+        "\^[[B" => history_down,
+        "\^[[1;3B" => forward_line,
+        "\^[[1;5B" => forward_line,
+        "\^[[1;4B" => end_of_expression,
+
+        %% ## Left
+        "\^[OD" => backward_char,
+        "\^[[D" => backward_char,
+        "\^[[3D" => backward_word,
+        "\^[[1;3D" => backward_word,
+        "\^[[5D" => backward_word,
+        "\^[[1;5D" => backward_word,
+
+        %% ## Right
+        "\^[OC" => forward_char,
+        "\^[[C" => forward_char,
+        "\^[[3C" => forward_word,
+        "\^[[1;3C" => forward_word,
+        "\^[[5C" => forward_word,
+        "\^[[1;5C" => forward_word,
+        default => none
+    }.
+valid_functions() ->
+    [auto_blink,           %% Automatically close the closest matching opening parenthesis
+     backward_char,        %% Move backward one character
+     backward_delete_char, %% Delete the character behind the cursor
+     backward_delete_word, %% Delete the word behind the cursor
+     backward_kill_line,   %% Delete all characters from the cursor to the beginning of the line and save them in the kill buffer
+     backward_kill_word,   %% Delete the word behind the cursor and save it in the kill buffer
+     backward_line,        %% Move backward one line
+     backward_word,        %% Move backward one word
+     beginning_of_expression,%% Move to the beginning of the expression
+     beginning_of_line,    %% Move to the beginning of the line
+     clear,                %% Clear the screen
+     clear_line,           %% Clear the current expression
+     end_of_expression,    %% Move to the end of the expression
+     end_of_line,          %% Move to the end of the line
+     forward_char,         %% Move forward one character
+     forward_delete_char,  %% Delete the character under the cursor
+     forward_delete_word,  %% Delete the characters until the closest non-word character
+     forward_line,         %% Move forward one line
+     forward_word,         %% Move forward one word
+     history_down,         %% Move to the next item in the history
+     history_up,           %% Move to the previous item in the history
+     %%jcl_menu,
+     kill_line,            %% Delete all characters from the cursor to the end of the line and save them in the kill buffer
+     kill_word,            %% Delete the word behind the cursor and save it in the kill buffer
+     new_line_finish,      %% Add a newline at the end of the line and try to evaluate the current expression
+     new_line,             %% Add a newline at the cursor position
+     none,                 %% Do nothing
+     open_editor,          %% Open the current line in an editor i.e. EDITOR=code -w
+     redraw_line,          %% Redraw the current line
+     search_cancel,        %% Cancel the current search
+     search_found,         %% Accept the current search result and submit it
+     search_quit,          %% Accept the current search result, but edit it before submitting
+     search,               %% Enter search mode, search the history
+     %%sig_stop,  
+     %%sig_term_menu,
+     skip_down,            %% Skip to the next line in the history that matches the current search expression
+     skip_up,              %% Skip to the previous line in the history that matches the current search expression
+     tab_expand_full,      %% Output all possible tab completions
+     tab_expand_quit,      %% Go back to normal mode
+     tab_expand,           %% Autocomplete the current word, or show 5 lines of possible completions
+     transpose_char,       %% Swap the character behind the cursor with the one in front of it
+     transpose_word,       %% Swap the word behind the cursor with the one in front of it
+     yank].                %% Insert the contents of the kill buffer at the cursor position
+
+%% Unused keys in normal mode:
+%% Ctrl+char
+%% ^Q
+%% ^S
+%% ^V
+%% ^@, ^\, ^], ^^, ^_  %% not straightforward how to type these
+%% 
+%% Alt-Shift-char, Alt-char or Esc + Shift-char, Esc + char
+%% ^[A, a
+%% ^[C
+%% ^[E, e
+%% ^[G, g
+%% ^[H, h
+%% ^[I, i
+%% ^[J, j
+%% ^[K, k
+%% ^[M, m
+%% ^[N, n
+%% ^[O, o
+%% ^[P, p
+%% ^[Q, q
+%% ^[R, r
+%% ^[S, s
+%% ^[U, u
+%% ^[V, v
+%% ^[W, w
+%% ^[X, x
+%% ^[Z, z
+%% ^[1, ^[2, ^[3, ^[4, ^[5, ^[6, ^[7, ^[8, ^[9, ^[0
+%% Any symbol that is typable while holding alt key, or esc key followed by a symbol:
+%% e.g. ^[!, ^[@, ^[#, ^[$, ^[%, ^[^, ^[&, ^[*, ^[(, ^[),
+%% (F1-F4)
+%% ^[OP, ^[OQ, ^[OR, ^[OS
+%% ^[[1;2P, ^[[1;2Q, ^[[1;2R, ^[[1;2S (Shift-F1-F4)
+%% ^[[1;5P, ^[[1;5Q, ^[[1;5R, ^[[1;5S (Ctrl-F1-F4)
+%% (F5-F12)
+%% ^[15~, ^[17~, ^[18~, ^[19~, ^[20~, ^[21~, ^[23~, ^[24~
+%% ^[[15;2~, ^[[17;2~, ^[[18;2~, ^[[19;2~, ^[[20;2~, ^[[21;2~, ^[[23;2~, ^[[24;2~ (Shift-F5-F12)
+%% ^[[15;5~, ^[[17;5~, ^[[18;5~, ^[[19;5~, ^[[20;5~, ^[[21;5~, ^[[23;5~, ^[[24;5~ (Ctrl-F5-F12)

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -37,6 +37,7 @@
 	     digraph,
 	     digraph_utils,
 	     edlin,
+	     edlin_key,
 	     edlin_context,
 	     edlin_expand,
 	     edlin_type_suggestion,


### PR DESCRIPTION
Adds functionality to override existing keybindings in the shell.

Also closes:
#6867 
#7227 
