### PR TITLE
Fix `ct_property_test` result handling for failing properties

### DIFF
--- a/lib/common_test/src/ct_property_test.erl
+++ b/lib/common_test/src/ct_property_test.erl
@@ -165,12 +165,15 @@ print_frequency_ranges(Options0) ->
 mk_ct_return(true, _Tool) ->
     true;
 mk_ct_return(Other, Tool) ->
-    try lists:last(hd(Tool:counterexample()))
-    of
-	{set,{var,_},{call,M,F,Args}} ->
-	    {fail, io_lib:format("~p:~tp/~p returned bad result",[M,F,length(Args)])}
-    catch
-	_:_ ->
+    case Tool:counterexample() of
+	[[_|_]=CE|_] ->
+	    case lists:last(CE) of
+		{set, {var, _}, {call, M, F, Args}} ->
+		    {fail, io_lib:format("~p:~tp/~p returned bad result", [M, F, length(Args)])};
+		_ ->
+		    {fail, Other}
+	    end;
+	_ ->
 	    {fail, Other}
     end.
 

--- a/lib/common_test/src/ct_property_test.erl
+++ b/lib/common_test/src/ct_property_test.erl
@@ -98,7 +98,7 @@ init_tool_extensions(_) ->
 quickcheck(Property, Config) ->
     Tool = proplists:get_value(property_test_tool,Config),
     F = function_name(quickcheck, Tool),
-    mk_ct_return( Tool:F(Property), Tool ).
+    mk_ct_return(Tool:F(Property)).
 
 
 %%%----------------------------------------------------------------
@@ -162,20 +162,10 @@ print_frequency_ranges(Options0) ->
 %%% 
 
 %%% Make return values back to the calling Common Test suite
-mk_ct_return(true, _Tool) ->
+mk_ct_return(true) ->
     true;
-mk_ct_return(Other, Tool) ->
-    case Tool:counterexample() of
-	[[_|_]=CE|_] ->
-	    case lists:last(CE) of
-		{set, {var, _}, {call, M, F, Args}} ->
-		    {fail, io_lib:format("~p:~tp/~p returned bad result", [M, F, length(Args)])};
-		_ ->
-		    {fail, Other}
-	    end;
-	_ ->
-	    {fail, Other}
-    end.
+mk_ct_return(Other) ->
+    {fail, Other}.
 
 %%% Check if a property testing tool is found
 which_module_exists([Module|Modules]) ->


### PR DESCRIPTION
While I have no clue what the `{set, {var, _}, {call, M, F, Args}}` part is all about (@HansN, maybe you can shed some light on this, `git blame` says this was done by you, albeit ~9 years ago :sweat_smile:), this fails with a `try_clause` exception if a property fails on input that is a non-empty list, like eg `[1, 2, 3]`. `Tool:counterexample()` will then return `[[1, 2, 3]]`, for which `lists:last(hd([[1, 2, 3]]))` will return `3`, for which there is no matching clause in the `try`.