### PR TITLE
Improve automation next to erlang/docker-erlang-otp builds

### DIFF
--- a/.github/workflows/trigger-docker-build.yaml
+++ b/.github/workflows/trigger-docker-build.yaml
@@ -1,0 +1,42 @@
+---
+"on":
+  workflow_dispatch:
+    inputs:
+      otp_version:
+        type: string
+        required: true
+      otp_download_sha256:
+        type: string
+        required: true
+
+jobs:
+  trigger-docker-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # As per https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow
+      #- name: Generate Authorization token
+      #  id: generate_token
+      #  uses: actions/create-github-app-token@v1
+      #  with:
+      #    app-id: ${{ secrets.APP_ID }}
+      #    private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      #    owner: erlang
+      #    repositories: docker-erlang-otp
+
+      - name: Trigger Docker container builds
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          TARGET_OWNER: erlang
+          TARGET_REPO: docker-erlang-otp
+          TARGET_WORKFLOW: dockerfiles.yaml
+          OTP_VERSION: ${{ github.event.inputs.otp_version }}
+          OTP_DOWNLOAD_SHA256: ${{ github.event.inputs.otp_download_sha256 }}
+        run: |
+          curl --location --silent \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: token ${GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --url "https://api.github.com/repos/${TARGET_OWNER}/${TARGET_REPO}/actions/workflows/${TARGET_WORKFLOW}/dispatches" \
+            --data "{ \"ref\": \"master\", \"inputs\": { \"otp_version\": \"${OTP_VERSION}\", \"otp_download_sha256\": \"${OTP_DOWNLOAD_SHA256}\" } }" \
+            --fail


### PR DESCRIPTION
## Motivation

To automate Erlang/OTP release -based Docker image building next to [`erlang/docker-erlang-otp`](https://github.com/erlang/docker-erlang-otp) (these days it's a manual process).

## Description

As per what's been recently discuss in the [#build-and-packaging EEF Slack channel](https://the-eef.slack.com/archives/CUQVCA5K8/p1698578278967999), and since `erlang/otp` accepts triggering builds next to `erlang/docker-erlang-otp` (I'm not sure the other way around is completely agreed upon, but am assuming it), I'm pushing this to make that happen.

`trigger-docker-build.yaml` will be triggered by a workflow from this repository (I'm not exactly sure which one, so ⚠️ need guidance) by having the generated OTP version (`otp_version`) and SHA256 checksum (`otp_download_sha256`) as inputs.

In my tests, I used a custom GitHub App I created for that purpose, but I'm not sure how you intended to do integration between these two repositories (which is why the workflow contains commented out instructions that can later be updated/removed).

The rest of the implementation (and as per @garazdawi's suggestion) follows the [GitHub Docs](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event) closely.

## Further considerations

I'll shortly open the sister pull request to this one, next to `erlang/docker-erlang-otp` and it's possible change requests from there end up changing this one, or vice-versa.

## Example

As an example of workflow dispatch triggering, here's what I used for my tests (note the **`# Requires`** comment).

```yaml
---
"on":
  - push
  - workflow_dispatch

jobs:
  release:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v4

      - env:
          GITHUB_TOKEN: ${{ github.token }}
        # Requires <repo>settings/actions: Workflow permissions > Read and write permissions
        run: |
          gh workflow run trigger_docker_build.yml \
            --repo "${GITHUB_REPOSITORY}" \
            --ref main \
            --raw-field otp_version=26.0.1 \
            --raw-field otp_download_sha256=dc02213328f88939013bedcbb7f170ffec60fc718ef685221c813b579f812602
```