### PR TITLE
asn1: Improve partial decode support

### DIFF
--- a/lib/asn1/src/Makefile
+++ b/lib/asn1/src/Makefile
@@ -66,6 +66,7 @@ CT_MODULES= \
 	asn1ct_tok \
 	asn1ct_parser2 \
 	asn1ct_table \
+	asn1ct_partial_decode \
 	$(EVAL_CT_MODULES)
 
 RT_MODULES= \

--- a/lib/asn1/src/asn1_db.erl
+++ b/lib/asn1/src/asn1_db.erl
@@ -106,7 +106,9 @@ loop(#state{parent = Parent, monitor = MRef, table = Table,
             loop(State);
         {save, OutFile, Mod} ->
             Mtab = ets:lookup_element(Table, Mod, 2),
-	    TempFile = OutFile ++ ".#temp",
+	    TempFile = OutFile ++
+                integer_to_list(erlang:unique_integer([positive])) ++
+                ".#temp",
             ok = ets:tab2file(Mtab, TempFile),
 	    ok = file:rename(TempFile, OutFile),
             loop(State);

--- a/lib/asn1/src/asn1ct.erl
+++ b/lib/asn1/src/asn1ct.erl
@@ -42,13 +42,12 @@
 	 maybe_rename_function/3,current_sindex/0,
 	 set_current_sindex/1,maybe_saved_sindex/2,
 	 parse_and_save/2,verbose/3,warning/3,warning/4,error/3,format_error/1]).
+-export([save_config/2,save_gen_state/2,save_gen_state/3]).
 -export([get_bit_string_format/0,use_legacy_types/0]).
 
 -include("asn1_records.hrl").
 -include_lib("stdlib/include/erl_compile.hrl").
 -include_lib("kernel/include/file.hrl").
-
--import(asn1ct_gen_ber_bin_v2,[encode_tag_val/3,decode_class/1]).
 
 -ifndef(vsn).
 -define(vsn,"0.0.1").
@@ -58,24 +57,6 @@
 -define(dupl_uniquedefs,1).
 -define(dupl_equaldefs,2).
 -define(dupl_eqdefs_uniquedefs,?dupl_equaldefs bor ?dupl_uniquedefs).
-
--define(CONSTRUCTED, 2#00100000). 
-
-%% macros used for partial decode commands
--define(CHOOSEN,choosen).
--define(SKIP,skip).
--define(SKIP_OPTIONAL,skip_optional).
-
-%% macros used for partial incomplete decode commands
--define(MANDATORY,mandatory).
--define(DEFAULT,default).
--define(OPTIONAL,opt).
--define(OPTIONAL_UNDECODED,opt_undec).
--define(PARTS,parts).
--define(UNDECODED,undec).
--define(ALTERNATIVE,alt).
--define(ALTERNATIVE_UNDECODED,alt_undec).
--define(ALTERNATIVE_PARTS,alt_parts).
 
 %% Removed functions
 
@@ -259,8 +240,12 @@ abs_listing(#st{code={M,_},outfile=OutFile}) ->
 
 generate_pass(#st{code=Code,outfile=OutFile,erule=Erule,opts=Opts}=St0) ->
     St = St0#st{code=undefined},		%Reclaim heap space
-    generate(Code, OutFile, Erule, Opts),
-    {ok,St}.
+    case generate(Code, OutFile, Erule, Opts) of
+        ok ->
+            {ok,St};
+        {error,Errors} ->
+            {error,St#st{error=Errors}}
+    end.
 
 compile_pass(#st{outfile=OutFile,opts=Opts0}=St) ->
     asn1_db:dbstop(),				%Reclaim memory.
@@ -335,11 +320,21 @@ clean_errors(Errors) when is_list(Errors) ->
     {Structured,Structured ++ AdHoc};
 clean_errors(AdHoc) -> {[],AdHoc}.
 
-print_structured_errors([_|_]=Errors) ->
-    _ = [io:format("~ts:~w: ~ts\n", [F,L,M:format_error(E)]) ||
-	    {structured_error,{F,L},M,E} <- Errors],
-    ok;
-print_structured_errors(_) -> ok.
+print_structured_errors(Errors) when is_list(Errors) ->
+    _ = [print_structured_error(F, M, E) ||
+            {structured_error,F,M,E} <- Errors],
+    ok.
+
+print_structured_error(F, M, Error) ->
+    Formatted = M:format_error(Error),
+    case F of
+        none ->
+            io:format("~ts\n", [Formatted]);
+        {File,none} ->
+            io:format("~ts: ~ts\n", [File,Formatted]);
+        {File,Line} when is_integer(Line) ->
+            io:format("~ts:~p: ~ts\n", [File,Line,Formatted])
+    end.
 
 compile1(File, #st{opts=Opts}=St0) ->
     compiler_verbose(File, Opts),
@@ -864,21 +859,17 @@ generate({M,CodeTuple}, OutFile, EncodingRule, Options) ->
     check_maps_option(Gen),
 
     %% create decoding function names and taglists for partial decode
-    try
-        specialized_decode_prepare(Gen, M)
-    catch
-        throw:{error, Reason} ->
-            warning("Error in configuration file: ~n~p~n",
-                    [Reason], Options,
-                    "Error in configuration file")
-    end,
-
-    asn1ct_gen:pgen(OutFile, Gen, Code),
-    cleanup_bit_string_format(),
-    erase(tlv_format), % used in ber
-    erase(class_default_type),% used in ber
-    asn1ct_table:delete(check_functions),
-    ok.
+    case specialized_decode_prepare(Gen, M) of
+        {error,_}=Error ->
+            Error;
+        ok ->
+            asn1ct_gen:pgen(OutFile, Gen, Code),
+            cleanup_bit_string_format(),
+            erase(tlv_format),                  % used in ber
+            erase(class_default_type),          % used in ber
+            asn1ct_table:delete(check_functions),
+            ok
+    end.
 
 init_gen_record(EncodingRule, Options) ->
     Erule = case EncodingRule of
@@ -1446,204 +1437,26 @@ prepare_bytes(Bytes) -> list_to_binary(Bytes).
 vsn() ->
     ?vsn.
 
-specialized_decode_prepare(#gen{erule=ber,options=Options}=Gen, M) ->
+specialized_decode_prepare(#gen{erule=ber,options=Options}=Gen, #module{name=Mod}) ->
     case lists:member(asn1config, Options) of
-	true ->
-	    special_decode_prepare_1(Gen, M);
-	false ->
-	    ok
+        true ->
+            case read_config_file(Gen, Mod) of
+                {ok,ConfigName,ConfigItems} ->
+                    try
+                        asn1ct_partial_decode:prepare(ConfigItems, Mod)
+                    catch
+                        throw:{structured_error,Error} ->
+                            {error,[{structured_error,{ConfigName,none},
+                                     asn1ct_partial_decode,Error}]}
+                    end;
+                no_config_file ->
+                    ok
+            end;
+        false ->
+            ok
     end;
 specialized_decode_prepare(_, _) ->
     ok.
-
-%% Reads the configuration file if it exists and stores information
-%% about partial decode and incomplete decode
-special_decode_prepare_1(#gen{options=Options}=Gen, M) ->
-    %% read configure file
-    ModName = case lists:keyfind(asn1config, 1, Options) of
-                  {_,MName} -> MName;
-                  false -> M#module.name
-              end,
-%%    io:format("ModName: ~p~nM#module.name: ~p~n~n",[ModName,M#module.name]),
-    case read_config_file(Gen, ModName) of
-        no_config_file ->
-            ok;
-        CfgList ->
-            SelectedDecode = get_config_info(CfgList,selective_decode),
-            ExclusiveDecode = get_config_info(CfgList,exclusive_decode),
-            CommandList = create_partial_decode_gen_info(M#module.name,
-                                                         SelectedDecode),
-            %% To convert CommandList to a proper list for the driver change
-            %% the list:[[choosen,Tag1],skip,[skip_optional,Tag2]] to L =
-            %% [5,2,Tag1,0,1,Tag2] where 5 is the length, and call
-            %% port_control(asn1_driver_port,3,[L| Bin])
-            save_config(partial_decode,CommandList),
-            save_gen_state(selective_decode,SelectedDecode),
-            CommandList2 = create_partial_inc_decode_gen_info(M#module.name,
-                                                              ExclusiveDecode),
-            Part_inc_tlv_tags = tlv_tags(CommandList2),
-            save_config(partial_incomplete_decode,Part_inc_tlv_tags),
-            save_gen_state(exclusive_decode,ExclusiveDecode,Part_inc_tlv_tags)
-    end.
-
-%% create_partial_inc_decode_gen_info/2
-%%
-%% Creates a list of tags out of the information in TypeNameList that
-%% tells which value will be incomplete decoded, i.e. each end
-%% component/type in TypeNameList. The significant types/components in
-%% the path from the toptype must be specified in the
-%% TypeNameList. Significant elements are all constructed types that
-%% branches the path to the leaf and the leaf it self.
-%%
-%% Returns a list of elements, where an element may be one of
-%% mandatory|[opt,Tag]|[bin,Tag]. mandatory correspond to a mandatory
-%% element that shall be decoded as usual. [opt,Tag] matches an
-%% OPTIONAL or DEFAULT element that shall be decoded as
-%% usual. [bin,Tag] corresponds to an element, mandatory, OPTIONAL or
-%% DEFAULT, that shall be left encoded (incomplete decoded).
-create_partial_inc_decode_gen_info(ModName,{Mod,[{Name,L}|Ls]}) when is_list(L) ->
-    TopTypeName = partial_inc_dec_toptype(L),
-    [{Name,TopTypeName,
-      create_partial_inc_decode_gen_info1(ModName,TopTypeName,{Mod,L})}|
-     create_partial_inc_decode_gen_info(ModName,{Mod,Ls})];
-create_partial_inc_decode_gen_info(_,{_,[]}) ->
-    [];
-create_partial_inc_decode_gen_info(_,[]) ->
-    [].
-
-create_partial_inc_decode_gen_info1(ModName,TopTypeName,{ModName,
-					    [_TopType|Rest]}) ->
-    case asn1_db:dbget(ModName,TopTypeName) of
-	#typedef{typespec=TS} ->
-	    TagCommand = get_tag_command(TS,?MANDATORY,mandatory),
-	    create_pdec_inc_command(ModName,get_components(TS#type.def),
-				    Rest,[TagCommand]);
-	_ ->
-	    throw({error,{"wrong type list in asn1 config file",
-			  TopTypeName}})
-    end;
-create_partial_inc_decode_gen_info1(M1,_,{M2,_}) when M1 /= M2 ->
-    throw({error,{"wrong module name in asn1 config file",
-		  M2}});
-create_partial_inc_decode_gen_info1(_,_,TNL) ->
-    throw({error,{"wrong type list in asn1 config file",
-		  TNL}}).
-
-%%
-%% Only when there is a 'ComponentType' the config data C1 may be a
-%% list, where the incomplete decode is branched. So, C1 may be a
-%% list, a "binary tuple", a "parts tuple" or an atom. The second
-%% element of a binary tuple and a parts tuple is an atom.
-create_pdec_inc_command(_ModName,_,[],Acc) ->
-    lists:reverse(Acc);
-create_pdec_inc_command(ModName,{Comps1,Comps2},TNL,Acc) 
-  when is_list(Comps1),is_list(Comps2) ->
-    create_pdec_inc_command(ModName,Comps1 ++ Comps2,TNL,Acc);
-%% The following two clauses match on the type after the top
-%% type. This one if the top type had no tag, i.e. a CHOICE.
-create_pdec_inc_command(ModN,Clist,[CL|_Rest],[[]]) when is_list(CL) ->
-    create_pdec_inc_command(ModN,Clist,CL,[]);
-create_pdec_inc_command(ModN,Clist,[CL|_Rest],Acc) when is_list(CL) ->
-    InnerDirectives=create_pdec_inc_command(ModN,Clist,CL,[]),
-    lists:reverse([InnerDirectives|Acc]);
-create_pdec_inc_command(ModName,
-			CList=[#'ComponentType'{name=Name,typespec=TS,
-						prop=Prop}|Comps],
-			TNL=[C1|Cs],Acc)  ->
-    case C1 of
-	{Name,undecoded} ->
-	    TagCommand = get_tag_command(TS,?UNDECODED,Prop),
-	    create_pdec_inc_command(ModName,Comps,Cs,concat_sequential(TagCommand,Acc));
-	{Name,parts} ->
-	    TagCommand = get_tag_command(TS,?PARTS,Prop),
-	    create_pdec_inc_command(ModName,Comps,Cs,concat_sequential(TagCommand,Acc));
-	L when is_list(L) ->
-            %% I guess this never happens due to previous clause.
-	    %% This case is only possible as the first element after
-	    %% the top type element, when top type is SEGUENCE or SET.
-	    %% Follow each element in L. Must note every tag on the
-	    %% way until the last command is reached, but it ought to
-	    %% be enough to have a "complete" or "complete optional"
-	    %% command for each component that is not specified in the
-	    %% config file. Then in the TLV decode the components with
-	    %% a "complete" command will be decoded by an ordinary TLV
-	    %% decode.
-	    create_pdec_inc_command(ModName,CList,L,Acc);
-	{Name,RestPartsList} when is_list(RestPartsList) ->
-	    %% Same as previous, but this may occur at any place in
-	    %% the structure. The previous is only possible as the
-	    %% second element.
-	    case get_tag_command(TS,?MANDATORY,Prop) of
-		?MANDATORY ->
-		    InnerDirectives=
-			create_pdec_inc_command(ModName,TS#type.def,
-						RestPartsList,[]),
-		    create_pdec_inc_command(ModName,Comps,Cs,
-					    [[?MANDATORY,InnerDirectives]|Acc]);
-		[Opt,EncTag] ->
-		    InnerDirectives = 
-			create_pdec_inc_command(ModName,TS#type.def,
-						RestPartsList,[]),
-		    create_pdec_inc_command(ModName,Comps,Cs,
-					    [[Opt,EncTag,InnerDirectives]|Acc])
-	    end;
-	_ ->
-            %% this component may not be in the config list
-	    TagCommand = get_tag_command(TS,?MANDATORY,Prop),
-	    create_pdec_inc_command(ModName,Comps,TNL,concat_sequential(TagCommand,Acc))
-    end;
-create_pdec_inc_command(ModName,
-			{'CHOICE',[#'ComponentType'{name=C1,
-						    typespec=TS,
-						    prop=Prop}|Comps]},
-			[{C1,Directive}|Rest],Acc) ->
-    case Directive of
-	List when is_list(List) ->
-	    TagCommand = get_tag_command(TS,?ALTERNATIVE,Prop),
-	    CompAcc = 
-		create_pdec_inc_command(ModName,
-					get_components(TS#type.def),List,[]),
-	    NewAcc = case TagCommand of
-			 [Command,Tag] when is_atom(Command) ->
-			     [[Command,Tag,CompAcc]|Acc];
-			 [L1,_L2|Rest] when is_list(L1) ->
-			     case lists:reverse(TagCommand) of
-				 [Atom|Comms] when is_atom(Atom) ->
-				     [concat_sequential(lists:reverse(Comms),
-							[Atom,CompAcc])|Acc];
-				 [[Command2,Tag2]|Comms] ->
-				     [concat_sequential(lists:reverse(Comms),
-							[[Command2,Tag2,CompAcc]])|Acc]
-			     end
-		     end,
-	    create_pdec_inc_command(ModName,{'CHOICE',Comps},Rest,
-				    NewAcc);
-	undecoded ->
-	    TagCommand = get_tag_command(TS,?ALTERNATIVE_UNDECODED,Prop),
-	    create_pdec_inc_command(ModName,{'CHOICE',Comps},Rest,
-				    concat_sequential(TagCommand,Acc));
-	parts ->
-	    TagCommand = get_tag_command(TS,?ALTERNATIVE_PARTS,Prop),
-	    create_pdec_inc_command(ModName,{'CHOICE',Comps},Rest,
-				    concat_sequential(TagCommand,Acc))
-    end;
-create_pdec_inc_command(ModName,
-			{'CHOICE',[#'ComponentType'{typespec=TS,
-						    prop=Prop}|Comps]},
-			TNL,Acc) ->
-    TagCommand = get_tag_command(TS,?ALTERNATIVE,Prop),
-    create_pdec_inc_command(ModName,{'CHOICE',Comps},TNL,
-			    concat_sequential(TagCommand,Acc));
-create_pdec_inc_command(M,{'CHOICE',{Cs1,Cs2}},TNL,Acc) 
-  when is_list(Cs1),is_list(Cs2) ->
-    create_pdec_inc_command(M,{'CHOICE',Cs1 ++ Cs2},TNL,Acc);
-create_pdec_inc_command(ModName,#'Externaltypereference'{module=M,type=Name},
-			TNL,Acc) ->
-    #type{def=Def} = get_referenced_type(M,Name),
-    create_pdec_inc_command(ModName,get_components(Def),TNL,Acc);
-create_pdec_inc_command(_,_,TNL,_) ->
-    throw({error,{"unexpected error when creating partial "
-		  "decode command",TNL}}).
 
 partial_inc_dec_toptype([T|_]) when is_atom(T) ->
     T;
@@ -1654,272 +1467,12 @@ partial_inc_dec_toptype([L|_]) when is_list(L) ->
 partial_inc_dec_toptype(_) ->
     throw({error,{"no top type found for partial incomplete decode"}}).
 
-
-%% Creates a list of tags out of the information in TypeList and Types
-%% that tells which value will be decoded.  Each constructed type that
-%% is in the TypeList will get a "choosen" command. Only the last
-%% type/component in the TypeList may be a primitive type. Components
-%% "on the way" to the final element may get the "skip" or the
-%% "skip_optional" command.
-%% CommandList = [Elements]
-%% Elements = {choosen,Tag}|{skip_optional,Tag}|skip
-%% Tag is a binary with the tag BER encoded.
-create_partial_decode_gen_info(ModName,{ModName,TypeLists}) ->
-    [create_partial_decode_gen_info1(ModName,TL) || TL <- TypeLists];
-create_partial_decode_gen_info(_,[]) ->
-    [];
-create_partial_decode_gen_info(_M1,{M2,_}) ->
-    throw({error,{"wrong module name in asn1 config file",
-		  M2}}).
-
-create_partial_decode_gen_info1(ModName,{FuncName,TypeList}) ->
-    case TypeList of
-	[TopType|Rest] ->
-	    case asn1_db:dbget(ModName,TopType) of
-		#typedef{typespec=TS} ->
-		    TagCommand = get_tag_command(TS,?CHOOSEN),
-		    Ret=create_pdec_command(ModName,
-					    get_components(TS#type.def),
-					    Rest,concat_tags(TagCommand,[])),
-		    {FuncName,Ret};
-		_ ->
-		    throw({error,{"wrong type list in asn1 config file",
-				  TypeList}})
-	    end;
-	_ ->
-	    []
-    end;
-create_partial_decode_gen_info1(_,_) ->
-    ok.
-
-%% create_pdec_command/4 for each name (type or component) in the
-%% third argument, TypeNameList, a command is created. The command has
-%% information whether the component/type shall be skipped, looked
-%% into or returned. The list of commands is returned.
-create_pdec_command(_ModName,_,[],Acc) ->
-    Remove_empty_lists =
-	fun([[]|L],Res,Fun) ->
-		Fun(L,Res,Fun);
-	   ([],Res,_) ->
-		Res;
-	   ([H|L],Res,Fun) ->
-		Fun(L,[H|Res],Fun)
-	end,
-    Remove_empty_lists(Acc,[],Remove_empty_lists);
-create_pdec_command(ModName,[#'ComponentType'{name=C1,typespec=TS}|_Comps],
-		    [C1|Cs],Acc) ->
-    %% this component is a constructed type or the last in the
-    %% TypeNameList otherwise the config spec is wrong
-    TagCommand = get_tag_command(TS,?CHOOSEN),
-    create_pdec_command(ModName,get_components(TS#type.def),
-			Cs,concat_tags(TagCommand,Acc));
-create_pdec_command(ModName,[#'ComponentType'{typespec=TS,
-					      prop=Prop}|Comps],
-		    [C2|Cs],Acc) ->
-    TagCommand = 
-	case Prop of
-	    mandatory ->
-		get_tag_command(TS,?SKIP);
-	    _ ->
-		get_tag_command(TS,?SKIP_OPTIONAL)
-	end,
-    create_pdec_command(ModName,Comps,[C2|Cs],concat_tags(TagCommand,Acc));
-create_pdec_command(ModName,{'CHOICE',[Comp=#'ComponentType'{name=C1}|_]},TNL=[C1|_Cs],Acc) ->
-    create_pdec_command(ModName,[Comp],TNL,Acc);
-create_pdec_command(ModName,{'CHOICE',[#'ComponentType'{}|Comps]},TNL,Acc) ->
-    create_pdec_command(ModName,{'CHOICE',Comps},TNL,Acc);
-create_pdec_command(ModName,{'CHOICE',{Cs1,Cs2}},TNL,Acc)
-  when is_list(Cs1),is_list(Cs2) ->
-    create_pdec_command(ModName,{'CHOICE',Cs1 ++ Cs2},TNL,Acc);
-create_pdec_command(ModName,#'Externaltypereference'{module=M,type=C1},
-		    TypeNameList,Acc) ->
-     #type{def=Def} = get_referenced_type(M,C1),
-    create_pdec_command(ModName,get_components(Def),TypeNameList,
-			Acc);
-create_pdec_command(ModName,TS=#type{def=Def},[C1|Cs],Acc) ->
-    %% This case when we got the "components" of a SEQUENCE/SET OF
-    case C1 of
-	[1] ->
-	    %% A list with an integer is the only valid option in a 'S
-	    %% OF', the other valid option would be an empty
-	    %% TypeNameList saying that the entire 'S OF' will be
-	    %% decoded.
-	    TagCommand = get_tag_command(TS,?CHOOSEN),
-	    create_pdec_command(ModName,Def,Cs,concat_tags(TagCommand,Acc));
-	[N] when is_integer(N) ->
-	    TagCommand = get_tag_command(TS,?SKIP),
-	    create_pdec_command(ModName,Def,[[N-1]|Cs],
-				concat_tags(TagCommand,Acc));
-	Err ->
-	    throw({error,{"unexpected error when creating partial "
-			  "decode command",Err}})
-    end;
-create_pdec_command(_,_,TNL,_) ->
-    throw({error,{"unexpected error when creating partial "
-		  "decode command",TNL}}).
-
-get_components(#'SEQUENCE'{components={C1,C2}}) when is_list(C1),is_list(C2) ->
-    C1++C2;
-get_components(#'SEQUENCE'{components=Components}) ->
-    Components;
-get_components(#'SET'{components={C1,C2}}) when is_list(C1),is_list(C2) ->
-    C1++C2;
-get_components(#'SET'{components=Components}) ->
-    Components;
-get_components({'SEQUENCE OF',Components}) ->
-    Components;
-get_components({'SET OF',Components}) ->
-    Components;
-get_components(Def) ->
-    Def.
-
-concat_sequential(L=[A,B],Acc) when is_atom(A),is_binary(B) ->
-    [L|Acc];
-concat_sequential(L,Acc) when is_list(L) ->
-    concat_sequential1(lists:reverse(L),Acc);
-concat_sequential(A,Acc)  ->
-    [A|Acc].
-concat_sequential1([],Acc) ->
-    Acc;
-concat_sequential1([[]],Acc) ->
-    Acc;
-concat_sequential1([El|RestEl],Acc) when is_list(El) ->
-    concat_sequential1(RestEl,[El|Acc]);
-concat_sequential1([mandatory|RestEl],Acc) ->
-    concat_sequential1(RestEl,[mandatory|Acc]);
-concat_sequential1(L,Acc) ->
-    [L|Acc].
-			
-
-many_tags([?SKIP])->   
-    false;
-many_tags([?SKIP_OPTIONAL,_]) ->
-    false;
-many_tags([?CHOOSEN,_]) ->
-    false;
-many_tags(_) ->
-    true.
-
-concat_tags(Ts,Acc) ->
-    case many_tags(Ts) of
-	true when is_list(Ts) ->
-	    lists:reverse(Ts)++Acc;
-	true ->
-	    [Ts|Acc];
-	false ->
-	    [Ts|Acc]
-    end.
-%% get_tag_command(Type,Command)
-
-%% Type is the type that has information about the tag Command tells
-%% what to do with the encoded value with the tag of Type when
-%% decoding. 
-get_tag_command(#type{tag=[]},_) ->
-    [];
-%% SKIP and SKIP_OPTIONAL shall return only one tag command regardless 
-get_tag_command(#type{},?SKIP) ->
-    ?SKIP;
-get_tag_command(#type{tag=Tags},?SKIP_OPTIONAL) ->
-    Tag=hd(Tags),
-    [?SKIP_OPTIONAL,encode_tag_val(decode_class(Tag#tag.class),
-				   Tag#tag.form,Tag#tag.number)];
-get_tag_command(#type{tag=[Tag]},Command) ->
-    %% encode the tag according to BER
-    [Command,encode_tag_val(decode_class(Tag#tag.class),Tag#tag.form, 
-			    Tag#tag.number)];
-get_tag_command(T=#type{tag=[Tag|Tags]},Command) ->
-    TC = get_tag_command(T#type{tag=[Tag]},Command),
-    TCs = get_tag_command(T#type{tag=Tags},Command),
-    case many_tags(TCs) of
-	true when is_list(TCs) ->
-	    [TC|TCs];
-	_ -> [TC|[TCs]]
-    end.
-
-%% get_tag_command/3 used by create_pdec_inc_command
-get_tag_command(#type{tag=[]},_,_) ->
-    [];
-get_tag_command(#type{tag=[Tag]},?MANDATORY,Prop) ->
-    case Prop of
-	mandatory ->
-	    ?MANDATORY;
-	{'DEFAULT',_} ->
-	    [?DEFAULT,encode_tag_val(decode_class(Tag#tag.class),
-				     Tag#tag.form,Tag#tag.number)];
-	_ -> [?OPTIONAL,encode_tag_val(decode_class(Tag#tag.class),
-				       Tag#tag.form,Tag#tag.number)]
-    end;
-get_tag_command(#type{tag=[Tag]},Command,Prop) ->
-    [anonymous_dec_command(Command,Prop),encode_tag_val(decode_class(Tag#tag.class),Tag#tag.form, Tag#tag.number)];
-get_tag_command(#type{tag=Tag},Command,Prop) when is_record(Tag,tag) ->
-    get_tag_command(#type{tag=[Tag]},Command,Prop);
-get_tag_command(T=#type{tag=[Tag|Tags]},Command,Prop) ->
-    [get_tag_command(T#type{tag=[Tag]},Command,Prop)|[
-     get_tag_command(T#type{tag=Tags},Command,Prop)]].
-
-anonymous_dec_command(?UNDECODED,'OPTIONAL') ->
-    ?OPTIONAL_UNDECODED;
-anonymous_dec_command(Command,_) ->
-    Command.
-
-get_referenced_type(M,Name) ->
-    case asn1_db:dbget(M,Name) of
-	#typedef{typespec=TS} ->
-	    case TS of
-		#type{def=#'Externaltypereference'{module=M2,type=Name2}} ->
-		    %% The tags have already been taken care of in the
-		    %% first reference where they were gathered in a
-		    %% list of tags.
-		    get_referenced_type(M2,Name2);
-		#type{} -> TS;
-		_  ->
-		    throw({error,{"unexpected element when"
-				  " fetching referenced type",TS}})
-	    end;
-	T ->
-	    throw({error,{"unexpected element when fetching "
-			  "referenced type",T}})
-    end.
-
-
-tlv_tags([]) ->
-    [];
-tlv_tags([mandatory|Rest]) ->
-    [mandatory|tlv_tags(Rest)];
-tlv_tags([[Command,Tag]|Rest]) when is_atom(Command),is_binary(Tag) ->
-    [[Command,tlv_tag(Tag)]|tlv_tags(Rest)];
-tlv_tags([[Command,Directives]|Rest]) when is_atom(Command),is_list(Directives) ->
-    [[Command,tlv_tags(Directives)]|tlv_tags(Rest)];
-%% remove all empty lists
-tlv_tags([[]|Rest]) ->
-    tlv_tags(Rest);
-tlv_tags([{Name,TopType,L1}|Rest]) when is_list(L1),is_atom(TopType) ->
-    [{Name,TopType,tlv_tags(L1)}|tlv_tags(Rest)];
-tlv_tags([[Command,Tag,L1]|Rest]) when is_list(L1),is_binary(Tag) ->
-    [[Command,tlv_tag(Tag),tlv_tags(L1)]|tlv_tags(Rest)];
-tlv_tags([[mandatory|Rest]]) ->
-    [[mandatory|tlv_tags(Rest)]];
-tlv_tags([L=[L1|_]|Rest]) when is_list(L1) ->
-    [tlv_tags(L)|tlv_tags(Rest)].
-
-tlv_tag(<<Cl:2,_:1,TagNo:5>>) when TagNo < 31 ->
-    (Cl bsl 16) + TagNo;
-tlv_tag(<<Cl:2,_:1,31:5,0:1,TagNo:7>>) ->
-    (Cl bsl 16) + TagNo;
-tlv_tag(<<Cl:2,_:1,31:5,Buffer/binary>>) ->
-    TagNo = tlv_tag1(Buffer,0),
-    (Cl bsl 16) + TagNo.
-tlv_tag1(<<0:1,PartialTag:7>>,Acc) ->
-    (Acc bsl 7) bor PartialTag;
-tlv_tag1(<<1:1,PartialTag:7,Buffer/binary>>,Acc) ->
-    tlv_tag1(Buffer,(Acc bsl 7) bor PartialTag).
-    
 %% Reads the content from the configuration file and returns the
 %% selected part chosen by InfoType. Assumes that the config file
 %% content is an Erlang term.
 read_config_file_info(ModuleName, InfoType) when is_atom(InfoType) ->
     Name = ensure_ext(ModuleName, ".asn1config"),
-    CfgList = read_config_file0(Name, []),
+    {ok,_,CfgList} = read_config_file0(Name, []),
     get_config_info(CfgList, InfoType).
 
 read_config_file(#gen{options=Options}, ModuleName) ->
@@ -1927,12 +1480,13 @@ read_config_file(#gen{options=Options}, ModuleName) ->
     Includes = [I || {i,I} <- Options],
     read_config_file0(Name, ["."|Includes]).
 
-read_config_file0(Name, [D|Dirs]) ->
-    case file:consult(filename:join(D, Name)) of
+read_config_file0(Name0, [Dir|Dirs]) ->
+    Name = filename:join(Dir, Name0),
+    case file:consult(Name) of
 	{ok,CfgList} ->
-	    CfgList;
+	    {ok,Name,CfgList};
 	{error,enoent} ->
-            read_config_file0(Name, Dirs);
+            read_config_file0(Name0, Dirs);
 	{error,Reason} ->
 	    Error = "error reading asn1 config file: " ++
 		file:format_error(Reason),
@@ -2396,7 +1950,7 @@ verbose(Format, Args, S) ->
     end.
 
 format_error({write_error,File,Reason}) ->
-    io_lib:format("writing output file ~s failed: ~s",
+    io_lib:format(<<"writing output file ~ts failed: ~s">>,
 		  [File,file:format_error(Reason)]).
 
 is_error(#state{options=Opts}) ->

--- a/lib/asn1/src/asn1ct_gen.erl
+++ b/lib/asn1/src/asn1ct_gen.erl
@@ -295,7 +295,7 @@ pgen_partial_types1(Erules,[{FuncName,[TopType|RestTypes]}|Rest]) ->
     CurrMod = get(currmod),
     TypeDef = asn1_db:dbget(CurrMod,TopType),
     traverse_type_structure(Erules,TypeDef,RestTypes,FuncName,
-			    TypeDef#typedef.name),
+			    [TypeDef#typedef.name]),
     pgen_partial_types1(Erules,Rest);
 pgen_partial_types1(_,[]) ->
     ok;

--- a/lib/asn1/src/asn1ct_partial_decode.erl
+++ b/lib/asn1/src/asn1ct_partial_decode.erl
@@ -1,0 +1,378 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2023. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(asn1ct_partial_decode).
+-export([prepare/2,format_error/1]).
+
+-include("asn1_records.hrl").
+
+prepare(Items, Mod) ->
+    _ = [prepare_item(Item, Mod) || Item <- Items],
+    ok.
+
+format_error({bad_decode_instruction,Term}) ->
+    io_lib:format(<<"badly formed exclusive decode instruction: ~p">>,
+                  [Term]);
+format_error({bad_exclusive_decode,Term}) ->
+    io_lib:format(<<"badly formed exclusive decode instructions: ~p">>,
+                  [Term]);
+format_error({bad_module_name,Mod,ShouldBe}) ->
+    io_lib:format(<<"the module name is ~p; expected it to be the same as the name"
+                    " of the ASN.1 module (~p)">>,
+                  [Mod,ShouldBe]);
+format_error({bad_selective_decode,Term}) ->
+    io_lib:format(<<"badly formed selective decode instructions: ~p">>,
+                  [Term]);
+format_error({bad_selective_decode_element,Term}) ->
+    io_lib:format(<<"badly formed element in selective decode instruction: ~p">>,
+                  [Term]);
+format_error({bad_selective_decode_type_list,Term}) ->
+    io_lib:format(<<"badly formed type list in selective decode instruction: ~p">>,
+                  [Term]);
+format_error({stepping_into_primitive,Path}) ->
+    io_lib:format(<<"the tail end of selective decode instructions attempts to ",
+                    "step into a primitive type:\n  ~p">>,
+                  [Path]);
+format_error({undefined_name,Type}) ->
+    io_lib:format(<<"name ~p not found">>, [Type]);
+format_error({undefined_type,Type}) ->
+    io_lib:format(<<"type ~p does not exist">>, [Type]).
+
+%%%
+%%% Common macros.
+%%%
+
+-define(ASN1CT_GEN_BER, asn1ct_gen_ber_bin_v2).
+
+%%%
+%%% Start of local functions.
+%%%
+
+prepare_item({selective_decode,SelectedDecode}, Mod) ->
+    CommandList = selective_decode(Mod, SelectedDecode),
+    asn1ct:save_config(partial_decode, CommandList),
+    asn1ct:save_gen_state(selective_decode, SelectedDecode),
+    ok;
+prepare_item({exclusive_decode,ExclusiveDecode}, Mod) ->
+    ExclusiveCommands = exclusive_decode(Mod, ExclusiveDecode),
+    asn1ct:save_config(partial_incomplete_decode, ExclusiveCommands),
+    asn1ct:save_gen_state(exclusive_decode, ExclusiveDecode, ExclusiveCommands),
+    ok.
+
+%%%
+%%% Handle exclusive decode.
+%%%
+
+-define(MANDATORY, mandatory).
+-define(DEFAULT, default).
+-define(OPTIONAL, opt).
+-define(OPTIONAL_UNDECODED, opt_undecoded).
+-define(PARTS, parts).
+-define(UNDECODED, undecoded).
+-define(ALTERNATIVE, alt).
+-define(ALTERNATIVE_UNDECODED, alt_undecoded).
+-define(ALTERNATIVE_PARTS, alt_parts).
+
+exclusive_decode(Mod, {ModI,Instructions}) when is_list(Instructions) ->
+    if
+        Mod =:= ModI ->
+            exclusive_decode_1(Mod, Instructions);
+        true ->
+            cfg_error({bad_module_name,ModI,Mod})
+    end;
+exclusive_decode(_Mod, Term) ->
+    cfg_error({bad_exclusive_decode,Term}).
+
+exclusive_decode_1(Mod, [{FunName,[TopType,Directives0]}|Is])
+  when is_atom(FunName), is_atom(TopType), is_list(Directives0) ->
+    Directives = exclusive_decode_map(Directives0),
+    [{FunName,TopType,exclusive_decode_2(Mod, TopType, Directives)} |
+     exclusive_decode_1(Mod, Is)];
+exclusive_decode_1(_Mod, []) ->
+    [];
+exclusive_decode_1(_Mod, Term) ->
+    cfg_error({bad_exclusive_decode,Term}).
+
+exclusive_decode_2(ModName, TopType, Directives) ->
+    case asn1_db:dbget(ModName, TopType) of
+	#typedef{typespec=TS} ->
+	    Acc = case get_tag_command(TS, ?MANDATORY, mandatory) of
+                      none -> [];
+                      TagCommand -> [TagCommand]
+                  end,
+	    exclusive_decode_command(get_components(TS#type.def),
+                                     Directives, Acc);
+	undefined ->
+            cfg_error({undefined_type,TopType})
+    end.
+
+exclusive_decode_map(Commands) ->
+    exclusive_decode_map(Commands, []).
+
+exclusive_decode_map([H|T], Acc) ->
+    case H of
+        {Name,Command0} when is_atom(Name) ->
+            Command =
+                if
+                    Command0 =:= ?UNDECODED; Command0 =:= ?PARTS ->
+                        Command0;
+                    is_list(Command0) ->
+                        exclusive_decode_map(Command0, []);
+                    true ->
+                        cfg_error({bad_decode_instruction,H})
+                end,
+            exclusive_decode_map(T, [{Name,Command}|Acc]);
+        _ ->
+            cfg_error({bad_decode_instruction,H})
+    end;
+exclusive_decode_map([], Acc) ->
+    maps:from_list(Acc).
+
+exclusive_decode_command(_, Commands, Acc) when map_size(Commands) =:= 0 ->
+    lists:reverse(Acc);
+exclusive_decode_command([#'ComponentType'{name=Name,typespec=TS,
+                                           prop=Prop}|Comps],
+                         Commands0, Acc) ->
+    case maps:take(Name, Commands0) of
+        {Command,Commands} when is_atom(Command) ->
+            TagCommand = get_tag_command(TS, Command, Prop),
+            exclusive_decode_command(Comps, Commands, [TagCommand|Acc]);
+        {InnerCommands0,Commands} when is_map(Commands0) ->
+            InnerCommands = exclusive_decode_command(TS#type.def,
+                                                     InnerCommands0, []),
+            case get_tag_command(TS, ?MANDATORY, Prop) of
+                ?MANDATORY ->
+                    exclusive_decode_command(Comps, Commands,
+                                             [{?MANDATORY,InnerCommands}|Acc]);
+                {Opt,EncTag} ->
+                    exclusive_decode_command(Comps, Commands,
+                                             [{Opt,EncTag,InnerCommands}|Acc])
+            end;
+        error ->
+            TagCommand = get_tag_command(TS, ?MANDATORY, Prop),
+            exclusive_decode_command(Comps, Commands0, [TagCommand|Acc])
+    end;
+exclusive_decode_command({'CHOICE',[_|_]=Cs}, Commands, Acc) ->
+    exclusive_decode_choice_cs(Cs, Commands, Acc);
+exclusive_decode_command({'CHOICE',{Cs1,Cs2}}, Commands, Acc)
+  when is_list(Cs1), is_list(Cs2) ->
+    exclusive_decode_choice_cs(Cs1 ++ Cs2, Commands, Acc);
+exclusive_decode_command(#'Externaltypereference'{module=M,type=Name},
+                         Commands, Acc) ->
+    #type{def=Def} = get_referenced_type(M, Name),
+    exclusive_decode_command(get_components(Def), Commands, Acc);
+exclusive_decode_command([], Commands, _) ->
+    [{Name,_}|_] = maps:to_list(maps:iterator(Commands, ordered)),
+    cfg_error({undefined_name,Name}).
+
+exclusive_decode_choice_cs(_, Commands, Acc) when map_size(Commands) =:= 0 ->
+    lists:reverse(Acc);
+exclusive_decode_choice_cs([#'ComponentType'{name=Name,typespec=TS}|Cs],
+                           Commands0, Acc) ->
+    case maps:take(Name, Commands0) of
+        {Inner,Commands} ->
+            case Inner of
+                ?UNDECODED ->
+                    TagCommand = get_tag_command(TS, ?ALTERNATIVE_UNDECODED, mandatory),
+                    exclusive_decode_choice_cs(Cs, Commands, [TagCommand|Acc]);
+                ?PARTS ->
+                    TagCommand = get_tag_command(TS, ?ALTERNATIVE_PARTS, mandatory),
+                    exclusive_decode_choice_cs(Cs, Commands, [TagCommand|Acc]);
+                _ when is_map(Inner) ->
+                    {Command,Tag} = get_tag_command(TS, ?ALTERNATIVE, mandatory),
+                    CompAcc = exclusive_decode_command(get_components(TS#type.def), Inner, []),
+                    exclusive_decode_choice_cs(Cs, Commands, [{Command,Tag,CompAcc}|Acc])
+            end;
+        error ->
+            TagCommand = get_tag_command(TS, ?ALTERNATIVE, mandatory),
+            exclusive_decode_choice_cs(Cs, Commands0, [TagCommand|Acc])
+    end.
+
+get_tag_command(#type{tag=[]}, _, _) ->
+    none;
+get_tag_command(#type{tag=[Tag]}, ?MANDATORY, Prop) ->
+    case Prop of
+        mandatory ->
+            ?MANDATORY;
+        {'DEFAULT',_} ->
+            {?DEFAULT,?ASN1CT_GEN_BER:tag_to_integer(Tag)};
+        _ ->
+            {?OPTIONAL,?ASN1CT_GEN_BER:tag_to_integer(Tag)}
+    end;
+get_tag_command(#type{tag=[Tag]}, Command, Prop) ->
+    {anonymous_dec_command(Command, Prop),
+     ?ASN1CT_GEN_BER:tag_to_integer(Tag)}.
+
+anonymous_dec_command(?UNDECODED, 'OPTIONAL') ->
+    ?OPTIONAL_UNDECODED;
+anonymous_dec_command(Command,_) ->
+    Command.
+
+%%%
+%%% Selective decode.
+%%%
+
+-define(CHOSEN, chosen).
+-define(SKIP, skip).
+-define(SKIP_OPTIONAL, skip_optional).
+
+selective_decode(Mod, {ModI,TypeLists}) ->
+    if
+        Mod =:= ModI ->
+            selective_decode1(Mod, TypeLists);
+        true ->
+            cfg_error({bad_module_name,ModI,Mod})
+    end;
+selective_decode(_, Bad) ->
+    cfg_error({bad_selective_decode,Bad}).
+
+selective_decode1(Mod, [TL|TypeLists]) ->
+    [selective_decode2(Mod, TL) |
+     selective_decode1(Mod, TypeLists)];
+selective_decode1(_, []) ->
+    [];
+selective_decode1(_, Bad) ->
+    cfg_error({bad_selective_decode,Bad}).
+
+selective_decode2(ModName, {FuncName,TypeList}) ->
+    case TypeList of
+        [TopType|Types] ->
+            case asn1_db:dbget(ModName, TopType) of
+                #typedef{typespec=TS} ->
+                    TagCommand = get_tag_command(TS, ?CHOSEN),
+                    Ret = selective_decode_command(get_components(TS#type.def),
+                                                   Types, concat_tags(TagCommand, [])),
+                    {FuncName,Ret};
+                undefined ->
+                    cfg_error({undefined_type,TopType})
+            end;
+        _ ->
+            cfg_error({bad_selective_decode_type_list,TypeList})
+    end;
+selective_decode2(_, Bad) ->
+    cfg_error({bad_selective_decode,Bad}).
+
+selective_decode_command(_, [], Acc) ->
+    lists:reverse(Acc);
+selective_decode_command([#'ComponentType'{name=Name,typespec=TS}|_],
+		    [Name], Acc) ->
+    TagCommand = get_tag_command(TS, ?CHOSEN),
+    lists:reverse(concat_tags(TagCommand, Acc));
+selective_decode_command([#'ComponentType'{name=Name,typespec=TS}|_],
+		    [Name|Cs], Acc) ->
+    case asn1ct_gen:type(asn1ct_gen:get_inner(TS#type.def)) of
+        {primitive,bif} ->
+            cfg_error({stepping_into_primitive,[Name|Cs]});
+        _ ->
+            TagCommand = get_tag_command(TS, ?CHOSEN),
+            selective_decode_command(get_components(TS#type.def),
+                                     Cs, concat_tags(TagCommand, Acc))
+    end;
+selective_decode_command([#'ComponentType'{typespec=TS,
+                                      prop=Prop}|Comps],
+		    [_|_]=Cs, Acc) ->
+    TagCommand = case Prop of
+                     mandatory ->
+                         get_tag_command(TS, ?SKIP);
+                     _ ->
+                         get_tag_command(TS, ?SKIP_OPTIONAL)
+                 end,
+    selective_decode_command(Comps, Cs, concat_tags(TagCommand, Acc));
+selective_decode_command({'CHOICE',[_|_]=Cs}, [Name|_]=TNL, Acc) ->
+    case lists:keyfind(Name, #'ComponentType'.name, Cs) of
+        #'ComponentType'{}=C ->
+            selective_decode_command([C], TNL, Acc);
+        false ->
+            cfg_error({undefined_name,Name})
+    end;
+selective_decode_command({'CHOICE',{Cs1,Cs2}}, TNL, Acc)
+  when is_list(Cs1), is_list(Cs2) ->
+    selective_decode_command({'CHOICE',Cs1 ++ Cs2}, TNL, Acc);
+selective_decode_command(#'Externaltypereference'{module=M,type=C1},
+		    TypeNameList, Acc) ->
+    #type{def=Def} = get_referenced_type(M, C1),
+    selective_decode_command(get_components(Def), TypeNameList, Acc);
+selective_decode_command(#type{def=Def}=TS, [C1|Cs], Acc0) ->
+    case C1 of
+        [N] when is_integer(N), N >= 1 ->
+            SkipTags = lists:duplicate(N - 1, ?SKIP),
+            Acc = SkipTags ++ Acc0,
+            TagCommand = get_tag_command(TS, ?CHOSEN),
+            selective_decode_command(Def, Cs, concat_tags(TagCommand, Acc));
+        Bad ->
+            cfg_error({bad_selective_decode_element,Bad})
+    end;
+selective_decode_command(_, [Name], _) ->
+    cfg_error({undefined_name,Name}).
+
+get_tag_command(#type{tag=[]}, _) ->
+    [];
+get_tag_command(#type{}, ?SKIP) ->
+    [?SKIP];
+get_tag_command(#type{tag=[Tag|_]}, ?SKIP_OPTIONAL) ->
+    #tag{class=Class,form=Form,number=TagNo} = Tag,
+    [{?SKIP_OPTIONAL,
+      ?ASN1CT_GEN_BER:encode_tag_val(?ASN1CT_GEN_BER:decode_class(Class),
+                                     Form, TagNo)}];
+get_tag_command(#type{tag=[Tag]}, Command) ->
+    #tag{class=Class,form=Form,number=TagNo} = Tag,
+    [{Command,
+      ?ASN1CT_GEN_BER:encode_tag_val(?ASN1CT_GEN_BER:decode_class(Class),
+                                     Form, TagNo)}];
+get_tag_command(T=#type{tag=[Tag|Tags]}, Command) ->
+    TC = get_tag_command(T#type{tag=[Tag]}, Command),
+    TCs = get_tag_command(T#type{tag=Tags}, Command),
+    TC ++ TCs.
+
+concat_tags(Ts, Acc) when is_list(Ts) ->
+    lists:reverse(Ts, Acc).
+
+%%%
+%%% Common utilities.
+%%%
+
+get_components(#'SEQUENCE'{components={Cs1,Cs2}}) when is_list(Cs1), is_list(Cs2) ->
+    Cs1 ++ Cs2;
+get_components(#'SEQUENCE'{components=Cs}) when is_list(Cs) ->
+    Cs;
+get_components(#'SET'{components={Cs1,Cs2}}) when is_list(Cs1), is_list(Cs2) ->
+    Cs1 ++ Cs2;
+get_components(#'SET'{components=Cs}) when is_list(Cs) ->
+    Cs;
+get_components({'SEQUENCE OF',#type{}=Component})->
+    Component;
+get_components({'SET OF',#type{}=Component}) ->
+    Component;
+get_components(Def) ->
+    Def.
+
+get_referenced_type(M0, Name0) ->
+    #typedef{typespec=TS} = asn1_db:dbget(M0, Name0),
+    case TS of
+        #type{def=#'Externaltypereference'{module=M,type=Name}} ->
+            %% The tags have already been taken care of in the first
+            %% reference where they were gathered in a list of tags.
+            get_referenced_type(M, Name);
+        #type{} ->
+            TS
+    end.
+
+cfg_error(Error) ->
+    throw({structured_error,Error}).

--- a/lib/asn1/src/asn1rtt_ber.erl
+++ b/lib/asn1/src/asn1rtt_ber.erl
@@ -160,22 +160,22 @@ decode_constructed_indefinite(Bin,Acc) ->
 
 %% decode_primitive_incomplete/2 decodes an encoded message incomplete
 %% by help of the pattern attribute (first argument).
-decode_primitive_incomplete([[default,TagNo]],Bin) -> %default
+decode_primitive_incomplete([{default,TagNo}], Bin) ->
     case decode_tag_and_length(Bin) of
 	{Form,TagNo,V,Rest} ->
-	    decode_incomplete2(Form,TagNo,V,[],Rest);
+	    decode_incomplete2(Form, TagNo, V, [], Rest);
 	_ ->
 	    asn1_NOVALUE
     end;
-decode_primitive_incomplete([[default,TagNo,Directives]],Bin) ->
+decode_primitive_incomplete([{default,TagNo,Directives}], Bin) ->
     %% default, constructed type, Directives points into this type
     case decode_tag_and_length(Bin) of
 	{Form,TagNo,V,Rest} ->
-	    decode_incomplete2(Form,TagNo,V,Directives,Rest);
+	    decode_incomplete2(Form, TagNo, V, Directives, Rest);
 	_ ->
 	    asn1_NOVALUE
     end;
-decode_primitive_incomplete([[opt,TagNo]],Bin) ->
+decode_primitive_incomplete([{opt,TagNo}],Bin) ->
     %% optional
     case decode_tag_and_length(Bin) of
 	{Form,TagNo,V,Rest} ->
@@ -183,16 +183,16 @@ decode_primitive_incomplete([[opt,TagNo]],Bin) ->
 	_ ->
 	    asn1_NOVALUE
     end;
-decode_primitive_incomplete([[opt,TagNo,Directives]],Bin) ->
+decode_primitive_incomplete([{opt,TagNo,Directives}], Bin) ->
     %% optional
     case decode_tag_and_length(Bin) of
 	{Form,TagNo,V,Rest} ->
-	    decode_incomplete2(Form,TagNo,V,Directives,Rest);
+	    decode_incomplete2(Form, TagNo, V, Directives, Rest);
 	_ ->
 	    asn1_NOVALUE
     end;
 %% An optional that shall be undecoded
-decode_primitive_incomplete([[opt_undec,Tag]],Bin) ->
+decode_primitive_incomplete([{opt_undecoded,Tag}], Bin) ->
     case decode_tag_and_length(Bin) of
 	{_,Tag,_,_} ->
 	    decode_incomplete_bin(Bin);
@@ -200,57 +200,56 @@ decode_primitive_incomplete([[opt_undec,Tag]],Bin) ->
 	    asn1_NOVALUE
     end;
 %% A choice alternative that shall be undecoded
-decode_primitive_incomplete([[alt_undec,TagNo]|RestAlts],Bin) ->
+decode_primitive_incomplete([{alt_undecoded,TagNo}|RestAlts], Bin) ->
     case decode_tag_and_length(Bin) of
 	{_,TagNo,_,_} ->
 	    decode_incomplete_bin(Bin);
 	_ ->
-	    decode_primitive_incomplete(RestAlts,Bin)
+	    decode_primitive_incomplete(RestAlts, Bin)
     end;
-decode_primitive_incomplete([[alt,TagNo]|RestAlts],Bin) ->
+decode_primitive_incomplete([{alt,TagNo}|RestAlts], Bin) ->
     case decode_tag_and_length(Bin) of
 	{_Form,TagNo,V,Rest} ->
 	    {{TagNo,V},Rest};
 	_ ->
 	    decode_primitive_incomplete(RestAlts,Bin)
     end;
-decode_primitive_incomplete([[alt,TagNo,Directives]|RestAlts],Bin) ->
+decode_primitive_incomplete([{alt,TagNo,Directives}|RestAlts], Bin) ->
     case decode_tag_and_length(Bin) of
 	{Form,TagNo,V,Rest} ->
 	    decode_incomplete2(Form,TagNo,V,Directives,Rest);
 	_ ->
 	    decode_primitive_incomplete(RestAlts,Bin)
     end;
-decode_primitive_incomplete([[alt_parts,TagNo]],Bin) ->
+decode_primitive_incomplete([{alt_parts,TagNo}], Bin) ->
     case decode_tag_and_length(Bin) of
 	{_Form,TagNo,V,Rest} ->
 	    {{TagNo,V},Rest};
 	_ ->
 	    asn1_NOVALUE
     end;
-decode_primitive_incomplete([[alt_parts,TagNo]|RestAlts],Bin) ->
+decode_primitive_incomplete([{alt_parts,TagNo}|RestAlts], Bin) ->
     case decode_tag_and_length(Bin) of
 	{_Form,TagNo,V,Rest} ->
 	    {{TagNo,decode_parts_incomplete(V)},Rest};
 	_ ->
-	    decode_primitive_incomplete(RestAlts,Bin)
+	    decode_primitive_incomplete(RestAlts, Bin)
     end;
-decode_primitive_incomplete([[undec,_TagNo]|_RestTag],Bin) ->
-    %% incomlete decode
+decode_primitive_incomplete([{undecoded,_TagNo}|_RestTag], Bin) ->
     decode_incomplete_bin(Bin);
-decode_primitive_incomplete([[parts,TagNo]|_RestTag],Bin) ->
+decode_primitive_incomplete([{parts,TagNo}|_RestTag],Bin) ->
     case decode_tag_and_length(Bin) of
 	{_Form,TagNo,V,Rest} ->
 	    {{TagNo,decode_parts_incomplete(V)},Rest};
 	Err ->
 	    {error,{asn1,"tag failure",TagNo,Err}}
     end;
-decode_primitive_incomplete([mandatory|RestTag],Bin) ->
+decode_primitive_incomplete([mandatory|RestTag], Bin) ->
     {Form,TagNo,V,Rest} = decode_tag_and_length(Bin),
     decode_incomplete2(Form,TagNo,V,RestTag,Rest);
 %% A choice that is a toptype or a mandatory component of a
 %% SEQUENCE or SET.
-decode_primitive_incomplete([[mandatory|Directives]],Bin) ->
+decode_primitive_incomplete([{mandatory,Directives}], Bin) ->
     {Form,TagNo,V,Rest} = decode_tag_and_length(Bin),
     decode_incomplete2(Form,TagNo,V,Directives,Rest);
 decode_primitive_incomplete([],Bin) ->
@@ -269,7 +268,7 @@ decode_parts_incomplete(Bin) ->
 
 
 %% decode_incomplete2 checks if V is a value of a constructed or
-%% primitive type, and continues the decode propeerly.
+%% primitive type, and continues the decode properly.
 decode_incomplete2(_Form=2,TagNo,V,TagMatch,_) ->
     %% constructed indefinite length
     {Vlist,Rest2} = decode_constr_indef_incomplete(TagMatch,V,[]),
@@ -288,16 +287,16 @@ decode_constructed_incomplete(_TagMatch,<<>>) ->
 decode_constructed_incomplete([mandatory|RestTag],Bin) ->
     {Tlv,Rest} = decode_primitive(Bin),
     [Tlv|decode_constructed_incomplete(RestTag,Rest)];
-decode_constructed_incomplete(Directives=[[Alt,_]|_],Bin)
-  when Alt =:= alt_undec; Alt =:= alt; Alt =:= alt_parts ->
+decode_constructed_incomplete([{Alt,_}|_]=Directives, Bin)
+  when Alt =:= alt_undecoded; Alt =:= alt; Alt =:= alt_parts ->
     {_Form,TagNo,V,Rest} = decode_tag_and_length(Bin),
     case incomplete_choice_alt(TagNo, Directives) of
-	{alt_undec,_} ->
+	{alt_undecoded,_} ->
 	    LenA = byte_size(Bin) - byte_size(Rest),
 	    <<A:LenA/binary,Rest/binary>> = Bin,
 	    A;
 	{alt,InnerDirectives} ->
-	    {Tlv,Rest} = decode_primitive_incomplete(InnerDirectives,V),
+	    {Tlv,Rest} = decode_primitive_incomplete(InnerDirectives, V),
 	    {TagNo,Tlv};
 	{alt_parts,_} ->
 	    [{TagNo,decode_parts_incomplete(V)}];
@@ -305,7 +304,7 @@ decode_constructed_incomplete(Directives=[[Alt,_]|_],Bin)
             %% if a choice alternative was encoded that
 	    %% was not specified in the config file,
 	    %% thus decode component anonomous.
-	    {Tlv,_}=decode_primitive(Bin),
+	    {Tlv,_} = decode_primitive(Bin),
 	    Tlv
     end;
 decode_constructed_incomplete([TagNo|RestTag],Bin) ->
@@ -337,12 +336,12 @@ decode_incomplete_bin(Bin) ->
     <<IncBin:IncLen/binary,Ret/binary>> = Bin,
     {IncBin,Ret}.
 
-incomplete_choice_alt(TagNo,[[Alt,TagNo]|Directives]) ->
+incomplete_choice_alt(TagNo, [{Alt,TagNo}|Directives]) ->
     {Alt,Directives};
-incomplete_choice_alt(TagNo,[D]) when is_list(D) ->
-    incomplete_choice_alt(TagNo,D);
-incomplete_choice_alt(TagNo,[_H|Directives]) ->
-    incomplete_choice_alt(TagNo,Directives);
+incomplete_choice_alt(TagNo, [D]) when is_list(D) ->
+    incomplete_choice_alt(TagNo, D);
+incomplete_choice_alt(TagNo, [_H|Directives]) ->
+    incomplete_choice_alt(TagNo, Directives);
 incomplete_choice_alt(_,[]) ->
     no_match.
 
@@ -353,35 +352,35 @@ incomplete_choice_alt(_,[]) ->
 %% Returns {ok,Value} or {error,Reason}
 %% Value is a binary that in turn must be decoded to get the decoded
 %% value.
-decode_selective([],Binary) ->
+decode_selective([], Binary) ->
     {ok,Binary};
-decode_selective([skip|RestPattern],Binary)->
-    {ok,RestBinary}=skip_tag(Binary),
-    {ok,RestBinary2}=skip_length_and_value(RestBinary),
-    decode_selective(RestPattern,RestBinary2);
-decode_selective([[skip_optional,Tag]|RestPattern],Binary) ->
-    case skip_optional_tag(Tag,Binary) of
-	{ok,RestBinary} ->
-	    {ok,RestBinary2}=skip_length_and_value(RestBinary),
-	    decode_selective(RestPattern,RestBinary2);
-	missing ->
-	    decode_selective(RestPattern,Binary)
+decode_selective([skip|RestPattern], Binary)->
+    {ok,RestBinary} = skip_tag(Binary),
+    {ok,RestBinary2} = skip_length_and_value(RestBinary),
+    decode_selective(RestPattern, RestBinary2);
+decode_selective([{skip_optional,Tag}|RestPattern], Binary) ->
+    case skip_optional_tag(Tag, Binary) of
+        {ok,RestBinary} ->
+            {ok,RestBinary2} = skip_length_and_value(RestBinary),
+            decode_selective(RestPattern, RestBinary2);
+        missing ->
+            decode_selective(RestPattern, Binary)
     end;
-decode_selective([[choosen,Tag]],Binary) ->
-    return_value(Tag,Binary);
-decode_selective([[choosen,Tag]|RestPattern],Binary) ->
-    case skip_optional_tag(Tag,Binary) of
-	{ok,RestBinary} ->
-	    {ok,Value} = get_value(RestBinary),
-	    decode_selective(RestPattern,Value);
-	missing ->
-	    {ok,<<>>}
+decode_selective([{chosen,Tag}], Binary) ->
+    return_value(Tag, Binary);
+decode_selective([{chosen,Tag}|RestPattern], Binary) ->
+    case skip_optional_tag(Tag, Binary) of
+        {ok,RestBinary} ->
+            {ok,Value} = get_value(RestBinary),
+            decode_selective(RestPattern,Value);
+        missing ->
+            {ok,<<>>}
     end;
 decode_selective(P,_) ->
     {error,{asn1,{partial_decode,"bad pattern",P}}}.
 
 return_value(Tag,Binary) ->
-    {ok,{Tag,RestBinary}}=get_tag(Binary),
+    {ok,{Tag,RestBinary}} = get_tag(Binary),
     {ok,{LenVal,_RestBinary2}} = get_length_and_value(RestBinary),
     {ok,<<Tag/binary,LenVal/binary>>}.
 

--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -965,11 +965,13 @@ specialized_decodes(Config, Rule, Opts) ->
                                "PartialDecSeq2.asn",
                                "PartialDecSeq3.asn",
                                "PartialDecMyHTTP.asn",
-                               "MEDIA-GATEWAY-CONTROL.asn",
                                "P-Record",
                                "PartialDecChoExtension.asn"],
                               Config,
-			      [Rule,legacy_erlang_types,asn1config|Opts]),
+			      [Rule,asn1config|Opts]),
+    asn1_test_lib:compile("MEDIA-GATEWAY-CONTROL.asn",
+                          Config,
+                          [Rule,legacy_erlang_types,asn1config|Opts]),
     test_partial_incomplete_decode:test(Config),
     test_selective_decode:test().
 

--- a/lib/asn1/test/asn1_SUITE_data/MEDIA-GATEWAY-CONTROL.asn1config
+++ b/lib/asn1/test/asn1_SUITE_data/MEDIA-GATEWAY-CONTROL.asn1config
@@ -1,7 +1,9 @@
+%% -*- erlang -*-
 {exclusive_decode,
-  {'MEDIA-GATEWAY-CONTROL',
-    [{decode_MegacoMessage_exclusive,['MegacoMessage',[{authHeader,undecoded},{mess,[{mId,undecoded},{messageBody,undecoded}]}]]},
-     {decode_Message_version,['Message',[{mId,undecoded},{messageBody,undecoded}]]}]}}.
+ {'MEDIA-GATEWAY-CONTROL',
+  [{decode_MegacoMessage_exclusive,
+    ['MegacoMessage',[{authHeader,undecoded},{mess,[{mId,undecoded},{messageBody,undecoded}]}]]},
+   {decode_Message_version,['Message',[{mId,undecoded},{messageBody,undecoded}]]}]}}.
 {selective_decode,
-	{'MEDIA-GATEWAY-CONTROL',
-	   [{decode_MegacoMessage_selective,['MegacoMessage',mess,version]}]}}.
+ {'MEDIA-GATEWAY-CONTROL',
+  [{decode_MegacoMessage_selective,['MegacoMessage',mess,version]}]}}.

--- a/lib/asn1/test/asn1_SUITE_data/PartialDecSeq.asn1config
+++ b/lib/asn1/test/asn1_SUITE_data/PartialDecSeq.asn1config
@@ -1,14 +1,19 @@
-{selective_decode,{'PartialDecSeq',
-	[{selected_decode_F1,['F',fb,b,[1],a]},
-	 {selected_decode_F2,['F',fb,b]},
-	 {selected_decode_F3,['F',fb,b,[1]]},
-	 {selected_decode_F4,['F',fb,d,da,[1],b,a]},
-	 {selected_decode_E1,['E',d,dc,dcc,dcca]}]}}.
-{exclusive_decode,{'PartialDecSeq',
-	[{decode_F_fb_incomplete,['F',[{fb,[{b,parts},{d,undecoded}]}]]},
-	 {decode_D_incomplete,['D',[{a,undecoded}]]},
-	 {decode_F_fb_exclusive2,['F',[{fb,[{b,parts},{d,[{da,parts}]}]}]]},	     {decode_F_fb_exclusive3,['F',[{fb,[{b,parts},{d,[{da,parts},{dc,[{dcc,undecoded}]}]}]}]]}]}}.
-{module_name,'Seq.asn1'}.
-{compile_options,[ber,debug_info]}.
-{multifile_compile,['M1.asn','M2.asn']}.
-
+%% -*- erlang -*-
+{selective_decode,
+ {'PartialDecSeq',
+  [{selected_decode_F1_1,['F',fb,b,[1],a]},
+   {selected_decode_F1_2,['F',fb,b,[2],a]},
+   {selected_decode_F2,['F',fb,b]},
+   {selected_decode_F3,['F',fb,b,[1]]},
+   {selected_decode_F4,['F',fb,d,da,[1],b,a]},
+   {selected_decode_F5,['F',fb]},
+   {selected_decode_E1,['E',d,dc,dcc,dcca]},
+   {selected_decode_E2,['E',b]}
+  ]}}.
+{exclusive_decode,
+ {'PartialDecSeq',
+  [{decode_E_b_incomplete,['E',[{b,parts}]]},
+   {decode_F_fb_incomplete,['F',[{fb,[{b,parts},{d,undecoded}]}]]},
+   {decode_D_incomplete,['D',[{a,undecoded}]]},
+   {decode_F_fb_exclusive2,['F',[{fb,[{b,parts},{d,[{da,parts}]}]}]]},
+   {decode_F_fb_exclusive3,['F',[{fb,[{b,parts},{d,[{da,parts},{dc,[{dcc,undecoded}]}]}]}]]}]}}.

--- a/lib/asn1/test/asn1_SUITE_data/PartialDecSeq2.asn
+++ b/lib/asn1/test/asn1_SUITE_data/PartialDecSeq2.asn
@@ -8,6 +8,13 @@ B ::= CHOICE {
   c  S
 }
 
+Bext ::= CHOICE {
+  a  INTEGER,
+  b  SEQUENCE {aa  INTEGER, ba  INTEGER},
+  ...,
+  c  S
+}
+
 S ::= SEQUENCE {
   a  BOOLEAN,
   b  BOOLEAN
@@ -25,5 +32,15 @@ D ::= SEQUENCE {
   a  INTEGER,
   b  BOOLEAN
 }
+
+SeqChoice ::= SEQUENCE {
+  c  CHOICE {
+        b BOOLEAN,
+        i INTEGER,
+        s VisibleString
+     },
+  d  OCTET STRING
+}
+
 
 END

--- a/lib/asn1/test/asn1_SUITE_data/PartialDecSeq2.asn1config
+++ b/lib/asn1/test/asn1_SUITE_data/PartialDecSeq2.asn1config
@@ -1,4 +1,14 @@
-%{partial_decode,{{module,'Seq2'},['F',fb,b,[1],a]}}.
-{exclusive_decode,{'PartialDecSeq2',
-	[{decode_A_c_b_incomplete,['A',[{c,[{a,undecoded},{b,undecoded}]}]]},
-	 {decode_D_incomplete,['D',[{a,undecoded}]]}]}}.
+%% -*- erlang -*-
+{exclusive_decode,
+ {'PartialDecSeq2',
+  [{decode_A_c_b_incomplete,['A',[{c,[{a,undecoded},{b,undecoded}]}]]},
+   {decode_D_incomplete,['D',[{a,undecoded}]]},
+   {decode_Bext_c_incomplete,['Bext',[{c,undecoded}]]},
+   {decode_Bext_c_b_incomplete,['Bext',[{c,[{b,undecoded}]}]]},
+   {decode_SeqChoice_c_b_d_incomplete,
+    ['SeqChoice',[{c,[{b,undecoded}]},
+                  {d,undecoded}]]},
+   {decode_SeqChoice_c_bis_incomplete,
+    ['SeqChoice',
+     [{c,[{b,undecoded},{i,undecoded},{s,undecoded}]}]]}
+  ]}}.

--- a/lib/asn1/test/asn1_SUITE_data/PartialDecSeq3.asn1config
+++ b/lib/asn1/test/asn1_SUITE_data/PartialDecSeq3.asn1config
@@ -1,2 +1,6 @@
-{exclusive_decode,{'PartialDecSeq3',
-	[{decode_S1_incomplete,['S1',[{b,[{c,parts}]},{c,[{a,parts}]},{d,parts}]]}]}}.
+%% -*- erlang -*-
+{exclusive_decode,
+ {'PartialDecSeq3',
+  [{decode_S1_incomplete,['S1',[{b,[{c,parts}]},{c,[{a,parts}]},{d,parts}]]},
+   {decode_S3_second,['S3',[{second,undecoded}]]}
+  ]}}.

--- a/lib/asn1/test/asn1_SUITE_data/TCAPPackage.asn1config
+++ b/lib/asn1/test/asn1_SUITE_data/TCAPPackage.asn1config
@@ -1,12 +1,15 @@
-{exclusive_decode, {'TCAPPackage',
-      [{decode_PackageType, ['PackageType', 
-            [{unidirectional, undecoded},
-            {queryWithPerm, [{componentPortion, parts}]},
-            {queryWithoutPerm, undecoded},
-            {response, [{componentPortion, parts}]},
-            {conversationWithPerm, undecoded},
-            {conversationWithoutPerm, undecoded},
-            {abort, undecoded}]]},
-      {decode_TransactionPDU, ['TransactionPDU',
-            [{componentPortion, parts}]]}]}}.
-
+%% -*- erlang -*-
+{exclusive_decode,
+ {'TCAPPackage',
+  [{decode_PackageType,
+    ['PackageType',
+     [{unidirectional, undecoded},
+      {queryWithPerm, [{componentPortion, parts}]},
+      {queryWithoutPerm, undecoded},
+      {response, [{componentPortion, parts}]},
+      {conversationWithPerm, undecoded},
+      {conversationWithoutPerm, undecoded},
+      {abort, undecoded}]]},
+   {decode_TransactionPDU,
+    ['TransactionPDU',
+     [{componentPortion, parts}]]}]}}.

--- a/lib/asn1/test/asn1_app_SUITE.erl
+++ b/lib/asn1/test/asn1_app_SUITE.erl
@@ -133,7 +133,8 @@ check_asn1ct_modules(Extra) ->
 		  asn1ct_gen_ber_bin_v2,asn1ct_value,
 		  asn1ct_tok,asn1ct_parser2,asn1ct_table,
 		  asn1ct_imm,asn1ct_func,asn1ct_rtt,
-		  asn1ct_eval_ext,asn1ct_gen_jer],
+		  asn1ct_eval_ext,asn1ct_gen_jer,
+                  asn1ct_partial_decode],
     case Extra -- ASN1CTMods of
 	[] ->
 	    ok;

--- a/lib/asn1/test/error_SUITE.erl
+++ b/lib/asn1/test/error_SUITE.erl
@@ -20,7 +20,9 @@
 
 -module(error_SUITE).
 -export([suite/0,all/0,groups/0,
-	 already_defined/1,bitstrings/1,
+	 already_defined/1,
+         bad_config_exclusive/1,bad_config_selective/1,
+         bitstrings/1,
 	 classes/1,constraints/1,constructed/1,enumerated/1,
 	 imports_exports/1,instance_of/1,integers/1,objects/1,
 	 object_field_extraction/1,oids/1,rel_oids/1,
@@ -38,6 +40,8 @@ groups() ->
     [{p,parallel(),
       [already_defined,
        bitstrings,
+       bad_config_exclusive,
+       bad_config_selective,
        classes,
        constraints,
        constructed,
@@ -89,6 +93,99 @@ already_defined(Config) ->
       {structured_error,{M,12},asn1ct_check,{already_defined,'i',3}}
      ]
     } = run(P, Config),
+    ok.
+
+bad_config_exclusive(Config) ->
+    M = 'BadConfigExclusive',
+    P = {M,
+         <<"BadConfigExclusive DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+              Seq ::= SEQUENCE {
+                    a INTEGER,
+                    b SEQUENCE OF INTEGER,
+                    c BOOLEAN
+              }
+            END\n">>},
+
+    Conf1 = [{exclusive_decode,{'WrongModuleName',[whatever]}}],
+    {error,{bad_module_name,'WrongModuleName',M}} = run(P, Config, Conf1),
+
+    Conf2 = [{exclusive_decode,wrong}],
+    {error,{bad_exclusive_decode,wrong}} = run(P, Config, Conf2),
+
+    Conf3 = [{exclusive_decode,{M,[wrong]}}],
+    {error,{bad_exclusive_decode,[wrong]}} = run(P, Config, Conf3),
+
+    Conf4 = [{exclusive_decode,{M,{42,[top_type,[]]}}}],
+    {error,{bad_exclusive_decode,_}} = run(P, Config, Conf4),
+
+    Conf5 = [{exclusive_decode,
+              {M, [{exclusive_Seq, ['TopType', [{b,parts}]]}]}}],
+    {error,{undefined_type,'TopType'}} = run(P, Config, Conf5),
+
+    Conf6 = [{exclusive_decode,
+              {M, [{exclusive_Seq, ['Seq', [{d,parts}]]}]}}],
+    {error,{undefined_name,d}} = run(P, Config, Conf6),
+
+    Conf7 = [{exclusive_decode,
+              {M, [{exclusive_Seq, ['Seq', [{b,whatever}]]}]}}],
+    {error,{bad_decode_instruction,{b,whatever}}} = run(P, Config, Conf7),
+
+    Conf8 = [{exclusive_decode,
+              {M, [{exclusive_Seq, ['Seq', [{a,b,c}]]}]}}],
+    {error,{bad_decode_instruction,{a,b,c}}} = run(P, Config, Conf8),
+
+    ok.
+
+bad_config_selective(Config) ->
+    M = 'BadConfigSelective',
+    P = {M,
+         <<"BadConfigSelective DEFINITIONS AUTOMATIC TAGS ::= BEGIN
+              Seq ::= SEQUENCE {
+                    a INTEGER,
+                    b SEQUENCE OF INTEGER,
+                    c BOOLEAN,
+                    cc CHOICE {
+                       ca INTEGER,
+                       cb BOOLEAN
+                    }
+              }
+            END\n">>},
+
+    Conf1 = [{selective_decode,{'WrongModuleName',[whatever]}}],
+    {error,{bad_module_name,'WrongModuleName',M}} = run(P, Config, Conf1),
+
+    Conf2 = [{selective_decode,wrong}],
+    {error,{bad_selective_decode,wrong}} = run(P, Config, Conf2),
+
+    Conf3 = [{selective_decode,{M,[wrong]}}],
+    {error,{bad_selective_decode,wrong}} = run(P, Config, Conf3),
+
+    Conf4 = [{selective_decode,{M,[{f,not_list}]}}],
+    {error,{bad_selective_decode_type_list,not_list}} = run(P, Config, Conf4),
+
+    Conf5 = [{selective_decode,{M,{42,[top_type,[]]}}}],
+    {error,{bad_selective_decode,{42,_}}} = run(P, Config, Conf5),
+
+    Conf6 = [{selective_decode,
+              {M, [{only_Seq_b, ['TopType', [{b,parts}]]}]}}],
+    {error,{undefined_type,'TopType'}} = run(P, Config, Conf6),
+
+    Conf7 = [{selective_decode,
+              {M, [{only_Seq_b, ['Seq', d]}]}}],
+    {error,{undefined_name,d}} = run(P, Config, Conf7),
+
+    Conf8 = [{selective_decode,
+              {M, [{only_Seq_b, ['Seq', b, whatever]}]}}],
+    {error,{bad_selective_decode_element,whatever}} = run(P, Config, Conf8),
+
+    Conf9 = [{selective_decode,
+              {M, [{only_Seq_something, ['Seq', cc, whatever]}]}}],
+    {error,{undefined_name,whatever}} = run(P, Config, Conf9),
+
+    Conf10 = [{selective_decode,
+               {M, [{only_Seq_something, ['Seq', a, x]}]}}],
+    {error,{stepping_into_primitive,[a,x]}} = run(P, Config, Conf10),
+
     ok.
 
 bitstrings(Config) ->
@@ -928,7 +1025,6 @@ values(Config) ->
     } = run(P, Config),
     ok.
 
-
 run({Mod,Spec}, Config) ->
     Base = atom_to_list(Mod) ++ ".asn1",
     File = filename:join(proplists:get_value(priv_dir, Config), Base),
@@ -936,3 +1032,22 @@ run({Mod,Spec}, Config) ->
     Include = filename:join(filename:dirname(Include0), "asn1_SUITE_data"),
     ok = file:write_file(File, Spec),
     asn1ct:compile(File, [{i, Include}]).
+
+run({Mod,Spec}, Config, Asn1ConfigTerm) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+
+    Asn1ConfigFile = filename:join(PrivDir, atom_to_list(Mod) ++ ".asn1config"),
+    Asn1ConfigData = [io_lib:format("~p. \n", [Term]) || Term <- Asn1ConfigTerm],
+    ok = file:write_file(Asn1ConfigFile, Asn1ConfigData),
+
+    Base = atom_to_list(Mod) ++ ".asn1",
+    File = filename:join(PrivDir, Base),
+    ok = file:write_file(File, Spec),
+
+    case asn1ct:compile(File, [{i, PrivDir}, asn1config]) of
+        {error,[{structured_error,{Asn1ConfigFile,none},
+                 asn1ct_partial_decode,Error}]} ->
+            {error,Error};
+        Other ->
+            Other
+    end.

--- a/lib/asn1/test/test_selective_decode.erl
+++ b/lib/asn1/test/test_selective_decode.erl
@@ -26,17 +26,22 @@
 test() ->
     FMsg = msg('F'),
     Bytes = roundtrip('PartialDecSeq', 'F', FMsg),
-    {ok,3} = 'PartialDecSeq':selected_decode_F1(Bytes),
+    {ok,3} = 'PartialDecSeq':selected_decode_F1_1(Bytes),
+    {ok,4} = 'PartialDecSeq':selected_decode_F1_2(Bytes),
     {ok,[{'D',3,true},{'D',4,false},{'D',5,true},{'D',6,true},
 	 {'D',7,false},{'D',8,true},{'D',9,true},{'D',10,false},
 	 {'D',11,true},{'D',12,true},{'D',13,false},{'D',14,true}]} =
 	'PartialDecSeq':selected_decode_F2(Bytes),
     {ok,{'D',3,true}} = 'PartialDecSeq':selected_decode_F3(Bytes),
     {ok,17} = 'PartialDecSeq':selected_decode_F4(Bytes),
-    
+    E_from_F = element(2, FMsg),
+    {ok,E_from_F} = 'PartialDecSeq':selected_decode_F5(Bytes),
+
     EMsg = msg('E'),
     Bytes2 = roundtrip('PartialDecSeq', 'E', EMsg),
     {ok,14} = 'PartialDecSeq':selected_decode_E1(Bytes2),
+    Emsg_b = msg('E_b'),
+    {ok,Emsg_b} = 'PartialDecSeq':selected_decode_E2(Bytes2),
 
     MGCMsg = msg('M-G-C'),
     Bytes3 = roundtrip('MEDIA-GATEWAY-CONTROL', 'MegacoMessage', MGCMsg),
@@ -61,7 +66,10 @@ msg('F') ->
     {fb,{'E',35,[{'D',3,true},{'D',4,false},{'D',5,true},{'D',6,true},{'D',7,false},{'D',8,true},{'D',9,true},{'D',10,false},{'D',11,true},{'D',12,true},{'D',13,false},{'D',14,true}],false,{da,[{'A',16,{'D',17,true}}]}}};
 
 msg('E') ->
-    {'E',10,[{'D',11,true},{'D',12,false}],false,{dc,{'E_d_dc',13,true,{'E_d_dc_dcc',14,15}}}};
+    {'E',10,msg('E_b'),false,{dc,{'E_d_dc',13,true,{'E_d_dc_dcc',14,15}}}};
+
+msg('E_b') ->
+    [{'D',11,true},{'D',12,false}];
 
 msg('M-G-C') ->
     {'MegacoMessage',asn1_NOVALUE,{'Message',1,{ip4Address,{'IP4Address',[125,125,125,111],55555}},{transactions,[{transactionReply,{'TransactionReply',50007,asn1_NOVALUE,{actionReplies,[{'ActionReply',0,asn1_NOVALUE,asn1_NOVALUE,[{auditValueReply,{auditResult,{'AuditResult',{'TerminationID',[],[255,255,255]},[{mediaDescriptor,{'MediaDescriptor',asn1_NOVALUE,{multiStream,[{'StreamDescriptor',1,{'StreamParms',{'LocalControlDescriptor',sendRecv,asn1_NOVALUE,asn1_NOVALUE,[{'PropertyParm',[0,11,0,7],[[52,48]],asn1_NOVALUE}]},{'LocalRemoteDescriptor',[[{'PropertyParm',[0,0,176,1],[[48]],asn1_NOVALUE},{'PropertyParm',[0,0,176,8],[[73,78,32,73,80,52,32,49,50,53,46,49,50,53,46,49,50,53,46,49,49,49]],asn1_NOVALUE},{'PropertyParm',[0,0,176,15],[[97,117,100,105,111,32,49,49,49,49,32,82,84,80,47,65,86,80,32,32,52]],asn1_NOVALUE},{'PropertyParm',[0,0,176,12],[[112,116,105,109,101,58,51,48]],asn1_NOVALUE}]]},{'LocalRemoteDescriptor',[[{'PropertyParm',[0,0,176,1],[[48]],asn1_NOVALUE},{'PropertyParm',[0,0,176,8],[[73,78,32,73,80,52,32,49,50,52,46,49,50,52,46,49,50,52,46,50,50,50]],asn1_NOVALUE},{'PropertyParm',[0,0,176,15],[[97,117,100,105,111,32,50,50,50,50,32,82,84,80,47,65,86,80,32,32,52]],asn1_NOVALUE},{'PropertyParm',[0,0,176,12],[[112,116,105,109,101,58,51,48]],asn1_NOVALUE}]]}}}]}}},{packagesDescriptor,[{'PackagesItem',[0,11],1},{'PackagesItem',[0,11],1}]},{statisticsDescriptor,[{'StatisticsParameter',[0,12,0,4],[[49,50,48,48]]},{'StatisticsParameter',[0,11,0,2],[[54,50,51,48,48]]},{'StatisticsParameter',[0,12,0,5],[[55,48,48]]},{'StatisticsParameter',[0,11,0,3],[[52,53,49,48,48]]},{'StatisticsParameter',[0,12,0,6],[[48,46,50]]},{'StatisticsParameter',[0,12,0,7],[[50,48]]},{'StatisticsParameter',[0,12,0,8],[[52,48]]}]}]}}}]}]}}}]}}};

--- a/lib/asn1/test/test_special_decode_performance.erl
+++ b/lib/asn1/test/test_special_decode_performance.erl
@@ -120,7 +120,7 @@ loop2(Mod,FS,Bin,N) ->
 
 get_selective_funcs('PartialDecSeq') ->
 %    [selected_decode_F1,selected_decode_F2,selected_decode_F3,selected_decode_F4];
-    [selected_decode_F1,selected_decode_F3,selected_decode_F4];
+    [selected_decode_F1_1,selected_decode_F3,selected_decode_F4];
 get_selective_funcs('MEDIA-GATEWAY-CONTROL') ->
     [decode_MegacoMessage_selective].
 


### PR DESCRIPTION
This pull request fixes multiple bugs in the "exclusive decode" and "selective decode" features for the BER backend of the ASN.1 compiler.

Errors in the configuration file now result error messages, instead of crashing the ASN.1 or Erlang compiler.

The undocumented option `{asn1config,ModuleName}` has been removed.