### PR TITLE
[erts] Fix local_node_hash

### DIFF
--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -179,6 +179,8 @@ void erts_late_init_external(void)
     /* pid... */
     memcpy(&lnid[lnid_ix], &pidstr[0], pidstr_len);
 
+    lnid_ix += pidstr_len;
+
     /*
      * Use least significant 32 bits of monotonic time as initial
      * value to hash...


### PR DESCRIPTION
Fixed minor hashing issue with the `local` option of `term_to_binary()`/`term_to_iovec()`.