### PR TITLE
Fix regressions in code:ensure_loaded/1

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -177,7 +177,7 @@ objfile_extension() ->
 load_file(Mod) when is_atom(Mod) ->
     case get_object_code(Mod) of
         error -> {error,nofile};
-        {Mod,Binary,File} -> load_module(Mod, File, Binary, false, false)
+        {Mod,Binary,File} -> load_module(Mod, File, Binary, false)
     end.
 
 -spec ensure_loaded(Module) -> {module, Module} | {error, What} when
@@ -190,7 +190,13 @@ ensure_loaded(Mod) when is_atom(Mod) ->
             case call({get_object_code_for_loading, Mod}) of
                 {module, Mod} -> {module, Mod};
                 {error, What} -> {error, What};
-                {Mod,Binary,File,Ref} -> load_module(Mod, File, Binary, false, Ref)
+                {Binary,File,Ref} ->
+                    case erlang:prepare_loading(Mod, Binary) of
+                        {error,_}=Error ->
+                            call({load_error, Ref, Mod, Error});
+                        Prepared ->
+                            call({load_module, Prepared, Mod, File, false, Ref})
+                    end
             end
     end.
 
@@ -209,7 +215,7 @@ load_abs(File, M) when (is_list(File) orelse is_atom(File)), is_atom(M) ->
             FileName = code_server:absname(FileName0),
             case erl_prim_loader:get_file(FileName) of
                 {ok,Bin,_} ->
-                    load_module(M, FileName, Bin, false, false);
+                    load_module(M, FileName, Bin, false);
                 error ->
                     {error, nofile}
             end;
@@ -227,16 +233,16 @@ load_abs(File, M) when (is_list(File) orelse is_atom(File)), is_atom(M) ->
 load_binary(Mod, File, Bin)
   when is_atom(Mod), (is_list(File) orelse is_atom(File)), is_binary(Bin) ->
     case modp(File) of
-        true -> load_module(Mod, File, Bin, true, false);
+        true -> load_module(Mod, File, Bin, true);
         false -> {error,badarg}
     end.
 
-load_module(Mod, File, Bin, Purge, EnsureLoaded) ->
+load_module(Mod, File, Bin, Purge) ->
     case erlang:prepare_loading(Mod, Bin) of
         {error,_}=Error ->
             Error;
         Prepared ->
-            call({load_module, Prepared, Mod, File, Purge, EnsureLoaded})
+            call({load_module, Prepared, Mod, File, Purge, false})
     end.
 
 modp(Atom) when is_atom(Atom) -> true;


### PR DESCRIPTION
The first regression is not attempt to
load code if mode is embedded.

Erlang/OTP 25 only attempted to perform
code loading if the mode was interactive:

https://github.com/erlang/otp/blob/maint-25/lib/kernel/src/code_server.erl#L301

This check was removed in #6736 as part of
the decentralization. However, we received
reports of increased cpu/memory usage in
Erlang/OTP 26.1 in a code that was calling
code:ensure_loaded/1 on a hot path. The
underlying code was fixed but, given #7503
added the server back into the equation for
ensure_loaded we can add the mode check
back to preserve Erlang/OTP 25 behaviour.

The second regression would cause the caller
process to deadlock if attempting to load a
file with invalid .beam more than once.

Closes #7721.
Closes #7725.