### PR TITLE
Various improvements to NIF/crypto upgrade and unload

### DIFF
--- a/erts/doc/references/erl_nif.md
+++ b/erts/doc/references/erl_nif.md
@@ -106,7 +106,7 @@ directive is used get function `init` called automatically when the module is
 loaded. Function `init` in turn calls `erlang:load_nif/2` which loads the NIF
 library and replaces the `hello` function with its native implementation in C.
 Once loaded, a NIF library is persistent. It will not be unloaded until the
-module code version that it belongs to is purged.
+module instance that it belongs to is purged.
 
 The [`-nifs()`](`e:system:modules.md#nifs_attribute`) attribute specifies which
 functions in the module that are to be replaced by NIFs.
@@ -530,7 +530,7 @@ calling NIF API functions. Functions exist for the following functionality:
   old code of this module with a loaded NIF library.
 
   Works as `load`, except that `*old_priv_data` already contains the value set
-  by the last call to `load` or `upgrade` for the old module code. `*priv_data`
+  by the last call to `load` or `upgrade` for the old module instance. `*priv_data`
   is initialized to `NULL` when `upgrade` is called. It is allowed to write to
   both `*priv_data` and `*old_priv_data.`
 
@@ -538,7 +538,7 @@ calling NIF API functions. Functions exist for the following functionality:
   `upgrade` is `NULL`.
 
 - **`void (*unload)(ErlNifEnv* caller_env, void* priv_data)`**{: #unload } -
-  `unload` is called when the module code that the NIF library belongs to is
+  `unload` is called when the module instance that the NIF library belongs to is
   purged as old. New code of the same module may or may not exist.
 
 ## Data Types
@@ -671,6 +671,18 @@ calling NIF API functions. Functions exist for the following functionality:
   [`enif_set_option()`](erl_nif.md#on_halt). Such an installed callback will be
   called when the runtime system is halting.
 
+- **`ErlNifOnUnloadThreadCallback`**{: #ErlNifOnUnloadThreadCallback }
+
+  ```text
+  typedef void ErlNifOnUnloadThreadCallback(void *priv_data);
+  ```
+
+  The function prototype of an _on_unload_thread_ callback function.
+
+  An _on_unload_thread_ callback can be installed using
+  [`enif_set_option()`](erl_nif.md#on_unload_thread). Such an installed callback
+  will be called by each scheduler thread when this module instance is purged.
+
 - **`ErlNifOption`**{: #ErlNifOption } - An enumeration of the options that can
   be set using [`enif_set_option()`](erl_nif.md#enif_set_option).
 
@@ -682,6 +694,10 @@ calling NIF API functions. Functions exist for the following functionality:
 
   - **[`ERL_NIF_OPT_ON_HALT`](erl_nif.md#on_halt)** - Install a callback that
     will be called when the runtime system halts with flushing enabled.
+
+  - **[`ERL_NIF_OPT_ON_UNLOAD_THREAD`](erl_nif.md#on_unload_thread)** - Install a
+    callback that will be called **by each scheduler thread**
+    when the module instance that the NIF library belongs to is purged as old.
 
 - **`ErlNifPid`**{: #ErlNifPid } - A process identifier (pid). In contrast to
   pid terms (instances of `ERL_NIF_TERM`), `ErlNifPid`s are self-contained and
@@ -3252,6 +3268,40 @@ will be returned. Currently the following options can be set:
   processes blocked in NIFs in the library that it is time to return in order to
   let the runtime system complete the halting. Such NIFs should be dirty NIFs,
   since ordinary NIFs should never block for a long time.
+
+- **[`ERL_NIF_OPT_ON_UNLOAD_THREAD`](erl_nif.md#ErlNifOption)**{: #on_unload_thread }
+  ```c
+  enif_set_option(env, ERL_NIF_OPT_ON_UNLOAD_THREAD, on_unload_thread)
+  ```
+
+  Install a callback that will be called **by each scheduler thread** when the
+  module instance that the NIF library belongs to is purged as old. A typical
+  use is to release thread specific data.
+
+  The `ERL_NIF_OPT_ON_UNLOAD_THREAD` option can only be set during loading of a
+  NIF library inside a call to [`load()`](erl_nif.md#load) or
+  [`upgrade()`](erl_nif.md#upgrade) and will fail if called somewhere else. The
+  `env` argument _must_ be the callback environment passed to the `load()` or
+  the `upgrade()` call.
+
+  The [`on_unload_thread`](erl_nif.md#ErlNifOnUnloadThreadCallback) argument
+  should be a function pointer to the callback to install. The
+  _on_unload_thread_ callback will be tied to the module instance with which the
+  NIF library instance has been loaded. That is, in case both a new and old
+  version of a module using the NIF library are loaded, they can both have
+  different, none, or the same _on_unload_thread_ callbacks installed. The
+  `ERL_NIF_OPT_ON_UNLOAD_THREAD` option can only be set once and cannot be
+  changed or removed once it has been installed for a module instance.
+
+  When the installed _on_unload_thread_ callback is called, it will be passed a
+  pointer to `priv_data` as argument. The `priv_data` pointer can be set when
+  loading the NIF library.
+
+  The calls to the _on_unload_thread_ function are made concurrently by the
+  different scheduler threads. There is no synchronization enforced between the
+  threads. However, the single finalizing call to the [`unload()`](erl_nif.md#unload)
+  callback for the module instance will not be made until all calls to
+  _on_unload_thread_ have returned.
 
 ## enif_set_pid_undefined()
 

--- a/erts/doc/references/erl_nif.md
+++ b/erts/doc/references/erl_nif.md
@@ -894,8 +894,8 @@ Returns pointer to the new environment.
 ## enif_alloc_resource()
 
 ```c
-void * enif_alloc_resource(ErlNifResourceType*
-        type, unsigned size);
+void * enif_alloc_resource(ErlNifResourceType* type,
+                           unsigned size);
 ```
 
 Allocates a memory-managed resource object of type `type` and size `size` bytes.
@@ -904,8 +904,10 @@ Allocates a memory-managed resource object of type `type` and size `size` bytes.
 
 ```c
 size_t enif_binary_to_term(ErlNifEnv *env,
-        const unsigned char* data, size_t size, ERL_NIF_TERM *term,
-        unsigned int opts);
+                           const unsigned char* data,
+			   size_t size,
+			   ERL_NIF_TERM *term,
+                           unsigned int opts);
 ```
 
 Creates a term that is the result of decoding the binary data at `data`, which
@@ -3164,7 +3166,11 @@ int enif_set_option(ErlNifEnv *env, ErlNifOption opt, ...);
 Set an option. On success, zero will be returned. On failure, a non zero value
 will be returned. Currently the following options can be set:
 
-- **`int enif_set_option(ErlNifEnv *env, `[`ERL_NIF_OPT_DELAY_HALT`](erl_nif.md#ErlNifOption)`)`**{: #delay_halt } -
+- **[`ERL_NIF_OPT_DELAY_HALT`](erl_nif.md#ErlNifOption)**{: #delay_halt }
+  ```c
+  enif_set_option(env, ERL_NIF_OPT_DELAY_HALT)
+  ```
+
   Enable delay of
   runtime system halt with flushing enabled until all calls to NIFs in the NIF
   library have returned. If the _delay halt_ feature has not been enabled, a
@@ -3203,7 +3209,10 @@ will be returned. Currently the following options can be set:
   Such NIFs should be dirty NIFs, since ordinary NIFs should never block for a
   long time.
 
-- **`int enif_set_option(ErlNifEnv *env, `[`ERL_NIF_OPT_ON_HALT`](erl_nif.md#ErlNifOption)`, `[`ErlNifOnHaltCallback`](erl_nif.md#ErlNifOnHaltCallback)` *on_halt)`**{: #on_halt } -
+- **[`ERL_NIF_OPT_ON_HALT`](erl_nif.md#ErlNifOption)**{: #on_halt }
+  ```c
+  enif_set_option(env, ERL_NIF_OPT_ON_HALT, on_halt)
+  ```
 
   Install a callback that will be called when the runtime system halts with
   flushing enabled.
@@ -3220,8 +3229,10 @@ will be returned. Currently the following options can be set:
   [`load()`](erl_nif.md#load) or [`upgrade()`](erl_nif.md#upgrade) call, and
   will fail if called somewhere else. The `env` argument _must_ be the callback
   environment passed to the `load()` or the `upgrade()` call. The `on_halt`
-  argument should be a function pointer to the callback to install. The _on
-  halt_ callback will be tied to the module instance with which the NIF library
+  argument should be a function pointer to the callback to install.
+
+  The [`on_halt`](erl_nif.md#ErlNifOnHaltCallback) callback will be tied to the
+  module instance with which the NIF library
   instance has been loaded. That is, in case both a new and old version of a
   module using the NIF library are loaded, they can both have different, none,
   or the same _on halt_ callbacks installed. When unloading the NIF library

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -205,6 +205,7 @@ typedef struct
 typedef ErlDrvMonitor ErlNifMonitor;
 
 typedef void ErlNifOnHaltCallback(void *priv_data);
+typedef void ErlNifOnUnloadThreadCallback(void *priv_data);
 
 typedef struct enif_resource_type_t ErlNifResourceType;
 typedef void ErlNifResourceDtor(ErlNifEnv*, void*);
@@ -332,7 +333,8 @@ typedef enum {
 
 typedef enum {
     ERL_NIF_OPT_DELAY_HALT = 1,
-    ERL_NIF_OPT_ON_HALT = 2
+    ERL_NIF_OPT_ON_HALT = 2,
+    ERL_NIF_OPT_ON_UNLOAD_THREAD = 3
 } ErlNifOption;
 
 #if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -1864,7 +1864,13 @@ handle_misc_aux_work(ErtsAuxWorkData *awdp,
 	erts_misc_aux_work_t *mawp = erts_thr_q_dequeue(q);
 	if (!mawp)
 	    break;
+#ifdef ERTS_ENABLE_LOCK_CHECK
+        awdp->lc_aux_arg = mawp->arg;
+#endif
 	mawp->func(mawp->arg);
+#ifdef ERTS_ENABLE_LOCK_CHECK
+        awdp->lc_aux_arg = NULL;
+#endif
 	misc_aux_work_free(mawp);
     }
 
@@ -2287,7 +2293,13 @@ handle_thr_prgr_later_op(ErtsAuxWorkData *awdp, erts_aint32_t aux_work, int wait
 	    awdp->later_op.last = NULL;
 	}
         awdp->later_op.list_len--;
+#ifdef ERTS_ENABLE_LOCK_CHECK
+        awdp->lc_aux_arg = lop->data;
+#endif
 	lop->func(lop->data);
+#ifdef ERTS_ENABLE_LOCK_CHECK
+        awdp->lc_aux_arg = NULL;
+#endif
 	if (!awdp->later_op.first) {
 	    awdp->later_op.size = thr_prgr_later_cleanup_op_threshold;
 	    awdp->later_op.last = NULL;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -606,6 +606,9 @@ typedef struct ErtsAuxWorkData_ {
 	    void *arg;
 	} wait_completed;
     } debug;
+#ifdef ERTS_ENABLE_LOCK_CHECK
+    void* lc_aux_arg;
+#endif
 } ErtsAuxWorkData;
 
 #define ERTS_SCHED_AUX_YIELD_DATA(ESDP, NAME) \

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -367,6 +367,7 @@ reload_error(Config) when is_list(Config) ->
 
     %%false= check_process_code(Pid, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,5,105}] = nif_mod_call_history(),
 
     true = lists:member(?MODULE, erlang:system_info(taints)),
@@ -404,6 +405,7 @@ upgrade(Config) when is_list(Config) ->
     upgraded = call(Pid,upgrade),
     false = check_process_code(Pid, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,7,107}] = nif_mod_call_history(),
 
     1 = nif_mod:lib_version(),
@@ -425,6 +427,7 @@ upgrade(Config) when is_list(Config) ->
     upgraded = call(Pid,upgrade),
     false = check_process_code(Pid, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,12,112}] = nif_mod_call_history(),
 
     1 = nif_mod:lib_version(),
@@ -438,6 +441,7 @@ upgrade(Config) when is_list(Config) ->
     {'DOWN', MRef, process, Pid, normal} = receive_any(),
     false = check_process_code(Pid, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,14,114}] = nif_mod_call_history(),
 
     %% Module upgrade with different lib version
@@ -467,6 +471,7 @@ upgrade(Config) when is_list(Config) ->
     upgraded = call(Pid2,upgrade),
     false = check_process_code(Pid2, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,6,106}] = nif_mod_call_history(),
 
     2 = nif_mod:lib_version(),
@@ -493,6 +498,7 @@ upgrade(Config) when is_list(Config) ->
     upgraded = call(Pid2,upgrade),
     false = check_process_code(Pid2, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,2,6,206}] = nif_mod_call_history(),
 
     1 = nif_mod:lib_version(),
@@ -506,6 +512,7 @@ upgrade(Config) when is_list(Config) ->
     {'DOWN', MRef2, process, Pid2, normal} = receive_any(),
     false= check_process_code(Pid2, nif_mod),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,4,104}] = nif_mod_call_history(),
 
     true = lists:member(?MODULE, erlang:system_info(taints)),
@@ -528,6 +535,7 @@ t_on_load(Config) when is_list(Config) ->
     ets:insert(nif_SUITE, {lib_version, 1}),
     API = proplists:get_value(nif_api_version, Config, ""),
     ets:insert(nif_SUITE, {nif_api_version, API}),
+    ets:insert(nif_SUITE, {tester, self()}),
     {module,nif_mod} = code:load_binary(nif_mod,File,Bin),
     hold_nif_mod_priv_data(nif_mod:get_priv_data_ptr()),
     [{load,1,1,101},{get_priv_data_ptr,1,2,102}] = nif_mod_call_history(),
@@ -545,6 +553,7 @@ t_on_load(Config) when is_list(Config) ->
     upgraded = call(Pid,upgrade),
     false = check_process_code(Pid, nif_mod),
     true = code:soft_purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,7,107}] = nif_mod_call_history(),
 
     1 = nif_mod:lib_version(),
@@ -563,6 +572,7 @@ t_on_load(Config) when is_list(Config) ->
     upgraded = call(Pid,upgrade),
     false = check_process_code(Pid, nif_mod),
     true = code:soft_purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,12,112}] = nif_mod_call_history(),
 
     1 = nif_mod:lib_version(),
@@ -576,6 +586,7 @@ t_on_load(Config) when is_list(Config) ->
     {'DOWN', MRef, process, Pid, normal} = receive_any(),
     false = check_process_code(Pid, nif_mod),
     true = code:soft_purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,14,114}] = nif_mod_call_history(),
 
     %% Module upgrade with different lib version
@@ -599,6 +610,7 @@ t_on_load(Config) when is_list(Config) ->
     upgraded = call(Pid2,upgrade),
     false = check_process_code(Pid2, nif_mod),
     true = code:soft_purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,6,106}] = nif_mod_call_history(),
 
     2 = nif_mod:lib_version(),
@@ -620,6 +632,7 @@ t_on_load(Config) when is_list(Config) ->
     upgraded = call(Pid2,upgrade),
     false = check_process_code(Pid2, nif_mod),
     true = code:soft_purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,2,6,206}] = nif_mod_call_history(),
 
     1 = nif_mod:lib_version(),
@@ -633,6 +646,7 @@ t_on_load(Config) when is_list(Config) ->
     {'DOWN', MRef2, process, Pid2, normal} = receive_any(),
     false= check_process_code(Pid2, nif_mod),
     true = code:soft_purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,4,104}] = nif_mod_call_history(),
 
     true = lists:member(?MODULE, erlang:system_info(taints)),
@@ -1217,7 +1231,7 @@ monitor_process_purge(Config) ->
 
     monitor_process_purge_do(Config, NifModBin, resource_dtor_A),
     erlang:garbage_collect(),
-    receive after 10 -> ok end,
+    receive unloaded -> ok end,
     [{{resource_dtor_A_v1,_},1,4,104},
      {unload,1,5,105}] = nif_mod_call_history(),
 
@@ -1225,7 +1239,7 @@ monitor_process_purge(Config) ->
     %% prevented NIF lib from being unloaded.
     monitor_process_purge_do(Config, NifModBin, null),
     erlang:garbage_collect(),
-    receive after 10 -> ok end,
+    receive unloaded -> ok end,
     [{unload,1,4,104}] = nif_mod_call_history(),
     ok.
 
@@ -1417,7 +1431,7 @@ t_dynamic_resource_call(Config) ->
     true = erlang:delete_module(nif_mod),
     true = erlang:purge_module(nif_mod),
 
-    receive after 10 -> ok end,
+    receive unloaded -> ok end,
     [{{resource_dtor_A_v1,_},1,2,102},
      {unload,1,3,103}] = nif_mod_call_history(),
 
@@ -1450,6 +1464,7 @@ dynamic_resource_call_do(Config, NifModBin) ->
 
     {0, 1002} = dynamic_resource_call(nif_mod, with_dyncall, R, 1000),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,3,103}] = nif_mod_call_history(),
 
     %% Upgrade resource type with missing dyncall implementation.
@@ -1461,6 +1476,7 @@ dynamic_resource_call_do(Config, NifModBin) ->
 
     {1, 1000} = dynamic_resource_call(nif_mod, with_dyncall, R, 1000),
     true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok end,
     [{unload,2,2,202}] = nif_mod_call_history(),
 
     keep_alive(R),
@@ -2286,6 +2302,7 @@ resource_takeover(Config) when is_list(Config) ->
                               ]),
     ?CHECK([{upgrade,2,1,201}], nif_mod_call_history()),
     true = erlang:purge_module(nif_mod),
+    timeout = receive unloaded -> error after 10 -> timeout end,
     ?CHECK([], nif_mod_call_history()),  % BGX2 keeping lib loaded
 
     BinA2 = read_resource(0,A2),
@@ -2299,6 +2316,7 @@ resource_takeover(Config) when is_list(Config) ->
     ?CHECK([], nif_mod_call_history()),    % no dtor
 
     ok = forget_resource(BGX2),  % calling dtor in orphan library v1 still loaded
+    receive unloaded -> ok end,
     ?CHECK([{{resource_dtor_B_v1,BinBGX2},1,6,106}, {unload,1,7,107}],
            nif_mod_call_history()),
 
@@ -2346,12 +2364,14 @@ resource_takeover(Config) when is_list(Config) ->
     {NGZ1,_BinNGZ1} = make_resource(4,Holder,"NGZ1"),
 
     false = code:purge(nif_mod),
+    timeout = receive unloaded -> error after 10 -> timeout end,
     [] = nif_mod_call_history(),
 
     ok = forget_resource(NGY1),
     [] = nif_mod_call_history(),
 
     ok = forget_resource(BGY1),  % calling dtor in orphan library v2 still loaded
+    receive unloaded -> ok end,
     [{{resource_dtor_B_v2,BinBGY1},2,8,208},{unload,2,9,209}] = nif_mod_call_history(),
 
     %% Module upgrade with other lib-version
@@ -2374,9 +2394,11 @@ resource_takeover(Config) when is_list(Config) ->
     %%false= check_process_code(Pid, nif_mod),
     false = code:purge(nif_mod),
     %% no unload here as we still have instances with destructors
+    timeout = receive unloaded -> error after 10 -> timeout end,
     [] = nif_mod_call_history(),
 
     ok = forget_resource(BGZ1),  % calling dtor in orphan library v2 still loaded
+    receive unloaded -> ok end,
     [{{resource_dtor_B_v2,BinBGZ1},2,10,210},{unload,2,11,211}] = nif_mod_call_history(),
 
     ok = forget_resource(NGZ1),
@@ -2474,9 +2496,11 @@ resource_takeover(Config) when is_list(Config) ->
     %% Test rolback after failed initial load
     %%
     false = code:purge(nif_mod),
+    receive unloaded -> ok end,
     [{unload,1,_,_}] = nif_mod_call_history(),
     true = code:delete(nif_mod),
     false = code:purge(nif_mod),
+    timeout = receive unloaded -> error after 10 -> timeout end,
     [] = nif_mod_call_history(),
 
 

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.erl
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.erl
@@ -48,7 +48,8 @@ on_load() ->
     [{data_dir, Path}] = ets:lookup(nif_SUITE, data_dir),
     [{lib_version, Ver}] = ets:lookup(nif_SUITE, lib_version),
     [{nif_api_version, API}] = ets:lookup(nif_SUITE, nif_api_version),
-    R = erlang:load_nif(filename:join(Path,libname(Ver,API)), []),
+    [{tester, Tester}] = ets:lookup(nif_SUITE, tester),
+    R = erlang:load_nif(filename:join(Path,libname(Ver,API)), [{tester,Tester}]),
     check_api_version(R, API).
 
 -endif.

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.h
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.h
@@ -17,6 +17,7 @@ typedef struct
     int ref_cnt;
     CallInfo* call_history;
     ErlNifResourceType* rt_arr[RT_MAX];
+    ErlNifPid tester_pid;
 }NifModPrivData;
 
 #define NifModPrivData_release(NMPD) \

--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -55,6 +55,9 @@
 /* NIF interface declarations */
 static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info);
 static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data, ERL_NIF_TERM load_info);
+#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,0) && !defined(HAS_LIBRESSL)
+static void unload_thread(void* priv_data);
+#endif
 static void unload(ErlNifEnv* env, void* priv_data);
 
 static int library_refc = 0; /* number of users of this dynamic library */
@@ -251,6 +254,10 @@ static int initialize(ErlNifEnv* env, ERL_NIF_TERM load_info)
     }
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,0) && !defined(HAS_LIBRESSL)
+    enif_set_option(env, ERL_NIF_OPT_ON_UNLOAD_THREAD, unload_thread);
+#endif
+
     if (library_initialized) {
 	/* Repeated loading of this library (module upgrade).
 	 * Atoms and callbacks are already set, we are done.
@@ -363,6 +370,15 @@ static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
     library_refc++;
     return 0;
 }
+
+#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,0) && !defined(HAS_LIBRESSL)
+static void unload_thread(void* priv_data)
+{
+    if (library_refc == 1) {
+        OPENSSL_thread_stop();
+    }
+}
+#endif
 
 static void unload(ErlNifEnv* env, void* priv_data)
 {


### PR DESCRIPTION
- Add an optional `unload_thread` callback to be called by every scheduler thread in order to release thread specific data when a NIF module is purged.
- Let crypto use `unload_thread` to call OPENSSL_thread_stop() to not leak thread specific data.
- Fix unload-load race to ensure all unload callbacks and dlclose() have returned before we allow reloading the same NIF module again.