### PR TITLE
stdlib: shell keyboard shortcut fixes

### DIFF
--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -1219,6 +1219,9 @@ test_valid_keymap(Config) when is_list(Config) ->
         send_tty(Term, "asdf"),
         send_tty(Term, "C-u"),
         check_content(Term, ">$"),
+        send_tty(Term, "1.\n"),
+        send_tty(Term, "C-b"),
+        check_content(Term, "2>\\s1\\s?.$"),
         ok
     after
         stop_tty(Term),

--- a/lib/kernel/test/interactive_shell_SUITE_data/valid_keymap.config
+++ b/lib/kernel/test/interactive_shell_SUITE_data/valid_keymap.config
@@ -15,7 +15,7 @@
 
 %% Ctrl-alpha keys 0-31
 "\^A" => beginning_of_line,
-"\^B" => backward_char,
+"\^B" => history_up,
 %"\^C" => sig_term_menu,    %% cannot be changed, yet
 "\^D" => forward_delete_char,
 "\^E" => end_of_line,

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -26,7 +26,6 @@
 -export([erase_line/0,erase_inp/1,redraw_line/1]).
 -export([length_before/1,length_after/1,prompt/1]).
 -export([current_line/1, current_chars/1]).
-
 -export([edit_line1/2]).
 -export([inverted_space_prompt/1]).
 -export([keymap/0]).


### PR DESCRIPTION
Fix so that ctrl+h, ctrl+backspace generate backward_delete_char
Fix overriding of keyboard shortcuts

closes #7749 , #7776 