### PR TITLE
Run all tests with label

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,13 +42,26 @@ jobs:
         id: apps
         run: |
           .github/scripts/path-filters.sh > .github/scripts/path-filters.yaml
+          ## Print path-filters for debug purposes
+          cat .github/scripts/path-filters.yaml
           ALL_APPS=$(grep '^[a-z_]*:' .github/scripts/path-filters.yaml | sed 's/:.*$//')
           ALL_APPS=$(jq -n --arg inarr "${ALL_APPS}" '$inarr | split("\n")' | tr '\n' ' ')
           echo "all=${ALL_APPS}" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v2.11.1
-        id: changes
+        id: app-changes
         with:
           filters: .github/scripts/path-filters.yaml
+      - name: Override changes
+        id: changes
+        env:
+            ALL_APPS: ${{ steps.apps.outputs.all }}
+            CHANGED_APPS: ${{ steps.app-changes.outputs.changes }}
+        run: |
+          if ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-build-and-check') }}; then
+              echo "changes=${ALL_APPS}" >> "$GITHUB_OUTPUT"
+          else
+              echo "changes=${CHANGED_APPS}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create initial pre-release tar
         run: .github/scripts/init-pre-release.sh otp_archive.tar.gz
       - name: Upload source tar archive

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,8 @@ name: Build and check Erlang/OTP
 on:
   push:
   pull_request:
+  schedule:
+      - cron: 0 1 * * *
 
 env:
     ## Equivalent to github.event_name == 'pull_request' ? github.base_ref : github.ref_name
@@ -57,7 +59,7 @@ jobs:
             ALL_APPS: ${{ steps.apps.outputs.all }}
             CHANGED_APPS: ${{ steps.app-changes.outputs.changes }}
         run: |
-          if ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-build-and-check') }}; then
+          if ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-build-and-check') }} || ${{ github.event_name == 'schedule' }}; then
               echo "changes=${ALL_APPS}" >> "$GITHUB_OUTPUT"
           else
               echo "changes=${CHANGED_APPS}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR makes it possible to force all tests to be run by adding the label `full-build-and-check` to a PR.

It also schedules a full build and check at 1 AM UTC for the master branch so that we can see if any tests fail on the master branch.

See #7304 for an earlier attempt at this.