### PR TITLE
Fix macOS wx build error on OTP-25.3.2.7

### DIFF
--- a/lib/wx/c_src/Makefile.in
+++ b/lib/wx/c_src/Makefile.in
@@ -182,7 +182,7 @@ $(TARGET_DIR)/wxe_driver$(SO_EXT): $(WX_OBJECTS)
 
 $(TARGET_DIR)/erl_gl$(SO_EXT): $(GL_OBJECTS)
 	$(V_at)mkdir -p $(TARGET_DIR)
-	$(V_CC) $(LDFLAGS) $(GL_OBJECTS) $(GL_LIBS) -o $@
+	$(V_CXX) $(LDFLAGS) $(GL_OBJECTS) $(GL_LIBS) -o $@
 
 $(WEBVIEW_LOADER_DLL_DEST): $(WEBVIEW_LOADER_DLL_ORIG)
 	$(INSTALL_PROGRAM) $< $@

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -5256,13 +5256,14 @@ esac
 
 
 
+EXTRA_LDFLAGS=
+
 case $host_os in
     darwin*)
-	LDFLAGS="$MAC_MIN -bundle -flat_namespace -undefined warning -fPIC $LDFLAGS"
-	# Check sizof_void_p as future will hold 64bit MacOS wx
-	if test $ac_cv_sizeof_void_p = 4; then
-	    LDFLAGS="-m32 $LDFLAGS"
-	fi
+        # beam.smp has not been built yet, so we must not use the
+        # -bundle_loader option in the configuration tests.
+	LDFLAGS="$MAC_MIN -bundle $LDFLAGS"
+	EXTRA_LDFLAGS=" -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
 	GL_LIBS="-framework OpenGL"
 	;;
     win32)
@@ -7027,6 +7028,8 @@ saved_LIBS=$LIBS
 
 if test X"$WX_HAVE_STATIC_LIBS" = X"true" ; then
    LIBS=$WX_LIBS_STATIC
+else
+   LIBS=$WX_LIBS
 fi
 
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -7087,6 +7090,8 @@ fi
 
 
 fi
+LDFLAGS="$LDFLAGS$EXTRA_LDFLAGS"
+
 
 
 if test "x$GCC" = xyes

--- a/lib/wx/configure.ac
+++ b/lib/wx/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script. -*-m4-*-
 
 dnl %CopyrightBegin%
 dnl
-dnl Copyright Ericsson AB 2008-2022. All Rights Reserved.
+dnl Copyright Ericsson AB 2008-2023. All Rights Reserved.
 dnl
 dnl Licensed under the Apache License, Version 2.0 (the "License");
 dnl you may not use this file except in compliance with the License.
@@ -200,13 +200,14 @@ AC_SUBST(GLIB_LIBS)
 AC_SUBST(OBJC_CC)
 AC_SUBST(OBJC_CFLAGS)
 
+EXTRA_LDFLAGS=
+
 case $host_os in
     darwin*)
-	LDFLAGS="$MAC_MIN -bundle -flat_namespace -undefined warning -fPIC $LDFLAGS"
-	# Check sizof_void_p as future will hold 64bit MacOS wx
-	if test $ac_cv_sizeof_void_p = 4; then
-	    LDFLAGS="-m32 $LDFLAGS"
-	fi		   
+        # beam.smp has not been built yet, so we must not use the
+        # -bundle_loader option in the configuration tests.
+	LDFLAGS="$MAC_MIN -bundle $LDFLAGS"
+	EXTRA_LDFLAGS=" -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
 	GL_LIBS="-framework OpenGL"
 	;;
     win32)
@@ -666,6 +667,8 @@ saved_LIBS=$LIBS
 
 if test X"$WX_HAVE_STATIC_LIBS" = X"true" ; then
    LIBS=$WX_LIBS_STATIC   
+else
+   LIBS=$WX_LIBS
 fi
 
 AC_LINK_IFELSE([AC_LANG_SOURCE([[
@@ -702,6 +705,8 @@ if test X"$CAN_LINK_WX" != X"yes" ; then
 fi
 
 ]) dnl - if test "$WXERL_CAN_BUILD_DRIVER" != "false"
+
+LDFLAGS="$LDFLAGS$EXTRA_LDFLAGS"
 
 AC_SUBST(WXERL_CAN_BUILD_DRIVER)
 


### PR DESCRIPTION
* This fix solves wx build error of OTP-25.3.2.7 on macOS 14.0 running Apple Silicon (M2 Pro) with Xcode 15.
* This fix is a backport of the fix for OTP-18768 in OTP-26.1.1.
* Reference: https://github.com/erlang/otp/pull/7670