### PR TITLE
ASN.1 JER: Refactor type-information handling

### DIFF
--- a/lib/asn1/test/Makefile
+++ b/lib/asn1/test/Makefile
@@ -42,6 +42,7 @@ MODULES= \
 	testChoTypeRefSeq \
 	testChoTypeRefSet \
 	testConstraints \
+	testContaining \
 	testDef \
 	testExtensionDefault \
 	testOpt \

--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -137,6 +137,7 @@ all() ->
      testNortel,
      test_WS_ParamClass,
      test_modified_x420,
+     testContaining,
 
      %% Some heavy tests.
      testTcapsystem,
@@ -627,7 +628,8 @@ parse(Config) ->
     [asn1_test_lib:compile(M, Config, [abs]) || M <- test_modules()].
 
 per(Config) ->
-    test(Config, fun per/3, [per,uper,{per,[maps]},{uper,[maps]}]).
+    test(Config, fun per/3,
+         [per,uper,{per,[maps]},{uper,[maps]},{per,[jer]}]).
 per(Config, Rule, Opts) ->
     module_test(per_modules(), Config, Rule, Opts).
 
@@ -1138,6 +1140,20 @@ testExtensionAdditionGroup(Config, Rule, Opts) ->
     asn1_test_lib:compile("EUTRA-RRC-Definitions", Config,
 			  [Rule,{record_name_prefix,"RRC-"}|Opts]),
     extensionAdditionGroup:run(Rule).
+
+testContaining(Config) ->
+    test(Config, fun testContaining/3).
+testContaining(Config, Rule, Opts) ->
+    asn1_test_lib:compile("Containing", Config, [Rule|Opts]),
+    testContaining:containing(Rule),
+    case {Rule,have_jsonlib()} of
+        {per,true} ->
+            io:format("Testing with both per and jer...\n"),
+            asn1_test_lib:compile("Containing", Config, [jer,Rule|Opts]),
+            testContaining:containing(per_jer);
+        _ ->
+            ok
+    end.
 
 per_modules() ->
     [X || X <- test_modules()].

--- a/lib/asn1/test/asn1_SUITE_data/Containing.asn1
+++ b/lib/asn1/test/asn1_SUITE_data/Containing.asn1
@@ -1,0 +1,20 @@
+Containing DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+   Config ::= SEQUENCE {
+     a INTEGER,
+     b BOOLEAN
+   }
+
+   Seq ::= SEQUENCE {
+     tag INTEGER,
+     contains BIT STRING (CONTAINING Config)
+   }
+
+   Str ::= OCTET STRING (CONTAINING Seq)
+
+   -- CONTAINING is ignored when ENCODED BY is present
+   Other ::= OCTET STRING (CONTAINING INTEGER ENCODED BY {joint-iso-itu-t(2) asn1(1)
+                                                          packed-encoding(3) basic(0) aligned(0)})
+   -- CONTAINING is ignored for nameless constructed types
+   NewSequence ::= BIT STRING (CONTAINING SEQUENCE { z BOOLEAN })
+END

--- a/lib/asn1/test/testContaining.erl
+++ b/lib/asn1/test/testContaining.erl
@@ -1,0 +1,52 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%%
+-module(testContaining).
+
+-export([containing/1]).
+
+containing(Rules) ->
+    RoundTrip =
+        case Rules of
+            per_jer ->
+                fun roundtrip_per_jer/2;
+            _ ->
+                fun roundtrip/2
+        end,
+    RoundTrip('Config', {'Config',42,true}),
+    RoundTrip('Seq', {'Seq',17,<<"abc">>}),
+    RoundTrip('Str', <<"xyz">>),
+    RoundTrip('Other', <<"other">>),
+    RoundTrip('NewSequence', <<1,2,3,4>>),
+
+    ok.
+
+roundtrip(Type, Value) ->
+    asn1_test_lib:roundtrip('Containing', Type, Value).
+
+roundtrip_per_jer(Type, Value) ->
+    Mod = 'Containing',
+    case Mod:jer_encode(Type, Value) of
+        {ok,Encoded} ->
+            {ok,Value} = Mod:jer_decode(Type, Encoded);
+        Encoded when is_binary(Encoded) ->
+            Value = Mod:jer_decode(Type, Encoded)
+    end,
+    Encoded.


### PR DESCRIPTION
This pull request refactors how type information for ASN.1 is handled for the JER back-end, and is a compatible change for applications that use the documented API. However, for a group of ASN.1 modules that depend on each other (such a `S1AP-PDU-Descriptions`, `S1AP-Contents`, `S1AP-IEs`, and so on), all members of the group must be recompiled if any one of the group members is recompiled.

The internal changes are intended to help tools that need to process type information for ASN.1 specifications, but note that the format of the type information may be updated in a future release. Tool makers must be prepared to update their tools if the format changes.

To explain the changes, I will use this ASN.1 specification as an example:

    Containing DEFINITIONS AUTOMATIC TAGS ::=
    BEGIN
      Config ::= SEQUENCE {
        a INTEGER,
        b BOOLEAN
      }

      Str ::= OCTET STRING (CONTAINING Config)
    END

The first change is that instead having one `typeinfo_Type/0` function for each ASN.1 type in a module, there is now a single `typeinfo/1` function.

For the example, the call `'Containing':typeinfo('Str')` retrieves the type information for the `Str` type.

The second change is that for types having a `CONTAINING` constraint, the constraint will be preserved in the type information. Thus, the type information returned for the `Str` type will be:

    {container,octet_string,{typeinfo,{'Containing','Config'}}}.