### PR TITLE
Support guards in maybe expression

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -648,16 +648,18 @@ exprs([], St) -> {[],St}.
 %% exprs([Expr], State) -> {[Cexpr],State}.
 %%  Flatten top-level exprs while handling maybe_match operators.
 
-maybe_match_exprs([{maybe_match,L,P0,E0}|Es0], Fail, St0) ->
+maybe_match_exprs([{maybe_match,L,P,E}|Es], Fail, St) ->
+    maybe_match_exprs([{maybe_match,L,P,[],E}|Es], Fail, St);
+maybe_match_exprs([{maybe_match,L,P0,G,E0}|Es0], Fail, St0) ->
     {Es1,St1} = maybe_match_exprs(Es0, Fail, St0),
     {C,St2} =
         case Es1 of
             [] ->
                 {AllName,StInt} = new_var_name(St1),
                 All = {var,L,AllName},
-                clause({clause,L,[{match,L,P0,All}],[],[All]}, StInt);
+                clause({clause,L,[{match,L,P0,All}],G,[All]}, StInt);
             [_|_] ->
-                {C0,StInt} = clause({clause,L,[P0],[],[{nil,0}]}, St1),
+                {C0,StInt} = clause({clause,L,[P0],G,[{nil,0}]}, St1),
                 {C0#iclause{body=Es1},StInt}
         end,
     {E1,Eps,St3} = novars(E0, St2),

--- a/lib/stdlib/examples/erl_id_trans.erl
+++ b/lib/stdlib/examples/erl_id_trans.erl
@@ -513,10 +513,11 @@ expr({'maybe',MaybeAnno,Es0,{'else',ElseAnno,Cs0}}) ->
     Es = exprs(Es0),
     Cs = clauses(Cs0),
     {'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}};
-expr({maybe_match,Anno,P0,E0}) ->
+expr({maybe_match,Anno,P0,G0,E0}) ->
     E = expr(E0),
+    G = guard(G0),
     P = pattern(P0),
-    {maybe_match,Anno,P,E};
+    {maybe_match,Anno,P,G,E};
 expr({match,Anno,P0,E0}) ->
     E1 = expr(E0),
     P1 = pattern(P0),

--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -142,7 +142,7 @@ exprs([E|Es], Bs0, Lf, Ef, RBs, FUVs) ->
 %%	 {failure,Value}
 %%  or raises an exception.
 
-maybe_match_exprs([{maybe_match,Anno,Lhs,Rhs0}|Es], Bs0, Lf, Ef) ->
+maybe_match_exprs([{maybe_match,Anno,Lhs,_G,Rhs0}|Es], Bs0, Lf, Ef) ->
     {value,Rhs,Bs1} = expr(Rhs0, Bs0, Lf, Ef, none),
     case match(Lhs, Rhs, Anno, Bs1, Bs1, Ef) of
 	{match,Bs} ->

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -424,10 +424,11 @@ expr({'maybe',MaybeAnno,Es0,{'else',ElseAnno,Cs0}}, St0) ->
     {Es,St1} = exprs(Es0, St0),
     {Cs,St2} = clauses(Cs0, St1),
     {{'maybe',MaybeAnno,Es,{'else',ElseAnno,Cs}},St2};
-expr({maybe_match,Anno,P0,E0}, St0) ->
+expr({maybe_match,Anno,P0,G0,E0}, St0) ->
     {E,St1} = expr(E0, St0),
-    {P,St2} = pattern(P0, St1),
-    {{maybe_match,Anno,P,E},St2};
+    {G,St2} = guard(G0, St1),
+    {P,St3} = pattern(P0, St2),
+    {{maybe_match,Anno,P,G,E},St3};
 expr({match,Anno,P0,E0}, St0) ->
     {E,St1} = expr(E0, St0),
     {P,St2} = pattern(P0, St1),

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2553,8 +2553,10 @@ expr({match,_Anno,P,E}, Vt, St0) ->
     {Evt,St1} = expr(E, Vt, St0),
     {Pvt,Pnew,St} = pattern(P, vtupdate(Evt, Vt), St1),
     {vtupdate(Pnew, vtmerge(Evt, Pvt)),St};
-expr({maybe_match,Anno,P,E}, Vt, St0) ->
-    expr({match,Anno,P,E}, Vt, St0);
+expr({maybe_match,Anno,P,G,E}, Vt, St0) ->
+    {Evt, St1} = expr({match,Anno,P,E}, Vt, St0),
+    {Gvt,St2} = guard(G, Evt, St1),
+    {vtupdate(Gvt, Evt), St2};
 expr({'maybe',Anno,Es}, Vt, St) ->
     %% No variables are exported.
     {Evt0, St1} = exprs(Es, Vt, St),

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -519,7 +519,8 @@ maybe_match_exprs -> maybe_match ',' maybe_match_exprs : ['$1' | '$3'].
 maybe_match_exprs -> expr : ['$1'].
 maybe_match_exprs -> expr ',' maybe_match_exprs : ['$1' | '$3'].
 
-maybe_match -> expr '?=' expr : {maybe_match,?anno('$2'),'$1','$3'}.
+maybe_match -> expr clause_guard '?=' expr :
+    {maybe_match,?anno('$3'),'$1','$2','$4'}.
 
 argument_list -> '(' ')' : {[],?anno('$1')}.
 argument_list -> '(' exprs ')' : {'$2',?anno('$1')}.
@@ -1110,7 +1111,7 @@ Erlang code.
 
 -type af_match(T) :: {'match', anno(), af_pattern(), T}.
 
--type af_maybe_match() :: {'maybe_match', anno(), af_pattern(), abstract_expr()}.
+-type af_maybe_match() :: {'maybe_match', anno(), af_pattern(), af_guard_seq(), abstract_expr()}.
 
 -type af_variable() :: {'var', anno(), atom()}. % | af_anon_variable()
 

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -709,7 +709,7 @@ lexpr({'maybe',_,Es}, _, Opts) ->
     {list,[{step,'maybe',body(Es, Opts)},{reserved,'end'}]};
 lexpr({'maybe',_,Es,{'else',_,Cs}}, _, Opts) ->
     {list,[{step,'maybe',body(Es, Opts)},{step,'else',cr_clauses(Cs, Opts)},{reserved,'end'}]};
-lexpr({maybe_match,_,Lhs,Rhs}, _, Opts) ->
+lexpr({maybe_match,_,Lhs,_G,Rhs}, _, Opts) ->
     Pl = lexpr(Lhs, 0, Opts),
     Rl = lexpr(Rhs, 0, Opts),
     {list,[{cstep,[Pl,leaf(" ?=")],Rl}]};

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -84,7 +84,8 @@
          redefined_builtin_type/1,
          tilde_k/1,
          match_float_zero/1,
-         undefined_module/1]).
+         undefined_module/1,
+         maybe_expression_guard/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -117,7 +118,8 @@ all() ->
      tilde_k,
      singleton_type_var_errors,
      match_float_zero,
-     undefined_module].
+     undefined_module,
+     maybe_expression_guard].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -5224,6 +5226,43 @@ undefined_module(Config) ->
              ">>,
     {errors,[{{1,2},erl_lint,undefined_module}],[]} = run_test2(Config, Code, []),
 
+    ok.
+
+maybe_expression_guard(Config) when is_list(Config) ->
+    EnableMaybe = {feature,maybe_expr,enable},
+    Ts = [{maybe_expression_guard1,
+            <<"-export([t/0]).
+                t() ->
+                    ok =
+                        maybe
+                            Int when Int > 0, Int < 2 ?= int(),
+                            ok
+                        else
+                            _ ->
+                                error
+                        end.
+
+                int() -> 1.
+                ">>,
+            [EnableMaybe],
+            []},
+            {maybe_expression_guard2,
+            <<"-export([t/0]).
+                t() ->
+                    error =
+                        maybe
+                            Int when Int =:= 0 ?= int(),
+                            ok
+                        else
+                            _ ->
+                                error
+                        end.
+
+                int() -> 1.
+                ">>,
+            [EnableMaybe],
+            []}],
+    [] = run(Config, Ts),
     ok.
 
 %%%


### PR DESCRIPTION
This PR implements guards in maybe expressions.
The motivation for the PR is [this topic](https://erlangforums.com/t/support-guards-in-erlang-maybe/2406) by @josevalim in Erlang Forums.

## Example

```erlang
-module(maybe_guard).
-feature(maybe_expr, enable).
-export([t/1]).

t(X) ->
    maybe 
        Zero when Zero =:= 0 ?= X,
	One when One > 0, One < 2 ?= one(),
	ok
    else
	X -> {nonzero, X}
    end.

one() -> 1.
```

```console
1> maybe_guard:t(0).
ok
2> maybe_guard:t(1).
{nonzero,1}
```

## Notes

There are things to fix, but this PR is to start the discussion for the implementation of this feature.