### PR TITLE
ct: Add -out parameter to ct_run

### DIFF
--- a/lib/common_test/doc/src/ct_hooks_chapter.xml
+++ b/lib/common_test/doc/src/ct_hooks_chapter.xml
@@ -511,6 +511,20 @@ results(State) ->
         use another level either change the <c>default</c> handler level before
         starting common_test, or use the <seemfa marker="kernel:logger#set_handler_config/3">
         <c>logger:set_handler_config/3</c></seemfa> API.</p>
+        <p>This hook supports the following options:</p>
+        <taglist>
+         <tag><c>{default_log_destination, file:filename() | undefined}</c></tag>
+         <item>
+           <p>Update the default logging handler to log into the specified file
+             instead of logging to standard output. If <c>undefined</c> is
+             passed - the default behaviour - then logging output will continue
+             to be directed to standard output.</p>
+           <p>The easiest way to configure this option is via the <c>-out</c>
+             option of <c>ct_run</c>, which passes along the argument value
+             into this option. For instance, <c>-out /dev/null</c> will skip
+             logging any output to standard output.</p>
+         </item>
+       </taglist>
        </item>
        <tag><c>cth_surefire</c></tag>
        <item>

--- a/lib/common_test/doc/src/ct_run_cmd.xml
+++ b/lib/common_test/doc/src/ct_run_cmd.xml
@@ -105,6 +105,7 @@
   [-label Label]
   [-logdir LogDir]
   [-logopts LogOpts]
+  [-out LoggerOutputDestination]
   [-verbosity GenVLevel | [Category1 VLevel1 and
    Category2 VLevel2 and .. CategoryN VLevelN]]
   [-silent_connections [ConnType1 ConnType2 .. ConnTypeN]]
@@ -145,6 +146,7 @@
   [-label Label]
   [-logdir LogDir]
   [-logopts LogOpts]
+  [-out LoggerOutputDestination]
   [-verbosity GenVLevel | [Category1 VLevel1 and
    Category2 VLevel2 and .. CategoryN VLevelN]]
   [-allow_user_terms]

--- a/lib/common_test/doc/src/run_test_chapter.xml
+++ b/lib/common_test/doc/src/run_test_chapter.xml
@@ -265,6 +265,12 @@
       <item><p>Enables modification of the logging behavior, see
       <seeguide marker="run_test_chapter#logopts">Log options</seeguide>.</p></item>
 
+      <tag><c><![CDATA[-out <log_output_filename>]]></c></tag>
+      <item><p>Redirects logging output to the specified filename as opposed
+      to the default of logging to standard output. For example,
+      <c>-out test_run.log</c> will forward any logging output to <c>test_run.log</c>
+      and <c>-out /dev/null</c> will discard any logging output.</p></item>
+
       <tag><c><![CDATA[-verbosity <levels>]]></c></tag>
       <item><p>Sets <seeguide marker="write_test_chapter#logging">verbosity levels
       for printouts</seeguide>.</p></item>

--- a/lib/kernel/src/logger_std_h.erl
+++ b/lib/kernel/src/logger_std_h.erl
@@ -528,6 +528,9 @@ write_to_dev(Bin, State) ->
     maybe_notify_error(write,Result,State2),
     State2#{synced=>false,write_res=>Result}.
 
+%% We cannot filesync writes to special devices such as /dev/null
+sync_dev(#{synced:=false,file_name:="/dev/null"}=State) ->
+    State#{synced=>true,sync_res=>ok};
 sync_dev(#{synced:=false}=State) ->
     State1 = #{fd:=Fd} = maybe_ensure_file(State),
     Result = ?file_datasync(Fd),


### PR DESCRIPTION
Allow configuring an alternative logging destination instead of stdout for any logger reports using the new `-out` flag.