### PR TITLE
ct: Allow ?config to return a default value

### DIFF
--- a/lib/common_test/doc/src/write_test_chapter.xml
+++ b/lib/common_test/doc/src/write_test_chapter.xml
@@ -281,6 +281,8 @@
     and lookup. <c>Common Test</c> provides a simple macro named <c>?config</c>,
     which returns a value of an item in <c>Config</c> given the key (exactly like
     <c>proplists:get_value</c>). Example: <c>PrivDir = ?config(priv_dir, Config)</c>.
+    An optional third argument may be provided to customize the return value
+    if the given key was not found, by default, <c>undefined</c> is returned.
     </p>
 
     <p>If the test case function crashes or exits purposely, it is considered

--- a/lib/common_test/src/test_server.erl
+++ b/lib/common_test/src/test_server.erl
@@ -28,7 +28,7 @@
 -export([get_loc/1,set_tc_state/1]).
 
 %%% TEST SUITE INTERFACE %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
--export([lookup_config/2]).
+-export([lookup_config/2, lookup_config/3]).
 -export([fail/0,fail/1,format/1,format/2,format/3]).
 -export([capture_start/0,capture_stop/0,capture_get/0]).
 -export([messages_get/0]).
@@ -1755,7 +1755,7 @@ print(Detail,Format,Args,Printer) ->
     test_server_ctrl:print(Detail, Format, Args, Printer).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% print_timsteamp(Detail,Leader) -> ok
+%% print_timestamp(Detail,Leader) -> ok
 %%
 %% Prints Leader followed by a time stamp (date and time). Depending on
 %% the Detail value, the output is directed to console, major and/or minor
@@ -1766,7 +1766,7 @@ print_timestamp(Detail,Leader) ->
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% lookup_config(Key,Config) -> {value,{Key,Value}} | undefined
+%% lookup_config(Key,Config) -> Value | undefined
 %% Key = term()
 %% Value = term()
 %% Config = [{Key,Value},...]
@@ -1782,6 +1782,18 @@ lookup_config(Key,Config) ->
 	    io:format("Could not find element ~tp in Config.~n",[Key]),
 	    undefined
     end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% lookup_config(Key, Config, Default) -> Value | Default
+%% Key = term()
+%% Value = term()
+%% Default = term()
+%% Config = [{Key,Value},...]
+%%
+%% Looks up a specific key in the config list, and returns the value
+%% of the associated key, or `Default' if the key doesn't exist.
+lookup_config(Key, Config, Default) ->
+    proplists:get_value(Key, Config, Default).
 
 %%
 %% IMPORTANT: get_loc/1 uses the name of this function when analysing

--- a/lib/common_test/test/ct_config_SUITE.erl
+++ b/lib/common_test/test/ct_config_SUITE.erl
@@ -70,7 +70,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 all() -> 
     [require, install_config, userconfig_static,
      userconfig_dynamic, testspec_legacy, testspec_static,
-     testspec_dynamic].
+     testspec_dynamic, config_default_value].
 
 groups() -> 
     [].
@@ -165,6 +165,12 @@ testspec_dynamic(Config) when is_list(Config) ->
 		     []),
 	    file:delete(filename:join(ConfigDir, "spec_dynamic.spec"))
     end.
+
+config_default_value(Config) when is_list(Config) ->
+    undefined = ?config(hopefully_undefined_value, Config),
+    undefined = ?config(hopefully_undefined_value, Config, undefined),
+    [] = ?config(hopefully_undefined_value, Config, []),
+    default = ?config(hopefully_undefined_value, Config, default).
 
 
 


### PR DESCRIPTION
For test cases that may have a config key defined but don't have to - an example can be found in PR #7803 that adds an optional `request_opts` field to facilitate passing IPv6 client options - having a second form of `?config` allowing a default value to be returned seems useful.