### PR TITLE
Properly handle BEAM files without the "Type" chunk

### DIFF
--- a/erts/emulator/beam/beam_file.c
+++ b/erts/emulator/beam/beam_file.c
@@ -595,6 +595,8 @@ static void init_fallback_type_table(BeamFile *beam) {
     types->fallback = 1;
 
     types->entries[0].type_union = BEAM_TYPE_ANY;
+    types->entries[0].metadata_flags = 0;
+    types->entries[0].size_unit = 1;
     types->entries[0].min = MAX_SMALL + 1;
     types->entries[0].max = MIN_SMALL - 1;
 }


### PR DESCRIPTION
When a BEAM file lacks a "Type" chunk, a default `any` type is set up, but all fields in the type was not initialized, which could lead to the JIT removing type tests when it was not safe to do so.