### PR TITLE
eunit: Add possibility to scale timeouts

### DIFF
--- a/lib/eunit/src/eunit.erl
+++ b/lib/eunit/src/eunit.erl
@@ -140,6 +140,11 @@ test(Tests) ->
 %% not automatically execute tests found in related module suffixed with "_tests".
 %% This behaviour might be unwanted if execution of modules found in a folder
 %% is ordered while it contains both source and test modules.</dd>
+%% <dt>`scale_timeouts'</dt>
+%% <dd>If this numeric value is set, timeouts will get scaled accordingly.
+%% It may be useful when running a set of tests on a slower host.
+%% Examples: `{scale_timeouts,10}' make the timeouts 10 times longer, while
+%% `{scale_timeouts,0.1}' would shorten them by a factor of 10.</dd>
 %% </dl>
 %%
 %% Options in the environment variable EUNIT are also included last in

--- a/lib/eunit/src/eunit_proc.erl
+++ b/lib/eunit/src/eunit_proc.erl
@@ -336,9 +336,21 @@ clear_timeout(Ref) ->
     erlang:cancel_timer(Ref).
 
 with_timeout(undefined, Default, F, St) ->
-    with_timeout(Default, F, St);
+    with_timeout(scale_timeout(Default, St), F, St);
 with_timeout(Time, _Default, F, St) ->
-    with_timeout(Time, F, St).
+    with_timeout(scale_timeout(Time, St), F, St).
+
+scale_timeout(infinity, _St) ->
+    infinity;
+scale_timeout(Time, St) ->
+    case proplists:get_value(scale_timeouts, St#procstate.options) of
+        undefined ->
+            Time;
+        N when is_integer(N) ->
+            N * Time;
+        N when is_float(N) ->
+            round(N * Time)
+    end.
 
 with_timeout(infinity, F, _St) ->
     %% don't start timers unnecessarily


### PR DESCRIPTION
Add an option to `eunit:test(..., Options)`:

    {scale_timeouts, N}

Motivation: I ran a bunch of tests on an s390 qemu guest on an x86_64 host to test some NIF code on big endian. This executed much slower, and some of the unit tests timed out. The default eunit timeout is 5 seconds. One can increase it, for example by using a test generator with a `{timeout, Seconds, TestOrTests}` and change xyz_test/0 to xyz_test/1. But this becomes tedious when there are many tests. And to commit such a change to the test code just to accommodate for an unusually slow host doesn't seem like an attractive way to go. Being able to scale the timeouts seems like a good middle ground.

Note that eunit can already read the `$EUNIT` environment var for one-off runs from the command line with increased timeouts.

I made the PR to target the maint branch. Let me know if I should change it to the master branch instead.