### PR TITLE
[pg] Fix typo potentially leading to crash

### DIFF
--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -424,7 +424,7 @@ handle_info({'DOWN', MRef, process, Pid, _Info}, #state{scope = Scope, remote = 
                 leave_remote_update_ets(Scope, ScopeMon, MG, Pids, [Group]) end, RemoteMap),
             {noreply, State#state{remote = NewRemote}};
         error ->
-            {noreply, MRef, State}
+            {noreply, State}
     end;
 
 %% handle scope monitor exiting


### PR DESCRIPTION
Typo introduced in #7659 may may cause pg to crash when 'DOWN' monitor message is in the queue while explicit leave is processed earlier.

Closes #7807