### PR TITLE
Add missing asn1 application in eldap.app.src

### DIFF
--- a/lib/eldap/src/eldap.app.src
+++ b/lib/eldap/src/eldap.app.src
@@ -3,7 +3,7 @@
   {vsn, "%VSN%"},
   {modules, [eldap, 'ELDAPv3']},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, asn1]},
   {env, []},
   {runtime_dependencies, ["stdlib-3.4","ssl-5.3.4","kernel-3.0","erts-6.0",
 			  "asn1-3.0"]}


### PR DESCRIPTION
Discovered via https://github.com/elixir-lang/elixir/issues/12985

In recent elixir (1.15.x) the compiler does code pruning to avoid loading not needed modules. Since eldap needs asn1 but is not declared into its applications, eldap fails to work in recent elixir due to asn1 modules not included at runtime.