### PR TITLE
shell bug fixes

### DIFF
--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -972,7 +972,7 @@ not_restricted(exit, []) ->
     true;
 not_restricted(fl, []) ->
     true;
-not_restricted(fd, [_]) ->
+not_restricted(fd, [_,_]) ->
     true;
 not_restricted(ft, [_]) ->
     true;
@@ -997,6 +997,8 @@ not_restricted(rr, [_]) ->
 not_restricted(rr, [_,_]) ->
     true;
 not_restricted(rr, [_,_,_]) ->
+    true;
+not_restricted(v, [_]) ->
     true;
 not_restricted(_, _) ->
     false.

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -277,7 +277,7 @@ get_command(Prompt, Eval, Bs, RT, FT, Ds) ->
                                         [text,{reserved_word_fun,ResWordFun}])
                   of
                       {ok,Toks,_EndPos} ->
-                          %% NOTE: we can handle function definitions, records and soon type declarations
+                          %% NOTE: we can handle function definitions, records and type declarations
                           %% but this cannot be handled by the function which only expects erl_parse:abstract_expressions()
                           %% for now just pattern match against those types and pass the string to shell local func.
                           case Toks of
@@ -298,7 +298,8 @@ get_command(Prompt, Eval, Bs, RT, FT, Ds) ->
                                   case Atom of
                                       record -> SpecialCase(rd);
                                       spec -> SpecialCase(ft);
-                                      type -> SpecialCase(td)
+                                      type -> SpecialCase(td);
+                                      _ -> erl_eval:extended_parse_exprs(Toks)
                                   end;
                               [{atom, _, FunName}, {'(', _}|_] ->
                                   case erl_parse:parse_form(Toks) of

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -185,11 +185,38 @@ comm_err(<<"ugly().">>),
 "exception exit: "
 "restricted shell module returned bad value non_conforming_reply" =
 comm_err(<<"1 - 2.">>),
+%% Make sure we test all local shell functions in a restricted shell.
+LocalFuncs = shell:local_func(),
+[] = lists:subtract(LocalFuncs, [v,h,b,f,fl,rd,rf,rl,rp,rr,history,results,catch_exception]),
+
+LocalFuncs2 = [
+    <<"A = 1.\nv(1).">>, <<"h().">>, <<"b().">>, <<"f().">>, <<"f(A).">>,
+    <<"fl()">>, <<"rd(foo,{bar}).">>, <<"rf().">>, <<"rf(foo).">>, <<"rl().">>, <<"rl(foo).">>, <<"rp([hej]).">>,
+    <<"rr(shell).">>, <<"rr(shell, shell_state).">>, <<"rr(shell,shell_state,[]).">>,
+    <<"history(20).">>, <<"results(20).">>, <<"catch_exception(0).">>],
+lists:foreach(fun(LocalFunc) ->
+        try
+            ("exception exit: restricted shell does not allow"++_Rest) = Error = local_func_error_t(LocalFunc),
+            error(Error)
+        catch
+            error:{badmatch, _} -> ok
+        end
+    end,
+    LocalFuncs2),
 "exception exit: restricted shell stopped"=
 comm_err(<<"begin shell:stop_restricted() end.">>),
 undefined =
 application:get_env(stdlib, restricted_shell),
 ok.
+
+local_func_error_t(B) ->
+    Reply = t(B),
+    S0 = lists:flatten(string:replace(Reply, "1\n", "")), %% v(1) requires special treatment
+    S1 = string:left(S0, string:chr(S0, $\n)-1),
+    S2 = string:strip(S1, left, $*),
+    S3 = string:strip(S2, both, $ ),
+    S = string:strip(S3, both, $"),
+    string:strip(S, right, $.).
 
 %% Check restricted shell when started from the command line.
 start_restricted_on_command_line(Config) when is_list(Config) ->

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -332,6 +332,7 @@ types(Config) when is_list(Config) ->
     [ok] = scan(<<"-spec foo(Bar) -> Baz when
         Bar :: string(),
         Baz :: integer().">>),
+    "exception error"++_ = comm_err(<<"-hej.">>),
     shell_attribute_test(Config),
     ok.
 shell_attribute_test(Config) ->


### PR DESCRIPTION
Allow local func v(), in a restricted shell
Prevent crash when writing a faulty attribute like '1> -hej.'

closes https://github.com/erlang/otp/issues/7765