### PR TITLE
Don't fail type assertion when BEAM file lacks types

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/instr_fun.cpp
@@ -403,7 +403,7 @@ void BeamModuleAssembler::emit_i_call_fun2(const ArgVal &Tag,
          * funs with the same arity. */
         mov_imm(ARG3, MAKE_FUN_HEADER(Arity.get(), 0, 0) & 0xFFFF);
 
-        ASSERT(Tag.as<ArgImmed>().get() != am_safe ||
+        ASSERT(Tag.as<ArgImmed>().get() != am_safe || beam->types.fallback ||
                exact_type<BeamTypeId::Fun>(Func));
         auto target =
                 emit_call_fun(always_one_of<BeamTypeId::AlwaysBoxed>(Func),
@@ -427,7 +427,7 @@ void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
          * funs with the same arity. */
         mov_imm(ARG3, MAKE_FUN_HEADER(Arity.get(), 0, 0) & 0xFFFF);
 
-        ASSERT(Tag.as<ArgImmed>().get() != am_safe ||
+        ASSERT(Tag.as<ArgImmed>().get() != am_safe || beam->types.fallback ||
                exact_type<BeamTypeId::Fun>(Func));
         auto target =
                 emit_call_fun(always_one_of<BeamTypeId::AlwaysBoxed>(Func),

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -372,7 +372,7 @@ void BeamModuleAssembler::emit_i_call_fun2(const ArgVal &Tag,
          * funs with the same arity. */
         mov_imm(ARG3, MAKE_FUN_HEADER(Arity.get(), 0, 0) & 0xFFFF);
 
-        ASSERT(Tag.as<ArgImmed>().get() != am_safe ||
+        ASSERT(Tag.as<ArgImmed>().get() != am_safe || beam->types.fallback ||
                exact_type<BeamTypeId::Fun>(Func));
         auto target =
                 emit_call_fun(always_one_of<BeamTypeId::AlwaysBoxed>(Func),
@@ -396,7 +396,7 @@ void BeamModuleAssembler::emit_i_call_fun2_last(const ArgVal &Tag,
          * funs with the same arity. */
         mov_imm(ARG3, MAKE_FUN_HEADER(Arity.get(), 0, 0) & 0xFFFF);
 
-        ASSERT(Tag.as<ArgImmed>().get() != am_safe ||
+        ASSERT(Tag.as<ArgImmed>().get() != am_safe || beam->types.fallback ||
                exact_type<BeamTypeId::Fun>(Func));
         auto target =
                 emit_call_fun(always_one_of<BeamTypeId::AlwaysBoxed>(Func),


### PR DESCRIPTION
In the DEBUG build, the assertion that checks that a fun about to be called is a fun would fail if the type information had been stripped from the BEAM file.