### PR TITLE
Fix ubuntu-base cache of old Erlang installs

### DIFF
--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -52,9 +52,11 @@ RUN apt-get install -y git curl && \
     chmod +x /usr/bin/kerl && \
     kerl update releases && \
     LATEST=$(kerl list releases | tail -1 | awk -F '.' '{print $1}') && \
-    echo "/usr/local/lib/erlang-${LATEST}/bin" > /home/${USER}/LATEST && \
     for release in $(seq $(( LATEST - 2 )) $(( LATEST ))); do \
       VSN=$(kerl list releases | grep "^$release" | tail -1); \
+      if [ $release = $LATEST ]; then \
+        echo "/usr/local/lib/erlang-${VSN}/bin" > /home/${USER}/LATEST; \
+      fi && \
       kerl build ${VSN} ${VSN} && \
       kerl install ${VSN} /usr/local/lib/erlang-${VSN}; \
     done && \
@@ -102,7 +104,7 @@ COPY --chown=${USER}:${GROUP} dockerfiles/init.sh /buildroot/
 WORKDIR /buildroot/
 
 ## Install test tools rebar3, proper and jsx
-RUN export PATH="$(cat /home/${USER}/LATEST)/${PATH}" && \
+RUN export PATH="$(cat /home/${USER}/LATEST):${PATH}" && \
     latest () { \
     local VSN=$(curl -sL "https://api.github.com/repos/$1/tags" | jq -r ".[] | .name" | grep -E '^v?[0-9]' | sort -V | tail -1); \
     curl -sL "https://github.com/$1/archive/$VSN.tar.gz" > $(basename $1).tar.gz; \

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache@v3
         with:
             path: otp_docker_base.tar
-            key: ${{ runner.os }}-${{ hashFiles('.github/dockerfiles/Dockerfile.ubuntu-base', '.github/scripts/build-base-image.sh') }}
+            key: ${{ runner.os }}-${{ hashFiles('.github/dockerfiles/Dockerfile.ubuntu-base', '.github/scripts/build-base-image.sh') }}-${{ hashFiles('OTP-VERSION') }}
       - name: Build BASE image
         run: .github/scripts/build-base-image.sh "${BASE_BRANCH}" 64-bit
       - name: Cache pre-built tar archives

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -107,15 +107,20 @@ jobs:
              "${{ needs.pr-number.outputs.result }}"
 
       - name: Deploy to github pages 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
-        with:
-          token: ${{ secrets.ERLANG_TOKEN }}
-          branch: master # The branch the action should deploy to.
-          folder: erlang.github.io # The folder the action should deploy.
-          repository-name: erlang/erlang.github.io
-          single-commit: true
+        run: |
+          cd erlang.github.io
+          set -x
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git add -u
+          git update-index --refresh
+          if ! git diff-index --quiet HEAD --; then
+            git commit -m "Update github pages content"
+            git push origin master
+          fi
 
-        ## Append some usefull links and tips to the test results posted by
+        ## Append some useful links and tips to the test results posted by
         ## Publish CT Test Results
       - uses: actions/github-script@v5.1.1
         if: always()


### PR DESCRIPTION
The old installed old Erlangs used for compatibility testing would not be updated when the should be. This PR makes sure that they are.