### PR TITLE
timer: Don't silently ignore errors when spawning processes

### DIFF
--- a/lib/stdlib/src/timer.erl
+++ b/lib/stdlib/src/timer.erl
@@ -601,12 +601,12 @@ do_apply({erlang, exit, [Name, Reason]}, _) ->
 do_apply({M,F,A}, false) ->
     try spawn(M, F, A)
     of _ -> {ok, spawn}
-    catch _:_ -> error
+    catch error:badarg -> error
     end;
 do_apply({M, F, A}, true) ->
     try spawn_monitor(M, F, A)
     of {_, Ref} -> {ok, {spawn, Ref}}
-    catch _:_ -> error
+    catch error:badarg -> error
     end.
 
 %% Get current time in milliseconds,


### PR DESCRIPTION
When a timer created by `timer` had expired and it was time to spawn a process to apply a user function, a `system_limit` exception (indicating that the limit for the number of processes in the system had been reached) would be silently ignored.

Since there is not really anything that can be done in this situation, be sure to terminate the system so that the problem is noticed. Note that that other parts of OTP don't attempt to cope with the failure to spawn processes because of a `system_limit` exception.

Fixes #7606