### PR TITLE
Enable engine support for OpenSSL versions >= 3.0

### DIFF
--- a/lib/crypto/c_src/Makefile.in
+++ b/lib/crypto/c_src/Makefile.in
@@ -209,6 +209,17 @@ endif
 # 	$(V_at)$(INSTALL_DIR) $(OBJDIR)
 # 	$(V_CC) -c -o $@ $(ALL_CFLAGS) $(CRYPTO_NO_DEPRECATE_WARN) $<
 
+# ---- Hard-coded removal of deprecated warning for ENGINE function calls
+$(OBJDIR)/engine$(TYPEMARKER).o: engine.c
+	$(V_at)$(INSTALL_DIR) $(OBJDIR)
+	$(V_CC) -c -o $@ $(ALL_CFLAGS) $(CRYPTO_NO_DEPRECATE_WARN) $<
+
+$(OBJDIR)/pkey$(TYPEMARKER).o: pkey.c
+	$(V_at)$(INSTALL_DIR) $(OBJDIR)
+	$(V_CC) -c -o $@ $(ALL_CFLAGS) $(CRYPTO_NO_DEPRECATE_WARN) $<
+
+# ---- End of Hard-coded removal of deprecated warning for ENGINE function calls
+
 $(OBJDIR)/%$(TYPEMARKER).o: %.c
 	$(V_at)$(INSTALL_DIR) $(OBJDIR)
 	$(V_CC) -MMD -c -o $@ $(ALL_CFLAGS) $<

--- a/lib/crypto/c_src/dss.c
+++ b/lib/crypto/c_src/dss.c
@@ -109,7 +109,7 @@ err:
 int dss_privkey_to_pubkey(ErlNifEnv* env, EVP_PKEY *pkey, ERL_NIF_TERM *ret)
 // HAS_3_0_API
 {
-    ERL_NIF_TERM result[5];
+    ERL_NIF_TERM result[4];
     BIGNUM *p = NULL, *q = NULL, *g = NULL, *pub = NULL;
 
     if (
@@ -119,8 +119,8 @@ int dss_privkey_to_pubkey(ErlNifEnv* env, EVP_PKEY *pkey, ERL_NIF_TERM *ret)
         || !EVP_PKEY_get_bn_param(pkey, "pub", &pub)
         || ((result[0] = bin_from_bn(env, p)) == atom_error)
         || ((result[1] = bin_from_bn(env, q)) == atom_error)
-        || ((result[1] = bin_from_bn(env, g)) == atom_error)
-        || ((result[1] = bin_from_bn(env, pub)) == atom_error)
+        || ((result[2] = bin_from_bn(env, g)) == atom_error)
+        || ((result[3] = bin_from_bn(env, pub)) == atom_error)
         )
         goto err;
 

--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -352,9 +352,7 @@
 /* If OPENSSL_NO_EC is set, there will be an error in ec.h included from engine.h
    So if EC is disabled, you can't use Engine either....
 */
-#if !defined(OPENSSL_NO_ENGINE) && \
-    !defined(HAS_3_0_API)
-/* Disable FIPS for 3.0 temporaryly until the support is added (might core dump) */
+#if !defined(OPENSSL_NO_ENGINE)
 # define HAS_ENGINE_SUPPORT
 #endif
 #endif


### PR DESCRIPTION
Engine support was earlier disabled in `crypto` for OpenSSL3.* as we had some problems getting it to work. Those problems are probably fixed now in OTP-26.1 by #7392, but the disabled engine was left behind.
