### PR TITLE
ct: Correctly handle custom stylesheets in results

### DIFF
--- a/lib/common_test/src/ct_framework.erl
+++ b/lib/common_test/src/ct_framework.erl
@@ -1420,7 +1420,7 @@ report(What,Data) ->
 	    %% top level test index page needs to be refreshed
 	    TestName = filename:basename(?val(topdir, Data), ".logs"),
 	    RunDir = ?val(rundir, Data),
-	    _ = ct_logs:make_all_suites_index({TestName,RunDir}),
+	    _ = ct_logs:make_all_suites_index({TestName,RunDir},unknown),
 	    ok;
 	tests_start ->
 	    ok;

--- a/lib/common_test/src/ct_master.erl
+++ b/lib/common_test/src/ct_master.erl
@@ -557,7 +557,7 @@ refresh_logs([D|Dirs],Refreshed) ->
 		    refresh_logs(Dirs,Refreshed);
 		false ->
 		    {ok,Cwd} = file:get_cwd(),
-		    case catch ct_run:refresh_logs(D) of
+		    case catch ct_run:refresh_logs(D, unknown) of
 			{'EXIT',Reason} ->
 			    ok = file:set_cwd(Cwd),
 			    refresh_logs(Dirs,[{D,{error,Reason}}|Refreshed]);

--- a/lib/common_test/src/ct_run.erl
+++ b/lib/common_test/src/ct_run.erl
@@ -25,7 +25,7 @@
 
 %% User interface
 -export([install/1,install/2,run/1,run/2,run/3,run_test/1,
-	 run_testspec/1,step/3,step/4,refresh_logs/1]).
+	 run_testspec/1,step/3,step/4,refresh_logs/2]).
 
 %% Misc internal API functions
 -export([variables_file_name/1,script_start1/2,run_test2/1, run_make/3]).
@@ -369,7 +369,7 @@ script_start1(Parent, Args) ->
     %% send final results to starting process waiting in script_start/0
     Parent ! {self(), Result}.
 
-run_or_refresh(Opts = #opts{logdir = LogDir}, Args) ->
+run_or_refresh(Opts = #opts{logdir = LogDir, stylesheet = CustomStylesheet}, Args) ->
     case proplists:get_value(refresh_logs, Args) of
 	undefined ->
 	    script_start2(Opts, Args);
@@ -383,12 +383,12 @@ run_or_refresh(Opts = #opts{logdir = LogDir}, Args) ->
 	    %% give the shell time to print version etc
 	    timer:sleep(500),
 	    io:nl(),
-	    case catch ct_logs:make_all_runs_index(refresh) of
+	    case catch ct_logs:make_all_runs_index(refresh, CustomStylesheet) of
 		{'EXIT',ARReason} ->
 		    ok = file:set_cwd(Cwd),
 		    {error,{all_runs_index,ARReason}};
 		_ ->
-		    case catch ct_logs:make_all_suites_index(refresh) of
+		    case catch ct_logs:make_all_suites_index(refresh, CustomStylesheet) of
 			{'EXIT',ASReason} ->
 			    ok = file:set_cwd(Cwd),
 			    {error,{all_suites_index,ASReason}};
@@ -705,6 +705,7 @@ script_start4(#opts{label = Label, profile = Profile,
 		    logopts = LogOpts,
 		    verbosity = Verbosity,
 		    enable_builtin_hooks = EnableBuiltinHooks,
+		    stylesheet = CustomStylesheet,
 		    logdir = LogDir, testspec_files = Specs}, _Args) ->
 
     %% label - used by ct_logs
@@ -723,7 +724,7 @@ script_start4(#opts{label = Label, profile = Profile,
 		  {enable_builtin_hooks,EnableBuiltinHooks}]) of
 	ok ->
 	    _ = ct_util:start(interactive, LogDir,
-			      add_verbosity_defaults(Verbosity)),
+			      add_verbosity_defaults(Verbosity), CustomStylesheet),
 	    ct_util:set_testdata({logopts, LogOpts}),
 	    log_ts_names(Specs),
 	    io:nl(),
@@ -893,7 +894,8 @@ run_test1(StartOpts) when is_list(StartOpts) ->
                                      all,
                                      StartOpts),
             application:set_env(common_test, keep_logs, KeepLogs),
-	    ok = refresh_logs(?abs(RefreshDir)),
+            CustomStylesheet = proplists:get_value(stylesheet, StartOpts),
+	    ok = refresh_logs(?abs(RefreshDir), CustomStylesheet),
 	    exit(done)
     end.
 
@@ -1479,18 +1481,18 @@ get_data_for_node(#testspec{label = Labels,
 	  scale_timetraps = ST,
 	  create_priv_dir = CreatePrivDir}.
 
-refresh_logs(LogDir) ->
+refresh_logs(LogDir, CustomStylesheet) ->
     {ok,Cwd} = file:get_cwd(),
     case file:set_cwd(LogDir) of
 	E = {error,_Reason} ->
 	    E;
 	_ ->
-	    case catch ct_logs:make_all_suites_index(refresh) of
+	    case catch ct_logs:make_all_suites_index(refresh, CustomStylesheet) of
 		{'EXIT',ASReason} ->
 		    ok = file:set_cwd(Cwd),
 		    {error,{all_suites_index,ASReason}};
 		_ ->
-		    case catch ct_logs:make_all_runs_index(refresh) of
+		    case catch ct_logs:make_all_runs_index(refresh, CustomStylesheet) of
 			{'EXIT',ARReason} ->
 			    ok = file:set_cwd(Cwd),
 			    {error,{all_runs_index,ARReason}};
@@ -1652,7 +1654,7 @@ do_run(Tests, Misc, LogDir, LogOpts) when is_list(Misc),
 
 do_run(Tests, Skip, Opts, Args) when is_record(Opts, opts) ->
     #opts{label = Label, profile = Profile,
-	  verbosity = VLvls} = Opts,
+	  verbosity = VLvls, stylesheet = CustomStylesheet} = Opts,
     %% label - used by ct_logs
     TestLabel =
 	if Label == undefined -> undefined;
@@ -1689,7 +1691,7 @@ do_run(Tests, Skip, Opts, Args) when is_record(Opts, opts) ->
 			"Note: TEST_SERVER_FRAMEWORK = " ++ Other))
 	    end,
 	    Verbosity = add_verbosity_defaults(VLvls),
-	    case ct_util:start(Opts#opts.logdir, Verbosity) of
+	    case ct_util:start(Opts#opts.logdir, Verbosity, CustomStylesheet) of
 		{error,interactive_mode} ->
 		    io:format("CT is started in interactive mode. "
 			      "To exit this mode, "

--- a/lib/common_test/src/ct_util.erl
+++ b/lib/common_test/src/ct_util.erl
@@ -26,7 +26,7 @@
 %%%
 -module(ct_util).
 
--export([start/0, start/1, start/2, start/3,
+-export([start/0, start/1, start/3, start/4,
 	 stop/1, update_last_run_index/0]).
 
 -export([register_connection/4, unregister_connection/1,
@@ -77,12 +77,13 @@
 
 -define(default_verbosity, [{default,?MAX_VERBOSITY},
 			    {'$unspecified',?MAX_VERBOSITY}]).
+-define(default_custom_stylesheet, undefined).
 
 -record(suite_data, {key,name,value}).
 
 %%%-----------------------------------------------------------------
 start() ->
-    start(normal, ".", ?default_verbosity).
+    start(normal, ".", ?default_verbosity, ?default_custom_stylesheet).
 %%% -spec start(Mode) -> Pid | exit(Error)
 %%%       Mode = normal | interactive
 %%%       Pid = pid()
@@ -98,18 +99,20 @@ start() ->
 %%%
 %%% See ct.
 start(LogDir) when is_list(LogDir) ->
-    start(normal, LogDir, ?default_verbosity);
+    start(normal, LogDir, ?default_verbosity, ?default_custom_stylesheet);
 start(Mode) ->
-    start(Mode, ".", ?default_verbosity).
+    start(Mode, ".", ?default_verbosity, ?default_custom_stylesheet).
 
-start(LogDir, Verbosity) when is_list(LogDir) ->
-    start(normal, LogDir, Verbosity).
+start(LogDir, Verbosity, CustomStylesheet) when is_list(LogDir) ->
+    start(normal, LogDir, Verbosity, CustomStylesheet).
 
-start(Mode, LogDir, Verbosity) ->
+start(Mode, LogDir, Verbosity, CustomStylesheet) ->
     case whereis(ct_util_server) of
 	undefined ->
 	    S = self(),
-	    Pid = spawn_link(fun() -> do_start(S, Mode, LogDir, Verbosity) end),
+	    Pid = spawn_link(fun() ->
+	        do_start(S, Mode, LogDir, Verbosity, CustomStylesheet)
+	    end),
 	    receive 
 		{Pid,started} -> Pid;
 		{Pid,Error} -> exit(Error);
@@ -126,7 +129,7 @@ start(Mode, LogDir, Verbosity) ->
 	    end
     end.
 
-do_start(Parent, Mode, LogDir, Verbosity) ->
+do_start(Parent, Mode, LogDir, Verbosity, CustomStylesheet) ->
     process_flag(trap_exit,true),
     register(ct_util_server,self()),
     mark_process(),
@@ -192,7 +195,7 @@ do_start(Parent, Mode, LogDir, Verbosity) ->
         ignore -> ok
     end,
 
-    {StartTime,TestLogDir} = ct_logs:init(Mode, Verbosity),
+    {StartTime,TestLogDir} = ct_logs:init(Mode, Verbosity, CustomStylesheet),
 
     ct_event:notify(#event{name=test_start,
 			   node=node(),
@@ -218,7 +221,7 @@ do_start(Parent, Mode, LogDir, Verbosity) ->
 	    self() ! {{stop,{self(),{user_error,CTHReason}}},
 		      {Parent,make_ref()}}
     end,
-    loop(Mode, [], StartDir).
+    loop(Mode, [], StartDir, CustomStylesheet).
 
 create_table(TableName,KeyPos) ->
     create_table(TableName,set,KeyPos).
@@ -320,18 +323,18 @@ get_verbosity(Category) ->
 	    {error,Reason}
     end.
 
-loop(Mode,TestData,StartDir) ->
+loop(Mode,TestData,StartDir,CustomStylesheet) ->
     receive 
 	{update_last_run_index,From} ->
 	    ct_logs:make_last_run_index(),
 	    return(From,ok),
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{{save_suite_data,{Key,Name,Value}},From} ->
 	    ets:insert(?suite_table, #suite_data{key=Key,
 						 name=Name,
 						 value=Value}),
 	    return(From,ok),
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{{read_suite_data,Key},From} ->
 	    case ets:lookup(?suite_table, Key) of
 		[#suite_data{key=Key,name=undefined,value=Value}] ->
@@ -341,7 +344,7 @@ loop(Mode,TestData,StartDir) ->
 		_ ->
 		    return(From,undefined)
 	    end,
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{{delete_suite_data,Key},From} ->
 	    if Key == all ->
 		    ets:delete_all_objects(?suite_table);
@@ -349,20 +352,20 @@ loop(Mode,TestData,StartDir) ->
 		    ets:delete(?suite_table, Key)
 	    end,
 	    return(From,ok),
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{{match_delete_suite_data,KeyPat},From} ->
 	    ets:match_delete(?suite_table, #suite_data{key=KeyPat,
 						       name='_',
 						       value='_'}),
 	    return(From,ok),
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{delete_testdata,From} ->
 	    return(From,ok),
-	    loop(From,[],StartDir);	
+	    loop(From,[],StartDir,CustomStylesheet);	
 	{{delete_testdata,Key},From} ->
 	    TestData1 = lists:keydelete(Key,1,TestData),
 	    return(From,ok),
-	    loop(From,TestData1,StartDir);
+	    loop(From,TestData1,StartDir,CustomStylesheet);
 	{{match_delete_testdata,{Key1,Key2}},From} ->
 	    %% handles keys with 2 elements
 	    TestData1 =
@@ -380,14 +383,14 @@ loop(Mode,TestData,StartDir) ->
 				     true
 			     end, TestData),
 	    return(From,ok),
-	    loop(From,TestData1,StartDir);
+	    loop(From,TestData1,StartDir,CustomStylesheet);
 	{{set_testdata,New = {Key,_Val}},From} ->
 	    TestData1 = lists:keydelete(Key,1,TestData),
 	    return(From,ok),
-	    loop(Mode,[New|TestData1],StartDir);
+	    loop(Mode,[New|TestData1],StartDir,CustomStylesheet);
 	{{get_testdata, all}, From} ->
 	    return(From, TestData),
-	    loop(From, TestData, StartDir);
+	    loop(From, TestData, StartDir,CustomStylesheet);
 	{{get_testdata,Key},From} ->
 	    case lists:keysearch(Key,1,TestData) of
 		{value,{Key,Val}} ->
@@ -395,7 +398,7 @@ loop(Mode,TestData,StartDir) ->
 		_ ->
 		    return(From,undefined)
 	    end,
-	    loop(From,TestData,StartDir);
+	    loop(From,TestData,StartDir,CustomStylesheet);
 	{{update_testdata,Key,Fun,Opts},From} ->
 	    TestData1 =
 		case lists:keysearch(Key,1,TestData) of
@@ -423,16 +426,16 @@ loop(Mode,TestData,StartDir) ->
 				TestData
 			end
 		end,
-	    loop(From,TestData1,StartDir);	    
+	    loop(From,TestData1,StartDir,CustomStylesheet);
 	{{set_cwd,Dir},From} ->
 	    return(From,file:set_cwd(Dir)),
-	    loop(From,TestData,StartDir);
+	    loop(From,TestData,StartDir,CustomStylesheet);
 	{reset_cwd,From} ->
 	    return(From,file:set_cwd(StartDir)),
-	    loop(From,TestData,StartDir);
+	    loop(From,TestData,StartDir,CustomStylesheet);
 	{get_start_dir,From} ->
 	    return(From,StartDir),
-	    loop(From,TestData,StartDir);
+	    loop(From,TestData,StartDir,CustomStylesheet);
 	{{stop,Info},From} ->
 	    test_server_io:reset_state(),
 	    {MiscIoName,MiscIoDivider,MiscIoFooter} =
@@ -467,7 +470,7 @@ loop(Mode,TestData,StartDir) ->
 	    test_server_io:stop([unexpected_io]),
 	    test_server_io:finish(),
 
-	    ct_logs:close(Info, StartDir),
+	    ct_logs:close(Info, StartDir, CustomStylesheet),
 	    ct_event:stop(),
 	    ct_config:stop(),
 	    ct_default_gl:stop(),
@@ -475,12 +478,12 @@ loop(Mode,TestData,StartDir) ->
 	    return(From, Info);
 	{Ref, _Msg} when is_reference(Ref) ->
 	    %% This clause is used when doing cast operations.
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{get_mode,From} ->
 	    return(From,Mode),
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{'EXIT',_Pid,normal} ->
-	    loop(Mode,TestData,StartDir);
+	    loop(Mode,TestData,StartDir,CustomStylesheet);
 	{'EXIT',Pid,Reason} ->
 	    case ets:lookup(?conn_table,Pid) of
 		[#conn{address=A,callback=CB}] ->
@@ -498,7 +501,7 @@ loop(Mode,TestData,StartDir) ->
 		    catch CB:close(Pid),
 		    %% in case CB:close failed to do this:
 		    unregister_connection(Pid),
-		    loop(Mode,TestData,StartDir);
+		    loop(Mode,TestData,StartDir,CustomStylesheet);
 		_ ->
 		    %% Let process crash in case of error, this shouldn't happen!
 		    io:format("\n\nct_util_server got EXIT "


### PR DESCRIPTION
Via @u3s comment in https://github.com/erlang/otp/pull/7428#issuecomment-1682615350. 

This is not the prettiest solution. The problem is that most of `ct_logs` header formatting had no idea that the custom style sheet was a thing, and neither did most of the sites calling it.