### PR TITLE
Fix failing debug assert on PowerPC

### DIFF
--- a/erts/emulator/sys/common/erl_mseg.c
+++ b/erts/emulator/sys/common/erl_mseg.c
@@ -1414,7 +1414,8 @@ erts_mseg_init(ErtsMsegInit_t *init)
     if (!IS_2POW(GET_PAGE_SIZE))
 	erts_exit(ERTS_ABORT_EXIT, "erts_mseg: Unexpected page_size %beu\n", GET_PAGE_SIZE);
 
-    ASSERT((MSEG_ALIGNED_SIZE % GET_PAGE_SIZE) == 0);
+    ASSERT((MSEG_ALIGNED_SIZE % GET_PAGE_SIZE) == 0
+	   || (GET_PAGE_SIZE % MSEG_ALIGNED_SIZE) == 0);
 
     for (i = 0; i < no_mseg_allocators; i++) {
 	ErtsMsegAllctr_t *ma = ERTS_MSEG_ALLCTR_IX(i);


### PR DESCRIPTION
and other machines where the page size is larger than 16kb.

```
PowerPC> erl -emu_type debug
sys/common/erl_mseg.c:1401:erts_mseg_init() Assertion failed: ((1 << (14)) % sysconf(_SC_PAGESIZE)) == 0
```
