### PR TITLE
binary module: Always reject bitstrings

### DIFF
--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1965,10 +1965,14 @@ BIF_RETTYPE erts_binary_part(Process *p, Eterm binary, Eterm epos, Eterm elen)
 	goto badarg;
     }
 
+    ERTS_GET_REAL_BIN(binary, orig, offset, bit_offset, bit_size);
+
+    if (bit_size != 0) {
+        goto badarg;
+    }
+
     hp = HeapFragOnlyAlloc(p, EXTRACT_SUB_BIN_HEAP_NEED);
     hp_end = hp + EXTRACT_SUB_BIN_HEAP_NEED;
-
-    ERTS_GET_REAL_BIN(binary, orig, offset, bit_offset, bit_size);
 
     result = erts_extract_sub_binary(&hp, orig, binary_bytes(orig),
                                      (offset + pos) * 8 + bit_offset,
@@ -2471,13 +2475,13 @@ static BIF_RETTYPE do_binary_copy(Process *p, Eterm bin, Eterm en)
     if (!term_to_Uint(en, &n)) {
 	goto badarg;
     }
-    if (!n) {
-	Eterm res_term = erts_new_heap_binary(p,NULL,0,&bytes);
-	BIF_RET(res_term);
-    }
     ERTS_GET_BINARY_BYTES(bin,bytes,bit_offs,bit_size);
     if (bit_size != 0) {
 	goto badarg;
+    }
+    if (n == 0) {
+        Eterm res_term = erts_new_heap_binary(p, NULL, 0, &bytes);
+        BIF_RET(res_term);
     }
 
     size = binary_size(bin);

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -125,6 +125,11 @@ badargs(Config) when is_list(Config) ->
 	?MASK_ERROR(
 	   binary_part(make_unaligned(<<1,2,3>>),{16#FF,
 						  -16#7FFF})),
+    badarg = ?MASK_ERROR(binary:part(<<1:1>>, id({0,0}))),
+    badarg = ?MASK_ERROR(binary_part(<<1:1>>, id({0,0}))),
+    badarg = ?MASK_ERROR(binary:part(<<1:1>>, id(0), 0)),
+    badarg = ?MASK_ERROR(binary_part(<<1:1>>, id(0), 0)),
+
     badarg =
 	?MASK_ERROR(
 	   binary:bin_to_list(<<1,2,3>>,{16#FF,
@@ -800,6 +805,8 @@ copy(Config) when is_list(Config) ->
     true = RS =:= RS2,
     false = erts_debug:same(RS, RS2),
     <<>> = ?MASK_ERROR(binary:copy(<<1,2,3>>,0)),
+    badarg = ?MASK_ERROR(binary:copy(<<1:1>>,0)),
+    badarg = ?MASK_ERROR(binary:copy(<<1,2,3:3>>,0)),
     badarg = ?MASK_ERROR(binary:copy(<<1,2,3:3>>,2)),
     badarg = ?MASK_ERROR(binary:copy([],0)),
     <<>> = ?MASK_ERROR(binary:copy(<<>>,0)),


### PR DESCRIPTION
The call `binary:copy(<<1:1>>, 0)` would return an empty binary instead of raising an exception. Similarly, calls to `binary:part/{2,3}` attempting to extract 0 bytes at position 0 of a bitstring would return an empty binary instead of raising an exception.