### PR TITLE
Fix for -Werror=format-security

### DIFF
--- a/erts/emulator/test/driver_SUITE_data/sys_info_drv_impl.c
+++ b/erts/emulator/test/driver_SUITE_data/sys_info_drv_impl.c
@@ -142,12 +142,12 @@ control(ErlDrvData drv_data,
     if (memcmp(((char *) sip) + ERL_DRV_SYS_INFO_SIZE,
 	       (char *) &deadbeef[0],
 	       sizeof(deadbeef)) != 0) {
-	res = sprintf(str, beyond_end_format);
+	res = sprintf(str, "%s", beyond_end_format);
     }
     else {
 	res = sys_info_drv_sprintf_sys_info(sip, str);
 	if (res > slen)
-	    res = sprintf(str, buf_overflow_format);
+	    res = sprintf(str, "%s", buf_overflow_format);
     }
     driver_free(sip);
     return res;


### PR DESCRIPTION
Hi

Have to pass either a string literal or format string to sprintf() when compiling with -Wformat -Wformat-security -Werror=format-security flags

gcc build command:

```
x86_64-poky-linux-gcc  -m64 -march=core2 -mtune=core2 -msse3 -mfpmath=sse -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -fcanon-prefix-map  -fmacro-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fmacro-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot=  -fmacro-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot=  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot-native=  -Wl,-z,relro,-z,now -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot -c -fPIC -D_THREAD_SAFE -D_REENTRANT  -O2 -pipe -g -feliminate-unused-debug-types -fcanon-prefix-map  -fmacro-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fmacro-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git=/usr/src/debug/erlang/26.1.2-r0  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot=  -fmacro-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot=  -fdebug-prefix-map=/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/recipe-sysroot-native=  -D_THREAD_SAFE -D_REENTRANT  -I/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git/erts/emulator/beam -I/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git/erts/emulator -I/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git/erts/emulator/sys/unix -I/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git/erts/include -I/build/tmp/work/core2-64-poky-linux/erlang/26.1.2/git/erts/include/x86_64-poky-linux-gnu -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DHAVE_LIBM=1 -DHAVE_STDIO_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_UNISTD_H=1 -DSTDC_HEADERS=1 -DHAVE_LINUX_TCP_H=1 -DHAVE_SANE_LINUX_TCP_H=1 -DHAVE_POLL_H=1 -DHAVE_STRERROR=1 -DHAVE_VSNPRINTF=1 -DHAVE_USLEEP=1 -DHAVE_LIBRESOLV=1 -DHAVE_FINITE=1 sys_info_base_drv.c
```

The result is:

```
| In file included from sys_info_base_drv.c:84:
| sys_info_drv_impl.c: In function 'control':
| sys_info_drv_impl.c:145:9: error: format not a string literal and no format arguments [-Werror=format-security]
|   145 |         res = sprintf(str, beyond_end_format);
|       |         ^~~
| sys_info_drv_impl.c:150:13: error: format not a string literal and no
format arguments [-Werror=format-security]
|   150 |             res = sprintf(str, buf_overflow_format);
|       |             ^~~
| cc1: some warnings being treated as errors
| make: *** [Makefile:51: sys_info_base_drv.so] Error 1
| Runtime terminating during boot ({make_failed,make})
|
| Crash dump is being written to: erl_crash.dump...done
| WARNING: exit code 1 from a shell command.
```

I'm not sure if this change breaks the test. Because looks like the test was design for that case.

