### PR TITLE
CI: Force rebuild of proper

### DIFF
--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -111,7 +111,7 @@ RUN export PATH="$(cat /home/${USER}/LATEST)/${PATH}" && \
     latest erlang/rebar3 && ls -la && \
     (tar xzf rebar3.tar.gz && cd rebar3-* && ./bootstrap && sudo cp rebar3 /usr/bin) && \
     latest proper-testing/proper && \
-    (tar xzf proper.tar.gz && mv proper-* proper && cd proper && make) && \
+    (tar xzf proper.tar.gz && mv proper-* proper && cd proper && make clean && make) && \
     latest talentdeficit/jsx && \
     (tar xzf jsx.tar.gz && mv jsx-* jsx && cd jsx && rebar3 compile)
 

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -43,6 +43,14 @@
 -compile({inline, [badarg_with_cause/2, badarg_with_info/1,
                    error_with_info/2]}).
 
+
+%% WIP: Dummy export to force STDLIB tests to be run. To be removed.
+-export([dummy/0]).
+
+-spec dummy() -> any().
+dummy() ->
+    ok.
+
 -spec at(Subject, Pos) -> byte() when
       Subject :: binary(),
       Pos :: non_neg_integer().


### PR DESCRIPTION
The runtime system on the master refuses to load BEAM files compiled before Erlang/OTP 24. As it seems that the tar file for proper contains old BEAM files, we must rebuild from scratch.