### PR TITLE
binary module: Always detect invalid patterns

### DIFF
--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1535,10 +1535,6 @@ binary_match(Process *p, Eterm arg1, Eterm arg2, Eterm arg3, Uint flags)
     if (parse_match_opts_list(arg3, arg1, &(ctx->hsstart), &(ctx->hsend))) {
 	goto badarg;
     }
-    if (ctx->hsend == 0) {
-	result = do_match_not_found_result(p, arg1, &ctx);
-	BIF_RET(result);
-    }
     if (maybe_binary_match_compile(ctx, arg2, &pat_bin) != BF_OK) {
 	goto badarg;
     }
@@ -1596,10 +1592,6 @@ binary_split(Process *p, Eterm arg1, Eterm arg2, Eterm arg3)
     }
     if (parse_split_opts_list(arg3, arg1, &(ctx->hsstart), &(ctx->hsend), &(ctx->flags))) {
 	goto badarg;
-    }
-    if (ctx->hsend == 0) {
-	result = do_split_not_found_result(p, arg1, &ctx);
-	BIF_RET(result);
     }
     if (maybe_binary_match_compile(ctx, arg2, &pat_bin) != BF_OK) {
 	goto badarg;

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -78,6 +78,15 @@ badargs(Config) when is_list(Config) ->
 	   binary:match(<<1,2,3>>,<<1>>,
 			[{scope,{16#FFFFFFFFFFFFFFFF,
 				 16#7FFFFFFFFFFFFFFF}}])),
+    badarg = ?MASK_ERROR(binary:match(<<>>,foobar)),
+    badarg = ?MASK_ERROR(binary:match(<<"abc">>,foobar,
+                                      [{scope,{0,0}}])),
+    badarg = ?MASK_ERROR(binary:matches(<<>>,foobar)),
+    badarg = ?MASK_ERROR(binary:matches(<<"abc">>,foobar,
+                                        [{scope,{0,0}}])),
+    badarg = ?MASK_ERROR(binary:replace(<<>>,foobar,<<>>)),
+    badarg = ?MASK_ERROR(binary:replace(<<"abc">>,foobar,<<>>,
+                                        [{scope,{0,0}}])),
     badarg =
 	?MASK_ERROR(
 	   binary:part(<<1,2,3>>,{16#FF,
@@ -237,6 +246,9 @@ badargs(Config) when is_list(Config) ->
     badarg =
 	?MASK_ERROR(
 	   binary:at([1,2,4],2)),
+
+    badarg = ?MASK_ERROR(binary:split(<<>>,foobar)),
+    badarg = ?MASK_ERROR(binary:split(<<"abc">>,foobar,[{scope,{0,0}}])),
 
     badarg = ?MASK_ERROR(binary:encode_hex("abc")),
     badarg = ?MASK_ERROR(binary:encode_hex(123)),


### PR DESCRIPTION
Several functions in the `binary` module would accept an invalid pattern (such as an atom) if the subject binary was empty or if the `{scope,{0,0}}` option was given. The following functions were affected:

    match/{2,3}
    matches/{2,3}
    replace/{3,4}
    split/{2,3}