### PR TITLE
Do not attempt to load code if mode is embedded

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -339,11 +339,12 @@ handle_call({get_object_code,Mod}, _From, St0) when is_atom(Mod) ->
 handle_call({get_object_code_for_loading,Mod}, From, St0) when is_atom(Mod) ->
     case erlang:module_loaded(Mod) of
         true -> {reply, {module, Mod}, St0};
-        false ->
+        false when St0#state.mode =:= interactive ->
             case wait_loading(St0, Mod, From) of
                 {true, St1} -> {noreply, St1};
                 false -> get_object_code_for_loading(St0, Mod, From)
-            end
+            end;
+        false -> {reply, {error,embedded}, St0}
     end;
 
 handle_call(stop,_From, S) ->


### PR DESCRIPTION
Erlang/OTP 25 only attempted to perform
code loading if the mode was interactive:

https://github.com/erlang/otp/blob/maint-25/lib/kernel/src/code_server.erl#L301

This check was removed in #6736 as part of
the decentralization. However, we received
reports of increased cpu/memory usage in
Erlang/OTP 26.1 in a code that was calling
code:ensure_loaded/1 on a hot path. The
underlying code was fixed but, given #7503
added the server back into the equation for
ensure_loaded, we can add the mode check
back to preserve Erlang/OTP 25 behaviour.