### PR TITLE
Fix link problem with Xcode 15

### DIFF
--- a/HOWTO/INSTALL-WIN32.md
+++ b/HOWTO/INSTALL-WIN32.md
@@ -61,8 +61,8 @@ This is the short story though, for the experienced and impatient:
     *   Get, build and install OpenSSL v1.1.1d or later (up to 1.1.1d
         tried & working) with static libs.
 
-    *   Get, build and install wxWidgets-3.1.3 or later (up to 3.1.3
-        tried & working) with static libs.
+    *   Get, build and install wxWidgets-3.2.2.1 or later (up to that
+        version tried & working) with static libs.
 
     *   Get the Erlang source distribution (from
         <http://www.erlang.org/download.html>) and unpack with `tar`
@@ -152,20 +152,20 @@ the different tools:
 *   wxWidgets (optional)
     You need this to build wx to use gui's in debugger and observer.
 
-    We recommend v3.1.4 or later.
-    Unpack into `c:/opt/local64/pgm/wxWidgets-3.1.4`
+    We recommend v3.2.2.1 or later.
+    Unpack into `c:/opt/local64/pgm/wxWidgets-3.2.2.1`
 
-    If the `wxUSE_POSTSCRIPT` isn't enabled in  `c:/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h`,
+    If the `wxUSE_POSTSCRIPT` isn't enabled in  `c:/opt/local64/pgm/wxWidgets-3.2.2.1/include/wx/msw/setup.h`,
     enable it.
 
     We recommend to enable for wxWebView wxUSE_WEBVIEW_EDGE.
     *   Download the nuget package 'Microsoft.Web.WebView2' (Version 0.9.488 or newer)
     *   Extract the package (it's a zip archive) to wxWidgets/3rdparty/webview2 (you should have 3rdparty/webview2/build/native/include/WebView2.h file after unpacking it)
-    *   Enable wxUSE_WEBVIEW_EDGE in `c:/opt/local64/pgm/wxWidgets-3.1.4/include/wx/msw/setup.h`
+    *   Enable wxUSE_WEBVIEW_EDGE in `c:/opt/local64/pgm/wxWidgets-3.2.2.1/include/wx/msw/setup.h`
 
     Build with:
 
-        C:\...\> cd c:\opt\local64\pgm\wxWidgets-3.1.4\build\msw
+        C:\...\> cd c:\opt\local64\pgm\wxWidgets-3.2.2.1\build\msw
         C:\...\> nmake TARGET_CPU=amd64 BUILD=release SHARED=0 DIR_SUFFIX_CPU= -f makefile.vc
 
     Remove the `TARGET_CPU=amd64` for 32bit build.

--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -6,7 +6,7 @@ Introduction
 
 This document describes how to build and install Erlang/OTP-%OTP-REL%.
 Erlang/OTP should be possible to build from source on any Unix/Linux system,
-including OS X. You are advised to read the whole document
+including macOS. You are advised to read the whole document
 before attempting to build and install Erlang/OTP.
 
 The source code can be downloaded from the official site of Erlang/OTP or GitHub.
@@ -38,7 +38,7 @@ These are the tools you need in order to unpack and build Erlang/OTP.
 
 Build the same way as when building the unpacked tar file.
 
-#### Building on OS X ####
+#### Building on macOS ####
 
 *   Xcode -- Download and install via the Mac App Store.
     Read about [Building on a Mac][] before proceeding.
@@ -533,7 +533,7 @@ Other useful information can be found at our GitHub wiki:
 
 Build the same way as when building the unpacked tar file.
 
-#### OS X (Darwin) ####
+#### macOS (Darwin) ####
 
 Make sure that the command `hostname` returns a valid fully qualified host
 name (this is configured in `/etc/hostconfig`). Otherwise you might experience
@@ -549,21 +549,24 @@ If you have Xcode 4.3, or later, you will also need to download
 
 #### Building with wxErlang ####
 
-If you want to build the `wx` application, you will need to get wxWidgets-3.0
-(`wxWidgets-3.0.3.tar.bz2` from <https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3/wxWidgets-3.0.3.tar.bz2>) or get it from github with bug fixes:
+wxWidgets-3.2.x is recommended for building the `wx` application
+(wxWidgets-3.0.x will also work). Download it from
+<https://www.wxwidgets.org/downloads> or from
+<https://github.com/wxWidgets/wxWidgets>. It is recommended to use the
+latest release in the 3.2 series, which at the time of writing
+is 3.2.2.1.
 
-    $ git clone --branch WX_3_0_BRANCH git@github.com:wxWidgets/wxWidgets.git
+Note that the wxWidgets-3.3 versions are experimental, but they should
+also work if 3.0 compatibility is enabled by adding
+`--enable-compat30` to the `configure` commands below.
 
-The wxWidgets-3.1 version should also work if 2.8 compatibility is enabled,
-add `--enable-compat28` to configure commands below.
-
-Configure and build wxWidgets (shared library on linux):
+On all other platforms, a shared library is built as follows:
 
     $ ./configure --prefix=/usr/local
     $ make && sudo make install
     $ export PATH=/usr/local/bin:$PATH
 
-Configure and build wxWidgets (static library on linux):
+On Linux, a static library is built as follows:
 
     $ export CFLAGS=-fPIC
     $ export CXXFLAGS=-fPIC
@@ -571,26 +574,28 @@ Configure and build wxWidgets (static library on linux):
     $ make && sudo make install
     $ export PATH=/usr/local/bin:$PATH
 
-Configure and build wxWidgets (on Mavericks - 10.9):
+On macOs, a static library compatible with macOS 13 (Ventura) and later is built
+as follows:
 
-    $ ./configure --with-cocoa --prefix=/usr/local
-    or without support for old versions and with static libs
-    $ ./configure --with-cocoa --prefix=/usr/local --with-macosx-version-min=10.9 --disable-shared
+    $ ./configure --prefix=/usr/local --with-macosx-version-min=13.0 --disable-shared
     $ make
     $ sudo make install
     $ export PATH=/usr/local/bin:$PATH
 
-Check that you got the correct wx-config
+Verify that the build and installation succeeded:
 
     $ which wx-config && wx-config --version-full
 
-Build Erlang/OTP
+Expected output is `/usr/local/bin/wx-config` on one line, followed by the full
+version number. For example, if you built version 3.2.2.1, the expected output is:
 
-    $ export PATH=/usr/local/bin:$PATH
-    $ cd $ERL_TOP
-    $ ./configure
-    $ make
-    $ sudo make install
+    /usr/local/bin/wx-config
+    3.2.2.1
+
+Build Erlang/OTP in the usual way. To verify that `wx` application is
+working run the following command:
+
+    $ erl -run wx demo
 
 
 #### Pre-built Source Release ####
@@ -780,6 +785,6 @@ Operating system
    [cross build]: INSTALL-CROSS.md
    [Required Utilities]: #Required-Utilities
    [Optional Utilities]: #Optional-Utilities
-   [Building on a Mac]: #Advanced-configuration-and-build-of-ErlangOTP_Building_OS-X-Darwin
+   [Building on a Mac]: #Advanced-configuration-and-build-of-ErlangOTP_Building_macOS-Darwin
    [Building with wxErlang]: #Advanced-configuration-and-build-of-ErlangOTP_Building_Building-with-wxErlang
    [libatomic_ops]: https://github.com/ivmai/libatomic_ops/

--- a/lib/wx/c_src/Makefile.in
+++ b/lib/wx/c_src/Makefile.in
@@ -182,7 +182,7 @@ $(TARGET_DIR)/wxe_driver$(SO_EXT): $(WX_OBJECTS)
 
 $(TARGET_DIR)/erl_gl$(SO_EXT): $(GL_OBJECTS)
 	$(V_at)mkdir -p $(TARGET_DIR)
-	$(V_CC) $(LDFLAGS) $(GL_OBJECTS) $(GL_LIBS) -o $@
+	$(V_CXX) $(LDFLAGS) $(GL_OBJECTS) $(GL_LIBS) -o $@
 
 $(WEBVIEW_LOADER_DLL_DEST): $(WEBVIEW_LOADER_DLL_ORIG)
 	$(INSTALL_PROGRAM) $< $@

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -5248,13 +5248,14 @@ esac
 
 
 
+EXTRA_LDFLAGS=
+
 case $host_os in
     darwin*)
-	LDFLAGS="$MAC_MIN -bundle -flat_namespace -undefined warning -fPIC $LDFLAGS"
-	# Check sizof_void_p as future will hold 64bit MacOS wx
-	if test $ac_cv_sizeof_void_p = 4; then
-	    LDFLAGS="-m32 $LDFLAGS"
-	fi
+        # beam.smp has not been built yet, so we must not use the
+        # -bundle_loader option in the configuration tests.
+	LDFLAGS="$MAC_MIN -bundle $LDFLAGS"
+	EXTRA_LDFLAGS=" -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
 	GL_LIBS="-framework OpenGL"
 	;;
     win32)
@@ -7019,6 +7020,8 @@ saved_LIBS=$LIBS
 
 if test X"$WX_HAVE_STATIC_LIBS" = X"true" ; then
    LIBS=$WX_LIBS_STATIC
+else
+   LIBS=$WX_LIBS
 fi
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -7079,6 +7082,8 @@ fi
 
 
 fi
+LDFLAGS="$LDFLAGS$EXTRA_LDFLAGS"
+
 
 
 if test "x$GCC" = xyes

--- a/lib/wx/configure.ac
+++ b/lib/wx/configure.ac
@@ -200,13 +200,14 @@ AC_SUBST(GLIB_LIBS)
 AC_SUBST(OBJC_CC)
 AC_SUBST(OBJC_CFLAGS)
 
+EXTRA_LDFLAGS=
+
 case $host_os in
     darwin*)
-	LDFLAGS="$MAC_MIN -bundle -flat_namespace -undefined warning -fPIC $LDFLAGS"
-	# Check sizof_void_p as future will hold 64bit MacOS wx
-	if test $ac_cv_sizeof_void_p = 4; then
-	    LDFLAGS="-m32 $LDFLAGS"
-	fi		   
+        # beam.smp has not been built yet, so we must not use the
+        # -bundle_loader option in the configuration tests.
+	LDFLAGS="$MAC_MIN -bundle $LDFLAGS"
+	EXTRA_LDFLAGS=" -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
 	GL_LIBS="-framework OpenGL"
 	;;
     win32)
@@ -666,6 +667,8 @@ saved_LIBS=$LIBS
 
 if test X"$WX_HAVE_STATIC_LIBS" = X"true" ; then
    LIBS=$WX_LIBS_STATIC   
+else
+   LIBS=$WX_LIBS
 fi
 
 AC_LINK_IFELSE([AC_LANG_SOURCE([[
@@ -702,6 +705,8 @@ if test X"$CAN_LINK_WX" != X"yes" ; then
 fi
 
 ]) dnl - if test "$WXERL_CAN_BUILD_DRIVER" != "false"
+
+LDFLAGS="$LDFLAGS$EXTRA_LDFLAGS"
 
 AC_SUBST(WXERL_CAN_BUILD_DRIVER)
 


### PR DESCRIPTION
The dynamic libraries for the `wx` application would fail to build with the new linker in Xcode 15 for macOS. One workaround is to force the old linker to be used, but that will stop working when the the old linker is eventually retired.

It turns out that `wx` uses a very old way to create dynamic libraries. Essentially it asks the linker to accept that there are references to undefined symbols, trusting that they will be defined when the dynamic library is loaded. That is done using the following options:

    -bundle -flat_namespace -undefined suppress

The option `-undefined suppress` is deprecated by the new linker and it will consider undefined symbols to be an error.

A more modern approaph to creating dynamic libraries is to use the the `-bundle_loader` option to point out an executable that can be used to satisfy references to undefined symbols:

     -bundle -bundle_loader $ERL_TOP/bin/aarch64-apple-darwin22.6.0/beam.smp

Care must be taken not to include the `-bundler_loader` option in `configure` tests that test linking, because the `beam.smp` executable has not been built at that time and the linker in older Xcode releases will complain if the executable does not exist. It seems that Xcode 15 will check that the executable exists only if there are references to undefined symbols.

While at it, update the ancient build instructions for wxWidgets.