### PR TITLE
Export documented and exposed type binary:part/0

### DIFF
--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -27,6 +27,7 @@
 
 -opaque cp() :: {'am' | 'bm', reference()}.
 -type part() :: {Start :: non_neg_integer(), Length :: integer()}.
+-export_type([part/0]).
 
 %%% BIFs.
 


### PR DESCRIPTION
Exposed (and documented) at https://www.erlang.org/doc/man/binary.html#type-part.