### PR TITLE
Fix keyboard configuration bugs

### DIFF
--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -402,6 +402,8 @@ shell_navigation(Config) ->
              check_location(Term, {0, 0}),
              send_tty(Term,"C-E"),
              check_location(Term, {0, width("{aaa,'b"++U++"b',ccc}")}),
+             send_tty(Term,"C-H"),
+             check_location(Term, {0, width("{aaa,'b"++U++"b',ccc")}),
              send_tty(Term,"C-A"),
              check_location(Term, {0, 0}),
              send_tty(Term,"Enter")

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -1215,6 +1215,10 @@ shell_ignore_pager_commands(Config) ->
 test_valid_keymap(Config) when is_list(Config) ->
     DataDir = proplists:get_value(data_dir,Config),
     Term = setup_tty([{args, ["-config", DataDir ++ "valid_keymap.config"]} | Config]),
+    Prompt = fun() -> ["\e[94m",54620,44397,50612,47,51312,49440,47568,"\e[0m"] end,
+    erpc:call(Term#tmux.node, application, set_env,
+              [stdlib, shell_prompt_func_test,
+               proplists:get_value(shell_prompt_func_test, Config, Prompt)]),
     try
         check_not_in_content(Term, "Invalid key"),
         check_not_in_content(Term, "Invalid function"),
@@ -1223,7 +1227,7 @@ test_valid_keymap(Config) when is_list(Config) ->
         check_content(Term, ">$"),
         send_tty(Term, "1.\n"),
         send_tty(Term, "C-b"),
-        check_content(Term, "2>\\s1\\s?.$"),
+        check_content(Term, "2>\\s1.$"),
         ok
     after
         stop_tty(Term),

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -1221,6 +1221,9 @@ test_valid_keymap(Config) when is_list(Config) ->
         send_tty(Term, "asdf"),
         send_tty(Term, "C-u"),
         check_content(Term, ">$"),
+        send_tty(Term, "1.\n"),
+        send_tty(Term, "C-b"),
+        check_content(Term, "2>\\s1\\s?.$"),
         ok
     after
         stop_tty(Term),

--- a/lib/kernel/test/interactive_shell_SUITE_data/valid_keymap.config
+++ b/lib/kernel/test/interactive_shell_SUITE_data/valid_keymap.config
@@ -15,7 +15,7 @@
 
 %% Ctrl-alpha keys 0-31
 "\^A" => beginning_of_line,
-"\^B" => backward_char,
+"\^B" => history_up,
 %"\^C" => sig_term_menu,    %% cannot be changed, yet
 "\^D" => forward_delete_char,
 "\^E" => end_of_line,

--- a/lib/stdlib/src/edlin_key.erl
+++ b/lib/stdlib/src/edlin_key.erl
@@ -117,26 +117,27 @@ merge(KeyMap) ->
 merge(_, [], KeyMap) ->
     KeyMap;
 merge(InputKeyMap, [Mode|ShellModes], KeyMap) ->
-    InputKeyMapModeValidated = #{},
-    maps:foreach(fun(Key, Value) when is_list(Key), is_atom(Value) ->
-        try
-            {key, Key, []} = get_valid_escape_key(Key, none),
-            case lists:member(Value,valid_functions()) of
-                true -> InputKeyMapModeValidated#{Key => Value};
-                false -> io:format(standard_error, "Invalid function ~p in entry {~p,~p}~n", [Value, Key, Value])
-            end
-        catch
-            _:_ ->
-                io:format(standard_error, "Invalid key ~p in entry {~p,~p}~n", [Key,Key,Value])
-        end;
-        (default, Value) ->
-            case lists:member(Value,valid_functions()) of
-                true -> InputKeyMapModeValidated#{default => Value};
-                false -> io:format(standard_error, "Invalid function ~p in entry {default,~p}~n", [Value, Value])
+    InputKeyMapModeValidated = maps:filtermap(
+        fun(Key, Value) when is_list(Key), is_atom(Value) ->
+            try
+                {key, Key, []} = get_valid_escape_key(Key, none),
+                case lists:member(Value,valid_functions()) of
+                    true -> {true, Value};
+                    false -> io:format(standard_error, "Invalid function ~p in entry {~p,~p}~n", [Value, Key, Value]), false
+                end
+            catch
+                _:_ ->
+                    io:format(standard_error, "Invalid key ~p in entry {~p,~p}~n", [Key,Key,Value]),
+                    false
             end;
-        (Key,Value) ->
-            io:format(standard_error, "Invalid entry {~p,~p}~n", [Key, Value])
-    end, maps:get(Mode, InputKeyMap, #{})),
+            (default, Value) ->
+                case lists:member(Value,valid_functions()) of
+                    true -> {true, Value};
+                    false -> io:format(standard_error, "Invalid function ~p in entry {default,~p}~n", [Value, Value]), false
+                end;
+            (Key,Value) ->
+                io:format(standard_error, "Invalid entry {~p,~p}~n", [Key, Value]), false
+        end, maps:get(Mode, InputKeyMap, #{})),
     KeyMap1 = KeyMap#{Mode => maps:merge(maps:get(Mode, KeyMap), InputKeyMapModeValidated)},
 
     merge(InputKeyMap, ShellModes, KeyMap1).

--- a/lib/stdlib/src/edlin_key.erl
+++ b/lib/stdlib/src/edlin_key.erl
@@ -188,7 +188,7 @@ normal_map() ->
         "\^E" => end_of_line,
         "\^F" => forward_char,
         %%"\^G" => jcl_menu, currently handled by user_drv.erl
-        "\^H" => backward_delete_word,
+        "\^H" => backward_delete_char,
         %%"\^I" => tab_expand, same as \t
         %%"\^J" => new_line_finish, same as \n
         "\^K" => kill_line,
@@ -225,7 +225,7 @@ normal_map() ->
         %% # Deletion keys
         %% ## Backspace
         "\^?" => backward_delete_char,
-        %% ## Ctrl+Backspace
+        %% ## Alt+Backspace
         "\^[\^?" => backward_kill_word,
         %% ## Del
         "\^[[3~" => forward_delete_char,


### PR DESCRIPTION
stdlib: fix shell keyboard configuration errors
Fix so that ctrl+h, ctrl+backspace generate backward_delete_char
Fix overriding of keyboard shortcuts

closes https://github.com/erlang/otp/issues/7749 , https://github.com/erlang/otp/issues/7776