### PR TITLE
Prevent pbkdf2_hmac function from blocking VM schedulers

### DIFF
--- a/lib/crypto/c_src/pbkdf2_hmac.c
+++ b/lib/crypto/c_src/pbkdf2_hmac.c
@@ -22,10 +22,10 @@
 #include "pbkdf2_hmac.h"
 #include "digest.h"
 
-ERL_NIF_TERM pbkdf2_hmac_nif(ErlNifEnv* env, int argc,
-                             const ERL_NIF_TERM argv[])
-{
 #ifdef HAS_PKCS5_PBKDF2_HMAC
+static ERL_NIF_TERM pbkdf2_hmac(ErlNifEnv* env, int argc,
+                                const ERL_NIF_TERM argv[])
+{
     ErlNifBinary pass, salt, out;
     ErlNifUInt64 iter, keylen;
     struct digest_type_t* digp = NULL;
@@ -43,15 +43,12 @@ ERL_NIF_TERM pbkdf2_hmac_nif(ErlNifEnv* env, int argc,
     if (!enif_inspect_binary(env, argv[2], &salt))
         return EXCP_BADARG_N(env, 2, "Not binary");
 
+    /* We already checked iter<0 and keylen<0 in pbkdf2_hmac_nif */
     if (!enif_get_uint64(env, argv[3], &iter))
         return EXCP_BADARG_N(env, 3, "Not integer");
-    if (iter < 1)
-        return EXCP_BADARG_N(env, 3, "Must be > 0");
 
     if (!enif_get_uint64(env, argv[4], &keylen))
         return EXCP_BADARG_N(env, 4, "Not integer");
-    if (keylen < 1)
-        return EXCP_BADARG_N(env, 4, "Must be > 0");
 
     if (!enif_alloc_binary(keylen, &out))
         return EXCP_ERROR(env, "Can't allocate binary");
@@ -65,6 +62,36 @@ ERL_NIF_TERM pbkdf2_hmac_nif(ErlNifEnv* env, int argc,
     }
 
     return enif_make_binary(env, &out);
+}
+#endif /* HAS_PKCS5_PBKDF2_HMAC */
+
+ERL_NIF_TERM pbkdf2_hmac_nif(ErlNifEnv* env, int argc,
+                             const ERL_NIF_TERM argv[])
+{
+#ifdef HAS_PKCS5_PBKDF2_HMAC
+    ErlNifUInt64 iter, keylen;
+
+    if (!enif_get_uint64(env, argv[3], &iter))
+        return EXCP_BADARG_N(env, 3, "Not integer");
+    if (iter < 1)
+        return EXCP_BADARG_N(env, 3, "Must be > 0");
+
+    if (!enif_get_uint64(env, argv[4], &keylen))
+        return EXCP_BADARG_N(env, 4, "Not integer");
+    if (keylen < 1)
+        return EXCP_BADARG_N(env, 4, "Must be > 0");
+
+    /* Use a direct call if iterations and keylen are relatively small. keylen
+       size of 64 is used as that's the longest currently implemented hash size
+       for sha512.
+    */
+    if (iter <= 100 && keylen <= 64)
+        return pbkdf2_hmac(env, argc, argv);
+
+    /* Use a dirty CPU scheduler for a potentially long running call */
+    return enif_schedule_nif(env, "pbkdf2_hmac",
+                             ERL_NIF_DIRTY_JOB_CPU_BOUND,
+                             pbkdf2_hmac, argc, argv);
 #else
     return EXCP_NOTSUP(env, "Unsupported CRYPTO_PKCS5_PBKDF2_HMAC");
 #endif

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -132,6 +132,8 @@
          use_all_eddh_generate_compute/1,
          pbkdf2_hmac/0,
          pbkdf2_hmac/1,
+         pbkdf2_hmac_invalid_input/0,
+         pbkdf2_hmac_invalid_input/1,
          privkey_to_pubkey/1,
 
          %% Others:
@@ -224,7 +226,8 @@ all() ->
      cipher_info,
      hash_info,
      hash_equals,
-     pbkdf2_hmac
+     pbkdf2_hmac,
+     pbkdf2_hmac_invalid_input
     ].
 
 -define(NEW_CIPHER_TYPE_SCHEMA,
@@ -4857,6 +4860,9 @@ pbkdf2_hmac(Config) when is_list(Config) ->
     F = fun (A, B, C, D) ->
             binary:encode_hex(crypto:pbkdf2_hmac(sha, A, B, C, D))
         end,
+    F256 = fun (A, B, C, D) ->
+            binary:encode_hex(crypto:pbkdf2_hmac(sha256, A, B, C, D))
+        end,
     %% RFC 6070
     <<"0C60C80F961F0E71F3A9B524AF6012062FE037A6">> =
       F(<<"password">>, <<"salt">>, 1, 20),
@@ -4903,13 +4909,52 @@ pbkdf2_hmac(Config) when is_list(Config) ->
     <<"6B9CF26D45455A43A5B8BB276A403B39">> =
       F(binary:encode_unsigned(16#f09d849e), <<"EXAMPLE.COMpianist">>, 50, 16),
     <<"6B9CF26D45455A43A5B8BB276A403B39E7FE37A0C41E02C281FF3069E1E94F52">> =
-      F(binary:encode_unsigned(16#f09d849e), <<"EXAMPLE.COMpianist">>, 50, 32)
+      F(binary:encode_unsigned(16#f09d849e), <<"EXAMPLE.COMpianist">>, 50, 32),
+
+    %% SHA256 variant. Test vectors from RFC 7914 (section 11)
+    <<"55AC046E56E3089FEC1691C22544B605"
+      "F94185216DDE0465E68B9D57C20DACBC"
+      "49CA9CCCF179B645991664B39D77EF31"
+      "7C71B845B1E30BD509112041D3A19783">> = F256(<<"passwd">>, <<"salt">>, 1, 64),
+    <<"4DDCD8F60B98BE21830CEE5EF22701F9"
+      "641A4418D04C0414AEFF08876B34AB56"
+      "A1D425A1225833549ADB841B51C9B317"
+      "6A272BDEBBA1D078478F62B397F33C8D">> = F256(<<"Password">>, <<"NaCl">>, 80000, 64)
   catch
     error:{notsup, _, "Unsupported CRYPTO_PKCS5_PBKDF2_HMAC"++_} ->
             {skip, "No CRYPTO_PKCS5_PBKDF2_HMAC"}
   end.
 
-
+pbkdf2_hmac_invalid_input() ->
+  [{doc, "Test the pbkdf2_hmac function with invalid input"}].
+pbkdf2_hmac_invalid_input(Config) when is_list(Config) ->
+  try
+    TestFun = fun(Hash, Pass, Salt, Iter, Keylen, ErrorStr) ->
+        try
+            crypto:pbkdf2_hmac(Hash, Pass, Salt, Iter, Keylen)
+        of
+            Res -> ct:fail("Unexpected result ~p", [Res])
+        catch
+            error:{badarg, {_, _}, ErrorStr} ->
+                ok;
+            error:badarg ->
+                % Erlang <25
+                ok;
+            Tag:Err ->
+                ct:fail("Unexpected exception ~p:~p", [Tag, Err])
+        end
+    end,
+    TestFun(sha42, <<"pass">>, <<"salt">>, 1, 1, "Bad digest type"),
+    TestFun(sha, "badpass", <<"salt">>, 1, 1, "Not binary"),
+    TestFun(sha, <<"pass">>, "badsalt", 1, 1, "Not binary"),
+    TestFun(sha, <<"pass">>, <<"salt">>, "baditer", 1, "Not integer"),
+    TestFun(sha, <<"pass">>, <<"salt">>, 0, 1, "Must be > 0"),
+    TestFun(sha, <<"pass">>, <<"salt">>, 1, "badlen", "Not integer"),
+    TestFun(sha, <<"pass">>, <<"salt">>, 1, 0, "Must be > 0")
+  catch
+    error:{notsup, _, "Unsupported CRYPTO_PKCS5_PBKDF2_HMAC"++_} ->
+            {skip, "No CRYPTO_PKCS5_PBKDF2_HMAC"}
+  end.
 get_priv_pub_from_sign_verify(L) ->
     lists:foldl(fun get_priv_pub/2, [], L).
 


### PR DESCRIPTION
**Replaced by #8173 and #8174.**

PBKDF2 functions are often meant to run for 100s of milliseconds at a time. Previously, they executed on the main schedulers, blocking them, and thus, were unsuitable for their purpose.

Update the function to use a direct call only if the iteration count is less than or equal to `100` [1] and the keylen is less than or equal to `64` [2].

Add a few extra tests for the `SHA56` variant, and some test cases for various invalid inputs.

[1] Based on `pbkdf2_hmac(sha256, <<"password">>, <<"salt">>, 100, 32)` running in about 75-200 microseconds on a sampling of various architectures.

[2] `64` bytes is the length of the `SHA512` HMAC, the size of the longest currently supported PBKDF2 hash function.

Fix: https://github.com/erlang/otp/issues/7769