### PR TITLE
`code` instead of `tt`

### DIFF
--- a/erts/emulator/asan/asan_logs_to_html
+++ b/erts/emulator/asan/asan_logs_to_html
@@ -79,7 +79,7 @@ run(OutDir, InDir) ->
     {ok, Host} = inet:gethostname(),
     Seconds = (erlang:monotonic_time(millisecond) - StartTime) / 1000,
     ok = io:format(Out, "\n<hr><p><small>This page was generated ~s\n"
-                   " by <tt>~s</tt>\n"
+                   " by <code>~s</code>\n"
                    " run by ~s@~s in ~.1f seconds.</small></p>\n",
                    [Time, ThisFile, User, Host, Seconds]),
 

--- a/lib/common_test/src/test_server_ctrl.erl
+++ b/lib/common_test/src/test_server_ctrl.erl
@@ -1523,7 +1523,7 @@ do_test_cases(TopCases, SkipCases,
 	    print(html, xhtml("\n<p><b>Host info:</b><br>\n",
 			      "\n<p><b>Host info:</b><br />\n")),
 	    print_who(test_server_sup:hoststr(), test_server_sup:get_username()),
-	    print(html, xhtml("<br>Used Erlang v~ts in <tt>~ts</tt></p>\n",
+	    print(html, xhtml("<br>Used Erlang v~ts in <code>~ts</code></p>\n",
 			      "<br />Used Erlang v~ts in \"~ts\"</p>\n"),
 		  [erlang:system_info(version), code:root_dir()]),
 	    
@@ -1531,7 +1531,7 @@ do_test_cases(TopCases, SkipCases,
 		    print(html, xhtml("\n<p><b>Target Info:</b><br>\n",
 				      "\n<p><b>Target Info:</b><br />\n")),
 		    print_who(TI#target_info.host, TI#target_info.username),
-		    print(html,xhtml("<br>Used Erlang v~ts in <tt>~ts</tt></p>\n",
+		    print(html,xhtml("<br>Used Erlang v~ts in <code>~ts</code></p>\n",
 				     "<br />Used Erlang v~ts in \"~ts\"</p>\n"),
 			  [TI#target_info.version, TI#target_info.root_dir]);
 	       true ->

--- a/lib/erl_docgen/priv/dtd/book.dtd
+++ b/lib/erl_docgen/priv/dtd/book.dtd
@@ -41,9 +41,9 @@
 <!ELEMENT preamble	      (contents?,preface?) >
 <!ELEMENT preface	      (title?,(%block;|quote|br|marker|warning|note|change|dont|do|table)*) >
 
-<!ELEMENT insidecover         (#PCDATA|br|theheader|vfill|vspace|tt|bold|
+<!ELEMENT insidecover         (#PCDATA|br|theheader|vfill|vspace|code|bold|
 			       include)* >
-<!ELEMENT tt                  (#PCDATA|br|theheader|vfill)* >
+<!ELEMENT code                (#PCDATA|br|theheader|vfill)* >
 <!ELEMENT bold                (#PCDATA|br|theheader|vfill)* >
 <!ELEMENT vfill               EMPTY >
 <!ELEMENT theheader           EMPTY >

--- a/lib/eunit/doc/overview.edoc
+++ b/lib/eunit/doc/overview.edoc
@@ -834,7 +834,7 @@ other code).
 <dd>This creates a test set from all the modules belonging to the
 specified application, by consulting the application's `.app' file
 (see `{file, FileName}'), or if no such file exists, by testing all
-object files in the application's <tt>ebin</tt>-directory (see `{dir,
+object files in the application's <code>ebin</code>-directory (see `{dir,
 Path}'); if that does not exist, the `code:lib_dir(AppName)' directory
 is used.
 </dd>

--- a/lib/xmerl/doc/examples/sdocbook2xhtml.erl
+++ b/lib/xmerl/doc/examples/sdocbook2xhtml.erl
@@ -258,10 +258,10 @@ colspec(_, Attrs,_,_)->
     [].
 
 command(Data,_,_,_)->
-    ["<b><tt>", Data, "</tt></b>"].
+    ["<b><code>", Data, "</code></b>"].
 
 computeroutput(Data,_,_,_)->
-    ["<tt>", Data, "</tt>"].
+    ["<code>", Data, "</code>"].
 
 copyright(Data,_,_,_)->
     [ "&copy; ", Data].
@@ -402,7 +402,7 @@ listitem(Data, Attrs, Parents, _)->
     markup("li", Attrs, Data).
 
 literal(Data, Attrs, Parents, _)->
-    markup("tt", Attrs, Data).
+    markup("code", Attrs, Data).
 
 %literallayout
 %{
@@ -669,7 +669,7 @@ ulink(Data, Attrs, Parents, E)->
 
 %% User input is Constant Bold
 userinput(Data, Attrs, Parents, E)->
-    ["<tt><b>", Data, "</b></tt>"].
+    ["<code><b>", Data, "</b></code>"].
 
 variablelist(Data, Attrs, Parents, E)->
     markup("dl", Attrs, Data).

--- a/lib/xmerl/doc/src/xmerl_examples.html
+++ b/lib/xmerl/doc/src/xmerl_examples.html
@@ -18,24 +18,24 @@
 
        <ul>
 
- 	<li>event function (<tt>
+ 	<li>event function (<code>
  	xmerl_scan:event_state/[1,2]
- 	</tt>)</li>
+ 	</code>)</li>
 
- 	<li>hook function (<tt>
+ 	<li>hook function (<code>
  	xmerl_scan:hook_state/[1,2]
- 	</tt>)</li>
+ 	</code>)</li>
 
- 	<li>fetch function (<tt>
- 	xmerl_scan:fetch_state/[1,2] </tt>)
+ 	<li>fetch function (<code>
+ 	xmerl_scan:fetch_state/[1,2] </code>)
  	</li>
 
- 	<li>continuation function (<tt>
- 	xmerl_scan:cont_state/[1,2] </tt>)
+ 	<li>continuation function (<code>
+ 	xmerl_scan:cont_state/[1,2] </code>)
  	</li>
 
- 	<li>rules function (<tt>
-       xmerl_scan:rules_state/[1,2] </tt>)
+ 	<li>rules function (<code>
+       xmerl_scan:rules_state/[1,2] </code>)
        </li>
 
  	<li>accumulator function</li>
@@ -46,16 +46,16 @@
 
        <p>For all of the above state access functions, the function
        with one argument
-       (e.g. <tt>event_state(GlobalState)</tt>)
+       (e.g. <code>event_state(GlobalState)</code>)
        will read the state variable, while the function with two
-       arguments (e.g.: <tt>event_state(NewEventState,
-       GlobalState)</tt>) will modify it.</p>
+       arguments (e.g.: <code>event_state(NewEventState,
+       GlobalState)</code>) will modify it.</p>
 
        <p>For each function, the description starts with the syntax
        for specifying the function in the
-       <a href="xmerl_scan.html#type-option_list"><tt>Option_list</tt></a>.
-       The general forms are <tt>{Tag, Fun}</tt>, or
-       <tt>{Tag, Fun, LocalState}</tt>. The
+       <a href="xmerl_scan.html#type-option_list"><code>Option_list</code></a>.
+       The general forms are <code>{Tag, Fun}</code>, or
+       <code>{Tag, Fun, LocalState}</code>. The
        second form can be used to initialize the state variable in
        question.</p>
 
@@ -68,22 +68,22 @@
  	functions, which do not really have anything to contribute to
  	the "global" user state, use their own state
  	variable instead. Another option (used in
- 	e.g. <tt>xmerl_eventp.erl</tt>) is for
+ 	e.g. <code>xmerl_eventp.erl</code>) is for
  	customization functions to share one of the local states (in
- 	<tt>xmerl_eventp.erl</tt>, the
+ 	<code>xmerl_eventp.erl</code>, the
  	continuation function and the fetch function both access the
- 	<tt>cont_state</tt>.)</p>
+ 	<code>cont_state</code>.)</p>
 
  	<p>Functions to access user state:</p>
 
  	<ul>
 
- 	  <li><tt>
- 	  xmerl_scan:user_state(GlobalState) </tt>
+ 	  <li><code>
+ 	  xmerl_scan:user_state(GlobalState) </code>
  	  </li>
 
- 	  <li><tt>xmerl_scan:user_state(UserState,
- 	  GlobalState) </tt></li>
+ 	  <li><code>xmerl_scan:user_state(UserState,
+ 	  GlobalState) </code></li>
 
  	</ul>
 
@@ -91,8 +91,8 @@
 
  	<h4 id="sect_1.1.2">1.2 Event Function</h4>
 
- 	<p><tt>{event_fun, fun()} | {event_fun, fun(),
- 	EventState}</tt></p>
+ 	<p><code>{event_fun, fun()} | {event_fun, fun(),
+ 	EventState}</code></p>
 
  	<p>The event function is called at the beginning and at the
  	end of a parsed entity. It has the following format and
@@ -111,8 +111,8 @@
 
 
  	<h4 id="sect_1.1.3">1.3 Hook Function</h4>
- 	<p> <tt>{hook_fun, fun()} | {hook_fun, fun(),
- 	HookState}</tt></p>
+ 	<p> <code>{hook_fun, fun()} | {hook_fun, fun(),
+ 	HookState}</code></p>
 
 
 
@@ -150,7 +150,7 @@
 
  	<h4 id="sect_1.1.4">1.4 Fetch Function</h4>
  <p>
- <tt>{fetch_fun, fun()} | {fetch_fun, fun(), FetchState}</tt>
+ <code>{fetch_fun, fun()} | {fetch_fun, fun(), FetchState}</code>
  </p>
  <p>The fetch function is called in order to fetch an external resource
  (e.g. a DTD).</p>
@@ -181,7 +181,7 @@
 
  	<h4 id="sect_1.1.5">1.5 Continuation Function</h4>
  <p>
- <tt>{continuation_fun, fun()} | {continuation_fun, fun(), ContinuationState}</tt>
+ <code>{continuation_fun, fun()} | {continuation_fun, fun(), ContinuationState}</code>
  </p>
  <p>The continuation function is called when the parser encounters the end
  of the byte stream. Format and semantics:</p>
@@ -208,9 +208,9 @@
 
  	<h4 id="sect_1.1.6">1.6 Rules Functions</h4>
  	<p>
- <tt>
+ <code>
  {rules, ReadFun : fun(), WriteFun : fun(), RulesState} |
- {rules, Table : ets()}</tt>
+ {rules, Table : ets()}</code>
  </p>
  	<p>The rules functions take care of storing scanner
  	information in a rules database. User-provided rules functions
@@ -227,7 +227,7 @@
  	  table is deleted.</li>
 
  	  <li>If the user specifies an ets table via the 
- 	<tt>{rules, Table}</tt> option, the
+ 	<code>{rules, Table}</code> option, the
  	scanner uses this table. When the scanner is done, it does
  	<em>not</em> delete the table.</li>
   
@@ -263,22 +263,22 @@
  	      <tr>
  		<td>notation</td>
  		<td>NotationName</td>
- 		<td><tt>{system, SL} | {public, PIDL, SL}</tt></td>
+ 		<td><code>{system, SL} | {public, PIDL, SL}</code></td>
  	      </tr>
  	      <tr>
  		<td>elem_def</td>
  		<td>ElementName</td>
- 		<td><tt>#xmlElement{content = ContentSpec}</tt></td>
+ 		<td><code>#xmlElement{content = ContentSpec}</code></td>
  	      </tr>
  	      <tr>
  		<td>parameter_entity</td>
  		<td>PEName</td>
- 		<td><tt>PEDef</tt></td>
+ 		<td><code>PEDef</code></td>
  	      </tr>
  	      <tr>
  		<td>entity</td>
  		<td>EntityName</td>
- 	  <td><tt>EntityDef</tt></td>
+ 	  <td><code>EntityDef</code></td>
  	      </tr>
  	    </tbody>
  	  </colgroup>
@@ -306,7 +306,7 @@
 
 
  	<h4 id="sect_1.1.7">1.7 Accumulator Function</h4>
- 	<p><tt>{acc_fun, fun()}</tt></p>
+ 	<p><code>{acc_fun, fun()}</code></p>
 
  	<p>The accumulator function is called to accumulate the
  	contents of an entity.When parsing very large files, it may
@@ -315,7 +315,7 @@
 
  	<p>Note that it is possible to even modify the parsed
  	entity before accumulating it, but this must be done with
- 	care. <tt>xmerl_scan</tt> performs
+ 	care. <code>xmerl_scan</code> performs
  	post-processing of the element for namespace management. Thus,
  	the element must keep its original structure for this to
  	work.</p>
@@ -341,7 +341,7 @@
  	<p>The close function is called when a document (either the
  	main document or an external DTD) has been completely
  	parsed. When xmerl_scan was started using
- 	<tt>xmerl_scan:file/[1,2]</tt>, the
+ 	<code>xmerl_scan:file/[1,2]</code>, the
  	file will be read in full, and closed immediately, before the
  	parsing starts, so when the close function is called, it will
  	not need to actually close the file. In this case, the close

--- a/lib/xmerl/doc/src/xmerl_xs_examples.html
+++ b/lib/xmerl/doc/src/xmerl_xs_examples.html
@@ -206,17 +206,17 @@ template(E)->
       </code></pre></td></tr></table>
       <p>
 	It is important to end with a call to
-	<tt>xmerl_xs:built_in_rules/2</tt>
+	<code>xmerl_xs:built_in_rules/2</code>
 	if you want any text to be written in "push" transforms. 
-	That are the ones using a lot <tt>xslapply( fun
-	template/1, E )</tt> instead of
-	<tt>value_of(select("xpath",E))</tt>,
+	That are the ones using a lot <code>xslapply( fun
+	template/1, E )</code> instead of
+	<code>value_of(select("xpath",E))</code>,
 	which is pull...
       </p>
     <hr />
 <p>The largest example is the stylesheet to transform this document
 	from the Simplified Docbook XML format to xhtml. The source
-	file is <tt>sdocbook2xhtml.erl</tt>.
+	file is <code>sdocbook2xhtml.erl</code>.
 </p>
 
   

--- a/lib/xmerl/src/xmerl.erl
+++ b/lib/xmerl/src/xmerl.erl
@@ -64,7 +64,7 @@ export(Content, Callback) ->
 %%	<li><code>#xmlComment{}</code></li>
 %%	<li><code>#xmlDecl{}</code></li>
 %% </ul>
-%% <p>(See <tt>xmerl.hrl</tt> for the record definitions.)
+%% <p>(See <code>xmerl.hrl</code> for the record definitions.)
 %% Text in <code>#xmlText{}</code> elements can be deep lists of
 %% characters and/or binaries.</p>
 %%

--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -22,8 +22,8 @@
 
 %% @doc This module is the interface to the XML parser, it handles XML 1.0.
 %%     The XML parser is activated through
-%%     <tt>xmerl_scan:string/[1,2]</tt> or
-%%     <tt>xmerl_scan:file/[1,2]</tt>.
+%%     <code>xmerl_scan:string/[1,2]</code> or
+%%     <code>xmerl_scan:file/[1,2]</code>.
 %%     It returns records of the type defined in xmerl.hrl.
 %% See also <a href="xmerl_examples.html">tutorial</a> on customization
 %% functions.
@@ -119,8 +119,8 @@
 %% @type xmlDocument() = #xmlDocument{}.
 %% The record definition is found in xmerl.hrl.
 %% @type document() = xmlElement() | xmlDocument(). <p>
-%% The document returned by <tt>xmerl_scan:string/[1,2]</tt> and
-%% <tt>xmerl_scan:file/[1,2]</tt>. The type of the returned record depends on
+%% The document returned by <code>xmerl_scan:string/[1,2]</code> and
+%% <code>xmerl_scan:file/[1,2]</code>. The type of the returned record depends on
 %% the value of the document option passed to the function.
 %% </p>
 


### PR DESCRIPTION
Following #7643, this removes all remains of (deprecated HTML element) `tt` from Erlang/OTP.

I'm opening it as a draft to signal I'll later rebase this on top of `maint`, since it contains changes from the aforementioned PR: I just wanna make sure CI passes and there's no obvious issues.

Also:

- I ran `make xmllint` and saw no issues (there's lots of warnings but eventually it exits with `0`)
- I ran `make dialyzer` and saw no issues