### PR TITLE
x32 support

### DIFF
--- a/erts/lib_src/pthread/ethread.c
+++ b/erts/lib_src/pthread/ethread.c
@@ -190,7 +190,7 @@ ppc_init__(void)
 void
 ethr_x86_cpuid__(int *eax, int *ebx, int *ecx, int *edx)
 {
-#if ETHR_SIZEOF_PTR == 4
+#if ETHR_SIZEOF_PTR == 4 && !defined(__ILP32__)
     int have_cpuid;
     /*
      * If it is possible to toggle eflags bit 21,
@@ -217,7 +217,7 @@ ethr_x86_cpuid__(int *eax, int *ebx, int *ecx, int *edx)
 	return;
     }
 #endif
-#if ETHR_SIZEOF_PTR == 4 && defined(__PIC__) && __PIC__
+#if ETHR_SIZEOF_PTR == 4 && defined(__PIC__) && __PIC__ && !defined(__ILP32__)
     /*
      * When position independent code is used in 32-bit mode, the B register
      * is used for storage of global offset table address, and we may not

--- a/lib/crypto/configure.ac
+++ b/lib/crypto/configure.ac
@@ -397,7 +397,7 @@ search_subdirs="lib"
 if test "$ac_cv_sizeof_void_p" = "8"; then
    search_subdirs="$search_subdirs lib64 lib/64"
 else
-   search_subdirs="$search_subdirs lib32 lib/32"
+   search_subdirs="$search_subdirs lib32 lib/32 libx32"
 fi
 test "$multiarch_dir" = "" || search_subdirs="lib/$multiarch_dir $search_subdirs"
 test "$with_ssl_lib_subdir" = "" || search_subdirs="$with_ssl_lib_subdir $search_subdirs"


### PR DESCRIPTION
Hello,

This PR is about two fixes that enable building Erlang/OTP for x32 ABI Linux.

Some references about x32 is here:

* https://en.wikipedia.org/wiki/X32_ABI
* https://sites.google.com/site/x32abi/home?authuser=0

I know that a few people would need x32 in their projects. But for sure that are cases where it would be desirable. So, I don´t expect that this PR would be accept. However the fixes seems not have any side effects when others architectures are build.

Also, I wrote a small blog post about my experience here: https://meta-erlang.github.io/blog/2023/09/02/index/ 

Thanks.