### PR TITLE
Fix autocompletion

### DIFF
--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -1055,7 +1055,8 @@ format_section_matches(Elems, LineWidth, Acc) ->
 
 format_section_matches1([], _, _) -> [];
 format_section_matches1(LS, LineWidth, Len) ->
-    L = lists:usort(fun special_sort/2, ordsets:to_list(LS)),
+    L0 = lists:sort(fun special_sort/2, ordsets:to_list(LS)),
+    L = lists:uniq(L0),
     Opt = case Len == 0 of
         true -> [];
         false -> [{title, Len}]

--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -381,17 +381,6 @@ add_to_last_nesting(Term, Nesting) ->
         {map, F, Fs, Args, U} ->
             List ++ [{map, F, Fs, Args ++ [Term], U}]
     end.
-
-close_nesting(Nesting) ->
-    Last = lists:last(Nesting),
-    case Last of
-        {tuple, _Args, _} ->
-            "}";
-        {list, _Args, _} ->
-            "]";
-        {map, _F, _Fs, _Args, _} ->
-            "}"
-    end.
 expand_function_parameter_type(Mod, MFA, FunType, Args, Unfinished, Nestings, FT) ->
     TypeTree = edlin_type_suggestion:type_tree(Mod, FunType, Nestings, FT),
 
@@ -465,17 +454,7 @@ expand_function_parameter_type(Mod, MFA, FunType, Args, Unfinished, Nestings, FT
                                                                      false ->")"
                                                                  end,
                                                             Atoms1 = edlin_type_suggestion:get_atoms(Constraints1, T, Nestings),
-                                                            {Res1, Expansion1, Matches1} = match(Word, Atoms1, CC),
-                                                            case Matches1 of
-                                                                [] ->
-                                                                    case match_arguments(TypeTree, Args ++ [Unfinished]) of
-                                                                        false -> {Res1, Expansion1, Matches1};
-                                                                        true ->
-                                                                            {yes, CC, [{CC, []}]}
-                                                                    end;
-                                                                _ ->
-                                                                    {Res1, Expansion1, Matches1}
-                                                            end
+                                                            match(Word, Atoms1, CC)
                                                         end,
                             Match1 = case Matches of
                                          [] -> [];
@@ -489,7 +468,7 @@ expand_function_parameter_type(Mod, MFA, FunType, Args, Unfinished, Nestings, FT
             end
     end.
 expand_nesting_content(T, Constraints, Nestings, Section) ->
-    {NestingType, UnfinishedNestingArg, NestingArgs} = case lists:last(Nestings) of
+    {NestingType, UnfinishedNestingArg, _NestingArgs} = case lists:last(Nestings) of
                                               {tuple, NestingArgs1, Unfinished1} -> {tuple, Unfinished1, NestingArgs1};
                                               {list, NestingArgs1, Unfinished1} -> {list, Unfinished1, NestingArgs1};
                                               {map, _, _, NestingArgs1, Unfinished1} -> {map, Unfinished1, NestingArgs1}
@@ -529,16 +508,6 @@ expand_nesting_content(T, Constraints, Nestings, Section) ->
                                                 fold_results([begin
                                                                   case NestingArity of
                                                                       none -> {no, [], []};
-                                                                      _ when NestingType =:= tuple ->
-                                                                          CC = case length(NestingArgs)+1 < NestingArity of
-                                                                                   true -> ", ";
-                                                                                   false -> close_nesting(Nestings)
-                                                                               end,
-                                                                          {yes, CC, [{CC, []}]};
-                                                                      _ when NestingType =:= list ->
-                                                                        {no, [], [{", ", []}, {"]", []}]};
-                                                                      _ when NestingType =:= map ->
-                                                                        {no, [], [{", ",[]},{"}", []}]};
                                                                       _ -> 
                                                                         {no, [], []}
                                                                   end
@@ -549,12 +518,6 @@ expand_nesting_content(T, Constraints, Nestings, Section) ->
                                                 fold_results([begin
                                                                   case NestingArity of
                                                                       none -> {no, [], []};
-                                                                      _ when NestingType =:= tuple ->
-                                                                          CC = case length(NestingArgs)+1 < NestingArity of
-                                                                                   true -> ", ";
-                                                                                   false -> close_nesting(Nestings)
-                                                                               end,
-                                                                          {yes, Expansion1++CC, [{Word2, [{ending, CC}]}]};
                                                                       _ -> 
                                                                         {Res1, Expansion1, Matches1}
                                                                   end

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -23,7 +23,7 @@
          init_per_group/2,end_per_group/2]).
 -export([normal/1, type_completion/1, quoted_fun/1, quoted_module/1, quoted_both/1, erl_1152/1, get_coverage/1,
          check_trailing/1, unicode/1, filename_completion/1, binding_completion/1, record_completion/1,
-         map_completion/1, function_parameter_completion/1, fun_completion/1]).
+         no_completion/1, map_completion/1, function_parameter_completion/1, fun_completion/1]).
 -record(a_record,
         {a_field   :: atom1 | atom2 | btom | 'my atom' | {atom3, {atom4, non_neg_integer()}} | 'undefined',
          b_field   :: boolean() | 'undefined',
@@ -50,7 +50,7 @@ suite() ->
 all() ->
     [normal, filename_completion, binding_completion, get_coverage, type_completion, 
      record_completion, fun_completion, map_completion, function_parameter_completion,
-     quoted_fun, quoted_module, quoted_both, erl_1152, check_trailing,
+     no_completion, quoted_fun, quoted_module, quoted_both, erl_1152, check_trailing,
      unicode].
 
 groups() ->
@@ -173,6 +173,12 @@ filename_completion(Config) ->
     file:set_cwd(CWD),
     R.
 
+no_completion(_Config) ->
+    %% No autocompletion, and no crashes
+    {no, _, _} = do_expand("[{"),
+    {no, _, _} = do_expand("a [{"),
+    {no, _, _} = do_expand("a [{{"),
+    ok.
 record_completion(_Config) ->
     %% test record completion for loaded records
     %% test record field name completion

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -515,6 +515,9 @@ get_coverage(Config) ->
     {_, _, M10} = edlin_expand:expand("ssh:connect({},["),
     do_format(M10),
     lists:flatten(edlin_expand:format_matches(M10, 20)),
+    %% Test that we are not filtering duplicates bit with different case or different string lengths
+    {yes,"e", M11} = do_expand("complete_function_parameter:cas"),
+    "\e[;1;4mfunctions\e[0m\ncaseSensitiveFunction(        casesensitivefunction(        \ncaseSensitiveFunctionName(\n" = do_format(M11),
     ok.
 
 %% Normal module name, some function names using quoted atoms.

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -203,12 +203,12 @@ record_completion(_Config) ->
                {"c_field",[{ending,"="}]},
                {"d_field",[{ending,"="}]}],
               options:=[highlight_all]}]} = do_expand("#a_record{a_field={atom3,b},"),
-    %% test match argument and closing parenthesis completion
-    {yes,", ",[]} = do_expand("#a_record{a_field={atom3"),
+    %% test match argument
+    {yes,_,[]} = do_expand("#a_record{a_field={atom3"),
     {no,[],[#{title:="types",elems:=[{"{atom4, ...}",[]}],options:=[{hide,title}]}]} = do_expand("#a_record{a_field={atom3,"),
     {no,[],[#{title:="types",elems:=[{"integer() >= 0",[]}],options:=[{hide,title}]}]} = do_expand("#a_record{a_field={atom3,{atom4, "),
-    {yes,"}",_} = do_expand("#a_record{a_field={atom3,{atom4, 1"),
-    {yes,"}",_} = do_expand("#a_record{a_field={atom3,{atom4, 1}"),
+    {no,_,_} = do_expand("#a_record{a_field={atom3,{atom4, 1"),
+    {no,_,_} = do_expand("#a_record{a_field={atom3,{atom4, 1}"),
     ok.
 
 fun_completion(_Config) ->
@@ -252,7 +252,7 @@ function_parameter_completion(Config) ->
     {no, [], [#{elems:=[#{elems:=[#{title:="types",elems:=[{"integer()",[]}]}]}]}]} = do_expand("complete_function_parameter:a_fun_name("),
     {no, [], [#{elems:=[#{elems:=[#{elems:=[{"integer()",[]}]}]}]}]} = do_expand("complete_function_parameter:a_fun_name(1,"),
     {no, [], [#{elems:=[#{elems:=[#{elems:=[{"integer()",[]}]}]}]}]}  = do_expand("complete_function_parameter : a_fun_name ( 1 , "),
-    {yes, ")", []} = do_expand("complete_function_parameter:a_fun_name(1,2"),
+    {no, [], []} = do_expand("complete_function_parameter:a_fun_name(1,2"),
     {no, [], []} = do_expand("complete_function_parameter:a_fun_name(1,2,"),
     {no, [], [#{elems:=[#{elems:=[#{elems:=[{"any()",[]},{"[any() | [Deeplist]]",[]}]}]}]}]} = do_expand("complete_function_parameter:a_deeplist_fun("),
     {no,[],[#{title:="typespecs",

--- a/lib/stdlib/test/edlin_expand_SUITE_data/complete_function_parameter.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE_data/complete_function_parameter.erl
@@ -50,7 +50,10 @@
     any_parameter_function/2,
     ann_type_parameter_function/2,
     ann_type_parameter_function2/2,
-    atom_parameter_function/2
+    atom_parameter_function/2,
+    caseSensitiveFunctionName/2,
+    caseSensitiveFunction/2,
+    casesensitivefunction/2
     ]).
 -record(a_record, {}).
 %% test first and second parameter
@@ -162,3 +165,10 @@ ann_type_parameter_function(_,_) -> false.
 
 -spec ann_type_parameter_function2(W::any(), V::atom()) -> boolean().
 ann_type_parameter_function2(_,_) -> false.
+
+-spec caseSensitiveFunctionName(A::atom(), B::any()) -> boolean().
+caseSensitiveFunctionName(_,_) -> false.
+-spec caseSensitiveFunction(A::atom(), B::any()) -> boolean().
+caseSensitiveFunction(_,_) -> false.
+-spec casesensitivefunction(A::atom(), B::any()) -> boolean().
+casesensitivefunction(_,_) -> false.


### PR DESCRIPTION
Fix so that the autocompletion doesn't suggest closing parenthesis
since this often times interfere with any module matches in
parameters of functions.
Fix so that functions with almost the same name or differenct cases
doesn't get removed from autocompletion suggestions.
Fix so that nested tuples doesn't crash the autocompletion

closes https://github.com/erlang/otp/issues/7723, https://github.com/erlang/otp/issues/7708