### PR TITLE
stdlib: garbage collect when saved shell history is reduced.

### DIFF
--- a/lib/stdlib/doc/src/shell.xml
+++ b/lib/stdlib/doc/src/shell.xml
@@ -144,6 +144,8 @@
       <tag><c>f(X)</c></tag>
       <item>
         <p>Removes the binding of variable <c>X</c>.</p>
+        <note><p>If a huge value is stored in a variable binding, you have to both call <c>f(X)</c> and
+    call <c>history(0)</c> or <c>results(0)</c> to free up that memory.</p></note>
       </item>
       <tag><c>h()</c></tag>
       <item>

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -244,6 +244,9 @@ server_loop(N0, Eval_0, Bs00, RT, Ds00, History0, Results0) ->
                     if
                         HB ->
                             garb(self());
+                        Results < Results0 ->
+                            erlang:display({garb}),
+                            garb(self());
                         true ->
                             ok
                     end,


### PR DESCRIPTION
If you bind a variable to a value that is very large, you may want to free up that memory when you don't need that variable anymore. You can call history(0) and f(), but you would have to wait for the shell process to do garbage collection or force it to free up that memory. This change makes the shell do garbage collection after history is called with a value lower than the currently configured saved history.
```
1> history(20).
10
2> history(0). %% Will trigger gc for the shell process
```