### PR TITLE
Fix windows CI (again)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -238,7 +238,7 @@ jobs:
         shell: cmd
         run: |
           choco install openssl
-          move "c:\\Program Files\\OpenSSL-Win64" "c:\\OpenSSL-Win64"
+          IF EXIST "c:\\Program Files\\OpenSSL-Win64" (move "c:\\Program Files\\OpenSSL-Win64" "c:\\OpenSSL-Win64") ELSE (move "c:\\Program Files\\OpenSSL" "c:\\OpenSSL-Win64")
 
       - name: Cache wxWidgets
         uses: actions/cache@v3


### PR DESCRIPTION
GitHub pushed a fix for the previous regression into their windows image, so effectively reverting the previous change. But avoid having to change this again making this conditional to work with both.