### PR TITLE
erts: Refactor bitstring (binary) handling

### DIFF
--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -1120,7 +1120,9 @@ RUN_OBJS += \
 	$(OBJDIR)/beam_file.o \
 	$(OBJDIR)/beam_types.o \
 	$(OBJDIR)/erl_term_hashing.o \
-	$(OBJDIR)/erl_bif_coverage.o
+	$(OBJDIR)/erl_bif_coverage.o \
+	$(OBJDIR)/erl_iolist.o \
+	$(OBJDIR)/erl_etp.o
 
 LTTNG_OBJS = $(OBJDIR)/erlang_lttng.o
 

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -383,6 +383,7 @@ atom is_constant
 atom is_seq_trace
 atom iterator
 atom io
+atom iolist_size_continue
 atom iodata
 atom iovec
 atom keypos
@@ -404,7 +405,7 @@ atom line_length
 atom linked_in_driver
 atom links
 atom list
-atom list_to_binary_continue
+atom list_to_bitstring_continue
 atom little
 atom loaded
 atom load_cancelled

--- a/erts/emulator/beam/beam_debug.c
+++ b/erts/emulator/beam/beam_debug.c
@@ -418,7 +418,9 @@ erts_debug_disassemble_1(BIF_ALIST_1)
          */
         code_ptr = 0;
     }
-    bin = new_binary(p, (byte *) dsbufp->str, dsbufp->str_len);
+    bin = erts_new_binary_from_data(p,
+                                    dsbufp->str_len,
+                                    (byte *) dsbufp->str);
     erts_destroy_tmp_dsbuf(dsbufp);
     hsz = 4+4;
     (void) erts_bld_uword(NULL, &hsz, (BeamInstr) code_ptr);

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -97,12 +97,12 @@ Eterm
 erts_preload_module(Process *c_p,
                     ErtsProcLocks c_p_locks,
                     Eterm group_leader, /* Group leader or NIL if none. */
-                    Eterm* modp,        /*
+                    Eterm *modp,        /*
                                          * Module name as an atom (NIL to not
                                          * check). On return, contains the
                                          * actual module name.
                                          */
-                    byte* code,         /* Points to the code to load */
+                    const byte* code,   /* Points to the code to load */
                     Uint size)          /* Size of code to load. */
 {
     Binary* magic = erts_alloc_loader_state();
@@ -121,7 +121,7 @@ erts_preload_module(Process *c_p,
 
 Eterm
 erts_prepare_loading(Binary* magic, Process *c_p, Eterm group_leader,
-                     Eterm* modp, byte* code, Uint unloaded_size)
+                     Eterm* modp, const byte *code, Uint unloaded_size)
 {
     enum beamfile_read_result read_result;
     Eterm retval = am_badfile;
@@ -656,10 +656,10 @@ erts_release_literal_area(ErtsLiteralArea* literal_area)
 
     while (oh) {
         switch (thing_subtag(oh->thing_word)) {
-        case REFC_BINARY_SUBTAG:
+        case BIN_REF_SUBTAG:
             {
-                Binary* bptr = ((ProcBin*)oh)->val;
-                erts_bin_release(bptr);
+                Binary *bin = ((BinRef*)oh)->val;
+                erts_bin_release(bin);
                 break;
             }
         case FUN_SUBTAG:

--- a/erts/emulator/beam/big.c
+++ b/erts/emulator/beam/big.c
@@ -3048,7 +3048,7 @@ static const Sint largest_power_of_base_lookup[36-1] = {
 #endif
 };
 
-static Eterm chars_to_integer(char *bytes, Uint size, const Uint base)
+static Eterm chars_to_integer(const byte *bytes, Uint size, const Uint base)
 {
     Sint i = 0;
     int neg = 0;
@@ -3119,8 +3119,7 @@ static Eterm chars_to_integer(char *bytes, Uint size, const Uint base)
 
 BIF_RETTYPE erts_internal_binary_to_integer_2(BIF_ALIST_2)
 {
-    byte *temp_alloc = NULL;
-    char *bytes;
+    const byte *temp_alloc = NULL, *bytes;
     Uint size;
     Uint base;
     Eterm res;
@@ -3129,17 +3128,17 @@ BIF_RETTYPE erts_internal_binary_to_integer_2(BIF_ALIST_2)
         BIF_RET(am_badarg);
     }
 
-    base = (Uint) signed_val(BIF_ARG_2);
+    base = (Uint)signed_val(BIF_ARG_2);
 
     if (base < 2 || base > 36) {
         BIF_RET(am_badarg);
     }
 
-    if ((bytes = (char*)erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc)) == NULL) {
+    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (bytes == NULL) {
         BIF_RET(am_badarg);
     }
 
-    size = binary_size(BIF_ARG_1);
     res = chars_to_integer(bytes, size, base);
     erts_free_aligned_binary_bytes(temp_alloc);
     BIF_RET(res);

--- a/erts/emulator/beam/binary.c
+++ b/erts/emulator/beam/binary.c
@@ -31,15 +31,13 @@
 #include "big.h"
 #include "erl_binary.h"
 #include "erl_bits.h"
+#include "erl_iolist.h"
 
-#define L2B_B2L_MIN_EXEC_REDS (CONTEXT_REDS/4)
-#define L2B_B2L_RESCHED_REDS (CONTEXT_REDS/40)
-
-static Export binary_to_list_continue_export;
-static Export list_to_binary_continue_export;
+#define B2L_MIN_EXEC_REDS (CONTEXT_REDS/4)
+#define B2L_RESCHED_REDS (CONTEXT_REDS/40)
 
 static BIF_RETTYPE binary_to_list_continue(BIF_ALIST_1);
-static BIF_RETTYPE list_to_binary_continue(BIF_ALIST_1);
+static Export binary_to_list_continue_export;
 
 void
 erts_init_binary(void)
@@ -52,192 +50,6 @@ erts_init_binary(void)
 			  am_erts_internal, am_binary_to_list_continue, 1,
 			  &binary_to_list_continue);
 
-    erts_init_trap_export(&list_to_binary_continue_export,
-			  am_erts_internal, am_list_to_binary_continue, 1,
-			  &list_to_binary_continue);
-
-}
-
-static ERTS_INLINE
-Eterm build_proc_bin(ErlOffHeap* ohp, Eterm* hp, Binary* bptr)
-{
-    ProcBin* pb = (ProcBin *) hp;
-    pb->thing_word = HEADER_PROC_BIN;
-    pb->size = bptr->orig_size;
-    pb->next = ohp->first;
-    ohp->first = (struct erl_off_heap_header*)pb;
-    pb->val = bptr;
-    pb->bytes = (byte*) bptr->orig_bytes;
-    pb->flags = 0;
-    OH_OVERHEAD(ohp, pb->size / sizeof(Eterm));
-
-    return make_binary(pb);
-}
-
-/** @brief Initiate a ProcBin for a full Binary.
- *  @param hp must point to PROC_BIN_SIZE available heap words.
- */
-Eterm erts_build_proc_bin(ErlOffHeap* ohp, Eterm* hp, Binary* bptr)
-{
-    return build_proc_bin(ohp, hp, bptr);
-}
-
-/*
- * Create a brand new binary from scratch.
- */
-Eterm
-new_binary(Process *p, const byte *buf, Uint len)
-{
-    Binary* bptr;
-
-    if (len <= ERL_ONHEAP_BIN_LIMIT) {
-	ErlHeapBin* hb = (ErlHeapBin *) HAlloc(p, heap_bin_size(len));
-	hb->thing_word = header_heap_bin(len);
-	hb->size = len;
-	if (buf != NULL) {
-	    sys_memcpy(hb->data, buf, len);
-	}
-	return make_binary(hb);
-    }
-
-    /*
-     * Allocate the binary struct itself.
-     */
-    bptr = erts_bin_nrml_alloc(len);
-    if (buf != NULL) {
-	sys_memcpy(bptr->orig_bytes, buf, len);
-    }
-
-    return build_proc_bin(&MSO(p), HAlloc(p, PROC_BIN_SIZE), bptr);
-}
-
-Eterm
-erts_heap_factory_new_binary(ErtsHeapFactory *hfact, byte *buf, Uint len,
-                             Uint reserve_size)
-{
-    Eterm *hp;
-    Binary* bptr;
-
-    if (len <= ERL_ONHEAP_BIN_LIMIT) {
-	ErlHeapBin* hb;
-        hp = erts_produce_heap(hfact, heap_bin_size(len), reserve_size);
-        hb = (ErlHeapBin *) hp;
-	hb->thing_word = header_heap_bin(len);
-	hb->size = len;
-	if (buf != NULL) {
-	    sys_memcpy(hb->data, buf, len);
-	}
-	return make_binary(hb);
-    }
-
-    /*
-     * Allocate the binary struct itself.
-     */
-    bptr = erts_bin_nrml_alloc(len);
-    if (buf != NULL) {
-	sys_memcpy(bptr->orig_bytes, buf, len);
-    }
-
-    hp = erts_produce_heap(hfact, PROC_BIN_SIZE, reserve_size);
-
-    return build_proc_bin(hfact->off_heap, hp, bptr);
-}
-
-
-
-/* 
- * When heap binary is not desired...
- */
-
-Eterm erts_new_mso_binary(Process *p, byte *buf, Uint len)
-{
-    Binary* bptr;
-
-    /*
-     * Allocate the binary struct itself.
-     */
-    bptr = erts_bin_nrml_alloc(len);
-    if (buf != NULL) {
-	sys_memcpy(bptr->orig_bytes, buf, len);
-    }
-
-    return build_proc_bin(&MSO(p), HAlloc(p, PROC_BIN_SIZE), bptr);
-}
-
-/*
- * Create a brand new binary from scratch on the heap.
- */
-
-Eterm
-erts_new_heap_binary(Process *p, byte *buf, int len, byte** datap)
-{
-    ErlHeapBin* hb = (ErlHeapBin *) HAlloc(p, heap_bin_size(len));
-
-    hb->thing_word = header_heap_bin(len);
-    hb->size = len;
-    if (buf != NULL) {
-	sys_memcpy(hb->data, buf, len);
-    }
-    *datap = (byte*) hb->data;
-    return make_binary(hb);
-}
-
-Eterm
-erts_realloc_binary(Eterm bin, size_t size)
-{
-    Eterm* bval = binary_val(bin);
-
-    if (thing_subtag(*bval) == HEAP_BINARY_SUBTAG) {
-	ASSERT(size <= binary_size(bin));
-	binary_size(bin) = size;
-    } else {			/* REFC */
-	ProcBin* pb = (ProcBin *) bval;
-	Binary* newbin = erts_bin_realloc(pb->val, size);
-	pb->val = newbin;
-	pb->size = size;
-	pb->bytes = (byte*) newbin->orig_bytes;
-	pb->flags = 0;
-	bin = make_binary(pb);
-    }
-    return bin;
-}
-
-byte*
-erts_get_aligned_binary_bytes_extra(Eterm bin, byte** base_ptr, ErtsAlcType_t allocator, unsigned extra)
-{
-    byte* bytes;
-    Eterm* real_bin;
-    Uint byte_size;
-    Uint offs = 0;
-    Uint bit_offs = 0;
-    
-    if (is_not_binary(bin)) {
-	return NULL;
-    }
-    byte_size = binary_size(bin);
-    real_bin = binary_val(bin);
-    if (*real_bin == HEADER_SUB_BIN) {
-	ErlSubBin* sb = (ErlSubBin *) real_bin;
-	if (sb->bitsize) {
-	    return NULL;
-	}
-	offs = sb->offs;
-	bit_offs = sb->bitoffs;
-	real_bin = binary_val(sb->orig);
-    }
-    if (*real_bin == HEADER_PROC_BIN) {
-	bytes = ((ProcBin *) real_bin)->bytes + offs;
-    } else {
-	bytes = (byte *)(&(((ErlHeapBin *) real_bin)->data)) + offs;
-    }
-    if (bit_offs) {
-	byte* buf = (byte *) erts_alloc(allocator, byte_size + extra);
-	*base_ptr = buf;
-	buf += extra;
-	erts_copy_bits(bytes, bit_offs, 1, buf, 0, 1, byte_size*8);	
-	bytes = buf;
-    }
-    return bytes;
 }
 
 Eterm
@@ -273,7 +85,7 @@ static Eterm integer_to_binary(Process *c_p, Eterm num, int base)
         Uint digits;
 
         digits = Sint_to_buf(signed_val(num), base, &c, sizeof(s));
-        res = new_binary(c_p, (byte*)c, digits);
+        res = erts_new_binary_from_data(c_p, digits, (byte*)c);
     } else {
         const int DIGITS_PER_RED = 16;
         Uint digits, n;
@@ -295,7 +107,7 @@ static Eterm integer_to_binary(Process *c_p, Eterm num, int base)
 
         bytes = (byte*)erts_alloc(ERTS_ALC_T_TMP, sizeof(byte) * digits);
         n = erts_big_to_binary_bytes(num, base, (char*)bytes, digits);
-        res = new_binary(c_p, bytes + digits - n, n);
+        res = erts_new_binary_from_data(c_p, n, &bytes[digits - n]);
         erts_free(ERTS_ALC_T_TMP, (void*)bytes);
     }
 
@@ -491,1119 +303,213 @@ static BIF_RETTYPE binary_to_list_continue(BIF_ALIST_1)
 
 BIF_RETTYPE binary_to_list_1(BIF_ALIST_1)
 {
-    Eterm real_bin;
-    Uint offset;
-    Uint size;
-    Uint bitsize;
-    Uint bitoffs;
+    Uint offset, size;
+    byte *base;
     int reds_left;
     int one_chunk;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	goto error;
+    if (is_not_bitstring(BIF_ARG_1)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
 
-    size = binary_size(BIF_ARG_1);
+    ERTS_GET_BITSTRING(BIF_ARG_1, base, offset, size);
+
+    if (size == 0) {
+        BIF_RET(NIL);
+    } else if (TAIL_BITS(size) != 0) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    base = &base[BYTE_OFFSET(offset)];
+    offset = BIT_OFFSET(offset);
+    size = BYTE_SIZE(size);
+
     reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
     one_chunk = size < reds_left*ERTS_B2L_BYTES_PER_REDUCTION;
     if (!one_chunk) {
-	if (size < L2B_B2L_MIN_EXEC_REDS*ERTS_B2L_BYTES_PER_REDUCTION) {
-	    if (reds_left <= L2B_B2L_RESCHED_REDS) {
-		/* Yield and do it with full context reds... */
-		ERTS_BIF_YIELD1(BIF_TRAP_EXPORT(BIF_binary_to_list_1),
-				BIF_P, BIF_ARG_1);
-	    }
-	    /* Allow a bit more reductions... */
-	    one_chunk = 1;
-	    reds_left = L2B_B2L_MIN_EXEC_REDS;
-	}
+        if (size < B2L_MIN_EXEC_REDS*ERTS_B2L_BYTES_PER_REDUCTION) {
+            if (reds_left <= B2L_RESCHED_REDS) {
+                /* Yield and do it with full context reds... */
+                ERTS_BIF_YIELD1(BIF_TRAP_EXPORT(BIF_binary_to_list_1),
+                                BIF_P, BIF_ARG_1);
+            }
+            /* Allow a bit more reductions... */
+            one_chunk = 1;
+            reds_left = B2L_MIN_EXEC_REDS;
+        }
     }
 
-    ERTS_GET_REAL_BIN(BIF_ARG_1, real_bin, offset, bitoffs, bitsize);
-    if (bitsize != 0) {
-	goto error;
-    }
-    if (size == 0) {
-	BIF_RET(NIL);
-    } else {
-	Eterm* hp = HAlloc(BIF_P, 2 * size);
-	byte* bytes = binary_bytes(real_bin)+offset;
-	return binary_to_list(BIF_P, hp, NIL, bytes, size,
-			      bitoffs, reds_left, one_chunk);
-    }
-
-    error:
-	BIF_ERROR(BIF_P, BADARG);
+    return binary_to_list(BIF_P,
+                          HAlloc(BIF_P, 2 * size),
+                          NIL,
+                          base,
+                          size,
+                          offset,
+                          reds_left,
+                          one_chunk);
 }
 
 BIF_RETTYPE binary_to_list_3(BIF_ALIST_3)
 {
-    byte* bytes;
-    Uint size;
-    Uint bitoffs;
-    Uint bitsize;
-    Uint i;
-    Uint start;
-    Uint stop;
-    Eterm* hp;
+    Uint start, stop, i;
+    Uint offset, size;
+    byte *base;
     int reds_left;
     int one_chunk;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	goto error;
+    if (is_not_bitstring(BIF_ARG_1)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
     if (!term_to_Uint(BIF_ARG_2, &start) || !term_to_Uint(BIF_ARG_3, &stop)) {
-	goto error;
+        BIF_ERROR(BIF_P, BADARG);
     }
-    size = binary_size(BIF_ARG_1);
+
+    ERTS_GET_BITSTRING(BIF_ARG_1, base, offset, size);
+
+    if (TAIL_BITS(size) != 0) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    size = BYTE_SIZE(size);
+
+    if (start < 1 || start > size || stop < 1 || stop > size || stop < start) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    if (size == 0) {
+        BIF_RET(NIL);
+    }
+
     reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
     one_chunk = size < reds_left*ERTS_B2L_BYTES_PER_REDUCTION;
     if (!one_chunk) {
-	if (size < L2B_B2L_MIN_EXEC_REDS*ERTS_B2L_BYTES_PER_REDUCTION) {
-	    if (reds_left <= L2B_B2L_RESCHED_REDS) {
-		/* Yield and do it with full context reds... */
-		ERTS_BIF_YIELD3(BIF_TRAP_EXPORT(BIF_binary_to_list_3),
-				BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3);
-	    }
-	    /* Allow a bit more reductions... */
-	    one_chunk = 1;
-	    reds_left = L2B_B2L_MIN_EXEC_REDS;
-	}
+        if (size < B2L_MIN_EXEC_REDS*ERTS_B2L_BYTES_PER_REDUCTION) {
+            if (reds_left <= B2L_RESCHED_REDS) {
+                /* Yield and do it with full context reds... */
+                ERTS_BIF_YIELD3(BIF_TRAP_EXPORT(BIF_binary_to_list_3),
+                                BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3);
+            }
+            /* Allow a bit more reductions... */
+            one_chunk = 1;
+            reds_left = B2L_MIN_EXEC_REDS;
+        }
     }
 
-    ERTS_GET_BINARY_BYTES(BIF_ARG_1, bytes, bitoffs, bitsize);
-    if (start < 1 || start > size || stop < 1 ||
-	stop > size || stop < start ) {
-	goto error;
-    }
-    i = stop-start+1;
-    hp = HAlloc(BIF_P, 2*i);
-    return binary_to_list(BIF_P, hp, NIL, bytes+start-1, i,
-			  bitoffs, reds_left, one_chunk);
-    error:
-	BIF_ERROR(BIF_P, BADARG);
+    i = stop - start + 1;
+
+    base = &base[BYTE_OFFSET(offset)];
+    return binary_to_list(BIF_P,
+                          HAlloc(BIF_P, 2 * i),
+                          NIL,
+                          &base[start - 1],
+                          i,
+                          BIT_OFFSET(offset),
+                          reds_left,
+                          one_chunk);
 }
 
 BIF_RETTYPE bitstring_to_list_1(BIF_ALIST_1)
 {
-    Eterm real_bin;
-    Uint offset;
-    Uint size;
-    Uint bitsize;
-    Uint bitoffs;
+    Uint offset, size;
     byte* bytes;
-    Eterm previous = NIL;
+    Eterm tail;
     Eterm* hp;
     int reds_left;
     int one_chunk;
+    Uint cells;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	BIF_ERROR(BIF_P, BADARG);
-    }
-    size = binary_size(BIF_ARG_1);
-    reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
-    one_chunk = size < reds_left*ERTS_B2L_BYTES_PER_REDUCTION;
-    if (!one_chunk) {
-	if (size < L2B_B2L_MIN_EXEC_REDS*ERTS_B2L_BYTES_PER_REDUCTION) {
-	    if (reds_left <= L2B_B2L_RESCHED_REDS) {
-		/* Yield and do it with full context reds... */
-		ERTS_BIF_YIELD1(BIF_TRAP_EXPORT(BIF_bitstring_to_list_1),
-				BIF_P, BIF_ARG_1);
-	    }
-	    /* Allow a bit more reductions... */
-	    one_chunk = 1;
-	    reds_left = L2B_B2L_MIN_EXEC_REDS;
-	}
-    }
-    ERTS_GET_REAL_BIN(BIF_ARG_1, real_bin, offset, bitoffs, bitsize);
-    bytes = binary_bytes(real_bin)+offset;
-    if (bitsize == 0) {
-	hp = HAlloc(BIF_P, 2 * size);
-    } else if (size == 0) {
-	hp = HAlloc(BIF_P, 2);
-	BIF_RET(CONS(hp,BIF_ARG_1,NIL));
-    } else {
-	ErlSubBin* last;
-
-	hp = HAlloc(BIF_P, ERL_SUB_BIN_SIZE+2+2*size);
-	last = (ErlSubBin *) hp;
-	last->thing_word = HEADER_SUB_BIN;
-	last->size = 0;
-	last->bitsize = bitsize;
-	last->offs = offset+size;
-	last->bitoffs = bitoffs;
-	last->orig = real_bin;
-	last->is_writable = 0;
-	hp += ERL_SUB_BIN_SIZE;
-	previous = CONS(hp, make_binary(last), previous);
-	hp += 2;
-    }
-
-    return binary_to_list(BIF_P, hp, previous, bytes, size,
-			  bitoffs, reds_left, one_chunk);
-}
-
-
-/* Turn a possibly deep list of ints (and binaries) into */
-/* One large binary object                               */
-
-typedef enum {
-    ERTS_L2B_OK,
-    ERTS_L2B_YIELD,
-    ERTS_L2B_TYPE_ERROR,
-    ERTS_L2B_OVERFLOW_ERROR
-} ErtsL2BResult;
-
-#define ERTS_L2B_STATE_INITER(C_P, ARG, BIF, SZFunc, TBufFunc)	\
-    {ERTS_IOLIST2BUF_STATE_INITER((C_P), (ARG)),				\
-	    (ARG), THE_NON_VALUE, (BIF), (SZFunc), (TBufFunc)}
-
-#define ERTS_L2B_STATE_MOVE(TO, FROM) \
-    sys_memcpy((void *) (TO), (void *) (FROM), sizeof(ErtsL2BState))
-
-typedef struct ErtsL2BState_ ErtsL2BState;
-
-struct ErtsL2BState_ {
-    ErtsIOList2BufState buf;
-    Eterm arg;
-    Eterm bin;
-    Export *bif;
-    int (*iolist_to_buf_size)(ErtsIOListState *);
-    ErlDrvSizeT (*iolist_to_buf)(ErtsIOList2BufState *);
-};
-
-static ERTS_INLINE ErtsL2BResult
-list_to_binary_engine(ErtsL2BState *sp)
-{
-    ErlDrvSizeT res;
-    Process *c_p = sp->buf.iolist.c_p;
-
-    /*
-     * have_size == 0 while sp->iolist_to_buf_size()
-     * has not finished the calculation.
-     */
-
-    if (!sp->buf.iolist.have_size) {
-	switch (sp->iolist_to_buf_size(&sp->buf.iolist)) {
-	case ERTS_IOLIST_YIELD:
-	    return ERTS_L2B_YIELD;
-	case ERTS_IOLIST_OVERFLOW:
-	    return ERTS_L2B_OVERFLOW_ERROR;
-	case ERTS_IOLIST_TYPE:
-	    return ERTS_L2B_TYPE_ERROR;
-	case ERTS_IOLIST_OK:
-	    break;
-	default:
-	    ASSERT(0);
-	    break;
-	}
-
-	ASSERT(sp->buf.iolist.have_size);
-
-	/*
-	 * Size calculated... Setup state for
-	 * sp->iolist_to_buf_*()
-	 */
-
-	sp->bin = new_binary(c_p,
-			     (byte *) NULL,
-			     sp->buf.iolist.size);
-
-	if (sp->buf.iolist.size == 0)
-	    return ERTS_L2B_OK;
-
-	sp->buf.buf = (char *) binary_bytes(sp->bin);
-	sp->buf.len = sp->buf.iolist.size;
-	sp->buf.iolist.obj = sp->arg;
-
-	if (sp->buf.iolist.reds_left <= 0) {
-	    BUMP_ALL_REDS(c_p);
-	    return ERTS_L2B_YIELD;
-	}
-    }
-
-    ASSERT(sp->buf.iolist.size != 0);
-    ASSERT(is_value(sp->bin));
-    ASSERT(sp->buf.buf);
-
-    res = sp->iolist_to_buf(&sp->buf);
-
-    if (!ERTS_IOLIST_TO_BUF_FAILED(res)) {
-	ASSERT(res == 0);
-	return ERTS_L2B_OK;
-    }
-
-    switch (res) {
-    case ERTS_IOLIST_TO_BUF_YIELD:
-	return ERTS_L2B_YIELD;
-    case ERTS_IOLIST_TO_BUF_OVERFLOW:
-	return ERTS_L2B_OVERFLOW_ERROR;
-    case ERTS_IOLIST_TO_BUF_TYPE_ERROR:
-	return ERTS_L2B_TYPE_ERROR;
-    default:
-	ERTS_INTERNAL_ERROR("Invalid return value from iolist_to_buf_yielding()");
-	return ERTS_L2B_TYPE_ERROR;
-    }
-}
-
-static int
-l2b_state_destructor(Binary *mbp)
-{
-    ErtsL2BState *sp = ERTS_MAGIC_BIN_DATA(mbp); 
-    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(mbp) == l2b_state_destructor);
-    DESTROY_SAVED_ESTACK(&sp->buf.iolist.estack);
-    return 1;
-}
-
-static ERTS_INLINE Eterm
-l2b_final_touch(Process *c_p, ErtsL2BState *sp)
-{
-    Eterm *hp;
-    ErlSubBin* sbin; 
-    if (sp->buf.offset == 0)
-	return sp->bin;
-
-    hp = HAlloc(c_p, ERL_SUB_BIN_SIZE);
-    ASSERT(sp->buf.offset > 0);
-    sbin = (ErlSubBin *) hp;
-    sbin->thing_word = HEADER_SUB_BIN;
-    sbin->size = sp->buf.iolist.size-1;
-    sbin->offs = 0;
-    sbin->orig = sp->bin;
-    sbin->bitoffs = 0;
-    sbin->bitsize = sp->buf.offset;
-    sbin->is_writable = 0;
-    return make_binary(sbin);
-}
-
-static BIF_RETTYPE
-list_to_binary_chunk(Eterm mb_eterm,
-		     ErtsL2BState* sp,
-		     int reds_left,
-		     int gc_disabled)
-{
-    Eterm err = BADARG;
-    BIF_RETTYPE ret;
-    Process *c_p = sp->buf.iolist.c_p;
-
-    sp->buf.iolist.reds_left = reds_left;
-    
-    switch (list_to_binary_engine(sp)) {
-
-    case ERTS_L2B_OK: {
-	Eterm result = l2b_final_touch(c_p, sp);
-	if (!gc_disabled || !erts_set_gc_state(c_p, 1))
-	    ERTS_BIF_PREP_RET(ret, result);
-	else
-	    ERTS_BIF_PREP_YIELD_RETURN(ret, c_p, result);
-	ASSERT(!(c_p->flags & F_DISABLE_GC));
-	break;
-    }
-    case ERTS_L2B_YIELD:
-	if (!gc_disabled) {
-	    /* first yield... */
-	    Eterm *hp;
-	    Binary *mbp = erts_create_magic_binary(sizeof(ErtsL2BState),
-						   l2b_state_destructor);
-	    ErtsL2BState *new_sp = ERTS_MAGIC_BIN_DATA(mbp);
-
-	    ERTS_L2B_STATE_MOVE(new_sp, sp);
-	    sp = new_sp;
-
-	    hp = HAlloc(c_p, ERTS_MAGIC_REF_THING_SIZE);
-	    mb_eterm = erts_mk_magic_ref(&hp, &MSO(c_p), mbp);
-
-	    ASSERT(is_value(mb_eterm));
-
-	    erts_set_gc_state(c_p, 0);
-	}
-
-	ASSERT(c_p->flags & F_DISABLE_GC);
-
-	ERTS_BIF_PREP_TRAP1(ret,
-			    &list_to_binary_continue_export,
-			    c_p,
-			    mb_eterm);
-	break;
-
-    case ERTS_L2B_OVERFLOW_ERROR:
-	err = SYSTEM_LIMIT;
-	/* fall through */
-
-    case ERTS_L2B_TYPE_ERROR:
-	if (!gc_disabled)
-	    ERTS_BIF_PREP_ERROR(ret, c_p, err);
-	else {
-	    if (erts_set_gc_state(c_p, 1))
-		ERTS_VBUMP_ALL_REDS(c_p);
-
-	    ERTS_BIF_PREP_ERROR_TRAPPED1(ret,
-					 c_p,
-					 err,
-					 sp->bif,
-					 sp->arg);
-	}
-
-	ASSERT(!(c_p->flags & F_DISABLE_GC));
-	break;
-
-    default:
-	ERTS_INTERNAL_ERROR("Invalid return value from list_to_binary_engine()");
-	ERTS_BIF_PREP_ERROR(ret,c_p, EXC_INTERNAL_ERROR);
-	break;
-    }
-    return ret;
-}
-
-static BIF_RETTYPE list_to_binary_continue(BIF_ALIST_1)
-{
-    Binary *mbp = erts_magic_ref2bin(BIF_ARG_1);
-
-    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(mbp) == l2b_state_destructor);
-    ASSERT(BIF_P->flags & F_DISABLE_GC);
-
-    return list_to_binary_chunk(BIF_ARG_1,
-				ERTS_MAGIC_BIN_DATA(mbp),
-				ERTS_BIF_REDS_LEFT(BIF_P),
-				1);
-}
-
-BIF_RETTYPE erts_list_to_binary_bif(Process *c_p, Eterm arg, Export *bif)
-{
-    int orig_reds_left = ERTS_BIF_REDS_LEFT(c_p);
-    BIF_RETTYPE ret;
-
-    if (orig_reds_left < L2B_B2L_MIN_EXEC_REDS) {
-	if (orig_reds_left <= L2B_B2L_RESCHED_REDS) {
-	    /* Yield and do it with full context reds... */
-	    ERTS_BIF_PREP_YIELD1(ret, bif, c_p, arg);
-	    return ret;
-	}
-	/* Allow a bit more reductions... */
-	orig_reds_left = L2B_B2L_MIN_EXEC_REDS;
-    }
-
-    if (is_nil(arg))
-	ERTS_BIF_PREP_RET(ret, new_binary(c_p, (byte *) "", 0));
-    else if (is_not_list(arg))
-	ERTS_BIF_PREP_ERROR(ret, c_p, BADARG);
-    else {
-	/* check for [binary()] case */
-	Eterm h = CAR(list_val(arg));
-	Eterm t = CDR(list_val(arg));
-	if (is_binary(h)
-	    && is_nil(t)
-	    && !(HEADER_SUB_BIN == *(binary_val(h))
-		 && (((ErlSubBin *)binary_val(h))->bitoffs != 0
-		     || ((ErlSubBin *)binary_val(h))->bitsize != 0))) {
-	    ERTS_BIF_PREP_RET(ret, h);
-	}
-	else {
-	    ErtsL2BState state = ERTS_L2B_STATE_INITER(c_p,
-						       arg,
-						       bif,
-						       erts_iolist_size_yielding,
-						       erts_iolist_to_buf_yielding);
-
-	    /*
-	     * First try to do it all at once without having to use
-	     * yielding iolist_to_buf().
-	     */
-	    state.buf.iolist.reds_left = orig_reds_left;
-	    switch (erts_iolist_size_yielding(&state.buf.iolist)) {
-	    case ERTS_IOLIST_OK: {
-		ErlDrvSizeT size = state.buf.iolist.size;
-		Eterm bin;
-		char *buf;
-
-		if (size == 0) {
-		    ERTS_BIF_PREP_RET(ret, new_binary(c_p, (byte *) NULL, 0));
-		    break; /* done */
-		}
-
-		bin = new_binary(c_p, (byte *) NULL, size);
-		buf = (char *) binary_bytes(bin);
-
-		if (size < ERTS_IOLIST_TO_BUF_BYTES_PER_RED*CONTEXT_REDS) {
-		    /* An (over) estimation of reductions  needed */
-		    int reds_left = state.buf.iolist.reds_left;
-		    int to_buf_reds = orig_reds_left - reds_left;
-		    to_buf_reds += size/ERTS_IOLIST_TO_BUF_BYTES_PER_RED;
-		    if (to_buf_reds <= reds_left) {
-			ErlDrvSizeT res;
-
-			res = erts_iolist_to_buf(arg, buf, size);
-			if (res == 0) {
-			    BUMP_REDS(c_p, to_buf_reds);
-			    ERTS_BIF_PREP_RET(ret, bin);
-			    break; /* done */
-			}
-			if (!ERTS_IOLIST_TO_BUF_FAILED(res))
-			    ERTS_INTERNAL_ERROR("iolist_size/iolist_to_buf mismatch");
-			if (res == ERTS_IOLIST_TO_BUF_OVERFLOW)
-			    goto overflow;
-			goto type_error;
-		    }
-		}
-		/*
-		 * Since size has been computed list_to_binary_chunk() expects
-		 * state prepared for iolist_to_buf.
-		 */
-		state.bin = bin;
-		state.buf.buf = buf;
-		state.buf.len = size;
-		state.buf.iolist.obj = arg;
-		/* Fall through... */
-	    }
-	    case ERTS_IOLIST_YIELD:
-		ret = list_to_binary_chunk(THE_NON_VALUE,
-					   &state,
-					   state.buf.iolist.reds_left,
-					   0);
-		break;
-	    case ERTS_IOLIST_OVERFLOW:
-	    overflow:
-		ERTS_BIF_PREP_ERROR(ret, c_p, SYSTEM_LIMIT);
-		break;
-	    case ERTS_IOLIST_TYPE:
-	    type_error:
-	    default:
-		ERTS_BIF_PREP_ERROR(ret, c_p, BADARG);
-		break;
-	    }
-	}
-    }
-    return ret;
-}
-
-BIF_RETTYPE list_to_binary_1(BIF_ALIST_1)
-{
-    return erts_list_to_binary_bif(BIF_P, BIF_ARG_1, BIF_TRAP_EXPORT(BIF_list_to_binary_1));
-}
-
-BIF_RETTYPE iolist_to_binary_1(BIF_ALIST_1)
-{
-    if (is_binary(BIF_ARG_1)) {
-        if (binary_bitsize(BIF_ARG_1) == 0) {
-            BIF_RET(BIF_ARG_1);
-        }
+    if (is_not_bitstring(BIF_ARG_1)) {
         BIF_ERROR(BIF_P, BADARG);
     }
-    return erts_list_to_binary_bif(BIF_P, BIF_ARG_1, BIF_TRAP_EXPORT(BIF_iolist_to_binary_1));
-}
 
-static int bitstr_list_len(ErtsIOListState *);
-static ErlDrvSizeT list_to_bitstr_buf_yielding(ErtsIOList2BufState *);
-static ErlDrvSizeT list_to_bitstr_buf_not_yielding(ErtsIOList2BufState *);
+    ERTS_GET_BITSTRING(BIF_ARG_1, bytes, offset, size);
 
-BIF_RETTYPE list_to_bitstring_1(BIF_ALIST_1)
-{
-    BIF_RETTYPE ret;
-
-    if (is_nil(BIF_ARG_1))
-	ERTS_BIF_PREP_RET(ret, new_binary(BIF_P, (byte *) "", 0));
-    else if (is_not_list(BIF_ARG_1))
-	ERTS_BIF_PREP_ERROR(ret, BIF_P, BADARG);
-    else {
-	/* check for [bitstring()] case */
-	Eterm h = CAR(list_val(BIF_ARG_1));
-	Eterm t = CDR(list_val(BIF_ARG_1));
-	if (is_binary(h) && is_nil(t)) {
-	    ERTS_BIF_PREP_RET(ret, h);
-	}
-	else {
-	    ErtsL2BState state = ERTS_L2B_STATE_INITER(BIF_P,
-						       BIF_ARG_1,
-						       BIF_TRAP_EXPORT(BIF_list_to_bitstring_1),
-						       bitstr_list_len,
-						       list_to_bitstr_buf_yielding);
-	    int orig_reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
-
-	    /*
-	     * First try to do it all at once without having to use
-	     * yielding list_to_bitstr_buf().
-	     */
-	    state.buf.iolist.reds_left = orig_reds_left;
-	    switch (bitstr_list_len(&state.buf.iolist)) {
-	    case ERTS_IOLIST_OK: {
-		ErlDrvSizeT size = state.buf.iolist.size;
-		
-		state.bin = new_binary(BIF_P, (byte *) NULL, size);
-		state.buf.buf = (char *) binary_bytes(state.bin);
-		state.buf.len = size;
-		state.buf.iolist.obj = BIF_ARG_1;
-
-		if (size < ERTS_IOLIST_TO_BUF_BYTES_PER_RED*CONTEXT_REDS) {
-		    /* An (over) estimation of reductions needed */
-		    int reds_left = state.buf.iolist.reds_left;
-		    int to_buf_reds = orig_reds_left - reds_left;
-		    to_buf_reds += size/ERTS_IOLIST_TO_BUF_BYTES_PER_RED;
-		    if (to_buf_reds <= reds_left) {
-			ErlDrvSizeT res;
-
-			res = list_to_bitstr_buf_not_yielding(&state.buf);
-			if (res == 0) {
-			    Eterm res_bin = l2b_final_touch(BIF_P, &state);
-			    BUMP_REDS(BIF_P, to_buf_reds);
-			    ERTS_BIF_PREP_RET(ret, res_bin);
-			    break; /* done */
-			}
-			if (!ERTS_IOLIST_TO_BUF_FAILED(res))
-			    ERTS_INTERNAL_ERROR("iolist_size/iolist_to_buf mismatch");
-			if (res == ERTS_IOLIST_TO_BUF_OVERFLOW)
-			    goto overflow;
-			goto type_error;
-		    }
-		}
-		/*
-		 * Since size has been computed list_to_binary_chunk() expects
-		 * the state prepared for list_to_bitstr_buf.
-		 */
-
-		/* Fall through... */
-	    }
-	    case ERTS_IOLIST_YIELD:
-		ret = list_to_binary_chunk(THE_NON_VALUE,
-					   &state,
-					   state.buf.iolist.reds_left,
-					   0);
-		break;
-	    case ERTS_IOLIST_OVERFLOW:
-	    overflow:
-		ERTS_BIF_PREP_ERROR(ret, BIF_P, SYSTEM_LIMIT);
-		break;
-	    case ERTS_IOLIST_TYPE:
-	    type_error:
-	    default:
-		ERTS_BIF_PREP_ERROR(ret, BIF_P, BADARG);
-		break;
-	    }
-	}
+    if (size == 0) {
+        BIF_RET(NIL);
     }
 
-    return ret;
+    /* One cell per byte, plus one more for the trailing bits if any. */
+    cells = NBYTES(size);
+
+    reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
+    one_chunk = cells < (reds_left * ERTS_B2L_BYTES_PER_REDUCTION);
+    if (!one_chunk) {
+        if (cells < (B2L_MIN_EXEC_REDS * ERTS_B2L_BYTES_PER_REDUCTION)) {
+            if (reds_left <= B2L_RESCHED_REDS) {
+                /* Yield and do it with full context reds... */
+                ERTS_BIF_YIELD1(BIF_TRAP_EXPORT(BIF_bitstring_to_list_1),
+                                BIF_P, BIF_ARG_1);
+            }
+
+            /* Allow a bit more reductions... */
+            one_chunk = 1;
+            reds_left = B2L_MIN_EXEC_REDS;
+        }
+    }
+
+    if (TAIL_BITS(size) == 0) {
+        hp = HAlloc(BIF_P, 2 * cells);
+        tail = NIL;
+    } else {
+        const Uint last_size = TAIL_BITS(size);
+        Eterm last;
+
+        hp = HAlloc(BIF_P, heap_bits_size(last_size) + 2 * cells);
+        last = erts_build_sub_bitstring(&hp,
+                                        0,
+                                        NULL,
+                                        bytes,
+                                        offset + size - last_size,
+                                        last_size);
+
+        tail = CONS(hp, last, NIL);
+        hp += 2;
+    }
+
+    return binary_to_list(BIF_P, hp, tail, &bytes[BYTE_OFFSET(offset)],
+                          BYTE_SIZE(size), BIT_OFFSET(offset),
+                          reds_left, one_chunk);
 }
 
 BIF_RETTYPE split_binary_2(BIF_ALIST_2)
 {
-    size_t orig_size, left_size, right_size;
-    Uint byte_offset, bit_offset, bit_size;
     Uint split_at;
 
-    Eterm *hp, *hp_end;
-    Eterm left, right;
-    Eterm real_bin;
-    Eterm result;
-    byte *bptr;
+    if (is_bitstring(BIF_ARG_1) && term_to_Uint(BIF_ARG_2, &split_at)) {
+        Uint offset, size;
+        Eterm br_flags;
+        BinRef *br;
+        byte *base;
 
-    if (is_not_binary(BIF_ARG_1)) {
-        BIF_ERROR(BIF_P, BADARG);
-    } else if (!term_to_Uint(BIF_ARG_2, &split_at)) {
-        BIF_ERROR(BIF_P, BADARG);
-    } else if ((orig_size = binary_size(BIF_ARG_1)) < split_at) {
-        BIF_ERROR(BIF_P, BADARG);
+        ERTS_GET_BITSTRING_REF(BIF_ARG_1, br_flags, br, base, offset, size);
+
+        if (split_at <= (size / 8)) {
+            Eterm left, right;
+            Uint heap_size;
+            Eterm *hp;
+
+            split_at *= 8;
+
+            heap_size = erts_extracted_bitstring_size(split_at) +
+                        erts_extracted_bitstring_size(size - split_at) +
+                        3;
+
+            hp = HAlloc(BIF_P, heap_size);
+            left = erts_build_sub_bitstring(&hp,
+                                            br_flags,
+                                            br,
+                                            base,
+                                            offset,
+                                            split_at);
+            right = erts_build_sub_bitstring(&hp,
+                                             br_flags,
+                                             br,
+                                             base,
+                                             offset + split_at,
+                                             size - split_at);
+            return TUPLE2(hp, left, right);
+        }
     }
 
-    left_size = split_at;
-    right_size = orig_size - split_at;
-
-    ERTS_GET_REAL_BIN(BIF_ARG_1, real_bin, byte_offset, bit_offset, bit_size);
-    bptr = binary_bytes(real_bin);
-
-    hp = HAlloc(BIF_P, EXTRACT_SUB_BIN_HEAP_NEED * 2 + 3);
-    hp_end = hp + (EXTRACT_SUB_BIN_HEAP_NEED * 2 + 3);
-
-    left = erts_extract_sub_binary(&hp, real_bin, bptr,
-                                   byte_offset * 8 + bit_offset,
-                                   left_size * 8);
-
-    right = erts_extract_sub_binary(&hp, real_bin, bptr,
-                                    (byte_offset + split_at) * 8 + bit_offset,
-                                    right_size * 8 + bit_size);
-
-    result = TUPLE2(hp, left, right);
-    hp += 3;
-
-    HRelease(BIF_P, hp_end, hp);
-
-    return result;
+    BIF_ERROR(BIF_P, BADARG);
 }
-
-
-/*
- * Local functions.
- */
-
-static int
-list_to_bitstr_buf_bcopy(ErtsIOList2BufState *state, Eterm obj, int *yield_countp);
-
-/*
- * The input list is assumed to be type-correct and the buffer is
- * assumed to be of sufficient size. Those assumptions are verified in
- * the DEBUG-built emulator.
- */
-static ErlDrvSizeT
-list_to_bitstr_buf(int yield_support, ErtsIOList2BufState *state)
-{
-
-#undef LIST_TO_BITSTR_BUF_BCOPY_DBG
-#undef LIST_TO_BITSTR_BUF_BCOPY
-#ifdef DEBUG
-#define LIST_TO_BITSTR_BUF_BCOPY_DBG					\
-    len -= size + (offset>7);
-#else
-#define LIST_TO_BITSTR_BUF_BCOPY_DBG
-#endif
-#define LIST_TO_BITSTR_BUF_BCOPY(CONSP)					\
-    do {								\
-	byte* bptr;							\
-	Uint bitsize;							\
-	Uint bitoffs;							\
-	Uint num_bits;							\
-	size_t size = binary_size(obj);					\
-	if (yield_support) {						\
-	    size_t max_size = ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;	\
-	    if (yield_count > 0)					\
-		max_size *= yield_count+1;				\
-	    if (size > max_size) {					\
-		state->objp = CONSP;					\
-		goto L_bcopy_yield;					\
-	    }								\
-	    if (size >= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT) {	\
-		int cost = (int) size;					\
-		cost /= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;	\
-		yield_count -= cost;					\
-	    }								\
-	}								\
-	ASSERT(size <= len);						\
-	ERTS_GET_BINARY_BYTES(obj, bptr, bitoffs, bitsize);		\
-	num_bits = 8*size+bitsize;					\
-	copy_binary_to_buffer(buf, offset, bptr, bitoffs, num_bits);	\
-	offset += bitsize;						\
-	buf += size + (offset>7);					\
-	LIST_TO_BITSTR_BUF_BCOPY_DBG;					\
-	offset = offset & 7;						\
-    } while(0)
-
-#ifdef DEBUG
-    ErlDrvSizeT len;
-#endif
-    Eterm obj;
-    char *buf;
-    Eterm *objp = NULL;
-    int offset;
-    int init_yield_count = 0, yield_count;
-    DECLARE_ESTACK(s);
-
-    obj = state->iolist.obj;
-    buf = state->buf;
-    offset = state->offset;
-#ifdef DEBUG
-    len = state->len;
-#endif
-
-    if (!yield_support) {
-	yield_count = init_yield_count = 0; /* Shut up faulty warning... >:-( */
-	goto L_again;
-    }
-    else {
-
-	if (state->iolist.reds_left <= 0)
-	    return ERTS_IOLIST_TO_BUF_YIELD;
-
-	ESTACK_CHANGE_ALLOCATOR(s, ERTS_ALC_T_SAVED_ESTACK);
-	init_yield_count = (ERTS_IOLIST_TO_BUF_YIELD_COUNT_PER_RED
-			    * state->iolist.reds_left);
-	yield_count = init_yield_count;
-
-	if (!state->iolist.estack.start)
-	    goto L_again;
-	else {
-	    int chk_stack;
-	    /* Restart; restore state... */
-	    ESTACK_RESTORE(s, &state->iolist.estack);
-
-	    if (!state->bcopy.bptr)
-		chk_stack = 0;
-	    else {
-		chk_stack = 1;
-		if (list_to_bitstr_buf_bcopy(state, THE_NON_VALUE, &yield_count)) {
-		    /* Yield again... */
-		    BUMP_ALL_REDS(state->iolist.c_p);
-		    state->iolist.reds_left = 0;
-		    ESTACK_SAVE(s, &state->iolist.estack);
-		    return ERTS_IOLIST_TO_BUF_YIELD;
-		}
-		buf = state->buf;
-		offset = state->offset;
-#ifdef DEBUG
-		len = state->len;
-#endif
-	    }
-
-	    objp = state->objp;
-	    state->objp = NULL;
-
-	    if (objp)
-		goto L_tail;
-	    if (!chk_stack)
-		goto L_again;
-	    /* check stack */
-	}
-    }
-    
-    while (!ESTACK_ISEMPTY(s)) {
-	obj = ESTACK_POP(s);
-    L_again:
-	if (is_list(obj)) {
-	    while (1) { /* Tail loop */
-		while (1) { /* Head loop */
-		    if (yield_support && --yield_count <= 0)
-			goto L_yield;
-		    objp = list_val(obj);
-		    obj = CAR(objp);
-		    if (is_byte(obj)) {
-			ASSERT(len > 0);
-			if (offset == 0) {
-			    *buf++ = unsigned_val(obj);
-			} else {
-			    *buf =  (char)((unsigned_val(obj) >> offset) | 
-					   ((*buf >> (8-offset)) << (8-offset)));
-			    buf++;
-			    *buf = (unsigned_val(obj) << (8-offset));
-			}   
-#ifdef DEBUG
-			len--;
-#endif
-		    } else if (is_binary(obj)) {
-			LIST_TO_BITSTR_BUF_BCOPY(objp);
-		    } else if (is_list(obj)) {
-			ESTACK_PUSH(s, CDR(objp));
-			continue; /* Head loop */
-		    } else {
-			ASSERT(is_nil(obj));
-		    }
-		    break;
-		}
-
-	    L_tail:
-
-		obj = CDR(objp);
-		if (is_list(obj)) {
-		    continue; /* Tail loop */
-		} else if (is_binary(obj)) {
-		    LIST_TO_BITSTR_BUF_BCOPY(NULL);
-		} else {
-		    ASSERT(is_nil(obj));
-		}
-		break;
-	    }
-	} else if (is_binary(obj)) {
-	    LIST_TO_BITSTR_BUF_BCOPY(NULL);
-	} else {
-	    if (yield_support && --yield_count <= 0)
-		goto L_yield;
-	    ASSERT(is_nil(obj));
-	}
-    }
-    
-    DESTROY_ESTACK(s);
-
-    if (yield_support) {
-	int reds;
-	CLEAR_SAVED_ESTACK(&state->iolist.estack);
-	reds = ((init_yield_count - yield_count - 1)
-		/ ERTS_IOLIST_TO_BUF_YIELD_COUNT_PER_RED) + 1;
-	BUMP_REDS(state->iolist.c_p, reds);
-	state->iolist.reds_left -= reds;
-	if (state->iolist.reds_left < 0)
-	    state->iolist.reds_left = 0;
-    }
-    state->buf = buf;
-    state->offset = offset;
-    return 0;
-
-L_bcopy_yield:
-
-    state->buf = buf;
-    state->offset = offset;
-#ifdef DEBUG
-    state->len = len;
-#endif
-
-    if (list_to_bitstr_buf_bcopy(state, obj, &yield_count) == 0)
-	ERTS_INTERNAL_ERROR("Missing yield");
-
-    BUMP_ALL_REDS(state->iolist.c_p);
-    state->iolist.reds_left = 0;
-    ESTACK_SAVE(s, &state->iolist.estack);
-    return ERTS_IOLIST_TO_BUF_YIELD;
-
-L_yield:
-
-    BUMP_ALL_REDS(state->iolist.c_p);
-    state->iolist.reds_left = 0;
-    state->iolist.obj = obj;
-    state->buf = buf;
-    state->offset = offset;
-    ESTACK_SAVE(s, &state->iolist.estack);
-#ifdef DEBUG
-    state->len = len;
-#endif
-    return ERTS_IOLIST_TO_BUF_YIELD;
-
-
-#undef LIST_TO_BITSTR_BUF_BCOPY_DBG
-#undef LIST_TO_BITSTR_BUF_BCOPY
-
-}
-
-static ErlDrvSizeT
-list_to_bitstr_buf_yielding(ErtsIOList2BufState *state)
-{
-    return list_to_bitstr_buf(1, state);
-}
-
-static ErlDrvSizeT
-list_to_bitstr_buf_not_yielding(ErtsIOList2BufState *state)
-{
-    return list_to_bitstr_buf(0, state);
-}
-
-static int
-list_to_bitstr_buf_bcopy(ErtsIOList2BufState *state, Eterm obj, int *yield_countp)
-{
-    int res;
-    char *buf = state->buf;
-    char *next_buf;
-    int offset = state->offset;
-    int next_offset;
-#ifdef DEBUG
-    ErlDrvSizeT len = state->len;
-    ErlDrvSizeT next_len;
-#endif
-    byte* bptr;
-    size_t size;
-    size_t max_size;
-    Uint bitoffs;
-    Uint num_bits;
-    Uint bitsize;
-    int yield_count = *yield_countp;
-
-    if (state->bcopy.bptr) {
-	bptr = state->bcopy.bptr;
-	size = state->bcopy.size;
-	bitoffs = state->bcopy.bitoffs;
-	bitsize = state->bcopy.bitsize;
-	state->bcopy.bptr = NULL;
-    }
-    else {
-
-	ASSERT(is_binary(obj));
-
-	size = binary_size(obj);
-
-	ASSERT(size <= len);
-
-	ERTS_GET_BINARY_BYTES(obj, bptr, bitoffs, bitsize);
-    }
-
-    max_size = (size_t) ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;
-    if (yield_count > 0)
-	max_size *= (size_t) (yield_count+1);
-
-    if (size <= max_size) {
-	if (size >= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT) {
-	    int cost = (int) size;
-	    cost /= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;
-	    yield_count -= cost;
-	}
-	next_offset = offset + bitsize;
-	next_buf = buf + size+(next_offset>7);
-#ifdef DEBUG
-	next_len = len - size+(next_offset>7);
-#endif
-	next_offset &= 7;
-	num_bits = 8*size+bitsize;
-	res = 0;
-    }
-    else {
-	ASSERT(0 < max_size && max_size < size);
-	yield_count = 0;
-	state->bcopy.bptr = bptr + max_size;
-	state->bcopy.bitoffs = bitoffs;
-	state->bcopy.bitsize = bitsize;
-	state->bcopy.size = size - max_size;
-	next_buf = buf + max_size;
-#ifdef DEBUG
-	next_len = len - max_size;
-#endif
-	next_offset = offset;
-	num_bits = 8*max_size;
-	size = max_size;
-	res = 1;
-    }
-
-    copy_binary_to_buffer(buf, offset, bptr, bitoffs, num_bits);
-
-    state->offset = next_offset;
-    state->buf = next_buf;
-#ifdef DEBUG
-    state->len = next_len;
-#endif
-    *yield_countp = yield_count;
-
-    return res;
-}
-
-static int
-bitstr_list_len(ErtsIOListState *state)
-{
-    Eterm* objp;
-    Eterm obj;
-    Uint len, offs;
-    int res, init_yield_count, yield_count;
-    DECLARE_ESTACK(s);
-
-    if (state->reds_left <= 0)
-	return ERTS_IOLIST_YIELD;
-
-    len = (Uint) state->size;
-    offs = state->offs;
-    obj = state->obj;
-
-    ESTACK_CHANGE_ALLOCATOR(s, ERTS_ALC_T_SAVED_ESTACK);
-    init_yield_count = ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED;
-    init_yield_count *= state->reds_left;
-    yield_count = init_yield_count;
-    if (state->estack.start) {
-	/* Restart; restore estack... */
-	ESTACK_RESTORE(s, &state->estack);
-    }
-
-    goto L_again;
-
-#define SAFE_ADD(Var, Val)			\
-    do {					\
-        Uint valvar = (Val);			\
-	Var += valvar;				\
-	if (Var < valvar) {			\
-	    goto L_overflow_error;		\
-	}					\
-    } while (0)
-
-#define SAFE_ADD_BITSIZE(Var, Bin)					\
-    do {								\
-	if (*binary_val(Bin) == HEADER_SUB_BIN) {			\
-            Uint valvar = ((ErlSubBin *) binary_val(Bin))->bitsize;	\
-	    Var += valvar;						\
-	    if (Var < valvar) {						\
-	         goto L_overflow_error;					\
-	    }								\
-        }								\
-    } while (0)
-
-    while (!ESTACK_ISEMPTY(s)) {
-	obj = ESTACK_POP(s);
-    L_again:
-	if (is_list(obj)) {
-	    while (1) { /* Tail loop */
-		while (1) { /* Head loop */
-		    if (--yield_count <= 0)
-			goto L_yield;
-		    objp = list_val(obj);
-		    /* Head */
-		    obj = CAR(objp);
-		    if (is_byte(obj)) {
-			len++;
-			if (len == 0) {
-			    goto L_overflow_error;
-			}
-		    } else if (is_binary(obj)) {
-			SAFE_ADD(len, binary_size(obj));
-			SAFE_ADD_BITSIZE(offs, obj);
-		    } else if (is_list(obj)) {
-			ESTACK_PUSH(s, CDR(objp));
-			continue; /* Head loop */
-		    } else if (is_not_nil(obj)) {
-			goto L_type_error;
-		    }
-		    break;
-		}
-		/* Tail */
-		obj = CDR(objp);
-		if (is_list(obj))
-		    continue; /* Tail loop */
-		else if (is_binary(obj)) {
-		    SAFE_ADD(len, binary_size(obj));
-		    SAFE_ADD_BITSIZE(offs, obj);
-		} else if (is_not_nil(obj)) {
-		    goto L_type_error;
-		}
-		break;
-	    }
-	} else {
-	    if (--yield_count <= 0)
-		goto L_yield;
-	    if (is_binary(obj)) {
-		SAFE_ADD(len, binary_size(obj));
-		SAFE_ADD_BITSIZE(offs, obj);
-	    } else if (is_not_nil(obj)) {
-		goto L_type_error;
-	    }
-	}
-    }
-#undef SAFE_ADD
-#undef SAFE_ADD_BITSIZE
-
-    /*
-     * Make sure that the number of bits in the bitstring will fit
-     * in an Uint to ensure that the binary can be matched using
-     * the binary syntax.
-     */
-    if (len << 3 < len) {
-	goto L_overflow_error;
-    }
-    len += (offs >> 3) + ((offs & 7) != 0);
-    if (len << 3 < len) {
-	goto L_overflow_error;
-    }
-    state->size = len;
-
-    res = ERTS_IOLIST_OK;
-
- L_return: {
-	int yc = init_yield_count - yield_count;
-	int reds;
-
-	DESTROY_ESTACK(s);
-	CLEAR_SAVED_ESTACK(&state->estack);
-
-	reds = (yc - 1)/ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED + 1;
-	BUMP_REDS(state->c_p, reds);
-	state->reds_left -= reds;
-	state->size = (ErlDrvSizeT) len;
-	state->have_size = 1;
-	return res;
-    }
-
- L_overflow_error:
-    res = ERTS_IOLIST_OVERFLOW;
-    len = 0;
-    goto L_return;
-
- L_type_error:
-    res = ERTS_IOLIST_TYPE;
-    len = 0;
-    goto L_return;
-
- L_yield:
-    BUMP_ALL_REDS(state->c_p);
-    state->reds_left = 0;
-    state->size = len;
-    state->offs = offs;
-    state->obj = obj;
-    ESTACK_SAVE(s, &state->estack);
-    return ERTS_IOLIST_YIELD;
-}
-

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -735,16 +735,16 @@ bin_check(void)
         oh_list = rp->off_heap.first;
         for (;;) {
             for (hdr = oh_list; hdr; hdr = hdr->next) {
-                if (hdr->thing_word == HEADER_PROC_BIN) {
-                    ProcBin *bp = (ProcBin*) hdr;
+                if (hdr->thing_word == HEADER_BIN_REF) {
+                    Binary *bin = ((BinRef*)hdr)->val;
                     if (!printed) {
                         erts_printf("Process %T holding binary data \n", rp->common.id);
                         printed = 1;
                     }
                     erts_printf("%p orig_size: %bpd, norefs = %bpd\n",
-                                bp->val,
-                                bp->val->orig_size,
-                                erts_refc_read(&bp->val->intern.refc, 1));
+                                bin,
+                                bin->orig_size,
+                                erts_refc_read(&bin->intern.refc, 1));
                 }
             }
             if (oh_list == rp->wrt_bins)

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -1997,7 +1997,7 @@ int erts_net_message(Port *prt,
 		     byte *hbuf,
 		     ErlDrvSizeT hlen,
                      Binary *bin,
-		     byte *buf,
+		     const byte *buf,
 		     ErlDrvSizeT len)
 {
     ErtsDistExternal ede, *edep = &ede;
@@ -4192,52 +4192,55 @@ BIF_RETTYPE
 dist_ctrl_put_data_2(BIF_ALIST_2)
 {
     DistEntry *dep;
-    ErlDrvSizeT size;
     Eterm input_handler;
     Uint32 conn_id;
     Binary *bin = NULL;
 
-    if (is_binary(BIF_ARG_2))
-        size = binary_size(BIF_ARG_2);
-    else if (is_nil(BIF_ARG_2))
-        size = 0;
-    else if (is_list(BIF_ARG_2))
+    if (is_list(BIF_ARG_2)) {
         BIF_TRAP2(dist_ctrl_put_data_trap,
                   BIF_P, BIF_ARG_1, BIF_ARG_2);
-    else
-        BIF_ERROR(BIF_P, BADARG);
+    }
 
     dep = erts_dhandle_to_dist_entry(BIF_ARG_1, &conn_id);
-    if (!dep)
+    if (!dep) {
         BIF_ERROR(BIF_P, BADARG);
+    }
 
-    input_handler = (Eterm) erts_atomic_read_nob(&dep->input_handler);
+    input_handler = (Eterm)erts_atomic_read_nob(&dep->input_handler);
 
-    if (input_handler != BIF_P->common.id)
+    if (input_handler != BIF_P->common.id) {
         BIF_ERROR(BIF_P, EXC_NOTSUP);
+    }
 
     erts_atomic64_inc_nob(&dep->in);
 
-    if (size != 0) {
-        byte *data, *temp_alloc = NULL;
+    if (is_bitstring(BIF_ARG_2)) {
+        ERTS_DECLARE_DUMMY(Eterm br_flags);
+        const byte *data, *temp_alloc = NULL;
+        Uint offset, size;
+        BinRef *br;
 
-        if (binary_bitoffset(BIF_ARG_2))
-            data = (byte *) erts_get_aligned_binary_bytes(BIF_ARG_2, &temp_alloc);
-        else {
-            Eterm real_bin;
-            ProcBin *proc_bin;
-            Uint offset, bitoffs, bitsize;
+        ERTS_PIN_BITSTRING(BIF_ARG_2, br_flags, br, data, offset, size);
 
-            ERTS_GET_REAL_BIN(BIF_ARG_2, real_bin, offset, bitoffs, bitsize);
-            ASSERT(bitoffs == 0);
-            data = binary_bytes(real_bin) + offset;
-            proc_bin = (ProcBin *)binary_val(real_bin);
-            if (proc_bin->thing_word == HEADER_PROC_BIN)
-                bin = proc_bin->val;
+        if (TAIL_BITS(size) != 0) {
+            BIF_ERROR(BIF_P, BADARG);
         }
 
-        if (!data)
+        if (BIT_OFFSET(offset) == 0) {
+            data = &data[BYTE_OFFSET(offset)];
+            size = BYTE_SIZE(size);
+
+            bin = br ? br->val : NULL;
+        } else {
+            ERTS_DECLARE_DUMMY(Uint dummy);
+            data = (byte *) erts_get_aligned_binary_bytes(BIF_ARG_2,
+                                                          &size,
+                                                          &temp_alloc);
+        }
+
+        if (!data) {
             BIF_ERROR(BIF_P, BADARG);
+        }
 
         erts_proc_unlock(BIF_P, ERTS_PROC_LOCK_MAIN);
 
@@ -4254,6 +4257,8 @@ dist_ctrl_put_data_2(BIF_ALIST_2)
 
         erts_free_aligned_binary_bytes(temp_alloc);
 
+    } else if (is_not_nil(BIF_ARG_2)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
 
     BIF_RET(am_ok);
@@ -4525,7 +4530,7 @@ dist_ctrl_get_data_1(BIF_ALIST_1)
     ASSERT(iov[0].iov_len == 0);
     ASSERT(!binv[0]);
 
-    hsz = 2 /* cons */ + PROC_BIN_SIZE;
+    hsz = 2 /* cons */ + ERL_REFC_BITS_SIZE;
     hsz *= vlen - 1;
 
     get_size = dep->opts & ERTS_DIST_CTRL_OPT_GET_SIZE;
@@ -4543,32 +4548,18 @@ dist_ctrl_get_data_1(BIF_ALIST_1)
     res = NIL;
 
     for (ix = vlen - 1; ix > 0; ix--) {
-        Binary *bin;
-        ProcBin *pb;
         Eterm bin_term;
+        Binary *bin;
 
         ASSERT(binv[ix]);
-
-        /*
-         * We intentionally avoid using sub binaries
-         * since the GC might convert those to heap
-         * binaries and by this ruin the nice preparation
-         * for usage of this data as I/O vector in
-         * nifs/drivers.
-         */
-        
         bin = ErlDrvBinary2Binary(binv[ix]);
-        pb = (ProcBin *) (char *) hp;
-        hp += PROC_BIN_SIZE;
-        pb->thing_word = HEADER_PROC_BIN;
-        pb->size = (Uint) iov[ix].iov_len;
-        pb->next = MSO(BIF_P).first;
-        MSO(BIF_P).first = (struct erl_off_heap_header*) pb;
-        pb->val = bin;
-        pb->bytes = (byte*) iov[ix].iov_base;
-        pb->flags = 0;
-        OH_OVERHEAD(&MSO(BIF_P), pb->size / sizeof(Eterm));
-        bin_term = make_binary(pb);
+        bin_term = erts_wrap_refc_bitstring(&MSO(BIF_P).first,
+                                            &MSO(BIF_P).overhead,
+                                            &hp,
+                                            bin,
+                                            iov[ix].iov_base,
+                                            0,
+                                            NBITS(iov[ix].iov_len));
 
         res = CONS(hp, bin_term, res);
         hp += 2;

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -151,7 +151,7 @@ i_bs_get_binary_all2.execute(Fail, Live, Unit, Dst) {
     ErlBinMatchBuffer *_mb;
     Eterm _result;
 
-    $GC_TEST_PRESERVE(EXTRACT_SUB_BIN_HEAP_NEED, $Live, context);
+    $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
     _mb = ms_matchbuffer(context);
     if (((_mb->size - _mb->offset) % $Unit) == 0) {
         LIGHT_SWAPOUT;
@@ -181,7 +181,7 @@ i_bs_get_binary2.execute(Fail, Live, Sz, Flags, Dst) {
     Eterm _result;
     Uint _size;
     $BS_GET_FIELD_SIZE($Sz, (($Flags) >> 3), $FAIL($Fail), _size);
-    $GC_TEST_PRESERVE(EXTRACT_SUB_BIN_HEAP_NEED, $Live, context);
+    $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
     _mb = ms_matchbuffer(context);
     LIGHT_SWAPOUT;
     _result = erts_bs_get_binary_2(c_p, _size, $Flags, _mb);
@@ -208,7 +208,7 @@ i_bs_get_binary_imm2.fetch(Ctx) {
 i_bs_get_binary_imm2.execute(Fail, Live, Sz, Flags, Dst) {
     ErlBinMatchBuffer *_mb;
     Eterm _result;
-    $GC_TEST_PRESERVE(EXTRACT_SUB_BIN_HEAP_NEED, $Live, context);
+    $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
     _mb = ms_matchbuffer(context);
     LIGHT_SWAPOUT;
     _result = erts_bs_get_binary_2(c_p, $Sz, $Flags, _mb);
@@ -427,49 +427,53 @@ bs_init.verify(Fail) {
 }
 
 bs_init.execute(Live, Dst) {
+    Uint num_bits, heap_extra;
+    Eterm new_binary;
+
     erts_bin_offset = 0;
 
-    if (BsOp1 <= ERL_ONHEAP_BIN_LIMIT) {
-        ErlHeapBin* hb;
+    num_bits = BsOp1 * CHAR_BIT;
+    heap_extra = BsOp2;
+
+    if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+        ErlHeapBits *hb;
         Uint bin_need;
 
-        bin_need = heap_bin_size(BsOp1);
-        $GC_TEST(0, bin_need+BsOp2+ERL_SUB_BIN_SIZE, $Live);
-        hb = (ErlHeapBin *) HTOP;
+        bin_need = heap_bits_size(num_bits);
+        $GC_TEST(0, bin_need + heap_extra + ERL_SUB_BITS_SIZE, $Live);
+
+        hb = (ErlHeapBits*)HTOP;
         HTOP += bin_need;
-        hb->thing_word = header_heap_bin(BsOp1);
-        hb->size = BsOp1;
+
+        hb->thing_word = header_heap_bits(num_bits);
+        ERTS_SET_HB_SIZE(hb, num_bits);
         erts_current_bin = (byte *) hb->data;
-        $Dst = make_binary(hb);
+
+        new_binary = make_bitstring(hb);
     } else {
         Binary* bptr;
-        ProcBin* pb;
 
-        $TEST_BIN_VHEAP(BsOp1 / sizeof(Eterm), BsOp2 + PROC_BIN_SIZE, $Live);
+        $TEST_BIN_VHEAP(NBYTES(num_bits) / sizeof(Eterm),
+                        heap_extra + ERL_REFC_BITS_SIZE,
+                        $Live);
 
-        /*
-         * Allocate the binary struct itself.
-         */
-        bptr = erts_bin_nrml_alloc(BsOp1);
+        bptr = erts_bin_nrml_alloc(NBYTES(num_bits));
         erts_current_bin = (byte *) bptr->orig_bytes;
 
-        /*
-         * Now allocate the ProcBin on the heap.
-         */
-        pb = (ProcBin *) HTOP;
-        HTOP += PROC_BIN_SIZE;
-        pb->thing_word = HEADER_PROC_BIN;
-        pb->size = BsOp1;
-        pb->next = MSO(c_p).first;
-        MSO(c_p).first = (struct erl_off_heap_header*) pb;
-        pb->val = bptr;
-        pb->bytes = (byte*) bptr->orig_bytes;
-        pb->flags = 0;
+        LIGHT_SWAPOUT;
 
-        OH_OVERHEAD(&(MSO(c_p)), BsOp1 / sizeof(Eterm));
+        new_binary = erts_wrap_refc_bitstring(&MSO(c_p).first,
+                                              &MSO(c_p).overhead,
+                                              &HEAP_TOP(c_p),
+                                              bptr,
+                                              erts_current_bin,
+                                              0,
+                                              num_bits);
 
-        $Dst = make_binary(pb);
+        LIGHT_SWAPIN;
     }
+
+    $Dst = new_binary;
 }
 
 #
@@ -527,15 +531,11 @@ bs_init_bits.verify(Fail) {
 
 bs_init_bits.execute(Live, Dst) {
      Eterm new_binary;
-     Uint num_bytes = ((Uint64)num_bits+(Uint64)7) >> 3;
 
-     if (num_bits & 7) {
-	 alloc += ERL_SUB_BIN_SIZE;
-     }
-     if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-	 alloc += heap_bin_size(num_bytes);
+     if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+        alloc += heap_bits_size(num_bits);
      } else {
-	 alloc += PROC_BIN_SIZE;
+        alloc += ERL_REFC_BITS_SIZE;
      }
 
      erts_bin_offset = 0;
@@ -545,58 +545,42 @@ bs_init_bits.execute(Live, Dst) {
       * alloc = Total number of words to allocate on heap
       * Operands: NotUsed NotUsed Dst
       */
-     if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-	 ErlHeapBin* hb;
+     if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+        ErlHeapBits *hb;
 
-         $test_heap(alloc, $Live);
-	 hb = (ErlHeapBin *) HTOP;
-	 HTOP += heap_bin_size(num_bytes);
-	 hb->thing_word = header_heap_bin(num_bytes);
-	 hb->size = num_bytes;
-	 erts_current_bin = (byte *) hb->data;
-	 new_binary = make_binary(hb);
+        $test_heap(alloc, $Live);
+
+        hb = (ErlHeapBits*) HTOP;
+        HTOP += heap_bits_size(num_bits);
+        hb->thing_word = header_heap_bits(num_bits);
+
+        ERTS_SET_HB_SIZE(hb, num_bits);
+
+        erts_current_bin = (byte*)hb->data;
+        new_binary = make_bitstring(hb);
      } else {
-	 Binary* bptr;
-	 ProcBin* pb;
+        Binary *bptr;
 
-         $TEST_BIN_VHEAP(num_bytes / sizeof(Eterm), alloc, $Live);
+        $TEST_BIN_VHEAP(NBYTES(num_bits) / sizeof(Eterm),
+                        alloc + ERL_REFC_BITS_SIZE,
+                        $Live);
 
-	 /*
-	  * Allocate the binary struct itself.
-	  */
-	 bptr = erts_bin_nrml_alloc(num_bytes);
-	 erts_current_bin = (byte *) bptr->orig_bytes;
+        bptr = erts_bin_nrml_alloc(NBYTES(num_bits));
+        erts_current_bin = (byte *) bptr->orig_bytes;
 
-	 /*
-	  * Now allocate the ProcBin on the heap.
-	  */
-	 pb = (ProcBin *) HTOP;
-	 HTOP += PROC_BIN_SIZE;
-	 pb->thing_word = HEADER_PROC_BIN;
-	 pb->size = num_bytes;
-	 pb->next = MSO(c_p).first;
-	 MSO(c_p).first = (struct erl_off_heap_header*) pb;
-	 pb->val = bptr;
-	 pb->bytes = (byte*) bptr->orig_bytes;
-	 pb->flags = 0;
-	 OH_OVERHEAD(&(MSO(c_p)), pb->size / sizeof(Eterm));
-	 new_binary = make_binary(pb);
+        LIGHT_SWAPOUT;
+
+        new_binary = erts_wrap_refc_bitstring(&MSO(c_p).first,
+                                              &MSO(c_p).overhead,
+                                              &HEAP_TOP(c_p),
+                                              bptr,
+                                              erts_current_bin,
+                                              0,
+                                              num_bits);
+
+        LIGHT_SWAPIN;
      }
 
-     if (num_bits & 7) {
-         ErlSubBin* sb;
-
-         sb = (ErlSubBin *) HTOP;
-         HTOP += ERL_SUB_BIN_SIZE;
-         sb->thing_word = HEADER_SUB_BIN;
-         sb->size = num_bytes - 1;
-         sb->bitsize = num_bits & 7;
-         sb->offs = 0;
-         sb->bitoffs = 0;
-         sb->is_writable = 0;
-         sb->orig = new_binary;
-         new_binary = make_binary(sb);
-     }
      HEAP_SPACE_VERIFIED(0);
      $Dst = new_binary;
 }
@@ -889,13 +873,12 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
     const BeamInstr* p_start = $NEXT_INSTRUCTION;
     const BeamInstr* p_end = p_start + n;
     const BeamInstr* p;
-    Uint num_bytes;
     Uint alloc = $Alloc;
     Eterm new_binary;
 
     /* We count the total number of bits in an unsigned integer. To avoid
-     * having to check for overflow when adding to `num_bits`, we ensure that the
-     * signed size of each segment fits in a word. */
+     * having to check for overflow when adding to `num_bits`, we ensure that
+     * the signed size of each segment fits in a word. */
     Uint num_bits = 0;
 
     /* Calculate size of binary in bits. */
@@ -911,22 +894,21 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             break;
         case BSC_BINARY_ALL:
             {
-                Uint byte_size;
                 Uint bit_size;
 
                 $BS_LOAD_SRC(p, Src);
-                if (is_not_binary(Src)) {
+                if (is_not_bitstring(Src)) {
                     $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
                 }
-                byte_size = binary_size(Src);
+
+                bit_size = bitstring_size(Src);
 #ifndef ARCH_64
-                if ((byte_size >> 28) != 0) {
-                    /* The size of the binary in bits will not fit in
-                     * a 32-bit signed integer. */
+                if (bit_size >= ERTS_SINT_MAX) {
+                    /* The size of the binary in bits will not fit in a 32-bit
+                     * signed integer. */
                     $BS_FAIL_INFO($Fail, SYSTEM_LIMIT, am_binary, am_size);
                 }
 #endif
-                bit_size = (byte_size << 3) + binary_bitsize(Src);
                 num_bits += bit_size;
             }
             break;
@@ -1085,85 +1067,61 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         Uint unit;
         Eterm Src;
 
-        if (alloc) {
-            $test_heap(alloc, $Live);
-        }
+        $test_heap(alloc, $Live);
 
         $BS_LOAD_UNIT(p, unit);
         $BS_LOAD_SRC(p, Src);
+
         new_binary = erts_bs_private_append_checked(c_p, Src, num_bits, unit);
+
         if (is_non_value(new_binary)) {
             $BS_FAIL_INFO($Fail, c_p->freason, c_p->fvalue, Src);
         }
         p_start += BSC_NUM_ARGS;
     } else {
-        num_bytes = ((Uint64)num_bits+(Uint64)7) >> 3;
-        if (num_bits & 7) {
-            alloc += ERL_SUB_BIN_SIZE;
-        }
-        if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-            alloc += heap_bin_size(num_bytes);
+        if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+            alloc += heap_bits_size(num_bits);
         } else {
-            alloc += PROC_BIN_SIZE;
+            alloc += ERL_REFC_BITS_SIZE;
         }
 
         /* num_bits = Number of bits to build
-         * num_bytes = Number of bytes to allocate in the binary
          * alloc = Total number of words to allocate on heap
          */
         erts_bin_offset = 0;
-        if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-            ErlHeapBin* hb;
+        if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+            ErlHeapBits *hb;
 
             $test_heap(alloc, $Live);
-            hb = (ErlHeapBin *) HTOP;
-            HTOP += heap_bin_size(num_bytes);
-            hb->thing_word = header_heap_bin(num_bytes);
-            hb->size = num_bytes;
+            hb = (ErlHeapBits *) HTOP;
+            HTOP += heap_bits_size(num_bits);
+            hb->thing_word = header_heap_bits(num_bits);
+            ERTS_SET_HB_SIZE(hb, num_bits);
             erts_current_bin = (byte *) hb->data;
-            new_binary = make_binary(hb);
+            new_binary = make_bitstring(hb);
         } else {
             Binary* bptr;
-            ProcBin* pb;
 
-            $TEST_BIN_VHEAP(num_bytes / sizeof(Eterm), alloc, $Live);
+            $TEST_BIN_VHEAP(NBYTES(num_bits) / sizeof(Eterm),
+                            alloc + ERL_REFC_BITS_SIZE,
+                            $Live);
 
-            /*
-             * Allocate the binary struct itself.
-             */
-            bptr = erts_bin_nrml_alloc(num_bytes);
-            erts_current_bin = (byte *) bptr->orig_bytes;
+            bptr = erts_bin_nrml_alloc(NBYTES(num_bits));
+            erts_current_bin = (byte *)bptr->orig_bytes;
 
-            /*
-             * Now allocate the ProcBin on the heap.
-             */
-            pb = (ProcBin *) HTOP;
-            HTOP += PROC_BIN_SIZE;
-            pb->thing_word = HEADER_PROC_BIN;
-            pb->size = num_bytes;
-            pb->next = MSO(c_p).first;
-            MSO(c_p).first = (struct erl_off_heap_header*) pb;
-            pb->val = bptr;
-            pb->bytes = (byte*) bptr->orig_bytes;
-            pb->flags = 0;
-            OH_OVERHEAD(&(MSO(c_p)), pb->size / sizeof(Eterm));
-            new_binary = make_binary(pb);
+            LIGHT_SWAPOUT;
+
+            new_binary = erts_wrap_refc_bitstring(&MSO(c_p).first,
+                                                  &MSO(c_p).overhead,
+                                                  &HEAP_TOP(c_p),
+                                                  bptr,
+                                                  erts_current_bin,
+                                                  0,
+                                                  num_bits);
+
+            LIGHT_SWAPIN;
         }
 
-        if (num_bits & 7) {
-            ErlSubBin* sb;
-
-            sb = (ErlSubBin *) HTOP;
-            HTOP += ERL_SUB_BIN_SIZE;
-            sb->thing_word = HEADER_SUB_BIN;
-            sb->size = num_bytes - 1;
-            sb->bitsize = num_bits & 7;
-            sb->offs = 0;
-            sb->bitoffs = 0;
-            sb->is_writable = 0;
-            sb->orig = new_binary;
-            new_binary = make_binary(sb);
-        }
         HEAP_SPACE_VERIFIED(0);
     }
 
@@ -1200,14 +1158,14 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             $BS_LOAD_SIZE(p, Size);
             $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
             if (!erts_new_bs_put_binary(c_p, Src, _size)) {
-                Eterm reason = is_binary(Src) ? am_short : am_type;
+                Eterm reason = is_bitstring(Src) ? am_short : am_type;
                 $BS_FAIL_INFO($Fail, BADARG, reason, Src);
             }
             break;
         case BSC_BINARY_FIXED_SIZE:
             $BS_LOAD_FIXED_SIZE(p, Size);
             if (!erts_new_bs_put_binary(c_p, Src, Size)) {
-                Eterm reason = is_binary(Src) ? am_short : am_type;
+                Eterm reason = is_bitstring(Src) ? am_short : am_type;
                 $BS_FAIL_INFO($Fail, BADARG, reason, Src);
             }
             break;
@@ -1576,14 +1534,18 @@ bs_get_tail.execute(Dst, Live) {
 
     ASSERT(header_is_bin_matchstate(*boxed_val(context)));
 
-    $GC_TEST_PRESERVE(EXTRACT_SUB_BIN_HEAP_NEED, $Live, context);
+    $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
 
     htop = HTOP;
 
     mb = ms_matchbuffer(context);
 
-    bin = erts_extract_sub_binary(&htop,mb->orig,mb->base,
-                                  mb->offset,mb->size - mb->offset);
+    bin = erts_build_sub_bitstring(&htop,
+                                   mb->orig & TAG_PTR_MASK__,
+                                   (BinRef*)boxed_val(mb->orig),
+                                   mb->base,
+                                   mb->offset,
+                                   mb->size - mb->offset);
     HTOP = htop;
 
     $REFRESH_GEN_DEST();
@@ -1624,7 +1586,7 @@ i_bs_start_match3_gp.execute(Live, Fail, Dst, Pos) {
         position = mb->offset;
 
         $Dst = context;
-    } else if (is_binary_header(header)) {
+    } else if (is_bitstring_header(header)) {
         ErlBinMatchState *ms;
 
         $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(0), live, context);
@@ -1672,7 +1634,7 @@ i_bs_start_match3.execute(Live, Fail, Dst) {
     if (header_is_bin_matchstate(header)) {
         ASSERT(HEADER_NUM_SLOTS(header) == 0);
         $Dst = context;
-    } else if (is_binary_header(header)) {
+    } else if (is_bitstring_header(header)) {
         ErlBinMatchState *ms;
 
         $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(0), live, context);
@@ -1837,7 +1799,7 @@ i_bs_start_match3.execute(Live, Fail, Dst) {
             $REFRESH_GEN_DEST();
             $Dst = make_matchstate(new_ms);
         }
-    } else if (is_binary_header(header)) {
+    } else if (is_bitstring_header(header)) {
         Eterm result;
 
         $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(1), live, context);
@@ -2080,8 +2042,12 @@ i_bs_get_fixed_binary.execute(Size, Dst) {
 
     htop = HTOP;
     mb = ms_matchbuffer(context);
-    result = erts_extract_sub_binary(&htop, mb->orig, mb->base,
-                                     mb->offset, size);
+    result = erts_build_sub_bitstring(&htop,
+                                      mb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(mb->orig),
+                                      mb->base,
+                                      mb->offset,
+                                      size);
     HTOP = htop;
 
     mb->offset += size;
@@ -2112,8 +2078,12 @@ i_bs_get_tail.execute(Dst) {
 
     htop = HTOP;
     mb = ms_matchbuffer(context);
-    result = erts_extract_sub_binary(&htop, mb->orig, mb->base,
-                                     mb->offset, mb->size - mb->offset);
+    result = erts_build_sub_bitstring(&htop,
+                                      mb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(mb->orig),
+                                      mb->base,
+                                      mb->offset,
+                                      mb->size - mb->offset);
     HTOP = htop;
 
     $Dst = result;

--- a/erts/emulator/beam/emu/generators.tab
+++ b/erts/emulator/beam/emu/generators.tab
@@ -1100,7 +1100,7 @@ gen.bs_match(Fail, Ctx, N, List) {
             ASSERT(List[src+3].type == TAG_u);
             ASSERT(List[src+4].type == TAG_u);
             size = List[src+3].val * List[src+4].val;
-            words_needed = erts_extracted_binary_size(size);
+            words_needed = erts_extracted_bitstring_size(size);
             break;
         case am_integer:
             ASSERT(List[src+3].type == TAG_u);
@@ -1111,7 +1111,7 @@ gen.bs_match(Fail, Ctx, N, List) {
             }
             break;
         case am_get_tail:
-            words_needed = EXTRACT_SUB_BIN_HEAP_NEED;
+            words_needed = BUILD_SUB_BITSTRING_HEAP_NEED;
             break;
         }
 

--- a/erts/emulator/beam/emu/instrs.tab
+++ b/erts/emulator/beam/emu/instrs.tab
@@ -881,13 +881,13 @@ is_boolean(Fail, Src) {
 }
 
 is_binary(Fail, Src) {
-    if (is_not_binary($Src) || binary_bitsize($Src) != 0) {
+    if (is_not_bitstring($Src) || TAIL_BITS(bitstring_size($Src)) != 0) {
         $FAIL($Fail);
     }
 }
 
 is_bitstring(Fail, Src) {
-  if (is_not_binary($Src)) {
+  if (is_not_bitstring($Src)) {
         $FAIL($Fail);
     }
 }

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -60,7 +60,7 @@ static BIF_RETTYPE binary_longest_prefix_trap(BIF_ALIST_3);
 static Export binary_longest_suffix_trap_export;
 static BIF_RETTYPE binary_longest_suffix_trap(BIF_ALIST_3);
 static Export binary_copy_trap_export;
-static BIF_RETTYPE binary_copy_trap(BIF_ALIST_2);
+static BIF_RETTYPE binary_copy_trap(BIF_ALIST_3);
 static Uint max_loop_limit;
 
 static BIF_RETTYPE
@@ -75,15 +75,15 @@ void erts_init_bif_binary(void)
 			  &binary_find_trap);
 
     erts_init_trap_export(&binary_longest_prefix_trap_export,
-			  am_erlang, am_binary_longest_prefix_trap, 3,
+			  am_erlang, am_binary_longest_prefix_trap, 4,
 			  &binary_longest_prefix_trap);
 
     erts_init_trap_export(&binary_longest_suffix_trap_export,
-			  am_erlang, am_binary_longest_suffix_trap, 3,
+			  am_erlang, am_binary_longest_suffix_trap, 4,
 			  &binary_longest_suffix_trap);
 
     erts_init_trap_export(&binary_copy_trap_export,
-			  am_erlang, am_binary_copy_trap, 2,
+			  am_erlang, am_binary_copy_trap, 3,
 			  &binary_copy_trap);
 
     max_loop_limit = 0;
@@ -274,7 +274,7 @@ typedef struct _binary_find_context BinaryFindContext;
 
 typedef struct _binary_find_search {
     void (*init) (BinaryFindContext *);
-    BFReturn (*find) (BinaryFindContext *, byte *);
+    BFReturn (*find) (BinaryFindContext *, const byte *);
     void (*done) (BinaryFindContext *);
 } BinaryFindSearch;
 
@@ -465,8 +465,8 @@ static ACTrie *create_acdata(MyAllocator *my, Uint len,
  * The same initialization of allocator and basic data for Boyer-Moore.
  * For single byte, we don't use goodshift and badshift, only memchr.
  */
-static BMData *create_bmdata(MyAllocator *my, byte *x, Uint len,
-			     Binary **the_bin /* out */)
+static BMData *create_bmdata(MyAllocator *my, const byte *x, Uint len,
+                             Binary **the_bin /* out */)
 {
     Uint datasize;
     BMData *bmd;
@@ -513,7 +513,8 @@ static BMData *create_bmdata(MyAllocator *my, byte *x, Uint len,
 /*
  * Helper called once for each search pattern
  */
-static void ac_add_one_pattern(MyAllocator *my, ACTrie *act, byte *x, Uint len)
+static void ac_add_one_pattern(MyAllocator *my, ACTrie *act,
+                               const byte *x, Uint len)
 {
     ACNode *acn = act->root;
     Uint32 n = ++act->counter; /* Always increase counter, even if it's a
@@ -631,7 +632,8 @@ static void ac_init_find_first_match(BinaryFindContext *ctx)
 
 #define AC_LOOP_FACTOR 10
 
-static BFReturn ac_find_first_match(BinaryFindContext *ctx, byte *haystack)
+static BFReturn ac_find_first_match(BinaryFindContext *ctx,
+                                    const byte *haystack)
 {
     ACFindFirstState *state = &(ctx->u.ff.d.ac);
     Uint *mpos = &(ctx->u.ff.pos);
@@ -722,7 +724,8 @@ static void ac_clean_find_all(BinaryFindContext *ctx)
  * Differs to the find_first function in that it stores all matches and the values
  * arte returned only in the state.
  */
-static BFReturn ac_find_all_non_overlapping(BinaryFindContext *ctx, byte *haystack)
+static BFReturn ac_find_all_non_overlapping(BinaryFindContext *ctx,
+                                            const byte *haystack)
 {
     ACFindAllState *state = &(ctx->u.fa.d.ac);
     Uint *reductions = &(ctx->reds);
@@ -826,7 +829,8 @@ static void bm_init_find_first_match(BinaryFindContext *ctx)
     state->len = ctx->hsend;
 }
 
-static BFReturn bm_find_first_match(BinaryFindContext *ctx, byte *haystack)
+static BFReturn bm_find_first_match(BinaryFindContext *ctx,
+                                    const byte *haystack)
 {
     BMFindFirstState *state = &(ctx->u.ff.d.bm);
     BMData *bmd = ERTS_MAGIC_BIN_DATA(ctx->pat_bin);
@@ -909,7 +913,8 @@ static void bm_clean_find_all(BinaryFindContext *ctx)
  * Differs to the find_first function in that it stores all matches and the
  * values are returned only in the state.
  */
-static BFReturn bm_find_all_non_overlapping(BinaryFindContext *ctx, byte *haystack)
+static BFReturn bm_find_all_non_overlapping(BinaryFindContext *ctx,
+                                            const byte *haystack)
 {
     BMFindAllState *state = &(ctx->u.fa.d.bm);
     BMData *bmd = ERTS_MAGIC_BIN_DATA(ctx->pat_bin);
@@ -1009,16 +1014,14 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	while (is_list(t)) {
 	    b = CAR(list_val(t));
 	    t = CDR(list_val(t));
-	    if (!is_binary(b)) {
+	    if (!is_bitstring(b)) {
 		goto badarg;
 	    }
-	    if (binary_bitsize(b) != 0) {
-		goto badarg;
-	    }
-	    size = binary_size(b);
-	    if (size == 0) {
-		goto badarg;
-	    }
+            size = bitstring_size(b);
+            if (size == 0 || TAIL_BITS(size) != 0) {
+                goto badarg;
+            }
+            size = BYTE_SIZE(size);
 	    ++words;
 	    characters += size;
 	}
@@ -1030,13 +1033,16 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	} else {
 	    comp_term = CAR(list_val(argument));
 	}
-    } else if (is_binary(argument)) {
-	if (binary_bitsize(argument) != 0) {
-	    goto badarg;
-	}
-	words = 1;
-	comp_term = argument;
-	characters = binary_size(argument);
+    } else if (is_bitstring(argument)) {
+        size = bitstring_size(argument);
+        if (size == 0 || TAIL_BITS(size) != 0) {
+            goto badarg;
+        }
+        size = BYTE_SIZE(size);
+
+        words = 1;
+        comp_term = argument;
+        characters = size;
     }
 
     if (characters == 0) {
@@ -1045,16 +1051,14 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
     ASSERT(words > 0);
 
     if (words == 1) {
-	byte *bytes;
-	Uint bitoffs, bitsize;
-	byte *temp_alloc = NULL;
-	MyAllocator my;
-	Binary *bin;
+        ERTS_DECLARE_DUMMY(Uint dummy);
+        const byte *temp_alloc = NULL, *bytes;
+        MyAllocator my;
+        Binary *bin;
 
-	ERTS_GET_BINARY_BYTES(comp_term, bytes, bitoffs, bitsize);
-	if (bitoffs != 0) {
-	    bytes = erts_get_aligned_binary_bytes(comp_term, &temp_alloc);
-	}
+        bytes = erts_get_aligned_binary_bytes(comp_term, &dummy, &temp_alloc);
+        ASSERT(bytes && characters == dummy);
+
         create_bmdata(&my, bytes, characters, &bin);
 	erts_free_aligned_binary_bytes(temp_alloc);
 	CHECK_ALLOCATOR(my);
@@ -1070,17 +1074,18 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
 	act = create_acdata(&my, characters, &qbuff, &bin);
 	t = comp_term;
 	while (is_list(t)) {
-	    byte *bytes;
-	    Uint bitoffs, bitsize;
-	    byte *temp_alloc = NULL;
-	    b = CAR(list_val(t));
-	    t = CDR(list_val(t));
-	    ERTS_GET_BINARY_BYTES(b, bytes, bitoffs, bitsize);
-	    if (bitoffs != 0) {
-		bytes = erts_get_aligned_binary_bytes(b, &temp_alloc);
-	    }
-	    ac_add_one_pattern(&my,act,bytes,binary_size(b));
-	    erts_free_aligned_binary_bytes(temp_alloc);
+            const byte *temp_alloc = NULL, *bytes;
+            Uint size;
+
+            b = CAR(list_val(t));
+            t = CDR(list_val(t));
+
+            size = 0;
+            bytes = erts_get_aligned_binary_bytes(b, &size, &temp_alloc);
+            ASSERT(bytes);
+
+            ac_add_one_pattern(&my,act,bytes, size);
+            erts_free_aligned_binary_bytes(temp_alloc);
 	}
 	ac_compute_failure_functions(act,qbuff);
 	CHECK_ALLOCATOR(my);
@@ -1265,19 +1270,27 @@ static BFReturn maybe_binary_match_compile(BinaryFindContext *ctx, Eterm arg, Bi
 
 static int parse_match_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp)
 {
+    Uint bin_size;
     Eterm *tp;
     Uint pos;
     Sint len;
+
+    ASSERT(is_bitstring(bin));
+    bin_size = bitstring_size(bin);
+    if (TAIL_BITS(bin_size) != 0) {
+        goto badarg;
+    }
+    bin_size = BYTE_SIZE(bin_size);
+
     if (l == THE_NON_VALUE || l == NIL) {
 	/* Invalid term or NIL, we're called from binary_match(es)_2 or
 	   have no options*/
 	*posp = 0;
-	*endp = binary_size(bin);
+	*endp = bin_size;
 	return 0;
     } else if (is_list(l)) {
 	do {
 	    Eterm t = CAR(list_val(l));
-	    Uint orig_size;
 	    if (!is_tuple(t)) {
 		goto badarg;
 	    }
@@ -1313,8 +1326,7 @@ static int parse_match_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp)
 	    }
 	    *endp = len + pos;
 	    *posp = pos;
-	    if ((orig_size = binary_size(bin)) < pos ||
-		orig_size < (*endp)) {
+	    if (bin_size < pos || bin_size < (*endp)) {
 		goto badarg;
 	    }
 	    l = CDR(list_val(l));
@@ -1331,18 +1343,27 @@ static int parse_match_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp)
 
 static int parse_split_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp, Uint *optp)
 {
+    Uint bin_size;
     Eterm *tp;
     Uint pos;
     Sint len;
+
+    ASSERT(is_bitstring(bin));
+    bin_size = bitstring_size(bin);
+    if (TAIL_BITS(bin_size) != 0) {
+        goto badarg;
+    }
+    bin_size = BYTE_SIZE(bin_size);
+
     *optp = 0;
     *posp = 0;
-    *endp = binary_size(bin);
+    *endp = bin_size;
+
     if (l == THE_NON_VALUE || l == NIL) {
 	return 0;
     } else if (is_list(l)) {
 	while(is_list(l)) {
 	    Eterm t = CAR(list_val(l));
-	    Uint orig_size;
 	    if (is_atom(t)) {
 		if (t == am_global) {
 		    *optp |= BF_FLAG_GLOBAL;
@@ -1395,8 +1416,7 @@ static int parse_split_opts_list(Eterm l, Eterm bin, Uint *posp, Uint *endp, Uin
 	    }
 	    *endp = len + pos;
 	    *posp = pos;
-	    if ((orig_size = binary_size(bin)) < pos ||
-		orig_size < (*endp)) {
+	    if (bin_size < pos || bin_size < (*endp)) {
 		goto badarg;
 	    }
 	    l = CDR(list_val(l));
@@ -1430,17 +1450,13 @@ static BFReturn do_binary_find(Process *p, Eterm subject, BinaryFindContext **ct
 
     switch (ctx->state) {
     case BFSearch: {
-	byte *bytes;
-	Uint bitoffs, bitsize;
-	byte *temp_alloc = NULL;
+        const byte *temp_alloc = NULL, *bytes;
+        ERTS_DECLARE_DUMMY(Uint size);
 
-	ERTS_GET_BINARY_BYTES(subject, bytes, bitoffs, bitsize);
-	if (bitsize != 0) {
-	    goto badarg;
-	}
-	if (bitoffs != 0) {
-	    bytes = erts_get_aligned_binary_bytes(subject, &temp_alloc);
-	}
+        bytes = erts_get_aligned_binary_bytes(subject, &size, &temp_alloc);
+        if (bytes == NULL) {
+            goto badarg;
+        }
 #ifdef HARDDEBUG
 	bf_context_dump(ctx);
 #endif
@@ -1528,7 +1544,7 @@ binary_match(Process *p, Eterm arg1, Eterm arg2, Eterm arg3, Uint flags)
     int runres;
     Eterm result;
 
-    if (is_not_binary(arg1) || binary_bitsize(arg1) != 0) {
+    if (is_not_bitstring(arg1)) {
 	goto badarg;
     }
     ctx->flags = flags;
@@ -1587,7 +1603,7 @@ binary_split(Process *p, Eterm arg1, Eterm arg2, Eterm arg3)
     int runres;
     Eterm result;
 
-    if (is_not_binary(arg1) || binary_bitsize(arg1) != 0) {
+    if (is_not_bitstring(arg1)) {
 	goto badarg;
     }
     if (parse_split_opts_list(arg3, arg1, &(ctx->hsstart), &(ctx->hsend), &(ctx->flags))) {
@@ -1723,9 +1739,10 @@ static Eterm do_split_not_found_result(Process *p, Eterm subject, BinaryFindCont
     Eterm ret;
 
     if (ctx->flags & (BF_FLAG_SPLIT_TRIM | BF_FLAG_SPLIT_TRIM_ALL)
-        && binary_size(subject) == 0) {
-	return NIL;
+        && bitstring_size(subject) == 0) {
+        return NIL;
     }
+
     hp = HAlloc(p, 2);
     ret = CONS(hp, subject, NIL);
     return ret;
@@ -1735,67 +1752,69 @@ static Eterm do_split_single_result(Process *p, Eterm subject, BinaryFindContext
 {
     BinaryFindContext *ctx = (*ctxp);
     BinaryFindFirstContext *ff = &(ctx->u.ff);
-    Sint pos;
-    Sint len;
-    size_t orig_size;
-    Eterm orig;
-    Uint offset;
-    Uint bit_offset;
-    Uint bit_size;
-    Uint hp_need;
-    Eterm *hp, *hp_end;
+    Sint pos, len;
     Eterm ret;
+
+    Uint subject_offset, subject_size;
+    Eterm first, rest;
+    const byte *base;
+    Eterm br_flags;
+    BinRef *br;
 
     pos = ff->pos;
     len = ff->len;
 
-    orig_size = binary_size(subject);
+    ERTS_GET_BITSTRING_REF(subject,
+                           br_flags,
+                           br,
+                           base,
+                           subject_offset,
+                           subject_size);
 
     if ((ctx->flags & (BF_FLAG_SPLIT_TRIM | BF_FLAG_SPLIT_TRIM_ALL)) &&
-	(orig_size - pos - len) == 0) {
-	if (pos == 0) {
-	    ret = NIL;
-	} else {
-	    Eterm extracted;
+        subject_size == NBITS(pos + len)) {
+        Eterm extracted;
 
-	    hp_need = EXTRACT_SUB_BIN_HEAP_NEED + 2;
+        if (pos > 0) {
+            Eterm *hp;
 
-	    hp = HAlloc(p, hp_need);
-	    hp_end = hp + hp_need;
+            hp = HAlloc(p, erts_extracted_bitstring_size(NBITS(pos)) + 2);
 
-	    ERTS_GET_REAL_BIN(subject, orig, offset, bit_offset, bit_size);
-	    extracted = erts_extract_sub_binary(&hp, orig, binary_bytes(orig),
-	                                        offset * 8 + bit_offset,
-	                                        pos * 8 + bit_size);
+            extracted = erts_build_sub_bitstring(&hp,
+                                                 br_flags,
+                                                 br,
+                                                 base,
+                                                 subject_offset,
+                                                 NBITS(pos));
 
-	    ret = CONS(hp, extracted, NIL);
-	    hp += 2;
-
-	    HRelease(p, hp_end, hp);
-
-	    return ret;
-	}
+            ret = CONS(hp, extracted, NIL);
+        } else {
+            ret = NIL;
+        }
     } else {
-        Eterm first, rest;
-
-        hp_need = (EXTRACT_SUB_BIN_HEAP_NEED + 2) * 2;
+        Uint hp_need = (BUILD_SUB_BITSTRING_HEAP_NEED + 2) * 2;
+        Eterm *hp, *hp_end;
 
         hp = HAlloc(p, hp_need);
         hp_end = hp + hp_need;
 
-        ERTS_GET_REAL_BIN(subject, orig, offset, bit_offset, bit_size);
-
         if ((ctx->flags & BF_FLAG_SPLIT_TRIM_ALL) && (pos == 0)) {
             first = NIL;
         } else {
-            first = erts_extract_sub_binary(&hp, orig, binary_bytes(orig),
-                                            offset * 8 + bit_offset,
-                                            pos * 8);
+            first = erts_build_sub_bitstring(&hp,
+                                             br_flags,
+                                             br,
+                                             base,
+                                             subject_offset,
+                                             NBITS(pos));
         }
 
-        rest = erts_extract_sub_binary(&hp, orig, binary_bytes(orig),
-                                       (offset + pos + len) * 8 + bit_offset,
-                                       (orig_size - pos - len) * 8 + bit_size);
+        rest = erts_build_sub_bitstring(&hp,
+                                        br_flags,
+                                        br,
+                                        base,
+                                        subject_offset + NBITS(pos + len),
+                                        subject_size - NBITS(pos + len));
 
         ret = CONS(hp, rest, NIL);
         hp += 2;
@@ -1816,16 +1835,16 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
     BinaryFindContext *ctx = (*ctxp);
     BinaryFindAllContext *fa = &(ctx->u.fa);
     FindallData *fad;
-    Eterm orig;
+    Eterm br_flags;
+    BinRef *br;
     size_t orig_size;
-    Uint offset;
-    Uint bit_offset;
-    Uint bit_size;
     Uint extracted_offset;
     Uint extracted_size;
     Eterm extracted;
     Uint do_trim;
     Sint i;
+    Uint offset, size;
+    byte *base;
     register Uint reds = ctx->reds;
 
     if (ctx->state == BFSearch) {
@@ -1838,7 +1857,7 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
 	}
 	fa->tail = fa->size - 1;
 	fa->head = fa->tail;
-	orig_size = binary_size(subject);
+	orig_size = BYTE_SIZE(bitstring_size(subject));
 	fa->end_pos = (Uint)(orig_size);
 	fa->term = NIL;
 	if (ctx->exported == 0 && ((fa->head + 1) >= reds)) {
@@ -1847,12 +1866,15 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
 	    fa = &(ctx->u.fa);
 	}
 	erts_factory_proc_prealloc_init(&(fa->factory), p, (fa->size + 1) *
-	                                (EXTRACT_SUB_BIN_HEAP_NEED + 2));
+	                                (BUILD_SUB_BITSTRING_HEAP_NEED + 2));
 	ctx->state = BFResult;
     }
 
-    ERTS_GET_REAL_BIN(subject, orig, offset, bit_offset, bit_size);
-    ASSERT(bit_size == 0);
+    ERTS_GET_BITSTRING_REF(subject, br_flags, br, base, offset, size);
+
+    ASSERT(TAIL_BITS(size) == 0);
+    (void)size;
+
     fad = fa->data;
     do_trim = ctx->flags & (BF_FLAG_SPLIT_TRIM | BF_FLAG_SPLIT_TRIM_ALL);
 
@@ -1867,14 +1889,16 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
 	    return THE_NON_VALUE;
 	}
 
-        extracted_offset = (offset + fad[i].pos + fad[i].len) * 8 + bit_offset;
-        extracted_size = (fa->end_pos - (fad[i].pos + fad[i].len)) * 8;
+        extracted_offset = NBITS(fad[i].pos + fad[i].len) + offset;
+        extracted_size = NBITS(fa->end_pos - (fad[i].pos + fad[i].len));
 
         if (!(extracted_size == 0 && do_trim)) {
-            extracted = erts_extract_sub_binary(&fa->factory.hp, orig,
-                                                binary_bytes(orig),
-                                                extracted_offset,
-                                                extracted_size);
+            extracted = erts_build_sub_bitstring(&fa->factory.hp,
+                                                 br_flags,
+                                                 br,
+                                                 base,
+                                                 extracted_offset,
+                                                 extracted_size);
             fa->term = CONS(fa->factory.hp, extracted, fa->term);
             fa->factory.hp += 2;
 
@@ -1887,14 +1911,16 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
     fa->head = i;
     ctx->reds = reds;
 
-    extracted_offset = offset * 8 + bit_offset;
-    extracted_size = fad[0].pos * 8;
+    extracted_offset = offset;
+    extracted_size = NBITS(fad[0].pos);
 
     if (!(extracted_size == 0 && do_trim)) {
-        extracted = erts_extract_sub_binary(&fa->factory.hp, orig,
-                                            binary_bytes(orig),
-                                            extracted_offset,
-                                            extracted_size);
+        extracted = erts_build_sub_bitstring(&fa->factory.hp,
+                                             br_flags,
+                                             br,
+                                             base,
+                                             extracted_offset,
+                                             extracted_size);
         fa->term = CONS(fa->factory.hp, extracted, fa->term);
         fa->factory.hp += 2;
     }
@@ -1927,63 +1953,60 @@ BIF_RETTYPE erts_binary_part(Process *p, Eterm binary, Eterm epos, Eterm elen)
 {
     Uint pos;
     Sint len;
-    size_t orig_size;
-    Eterm orig;
-    Uint offset;
-    Uint bit_offset;
-    Uint bit_size;
+    Uint offset, size;
+    byte *base;
+    Eterm br_flags;
+    BinRef *br;
     Eterm *hp, *hp_end;
     Eterm result;
 
-    if (is_not_binary(binary)) {
-	goto badarg;
+    if (is_not_bitstring(binary) ||
+        !term_to_Uint(epos, &pos) ||
+        !term_to_Sint(elen, &len)) {
+        BIF_ERROR(p, BADARG);
     }
-    if (!term_to_Uint(epos, &pos)) {
-	goto badarg;
-    }
-    if (!term_to_Sint(elen, &len)) {
-	goto badarg;
-    }
+
     if (len < 0) {
-	Uint lentmp = -(Uint)len;
-	/* overflow */
-	if ((Sint)lentmp < 0) {
-	    goto badarg;
-	}
-	len = lentmp;
-	if (len > pos) {
-	    goto badarg;
-	}
-	pos -= len;
+        Uint lentmp = -(Uint)len;
+
+        /* overflow */
+        if ((Sint)lentmp < 0) {
+            BIF_ERROR(p, BADARG);
+        }
+
+        len = lentmp;
+
+        if (len > pos) {
+            BIF_ERROR(p, BADARG);
+        }
+
+        pos -= len;
     }
+
     /* overflow */
     if ((pos + len) < pos || (len > 0 && (pos + len) == pos)){
-	goto badarg;
-    }
-    if ((orig_size = binary_size(binary)) < pos ||
-	orig_size < (pos + len)) {
-	goto badarg;
+        BIF_ERROR(p, BADARG);
     }
 
-    ERTS_GET_REAL_BIN(binary, orig, offset, bit_offset, bit_size);
+    ERTS_GET_BITSTRING_REF(binary, br_flags, br, base, offset, size);
 
-    if (bit_size != 0) {
-        goto badarg;
+    if (TAIL_BITS(size) != 0 || BYTE_SIZE(size) < (pos + len)) {
+        BIF_ERROR(p, BADARG);
     }
 
-    hp = HeapFragOnlyAlloc(p, EXTRACT_SUB_BIN_HEAP_NEED);
-    hp_end = hp + EXTRACT_SUB_BIN_HEAP_NEED;
+    hp = HeapFragOnlyAlloc(p, BUILD_SUB_BITSTRING_HEAP_NEED);
+    hp_end = hp + BUILD_SUB_BITSTRING_HEAP_NEED;
 
-    result = erts_extract_sub_binary(&hp, orig, binary_bytes(orig),
-                                     (offset + pos) * 8 + bit_offset,
-                                     len * 8);
+    result = erts_build_sub_bitstring(&hp,
+                                      br_flags,
+                                      br,
+                                      base,
+                                      offset + NBITS(pos),
+                                      NBITS(len));
 
     HRelease(p, hp_end, hp);
 
     BIF_RET(result);
-
- badarg:
-    BIF_ERROR(p, BADARG);
 }
 
 /*************************************************************
@@ -2013,614 +2036,462 @@ BIF_RETTYPE binary_binary_part_2(BIF_ALIST_2)
    BIF_ERROR(BIF_P,BADARG);
 }
 
-typedef struct {
-    int type;            /* CL_TYPE_XXX */
-    byte *temp_alloc;    /* Used for erts_get/free_aligned, i.e. CL_TYPE_ALIGNED */
-    unsigned char *buff; /* Used for all types, malloced if CL_TYPE_HEAP */
-    Uint bufflen;        /* The length (in bytes) of buffer */
-} CommonData;
-
 #define COMMON_LOOP_FACTOR 10
 
-#define DIRECTION_PREFIX 0
-#define DIRECTION_SUFFIX 1
+#define DIRECTION_PREFIX 1
+#define DIRECTION_SUFFIX -1
 
-#define CL_OK 0
-#define CL_RESTART 1
+static const byte *
+longest_common_copy_bits(int direction,
+                         Eterm binary,
+                         byte *scratchpad,
+                         Uint position,
+                         Uint stride) {
+    Uint offset, size;
+    const byte *base;
 
-/* The type field in the above structure */
-#define CL_TYPE_EMPTY 0 /* End of array */
-#define CL_TYPE_HEAP 1
-#define CL_TYPE_ALIGNED 2
-#define CL_TYPE_COMMON 3 /* emacsulated */
-#define CL_TYPE_HEAP_NOALLOC 4 /* Will need allocating when trapping */
+    ERTS_GET_BITSTRING(binary, base, offset, size);
 
-
-static int do_search_forward(CommonData *cd, Uint *posp, Uint *redsp)
-{
-    Uint pos = *posp;
-    Sint reds = (Sint) *redsp;
-    int i;
-    unsigned char current = 0;
-
-    for(;;) {
-	for(i = 0; cd[i].type != CL_TYPE_EMPTY; ++i) {
-	    if (pos >= cd[i].bufflen) {
-		*posp = pos;
-		if (reds > 0) {
-		    *redsp = (Uint) reds;
-		} else {
-		    *redsp = 0;
-		}
-		return CL_OK;
-	    }
-	    if (i == 0) {
-		current = cd[i].buff[pos];
-	    } else {
-		if (cd[i].buff[pos] != current) {
-		    *posp = pos;
-		    if (reds > 0) {
-			*redsp = (Uint) reds;
-		    } else {
-			*redsp = 0;
-		    }
-		    return CL_OK;
-		}
-	    }
-	    --reds;
-	}
-	++pos;
-	if (reds <= 0) {
-	    *posp = pos;
-	    *redsp = 0;
-	    return CL_RESTART;
-	}
+    /* When searching backwards, the position is from the back of the binary.
+     * Adjust the offset so that the returned base will point at `stride` bits
+     * from our current position. */
+    if (direction == DIRECTION_SUFFIX) {
+        ASSERT(size >= position + stride);
+        offset += (size - position - stride);
+    } else {
+        ASSERT(direction == DIRECTION_PREFIX);
+        offset += position;
     }
-}
-static int do_search_backward(CommonData *cd, Uint *posp, Uint *redsp)
-{
-    Uint pos = *posp;
-    Sint reds = (Sint) *redsp;
-    int i;
-    unsigned char current = 0;
 
-    for(;;) {
-	for(i = 0; cd[i].type != CL_TYPE_EMPTY; ++i) {
-	    if (pos >= cd[i].bufflen) {
-		*posp = pos;
-		if (reds > 0) {
-		    *redsp = (Uint) reds;
-		} else {
-		    *redsp = 0;
-		}
-		return CL_OK;
-	    }
-	    if (i == 0) {
-		current = cd[i].buff[cd[i].bufflen - 1 - pos];
-	    } else {
-		if (cd[i].buff[cd[i].bufflen - 1 - pos] != current) {
-		    *posp = pos;
-		    if (reds > 0) {
-			*redsp = (Uint) reds;
-		    } else {
-			*redsp = 0;
-		    }
-		    return CL_OK;
-		}
-	    }
-	    --reds;
-	}
-	++pos;
-	if (reds <= 0) {
-	    *posp = pos;
-	    *redsp = 0;
-	    return CL_RESTART;
-	}
+    if (BIT_OFFSET(offset) != 0) {
+        /* Note that we do not have to clear partial bytes in the scratchpad,
+         * as we don't support arbitrary bitstrings, only binaries. */
+        copy_binary_to_buffer(scratchpad, 0, base, offset, stride);
+        return scratchpad;
     }
+
+    return &base[BYTE_OFFSET(offset)];
 }
 
-static int cleanup_common_data(Binary *bp)
-{
-    int i;
-    CommonData *cd;
-    cd = (CommonData *) ERTS_MAGIC_BIN_DATA(bp);
-    for (i=0;cd[i].type != CL_TYPE_EMPTY;++i) {
-	switch (cd[i].type) {
-	case CL_TYPE_HEAP:
-	    erts_free(ERTS_ALC_T_BINARY_BUFFER,cd[i].buff);
-	    break;
-	case CL_TYPE_ALIGNED:
-	    erts_free_aligned_binary_bytes_extra(cd[i].temp_alloc, ERTS_ALC_T_BINARY_BUFFER);
-	    break;
-	default:
-	    break;
-	}
-    }
-    return 1;
+static BIF_RETTYPE
+continue_longest_common(Process *p,
+                        int direction,
+                        Eterm binaries,
+                        Uint binary_index,
+                        Uint smallest_size,
+                        Uint position) {
+    Sint reds, save_reds;
+    Eterm *binary_array;
+    Uint binary_count;
+
+    binary_array = tuple_val(binaries);
+    binary_count = arityval(binary_array[0]);
+    binary_array += 1;
+
+    ASSERT(direction == DIRECTION_PREFIX || direction == DIRECTION_SUFFIX);
+    ASSERT(binary_index >= 1 &&
+           binary_index < binary_count &&
+           binary_count >= 2);
+
+    reds = save_reds = get_reds(p, COMMON_LOOP_FACTOR);
+
+    do {
+        byte __scratchpad[2][ERTS_CACHE_LINE_SIZE];
+        const byte *ref_bytes;
+        Sint stride;
+
+        if (reds < 0) {
+            Export *trap_export = (direction == DIRECTION_PREFIX) ?
+                &binary_longest_prefix_trap_export :
+                &binary_longest_suffix_trap_export;
+
+            BUMP_ALL_REDS(p);
+            BIF_TRAP4(trap_export,
+                      p,
+                      binaries,
+                      make_small(binary_index),
+                      erts_make_integer(smallest_size, p),
+                      erts_make_integer(position, p));
+        }
+
+        ASSERT(position < smallest_size);
+        stride = MIN(smallest_size - position, NBITS(sizeof(__scratchpad[0])));
+
+        ref_bytes = longest_common_copy_bits(direction,
+                                             binary_array[0],
+                                             __scratchpad[0],
+                                             position,
+                                             stride);
+
+        /* Handle all other binaries at this position, advancing it iff all
+         * binaries agree on a common prefix or suffix. */
+        while (reds >= 0 && position < smallest_size) {
+            const byte *cmp_bytes;
+
+            ASSERT(stride > 0);
+
+            cmp_bytes = longest_common_copy_bits(direction,
+                                                 binary_array[binary_index],
+                                                 __scratchpad[1],
+                                                 position,
+                                                 stride);
+
+            for (Sint offset = 0; offset < stride; offset += 8) {
+                Sint i = BYTE_OFFSET((direction == DIRECTION_PREFIX ?
+                                      offset :
+                                      stride - offset - 8));
+
+                if (ref_bytes[i] != cmp_bytes[i]) {
+                    smallest_size = position + offset;
+                    stride = offset;
+
+                    if (direction == DIRECTION_SUFFIX) {
+                        /* As the next binary (if any) will be compared with a
+                         * smaller stride -- placing the tail of the binary at
+                         * a different offset -- we need to shunt the reference
+                         * pointer to match.
+                         *
+                         * Note that this may bump the pointer one-past-the-end
+                         * of the binary (which is legal unless dereferenced),
+                         * but we return immediately after in that case. */
+                        ref_bytes += i + 1;
+                    }
+
+                    break;
+                }
+            }
+
+            binary_index++;
+            reds -= stride;
+
+            if (binary_index == binary_count) {
+                position += stride;
+                binary_index = 1;
+                break;
+            }
+        }
+    } while (position < smallest_size);
+
+    ASSERT(position == smallest_size);
+    BUMP_REDS(p, (save_reds - reds) / COMMON_LOOP_FACTOR);
+    BIF_RET(erts_make_integer(BYTE_OFFSET(position), p));
 }
 
-static BIF_RETTYPE do_longest_common(Process *p, Eterm list, int direction)
+static BIF_RETTYPE
+start_longest_common(Process *p, Eterm list, int direction)
 {
-    Eterm l = list;
-    int n = 0;
-    Binary *mb;
-    CommonData *cd;
-    int i = 0;
-    Uint reds = get_reds(p, COMMON_LOOP_FACTOR);
-    Uint save_reds = reds;
-    int res;
-    Export *trapper;
-    Uint pos;
-    Eterm epos;
+    Uint smallest_size = ERTS_UINT_MAX;
+    Uint binary_count, i;
     Eterm *hp;
-    Eterm bin_term;
-    Eterm b;
+    Eterm l;
 
     /* First just count the number of binaries */
-    while (is_list(l)) {
-	b = CAR(list_val(l));
-	if (!is_binary(b)) {
-	    goto badarg;
-	}
-	++n;
-	l = CDR(list_val(l));
-    }
-    if (l != NIL || n == 0) {
-	goto badarg;
+    for (l = list, binary_count = 0; is_list(l); binary_count++) {
+        Eterm *cell = list_val(l);
+        Eterm binary;
+        Uint size;
+
+        binary = CAR(cell);
+        l = CDR(cell);
+
+        if (!is_bitstring(binary)) {
+            BIF_ERROR(p, BADARG);
+        }
+
+        size = bitstring_size(binary);
+
+        if (TAIL_BITS(size)) {
+            BIF_ERROR(p, BADARG);
+        }
+
+        smallest_size = MIN(smallest_size, size);
     }
 
-    /* OK, now create a buffer of the right size, we can do a magic binary right away,
-       that's not too costly. */
-    mb = erts_create_magic_binary((n+1)*sizeof(CommonData),cleanup_common_data);
-    cd = (CommonData *) ERTS_MAGIC_BIN_DATA(mb);
-    l = list;
-    while (is_list(l)) {
-	ERTS_DECLARE_DUMMY(Uint bitoffs);
-	Uint bitsize;
-	ERTS_DECLARE_DUMMY(Uint offset);
-	Eterm real_bin;
-	ProcBin* pb;
+    if (binary_count >= MAX_ARITYVAL) {
+        BIF_ERROR(p, SYSTEM_LIMIT);
+    } else if (l != NIL || binary_count == 0) {
+        BIF_ERROR(p, BADARG);
+    }
 
-	cd[i].type = CL_TYPE_EMPTY;
-	b = CAR(list_val(l));
-	ERTS_GET_REAL_BIN(b, real_bin, offset, bitoffs, bitsize);
-	if (bitsize != 0) {
-	    erts_bin_free(mb);
-	    goto badarg;
-	}
-	cd[i].bufflen = binary_size(b);
-	cd[i].temp_alloc = NULL;
-	if (*(binary_val(real_bin)) == HEADER_PROC_BIN) {
-	    pb = (ProcBin *) binary_val(real_bin);
-	    if (pb->flags) {
-		erts_emasculate_writable_binary(pb);
-	    }
-	    cd[i].buff = erts_get_aligned_binary_bytes_extra(b, &(cd[i].temp_alloc),
-							     ERTS_ALC_T_BINARY_BUFFER,0);
-	    cd[i].type = (cd[i].temp_alloc != NULL) ? CL_TYPE_ALIGNED : CL_TYPE_COMMON;
-	} else { /* Heap binary */
-	    cd[i].buff = erts_get_aligned_binary_bytes_extra(b, &(cd[i].temp_alloc),
-							     ERTS_ALC_T_BINARY_BUFFER,0);
-	    /* CL_TYPE_HEAP_NOALLOC means you have to copy if trapping */
-	    cd[i].type = (cd[i].temp_alloc != NULL) ? CL_TYPE_ALIGNED : CL_TYPE_HEAP_NOALLOC;
-	}
-	++i;
-	l = CDR(list_val(l));
+    /* Weed out trivial cases as they complicate the main loop. */
+    if (smallest_size == 0 || binary_count == 1) {
+        return erts_make_integer(smallest_size / 8, p);
     }
-    cd[i].type = CL_TYPE_EMPTY;
-#if defined(DEBUG) || defined(VALGRIND)
-    cd[i].temp_alloc = NULL;
-    cd[i].buff = NULL;
-    cd[i].bufflen = 0;
-#endif
 
-    pos = 0;
-    if (direction == DIRECTION_PREFIX) {
-	trapper = &binary_longest_prefix_trap_export;
-	res = do_search_forward(cd,&pos,&reds);
-    } else {
-	ASSERT(direction == DIRECTION_SUFFIX);
-	trapper = &binary_longest_suffix_trap_export;
-	res = do_search_backward(cd,&pos,&reds);
+    hp = HAlloc(p, binary_count + 1);
+    hp[0] = make_arityval(binary_count);
+
+    for (l = list, i = 1; i <= binary_count; i++) {
+        Eterm *cell = list_val(l);
+
+        hp[i] = CAR(cell);
+        l = CDR(cell);
     }
-    epos = erts_make_integer(pos,p);
-    if (res == CL_OK) {
-	erts_bin_free(mb);
-	BUMP_REDS(p, (save_reds - reds) / COMMON_LOOP_FACTOR);
-	BIF_RET(epos);
-    } else {
-	ASSERT(res == CL_RESTART);
-	/* Copy all heap binaries that are not already copied (aligned) */
-	for(i = 0; i < n; ++i) {
-	    if (cd[i].type == CL_TYPE_HEAP_NOALLOC) {
-		unsigned char *tmp = cd[i].buff;
-		cd[i].buff = erts_alloc(ERTS_ALC_T_BINARY_BUFFER, cd[i].bufflen);
-		sys_memcpy(cd[i].buff,tmp,cd[i].bufflen);
-		cd[i].type = CL_TYPE_HEAP;
-	    }
-	}
-	hp = HAlloc(p, ERTS_MAGIC_REF_THING_SIZE);
-	bin_term = erts_mk_magic_ref(&hp, &MSO(p), mb);
-	BUMP_ALL_REDS(p);
-	BIF_TRAP3(trapper, p, bin_term, epos,list);
-    }
- badarg:
-    BIF_ERROR(p,BADARG);
+
+    return continue_longest_common(p,
+                                   direction,
+                                   make_tuple(hp),
+                                   1,
+                                   smallest_size,
+                                   0);
 }
 
-static BIF_RETTYPE do_longest_common_trap(Process *p, Eterm bin_term, Eterm current_pos,
-					  Eterm orig_list, int direction)
-{
-    Uint reds = get_reds(p, COMMON_LOOP_FACTOR);
-    Uint save_reds = reds;
-    Uint pos;
-    Binary *bin;
-    CommonData *cd;
-    int res;
-    Eterm epos;
-    Export *trapper;
+static BIF_RETTYPE binary_longest_common_trap(Process *p,
+                                              int direction,
+                                              Eterm *reg) {
+    Uint smallest_size, binary_index, position;
+    int success = 1;
 
-#ifdef DEBUG
-    int r;
-    r = term_to_Uint(current_pos, &pos);
-    ASSERT(r != 0);
-#else
-    term_to_Uint(current_pos, &pos);
-#endif
-    bin = erts_magic_ref2bin(bin_term);
-    cd = (CommonData *) ERTS_MAGIC_BIN_DATA(bin);
-    if (direction == DIRECTION_PREFIX) {
-	trapper = &binary_longest_prefix_trap_export;
-	res = do_search_forward(cd,&pos,&reds);
-    } else {
-	ASSERT(direction == DIRECTION_SUFFIX);
-	trapper = &binary_longest_suffix_trap_export;
-	res = do_search_backward(cd,&pos,&reds);
-    }
-    epos = erts_make_integer(pos,p);
-    if (res == CL_OK) {
-	BUMP_REDS(p, (save_reds - reds) / COMMON_LOOP_FACTOR);
-	BIF_RET(epos);
-    } else {
-	ASSERT(res == CL_RESTART);
-	/* Copy all heap binaries that are not already copied (aligned) */
-	BUMP_ALL_REDS(p);
-	BIF_TRAP3(trapper, p, bin_term, epos, orig_list);
-    }
+    ERTS_CT_ASSERT(MAX_ARITYVAL < MAX_SMALL);
+    binary_index = unsigned_val(reg[1]);
+    success &= term_to_Uint(reg[2], &smallest_size);
+    success &= term_to_Uint(reg[3], &position);
+
+    ASSERT(success);
+    (void)success;
+
+    return continue_longest_common(p,
+                                   direction,
+                                   reg[0],
+                                   binary_index,
+                                   smallest_size,
+                                   position);
 }
 
-static BIF_RETTYPE binary_longest_prefix_trap(BIF_ALIST_3)
+static BIF_RETTYPE binary_longest_prefix_trap(BIF_ALIST_4)
 {
-    return do_longest_common_trap(BIF_P,BIF_ARG_1,BIF_ARG_2,BIF_ARG_3,DIRECTION_PREFIX);
+    return binary_longest_common_trap(BIF_P,
+                                      DIRECTION_PREFIX,
+                                      BIF__ARGS);
 }
 
-static BIF_RETTYPE binary_longest_suffix_trap(BIF_ALIST_3)
+static BIF_RETTYPE binary_longest_suffix_trap(BIF_ALIST_4)
 {
-    return do_longest_common_trap(BIF_P,BIF_ARG_1,BIF_ARG_2,BIF_ARG_3,DIRECTION_SUFFIX);
+    return binary_longest_common_trap(BIF_P,
+                                      DIRECTION_SUFFIX,
+                                      BIF__ARGS);
 }
 
 BIF_RETTYPE binary_longest_common_prefix_1(BIF_ALIST_1)
 {
-    return do_longest_common(BIF_P,BIF_ARG_1,DIRECTION_PREFIX);
+    return start_longest_common(BIF_P, BIF_ARG_1, DIRECTION_PREFIX);
 }
 
 BIF_RETTYPE binary_longest_common_suffix_1(BIF_ALIST_1)
 {
-    return do_longest_common(BIF_P,BIF_ARG_1,DIRECTION_SUFFIX);
+    return start_longest_common(BIF_P, BIF_ARG_1, DIRECTION_SUFFIX);
 }
 
 BIF_RETTYPE binary_first_1(BIF_ALIST_1)
 {
-    byte* bytes;
-    Uint byte_size;
-    Uint bit_offs;
-    Uint bit_size;
-    Uint res;
+    if (is_bitstring(BIF_ARG_1)) {
+        Uint offset, size;
+        const byte *base;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	goto badarg;
+        ERTS_GET_BITSTRING(BIF_ARG_1, base, offset, size);
+
+        if ((size % 8) == 0 && size >= 8) {
+            byte first_byte;
+
+            copy_binary_to_buffer(&first_byte,
+                                  0,
+                                  base,
+                                  offset,
+                                  8);
+
+            BIF_RET(make_small(first_byte));
+        }
     }
-    byte_size = binary_size(BIF_ARG_1);
-    if (!byte_size) {
-	goto badarg;
-    }
-    ERTS_GET_BINARY_BYTES(BIF_ARG_1,bytes,bit_offs,bit_size);
-    if (bit_size) {
-	goto badarg;
-    }
-    if (bit_offs) {
-	res = ((((Uint) bytes[0]) << bit_offs) | (((Uint) bytes[1]) >> (8-bit_offs))) & 0xFF;
-    } else {
-	res = bytes[0];
-    }
-    BIF_RET(make_small(res));
- badarg:
-    BIF_ERROR(BIF_P,BADARG);
+
+    BIF_ERROR(BIF_P, BADARG);
 }
 
 BIF_RETTYPE binary_last_1(BIF_ALIST_1)
 {
-    byte* bytes;
-    Uint byte_size;
-    Uint bit_offs;
-    Uint bit_size;
-    Uint res;
+    if (is_bitstring(BIF_ARG_1)) {
+        Uint offset, size;
+        const byte *base;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	goto badarg;
+        ERTS_GET_BITSTRING(BIF_ARG_1, base, offset, size);
+
+        if ((size % 8) == 0 && size >= 8) {
+            byte last_byte;
+
+            copy_binary_to_buffer(&last_byte,
+                                  0,
+                                  base,
+                                  offset + size - 8,
+                                  8);
+
+            BIF_RET(make_small(last_byte));
+        }
     }
-    byte_size = binary_size(BIF_ARG_1);
-    if (!byte_size) {
-	goto badarg;
-    }
-    ERTS_GET_BINARY_BYTES(BIF_ARG_1,bytes,bit_offs,bit_size);
-    if (bit_size) {
-	goto badarg;
-    }
-    if (bit_offs) {
-	res = ((((Uint) bytes[byte_size-1]) << bit_offs) |
-	       (((Uint) bytes[byte_size]) >> (8-bit_offs))) & 0xFF;
-    } else {
-	res = bytes[byte_size-1];
-    }
-    BIF_RET(make_small(res));
- badarg:
-    BIF_ERROR(BIF_P,BADARG);
+
+    BIF_ERROR(BIF_P, BADARG);
 }
 
 BIF_RETTYPE binary_at_2(BIF_ALIST_2)
 {
-    byte* bytes;
-    Uint byte_size;
-    Uint bit_offs;
-    Uint bit_size;
-    Uint res;
-    Uint index;
+    if (is_bitstring(BIF_ARG_1)) {
+        Uint index;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	goto badarg;
-    }
-    byte_size = binary_size(BIF_ARG_1);
-    if (!byte_size) {
-	goto badarg;
-    }
-    if (!term_to_Uint(BIF_ARG_2, &index)) {
-	goto badarg;
-    }
-    if (index >= byte_size) {
-	goto badarg;
-    }
-    ERTS_GET_BINARY_BYTES(BIF_ARG_1,bytes,bit_offs,bit_size);
-    if (bit_size) {
-	goto badarg;
-    }
-    if (bit_offs) {
-	res = ((((Uint) bytes[index]) << bit_offs) |
-	       (((Uint) bytes[index+1]) >> (8-bit_offs))) & 0xFF;
-    } else {
-	res = bytes[index];
-    }
-    BIF_RET(make_small(res));
- badarg:
-    BIF_ERROR(BIF_P,BADARG);
-}
+        if (term_to_Uint(BIF_ARG_2, &index) &&
+            index < (ERTS_UINT_MAX / 8)) {
+            Uint offset, size;
+            const byte *base;
 
-BIF_RETTYPE binary_list_to_bin_1(BIF_ALIST_1)
-{
-    return erts_list_to_binary_bif(BIF_P, BIF_ARG_1, BIF_TRAP_EXPORT(BIF_binary_list_to_bin_1));
+            ERTS_GET_BITSTRING(BIF_ARG_1, base, offset, size);
+            index *= 8;
+
+            if ((size % 8) == 0 && index < size && (size - index) >= 8) {
+                byte indexed_byte;
+
+                copy_binary_to_buffer(&indexed_byte,
+                                      0,
+                                      base,
+                                      offset + index,
+                                      8);
+
+                BIF_RET(make_small(indexed_byte));
+            }
+        }
+    }
+
+    BIF_ERROR(BIF_P, BADARG);
 }
 
 typedef struct {
-    Uint times_left;
+    byte *source_bytes;
+    Uint source_offset;
     Uint source_size;
-    int source_type;
-    byte *source;
-    byte *temp_alloc;
-    Uint result_pos;
-    Binary *result;
+
+    byte *target_bytes;
+    Uint target_size;
+
+    Uint copied_bits;
 } CopyBinState;
 
-#define BC_TYPE_EMPTY 0
-#define BC_TYPE_HEAP 1
-#define BC_TYPE_ALIGNED 2 /* May or may not point to (emasculated) binary, temp_alloc field is set
-			     so that erts_free_aligned_binary_bytes_extra can handle either */
+/* Number of bits to copy per reduction. */
+#define BITSTRING_COPY_LOOP_FACTOR (ERTS_CACHE_LINE_SIZE * 8)
 
+static ERTS_FORCE_INLINE void
+binary_copy_loop(CopyBinState *cbs, Uint trap_offset) {
+    while (cbs->copied_bits < trap_offset) {
+        Uint copy_offset, copy_stride;
 
-#define BINARY_COPY_LOOP_FACTOR 100
+        copy_offset = cbs->copied_bits % cbs->source_size;
+        copy_stride = MIN(trap_offset - cbs->copied_bits,
+                          cbs->source_size - copy_offset);
 
-static int cleanup_copy_bin_state(Binary *bp)
-{
-    CopyBinState *cbs = (CopyBinState *) ERTS_MAGIC_BIN_DATA(bp);
-    if (cbs->result != NULL) {
-	erts_bin_free(cbs->result);
-	cbs->result = NULL;
+        copy_binary_to_buffer(cbs->target_bytes,
+                              cbs->copied_bits,
+                              cbs->source_bytes,
+                              cbs->source_offset + copy_offset,
+                              copy_stride);
+
+        cbs->copied_bits += copy_stride;
     }
-    switch (cbs->source_type) {
-    case BC_TYPE_HEAP:
-	erts_free(ERTS_ALC_T_BINARY_BUFFER,cbs->source);
-	break;
-    case BC_TYPE_ALIGNED:
-	erts_free_aligned_binary_bytes_extra(cbs->temp_alloc,
-					     ERTS_ALC_T_BINARY_BUFFER);
-	break;
-    default:
-	/* otherwise do nothing */
-	break;
-    }
-    cbs->source_type =  BC_TYPE_EMPTY;
-    return 1;
+
+    ASSERT(cbs->copied_bits == trap_offset);
 }
 
-/*
- * Binary *erts_bin_nrml_alloc(Uint size);
- * Binary *erts_bin_realloc(Binary *bp, Uint size);
- * void erts_bin_free(Binary *bp);
- */
 static BIF_RETTYPE do_binary_copy(Process *p, Eterm bin, Eterm en)
 {
-    Uint n;
-    byte *bytes;
-    ERTS_DECLARE_DUMMY(Uint bit_offs);
-    Uint bit_size;
-    size_t size;
-    Uint reds = get_reds(p, BINARY_COPY_LOOP_FACTOR);
-    Uint target_size;
-    byte *t;
-    Uint pos;
+    Uint duplicate_count, max_copy_bits;
+    Eterm result = THE_NON_VALUE;
+    CopyBinState cbs;
 
-
-    if (is_not_binary(bin)) {
-	goto badarg;
-    }
-    if (!term_to_Uint(en, &n)) {
-	goto badarg;
-    }
-    ERTS_GET_BINARY_BYTES(bin,bytes,bit_offs,bit_size);
-    if (bit_size != 0) {
-	goto badarg;
-    }
-    if (n == 0) {
-        Eterm res_term = erts_new_heap_binary(p, NULL, 0, &bytes);
-        BIF_RET(res_term);
+    if (is_not_bitstring(bin) || !term_to_Uint(en, &duplicate_count)) {
+        BIF_ERROR(p, BADARG);
     }
 
-    size = binary_size(bin);
-    target_size = size * n;
+    ERTS_GET_BITSTRING(bin,
+                       cbs.source_bytes,
+                       cbs.source_offset,
+                       cbs.source_size);
 
-    if ((target_size - size) >= reds) {
-	Eterm orig;
-	ERTS_DECLARE_DUMMY(Uint offset);
-	ERTS_DECLARE_DUMMY(Uint bit_offset);
-	ERTS_DECLARE_DUMMY(Uint bit_size);
-	CopyBinState *cbs;
-	Eterm *hp;
-	Eterm trap_term;
-	int i;
-
-	/* We will trap, set up the structure for trapping right away */
-	Binary *mb = erts_create_magic_binary(sizeof(CopyBinState),
-					      cleanup_copy_bin_state);
-	cbs = ERTS_MAGIC_BIN_DATA(mb);
-
-	cbs->temp_alloc = NULL;
-	cbs->source = NULL;
-
-	ERTS_GET_REAL_BIN(bin, orig, offset, bit_offset, bit_size);
-	if (*(binary_val(orig)) == HEADER_PROC_BIN) {
-	    ProcBin* pb = (ProcBin *) binary_val(orig);
-	    if (pb->flags) {
-		erts_emasculate_writable_binary(pb);
-	    }
-	    cbs->source =
-		erts_get_aligned_binary_bytes_extra(bin,
-						    &(cbs->temp_alloc),
-						    ERTS_ALC_T_BINARY_BUFFER,
-						    0);
-	    cbs->source_type = BC_TYPE_ALIGNED;
-	} else { /* Heap binary */
-	    cbs->source =
-		erts_get_aligned_binary_bytes_extra(bin,
-						    &(cbs->temp_alloc),
-						    ERTS_ALC_T_BINARY_BUFFER,
-						    0);
-	    if (!(cbs->temp_alloc)) { /* alignment not needed, need to copy */
-		byte *tmp = erts_alloc(ERTS_ALC_T_BINARY_BUFFER,size);
-		sys_memcpy(tmp,cbs->source,size);
-		cbs->source = tmp;
-		cbs->source_type = BC_TYPE_HEAP;
-	    } else {
-		cbs->source_type = BC_TYPE_ALIGNED;
-	    }
-	}
-	cbs->result = erts_bin_nrml_alloc(target_size); /* Always offheap
-							   if trapping */
-	t = (byte *) cbs->result->orig_bytes; /* No offset or anything */
-	pos = 0;
-	i = 0;
-	while (pos < reds) {
-	    sys_memcpy(t+pos,cbs->source, size);
-	    pos += size;
-	    ++i;
-	}
-	cbs->source_size = size;
-	cbs->result_pos = pos;
-	cbs->times_left = n-i;
-	hp = HAlloc(p, ERTS_MAGIC_REF_THING_SIZE);
-	trap_term = erts_mk_magic_ref(&hp, &MSO(p), mb);
-	BUMP_ALL_REDS(p);
-	BIF_TRAP2(&binary_copy_trap_export, p, bin, trap_term);
-    } else {
-	Eterm res_term;
-	byte *temp_alloc = NULL;
-	byte *source =
-	    erts_get_aligned_binary_bytes(bin,
-					  &temp_alloc);
-	if (target_size <= ERL_ONHEAP_BIN_LIMIT) {
-	    res_term = erts_new_heap_binary(p,NULL,target_size,&t);
-	} else {
-	    res_term = erts_new_mso_binary(p,NULL,target_size);
-	    t = ((ProcBin *) binary_val(res_term))->bytes;
-	}
-	pos = 0;
-	while (pos < target_size) {
-	    sys_memcpy(t+pos,source, size);
-	    pos += size;
-	}
-	erts_free_aligned_binary_bytes(temp_alloc);
-	BUMP_REDS(p,pos / BINARY_COPY_LOOP_FACTOR);
-	BIF_RET(res_term);
+    if (TAIL_BITS(cbs.source_size) != 0) {
+        BIF_ERROR(p, BADARG);
     }
- badarg:
-    BIF_ERROR(p,BADARG);
+
+    if (duplicate_count == 0 || cbs.source_size == 0) {
+        BIF_RET(erts_new_bitstring_from_data(p, 0, (byte*)""));
+    }
+
+    if (duplicate_count >= (ERTS_UINT_MAX / cbs.source_size)) {
+        BIF_ERROR(p, SYSTEM_LIMIT);
+    }
+
+    max_copy_bits = get_reds(p, BITSTRING_COPY_LOOP_FACTOR);
+
+    cbs.target_size = cbs.source_size * duplicate_count;
+    cbs.copied_bits = 0;
+
+    result = erts_new_bitstring(p, cbs.target_size, &cbs.target_bytes);
+
+    binary_copy_loop(&cbs, MIN(max_copy_bits, cbs.target_size));
+
+    if (cbs.copied_bits < cbs.target_size) {
+        ERTS_BIF_YIELD3(&binary_copy_trap_export,
+                        p,
+                        bin,
+                        result,
+                        erts_make_integer(cbs.copied_bits, p));
+    }
+
+    ASSERT(cbs.copied_bits == cbs.target_size);
+    BUMP_REDS(p, cbs.target_size / BITSTRING_COPY_LOOP_FACTOR);
+
+    BIF_RET(result);
 }
 
-BIF_RETTYPE binary_copy_trap(BIF_ALIST_2)
+static BIF_RETTYPE binary_copy_trap(BIF_ALIST_3)
 {
-    Uint n;
-    size_t size;
-    Uint reds = get_reds(BIF_P, BINARY_COPY_LOOP_FACTOR);
-    byte *t;
-    Uint pos;
-    Binary *mb = erts_magic_ref2bin(BIF_ARG_2);
-    CopyBinState *cbs = (CopyBinState *) ERTS_MAGIC_BIN_DATA(mb);
-    Uint opos;
+    Uint initial_target_offset, trap_offset, max_copy_bits;
+    ERTS_DECLARE_DUMMY(Uint target_offset);
+    CopyBinState cbs;
 
-    /* swapout... */
-    n = cbs->times_left;
-    size = cbs->source_size;
-    opos = pos = cbs->result_pos;
-    t = (byte *) cbs->result->orig_bytes; /* "well behaved" binary */
-    if ((n-1) * size >= reds) {
-	Uint i = 0;
-	while ((pos - opos) < reds) {
-	    sys_memcpy(t+pos,cbs->source, size);
-	    pos += size;
-	    ++i;
-	}
-	cbs->result_pos = pos;
-	cbs->times_left -= i;
-	BUMP_ALL_REDS(BIF_P);
-	BIF_TRAP2(&binary_copy_trap_export, BIF_P, BIF_ARG_1, BIF_ARG_2);
-    } else {
-	Binary *save;
-        Eterm resbin;
-	Uint target_size = cbs->result->orig_size;
-	while (pos < target_size) {
-	    sys_memcpy(t+pos,cbs->source, size);
-	    pos += size;
-	}
-	save = cbs->result;
-	cbs->result = NULL;
-	cleanup_copy_bin_state(mb); /* now cbs is dead */
+    ERTS_GET_BITSTRING(BIF_ARG_1,
+                       cbs.source_bytes,
+                       cbs.source_offset,
+                       cbs.source_size);
 
-        resbin = erts_build_proc_bin(&MSO(BIF_P),
-                                     HAlloc(BIF_P, PROC_BIN_SIZE),
-                                     save);
-        BUMP_REDS(BIF_P,(pos - opos) / BINARY_COPY_LOOP_FACTOR);
-	BIF_RET(resbin);
+    /* This function cannot be traced, so it's safe to update the contents. */
+    ERTS_GET_BITSTRING(BIF_ARG_2,
+                       cbs.target_bytes,
+                       target_offset,
+                       cbs.target_size);
+    ASSERT(target_offset == 0);
+
+    ERTS_ASSERT(term_to_Uint(BIF_ARG_3, &cbs.copied_bits));
+
+    max_copy_bits = get_reds(BIF_P, BITSTRING_COPY_LOOP_FACTOR);
+    initial_target_offset = cbs.copied_bits;
+    trap_offset = cbs.target_size;
+
+    if ((ERTS_UINT_MAX - max_copy_bits) < initial_target_offset &&
+        (initial_target_offset + max_copy_bits < trap_offset)) {
+        trap_offset = initial_target_offset + max_copy_bits;
     }
-}
 
+    binary_copy_loop(&cbs, trap_offset);
+    ASSERT(cbs.copied_bits <= cbs.target_size);
+
+    if (cbs.copied_bits == cbs.target_size) {
+        Uint bits_copied;
+
+        bits_copied = cbs.copied_bits - initial_target_offset;
+        BUMP_REDS(BIF_P, bits_copied / BITSTRING_COPY_LOOP_FACTOR);
+
+        BIF_RET(BIF_ARG_2);
+    }
+
+    ERTS_BIF_YIELD3(&binary_copy_trap_export,
+                    BIF_P,
+                    BIF_ARG_1,
+                    BIF_ARG_2,
+                    erts_make_integer(cbs.copied_bits, BIF_P));
+}
 
 BIF_RETTYPE binary_copy_1(BIF_ALIST_1)
 {
@@ -2634,25 +2505,28 @@ BIF_RETTYPE binary_copy_2(BIF_ALIST_2)
 
 BIF_RETTYPE binary_referenced_byte_size_1(BIF_ALIST_1)
 {
-    ErlSubBin *sb;
-    ProcBin *pb;
-    Eterm res;
-    Eterm bin = BIF_ARG_1;
+    ERTS_DECLARE_DUMMY(const byte *base);
+    ERTS_DECLARE_DUMMY(Uint offset);
+    ERTS_DECLARE_DUMMY(Eterm br_flags);
+    const BinRef *br;
+    Uint size;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	BIF_ERROR(BIF_P,BADARG);
+    if (is_not_bitstring(BIF_ARG_1)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
-    sb = (ErlSubBin *) binary_val(bin);
-    if (sb->thing_word == HEADER_SUB_BIN) {
-	bin = sb->orig;
+
+    ERTS_GET_BITSTRING_REF(BIF_ARG_1,
+                           br_flags,
+                           br,
+                           base,
+                           offset,
+                           size);
+
+    if (br != NULL) {
+        size = (br->val)->orig_size;
     }
-    pb = (ProcBin *) binary_val(bin);
-    if (pb->thing_word == HEADER_PROC_BIN) {
-	res = erts_make_integer((Uint) pb->val->orig_size, BIF_P);
-    } else { /* heap binary */
-	res = erts_make_integer((Uint) ((ErlHeapBin *) pb)->size, BIF_P);
-    }
-    BIF_RET(res);
+
+    BIF_RET(erts_make_integer(size, BIF_P));
 }
 
 #define END_BIG 0
@@ -2710,8 +2584,8 @@ static BIF_RETTYPE do_encode_unsigned(Process *p, Eterm uns, Eterm endianess)
 
 	u = (Uint) x;
 	n = get_need(u);
-	ASSERT(n <= ERL_ONHEAP_BIN_LIMIT);
-	res = erts_new_heap_binary(p, NULL, n, &b);
+	ASSERT(n <= ERL_ONHEAP_BINARY_LIMIT);
+        res = erts_new_binary(p, n, &b);
 	if (endianess == am_big) {
 	    for(i=n-1;i>=0;--i) {
 		b[i] = u & 0xFF;
@@ -2736,13 +2610,9 @@ static BIF_RETTYPE do_encode_unsigned(Process *p, Eterm uns, Eterm endianess)
 	if(BIG_SIGN(bigp)) {
 	    goto badarg;
 	}
+
 	n = (num_parts-1)*sizeof(ErtsDigit)+get_need(BIG_DIGIT(bigp,(num_parts-1)));
-	if (n <= ERL_ONHEAP_BIN_LIMIT) {
-	    res = erts_new_heap_binary(p,NULL,n,&b);
-	} else {
-	    res = erts_new_mso_binary(p,NULL,n);
-	    b = ((ProcBin *) binary_val(res))->bytes;
-	}
+        res = erts_new_binary(p, n, &b);
 
 	if (endianess == am_big) {
 	    Sint i,j;
@@ -2774,21 +2644,27 @@ static BIF_RETTYPE do_encode_unsigned(Process *p, Eterm uns, Eterm endianess)
 
 static BIF_RETTYPE do_decode_unsigned(Process *p, Eterm uns, Eterm endianess)
 {
+    Uint offset, size;
+    Uint bitoffs;
     byte *bytes;
-    Uint bitoffs, bitsize;
-    Uint size;
     Eterm res;
 
-    if (is_not_binary(uns) || is_not_atom(endianess) ||
+    if (is_not_bitstring(uns) || is_not_atom(endianess) ||
 	(endianess != am_big && endianess != am_little)) {
 	goto badarg;
     }
-    ERTS_GET_BINARY_BYTES(uns, bytes, bitoffs, bitsize);
-    if (bitsize != 0) {
-	goto badarg;
+
+    ERTS_GET_BITSTRING(uns, bytes, offset, size);
+
+    if (TAIL_BITS(size) != 0) {
+        goto badarg;
     }
+
+    bytes = &bytes[BYTE_OFFSET(offset)];
+    bitoffs = BIT_OFFSET(offset);
+    size = BYTE_SIZE(size);
+
     /* align while rolling */
-    size = binary_size(uns);
     if (bitoffs) {
 	if (endianess == am_big) {
 	    while (size && (((((Uint) bytes[0]) << bitoffs) |

--- a/erts/emulator/beam/erl_bif_chksum.c
+++ b/erts/emulator/beam/erl_bif_chksum.c
@@ -32,7 +32,7 @@
 #include "zlib.h"
 
 
-typedef void (*ChksumFun)(void *sum_in_out, unsigned char *buf, 
+typedef void (*ChksumFun)(void *sum_in_out, const byte *buf,
 			  unsigned buflen);
 
 /* Hidden trap target */
@@ -42,12 +42,10 @@ static Export chksum_md5_2_exp;
 
 void erts_init_bif_chksum(void)
 {
-    /* Non visual BIF to trap to. */
     erts_init_trap_export(&chksum_md5_2_exp,
-			  am_erlang, ERTS_MAKE_AM("md5_trap"), 2,
-			  &md5_2);
+                          am_erlang, ERTS_MAKE_AM("md5_trap"), 2,
+                          &md5_2);
 }
-    
 
 static Eterm do_chksum(ChksumFun sumfun, Process *p, Eterm ioterm, int left, 
 		       void *sum, int *res, int *err)
@@ -56,71 +54,47 @@ static Eterm do_chksum(ChksumFun sumfun, Process *p, Eterm ioterm, int left,
     Eterm obj;
     int c;
     DECLARE_ESTACK(stack);
-    unsigned char *bytes = NULL;
     int numbytes = 0;
+    byte *buf = NULL;
 
     *err = 0;
     if (left <= 0 || is_nil(ioterm)) {
-	DESTROY_ESTACK(stack);
-	*res = 0;
-	return ioterm;
+        DESTROY_ESTACK(stack);
+        *res = 0;
+        return ioterm;
+    } else if (is_bitstring(ioterm)) {
+        Eterm res_term = NIL;
+        const byte *temp_alloc = NULL, *bytes;
+        Uint size;
+
+        /* As we've already checked that this is a bitstring, this can only
+         * fail when we've got a non-binary. */
+        bytes = erts_get_aligned_binary_bytes(ioterm, &size, &temp_alloc);
+        if (bytes == NULL) {
+            *res = 0;
+            *err = 1;
+            DESTROY_ESTACK(stack);
+            return NIL;
+        }
+
+        if (size > left) {
+            res_term = erts_make_sub_binary(p, ioterm, left, (size - left));
+            size = left;
+        }
+
+        (*sumfun)(sum, bytes, size);
+        *res = size;
+
+        DESTROY_ESTACK(stack);
+        erts_free_aligned_binary_bytes(temp_alloc);
+        return res_term;
     }
-    if(is_binary(ioterm)) {
-	Uint bitoffs;
-	Uint bitsize;
-	Uint size;
-	Eterm res_term = NIL;
-	unsigned char *bytes;
-	byte *temp_alloc = NULL;
-	
-	ERTS_GET_BINARY_BYTES(ioterm, bytes, bitoffs, bitsize);
-	if (bitsize != 0) {
-	    *res = 0;
-	    *err = 1;
-	    DESTROY_ESTACK(stack);
-	    return NIL;
-	}
-	if (bitoffs != 0) {
-	    bytes = erts_get_aligned_binary_bytes(ioterm, &temp_alloc);
-	    /* The call to erts_get_aligned_binary_bytes cannot fail as 
-	       we'we already checked bitsize and that this is a binary */
-	}
 
-	size = binary_size(ioterm);
-
-
-	if (size > left) {
-	    Eterm *hp;
-	    ErlSubBin *sb;
-	    Eterm orig;
-	    Uint offset;
-	    /* Split the binary in two parts, of which we 
-	       only process the first */
-	    hp = HAlloc(p, ERL_SUB_BIN_SIZE);
-	    sb = (ErlSubBin *) hp;
-	    ERTS_GET_REAL_BIN(ioterm, orig, offset, bitoffs, bitsize);
-	    sb->thing_word = HEADER_SUB_BIN;
-	    sb->size = size - left;
-	    sb->offs = offset + left;
-	    sb->orig = orig;
-	    sb->bitoffs = bitoffs;
-	    sb->bitsize = bitsize;
-	    sb->is_writable = 0;
-	    res_term = make_binary(sb);
-	    size = left;
-	}
-	(*sumfun)(sum, bytes, size);
-	*res = size;
-	DESTROY_ESTACK(stack);
-	erts_free_aligned_binary_bytes(temp_alloc);
-	return res_term;
-    }
-	
     if (!is_list(ioterm)) {
-	*res = 0;
-	*err = 1;
-	DESTROY_ESTACK(stack);
-	return NIL;
+        *res = 0;
+        *err = 1;
+        DESTROY_ESTACK(stack);
+        return NIL;
     }
 
     /* OK a list, needs to be processed in order, handling each flat list-level
@@ -143,20 +117,20 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    int bsize = 0;
 		    for(;;) {
 			if (bsize >= numbytes) {
-			    if (!bytes) {
-				bytes = erts_alloc(ERTS_ALC_T_TMP, 
-						   numbytes = 500);
+			    if (!buf) {
+                                numbytes = 500;
+                                buf = erts_alloc(ERTS_ALC_T_TMP, numbytes);
 			    } else {
 				if (numbytes > left) {
 				    numbytes += left;
 				} else {
 				    numbytes *= 2;
 				}
-				bytes = erts_realloc(ERTS_ALC_T_TMP, bytes,
-						     numbytes);
+                                buf = erts_realloc(ERTS_ALC_T_TMP, buf,
+                                                    numbytes);
 			    }
 			}  
-			bytes[bsize++] = (unsigned char) unsigned_val(obj);
+			buf[bsize++] = (unsigned char) unsigned_val(obj);
 			--left;
 			ioterm = CDR(objp);
 			if (!is_list(ioterm)) {
@@ -170,7 +144,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 			    break;
 			}
 		    }
-		    (*sumfun)(sum, bytes, bsize);
+		    (*sumfun)(sum, buf, bsize);
 		    *res += bsize;
 		} else if (is_nil(obj)) {
 		    ioterm = CDR(objp);
@@ -185,7 +159,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    ESTACK_PUSH(stack,CDR(objp));
 		    ioterm = obj;
 		    goto L_Again;
-		} else if (is_binary(obj)) {
+		} else if (is_bitstring(obj)) {
 		    int sres, serr;
 		    Eterm rest_term;
 		    rest_term = do_chksum(sumfun, p, obj, left, sum, &sres,
@@ -194,8 +168,8 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    if (serr != 0) {
 			*err = 1;
 			DESTROY_ESTACK(stack);
-			if (bytes != NULL)
-			    erts_free(ERTS_ALC_T_TMP, bytes);
+			if (buf != NULL)
+			    erts_free(ERTS_ALC_T_TMP, buf);
 			return NIL;
 		    }
 		    left -= sres;
@@ -217,8 +191,8 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		} else {
 		    *err = 1;
 		    DESTROY_ESTACK(stack);
-		    if (bytes != NULL)
-			erts_free(ERTS_ALC_T_TMP, bytes);
+		    if (buf != NULL)
+			erts_free(ERTS_ALC_T_TMP, buf);
 		    return NIL;
 		} 
 		if (!left || is_nil(ioterm) || !is_list(ioterm)) {
@@ -250,23 +224,23 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		ioterm = NIL;
 	    } else
 #endif 
-	    if is_binary(ioterm) {
+	    if (is_bitstring(ioterm)) {
 		int sres, serr;
 		ioterm = do_chksum(sumfun, p, ioterm, left, sum, &sres, &serr);
 		*res +=sres;
 		if (serr != 0) {
 		    *err = 1;
 		    DESTROY_ESTACK(stack);
-		    if (bytes != NULL)
-			erts_free(ERTS_ALC_T_TMP, bytes);
+		    if (buf != NULL)
+			erts_free(ERTS_ALC_T_TMP, buf);
 		    return NIL;
 		}
 		left -= sres;
 	    } else {
 		*err = 1;
 		DESTROY_ESTACK(stack);
-		if (bytes != NULL)
-		    erts_free(ERTS_ALC_T_TMP, bytes);
+		if (buf != NULL)
+		    erts_free(ERTS_ALC_T_TMP, buf);
 		return NIL;
 	    }
 	}
@@ -281,29 +255,29 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 	}
     }
     DESTROY_ESTACK(stack);
-    if (bytes != NULL)
-	erts_free(ERTS_ALC_T_TMP, bytes);
+    if (buf != NULL)
+	erts_free(ERTS_ALC_T_TMP, buf);
     return ioterm;
 }
 
-static void adler32_wrap(void *vsum, unsigned char *buf, unsigned buflen)
+static void adler32_wrap(void *vsum, const byte *buf, unsigned buflen)
 {
     unsigned long sum = *((unsigned long *) vsum);
     sum = adler32(sum,buf,buflen);
     *((unsigned long *) vsum) = sum;
 }
 
-static void crc32_wrap(void *vsum, unsigned char *buf, unsigned buflen)
+static void crc32_wrap(void *vsum, const byte *buf, unsigned buflen)
 {
     unsigned long sum = *((unsigned long *) vsum);
     sum = crc32(sum,buf,buflen);
     *((unsigned long *) vsum) = sum;
 }
 
-static void md5_wrap(void *vsum, unsigned char *buf, unsigned buflen)
+static void md5_wrap(void *vsum, const byte *buf, unsigned buflen)
 {
     MD5_CTX *ctx = ((MD5_CTX *) vsum);
-    MD5Update(ctx,buf,buflen);
+    MD5Update(ctx, (unsigned char*)buf, buflen);
 }
 
 #define BYTES_PER_REDUCTION 10
@@ -477,62 +451,78 @@ adler32_combine_3(BIF_ALIST_3)
 BIF_RETTYPE
 md5_1(BIF_ALIST_1)
 {
-    Eterm bin;
-    byte* bytes;
-    Eterm rest;
+    Eterm bin, rest;
     int res, err;
 
     MD5_CTX context;
     MD5Init(&context);
-    
+
     rest = do_chksum(&md5_wrap,BIF_P,BIF_ARG_1,100,(void *) &context,&res,
-		     &err);
+                     &err);
+
     if (err != 0) {
-	BUMP_REDS(BIF_P,res);
-	BIF_ERROR(BIF_P, BADARG);
+        BUMP_REDS(BIF_P,res);
+        BIF_ERROR(BIF_P, BADARG);
     }
+
     if (rest != NIL) {
-	BUMP_ALL_REDS(BIF_P);
-	 bin = new_binary(BIF_P, (byte *) &context, sizeof(MD5_CTX));
-	 BIF_TRAP2(&chksum_md5_2_exp, BIF_P, bin, rest);
+        BUMP_ALL_REDS(BIF_P);
+
+        bin = erts_new_binary_from_data(BIF_P, sizeof(MD5_CTX), (byte*)&context);
+
+        BIF_TRAP2(&chksum_md5_2_exp, BIF_P, bin, rest);
+    } else {
+        byte checksum[MD5_SIZE];
+
+        BUMP_REDS(BIF_P, res);
+        MD5Final(checksum, &context);
+
+        return erts_new_binary_from_data(BIF_P, MD5_SIZE, checksum);
     }
-    BUMP_REDS(BIF_P,res);
-    bin = new_binary(BIF_P, (byte *)NULL, 16);
-    bytes = binary_bytes(bin);
-    MD5Final(bytes, &context);
-    BIF_RET(bin);
 }
 
 /* Hidden trap target */
 static BIF_RETTYPE
 md5_2(BIF_ALIST_2)
 {
-    byte *bytes;
+    Uint offset, size;
     MD5_CTX context;
+    byte *bytes;
     Eterm rest;
     Eterm bin;
     int res, err;
 
     /* No need to check context, this function cannot be called with unaligned
-       or badly sized context as it's always trapped to. */
-    bytes = binary_bytes(BIF_ARG_1);
-    sys_memcpy(&context,bytes,sizeof(MD5_CTX));
-    rest = do_chksum(&md5_wrap,BIF_P,BIF_ARG_2,100,(void *) &context,&res,
-		     &err);
+     * or badly sized context as it's always trapped to. */
+    ERTS_GET_BITSTRING(BIF_ARG_1, bytes, offset, size);
+
+    ASSERT((offset == 0) && (size == NBITS(sizeof(MD5_CTX))));
+    (void)offset;
+    (void)size;
+
+    sys_memcpy(&context, bytes, sizeof(MD5_CTX));
+    rest = do_chksum(&md5_wrap, BIF_P, BIF_ARG_2, 100, (void*)&context, &res,
+                     &err);
+
     if (err != 0) {
-	BUMP_REDS(BIF_P,res);
-	BIF_ERROR(BIF_P, BADARG);
+        BUMP_REDS(BIF_P,res);
+        BIF_ERROR(BIF_P, BADARG);
     }
+
     if (rest != NIL) {
-	BUMP_ALL_REDS(BIF_P);
-	bin = new_binary(BIF_P, (byte *) &context, sizeof(MD5_CTX));
-	BIF_TRAP2(&chksum_md5_2_exp, BIF_P, bin, rest);
+        BUMP_ALL_REDS(BIF_P);
+
+        bin = erts_new_binary_from_data(BIF_P, sizeof(MD5_CTX), (byte*)&context);
+
+        BIF_TRAP2(&chksum_md5_2_exp, BIF_P, bin, rest);
+    } else {
+        byte checksum[MD5_SIZE];
+
+        BUMP_REDS(BIF_P, res);
+        MD5Final(checksum, &context);
+
+        return erts_new_binary_from_data(BIF_P, MD5_SIZE, checksum);
     }
-    BUMP_REDS(BIF_P,res);
-    bin = new_binary(BIF_P, (byte *)NULL, 16);
-    bytes = binary_bytes(bin);
-    MD5Final(bytes, &context);
-    BIF_RET(bin);
 }
 
 BIF_RETTYPE
@@ -541,42 +531,45 @@ md5_init_0(BIF_ALIST_0)
     Eterm bin;
     byte* bytes;
 
-    bin = erts_new_heap_binary(BIF_P, (byte *)NULL, sizeof(MD5_CTX), &bytes);
-    MD5Init((MD5_CTX *)bytes);
+    bin = erts_new_binary(BIF_P, sizeof(MD5_CTX), &bytes);
+    MD5Init((MD5_CTX*)bytes);
+
     BIF_RET(bin);
 }
 
 BIF_RETTYPE
 md5_update_2(BIF_ALIST_2)
 {
-    byte *bytes;
-    MD5_CTX context;
+    const byte *temp_alloc = NULL, *bytes;
+    MD5_CTX *context;
     Eterm rest;
     Eterm bin;
     int res, err;
-    byte *temp_alloc = NULL;
+    Uint size;
 
-    if ((bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc)) == NULL) {
-	erts_free_aligned_binary_bytes(temp_alloc);
-	BIF_ERROR(BIF_P, BADARG);
+    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (bytes == NULL || size != sizeof(MD5_CTX)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
-    if (binary_size(BIF_ARG_1) != sizeof(MD5_CTX)) {
-	erts_free_aligned_binary_bytes(temp_alloc);
-	BIF_ERROR(BIF_P, BADARG);
-    }
-    sys_memcpy(&context,bytes,sizeof(MD5_CTX));
+
+    bin = erts_new_binary(BIF_P, sizeof(MD5_CTX), (byte**)&context);
+    sys_memcpy(context, bytes, sizeof(MD5_CTX));
+
     erts_free_aligned_binary_bytes(temp_alloc);
-    rest = do_chksum(&md5_wrap,BIF_P,BIF_ARG_2,100,(void *) &context,&res,
-		     &err);
+
+    rest = do_chksum(&md5_wrap, BIF_P, BIF_ARG_2, 100, (void *)context, &res,
+                     &err);
+
     if (err != 0) {
-	BUMP_REDS(BIF_P,res);
-	BIF_ERROR(BIF_P, BADARG);
+        BUMP_REDS(BIF_P, res);
+        BIF_ERROR(BIF_P, BADARG);
     }
-    bin = new_binary(BIF_P, (byte *) &context, sizeof(MD5_CTX));
+
     if (rest != NIL) {
-	BUMP_ALL_REDS(BIF_P);
-	BIF_TRAP2(BIF_TRAP_EXPORT(BIF_md5_update_2), BIF_P, bin, rest);
+        BUMP_ALL_REDS(BIF_P);
+        BIF_TRAP2(BIF_TRAP_EXPORT(BIF_md5_update_2), BIF_P, bin, rest);
     }
+
     BUMP_REDS(BIF_P,res);
     BIF_RET(bin);
 }
@@ -584,23 +577,22 @@ md5_update_2(BIF_ALIST_2)
 BIF_RETTYPE
 md5_final_1(BIF_ALIST_1)
 {
-    Eterm bin;
-    byte* context;
-    byte* result;
+    const byte *temp_alloc = NULL, *context;
     MD5_CTX ctx_copy;
-    byte* temp_alloc = NULL;
+    byte* result;
+    Uint size;
+    Eterm bin;
 
-    if ((context = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc)) == NULL) {
-    error:
-	erts_free_aligned_binary_bytes(temp_alloc);
-	BIF_ERROR(BIF_P, BADARG);
+    context = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (context == NULL || size != sizeof(MD5_CTX)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
-    if (binary_size(BIF_ARG_1) != sizeof(MD5_CTX)) {
-	goto error;
-    }
-    bin = erts_new_heap_binary(BIF_P, (byte *)NULL, 16, &result);
+
     sys_memcpy(&ctx_copy, context, sizeof(MD5_CTX));
     erts_free_aligned_binary_bytes(temp_alloc);
+
+    bin = erts_new_binary(BIF_P, MD5_SIZE, &result);
     MD5Final(result, &ctx_copy);
+
     BIF_RET(bin);
 }

--- a/erts/emulator/beam/erl_bif_ddll.c
+++ b/erts/emulator/beam/erl_bif_ddll.c
@@ -49,6 +49,7 @@
 #include "erl_bif_unique.h"
 #include "dtrace-wrapper.h"
 #include "lttng-wrapper.h"
+#include "erl_iolist.h"
 
 /*
  * Local types

--- a/erts/emulator/beam/erl_bif_op.c
+++ b/erts/emulator/beam/erl_bif_op.c
@@ -202,15 +202,16 @@ BIF_RETTYPE is_tuple_1(BIF_ALIST_1)
 
 BIF_RETTYPE is_binary_1(BIF_ALIST_1)
 {
-    if (is_binary(BIF_ARG_1) && binary_bitsize(BIF_ARG_1) == 0) {
-	BIF_RET(am_true);
+    if (is_bitstring(BIF_ARG_1) && TAIL_BITS(bitstring_size(BIF_ARG_1)) == 0) {
+        BIF_RET(am_true);
     }
+
     BIF_RET(am_false);
 }
 
 BIF_RETTYPE is_bitstring_1(BIF_ALIST_1)
 {
-    if (is_binary(BIF_ARG_1)) {
+    if (is_bitstring(BIF_ARG_1)) {
 	BIF_RET(am_true);
     }
     BIF_RET(am_false);

--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -46,6 +46,8 @@
 #include "erl_proc_sig_queue.h"
 #include "erl_osenv.h"
 
+#define HALLOC_EXTRA 200
+
 static Port *open_port(Process* p, Eterm name, Eterm settings, int *err_typep, int *err_nump);
 static int merge_global_environment(erts_osenv_t *env, Eterm key_value_pairs);
 static char **convert_args(Eterm);
@@ -1279,58 +1281,32 @@ struct packet_callback_args
 {
     Process* p;  /* In */
     Eterm res;   /* Out */
+    ErtsHeapFactory factory;
     int string_as_bin; /* return strings as binaries (http_bin): */
-    byte* aligned_ptr;
-    Uint bin_sz;
+    const byte *aligned_ptr;
     Eterm orig;
-    Uint bin_offs;
-    byte bin_bitoffs;
+    Uint bin_sz;
 };
 
 #define in_area(ptr,start,nbytes) \
     ((UWord)((char*)(ptr) - (char*)(start)) < (nbytes))
 
 static Eterm
-http_bld_string(struct packet_callback_args* pca, Uint **hpp, Uint *szp,
-		const char *str, Sint len)
+http_bld_string(struct packet_callback_args* pca, const char *str, Sint len)
 {
-    Eterm res = THE_NON_VALUE;
-    Uint size;
-    int make_subbin;
-
     if (pca->string_as_bin) {
-	size = heap_bin_size(len);
-	make_subbin = (size > ERL_SUB_BIN_SIZE
-		       && in_area(str, pca->aligned_ptr, pca->bin_sz));
-	if (szp) {
-	    *szp += make_subbin ? ERL_SUB_BIN_SIZE : size;
-	}
-	if (hpp) {
-	    res = make_binary(*hpp);
-	    if (make_subbin) {
-		ErlSubBin* bin = (ErlSubBin*) *hpp;
-		bin->thing_word = HEADER_SUB_BIN;
-		bin->size = len;
-		bin->offs = pca->bin_offs + ((byte*)str - pca->aligned_ptr);
-		bin->orig = pca->orig;
-		bin->bitoffs = pca->bin_bitoffs;
-		bin->bitsize = 0;
-		bin->is_writable = 0;
-		*hpp += ERL_SUB_BIN_SIZE;
-	    }
-	    else {
-		ErlHeapBin* bin = (ErlHeapBin*) *hpp;
-		bin->thing_word = header_heap_bin(len);
-		bin->size = len;
-		sys_memcpy(bin->data, str, len);
-		*hpp += size;
-	    }
-	}
+        if (!ErtsInArea(str, pca->aligned_ptr, pca->bin_sz)) {
+            return erts_new_binary_from_data(pca->p, len, (byte*)str);
+        }
+
+        return erts_make_sub_binary(pca->p,
+                                    pca->orig,
+                                    ((byte*)str - pca->aligned_ptr),
+                                    len);
+    } else {
+        Eterm *hp = erts_produce_heap(&pca->factory, len * 2, HALLOC_EXTRA);
+        return erts_bld_string_n(&hp, NULL, str, len);
     }
-    else {
-	res = erts_bld_string_n(hpp, szp, str, len);
-    }
-    return res;
 }
 
 static int http_response_erl(void *arg, int major, int minor,
@@ -1339,54 +1315,59 @@ static int http_response_erl(void *arg, int major, int minor,
     /* {http_response,{Major,Minor},Status,"Phrase"} */
     struct packet_callback_args* pca = (struct packet_callback_args*) arg;    
     Eterm phrase_term, ver;
-    Uint hsize = 3 + 5;
-    Eterm* hp;
-#ifdef DEBUG
-    Eterm* hend;
-#endif
+    Eterm *hp;
 
-    http_bld_string(pca, NULL, &hsize, phrase, phrase_len);
-    hp = HAlloc(pca->p, hsize);
-#ifdef DEBUG
-    hend = hp + hsize;
-#endif
-    phrase_term = http_bld_string(pca, &hp, NULL, phrase, phrase_len);
-    ver = TUPLE2(hp, make_small(major), make_small(minor));
-    hp += 3;
-    pca->res = TUPLE4(hp, am_http_response, ver, make_small(status), phrase_term);
-    ASSERT(hp+5==hend);
+    phrase_term = http_bld_string(pca, phrase, phrase_len);
+
+    hp = erts_produce_heap(&pca->factory, 3 + 5, HALLOC_EXTRA);
+    ver = TUPLE2(&hp[0], make_small(major), make_small(minor));
+    pca->res = TUPLE4(&hp[3],
+                      am_http_response,
+                      ver,
+                      make_small(status),
+                      phrase_term);
+
     return 1;
-}   
-    
-static Eterm http_bld_uri(struct packet_callback_args* pca,
-			  Eterm** hpp, Uint* szp, const PacketHttpURI* uri)
+}
+
+static Eterm http_bld_uri(struct packet_callback_args* pca, const PacketHttpURI* uri)
 {
     Eterm s1, s2;
+
     if (uri->type == URI_STAR) {
         return am_Times; /* '*' */
     }
 
-    s1 = http_bld_string(pca, hpp, szp, uri->s1_ptr, uri->s1_len);
+    s1 = http_bld_string(pca, uri->s1_ptr, uri->s1_len);
 
     switch (uri->type) {
     case URI_ABS_PATH:
-        return erts_bld_tuple(hpp, szp, 2, am_abs_path, s1);
+        {
+            Eterm *hp = erts_produce_heap(&pca->factory, 3, HALLOC_EXTRA);
+            return TUPLE2(hp, am_abs_path, s1);
+        }
     case URI_HTTP:
     case URI_HTTPS:
-        s2 = http_bld_string(pca, hpp, szp, uri->s2_ptr, uri->s2_len);
-        return erts_bld_tuple
-            (hpp, szp, 5, am_absoluteURI, 
-             ((uri->type==URI_HTTP) ? am_http : am_https),
-             s1, 
-             ((uri->port==0) ? am_undefined : make_small(uri->port)),
-             s2);
-        
+        {
+            Eterm *hp;
+            s2 = http_bld_string(pca, uri->s2_ptr, uri->s2_len);
+            hp = erts_produce_heap(&pca->factory, 6, HALLOC_EXTRA);
+            return TUPLE5(hp,
+                          am_absoluteURI,
+                          ((uri->type==URI_HTTP) ? am_http : am_https),
+                          s1,
+                          ((uri->port==0) ? am_undefined : make_small(uri->port)),
+                          s2);
+        }
     case URI_STRING:
         return s1;
     case URI_SCHEME:
-        s2 = http_bld_string(pca, hpp, szp, uri->s2_ptr, uri->s2_len);
-        return erts_bld_tuple(hpp, szp, 3, am_scheme, s1, s2);
-                              
+        {
+            Eterm *hp;
+            s2 = http_bld_string(pca, uri->s2_ptr, uri->s2_len);
+            hp = erts_produce_heap(&pca->factory, 4, HALLOC_EXTRA);
+            return TUPLE3(hp, am_scheme, s1, s2);
+        }
     default:
         erts_exit(ERTS_ERROR_EXIT, "%s, line %d: type=%u\n", __FILE__, __LINE__, uri->type);
     }
@@ -1398,71 +1379,53 @@ static int http_request_erl(void* arg, const http_atom_t* meth,
 {
     struct packet_callback_args* pca = (struct packet_callback_args*) arg;    
     Eterm meth_term, uri_term, ver_term;
-    Uint sz = 0;
-    Uint* szp = &sz;
-    Eterm* hp;
-    Eterm** hpp = NULL;
+    Eterm *hp;
 
     /* {http_request,Meth,Uri,Version} */
+    meth_term = (meth != NULL) ?
+        meth->atom :
+        http_bld_string(pca, meth_ptr, meth_len);
+    uri_term = http_bld_uri(pca, uri);
 
-    for (;;) {
-        meth_term = (meth!=NULL) ? meth->atom :
-	    http_bld_string(pca, hpp, szp, meth_ptr, meth_len);
-        uri_term = http_bld_uri(pca, hpp, szp, uri);
-        ver_term = erts_bld_tuple(hpp, szp, 2,
-                                  make_small(major), make_small(minor));
-        pca->res = erts_bld_tuple(hpp, szp, 4, am_http_request, meth_term,
-                                  uri_term, ver_term); 
-        if (hpp != NULL) break;
-        hpp = &hp;
-        hp = HAlloc(pca->p, sz);
-        szp = NULL;        
-    }
+    hp = erts_produce_heap(&pca->factory, 3 + 5, HALLOC_EXTRA);
+    ver_term = TUPLE2(&hp[0], make_small(major), make_small(minor));
+    pca->res = TUPLE4(&hp[3], am_http_request, meth_term, uri_term, ver_term);
+
     return 1;
 }
 
 static int
 http_header_erl(void* arg, const http_atom_t* name,
-		const char* name_ptr, int name_len,
-		const char* oname_ptr, int oname_len,
-		const char* value_ptr, int value_len)
+                const char* name_ptr, int name_len,
+                const char* oname_ptr, int oname_len,
+                const char* value_ptr, int value_len)
 {
     struct packet_callback_args* pca = (struct packet_callback_args*) arg;    
     Eterm bit_term, name_term, oname_term, val_term;
-    Uint sz = 6;
-    Eterm* hp;
-#ifdef DEBUG
-    Eterm* hend;
-#endif
-    
+    Eterm *hp;
+
     /* {http_header,Bit,Name,Oname,Value} */
-
-    if (name == NULL) {
-	http_bld_string(pca, NULL, &sz, name_ptr, name_len);
-    }
-    http_bld_string(pca, NULL, &sz, oname_ptr, oname_len);
-    http_bld_string(pca, NULL, &sz, value_ptr, value_len);
-
-    hp = HAlloc(pca->p, sz);
-#ifdef DEBUG
-    hend = hp + sz;
-#endif	
-
     if (name != NULL) {
-	bit_term = make_small(name->index+1);
-	name_term = name->atom;
-    }
-    else {	
-	bit_term = make_small(0);	
-	name_term = http_bld_string(pca, &hp,NULL,name_ptr,name_len);
+        bit_term = make_small(name->index+1);
+        name_term = name->atom;
+    } else {
+        bit_term = make_small(0);
+        name_term = http_bld_string(pca, name_ptr, name_len);
     }
 
-    oname_term = http_bld_string(pca, &hp, NULL, oname_ptr, oname_len);
-    val_term = http_bld_string(pca, &hp, NULL, value_ptr, value_len);
-    pca->res = TUPLE5(hp, am_http_header, bit_term, name_term, oname_term, val_term);
-    ASSERT(hp+6==hend);
+    oname_term = http_bld_string(pca, oname_ptr, oname_len);
+    val_term = http_bld_string(pca, value_ptr, value_len);
+
+    hp = erts_produce_heap(&pca->factory, 6, HALLOC_EXTRA);
+    pca->res = TUPLE5(hp,
+                      am_http_header,
+                      bit_term,
+                      name_term,
+                      oname_term,
+                      val_term);
+
     return 1;
-}   
+}
 
 static int http_eoh_erl(void* arg)
 {
@@ -1476,21 +1439,11 @@ static int http_error_erl(void* arg, const char* buf, int len)
 {
     /* {http_error,Line} */
     struct packet_callback_args* pca = (struct packet_callback_args*) arg;
-    Uint sz = 3;
     Eterm* hp;
-#ifdef DEBUG
-    Eterm* hend;
-#endif
 
-    http_bld_string(pca, NULL, &sz, buf, len);
+    hp = erts_produce_heap(&pca->factory, 3, HALLOC_EXTRA);
+    pca->res = TUPLE2(hp, am_http_error, http_bld_string(pca, buf, len));
 
-    hp = HAlloc(pca->p, sz);
-#ifdef DEBUG
-    hend = hp + sz;
-#endif
-    pca->res = erts_bld_tuple(&hp, NULL, 2, am_http_error,
-			      http_bld_string(pca, &hp, NULL, buf, len));
-    ASSERT(hp==hend);
     return 1;
 }
 
@@ -1501,19 +1454,23 @@ int ssl_tls_erl(void* arg, unsigned type, unsigned major, unsigned minor,
     struct packet_callback_args* pca = (struct packet_callback_args*) arg;
     Eterm* hp;
     Eterm ver;
-    Eterm bin = new_binary(pca->p, NULL, plen+len);
-    byte* bin_ptr = binary_bytes(bin);
+    byte* bin_ptr;
 
-    sys_memcpy(bin_ptr+plen, buf, len);
+    Eterm bin = erts_hfact_new_bitstring(&pca->factory,
+                                         0,
+                                         NBITS(plen + len),
+                                         &bin_ptr);
+    sys_memcpy(bin_ptr + plen, buf, len);
+
     if (plen) {
         sys_memcpy(bin_ptr, prefix, plen);
     }
 
     /* {ssl_tls,NIL,ContentType,{Major,Minor},Bin} */
-    hp = HAlloc(pca->p, 3+6);
-    ver = TUPLE2(hp, make_small(major), make_small(minor));
-    hp += 3;
-    pca->res = TUPLE5(hp, am_ssl_tls, NIL, make_small(type), ver, bin);
+    hp = erts_produce_heap(&pca->factory, 3 + 6, HALLOC_EXTRA);
+    ver = TUPLE2(&hp[0], make_small(major), make_small(minor));
+    pca->res = TUPLE5(&hp[3], am_ssl_tls, NIL, make_small(type), ver, bin);
+
     return 1;
 }
 
@@ -1536,22 +1493,17 @@ PacketCallbacks packet_callbacks_erl = {
 */
 BIF_RETTYPE decode_packet_3(BIF_ALIST_3)
 {
+
     unsigned max_plen = 0;   /* Packet max length, 0=no limit */
     unsigned trunc_len = 0;  /* Truncate lines if longer, 0=no limit */
     int http_state = 0;      /* 0=request/response 1=header */
-    int packet_sz;           /*-------Binaries involved: ------------------*/
-    byte* bin_ptr;           /*| orig: original binary                     */
-    byte bin_bitsz;          /*| bin: BIF_ARG_2, may be sub-binary of orig */
-	                     /*| packet: prefix of bin                     */
-    char* body_ptr;          /*| body: part of packet to return            */
-    int body_sz;             /*| rest: bin without packet                  */
+    int packet_sz;
+    char* body_ptr;
+    int body_sz;
     struct packet_callback_args pca;
     enum PacketParseType type;
-    Eterm* hp;
-    Eterm* hend;
-    ErlSubBin* rest;
+    const byte *temp_alloc = NULL;
     Eterm res;
-    Eterm options;
     int   code;
     char  delimiter = '\n';
 
@@ -1576,123 +1528,109 @@ BIF_RETTYPE decode_packet_3(BIF_ALIST_3)
         BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
     }
 
-    if (!is_binary(BIF_ARG_2) ||
+    if (!is_bitstring(BIF_ARG_2) ||
         (!is_list(BIF_ARG_3) && !is_nil(BIF_ARG_3))) {
         BIF_ERROR(BIF_P, BADARG);
     }
 
-    options = BIF_ARG_3;
-    while (!is_nil(options)) {
-        Eterm* cons = list_val(options);
-        if (is_tuple(CAR(cons))) {
-            Eterm* tpl = tuple_val(CAR(cons));
-            Uint val;
-            if (tpl[0] == make_arityval(2) &&
-		term_to_Uint(tpl[2],&val) && val <= UINT_MAX) {
-                switch (tpl[1]) {
-                case am_packet_size:
-                    max_plen = val;
-                    goto next_option;
-                case am_line_length:
-                    trunc_len = val;
-                    goto next_option;
-                case am_line_delimiter:
-                    if (type == TCP_PB_LINE_LF && val <= 255) {
-                        delimiter = (char)val;
-                        goto next_option;
+    for (Eterm options = BIF_ARG_3, *cell = NULL;
+         !is_nil(options);
+         options = CDR(cell)) {
+        if (is_list(options)) {
+            cell = list_val(options);
+
+            if (is_tuple(CAR(cell))) {
+                Eterm *tpl = tuple_val(CAR(cell));
+                Uint val;
+
+                if (tpl[0] == make_arityval(2) &&
+                    term_to_Uint(tpl[2], &val) && val <= UINT_MAX) {
+                    switch (tpl[1]) {
+                    case am_packet_size:
+                        max_plen = val;
+                        continue;
+                    case am_line_length:
+                        trunc_len = val;
+                        continue;
+                    case am_line_delimiter:
+                        if (type == TCP_PB_LINE_LF && val <= 255) {
+                            delimiter = (char)val;
+                            continue;
+                        }
                     }
                 }
             }
         }
+
         BIF_ERROR(BIF_P, BADARG);
-
-    next_option:       
-        options = CDR(cons);
     }
 
+    pca.orig = BIF_ARG_2;
+    pca.aligned_ptr = erts_get_aligned_binary_bytes(pca.orig,
+                                                    &pca.bin_sz,
+                                                    &temp_alloc);
+    if (pca.aligned_ptr == NULL) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
 
-    pca.bin_sz = binary_size(BIF_ARG_2);
-    ERTS_GET_BINARY_BYTES(BIF_ARG_2, bin_ptr, pca.bin_bitoffs, bin_bitsz);  
-    if (pca.bin_bitoffs != 0) {
-        pca.aligned_ptr = erts_alloc(ERTS_ALC_T_TMP, pca.bin_sz);
-        erts_copy_bits(bin_ptr, pca.bin_bitoffs, 1, pca.aligned_ptr, 0, 1, pca.bin_sz*8);
-    }
-    else {
-        pca.aligned_ptr = bin_ptr;
-    }
     packet_sz = packet_get_length(type, (char*)pca.aligned_ptr, pca.bin_sz,
                                   max_plen, trunc_len, delimiter, &http_state);
-    if (!(packet_sz > 0 && packet_sz <= pca.bin_sz)) {
-        if (packet_sz < 0) {
-	    goto error;
+
+    if (packet_sz < 0) {
+        Eterm *hp = HAlloc(BIF_P, 3);
+        res = TUPLE2(hp, am_error, am_invalid);
+    } else if (packet_sz == 0 || packet_sz > pca.bin_sz) {
+        Eterm* hp = HAlloc(BIF_P, 3);
+        Eterm required_size = (packet_sz == 0) ?
+            am_undefined :
+            erts_make_integer(packet_sz, BIF_P);
+        res = TUPLE2(hp, am_more, required_size);
+    } else {
+        /* We got a whole packet, parse it */
+        body_ptr = (char*) pca.aligned_ptr;
+        body_sz = packet_sz;
+        packet_get_body(type, (const char**) &body_ptr, &body_sz);
+        ASSERT(body_sz <= packet_sz);
+
+        pca.p = BIF_P;
+        pca.res = THE_NON_VALUE;
+        pca.string_as_bin = (type == TCP_PB_HTTP_BIN ||
+                             type == TCP_PB_HTTPH_BIN);
+
+        erts_factory_proc_init(&pca.factory, BIF_P);
+        code = packet_parse(type, (char*)pca.aligned_ptr, packet_sz,
+                            &http_state, &packet_callbacks_erl, &pca);
+
+        if (code < 0) {
+            Eterm *hp = erts_produce_heap(&pca.factory, 3, 0);
+            res = TUPLE2(hp, am_error, am_invalid);
+        } else {
+            Eterm *hp = erts_produce_heap(&pca.factory, 4, 0);
+            Eterm rest;
+
+            if (code == 0) {
+                /* no special packet parsing, make plain binary */
+                pca.res = erts_make_sub_binary(BIF_P, BIF_ARG_2,
+                                               (body_ptr - (char*)pca.aligned_ptr),
+                                               body_sz);
+            } else {
+                ASSERT(pca.res != THE_NON_VALUE);
+            }
+
+            rest = erts_make_sub_binary(BIF_P, BIF_ARG_2,
+                                        packet_sz,
+                                        pca.bin_sz - packet_sz);
+
+            res = TUPLE3(hp, am_ok, pca.res, rest);
         }
-        else { /* not enough data */
-            Eterm plen = (packet_sz==0) ? am_undefined : 
-                erts_make_integer(packet_sz, BIF_P);
-            Eterm* hp = HAlloc(BIF_P,3);        
-            res = TUPLE2(hp, am_more, plen);
-            goto done;
-        }
-    }
-    /* We got a whole packet */
 
-    body_ptr = (char*) pca.aligned_ptr;
-    body_sz = packet_sz;
-    packet_get_body(type, (const char**) &body_ptr, &body_sz);
-
-    ERTS_GET_REAL_BIN(BIF_ARG_2, pca.orig, pca.bin_offs, pca.bin_bitoffs, bin_bitsz);
-    pca.p = BIF_P;
-    pca.res = THE_NON_VALUE;
-    pca.string_as_bin = (type == TCP_PB_HTTP_BIN || type == TCP_PB_HTTPH_BIN);
-    code = packet_parse(type, (char*)pca.aligned_ptr, packet_sz, &http_state,
-			&packet_callbacks_erl, &pca);
-    if (code == 0) { /* no special packet parsing, make plain binary */
-        ErlSubBin* body;
-        Uint hsz = 2*ERL_SUB_BIN_SIZE + 4;
-        hp = HAlloc(BIF_P, hsz);
-        hend = hp + hsz;
-
-        body = (ErlSubBin *) hp;
-        body->thing_word = HEADER_SUB_BIN;
-        body->size = body_sz;
-        body->offs = pca.bin_offs + (body_ptr - (char*)pca.aligned_ptr);
-        body->orig = pca.orig;
-        body->bitoffs = pca.bin_bitoffs;
-        body->bitsize = 0;
-        body->is_writable = 0;
-        hp += ERL_SUB_BIN_SIZE;
-        pca.res = make_binary(body);
-    }
-    else if (code > 0) {
-	Uint hsz = ERL_SUB_BIN_SIZE + 4;
-	ASSERT(pca.res != THE_NON_VALUE);
-	hp = HAlloc(BIF_P, hsz);
-	hend = hp + hsz;
-    }
-    else {
-error:
-	hp = HAlloc(BIF_P,3);        
-	res = TUPLE2(hp, am_error, am_invalid);
-	goto done;
+        erts_factory_close(&pca.factory);
     }
 
-    rest = (ErlSubBin *) hp;
-    rest->thing_word = HEADER_SUB_BIN;
-    rest->size = pca.bin_sz - packet_sz;
-    rest->offs = pca.bin_offs + packet_sz;
-    rest->orig = pca.orig;
-    rest->bitoffs = pca.bin_bitoffs;
-    rest->bitsize = bin_bitsz;   /* The extra bits go into the rest. */
-    rest->is_writable = 0;
-    hp += ERL_SUB_BIN_SIZE;
-    res = TUPLE3(hp, am_ok, pca.res, make_binary(rest));
-    hp += 4;
-    ASSERT(hp==hend); (void)hend;
-
-done:
-    if (pca.aligned_ptr != bin_ptr) {
-        erts_free(ERTS_ALC_T_TMP, pca.aligned_ptr);
+    if (temp_alloc != NULL) {
+        erts_free_aligned_binary_bytes(temp_alloc);
     }
+
     BIF_RET(res);
 }
 

--- a/erts/emulator/beam/erl_binary.h
+++ b/erts/emulator/beam/erl_binary.h
@@ -35,24 +35,36 @@
 ** in reality are equal.
 */
 
-#ifdef ARCH_32
- /* *DO NOT USE* only for alignment. */
-#define ERTS_BINARY_STRUCT_ALIGNMENT Uint32 align__;
-#else
+enum binary_flags {
+    BIN_FLAG_MAGIC =            (1 << 0),
+    BIN_FLAG_DRV =              (1 << 1),
+
+    /* Whether the binary is writable and/or actively written to. These are
+     * valid iff the reference count is 1: any kind of observation, including
+     * copying to another process, must clear these flags. */
+    BIN_FLAG_WRITABLE =         (1 << 2),
+    BIN_FLAG_ACTIVE_WRITER =    (1 << 3),
+};
+
 #define ERTS_BINARY_STRUCT_ALIGNMENT
-#endif
 
 /* Add fields in binary_internals, otherwise the drivers crash */
 struct binary_internals {
     UWord flags;
+    /* Valid iff one of BIN_FLAG_WRITABLE and BIN_FLAG_MAGIC is set. */
+    UWord apparent_size;
     erts_refc_t refc;
+
     ERTS_BINARY_STRUCT_ALIGNMENT
 };
-
 
 typedef struct binary {
     struct binary_internals intern;
     SWord orig_size;
+
+    /* Note that this field has to be 8-byte aligned even on 32-bit
+     * platforms. Any required padding should be added at the tail of
+     * the binary_internals struct above. */
     char orig_bytes[1]; /* to be continued */
 } Binary;
 
@@ -61,6 +73,13 @@ typedef struct binary {
 
 #if ERTS_REF_NUMBERS != 3
 #error "Update ErtsMagicBinary"
+#endif
+
+#ifdef ARCH_32
+ /* *DO NOT USE* only for alignment. */
+#define ERTS_MAGIC_BINARY_STRUCT_ALIGNMENT Uint32 align__;
+#else
+#define ERTS_MAGIC_BINARY_STRUCT_ALIGNMENT
 #endif
 
 typedef struct magic_binary ErtsMagicBinary;
@@ -72,7 +91,7 @@ struct magic_binary {
     ErtsAlcType_t alloc_type;
     union {
         struct {
-            ERTS_BINARY_STRUCT_ALIGNMENT
+            ERTS_MAGIC_BINARY_STRUCT_ALIGNMENT
             char data[1];
         } aligned;
         struct {
@@ -144,10 +163,6 @@ typedef union {
 				(((char *) (D)) \
 				 - offsetof(ErtsBinary, driver.binary)))
 
-/* A "magic" binary flag */
-#define BIN_FLAG_MAGIC      1
-#define BIN_FLAG_DRV        2
-
 #endif /* ERL_BINARY_H__TYPES__ */
 
 #if !defined(ERL_BINARY_H__) && !defined(ERTS_BINARY_TYPES_ONLY__)
@@ -158,118 +173,8 @@ typedef union {
 #include "erl_bif_unique.h"
 #include "erl_bits.h"
 
-/*
- * Maximum number of bytes to place in a heap binary.
- */
-
-#define ERL_ONHEAP_BIN_LIMIT 64
-
-#define ERL_SUB_BIN_SIZE (sizeof(ErlSubBin)/sizeof(Eterm))
-#define HEADER_SUB_BIN	_make_header(ERL_SUB_BIN_SIZE-2,_TAG_HEADER_SUB_BIN)
-
-/*
- * This structure represents a HEAP_BINARY.
- */
-
-typedef struct erl_heap_bin {
-    Eterm thing_word;		/* Subtag HEAP_BINARY_SUBTAG. */
-    Uint size;			/* Binary size in bytes. */
-    Eterm data[1];		/* The data in the binary. */
-} ErlHeapBin;
-
-#define heap_bin_size(num_bytes)		\
-  (sizeof(ErlHeapBin)/sizeof(Eterm) - 1 +	\
-   ((num_bytes)+sizeof(Eterm)-1)/sizeof(Eterm))
-
-#define header_heap_bin(num_bytes) \
-  _make_header(heap_bin_size(num_bytes)-1,_TAG_HEADER_HEAP_BIN)
-
-/*
- * Get the size in bytes of any type of binary.
- */
-
-#define binary_size(Bin) (binary_val(Bin)[1])
-
-#define binary_bitsize(Bin)			\
-  ((*binary_val(Bin) == HEADER_SUB_BIN) ?	\
-   ((ErlSubBin *) binary_val(Bin))->bitsize:	\
-   0)
-
-#define binary_bitoffset(Bin)			\
-  ((*binary_val(Bin) == HEADER_SUB_BIN) ?	\
-   ((ErlSubBin *) binary_val(Bin))->bitoffs:	\
-   0)
-
-/*
- * Get the pointer to the actual data bytes in a binary.
- * Works for any type of binary. Always use binary_bytes() if
- * you know that the binary cannot be a sub binary.
- *
- * Bin: input variable (Eterm)
- * Bytep: output variable (byte *)
- * Bitoffs: output variable (Uint)
- * Bitsize: output variable (Uint)
- */
-
-#define ERTS_GET_BINARY_BYTES(Bin,Bytep,Bitoffs,Bitsize)                \
-do {									\
-    Eterm* _real_bin = binary_val(Bin);		                	\
-    Uint _offs = 0;							\
-    Bitoffs = Bitsize = 0;						\
-    if (*_real_bin == HEADER_SUB_BIN) {					\
-	ErlSubBin* _sb = (ErlSubBin *) _real_bin;			\
-	_offs = _sb->offs;						\
-        Bitoffs = _sb->bitoffs;						\
-        Bitsize = _sb->bitsize;						\
-	_real_bin = binary_val(_sb->orig);	        		\
-    }									\
-    if (*_real_bin == HEADER_PROC_BIN) {				\
-	Bytep = ((ProcBin *) _real_bin)->bytes + _offs;			\
-    } else {								\
-	Bytep = (byte *)(&(((ErlHeapBin *) _real_bin)->data)) + _offs;	\
-    }									\
-} while (0)
-
-/*
- * Get the real binary from any binary type, where "real" means
- * a REFC or HEAP binary. Also get the byte and bit offset into the
- * real binary. Useful if you want to build a SUB binary from
- * any binary.
- *
- * Bin: Input variable (Eterm)
- * RealBin: Output variable (Eterm)
- * ByteOffset: Output variable (Uint)
- * BitOffset: Offset in bits (Uint)
- * BitSize: Extra bit size (Uint)
- */
-
-#define ERTS_GET_REAL_BIN(Bin, RealBin, ByteOffset, BitOffset, BitSize) \
-  do {									\
-    ErlSubBin* _sb = (ErlSubBin *) binary_val(Bin);	                \
-    if (_sb->thing_word == HEADER_SUB_BIN) {				\
-      RealBin = _sb->orig;						\
-      ByteOffset = _sb->offs;						\
-      BitOffset = _sb->bitoffs;						\
-      BitSize = _sb->bitsize;						\
-    } else {								\
-      RealBin = Bin;							\
-      ByteOffset = BitOffset = BitSize = 0;				\
-    }									\
-  } while (0)
-
-/*
- * Get a pointer to the binary bytes, for a heap or refc binary
- * (NOT sub binary).
- */
-#define binary_bytes(Bin)						\
-  (*binary_val(Bin) == HEADER_PROC_BIN ?				\
-   ((ProcBin *) binary_val(Bin))->bytes :				\
-   (ASSERT(thing_subtag(*binary_val(Bin)) == HEAP_BINARY_SUBTAG),	\
-   (byte *)(&(((ErlHeapBin *) binary_val(Bin))->data))))
-
 void erts_init_binary(void);
 
-byte* erts_get_aligned_binary_bytes_extra(Eterm, byte**, ErtsAlcType_t, unsigned extra);
 /* Used by unicode module */
 Eterm erts_bin_bytes_to_list(Eterm previous, Eterm* hp, const byte* bytes, Uint size, Uint bitoffs);
 
@@ -299,9 +204,6 @@ typedef struct {
 #define ERTS_CHK_BIN_ALIGNMENT(B) \
   do { ASSERT(!(B) || (((UWord) &((Binary *)(B))->orig_bytes[0]) & ERTS_BIN_ALIGNMENT_MASK) == ((UWord) 0)); } while(0)
 
-ERTS_GLB_INLINE byte* erts_get_aligned_binary_bytes(Eterm bin, byte** base_ptr);
-ERTS_GLB_INLINE void erts_free_aligned_binary_bytes(byte* buf);
-ERTS_GLB_INLINE void erts_free_aligned_binary_bytes_extra(byte* buf, ErtsAlcType_t);
 ERTS_GLB_INLINE Binary *erts_bin_drv_alloc_fnf(Uint size);
 ERTS_GLB_INLINE Binary *erts_bin_drv_alloc(Uint size);
 ERTS_GLB_INLINE Binary *erts_bin_nrml_alloc_fnf(Uint size);
@@ -334,26 +236,6 @@ ERTS_GLB_INLINE erts_atomic_t *erts_binary_to_magic_indirection(Binary *bp);
 #if ERTS_GLB_INLINE_INCL_FUNC_DEF
 
 #include <stddef.h> /* offsetof */
-
-ERTS_GLB_INLINE byte*
-erts_get_aligned_binary_bytes(Eterm bin, byte** base_ptr)
-{
-    return erts_get_aligned_binary_bytes_extra(bin, base_ptr, ERTS_ALC_T_TMP, 0);
-}
-
-ERTS_GLB_INLINE void
-erts_free_aligned_binary_bytes_extra(byte* buf, ErtsAlcType_t allocator)
-{
-    if (buf) {
-	erts_free(allocator, (void *) buf);
-    }
-}
-
-ERTS_GLB_INLINE void
-erts_free_aligned_binary_bytes(byte* buf)
-{
-    erts_free_aligned_binary_bytes_extra(buf,ERTS_ALC_T_TMP);
-}
 
 /* Explicit extra bytes allocated to counter buggy drivers.
 ** These extra bytes where earlier (< R13B04) added by an alignment-bug
@@ -523,6 +405,7 @@ erts_create_magic_binary_x(Uint size, int (*destructor)(Binary *),
 	erts_alloc_n_enomem(ERTS_ALC_T2N(alloc_type), bsize);
     ERTS_CHK_BIN_ALIGNMENT(bptr);
     bptr->intern.flags = BIN_FLAG_MAGIC;
+    bptr->intern.apparent_size = size;
     bptr->orig_size = unaligned ? ERTS_MAGIC_BIN_UNALIGNED_ORIG_SIZE(size)
                                 : ERTS_MAGIC_BIN_ORIG_SIZE(size);
     erts_refc_init(&bptr->intern.refc, 0);

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -99,70 +99,52 @@ static byte get_bit(byte b, size_t a_offs);
   }while(0)					\
 
 Eterm
-erts_bs_start_match_2(Process *p, Eterm Binary, Uint Max)
+erts_bs_start_match_2(Process *p, Eterm bin, Uint Max)
 {
-    Eterm Orig;
-    Uint offs;
-    Uint* hp;
-    Uint NeededSize;
     ErlBinMatchState *ms;
-    Uint bitoffs;
-    Uint bitsize;
-    Uint total_bin_size;
-    ProcBin* pb;
+    Uint offset, size;
+    byte *base;
+    Eterm br_flags;
+    BinRef *br;
+    Uint* hp;
 
-    ASSERT(is_binary(Binary));
+    ASSERT(is_bitstring(bin));
 
-    total_bin_size = binary_size(Binary);
-    ASSERT(total_bin_size <= ERTS_UWORD_MAX / CHAR_BIT);
-
-    NeededSize = ERL_BIN_MATCHSTATE_SIZE(Max);
-    hp = HeapOnlyAlloc(p, NeededSize);
+    hp = HeapOnlyAlloc(p, ERL_BIN_MATCHSTATE_SIZE(Max));
     ms = (ErlBinMatchState *) hp;
-    ERTS_GET_REAL_BIN(Binary, Orig, offs, bitoffs, bitsize);
-    pb = (ProcBin *) boxed_val(Orig);
-    if (pb->thing_word == HEADER_PROC_BIN && pb->flags != 0) {
-	erts_emasculate_writable_binary(pb);
-    }
+
+    ERTS_PIN_BITSTRING(bin, br_flags, br, base, offset, size);
+
     ms->thing_word = HEADER_BIN_MATCHSTATE(Max);
-    (ms->mb).orig = Orig;
-    (ms->mb).base = binary_bytes(Orig);
-    (ms->mb).offset = ms->save_offset[0] = 8 * offs + bitoffs;
-    (ms->mb).size = total_bin_size * 8 + (ms->mb).offset + bitsize;
+    (ms->mb).orig = br ? ((Eterm)br | br_flags) : bin;
+    (ms->mb).base = base;
+    (ms->mb).offset = ms->save_offset[0] = offset;
+    (ms->mb).size = offset + size;
+
     return make_matchstate(ms);
 }
 
-ErlBinMatchState *erts_bs_start_match_3(Process *p, Eterm Binary)
+ErlBinMatchState *erts_bs_start_match_3(Process *p, Eterm bin)
 {
-    Eterm Orig;
-    Uint offs;
-    Uint* hp;
-    Uint NeededSize;
     ErlBinMatchState *ms;
-    Uint bitoffs;
-    Uint bitsize;
-    Uint total_bin_size;
-    ProcBin* pb;
+    Uint offset, size;
+    byte *base;
+    Eterm br_flags;
+    BinRef *br;
+    Uint* hp;
 
-    ASSERT(is_binary(Binary));
+    ASSERT(is_bitstring(bin));
 
-    total_bin_size = binary_size(Binary);
-    ASSERT(total_bin_size <= ERTS_UWORD_MAX / CHAR_BIT);
-
-    NeededSize = ERL_BIN_MATCHSTATE_SIZE(0);
-    hp = HeapOnlyAlloc(p, NeededSize);
+    hp = HeapOnlyAlloc(p, ERL_BIN_MATCHSTATE_SIZE(0));
     ms = (ErlBinMatchState *) hp;
-    ERTS_GET_REAL_BIN(Binary, Orig, offs, bitoffs, bitsize);
-    pb = (ProcBin *) boxed_val(Orig);
-    if (pb->thing_word == HEADER_PROC_BIN && pb->flags != 0) {
-        erts_emasculate_writable_binary(pb);
-    }
+
+    ERTS_PIN_BITSTRING(bin, br_flags, br, base, offset, size);
 
     ms->thing_word = HEADER_BIN_MATCHSTATE(0);
-    (ms->mb).orig = Orig;
-    (ms->mb).base = binary_bytes(Orig);
-    (ms->mb).offset = 8 * offs + bitoffs;
-    (ms->mb).size = total_bin_size * 8 + (ms->mb).offset + bitsize;
+    (ms->mb).orig = br ? ((Eterm)br | br_flags) : bin;
+    (ms->mb).base = base;
+    (ms->mb).offset = offset;
+    (ms->mb).size = offset + size;
 
     return ms;
 }
@@ -170,25 +152,35 @@ ErlBinMatchState *erts_bs_start_match_3(Process *p, Eterm Binary)
 #ifdef DEBUG
 # define CHECK_MATCH_BUFFER(MB) check_match_buffer(MB)
 
-static void check_match_buffer(ErlBinMatchBuffer* mb)
+static void check_match_buffer(const ErlBinMatchBuffer *mb)
 {
-    Eterm realbin;
-    Uint byteoffs;
-    byte* bytes, bitoffs, bitsz;
-    ProcBin* pb;
-    ERTS_GET_REAL_BIN(mb->orig, realbin, byteoffs, bitoffs, bitsz);
-    bytes = binary_bytes(realbin) + byteoffs;
-    ERTS_ASSERT(mb->base >= bytes && mb->base <= (bytes + binary_size(mb->orig)));
-    pb = (ProcBin *) boxed_val(realbin);
-    if (pb->thing_word == HEADER_PROC_BIN)
-        ERTS_ASSERT(pb->flags == 0);
+    Eterm *unboxed = boxed_val(mb->orig);
+    const byte *base;
+    Uint size;
+
+    if (*unboxed == HEADER_BIN_REF) {
+        const BinRef *br = (BinRef*)unboxed;
+        size = NBITS((br->val)->orig_size);
+        base = (byte*)br->bytes;
+        ASSERT(!((br->val)->intern.flags &
+                 (BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)));
+    } else {
+        const ErlHeapBits *hb = (ErlHeapBits*)unboxed;
+        size = hb->size;
+        base = (byte*)hb->data;
+    }
+
+    ASSERT(mb->size <= size);
+    ASSERT(mb->base >= base && mb->base <= (base + NBYTES(size)));
+    ASSERT(mb->offset <= (size - NBITS(mb->base - base)));
 }
 #else
 # define CHECK_MATCH_BUFFER(MB)
 #endif
 
 Eterm
-erts_bs_get_integer_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
+erts_bs_get_integer_2(
+Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
 {
     Uint bytes;
     Uint bits;
@@ -458,9 +450,11 @@ erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffe
      * From now on, we can't fail.
      */
 
-    result = erts_extract_sub_binary(&HEAP_TOP(p),
-                                     mb->orig, mb->base,
-                                     mb->offset, num_bits);
+    result = erts_build_sub_bitstring(&HEAP_TOP(p),
+                                      mb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(mb->orig),
+                                      mb->base,
+                                      mb->offset, num_bits);
 
     mb->offset += num_bits;
 
@@ -540,9 +534,11 @@ erts_bs_get_binary_all_2(Process *p, ErlBinMatchBuffer* mb)
     CHECK_MATCH_BUFFER(mb);
     bit_size = mb->size - mb->offset;
 
-    result = erts_extract_sub_binary(&HEAP_TOP(p),
-                                     mb->orig, mb->base,
-                                     mb->offset, bit_size);
+    result = erts_build_sub_bitstring(&HEAP_TOP(p),
+                                      mb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(mb->orig),
+                                      mb->base,
+                                      mb->offset, bit_size);
 
     mb->offset = mb->size;
 
@@ -1072,22 +1068,26 @@ erts_bs_put_utf16(ERL_BITS_PROTO_2(Eterm arg, Uint flags))
 int
 erts_new_bs_put_binary(Process *c_p, Eterm arg, Uint num_bits)
 {
-    byte *bptr;
-    Uint bitoffs;
-    Uint bitsize; 
     ERL_BITS_DEFINE_STATEP(c_p);
+    Uint offset, size;
+    byte *base;
 
-    if (!is_binary(arg)) {
+    if (!is_bitstring(arg)) {
         c_p->fvalue = arg;
         return 0;
     }
-    ERTS_GET_BINARY_BYTES(arg, bptr, bitoffs, bitsize);
-    if (num_bits > 8*binary_size(arg)+bitsize) {
+
+    ERTS_GET_BITSTRING(arg, base, offset, size);
+
+    if (num_bits > size) {
         c_p->fvalue = arg;
-	return 0;
+        return 0;
     }
-    copy_binary_to_buffer(erts_current_bin, erts_bin_offset, bptr, bitoffs, num_bits);
+
+    copy_binary_to_buffer(erts_current_bin, erts_bin_offset,
+                          base, offset, num_bits);
     erts_bin_offset += num_bits;
+
     BUMP_REDS(c_p, num_bits / BITS_PER_REDUCTION);
     return 1;
 }
@@ -1095,33 +1095,26 @@ erts_new_bs_put_binary(Process *c_p, Eterm arg, Uint num_bits)
 int
 erts_new_bs_put_binary_all(Process *c_p, Eterm arg, Uint unit)
 {
-   byte *bptr;
-   Uint bitoffs;
-   Uint bitsize;
-   Uint num_bits;
-   ERL_BITS_DEFINE_STATEP(c_p);
+    ERL_BITS_DEFINE_STATEP(c_p);
+    Uint offset, size;
+    byte *base;
 
-   /*
-    * This instruction is always preceded by a size calculation that
-    * will guarantee that 'arg' is a binary.
-    */
-   ASSERT(is_binary(arg));
+    /* This instruction is always preceded by a size calculation that 
+     * guarantees that 'arg' is a bitstring. */
+    ASSERT(is_bitstring(arg));
+    ERTS_GET_BITSTRING(arg, base, offset, size);
 
-   ERTS_GET_BINARY_BYTES(arg, bptr, bitoffs, bitsize);
-   num_bits = 8*binary_size(arg)+bitsize;
-   if (unit == 8) {
-       if (bitsize != 0) {
-           c_p->fvalue = arg;
-	   return 0;
-       }
-   } else if (unit != 1 && num_bits % unit != 0) {
-       c_p->fvalue = arg;
-       return 0;
-   }
-   copy_binary_to_buffer(erts_current_bin, erts_bin_offset, bptr, bitoffs, num_bits);
-   erts_bin_offset += num_bits;
-   BUMP_REDS(c_p, num_bits / BITS_PER_REDUCTION);
-   return 1;
+    if (unit != 1 && (size % unit) != 0) {
+        c_p->fvalue = arg;
+        return 0;
+    }
+
+    copy_binary_to_buffer(erts_current_bin, erts_bin_offset,
+                          base, offset, size);
+    erts_bin_offset += size;
+
+    BUMP_REDS(c_p, size / BITS_PER_REDUCTION);
+    return 1;
 }
 
 /*
@@ -1434,21 +1427,56 @@ erts_new_bs_put_string(ERL_BITS_PROTO_2(byte* iptr, Uint num_bytes))
 }
 
 static ERTS_INLINE
-void increase_proc_bin_sz(Process* p, ProcBin* pb, Uint new_size)
+void update_wb_overhead(Process *p,
+                        const BinRef *bin_ref,
+                        Uint old_size,
+                        Uint new_size)
 {
-    if (new_size > pb->size) {
-        const Uint incr = (new_size / sizeof(Eterm) -
-                           pb->size / sizeof(Eterm));
-        if (ErtsInBetween(pb, OLD_HEAP(p), OLD_HTOP(p))) {
+    ASSERT(new_size >= old_size);
+    if (new_size > old_size) {
+        const Uint incr = (NBYTES(new_size) / sizeof(Eterm) -
+                           NBYTES(old_size) / sizeof(Eterm));
+        if (ErtsInBetween(bin_ref, OLD_HEAP(p), OLD_HTOP(p))) {
             p->bin_old_vheap += incr;
-        }
-        else {
+        } else {
             OH_OVERHEAD(&MSO(p), incr);
         }
-        pb->size = new_size;
     }
-    else
-        ASSERT(new_size == pb->size);
+}
+
+static void
+build_writable_bitstring(Process *p,
+                         Eterm **hpp,
+                         Binary *bin,
+                         Uint apparent_size,
+                         BinRef **brp,
+                         ErlSubBits **sbp)
+{
+    ErlSubBits *sb;
+    BinRef *br;
+
+    sb = (ErlSubBits*)&(*hpp)[0];
+    br = (BinRef*)&(*hpp)[ERL_SUB_BITS_SIZE];
+    *hpp += ERL_SUB_BITS_SIZE + ERL_BIN_REF_SIZE;
+
+    bin->intern.flags |= BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER;
+    bin->intern.apparent_size = NBYTES(apparent_size);
+
+    br->thing_word = HEADER_BIN_REF;
+    br->next = p->wrt_bins;
+    p->wrt_bins = (struct erl_off_heap_header*)br;
+    br->val = bin;
+
+    MSO(p).overhead += apparent_size / (sizeof(Eterm) * 8);
+
+    br->bytes = (byte*)bin->orig_bytes;
+
+    sb->thing_word = HEADER_SUB_BITS;
+    sb->is_writable = 1;
+    sb->orig = make_bitstring(br);
+
+    *brp = br;
+    *sbp = sb;
 }
 
 Eterm
@@ -1486,8 +1514,8 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
     Eterm bin;			/* Given binary */
     Eterm* ptr;
     Eterm hdr;
-    ErlSubBin* sb;
-    ProcBin* pb;
+    ErlSubBits* sb;
+    BinRef* br;
     Binary* binp;
     Uint heap_need;
     Uint used_size_in_bits;
@@ -1507,27 +1535,30 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
     }
     ptr = boxed_val(bin);
     hdr = *ptr;
-    if (!is_binary_header(hdr)) {
+    if (!is_bitstring_header(hdr)) {
 	goto type_error;
     }
-    if (hdr != HEADER_SUB_BIN) {
+    if (hdr != HEADER_SUB_BITS) {
 	goto not_writable;
     }
-    sb = (ErlSubBin *) ptr;
+    sb = (ErlSubBits*)ptr;
     if (!sb->is_writable) {
 	goto not_writable;
     }
-    pb = (ProcBin *) boxed_val(sb->orig);
-    ASSERT(pb->thing_word == HEADER_PROC_BIN);
-    if ((pb->flags & PB_IS_WRITABLE) == 0) {
-	goto not_writable;
+
+    br = (BinRef *) boxed_val(sb->orig);
+    ASSERT(br->thing_word == HEADER_BIN_REF);
+    binp = br->val;
+
+    if ((binp->intern.flags & BIN_FLAG_WRITABLE) == 0) {
+        goto not_writable;
     }
 
     /*
      * OK, the binary is writable.
      */
 
-    erts_bin_offset = 8*sb->size + sb->bitsize;
+    erts_bin_offset = sb->size;
     if (unit > 1) {
 	if ((unit == 8 && (erts_bin_offset & 7) != 0) ||
 	    (unit != 8 && (erts_bin_offset % unit) != 0)) {
@@ -1552,44 +1583,42 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
 
     used_size_in_bits = erts_bin_offset + build_size_in_bits;
 
-    sb->is_writable = 0;	/* Make sure that no one else can write. */
+    /* Make sure that no one else can append to the incoming bitstring. */
+    sb->is_writable = 0;
 
-    increase_proc_bin_sz(c_p, pb, NBYTES(used_size_in_bits));
-    pb->flags |= PB_ACTIVE_WRITER;
+    update_wb_overhead(c_p, br, sb->size, used_size_in_bits);
+    binp->intern.flags |= BIN_FLAG_ACTIVE_WRITER;
 
-    /*
-     * Reallocate the binary if it is too small.
-     */
-    binp = pb->val;
-    if (binp->orig_size < pb->size) {
-	Uint new_size = GROW_PROC_BIN_SIZE(pb->size);
+    /* Reallocate the underlying binary if it is too small. */
+    if (binp->orig_size < NBYTES(used_size_in_bits)) {
+        Uint new_size = GROW_PROC_BIN_SIZE(NBYTES(used_size_in_bits));
 
-	binp = erts_bin_realloc(binp, new_size);
-	pb->val = binp;
-	pb->bytes = (byte *) binp->orig_bytes;
-        BUMP_REDS(c_p, pb->size / BITS_PER_REDUCTION);
+        binp = erts_bin_realloc(binp, new_size);
+        br->val = binp;
+        br->bytes = (byte*)binp->orig_bytes;
+
+        BUMP_REDS(c_p, erts_bin_offset / BITS_PER_REDUCTION);
     }
-    erts_current_bin = pb->bytes;
 
-    /*
-     * Allocate heap space and build a new sub binary.
-     */
+    binp->intern.apparent_size = NBYTES(used_size_in_bits);
+    erts_current_bin = br->bytes;
+
+    /* Allocate heap space and build a new sub binary. */
     reg[live] = sb->orig;
-    heap_need = ERL_SUB_BIN_SIZE + extra_words;
+
+    heap_need = ERL_SUB_BITS_SIZE + extra_words;
     if (HeapWordsLeft(c_p) < heap_need) {
-	(void) erts_garbage_collect(c_p, heap_need, reg, live+1);
+        (void)erts_garbage_collect(c_p, heap_need, reg, live + 1);
     }
-    sb = (ErlSubBin *) c_p->htop;
-    c_p->htop += ERL_SUB_BIN_SIZE;
-    sb->thing_word = HEADER_SUB_BIN;
-    sb->size = BYTE_OFFSET(used_size_in_bits);
-    sb->bitsize = BIT_OFFSET(used_size_in_bits);
-    sb->offs = 0;
-    sb->bitoffs = 0;
+
+    sb = (ErlSubBits *) c_p->htop;
+    c_p->htop += ERL_SUB_BITS_SIZE;
+    sb->thing_word = HEADER_SUB_BITS;
+    ERTS_SET_SB_RANGE(sb, 0, used_size_in_bits);
     sb->is_writable = 1;
     sb->orig = reg[live];
 
-    return make_binary(sb);
+    return make_bitstring(sb);
 
     /*
      * The binary is not writable. We must create a new writable binary and
@@ -1597,103 +1626,67 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
      */
  not_writable:
     {
-	Uint used_size_in_bytes; /* Size of old binary + data to be built */
-	Uint bin_size;
-	Binary* bptr;
-	byte* src_bytes;
-	Uint bitoffs;
-	Uint bitsize;
-	Eterm* hp;
+        Uint src_offset, src_size;
+        byte* src_bytes;
+        Uint alloc_size;
+        ErlSubBits *sb;
+        BinRef *br;
 
-        /*
-	 * Allocate heap space.
-	 */
-	heap_need = PROC_BIN_SIZE + ERL_SUB_BIN_SIZE + extra_words;
-	if (HeapWordsLeft(c_p) < heap_need) {
-	    (void) erts_garbage_collect(c_p, heap_need, reg, live+1);
+        heap_need = ERL_REFC_BITS_SIZE + extra_words;
+        if (HeapWordsLeft(c_p) < heap_need) {
+            (void) erts_garbage_collect(c_p, heap_need, reg, live+1);
             bin = reg[live];
-	}
-	hp = c_p->htop;
+        }
 
-	/*
-	 * Calculate sizes. The size of the new binary, is the sum of the
-	 * build size and the size of the old binary. Allow some room
-	 * for growing.
-	 */
-	ERTS_GET_BINARY_BYTES(bin, src_bytes, bitoffs, bitsize);
-	erts_bin_offset = 8*binary_size(bin) + bitsize;
-	if (unit > 1) {
-	    if ((unit == 8 && (erts_bin_offset & 7) != 0) ||
-                (unit != 8 && (erts_bin_offset % unit) != 0)) {
-                c_p->fvalue = am_unit;
-		goto badarg;
-	    }
-	}
+        /* Calculate sizes. The size of the new binary, is the sum of the
+         * build size and the size of the old binary. Allow some room
+         * for growing. */
+        ERTS_GET_BITSTRING(bin, src_bytes, src_offset, src_size);
 
-	if (build_size_in_bits == 0) {
+        if (unit > 1 && (src_size % unit) != 0) {
+            c_p->fvalue = am_unit;
+            goto badarg;
+        }
+
+        if (build_size_in_bits == 0) {
             return bin;
-	}
+        }
 
-        if((ERTS_UINT_MAX - build_size_in_bits) < erts_bin_offset) {
+        if((ERTS_UINT_MAX - build_size_in_bits) < src_size) {
             c_p->fvalue = am_size;
             c_p->freason = SYSTEM_LIMIT;
             return THE_NON_VALUE;
         }
 
-        used_size_in_bits = erts_bin_offset + build_size_in_bits;
-        used_size_in_bytes = NBYTES(used_size_in_bits);
+        used_size_in_bits = src_size + build_size_in_bits;
 
         if(used_size_in_bits < (ERTS_UINT_MAX / 2)) {
-            bin_size = GROW_PROC_BIN_SIZE(used_size_in_bytes);
+            alloc_size = GROW_PROC_BIN_SIZE(NBYTES(used_size_in_bits));
         } else {
-            bin_size = NBYTES(ERTS_UINT_MAX);
+            alloc_size = NBYTES(ERTS_UINT_MAX);
         }
 
-	bin_size = (bin_size < 256) ? 256 : bin_size;
+        ASSERT(HeapWordsLeft(c_p) >= ERL_REFC_BITS_SIZE);
+        build_writable_bitstring(c_p,
+                                 &c_p->htop,
+                                 erts_bin_nrml_alloc(MAX(alloc_size, 256)),
+                                 used_size_in_bits,
+                                 &br,
+                                 &sb);
 
-	/*
-	 * Allocate the binary data struct itself.
-	 */
-	bptr = erts_bin_nrml_alloc(bin_size);
-	erts_current_bin = (byte *) bptr->orig_bytes;
+        erts_current_bin = (byte*)(br->val)->orig_bytes;
+        erts_bin_offset = src_size;
 
-	/*
-	 * Now allocate the ProcBin on the heap.
-	 */
-	pb = (ProcBin *) hp;
-	hp += PROC_BIN_SIZE;
-	pb->thing_word = HEADER_PROC_BIN;
-	pb->size = used_size_in_bytes;
-	pb->next = c_p->wrt_bins;
-        c_p->wrt_bins = (struct erl_off_heap_header*)pb;
-	pb->val = bptr;
-	pb->bytes = (byte*) bptr->orig_bytes;
-	pb->flags = PB_IS_WRITABLE | PB_ACTIVE_WRITER;
-	OH_OVERHEAD(&(MSO(c_p)), pb->size / sizeof(Eterm));
+        copy_binary_to_buffer(erts_current_bin,
+                              0,
+                              src_bytes,
+                              src_offset,
+                              src_size);
+        BUMP_REDS(c_p, src_size / BITS_PER_REDUCTION);
 
-	/*
-	 * Now allocate the sub binary and set its size to include the
-	 * data about to be built.
-	 */
-	sb = (ErlSubBin *) hp;
-	hp += ERL_SUB_BIN_SIZE;
-	sb->thing_word = HEADER_SUB_BIN;
-	sb->size = BYTE_OFFSET(used_size_in_bits);
-	sb->bitsize = BIT_OFFSET(used_size_in_bits);
-	sb->offs = 0;
-	sb->bitoffs = 0;
-	sb->is_writable = 1;
-	sb->orig = make_binary(pb);
+        ERTS_SET_SB_RANGE(sb, 0, used_size_in_bits);
 
-	c_p->htop = hp;
-	
-	/*
-	 * Now copy the data into the binary.
-	 */
-	copy_binary_to_buffer(erts_current_bin, 0, src_bytes, bitoffs, erts_bin_offset);
-        BUMP_REDS(c_p, erts_bin_offset / BITS_PER_REDUCTION);
-
-	return make_binary(sb);
+        return make_bitstring(sb);
     }
 }
 
@@ -1725,26 +1718,21 @@ erts_bs_private_append(Process* p, Eterm bin, Eterm build_size_term, Uint unit)
 Eterm
 erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, Uint unit)
 {
-    Eterm* ptr;
-    ErlSubBin* sb;
-    ProcBin* pb;
-    Binary* binp;
-    Uint pos_in_bits_after_build;
+    Uint new_position, new_size, used_size;
+    Binary *refc_binary;
+    ErlSubBits *sb;
+    BinRef *br;
+
     ERL_BITS_DEFINE_STATEP(p);
 
-    ptr = boxed_val(bin);
-    ASSERT(*ptr == HEADER_SUB_BIN);
+    sb = (ErlSubBits*)bitstring_val(bin);
+    ASSERT(sb->thing_word == HEADER_SUB_BITS);
 
-    sb = (ErlSubBin *) ptr;
-    ASSERT(sb->is_writable);
+    br = (BinRef*)boxed_val(sb->orig);
+    ASSERT(br->thing_word == HEADER_BIN_REF);
 
-    pb = (ProcBin *) boxed_val(sb->orig);
-    ASSERT(pb->thing_word == HEADER_PROC_BIN);
-
-    /*
-     * Calculate new size in bytes.
-     */
-    erts_bin_offset = 8*sb->size + sb->bitsize;
+    /* Calculate new size in bits. */
+    erts_bin_offset = sb->size;
 
     if((ERTS_UINT_MAX - build_size_in_bits) < erts_bin_offset) {
         p->fvalue = am_size;
@@ -1752,76 +1740,59 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
         return THE_NON_VALUE;
     }
 
-    pos_in_bits_after_build = erts_bin_offset + build_size_in_bits;
-    increase_proc_bin_sz(p, pb, (pos_in_bits_after_build+7) >> 3);
+    refc_binary = br->val;
 
-    /*
-     * Reallocate the binary if it is too small.
-     */
-    binp = pb->val;
-    if (binp->orig_size < pb->size) {
-	Uint new_size = GROW_PROC_BIN_SIZE(pb->size);
+    new_position = erts_bin_offset + build_size_in_bits;
+    update_wb_overhead(p, br, sb->size, new_position);
 
-        BUMP_REDS(p, pb->size / BITS_PER_REDUCTION);
-	if (pb->flags & PB_IS_WRITABLE) {
-	    /*
-	     * This is the normal case - the binary is writable.
-	     * There are no other references to the binary, so it
-	     * is safe to reallocate it.
-	     */
-	    binp = erts_bin_realloc(binp, new_size);
-	    pb->val = binp;
-	    pb->bytes = (byte *) binp->orig_bytes;
-	} else {
-	    /*
-	     * The binary is NOT writable. The only way that is
-	     * supposed to happen if is call trace has been turned
-	     * on. That means that a trace process now has (or have
-	     * had) a reference to the binary, so we are not allowed
-	     * to reallocate the binary. Instead, we must allocate a new
-             * binary and copy the contents of the old binary into it.
-             *
-             * Also make a new ProcBin as the old one may have been moved
-             * from the 'wrt_bins' list to the regular 'off_heap' list by
-             * the GC. To move it back would mean traversing the off_heap list
-             * from the start. So instead create a new ProcBin for this
-             * (hopefully) rare case.
-	     */
-	    Binary* bptr = erts_bin_nrml_alloc(new_size);
-            ProcBin* new_pb;
-            Uint sz = PROC_BIN_SIZE;
+    used_size = NBYTES(new_position);
+    new_size = GROW_PROC_BIN_SIZE(used_size);
 
-            sys_memcpy(bptr->orig_bytes, binp->orig_bytes, binp->orig_size);
+    if (refc_binary->intern.flags & BIN_FLAG_WRITABLE) {
+        /* This is the normal case - the binary is writable. There are no other
+         * references to the binary, so it is safe to reallocate it when it's
+         * too small. */
+        ASSERT(sb->is_writable);
+        ASSERT(erts_refc_read(&refc_binary->intern.refc, 1) == 1);
+        if (refc_binary->orig_size < used_size) {
+            refc_binary = erts_bin_realloc(refc_binary, new_size);
+            br->val = refc_binary;
+            br->bytes = (byte*)refc_binary->orig_bytes;
 
-            /* If the subbinary is on the mature or old heap, we need to also move it */
-            if (ErtsInBetween(sb, OLD_HEAP(p), OLD_HTOP(p)) ||
-                ErtsInBetween(sb, HEAP_START(p), HIGH_WATER(p))) {
-                sz += ERL_SUB_BIN_SIZE;
-            }
+            BUMP_REDS(p, erts_bin_offset / BITS_PER_REDUCTION);
+        }
+    } else {
+        /* The binary is NOT writable. The only way that this can happen is
+         * when call tracing is turned on, which means that a trace process now
+         * has (or have had) a reference to underlying binary. We are therefore
+         * unable to reallocate the binary, and must instead allocate a new
+         * binary and make a copy of the data.
+         *
+         * We'll also make a new BinRef as the old one may have been moved from
+         * the `wrt_bins` list to the regular `off_heap` list by the GC. To
+         * To move it back would mean traversing the `off_heap` list from the
+         * start, so we'll create a new BinRef instead for this (hopefully)
+         * rare case. */
+        Binary *new_binary = erts_bin_nrml_alloc(new_size);
+        Eterm *hp = HeapFragOnlyAlloc(p, ERL_REFC_BITS_SIZE);
 
-            new_pb = (ProcBin*) HeapFragOnlyAlloc(p, sz);
-            new_pb->thing_word = HEADER_PROC_BIN;
-            new_pb->size = pb->size;
-            new_pb->val = bptr;
-            new_pb->bytes = (byte *) bptr->orig_bytes;
-            new_pb->next = p->wrt_bins;
-            p->wrt_bins = (struct erl_off_heap_header*) new_pb;
-            pb = new_pb;
-            if (sz != PROC_BIN_SIZE) {
-                ErlSubBin *new_sb = (ErlSubBin*)(new_pb+1);
-                sys_memcpy(new_sb, sb, sizeof(*new_sb));
-                sb = new_sb;
-                bin = make_binary(sb);
-            }
-            sb->orig = make_binary(new_pb);
-	}
+        build_writable_bitstring(p, &hp, new_binary, new_position, &br, &sb);
+
+        sys_memcpy(new_binary->orig_bytes,
+                   refc_binary->orig_bytes,
+                   MIN(refc_binary->orig_size, new_size));
+
+        BUMP_REDS(p, erts_bin_offset / BITS_PER_REDUCTION);
+        refc_binary = new_binary;
     }
-    pb->flags = PB_IS_WRITABLE | PB_ACTIVE_WRITER;
 
-    erts_current_bin = pb->bytes;
+    refc_binary->intern.flags = BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER;
+    refc_binary->intern.apparent_size = used_size;
 
-    sb->size = pos_in_bits_after_build >> 3;
-    sb->bitsize = pos_in_bits_after_build & 7;
+    ERTS_SET_SB_RANGE(sb, 0, new_position);
+
+    erts_current_bin = br->bytes;
+
     return bin;
 }
 
@@ -1829,81 +1800,60 @@ Eterm
 erts_bs_init_writable(Process* p, Eterm sz)
 {
     Uint bin_size = 1024;
-    Uint heap_need;
-    Binary* bptr;
-    ProcBin* pb;
-    ErlSubBin* sb;
-    Eterm* hp;
-    
+    ErlSubBits *sb;
+    BinRef *br;
+
     if (is_small(sz)) {
-	Sint s = signed_val(sz);
-	if (s >= 0) {
-	    bin_size = (Uint) s;
-	}
+        Sint s = signed_val(sz);
+        if (s >= 0) {
+            bin_size = (Uint) s;
+        }
     }
 
-    /*
-     * Allocate heap space.
-     */
-    heap_need = PROC_BIN_SIZE + ERL_SUB_BIN_SIZE;
-    if (HeapWordsLeft(p) < heap_need) {
-	(void) erts_garbage_collect(p, heap_need, NULL, 0);
+    if (HeapWordsLeft(p) < ERL_REFC_BITS_SIZE) {
+        (void)erts_garbage_collect(p, ERL_REFC_BITS_SIZE, NULL, 0);
     }
-    hp = p->htop;
-    
-    /*
-     * Allocate the binary data struct itself.
-     */
-    bptr = erts_bin_nrml_alloc(bin_size);
-    
-    /*
-     * Now allocate the ProcBin on the heap.
-     */
-    pb = (ProcBin *) hp;
-    hp += PROC_BIN_SIZE;
-    pb->thing_word = HEADER_PROC_BIN;
-    pb->size = 0;
-    pb->next = p->wrt_bins;
-    p->wrt_bins = (struct erl_off_heap_header*) pb;
-    pb->val = bptr;
-    pb->bytes = (byte*) bptr->orig_bytes;
-    pb->flags = PB_IS_WRITABLE | PB_ACTIVE_WRITER;
-    OH_OVERHEAD(&(MSO(p)), pb->size / sizeof(Eterm));
-    
-    /*
-     * Now allocate the sub binary.
-     */
-    sb = (ErlSubBin *) hp;
-    hp += ERL_SUB_BIN_SIZE;
-    sb->thing_word = HEADER_SUB_BIN;
-    sb->size = 0;
-    sb->offs = 0;
-    sb->bitsize = 0;
-    sb->bitoffs = 0;
-    sb->is_writable = 1;
-    sb->orig = make_binary(pb);
 
-    p->htop = hp;
-    return make_binary(sb);
+    build_writable_bitstring(p,
+                             &p->htop,
+                             erts_bin_nrml_alloc(bin_size),
+                             bin_size * 8,
+                             &br, &sb);
+    ERTS_SET_SB_RANGE(sb, 0, 0);
+    (void)br;
+
+    return make_bitstring(sb);
 }
 
-void
-erts_emasculate_writable_binary(ProcBin* pb)
-{
-    Binary* binp;
-    Uint unused;
+int erts_pin_writable_binary(BinRef *br) {
+    enum binary_flags flags;
+    Binary *refc_binary;
 
-    pb->flags = 0;
-    binp = pb->val;
-    ASSERT(binp->orig_size >= pb->size);
-    unused = binp->orig_size - pb->size;
-    /* Our allocators are 8 byte aligned, i.e., shrinking with
-       less than 8 bytes will have no real effect */
-    if (unused >= 8) {
-	binp = erts_bin_realloc(binp, pb->size);
-	pb->val = binp;
-	pb->bytes = (byte *) binp->orig_bytes;
+    refc_binary = br->val;
+    flags = refc_binary->intern.flags;
+
+    if (flags & (BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)) {
+        Uint apparent_size = refc_binary->intern.apparent_size;
+
+        ASSERT(refc_binary->orig_size >= apparent_size);
+        ASSERT((flags & ~(BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)) == 0);
+        ASSERT(erts_refc_read(&refc_binary->intern.refc, 1) == 1);
+
+        refc_binary->intern.flags = 0;
+
+        /* Our allocators are 8 byte aligned, i.e., shrinking with less than 8
+         * bytes will have no real effect */
+        if (refc_binary->orig_size - apparent_size >= 8) {
+            refc_binary = erts_bin_realloc(refc_binary, apparent_size);
+
+            br->val = refc_binary;
+            br->bytes = (byte*)refc_binary->orig_bytes;
+
+            return 1;
+        }
     }
+
+    return 0;
 }
 
 Uint32
@@ -2116,26 +2066,21 @@ get_bit(byte b, size_t offs)
     return (b >> (7-offs)) & 1;
 }
 
-int
-erts_cmp_bits(byte* a_ptr, size_t a_offs, byte* b_ptr, size_t b_offs, size_t size) 
+int erts_cmp_bits__(const byte *a_ptr,
+                    Uint a_offs,
+                    const byte *b_ptr,
+                    Uint b_offs,
+                    Uint size)
 {
-    byte a;
-    byte b;
-    byte a_bit;
-    byte b_bit;
-    Uint lshift;
-    Uint rshift;
+    Uint lshift, rshift;
+    byte a_bit, b_bit;
+    byte a, b;
     int cmp;
-    
-    ASSERT(a_offs < 8 && b_offs < 8);
 
-    if (size == 0)
-        return 0;
-
-    if (((a_offs | b_offs | size) & 7) == 0) {
-	int byte_size = size >> 3;
-	return sys_memcmp(a_ptr, b_ptr, byte_size);
-    }
+    /* The inlined wrapper should take care of these cases. */
+    ASSERT(((a_offs | b_offs | size) & 7) != 0);
+    ASSERT(((a_offs | b_offs) & ~7) == 0);
+    ASSERT(size > 0);
 
     /* Compare bit by bit until a_ptr is aligned on byte boundary */
     a = *a_ptr++;
@@ -2345,54 +2290,252 @@ erts_copy_bits(const byte* src, /* Base pointer to source. */
     }
 }
 
-/*
- * Calculate sufficient heap space for a binary extracted by
- * erts_extract_sub_binary().
- */
-Uint erts_extracted_binary_size(Uint bit_size)
+Eterm erts_build_sub_bitstring(Eterm **hp,
+                               Eterm br_flags,
+                               const BinRef *br,
+                               const byte *base,
+                               Uint offset, Uint size)
 {
-    Uint byte_size = BYTE_OFFSET(bit_size);
-    ERTS_CT_ASSERT(ERL_SUB_BIN_SIZE <= ERL_ONHEAP_BIN_LIMIT);
+    ERTS_CT_ASSERT(sizeof(ErlSubBits) <= ERL_ONHEAP_BINARY_LIMIT);
 
-    if (BIT_OFFSET(bit_size) == 0 && byte_size <= ERL_ONHEAP_BIN_LIMIT) {
-        return heap_bin_size(byte_size);
+    if (size <= ERL_ONHEAP_BITS_LIMIT) {
+        Eterm result = HEAP_BITSTRING(*hp, base, offset, size);
+        *hp += heap_bits_size(size);
+        return result;
     } else {
-        return ERL_SUB_BIN_SIZE;
+        ErlSubBits *sb = (ErlSubBits*)*hp;
+        *hp += ERL_SUB_BITS_SIZE;
+
+        ASSERT(br && ((br_flags & _TAG_PRIMARY_MASK) == TAG_PRIMARY_BOXED));
+
+        sb->thing_word = HEADER_SUB_BITS;
+        ERTS_SET_SB_RANGE(sb, offset, size);
+        sb->orig = ((Eterm)br) | br_flags;
+        sb->is_writable = 0;
+
+        return make_bitstring(sb);
     }
 }
 
-Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
-                              Uint bit_offset, Uint bit_size)
+Eterm erts_wrap_refc_bitstring(struct erl_off_heap_header **oh,
+                               Uint64 *overhead,
+                               Eterm **hpp,
+                               Binary *bin,
+                               byte *bytes,
+                               Uint offset,
+                               Uint size)
 {
-    Uint byte_offset, byte_size;
+    ErlSubBits *sb = (ErlSubBits*)&(*hpp)[ERL_BIN_REF_SIZE];
+    BinRef *br = (BinRef*)*hpp;
 
-    ERTS_CT_ASSERT(ERL_SUB_BIN_SIZE <= ERL_ONHEAP_BIN_LIMIT);
+    ASSERT(bin != NULL);
 
-    byte_offset = BYTE_OFFSET(bit_offset);
-    byte_size = BYTE_OFFSET(bit_size);
+    br->thing_word = HEADER_BIN_REF;
+    br->next = (*oh);
+    br->val = bin;
+    br->bytes = bytes;
 
-    if (BIT_OFFSET(bit_size) == 0 && byte_size <= ERL_ONHEAP_BIN_LIMIT) {
-        ErlHeapBin *hb = (ErlHeapBin*)*hp;
-        *hp += heap_bin_size(byte_size);
+    sb->thing_word = HEADER_SUB_BITS;
+    sb->is_writable = 0;
+    sb->orig = make_boxed((Eterm*)br);
+    ERTS_SET_SB_RANGE(sb, offset, size);
 
-        hb->thing_word = header_heap_bin(byte_size);
-        hb->size = byte_size;
+    *oh = (struct erl_off_heap_header*)br;
+    *overhead += size / NBITS(sizeof(Eterm));
+    *hpp += ERL_REFC_BITS_SIZE;
 
-        copy_binary_to_buffer(hb->data, 0, base_data, bit_offset, bit_size);
+    return make_bitstring(sb);
+}
 
-        return make_binary(hb);
+Eterm erts_make_sub_bitstring(Process *p,
+                              Eterm bitstring,
+                              Uint offset,
+                              Uint size)
+{
+    Uint inner_offset, inner_size;
+    const byte *base;
+    Eterm br_flags;
+    BinRef *br;
+    Eterm *hp;
+
+    ERTS_GET_BITSTRING_REF(bitstring,
+                           br_flags,
+                           br,
+                           base,
+                           inner_offset,
+                           inner_size);
+
+    ASSERT((offset + size) <= inner_size);
+    (void)inner_size;
+
+    hp = HAlloc(p, erts_extracted_bitstring_size(size));
+    return erts_build_sub_bitstring(&hp,
+                                    br_flags,
+                                    br,
+                                    base,
+                                    inner_offset + offset,
+                                    size);
+}
+
+Eterm erts_make_sub_binary(Process *p,
+                           Eterm bitstring,
+                           Uint offset,
+                           Uint size)
+{
+    ASSERT(offset < (ERTS_UWORD_MAX - size));
+    ASSERT(IS_BINARY_SIZE_OK(offset + size));
+    return erts_make_sub_bitstring(p,
+                                   bitstring,
+                                   NBITS(offset),
+                                   NBITS(size));
+}
+
+Eterm
+erts_hfact_new_bitstring(ErtsHeapFactory *hfact, Uint reserve_size,
+                         Uint size, byte **datap)
+{
+    if (size <= ERL_ONHEAP_BITS_LIMIT) {
+        ErlHeapBits *hb = (ErlHeapBits*)erts_produce_heap(hfact,
+                                                          heap_bits_size(size),
+                                                          reserve_size);
+
+        hb->thing_word = header_heap_bits(size);
+        ERTS_SET_HB_SIZE(hb, size);
+
+        *datap = (byte*)hb->data;
+
+        return make_bitstring(hb);
     } else {
-        ErlSubBin *sb = (ErlSubBin*)*hp;
-        *hp += ERL_SUB_BIN_SIZE;
+        Binary *refc_binary = erts_bin_nrml_alloc(NBYTES(size));
+        Eterm *hp = erts_produce_heap(hfact,
+                                      ERL_REFC_BITS_SIZE,
+                                      reserve_size);
 
-        sb->thing_word = HEADER_SUB_BIN;
-        sb->size = byte_size;
-        sb->offs = byte_offset;
-        sb->orig = base_bin;
-        sb->bitoffs = BIT_OFFSET(bit_offset);
-        sb->bitsize = BIT_OFFSET(bit_size);
-        sb->is_writable = 0;
+        *datap = (byte*)refc_binary->orig_bytes;
 
-        return make_binary(sb);
+        return erts_wrap_refc_bitstring(&(hfact->off_heap)->first,
+                                        &(hfact->off_heap)->overhead,
+                                        &hp,
+                                        refc_binary,
+                                        (byte*)refc_binary->orig_bytes,
+                                        0,
+                                        size);
     }
+}
+
+Eterm
+erts_hfact_new_binary_from_data(ErtsHeapFactory *hfact, Uint reserve_size,
+                                Uint size, const byte *data)
+{
+    Eterm result;
+    byte *base;
+
+    ASSERT(IS_BINARY_SIZE_OK(size));
+    result = erts_hfact_new_bitstring(hfact,
+                                      reserve_size,
+                                      NBITS(size),
+                                      &base);
+
+    if (size > 0) {
+        sys_memcpy(base, data, size);
+    }
+
+    return result;
+}
+
+Eterm
+erts_new_bitstring_refc(Process *p, Uint size, Binary **binp, byte **datap)
+{
+    if (size <= ERL_ONHEAP_BITS_LIMIT) {
+        ErlHeapBits *hb;
+
+        hb = (ErlHeapBits *)HAlloc(p, heap_bits_size(size));
+        hb->thing_word = header_heap_bits(size);
+        ERTS_SET_HB_SIZE(hb, size);
+
+        *datap = (byte*)hb->data;
+
+        return make_bitstring(hb);
+    } else {
+        Binary *refc_binary = erts_bin_nrml_alloc(NBYTES(size));
+        Eterm *hp = HAlloc(p, ERL_REFC_BITS_SIZE);
+
+        *datap = (byte*)refc_binary->orig_bytes;
+        *binp = refc_binary;
+
+        return erts_wrap_refc_bitstring(&MSO(p).first,
+                                        &MSO(p).overhead,
+                                        &hp,
+                                        refc_binary,
+                                        (byte*)refc_binary->orig_bytes,
+                                        0,
+                                        size);
+    }
+}
+
+Eterm
+erts_new_bitstring(Process *p, Uint size, byte **datap)
+{
+    Binary *unused;
+    return erts_new_bitstring_refc(p, size, &unused, datap);
+}
+
+Eterm erts_new_bitstring_from_data(Process *p, Uint size, const byte *data) {
+    Eterm result;
+    byte *bytes;
+
+    result = erts_new_bitstring(p, size, &bytes);
+
+    if (size > 0) {
+        sys_memcpy(bytes, data, NBYTES(size));
+    }
+
+    return result;
+}
+
+Eterm
+erts_new_binary_refc(Process *p, Uint size, Binary **binp, byte **datap)
+{
+    ASSERT(IS_BINARY_SIZE_OK(size));
+    return erts_new_bitstring_refc(p, NBITS(size), binp, datap);
+}
+
+Eterm
+erts_new_binary(Process *p, Uint size, byte **datap)
+{
+    ASSERT(IS_BINARY_SIZE_OK(size));
+    return erts_new_bitstring(p, NBITS(size), datap);
+}
+
+Eterm erts_new_binary_from_data(Process *p, Uint size, const byte *data)
+{
+    ASSERT(IS_BINARY_SIZE_OK(size));
+    return erts_new_bitstring_from_data(p, NBITS(size), data);
+}
+
+Eterm
+erts_shrink_binary_term(Eterm binary, size_t size)
+{
+    Eterm* ptr = bitstring_val(binary);
+
+    if (thing_subtag(*ptr) == HEAP_BITS_SUBTAG) {
+        ErlHeapBits *hb = (ErlHeapBits*)ptr;
+        ASSERT(TAIL_BITS(hb->size) == 0 && hb->size >= NBITS(size));
+        ERTS_SET_HB_SIZE(hb, NBITS(size));
+    } else {
+        ErlSubBits *sb = (ErlSubBits*)ptr;
+        BinRef *br = (BinRef*)boxed_val(sb->orig);
+
+        ASSERT(TAIL_BITS(sb->size) == 0 && sb->size >= NBITS(size));
+        ERTS_SET_SB_RANGE(sb, sb->offs, NBITS(size));
+
+        /* Our allocators are 8-byte aligned, so don't bother reallocating for
+         * differences smaller than that. */
+        if (size < (NBYTES(sb->size) + 8)) {
+            br->val = erts_bin_realloc(br->val, size);
+            br->bytes = (byte*)(br->val)->orig_bytes;
+        }
+    }
+
+    return binary;
 }

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -21,27 +21,10 @@
 #ifndef __ERL_BITS_H__
 #define __ERL_BITS_H__
 
-/*
- * This structure represents a SUB_BINARY.
- *
- * Note: The last field (orig) is not counted in arityval in the header.
- * This simplifies garbage collection.
- */
+/* ************************************************************************* */
 
-typedef struct erl_sub_bin {
-    Eterm thing_word;		/* Subtag SUB_BINARY_SUBTAG. */
-    Uint size;			/* Binary size in bytes. */
-    Uint offs;			/* Offset into original binary. */
-    byte bitsize;
-    byte bitoffs;
-    byte is_writable;		/* The underlying binary is writable */
-    Eterm orig;			/* Original binary (REFC or HEAP binary). */
-} ErlSubBin;
-
-/*
- * This structure represents a binary to be matched.
- */
-
+/** @brief This structure represents a binary to be matched, we plan to replace
+ * this with ErlSubBits in the near future. */
 typedef struct erl_bin_match_buffer {
     Eterm orig;			/* Original binary term. */
     byte* base;			/* Current position in binary. */
@@ -49,19 +32,7 @@ typedef struct erl_bin_match_buffer {
     size_t size;		/* Size of binary in bits. */
 } ErlBinMatchBuffer;
 
-struct erl_bits_state {
-    /*
-     * Pointer to the beginning of the current binary.
-     */
-    byte* erts_current_bin_;
-
-    /*
-     * Offset in bits into the current binary.
-     */
-    Uint erts_bin_offset_;
-};
-
-typedef struct erl_bin_match_struct{
+typedef struct erl_bin_match_struct {
   Eterm thing_word;
   ErlBinMatchBuffer mb;		/* Present match buffer */
   Eterm save_offset[1];         /* Saved offsets, only valid for contexts
@@ -75,9 +46,112 @@ typedef struct erl_bin_match_struct{
 #define HEADER_NUM_SLOTS(hdr) \
     (header_arity(hdr) - (offsetof(ErlBinMatchState, save_offset) / sizeof(Eterm)) + 1)
 
-#define make_matchstate(_Ms) make_boxed((Eterm*)(_Ms))  
+#define make_matchstate(_Ms) make_boxed((Eterm*)(_Ms))
 #define ms_matchbuffer(_Ms) &(((ErlBinMatchState*) boxed_val(_Ms))->mb)
 
+#define matchbuffer_base(Bin)                                                 \
+  (*boxed_val(Bin) == HEADER_BIN_REF ?                                        \
+   ((BinRef*)boxed_val(Bin))->bytes :                                         \
+   (ASSERT(thing_subtag(*boxed_val(Bin)) == HEAP_BITS_SUBTAG),                \
+   (byte*)(&(((ErlHeapBits*)boxed_val(Bin))->data))))
+
+/* ************************************************************************* */
+
+/** @brief returns the number of bytes needed to store \c x bits. */
+#define NBYTES(x)  (((Uint64)(x) + (Uint64) 7) >> 3)
+/** @brief returns the number of bits there are in \c x bytes. */
+#define NBITS(x)  ((Uint64)(x) << 3)
+
+#define BYTE_OFFSET(offset_in_bits) ((Uint)(offset_in_bits) >> 3)
+#define BIT_OFFSET(offset_in_bits) ((offset_in_bits) & 7)
+
+/* As the above, but slightly renamed to avoid confusing sizes and offsets. */
+#define BYTE_SIZE(size_in_bits) BYTE_OFFSET(size_in_bits)
+#define TAIL_BITS(size_in_bits) BIT_OFFSET(size_in_bits)
+
+/* ************************************************************************* */
+
+#define bitstring_size(Bin) (bitstring_val(Bin)[1])
+
+/* This structure represents the term form of an off-heap bitstring.
+ *
+ * Note: The last field (orig) is not counted in arityval in the header to
+ * simplify garbage collection. */
+typedef struct erl_sub_bits {
+    Eterm thing_word;           /* Subtag SUB_BITS_SUBTAG. */
+    Uint size;                  /* Size in bits. */
+    Uint offs;                  /* Offset in bits. */
+    byte is_writable;           /* The underlying Binary* is writable */
+    Eterm orig;                 /* Boxed BinRef* */
+} ErlSubBits;
+
+/** @brief The size in words of an ErlSubBits. */
+#define ERL_SUB_BITS_SIZE (sizeof(ErlSubBits) / sizeof(Eterm))
+
+#define HEADER_SUB_BITS _make_header(ERL_SUB_BITS_SIZE-2,_TAG_HEADER_SUB_BITS)
+
+/** @brief A handle to an off-heap binary. While terms internally, these can
+ * only be referred to by sub-bitstrings, and should never be exposed to the
+ * user. */
+typedef struct bin_ref {
+    Eterm thing_word;           /* Subtag BIN_REF_SUBTAG. */
+    Binary *val;                /* Pointer to Binary structure. */
+    struct erl_off_heap_header *next;
+    byte *bytes;                /* Pointer to the actual data bytes. */
+} BinRef;
+
+/* process binaries stuff (special case of binaries) */
+#define HEADER_BIN_REF _make_header(ERL_BIN_REF_SIZE-1,_TAG_HEADER_BIN_REF)
+
+/** @brief The size in words of a BinRef. */
+#define ERL_BIN_REF_SIZE (sizeof(BinRef)/sizeof(Eterm))
+
+/** @brief The size in words needed to describe an off-heap binary as a term. */
+#define ERL_REFC_BITS_SIZE (ERL_BIN_REF_SIZE+ERL_SUB_BITS_SIZE)
+
+/** @brief A heap bitstring */
+typedef struct erl_heap_bits {
+    Eterm thing_word;           /* Subtag HEAP_BITS_SUBTAG. */
+    Uint size;
+    Eterm data[1];              /* The data in the binary. */
+} ErlHeapBits;
+
+#define heap_bin_size__(num_bytes)                                            \
+  (sizeof(ErlHeapBits)/sizeof(Eterm) - 1 +                                    \
+   ((num_bytes) + sizeof(Eterm) - 1)/sizeof(Eterm))
+
+#define heap_bits_size(num_bits)                                              \
+    heap_bin_size__(NBYTES(num_bits))
+
+#define header_heap_bits(num_bits) \
+  _make_header(heap_bits_size(num_bits)-1,_TAG_HEADER_HEAP_BITS)
+
+/* Maximum number of bytes/bits to place in a heap binary.*/
+#define ERL_ONHEAP_BINARY_LIMIT 64
+#define ERL_ONHEAP_BITS_LIMIT (ERL_ONHEAP_BINARY_LIMIT * 8)
+
+/** @brief Helper for creating heap bitstrings from arbitrary data */
+#define HEAP_BITSTRING(hp, data, offset, size)                                \
+    (ASSERT(size <= ERL_ONHEAP_BITS_LIMIT),                                   \
+     (hp)[0] = header_heap_bits(size),                                        \
+     (hp)[1] = size,                                                          \
+     copy_binary_to_buffer((byte*)&(hp)[2], 0, (byte*)data, offset, size),    \
+     make_bitstring(hp))
+
+/* ************************************************************************* */
+/* Binary construction */
+
+struct erl_bits_state {
+    /*
+     * Pointer to the beginning of the current binary.
+     */
+    byte* erts_current_bin_;
+
+    /*
+     * Offset in bits into the current binary.
+     */
+    Uint erts_bin_offset_;
+};
 
 /*
  * Reentrant API with the state passed as a parameter.
@@ -109,26 +183,6 @@ typedef struct erl_bin_match_struct{
 #define erts_bin_offset		(ErlBitsState.erts_bin_offset_)
 #define erts_current_bin	(ErlBitsState.erts_current_bin_)
 
-#define copy_binary_to_buffer(DstBuffer, DstBufOffset, SrcBuffer, SrcBufferOffset, NumBits) \
-  do {											    \
-    if (BIT_OFFSET(DstBufOffset) == 0 && (SrcBufferOffset == 0) &&			    \
-        (BIT_OFFSET(NumBits)==0) && (NumBits != 0)) {					    \
-      sys_memcpy(((byte*)DstBuffer)+BYTE_OFFSET(DstBufOffset),					    \
-		 SrcBuffer, NBYTES(NumBits));						    \
-    } else {										    \
-      erts_copy_bits(SrcBuffer, SrcBufferOffset, 1,					    \
-        (byte*)DstBuffer, DstBufOffset, 1, NumBits);					    \
-    }											    \
-  }  while (0)
-
-/*
- * NBYTES(x) returns the number of bytes needed to store x bits.
- */
-
-#define NBYTES(x)  (((Uint64)(x) + (Uint64) 7) >> 3) 
-#define BYTE_OFFSET(ofs) ((Uint) (ofs) >> 3)
-#define BIT_OFFSET(ofs) ((ofs) & 7)
-
 /*
  * Return number of Eterm words needed for allocation with HAlloc(),
  * given a number of bytes.
@@ -140,9 +194,8 @@ typedef struct erl_bin_match_struct{
  */
 #define ERL_UNIT_BITS 8
 
-/*
- * Binary matching.
- */
+/* ************************************************************************* */
+/* Helpers for the bitstring syntax */
 
 Eterm erts_bs_start_match_2(Process *p, Eterm Bin, Uint Max);
 ErlBinMatchState *erts_bs_start_match_3(Process *p, Eterm Bin);
@@ -150,14 +203,11 @@ Eterm erts_bs_get_integer_2(Process *p, Uint num_bits, unsigned flags, ErlBinMat
 Eterm erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb);
 
 /* These will create heap binaries when appropriate, so they require free space
- * up to EXTRACT_SUB_BIN_HEAP_NEED. */
+ * up to BUILD_SUB_BITSTRING_HEAP_NEED. */
 Eterm erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb);
 Eterm erts_bs_get_binary_all_2(Process *p, ErlBinMatchBuffer* mb);
 
-/*
- * Binary construction, new instruction set.
- */
-
+/* Binary construction, new instruction set. */
 int erts_new_bs_put_integer(ERL_BITS_PROTO_3(Eterm Integer, Uint num_bits, unsigned flags));
 int erts_bs_put_utf8(ERL_BITS_PROTO_1(Eterm Integer));
 int erts_bs_put_utf16(ERL_BITS_PROTO_2(Eterm Integer, Uint flags));
@@ -177,34 +227,191 @@ Eterm erts_bs_private_append(Process* p, Eterm bin, Eterm sz, Uint unit);
 Eterm erts_bs_private_append_checked(Process* p, Eterm bin, Uint size, Uint unit);
 Eterm erts_bs_init_writable(Process* p, Eterm sz);
 
-/*
- * Common utilities.
- */
+/* ************************************************************************* */
+/* Copy and comparison routines. */
+
+ERTS_GLB_INLINE void
+copy_binary_to_buffer(byte *dst_base, Uint dst_offset,
+                      const byte *src_base, Uint src_offset,
+                      Uint size);
+
 void erts_copy_bits(const byte* src, size_t soffs, int sdir,
                     byte* dst, size_t doffs, int ddir, size_t n);
-int erts_cmp_bits(byte* a_ptr, size_t a_offs, byte* b_ptr, size_t b_offs, size_t size); 
 
-/*
- * Calculate the heap space for a binary extracted by
- * erts_extract_sub_binary().
- */
-Uint erts_extracted_binary_size(Uint bit_size);
+ERTS_GLB_INLINE int erts_cmp_bits(const byte* a_ptr,
+                                  Uint a_offs,
+                                  const byte* b_ptr,
+                                  Uint b_offs,
+                                  Uint size);
+int erts_cmp_bits__(const byte* a_ptr,
+                    Uint a_offs,
+                    const byte* b_ptr,
+                    Uint b_offs,
+                    Uint size);
 
-/* Extracts a region from base_bin as a sub-binary or heap binary, whichever
- * is the most appropriate.
+/* ************************************************************************* */
+/* Bitstring creation/management */
+
+/** @brief Pins an off-heap binary in place, ensuring that it cannot be moved
+ * by the writable-binary optimization. */
+int erts_pin_writable_binary(BinRef *br);
+
+/* Calculate the heap space for a binary extracted by
+ * erts_build_sub_bitstring(). */
+ERTS_GLB_INLINE Uint erts_extracted_bitstring_size(Uint size);
+
+/* Conservative estimate of the number of words required for
+ * erts_build_sub_bitstring() when the number of bits is unknown. */
+#define BUILD_SUB_BITSTRING_HEAP_NEED \
+    (MAX(ERL_SUB_BITS_SIZE, heap_bits_size(ERL_ONHEAP_BITS_LIMIT)))
+
+/** @brief Extracts a region from base_bin as a sub-bitstring or heap bitstring,
+ * whichever is the most appropriate.
+ *
+ * Note that you cannot pass sub-bitstrings directly here: to build a
+ * sub-bitstring from another, its underlying BinRef* and offset must be
+ * extracted and passed here.
  *
  * The caller must ensure that there's enough free space at *hp by using
- * erts_extracted_binary_size().
- * */
-Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
-                              Uint bit_offset, Uint num_bits);
+ * \c erts_extracted_bitstring_size */
+Eterm erts_build_sub_bitstring(Eterm **hp,
+                               Eterm br_flags,
+                               const BinRef *br,
+                               const byte *base,
+                               Uint offset,
+                               Uint size);
 
-/*
- * Conservative estimate of the number of words required for
- * erts_extract_sub_binary() when the number of bits is unknown.
- */
-#define EXTRACT_SUB_BIN_HEAP_NEED \
-    (MAX(ERL_SUB_BIN_SIZE, heap_bin_size(ERL_ONHEAP_BIN_LIMIT)))
+/* As erts_build_sub_bitstring, but handles allocation and base_bin
+ * extraction. */
+Eterm erts_make_sub_bitstring(Process *p, Eterm bitstring, Uint offset, Uint size);
+Eterm erts_make_sub_binary(Process *p, Eterm bitstring, Uint offset, Uint size);
+
+Eterm erts_new_bitstring(Process *p, Uint size, byte **datap);
+Eterm erts_new_bitstring_refc(Process *p, Uint size, Binary **binp, byte **datap);
+Eterm erts_new_bitstring_from_data(Process *p, Uint size, const byte *data);
+
+/* As erts_new_bitstring[_xyz] bit with sizes in bytes rather than bits */
+Eterm erts_new_binary(Process *p, Uint size, byte **datap);
+Eterm erts_new_binary_refc(Process *p, Uint size, Binary **binp, byte **datap);
+Eterm erts_new_binary_from_data(Process *p, Uint size, const byte *data);
+
+Eterm erts_hfact_new_bitstring(ErtsHeapFactory *hfact,
+                               Uint extra,
+                               Uint size,
+                               byte **datap);
+Eterm erts_hfact_new_binary_from_data(ErtsHeapFactory *hfact,
+                                      Uint extra,
+                                      Uint size,
+                                      const byte *data);
+
+/** @brief Builds a combined ErlSubBits+BinRef for a full binary, without
+ * making a copy if it's smaller than the on-heap bitstring limit.
+ *
+ * @param hpp must have at least ERL_REFC_BITS_SIZE words available during
+ * migration. */
+Eterm erts_wrap_refc_bitstring(struct erl_off_heap_header **oh,
+                               Uint64 *overhead,
+                               Eterm **hpp,
+                               Binary *bin,
+                               byte *data,
+                               Uint offset,
+                               Uint size);
+
+#define ERTS_BR_OVERHEAD(oh, br)                                              \
+    do {                                                                      \
+        (oh)->overhead += ((br)->val)->orig_size / sizeof(Eterm);             \
+    } while(0)
+
+#define ERTS_SET_HB_SIZE(hb, bit_size)                                        \
+    do {                                                                      \
+        Uint __bit_size = (bit_size);                                         \
+        (hb)->size = __bit_size;                                              \
+    } while(0)
+
+#define ERTS_SET_SB_RANGE(sb, bit_offset, bit_size)                           \
+    do {                                                                      \
+        Uint __bit_size = (bit_size);                                         \
+        Uint __bit_offset = (bit_offset);                                     \
+        (sb)->size = __bit_size;                                              \
+        (sb)->offs = __bit_offset;                                            \
+    } while(0)
+
+/** @brief Extracts a window into the given bitstring. */
+#define ERTS_GET_BITSTRING(Bin,                                               \
+                           Base,                                              \
+                           BitOffset,                                         \
+                           BitSize)                                           \
+    do {                                                                      \
+        ERTS_DECLARE_DUMMY(const BinRef *_unused_br);                         \
+        ERTS_DECLARE_DUMMY(Eterm _unused_br_tag);                             \
+        ERTS_GET_BITSTRING_REF(Bin,                                           \
+                               _unused_br_tag,                                \
+                               _unused_br,                                    \
+                               Base,                                          \
+                               BitOffset,                                     \
+                               BitSize);                                      \
+    } while (0)
+
+/** @brief As \c ERTS_GET_BITSTRING but also extracts the underlying binary
+ * reference, if any. */
+#define ERTS_GET_BITSTRING_REF(Bin, RefFlags, Ref, Base, Offset, Size)        \
+    do {                                                                      \
+        const Eterm *_unboxed = bitstring_val(Bin);                           \
+        Size = _unboxed[1];                                                   \
+        if (*_unboxed == HEADER_SUB_BITS) {                                   \
+            ErlSubBits* _sb = (ErlSubBits*)_unboxed;                          \
+            BinRef *_br = ((BinRef*)boxed_val(_sb->orig));                    \
+            ASSERT(_br->thing_word == HEADER_BIN_REF);                        \
+            Base = &_br->bytes[0];                                            \
+            RefFlags = _sb->orig & TAG_PTR_MASK__;                            \
+            Ref = _br;                                                        \
+            Offset = _sb->offs;                                               \
+        } else {                                                              \
+            const ErlHeapBits *_hb = ((ErlHeapBits*)_unboxed);                \
+            Base = (byte*)&_hb->data[0];                                      \
+            Offset = 0;                                                       \
+            RefFlags = 0;                                                     \
+            Ref = NULL;                                                       \
+        }                                                                     \
+    } while (0)
+
+/** @brief As \c ERTS_GET_BITSTRING_REF but also pins writable binaries in
+ * place, shrinking and preventing them from being reallocated. */
+#define ERTS_PIN_BITSTRING(Bin, RefFlags, Ref, Base, Offset, Size)            \
+    do {                                                                      \
+        const Eterm *_unboxed = bitstring_val(Bin);                           \
+        Size = _unboxed[1];                                                   \
+        if (*_unboxed == HEADER_SUB_BITS) {                                   \
+            ErlSubBits* _sb = (ErlSubBits*)_unboxed;                          \
+            BinRef *_br = ((BinRef*)boxed_val(_sb->orig));                    \
+            ASSERT(_br->thing_word == HEADER_BIN_REF);                        \
+            erts_pin_writable_binary(_br);                                    \
+            Base = &_br->bytes[0];                                            \
+            Offset = _sb->offs;                                               \
+            RefFlags = _sb->orig & TAG_PTR_MASK__;                            \
+            Ref = _br;                                                        \
+        } else {                                                              \
+            const ErlHeapBits *_hb = ((ErlHeapBits*)_unboxed);                \
+            Base = (byte*)&_hb->data[0];                                      \
+            Ref = NULL;                                                       \
+            Offset = 0;                                                       \
+        }                                                                     \
+    } while (0)
+
+ERTS_GLB_INLINE const byte*
+erts_get_aligned_binary_bytes_extra(Eterm bin,
+                                    Uint *size_ptr,
+                                    const byte **base_ptr,
+                                    ErtsAlcType_t allocator,
+                                    Uint extra);
+ERTS_GLB_INLINE const byte*
+erts_get_aligned_binary_bytes(Eterm bin,
+                              Uint *size_ptr,
+                              const byte** base_ptr);
+ERTS_GLB_INLINE void
+erts_free_aligned_binary_bytes_extra(const byte* buf, ErtsAlcType_t);
+ERTS_GLB_INLINE void
+erts_free_aligned_binary_bytes(const byte* buf);
 
 /*
  * Flags for bs_create_bin / bs_get_* / bs_put_* / bs_init* instructions.
@@ -235,5 +442,120 @@ Eterm erts_extract_sub_binary(Eterm **hp, Eterm base_bin, byte *base_data,
 #define BSC_UTF32              12
 
 #define BSC_NUM_ARGS            5
+
+#if ERTS_GLB_INLINE_INCL_FUNC_DEF
+
+ERTS_GLB_INLINE void
+copy_binary_to_buffer(byte *dst_base, Uint dst_offset,
+                      const byte *src_base, Uint src_offset,
+                      Uint size)
+{
+    if (size > 0) {
+        dst_base += BYTE_OFFSET(dst_offset);
+        src_base += BYTE_OFFSET(src_offset);
+
+        if (((dst_offset | src_offset | size) & 7) == 0) {
+            sys_memcpy(dst_base, src_base, BYTE_SIZE(size));
+        }
+
+        erts_copy_bits(src_base, BIT_OFFSET(src_offset), 1,
+                       dst_base, BIT_OFFSET(dst_offset), 1,
+                       size);
+    }
+}
+
+ERTS_GLB_INLINE int
+erts_cmp_bits(const byte* a_ptr,
+              Uint a_offs,
+              const byte* b_ptr,
+              Uint b_offs,
+              Uint size)
+{
+    if (size > 0) {
+        a_ptr += BYTE_OFFSET(a_offs);
+        b_ptr += BYTE_OFFSET(b_offs);
+
+        if (((a_offs | b_offs | size) & 7) == 0) {
+            return sys_memcmp(a_ptr, b_ptr, BYTE_SIZE(size));
+        }
+
+        return erts_cmp_bits__(a_ptr,
+                               BIT_OFFSET(a_offs),
+                               b_ptr,
+                               BIT_OFFSET(b_offs),
+                               size);
+    }
+
+    return 0;
+}
+
+ERTS_GLB_INLINE Uint
+erts_extracted_bitstring_size(Uint size)
+{
+    if (size <= ERL_ONHEAP_BITS_LIMIT) {
+        return heap_bits_size(size);
+    } else {
+        ERTS_CT_ASSERT(ERL_SUB_BITS_SIZE <= ERL_ONHEAP_BINARY_LIMIT);
+        return ERL_SUB_BITS_SIZE;
+    }
+}
+
+ERTS_GLB_INLINE const byte*
+erts_get_aligned_binary_bytes(Eterm bin, Uint *size_ptr, const byte **base_ptr)
+{
+    return erts_get_aligned_binary_bytes_extra(bin,
+                                               size_ptr,
+                                               base_ptr,
+                                               ERTS_ALC_T_TMP,
+                                               0);
+}
+
+ERTS_GLB_INLINE const byte*
+erts_get_aligned_binary_bytes_extra(Eterm bin,
+                                    Uint *size_ptr,
+                                    const byte **base_ptr,
+                                    ErtsAlcType_t allocator,
+                                    Uint extra)
+{
+    if (is_bitstring(bin)) {
+        Uint offset, size;
+        const byte *base;
+
+        ERTS_GET_BITSTRING(bin, base, offset, size);
+
+        if (TAIL_BITS(size) == 0) {
+            *size_ptr = BYTE_SIZE(size);
+
+            if (BIT_OFFSET(offset) != 0) {
+                byte *bytes = (byte*)erts_alloc(allocator,
+                                                NBYTES(size) + extra);
+                *base_ptr = bytes;
+
+                erts_copy_bits(base, offset, 1, &bytes[extra], 0, 1, size);
+                return &bytes[extra];
+            }
+
+            return &base[BYTE_OFFSET(offset)];
+        }
+    }
+
+    return NULL;
+}
+
+ERTS_GLB_INLINE void
+erts_free_aligned_binary_bytes_extra(const byte *bytes, ErtsAlcType_t allocator)
+{
+    if (bytes) {
+        erts_free(allocator, (void*)bytes);
+    }
+}
+
+ERTS_GLB_INLINE void
+erts_free_aligned_binary_bytes(const byte *bytes)
+{
+    erts_free_aligned_binary_bytes_extra(bytes, ERTS_ALC_T_TMP);
+}
+
+#endif /* ERTS_GLB_INLINE_INCL_FUNC_DEF */
 
 #endif /* __ERL_BITS_H__ */

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -2658,8 +2658,9 @@ restart:
 	    erts_dsprintf_buf_t *dsbufp = erts_create_tmp_dsbuf(0);
             ASSERT(c_p == self);
 	    print_process_info(ERTS_PRINT_DSBUF, (void *) dsbufp, c_p, ERTS_PROC_LOCK_MAIN);
-	    *esp++ = new_binary(build_proc, (byte *)dsbufp->str,
-				dsbufp->str_len);
+            *esp++ = erts_new_binary_from_data(build_proc,
+                                               dsbufp->str_len,
+                                               (byte *)dsbufp->str);
 	    erts_destroy_tmp_dsbuf(dsbufp);
 	    break;
 	}
@@ -3199,7 +3200,7 @@ void db_do_update_element(DbUpdateHandle* handle,
 		case _TAG_HEADER_POS_BIG:
 		case _TAG_HEADER_NEG_BIG:
 		case _TAG_HEADER_FLOAT:
-		case _TAG_HEADER_HEAP_BIN:
+		case _TAG_HEADER_HEAP_BITS:
 		    newval_sz = header_arity(*newp) + 1;
 		    if (is_boxed(oldval)) {
 			oldp = boxed_val(oldval);
@@ -3207,7 +3208,7 @@ void db_do_update_element(DbUpdateHandle* handle,
 			case _TAG_HEADER_POS_BIG:
 			case _TAG_HEADER_NEG_BIG:
 			case _TAG_HEADER_FLOAT:
-			case _TAG_HEADER_HEAP_BIN:
+			case _TAG_HEADER_HEAP_BITS:
 			    oldval_sz = header_arity(*oldp) + 1;
 			    if (oldval_sz == newval_sz) {
 				/* "self contained" terms of same size, do memcpy */
@@ -3729,7 +3730,7 @@ done:
 }
 
 /* Our own "cleanup_offheap"
- * as ProcBin and ErtsMRefThing may be unaligned in compressed terms
+ * as BinRef and ErtsMRefThing may be unaligned in compressed terms
 */
 void db_cleanup_offheap_comp(DbTerm* obj)
 {
@@ -3739,8 +3740,8 @@ void db_cleanup_offheap_comp(DbTerm* obj)
     for (u.hdr = obj->first_oh; u.hdr; u.hdr = u.hdr->next) {
         erts_align_offheap(&u, &tmp);
         switch (thing_subtag(u.hdr->thing_word)) {
-        case REFC_BINARY_SUBTAG:
-            erts_bin_release(u.pb->val);
+        case BIN_REF_SUBTAG:
+            erts_bin_release(u.br->val);
             break;
         case FUN_SUBTAG:
             /* We _KNOW_ that this is a local fun, otherwise it would not

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -3384,8 +3384,14 @@ static void* copy_to_comp(int keypos, Eterm obj, DbTerm* dest,
 		tpl[i] = src[i];
 	    }
 	    else {
-		tpl[i] = ext2elem(tpl, top.cp);
-		top.cp = erts_encode_ext_ets(src[i], top.cp, &dest->first_oh);
+#ifdef DEBUG
+                Uint encoded_size = erts_encode_ext_size_ets(src[i]);
+                byte *orig_cp = top.cp;
+#endif
+                tpl[i] = ext2elem(tpl, top.cp);
+
+                top.cp = erts_encode_ext_ets(src[i], top.cp, &dest->first_oh);
+                ASSERT(top.cp == &orig_cp[encoded_size]);
 	    }
 	}
     }

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -577,11 +577,11 @@ ERTS_GLB_INLINE Binary *erts_db_get_match_prog_binary_unchecked(Eterm term);
 
 /** @brief Ensure off-heap header is word aligned, make a temporary copy if
  * not. Needed when inspecting ETS off-heap lists that may contain unaligned
- * ProcBin and ErtsMRefThing if table is 'compressed'.
+ * BinRef and ErtsMRefThing if table is 'compressed'.
  */
 union erts_tmp_aligned_offheap
 {
-    ProcBin proc_bin;
+    BinRef proc_bin;
     ErtsMRefThing mref_thing;
 };
 ERTS_GLB_INLINE void erts_align_offheap(union erl_off_heap_ptr*,
@@ -625,7 +625,7 @@ erts_align_offheap(union erl_off_heap_ptr* ohp,
 {
     if ((UWord)ohp->voidp % sizeof(UWord) != 0) {
         /*
-         * ETS store word unaligned ProcBin and ErtsMRefThing in its compressed
+         * ETS store word unaligned BinRef and ErtsMRefThing in its compressed
          * format. Make a temporary aligned copy.
          *
          * Warning, must pass (void*)-variable to memcpy. Otherwise it will
@@ -633,9 +633,9 @@ erts_align_offheap(union erl_off_heap_ptr* ohp,
          * about word aligned memory (type cast is not enough).
          */
         sys_memcpy(tmp, ohp->voidp, sizeof(Eterm)); /* thing_word */
-        if (tmp->proc_bin.thing_word == HEADER_PROC_BIN) {
+        if (tmp->proc_bin.thing_word == HEADER_BIN_REF) {
             sys_memcpy(tmp, ohp->voidp, sizeof(tmp->proc_bin));
-            ohp->pb = &tmp->proc_bin;
+            ohp->br = &tmp->proc_bin;
         }
         else {
             sys_memcpy(tmp, ohp->voidp, sizeof(tmp->mref_thing));

--- a/erts/emulator/beam/erl_debug.c
+++ b/erts/emulator/beam/erl_debug.c
@@ -186,11 +186,14 @@ pdisplay1(fmtfn_t to, void *to_arg, Process* p, Eterm obj)
 	    erts_print(to, to_arg, "%.20e", ff.fd);
 	}
 	break;
-    case BINARY_DEF:
+    case BITSTRING_DEF:
 	erts_print(to, to_arg, "#Bin");
 	break;
     case MATCHSTATE_DEF:
         erts_print(to, to_arg, "#Matchstate");
+        break;
+    case BIN_REF_DEF:
+        erts_print(to, to_arg, "#BinRef");
         break;
     default:
 	erts_print(to, to_arg, "unknown object %x", obj);

--- a/erts/emulator/beam/erl_etp.c
+++ b/erts/emulator/beam/erl_etp.c
@@ -1,0 +1,158 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2023-2023. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+/* This module contains explicit constants that a debugger can use to better
+ * navigate the emulator's data structures, helping us avoid hardcoding
+ * constants into scripts. */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "sys.h"
+#include "global.h"
+#include "erl_version.h"
+#include "erl_map.h"
+
+const int etp_smp_compiled = 1;
+const int etp_thread_compiled = 1;
+const char etp_erts_version[] = ERLANG_VERSION;
+const char etp_otp_release[] = ERLANG_OTP_RELEASE;
+const char etp_arch[] = ERLANG_ARCHITECTURE;
+#if ERTS_ENABLE_KERNEL_POLL
+const int erts_use_kernel_poll = 1;
+const int etp_kernel_poll_support = 1;
+#else
+const int erts_use_kernel_poll = 0;
+const int etp_kernel_poll_support = 0;
+#endif
+#if defined(ARCH_64)
+const int etp_arch_bits = 64;
+#elif defined(ARCH_32)
+const int etp_arch_bits = 32;
+#else
+# error "Not 64-bit, nor 32-bit arch"
+#endif
+#ifdef BEAMASM
+const int etp_beamasm = 1;
+#else
+const int etp_beamasm = 0;
+#endif
+#ifdef DEBUG
+const int etp_debug_compiled = 1;
+#else
+const int etp_debug_compiled = 0;
+#endif
+#ifdef ERTS_ENABLE_LOCK_COUNT
+const int etp_lock_count = 1;
+#else
+const int etp_lock_count = 0;
+#endif
+#ifdef ERTS_ENABLE_LOCK_CHECK
+const int etp_lock_check = 1;
+#else
+const int etp_lock_check = 0;
+#endif
+const int etp_endianness = ERTS_ENDIANNESS;
+const Eterm etp_ref_header = ERTS_REF_THING_HEADER;
+#ifdef ERTS_MAGIC_REF_THING_HEADER
+const Eterm etp_magic_ref_header = ERTS_MAGIC_REF_THING_HEADER;
+#else
+const Eterm etp_magic_ref_header = ERTS_REF_THING_HEADER;
+#endif
+const Eterm etp_the_non_value = THE_NON_VALUE;
+#ifdef TAG_LITERAL_PTR
+const Eterm etp_ptr_mask = (~(Eterm)7);
+const Eterm etp_tag_literal_ptr = TAG_LITERAL_PTR;
+#else
+const Eterm etp_ptr_mask = (~(Eterm)3);
+const Eterm etp_tag_literal_ptr = 0;
+#endif
+#ifdef ERTS_HOLE_MARKER
+const Eterm etp_hole_marker = ERTS_HOLE_MARKER;
+#else
+const Eterm etp_hole_marker = 0;
+#endif
+
+const Eterm etp_arityval_subtag = ARITYVAL_SUBTAG;
+const Eterm etp_bin_matchstate_subtag = BIN_MATCHSTATE_SUBTAG;
+const Eterm etp_big_tag_mask = _BIG_TAG_MASK;
+const Eterm etp_big_sign_bit = _BIG_SIGN_BIT;
+const Eterm etp_pos_big_subtag = POS_BIG_SUBTAG;
+const Eterm etp_neg_big_subtag = NEG_BIG_SUBTAG;
+const Eterm etp_ref_subtag = REF_SUBTAG;
+const Eterm etp_fun_subtag = FUN_SUBTAG;
+const Eterm etp_float_subtag = FLOAT_SUBTAG;
+const Eterm etp_bitstring_tag_mask = _BITSTRING_TAG_MASK;
+const Eterm etp_heap_bits_subtag = HEAP_BITS_SUBTAG;
+const Eterm etp_sub_bits_subtag = SUB_BITS_SUBTAG;
+const Eterm etp_bin_ref_subtag = BIN_REF_SUBTAG;
+const Eterm etp_map_subtag = MAP_SUBTAG;
+const Eterm etp_external_tag_mask = _EXTERNAL_TAG_MASK;
+const Eterm etp_external_pid_subtag = EXTERNAL_PID_SUBTAG;
+const Eterm etp_external_port_subtag = EXTERNAL_PORT_SUBTAG;
+const Eterm etp_external_ref_subtag = EXTERNAL_REF_SUBTAG;
+
+const Eterm etp_tag_header_arityval = _TAG_HEADER_ARITYVAL;
+const Eterm etp_tag_header_fun = _TAG_HEADER_FUN;
+const Eterm etp_tag_header_pos_big = _TAG_HEADER_POS_BIG;
+const Eterm etp_tag_header_neg_big = _TAG_HEADER_NEG_BIG;
+const Eterm etp_tag_header_float = _TAG_HEADER_FLOAT;
+const Eterm etp_tag_header_ref = _TAG_HEADER_REF;
+const Eterm etp_tag_header_bin_ref = _TAG_HEADER_BIN_REF;
+const Eterm etp_tag_header_heap_bits = _TAG_HEADER_HEAP_BITS;
+const Eterm etp_tag_header_sub_bits = _TAG_HEADER_SUB_BITS;
+const Eterm etp_tag_header_external_pid = _TAG_HEADER_EXTERNAL_PID;
+const Eterm etp_tag_header_external_port = _TAG_HEADER_EXTERNAL_PORT;
+const Eterm etp_tag_header_external_ref = _TAG_HEADER_EXTERNAL_REF;
+const Eterm etp_tag_header_bin_matchstate = _TAG_HEADER_BIN_MATCHSTATE;
+const Eterm etp_tag_header_map = _TAG_HEADER_MAP;
+
+const Eterm etp_tag_header_mask = _TAG_HEADER_MASK;
+const Eterm etp_header_subtag_mask = _HEADER_SUBTAG_MASK;
+const Eterm etp_header_arity_offs = _HEADER_ARITY_OFFS;
+
+const Eterm etp_tag_primary_size = _TAG_PRIMARY_SIZE;
+const Eterm etp_tag_primary_mask = _TAG_PRIMARY_MASK;
+const Eterm etp_tag_primary_header = TAG_PRIMARY_HEADER;
+const Eterm etp_tag_primary_list = TAG_PRIMARY_LIST;
+const Eterm etp_tag_primary_boxed = TAG_PRIMARY_BOXED;
+const Eterm etp_tag_primary_immed1 = TAG_PRIMARY_IMMED1;
+
+const Eterm etp_tag_immed1_size = _TAG_IMMED1_SIZE;
+const Eterm etp_tag_immed1_mask = _TAG_IMMED1_MASK;
+const Eterm etp_tag_immed1_pid = _TAG_IMMED1_PID;
+const Eterm etp_tag_immed1_port = _TAG_IMMED1_PORT;
+const Eterm etp_tag_immed1_immed2 = _TAG_IMMED1_IMMED2;
+const Eterm etp_tag_immed1_small = _TAG_IMMED1_SMALL;
+
+const Eterm etp_tag_immed2_size = _TAG_IMMED2_SIZE;
+const Eterm etp_tag_immed2_mask = _TAG_IMMED2_MASK;
+const Eterm etp_tag_immed2_atom = _TAG_IMMED2_ATOM;
+const Eterm etp_tag_immed2_catch = _TAG_IMMED2_CATCH;
+const Eterm etp_tag_immed2_nil = _TAG_IMMED2_NIL;
+
+const Eterm etp_header_map_subtag_mask = _HEADER_MAP_SUBTAG_MASK;
+const Eterm etp_header_map_hashmap_head_mask = _HEADER_MAP_HASHMAP_HEAD_MASK;
+
+const Eterm etp_map_subtag_node_bitmap = HAMT_SUBTAG_NODE_BITMAP;
+const Eterm etp_map_subtag_head_array = HAMT_SUBTAG_HEAD_ARRAY;
+const Eterm etp_map_subtag_head_bitmap = HAMT_SUBTAG_HEAD_BITMAP;
+const Eterm etp_map_subtag_head_flatmap = HAMT_SUBTAG_HEAD_FLATMAP;

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -33,7 +33,6 @@
 
 #define IS_MOVED_BOXED(x)	(!is_header((x)))
 #define IS_MOVED_CONS(x)	(is_non_value((x)))
-Eterm* erts_sub_binary_to_heap_binary(Eterm *ptr, Eterm **hpp, Eterm *orig);
 
 ERTS_GLB_INLINE void move_cons(Eterm *ERTS_RESTRICT ptr, Eterm car, Eterm **hpp,
                                Eterm *orig);
@@ -67,15 +66,7 @@ ERTS_GLB_INLINE Eterm* move_boxed(Eterm *ERTS_RESTRICT ptr, Eterm hdr, Eterm **h
     ASSERT(is_header(hdr));
     nelts = header_arity(hdr);
     switch ((hdr) & _HEADER_SUBTAG_MASK) {
-    case SUB_BINARY_SUBTAG:
-        {
-            ErlSubBin *sb = (ErlSubBin *)ptr;
-            /* convert sub-binary to heap-binary if applicable */
-            if (sb->bitsize == 0 && sb->bitoffs == 0 &&
-                sb->is_writable == 0 && sb->size <= sizeof(Eterm) * 3) {
-                return erts_sub_binary_to_heap_binary(ptr, hpp, orig);
-            }
-        }
+    case SUB_BITS_SUBTAG:
         nelts++;
         break;
     case MAP_SUBTAG:

--- a/erts/emulator/beam/erl_io_queue.h
+++ b/erts/emulator/beam/erl_io_queue.h
@@ -124,33 +124,38 @@ ERTS_GLB_INLINE
 int erts_ioq_iodata_vec_len(Eterm obj, int* vsize, Uint* csize,
                             Uint* pvsize, Uint* pcsize,
                             size_t* total_size, Uint blimit) {
-  if (is_binary(obj)) {
-    /* We optimize for when we get a procbin without a bit-offset
-     * that fits in one iov slot
-     */
-    Eterm real_bin;
-    byte bitoffs;
-    byte bitsize;
-    ERTS_DECLARE_DUMMY(Uint offset);
-    Uint size = binary_size(obj);
-    ERTS_GET_REAL_BIN(obj, real_bin, offset, bitoffs, bitsize);
-    if (size < MAX_SYSIOVEC_IOVLEN && bitoffs == 0 && bitsize == 0) {
-      *vsize = 1;
-      *pvsize = 1;
-      if (thing_subtag(*binary_val(real_bin)) == REFC_BINARY_SUBTAG) {
-          *csize = 0;
-          *pcsize = 0;
-      } else {
-          *csize = size;
-          *pcsize = size;
-      }
-      *total_size = size;
-      return 0;
-    }
-  }
+    if (is_bitstring(obj)) {
+        /* We optimize for when we get a binary without a bit-offset that fits
+         * in one iov slot */
+        ERTS_DECLARE_DUMMY(Eterm br_flags);
+        ERTS_DECLARE_DUMMY(byte *base);
+        Uint offset, size;
+        BinRef *br;
 
-  return erts_ioq_iolist_vec_len(obj, vsize, csize,
-                                 pvsize, pcsize, total_size, blimit);
+        ERTS_GET_BITSTRING_REF(obj, br_flags, br, base, offset, size);
+
+        if (size < MAX_SYSIOVEC_IOVLEN &&
+            BIT_OFFSET(offset) == 0 &&
+            TAIL_BITS(size) == 0) {
+            size = BYTE_SIZE(size);
+            *vsize = 1;
+            *pvsize = 1;
+
+            if (br) {
+                *csize = 0;
+                *pcsize = 0;
+            } else {
+                *csize = size;
+                *pcsize = size;
+            }
+
+            *total_size = size;
+            return 0;
+        }
+    }
+
+    return erts_ioq_iolist_vec_len(obj, vsize, csize,
+                                   pvsize, pcsize, total_size, blimit);
 }
 
 ERTS_GLB_INLINE
@@ -161,38 +166,44 @@ int erts_ioq_iodata_to_vec(Eterm obj,
                            Uint bin_limit,
                            int driver)
 {
-    if (is_binary(obj)) {
-        Eterm real_bin;
-        byte bitoffs;
-        byte bitsize;
-        Uint offset;
-        Uint size = binary_size(obj);
-        ERTS_GET_REAL_BIN(obj, real_bin, offset, bitoffs, bitsize);
-        if (size < MAX_SYSIOVEC_IOVLEN && bitoffs == 0 && bitsize == 0) {
-            Eterm *bptr = binary_val(real_bin);
-            if (thing_subtag(*bptr) == REFC_BINARY_SUBTAG) {
-                ProcBin *pb = (ProcBin *)bptr;
-                if (pb->flags)
-                    erts_emasculate_writable_binary(pb);
-                iov[0].iov_base = pb->bytes+offset;
-                iov[0].iov_len = size;
-                if (driver)
-                    binv[0] = (ErtsIOQBinary*)Binary2ErlDrvBinary(pb->val);
-                else
-                    binv[0] = (ErtsIOQBinary*)pb->val;
+    if (is_bitstring(obj)) {
+        ERTS_DECLARE_DUMMY(Eterm br_flags);
+        Uint offset, size;
+        byte *base;
+        BinRef *br;
+
+        ERTS_PIN_BITSTRING(obj, br_flags, br, base, offset, size);
+        ASSERT(TAIL_BITS(size) == 0);
+
+        if (NBYTES(size) < MAX_SYSIOVEC_IOVLEN) {
+            if (br && BIT_OFFSET(offset) == 0) {
+                Binary *refc_binary = br->val;
+
+                iov[0].iov_base = &base[BYTE_OFFSET(offset)];
+                iov[0].iov_len = NBYTES(size);
+
+                if (driver) {
+                    binv[0] = (ErtsIOQBinary*)Binary2ErlDrvBinary(refc_binary);
+                } else {
+                    binv[0] = (ErtsIOQBinary*)refc_binary;
+                }
+
                 return 1;
-            } else {
-                ErlHeapBin* hb = (ErlHeapBin *)bptr;
+            } else if (br == NULL) {
                 byte *buf = driver ? (byte*)cbin->driver.orig_bytes :
-                    (byte*)cbin->nif.orig_bytes;
-		copy_binary_to_buffer(buf, 0, ((byte *) hb->data)+offset, 0, 8*size);
+                                     (byte*)cbin->nif.orig_bytes;
+
+                copy_binary_to_buffer(buf, 0, base, offset, size);
+
                 iov[0].iov_base = buf;
-                iov[0].iov_len = size;
+                iov[0].iov_len = NBYTES(size);
                 binv[0] = cbin;
+
                 return 1;
             }
         }
     }
+
     return erts_ioq_iolist_to_vec(obj, iov, binv, cbin, bin_limit, driver);
 }
 

--- a/erts/emulator/beam/erl_iolist.c
+++ b/erts/emulator/beam/erl_iolist.c
@@ -1,0 +1,968 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2023. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "erl_iolist.h"
+
+#include "bif.h"
+#include "erl_bits.h"
+#include "erl_binary.h"
+#include "erl_process.h"
+
+#define IOL2B_MIN_EXEC_REDS (CONTEXT_REDS / 4)
+#define IOL2B_RESCHED_REDS (CONTEXT_REDS / 40)
+
+static Export list_to_bitstring_continue_export;
+static Export iolist_size_continue_export;
+
+static BIF_RETTYPE list_to_bitstring_continue(BIF_ALIST_1);
+static BIF_RETTYPE iolist_size_continue(BIF_ALIST_1);
+
+void
+erts_init_iolist(void)
+{
+    erts_init_trap_export(&list_to_bitstring_continue_export,
+                          am_erts_internal, am_list_to_bitstring_continue, 1,
+                          &list_to_bitstring_continue);
+
+    erts_init_trap_export(&iolist_size_continue_export,
+                          am_erts_internal, am_iolist_size_continue, 1,
+                          &iolist_size_continue);
+}
+
+/* ************************************************************************* */
+
+#define ERTS_IOLIST_STATE_INITER(C_P, OBJ)                                    \
+    {{NULL, NULL, NULL, ERTS_ALC_T_INVALID}, /* Stack */                      \
+     (C_P),                                                                   \
+     (OBJ),                                                                   \
+     0,                                      /* Size */                       \
+     0,                                      /* Size valid */                 \
+     0}                                      /* Reductions left */
+
+#define ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED 8
+
+typedef struct {
+    ErtsEStack estack;
+    Process *c_p;
+    Eterm obj;
+    ErlDrvSizeT size;
+    int have_size;
+    int reds_left;
+} ErtsIOListState;
+
+enum iolist_action {
+    ERTS_IOLIST_OK,
+    ERTS_IOLIST_OVERFLOW,
+    ERTS_IOLIST_TYPE,
+    ERTS_IOLIST_YIELD
+};
+
+/* This MUST report type and unit errors in exactly the same way as
+ * `generic_iol2b` so that the latter can elect to skip error checking.
+ *
+ * Note that overflow errors are reported differently: the size routine reports
+ * overflow when the size in bits is larger than that which can be represented
+ * in a word, whereas the conversion routine reports overflow when the provided
+ * buffer is too small. (The latter iff one hasn't guaranteed that it will fit
+ * beforehand by calling the size routine.) */
+static ERTS_FORCE_INLINE
+enum iolist_action generic_iolist_size(ErtsIOListState *state,
+                                       const int Unit,
+                                       const int YieldSupport)
+{
+    enum iolist_action res = ERTS_IOLIST_OK;
+    int init_yield_count, yield_count;
+    DECLARE_ESTACK(s);
+    Uint size;
+    Eterm obj;
+
+    ASSERT((YieldSupport) == !!(YieldSupport));
+    ASSERT((Unit) == 1 || (Unit) == 8);
+    ASSERT(state->size == 0 || ((YieldSupport) && state->estack.start));
+
+    size = state->size;
+    obj = state->obj;
+
+    if (YieldSupport) {
+        if (state->reds_left <= 0) {
+            return ERTS_IOLIST_YIELD;
+        }
+
+        ESTACK_CHANGE_ALLOCATOR(s, ERTS_ALC_T_SAVED_ESTACK);
+        init_yield_count = ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED;
+        init_yield_count *= state->reds_left;
+        yield_count = init_yield_count;
+
+        if (state->estack.start) {
+            ESTACK_RESTORE(s, &state->estack);
+        }
+    } else {
+        init_yield_count = yield_count = 0;
+    }
+
+    goto L_start;
+
+    while (!ESTACK_ISEMPTY(s)) {
+        obj = ESTACK_POP(s);
+
+    L_start:
+        while (is_list(obj)) {
+            Eterm *cell = list_val(obj);
+            Eterm head, tail;
+
+            if ((YieldSupport) && --yield_count <= 0) {
+                goto L_yield;
+            }
+
+            /* Note that we don't update `obj` straight away: if we have to
+             * bail on a size overflow, we don't want to return into the main
+             * loop with the raw `head` as that may be a type error. */
+            head = CAR(cell);
+            tail = CDR(cell);
+
+            if (is_byte(head)) {
+                if (ERTS_UNLIKELY(size > (ERTS_UWORD_MAX - 8))) {
+                    goto L_overflow;
+                }
+                size += 8;
+            } else  if (is_bitstring(head)) {
+                Uint head_size = bitstring_size(head);
+                if ((head_size % (Unit)) != 0) {
+                    goto L_type_error;
+                }
+                if (ERTS_UNLIKELY(size > (ERTS_UWORD_MAX - head_size))) {
+                    goto L_overflow;
+                }
+                size += head_size;
+            } else if (is_list(head)) {
+                /* Deal with the inner list in `head` first, handling our tail
+                 * later */
+                ESTACK_PUSH(s, tail);
+                obj = head;
+                continue;
+            } else if (is_not_nil(head)) {
+                goto L_type_error;
+            }
+
+            obj = tail;
+        }
+
+        if ((YieldSupport) && --yield_count <= 0) {
+            goto L_yield;
+        } else if (is_bitstring(obj)) {
+            Uint obj_size = bitstring_size(obj);
+            if ((obj_size % (Unit)) != 0) {
+                goto L_type_error;
+            }
+            if (ERTS_UNLIKELY(size > (ERTS_UWORD_MAX - obj_size))) {
+                goto L_overflow;
+            }
+            size += obj_size;
+        } else if (is_not_nil(obj)) {
+            goto L_type_error;
+        }
+    }
+
+    ASSERT((size % (Unit)) == 0);
+    state->have_size = 1;
+    state->size = size;
+
+    res = ERTS_IOLIST_OK;
+
+L_finished:
+    DESTROY_ESTACK(s);
+    CLEAR_SAVED_ESTACK(&state->estack);
+
+L_return:
+    if (YieldSupport) {
+        int reds, yc;
+
+        yc = init_yield_count - yield_count;
+        reds = (yc - 1) / ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED + 1;
+
+        BUMP_REDS(state->c_p, reds);
+        state->reds_left -= reds;
+    }
+
+    return res;
+
+L_overflow:
+    /* This is not necessarily an error as we may be allowed to calculate
+     * sizes that can't fit into a word, for example erlang:iolist_size/1.
+     *
+     * Hence, we save our current state to allow resuming after adding the
+     * current size to a larger accumulator. Note that the size referred
+     * here is prior to adding the size of the current object. */
+    if (YieldSupport) {
+        ESTACK_SAVE(s, &state->estack);
+    }
+
+    state->size = size;
+    state->obj = obj;
+
+    res = ERTS_IOLIST_OVERFLOW;
+    goto L_return;
+
+L_type_error:
+    res = ERTS_IOLIST_TYPE;
+    goto L_finished;
+
+L_yield:
+    ASSERT(YieldSupport);
+
+    BUMP_ALL_REDS(state->c_p);
+    state->size = size;
+    state->reds_left = 0;
+    state->obj = obj;
+
+    ESTACK_SAVE(s, &state->estack);
+    return ERTS_IOLIST_YIELD;
+}
+
+/* ************************************************************************* */
+
+#define ERTS_IOLIST2BUF_STATE_INITER(C_P, OBJ)                                \
+    {ERTS_IOLIST_STATE_INITER((C_P), (OBJ)),                                  \
+     {NULL, 0, 0},                              /* Bitstring copy state */    \
+     NULL,                                      /* Base */                    \
+     0}                                         /* Offset */
+
+#define ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT 32
+#define ERTS_IOLIST_TO_BUF_BITS_PER_YIELD_COUNT                               \
+    (ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT / CHAR_BIT)
+#define ERTS_IOLIST_TO_BUF_YIELD_COUNT_PER_RED 8
+#define ERTS_IOLIST_TO_BUF_BYTES_PER_RED \
+    (ERTS_IOLIST_TO_BUF_YIELD_COUNT_PER_RED *                                 \
+     ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT)
+
+typedef struct {
+    ErtsIOListState iolist;
+
+    struct {
+        byte *base;
+        Uint offset;
+        Uint size;
+    } bcopy;
+
+    byte *base;
+    ErlDrvSizeT offset;
+} ErtsIOList2BufState;
+
+static ERTS_INLINE
+enum iolist_action generic_iol2b_copy_bitstring(ErtsIOList2BufState *state,
+                                                Eterm obj,
+                                                int *yield_countp,
+                                                const int YieldSupport)
+{
+    Uint offset, size;
+    Uint copy_size;
+    byte* base;
+    int yield_count;
+
+    if (state->bcopy.base) {
+        ASSERT(YieldSupport);
+
+        base = state->bcopy.base;
+        offset = state->bcopy.offset;
+        size = state->bcopy.size;
+
+        state->bcopy.base = NULL;
+    } else {
+        ASSERT(is_bitstring(obj));
+        ERTS_GET_BITSTRING(obj, base, offset, size);
+    }
+
+    ASSERT(size <= (state->iolist.size - state->offset));
+
+    ERTS_CT_ASSERT((CONTEXT_REDS * ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED) <
+                   (ERTS_UINT_MAX / ERTS_IOLIST_TO_BUF_BITS_PER_YIELD_COUNT));
+
+    if (YieldSupport) {
+        Uint copy_limit;
+
+        yield_count = *yield_countp;
+
+        ASSERT(yield_count >= 0);
+        copy_limit = (Uint)yield_count + 1;
+        copy_limit *= ERTS_IOLIST_TO_BUF_BITS_PER_YIELD_COUNT;
+
+        copy_size = MIN(size, copy_limit);
+    } else {
+        copy_size = size;
+    }
+
+    copy_binary_to_buffer(state->base, state->offset, base, offset, copy_size);
+    state->offset += copy_size;
+
+    if (YieldSupport) {
+        if (copy_size < size) {
+            state->bcopy.base = base;
+            state->bcopy.offset = offset + copy_size;
+            state->bcopy.size = size - copy_size;
+
+            *yield_countp = 0;
+
+            return 1;
+        }
+
+        yield_count -= copy_size / ERTS_IOLIST_TO_BUF_BITS_PER_YIELD_COUNT;
+        *yield_countp = yield_count;
+    }
+
+    return 0;
+}
+
+/* This MUST report type and unit errors in exactly the same way as
+ * `generic_iolist_size`, so that the former can be used to pre-check errors
+ * for this routine, letting us skip error checking here if we wish. */
+static ERTS_FORCE_INLINE
+int generic_iol2b(ErtsIOList2BufState *copy_state,
+                  const int Unit,
+                  const int ErrorSupport,
+                  const int YieldSupport)
+{
+    enum iolist_action res = ERTS_IOLIST_OK;
+    int init_yield_count, yield_count;
+    ErtsIOListState *list_state;
+    DECLARE_ESTACK(s);
+    byte *base;
+    Eterm obj;
+
+    ASSERT((YieldSupport) == !!(YieldSupport));
+    ASSERT((ErrorSupport) == !!(ErrorSupport));
+    ASSERT((Unit) == 1 || (Unit) == 8);
+
+    list_state = &copy_state->iolist;
+    ASSERT(list_state->have_size && copy_state->offset < list_state->size);
+
+    base = copy_state->base;
+    obj = list_state->obj;
+
+    if (YieldSupport) {
+        if (list_state->reds_left <= 0) {
+            return ERTS_IOLIST_YIELD;
+        }
+
+        ESTACK_CHANGE_ALLOCATOR(s, ERTS_ALC_T_SAVED_ESTACK);
+        init_yield_count = ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED;
+        init_yield_count *= list_state->reds_left;
+        yield_count = init_yield_count;
+
+        if (list_state->estack.start) {
+            ESTACK_RESTORE(s, &list_state->estack);
+        }
+    } else {
+        init_yield_count = yield_count = 0;
+    }
+
+    goto L_start;
+
+    while (!ESTACK_ISEMPTY(s)) {
+        obj = ESTACK_POP(s);
+
+    L_start:
+        while (is_list(obj)) {
+            Eterm *cell = list_val(obj);
+
+            if ((YieldSupport) && --yield_count <= 0) {
+                goto L_yield;
+            }
+
+            obj = CAR(cell);
+
+            if (is_byte(obj)) {
+                Uint shift, byte_offset;
+
+                if (ErrorSupport) {
+                    if ((list_state->size - copy_state->offset) < 8) {
+                        goto L_overflow_error;
+                    }
+                }
+
+                byte_offset = copy_state->offset / 8;
+                shift = copy_state->offset % 8;
+
+                if ((Unit) == 8 || (shift == 0)) {
+                    ASSERT(shift == 0);
+                    base[byte_offset] = unsigned_val(obj);
+                } else if ((Unit) == 1) {
+                    byte leading_bits = base[byte_offset];
+
+                    base[byte_offset] =
+                        (byte)(unsigned_val(obj) >> shift) |
+                        ((leading_bits >> (8 - shift)) << (8 - shift));
+                    base[byte_offset + 1] = (unsigned_val(obj) << (8 - shift));
+                }
+
+                copy_state->offset += 8;
+            } else if (is_bitstring(obj)) {
+                if (ErrorSupport) {
+                    Uint size = bitstring_size(obj);
+
+                    if ((size % (Unit)) != 0) {
+                        goto L_type_error;
+                    } else if ((list_state->size - copy_state->offset) < size) {
+                        goto L_overflow_error;
+                    }
+                }
+
+                if (generic_iol2b_copy_bitstring(copy_state,
+                                                 obj,
+                                                 &yield_count,
+                                                 YieldSupport)) {
+                    list_state->obj = obj;
+                    ESTACK_PUSH(s, CDR(cell));
+                    goto L_yield;
+                }
+            } else if (is_list(obj)) {
+                /* Deal with the inner list in `obj` first, handling our tail
+                 * later */
+                ESTACK_PUSH(s, CDR(cell));
+                continue;
+            } else if ((ErrorSupport) && is_not_nil(obj)) {
+                goto L_type_error;
+            }
+
+            obj = CDR(cell);
+        }
+
+        if ((YieldSupport) && --yield_count <= 0) {
+            goto L_yield;
+        } else if (is_bitstring(obj)) {
+            if (ErrorSupport) {
+                Uint size = bitstring_size(obj);
+
+                if ((size % (Unit)) != 0) {
+                    goto L_type_error;
+                } else if ((list_state->size - copy_state->offset) < size) {
+                    goto L_overflow_error;
+                }
+            }
+
+            if (generic_iol2b_copy_bitstring(copy_state,
+                                             obj,
+                                             &yield_count,
+                                             YieldSupport)) {
+                list_state->obj = obj;
+                goto L_yield;
+            }
+        } else if ((ErrorSupport) && is_not_nil(obj)) {
+            goto L_type_error;
+        }
+    }
+
+    res = ERTS_IOLIST_OK;
+
+L_return:
+    if (YieldSupport) {
+        int reds, yc;
+
+        yc = init_yield_count - yield_count;
+        reds = (yc - 1) / ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED + 1;
+        BUMP_REDS(list_state->c_p, reds);
+        list_state->reds_left -= reds;
+    }
+
+    DESTROY_ESTACK(s);
+    CLEAR_SAVED_ESTACK(&list_state->estack);
+
+    return res;
+
+L_overflow_error:
+    res = ERTS_IOLIST_OVERFLOW;
+    goto L_return;
+
+L_type_error:
+    res = ERTS_IOLIST_TYPE;
+    goto L_return;
+
+L_yield:
+    ASSERT(YieldSupport);
+
+    /* As the yielding variants have already checked the list for errors, there
+     * is no need to continue after having copied everything of substance: just
+     * return that everything went well.
+     *
+     * While we could do this in the main loop, it makes it more cluttered and
+     * probably just costs performance in the average case. Doing it here
+     * simplifies trapping as we can assume that there's always work to be done
+     * on entry. */
+    ASSERT(copy_state->offset <= list_state->size);
+    if (copy_state->offset == list_state->size) {
+        res = ERTS_IOLIST_OK;
+        goto L_return;
+    }
+
+    BUMP_ALL_REDS(list_state->c_p);
+    list_state->reds_left = 0;
+    list_state->obj = obj;
+
+    ESTACK_SAVE(s, &list_state->estack);
+    return ERTS_IOLIST_YIELD;
+}
+
+/* ************************************************************************* */
+
+ErlDrvSizeT erts_iolist_to_buf(Eterm obj, char *data, ErlDrvSizeT size)
+{
+    ErtsIOList2BufState state = { .iolist.have_size = 1,
+                                  .iolist.size = size * 8,
+                                  .iolist.obj = obj,
+                                  .base = (byte*)data };
+
+    if (size > 0) {
+        switch (generic_iol2b(&state, 8, 1, 0)) {
+        case ERTS_IOLIST_OVERFLOW:
+            return ERTS_IOLIST_TO_BUF_OVERFLOW;
+        case ERTS_IOLIST_TYPE:
+            return ERTS_IOLIST_TO_BUF_TYPE_ERROR;
+        case ERTS_IOLIST_OK:
+            ASSERT(ERTS_IOLIST_TO_BUF_SUCCEEDED(state.offset));
+            return size - (state.offset / 8);
+        case ERTS_IOLIST_YIELD:
+            ERTS_INTERNAL_ERROR("unreachable");
+        }
+    }
+
+    return 0;
+}
+
+int erts_iolist_size(Eterm obj, ErlDrvSizeT *sizep)
+{
+    ErtsIOListState state = { .obj = obj };
+    int res;
+
+    res = generic_iolist_size(&state, 8, 0);
+    *sizep = state.size / 8;
+
+    return res != ERTS_IOLIST_OK;
+}
+
+/* ************************************************************************* */
+
+/* Turn a possibly deep list of ints (and binaries) into one large bitstring */
+
+#define ERTS_L2B_STATE_INITER(C_P, ARG, BIF, SZFunc, TBufFunc)                \
+    {ERTS_IOLIST2BUF_STATE_INITER((C_P), (ARG)),                              \
+     THE_NON_VALUE, (ARG), (BIF), (SZFunc), (TBufFunc)}
+
+typedef struct ErtsL2BState_ ErtsL2BState;
+
+struct ErtsL2BState_ {
+    ErtsIOList2BufState buf;
+
+    Eterm result;
+    Eterm arg;
+
+    Export *bif;
+
+    int (*iolist_to_buf_size)(ErtsIOListState *);
+    int (*iolist_to_buf)(ErtsIOList2BufState *);
+};
+
+static ERTS_INLINE
+enum iolist_action list_to_bitstring_engine(ErtsL2BState *sp)
+{
+    ErtsIOList2BufState *copy_state;
+    ErtsIOListState *list_state;
+    Process *c_p;
+
+    copy_state = &sp->buf;
+    list_state = &copy_state->iolist;
+    c_p = list_state->c_p;
+
+    /* have_size == 0 until sp->iolist_to_buf_size() finishes */
+    if (!list_state->have_size) {
+        int res = sp->iolist_to_buf_size(list_state);
+
+        switch (res) {
+        case ERTS_IOLIST_YIELD:
+        case ERTS_IOLIST_OVERFLOW:
+        case ERTS_IOLIST_TYPE:
+            return res;
+        case ERTS_IOLIST_OK:
+            ASSERT(list_state->have_size);
+            break;
+        }
+
+        sp->result = erts_new_bitstring(c_p,
+                                        list_state->size,
+                                        (byte**)&copy_state->base);
+
+        if (list_state->size == 0) {
+            return ERTS_IOLIST_OK;
+        }
+
+        list_state->obj = sp->arg;
+
+        if (list_state->reds_left <= 0) {
+            BUMP_ALL_REDS(c_p);
+            return ERTS_IOLIST_YIELD;
+        }
+    }
+
+    ASSERT(list_state->size > 0 && is_value(sp->arg) && copy_state->base);
+    return sp->iolist_to_buf(copy_state);
+}
+
+static int
+l2b_state_destructor(Binary *mbp)
+{
+    ErtsL2BState *sp = ERTS_MAGIC_BIN_DATA(mbp);
+    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(mbp) == l2b_state_destructor);
+    DESTROY_SAVED_ESTACK(&sp->buf.iolist.estack);
+    return 1;
+}
+
+static BIF_RETTYPE
+list_to_bitstring_dispatch(Eterm mb_eterm, ErtsL2BState* sp, int gc_disabled)
+{
+    Process *c_p = sp->buf.iolist.c_p;
+    enum iolist_action action;
+
+    ASSERT(is_non_value(mb_eterm) ^ gc_disabled);
+    ASSERT(gc_disabled == !!(c_p->flags & F_DISABLE_GC));
+
+    action = list_to_bitstring_engine(sp);
+    switch (action) {
+    case ERTS_IOLIST_OK:
+        if (gc_disabled) {
+            erts_set_gc_state(c_p, 1);
+        }
+
+        ASSERT(!(c_p->flags & F_DISABLE_GC));
+        BIF_RET(sp->result);
+        break;
+    case ERTS_IOLIST_YIELD:
+        if (!gc_disabled) {
+            ErtsL2BState *new_sp;
+            Binary *mbp;
+            Eterm *hp;
+
+            mbp = erts_create_magic_binary(sizeof(ErtsL2BState),
+                                        l2b_state_destructor);
+            new_sp = ERTS_MAGIC_BIN_DATA(mbp);
+            *new_sp = *sp;
+
+            hp = HAlloc(c_p, ERTS_MAGIC_REF_THING_SIZE);
+            mb_eterm = erts_mk_magic_ref(&hp, &MSO(c_p), mbp);
+
+            erts_set_gc_state(c_p, 0);
+        }
+
+        BIF_TRAP1(&list_to_bitstring_continue_export, c_p, mb_eterm);
+        break;
+    default:
+        {
+            Uint reason;
+
+            if (gc_disabled && erts_set_gc_state(c_p, 1)) {
+                ERTS_VBUMP_ALL_REDS(c_p);
+            }
+
+            if (action == ERTS_IOLIST_OVERFLOW) {
+                reason = SYSTEM_LIMIT;
+            } else {
+                reason = BADARG;
+            }
+
+            ASSERT(!(c_p->flags & F_DISABLE_GC));
+            ERTS_BIF_ERROR_TRAPPED1(c_p, reason, sp->bif, sp->arg);
+        }
+        break;
+    }
+}
+
+static BIF_RETTYPE list_to_bitstring_continue(BIF_ALIST_1)
+{
+    Binary *mbp = erts_magic_ref2bin(BIF_ARG_1);
+    ErtsL2BState *state;
+
+    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(mbp) == l2b_state_destructor);
+    ASSERT(BIF_P->flags & F_DISABLE_GC);
+
+    state = (ErtsL2BState*)ERTS_MAGIC_BIN_DATA(mbp);
+    state->buf.iolist.reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
+
+    return list_to_bitstring_dispatch(BIF_ARG_1, state, 1);
+}
+
+static int list_to_binary_size(ErtsIOListState *state)
+{
+    return generic_iolist_size(state, 8, 1);
+}
+
+static int list_to_binary_copy(ErtsIOList2BufState *state)
+{
+    return generic_iol2b(state, 8, 0, 1);
+}
+
+static int list_to_bitstring_size(ErtsIOListState *state)
+{
+    return generic_iolist_size(state, 1, 1);
+}
+
+static int list_to_bitstring_copy(ErtsIOList2BufState *state)
+{
+    return generic_iol2b(state, 1, 0, 1);
+}
+
+static BIF_RETTYPE list_to_bitstring_bif(Process *c_p,
+                                         Eterm arg,
+                                         Export *bif,
+                                         const int Unit)
+{
+    int reds_left = ERTS_BIF_REDS_LEFT(c_p);
+
+    ASSERT((Unit) == 1 || (Unit) == 8);
+
+    if (reds_left < IOL2B_MIN_EXEC_REDS) {
+        if (reds_left <= IOL2B_RESCHED_REDS) {
+            /* Yield and do it with full context reds... */
+            ERTS_BIF_YIELD1(bif, c_p, arg);
+        }
+
+        /* Allow a bit more reductions... */
+        reds_left = IOL2B_MIN_EXEC_REDS;
+    }
+
+    if (is_nil(arg)) {
+        BIF_RET(erts_new_bitstring_from_data(c_p, 0, (byte*)""));
+    } else if (is_not_list(arg)) {
+        BIF_ERROR(c_p, BADARG);
+    } else {
+        /* Check for [bitstring()] case */
+        Eterm h = CAR(list_val(arg)), t = CDR(list_val(arg));
+
+        if (is_bitstring(h) && is_nil(t) && (bitstring_size(h) % (Unit)) == 0) {
+            BIF_RET(h);
+        } else {
+            int (*size_func)(ErtsIOListState *) = ((Unit) == 8) ?
+                list_to_binary_size :
+                list_to_bitstring_size;
+            int (*copy_func)(ErtsIOList2BufState *) = ((Unit) == 8) ?
+                list_to_binary_copy :
+                list_to_bitstring_copy;
+            ErtsL2BState state = ERTS_L2B_STATE_INITER(c_p,
+                                                       arg,
+                                                       bif,
+                                                       size_func,
+                                                       copy_func);
+            state.buf.iolist.reds_left = reds_left;
+            return list_to_bitstring_dispatch(THE_NON_VALUE, &state, 0);
+        }
+    }
+}
+
+BIF_RETTYPE binary_list_to_bin_1(BIF_ALIST_1)
+{
+    return list_to_bitstring_bif(BIF_P, BIF_ARG_1,
+                                 BIF_TRAP_EXPORT(BIF_binary_list_to_bin_1), 8);
+}
+
+BIF_RETTYPE list_to_binary_1(BIF_ALIST_1)
+{
+    return list_to_bitstring_bif(BIF_P, BIF_ARG_1,
+                                 BIF_TRAP_EXPORT(BIF_list_to_binary_1), 8);
+}
+
+BIF_RETTYPE iolist_to_binary_1(BIF_ALIST_1)
+{
+    if (is_bitstring(BIF_ARG_1)) {
+        if ((bitstring_size(BIF_ARG_1) % 8) == 0) {
+            BIF_RET(BIF_ARG_1);
+        }
+
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    return list_to_bitstring_bif(BIF_P, BIF_ARG_1,
+                                 BIF_TRAP_EXPORT(BIF_iolist_to_binary_1), 8);
+}
+
+BIF_RETTYPE list_to_bitstring_1(BIF_ALIST_1)
+{
+    return list_to_bitstring_bif(BIF_P, BIF_ARG_1,
+                                 BIF_TRAP_EXPORT(BIF_list_to_bitstring_1), 1);
+}
+
+/* ************************************************************************* */
+
+/* iolist_size/1 has historically allowed sizes without any upper bound, not
+ * even honoring BIG_ARITY_MAX. This is silly as the only way to reach it is to
+ * create a large binary and reference it in absurdum in the same iolist, but
+ * I'm hesitant to break compatibility here as we released a gray patch for a
+ * bug where the size was truncated when it went beyond the capacity of a word.
+ *
+ * While allowing sizes up to BIG_ARITY_MAX would be trivial, the intermediate
+ * results would make us run out of memory long before that since the GC is
+ * disabled, so we'll compromise by raising a system limit exception once the
+ * size becomes obscene. */
+#define IOLIST_SIZE_MAX_BIGNUM_ARITY 64
+
+typedef struct {
+    ErtsIOListState iolist;
+    Eterm accumulator;
+    Eterm arg;
+} IOListSizeState;
+
+static int iolist_size_destructor(Binary *mbp)
+{
+    IOListSizeState *sp = ERTS_MAGIC_BIN_DATA(mbp);
+    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(mbp) == iolist_size_destructor);
+    DESTROY_SAVED_ESTACK(&sp->iolist.estack);
+    return 1;
+}
+
+static int iolist_size_accumulate(IOListSizeState *sp, Process *c_p)
+{
+    Uint size_in_bytes;
+
+    ASSERT((sp->iolist.size % 8) == 0);
+    size_in_bytes = sp->iolist.size / 8;
+    sp->iolist.size = 0;
+
+    if (is_immed(sp->accumulator)) {
+        ERTS_CT_ASSERT((ERTS_UINT_MAX / 8) <= (ERTS_UINT_MAX - MAX_SMALL));
+        size_in_bytes += unsigned_val(sp->accumulator);
+    } else if (is_value(sp->accumulator)) {
+        Uint actual_size, guessed_size;
+        Eterm result;
+        Eterm *hp;
+
+        guessed_size = BIG_NEED_SIZE(big_size(sp->accumulator) + 1);
+        if (guessed_size > IOLIST_SIZE_MAX_BIGNUM_ARITY) {
+            return 0;
+        }
+
+        hp = HAlloc(c_p, guessed_size);
+
+        result = big_plus_small(sp->accumulator,
+                                size_in_bytes,
+                                hp);
+
+        actual_size = BIG_NEED_SIZE(big_size(result));
+        ASSERT(actual_size <= guessed_size);
+
+        HRelease(c_p, &hp[guessed_size], &hp[actual_size]);
+
+        sp->accumulator = result;
+        return 1;
+    }
+
+    sp->accumulator = erts_make_integer(size_in_bytes, c_p);
+    return 1;
+}
+
+static BIF_RETTYPE
+iolist_size_dispatch(Eterm mb_eterm, IOListSizeState *sp, int gc_disabled)
+{
+    Process *c_p = sp->iolist.c_p;
+    Uint reason;
+
+    ASSERT(is_non_value(mb_eterm) ^ gc_disabled);
+    ASSERT(gc_disabled == !!(c_p->flags & F_DISABLE_GC));
+
+    switch (generic_iolist_size(&sp->iolist, 8, 1)) {
+    case ERTS_IOLIST_YIELD:
+        if (!gc_disabled) {
+            IOListSizeState *new_sp;
+            Binary *mbp;
+            Eterm *hp;
+
+            mbp = erts_create_magic_binary(sizeof(IOListSizeState),
+                                           iolist_size_destructor);
+            new_sp = (IOListSizeState*)ERTS_MAGIC_BIN_DATA(mbp);
+            *new_sp = *sp;
+
+            hp = HAlloc(c_p, ERTS_MAGIC_REF_THING_SIZE);
+            mb_eterm = erts_mk_magic_ref(&hp, &MSO(c_p), mbp);
+
+            erts_set_gc_state(c_p, 0);
+        }
+
+        BIF_TRAP1(&iolist_size_continue_export, c_p, mb_eterm);
+    case ERTS_IOLIST_OK:
+        if (iolist_size_accumulate(sp, c_p)) {
+            if (gc_disabled) {
+                erts_set_gc_state(c_p, 1);
+            }
+
+            ASSERT(!(c_p->flags & F_DISABLE_GC));
+            return sp->accumulator;
+        }
+
+        reason = SYSTEM_LIMIT;
+        break;
+    case ERTS_IOLIST_OVERFLOW:
+        /* Result too large to fit into sp->iolist.size, accumulate current
+         * size in an integer term and start over where we left off. */
+        if (iolist_size_accumulate(sp, c_p)) {
+            return iolist_size_dispatch(mb_eterm, sp, gc_disabled);
+        }
+
+        reason = SYSTEM_LIMIT;
+        break;
+    case ERTS_IOLIST_TYPE:
+    default:
+        reason = BADARG;
+        break;
+    }
+
+    if (gc_disabled && erts_set_gc_state(c_p, 1)) {
+        ERTS_VBUMP_ALL_REDS(c_p);
+    }
+
+    ASSERT(!(c_p->flags & F_DISABLE_GC));
+    ERTS_BIF_ERROR_TRAPPED1(c_p,
+                            reason,
+                            BIF_TRAP_EXPORT(BIF_iolist_size_1),
+                            sp->arg);
+}
+
+static BIF_RETTYPE iolist_size_continue(BIF_ALIST_1)
+{
+    Binary *mbp = erts_magic_ref2bin(BIF_ARG_1);
+    IOListSizeState *state;
+
+    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(mbp) == iolist_size_destructor);
+    ASSERT(BIF_P->flags & F_DISABLE_GC);
+
+    state = (IOListSizeState*)ERTS_MAGIC_BIN_DATA(mbp);
+    state->iolist.reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
+
+    return iolist_size_dispatch(BIF_ARG_1, state, 1);
+}
+
+BIF_RETTYPE iolist_size_1(BIF_ALIST_1)
+{
+    IOListSizeState state =
+        {ERTS_IOLIST_STATE_INITER(BIF_P, BIF_ARG_1),
+         THE_NON_VALUE,
+         BIF_ARG_1};
+
+    state.iolist.reds_left = ERTS_BIF_REDS_LEFT(BIF_P);
+
+    return iolist_size_dispatch(THE_NON_VALUE, &state, 0);
+}

--- a/erts/emulator/beam/erl_iolist.h
+++ b/erts/emulator/beam/erl_iolist.h
@@ -1,0 +1,71 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2023. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+/*
+ * This module contains methods for dealing with io-/bitstring lists,
+ * which follow this structure:
+ *
+ * head ::= Bitstring
+ *        |   Byte (i.e integer in range [0..255]
+ *        |   list
+ *        ;
+ *
+ * tail ::= []
+ *        |   Bitstring
+ *        |   list
+ *        ;
+ *
+ * list ::= []
+ *        |   Bitstring
+ *        |   [ head | tail]
+ *        ;
+ */
+
+#if !defined(ERL_IOLIST_H)
+#    define ERL_IOLIST_H
+
+#include "sys.h"
+#include "global.h"
+
+#define ERTS_IOLIST_TO_BUF_OVERFLOW	(~((ErlDrvSizeT) 0))
+#define ERTS_IOLIST_TO_BUF_TYPE_ERROR	(~((ErlDrvSizeT) 1))
+#define ERTS_IOLIST_TO_BUF_YIELD	(~((ErlDrvSizeT) 2))
+#define ERTS_IOLIST_TO_BUF_FAILED(R) \
+    (((R) & (~((ErlDrvSizeT) 3))) == (~((ErlDrvSizeT) 3)))
+#define ERTS_IOLIST_TO_BUF_SUCCEEDED(R) \
+    (!ERTS_IOLIST_TO_BUF_FAILED((R)))
+
+void erts_init_iolist(void);
+
+/** @brief Copies the contents of the `iodata` \c obj into the \c data
+ *
+ * @param size the size of the buffer pointed to by \c data
+ *
+ * @return On success, returns the number of bytes remaining in the given
+ * buffer.
+ *
+ * On failure, ERTS_IOLIST_TO_BUF_OVERFLOW signals overflow, and
+ * ERTS_IOLIST_TO_BUF_TYPE_ERROR signals a type error (including that the
+ * result would not be a whole number of bytes).
+ */
+ErlDrvSizeT erts_iolist_to_buf(Eterm obj, char *data, ErlDrvSizeT size);
+int erts_iolist_size(Eterm, ErlDrvSizeT *);
+
+#endif

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -3377,11 +3377,11 @@ BIF_RETTYPE erts_internal_term_type_1(BIF_ALIST_1) {
                         default:
                             erts_exit(ERTS_ABORT_EXIT, "term_type: bad map header type %d\n", MAP_HEADER_TYPE(hdr));
                     }
-                case REFC_BINARY_SUBTAG:
+                case BIN_REF_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("refc_binary"));
-                case HEAP_BINARY_SUBTAG:
+                case HEAP_BITS_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("heap_binary"));
-                case SUB_BINARY_SUBTAG:
+                case SUB_BITS_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("sub_binary"));
                 case BIN_MATCHSTATE_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("matchstate"));

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -167,8 +167,8 @@ erts_cleanup_offheap_list(struct erl_off_heap_header* first)
 
     for (u.hdr = first; u.hdr; u.hdr = u.hdr->next) {
 	switch (thing_subtag(u.hdr->thing_word)) {
-	case REFC_BINARY_SUBTAG:
-            erts_bin_release(u.pb->val);
+	case BIN_REF_SUBTAG:
+            erts_bin_release(u.br->val);
 	    break;
 	case FUN_SUBTAG:
             /* We _KNOW_ that this is a local fun, otherwise it would not

--- a/erts/emulator/beam/erl_message.h
+++ b/erts/emulator/beam/erl_message.h
@@ -63,11 +63,20 @@ typedef struct erl_mesg ErtsMessage;
 /*
  * This struct represents data that must be updated by structure copy,
  * but is stored outside of any heap.
+ *
+ * Remember to update the static assertions in `erts_init_gc` whenever a new
+ * off-heap term type is added.
  */
 
 struct erl_off_heap_header {
     Eterm thing_word;
-    Uint size;
+
+    /* As an optimization, the first word of user data is stored before the
+     * next pointer so that the meaty part of the term (e.g. ErtsDispatchable)
+     * can be loaded together with the thing word on architectures that
+     * support it. */
+    UWord opaque;
+
     struct erl_off_heap_header* next;
 };
 

--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -1569,7 +1569,7 @@ insert_offheap(ErlOffHeap *oh, int type, Eterm id)
                     insert_dist_entry(ctx->dep, type, id, 0);
             }
 	    break;
-	case REFC_BINARY_SUBTAG:
+	case BIN_REF_SUBTAG:
 	case FUN_SUBTAG:
 	    break; /* No need to */
 	default:
@@ -2114,24 +2114,24 @@ setup_reference_table(void)
     }
 
     { /* Add binaries stored elsewhere ... */
-	ErlOffHeap oh;
-	ProcBin pb[2];
-	int i = 0;
-	Binary *default_match_spec;
-	Binary *default_meta_match_spec;
+        ErlOffHeap oh;
+        BinRef bin_ref[2];
+        int i = 0;
+        Binary *default_match_spec;
+        Binary *default_meta_match_spec;
 
-	oh.first = NULL;
-	/* Only the ProcBin members thing_word, val and next will be inspected
-	   (by insert_offheap()) */
+        oh.first = NULL;
+        /* Only the BinRef members thing_word, val and next will be inspected
+           (by insert_offheap()) */
 #undef  ADD_BINARY
-#define ADD_BINARY(Bin)				 	     \
-	if ((Bin)) {					     \
-	    pb[i].thing_word = REFC_BINARY_SUBTAG;           \
-	    pb[i].val = (Bin);				     \
-	    pb[i].next = oh.first;		             \
-	    oh.first = (struct erl_off_heap_header*) &pb[i]; \
-	    i++;				             \
-	}
+#define ADD_BINARY(Bin)                                                       \
+        if ((Bin)) {                                                          \
+            bin_ref[i].thing_word = BIN_REF_SUBTAG;                       \
+            bin_ref[i].val = (Bin);                                           \
+            bin_ref[i].next = oh.first;                                       \
+            oh.first = (struct erl_off_heap_header*) &bin_ref[i];             \
+            i++;                                                              \
+        }
 
 	erts_get_default_trace_pattern(NULL,
 				       &default_match_spec,

--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -576,14 +576,18 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
 	    PRINT_DOUBLE(res, fn, arg, 'e', 6, 0, ff.fd);
 	}
 	    break;
-	case BINARY_DEF:
+	case BITSTRING_DEF:
 	    {
-		byte* bytep;
-		Uint bytesize = binary_size(obj);
-		Uint bitoffs;
-		Uint bitsize;
-		byte octet;
-		ERTS_GET_BINARY_BYTES(obj, bytep, bitoffs, bitsize);
+                Uint bitoffs, bitsize, bytesize;
+                Uint size, offset;
+                byte* bytep;
+                byte octet;
+
+                ERTS_GET_BITSTRING(obj, bytep, offset, size);
+                bytep += BYTE_OFFSET(offset);
+                bitoffs = BIT_OFFSET(offset);
+                bytesize = BYTE_SIZE(size);
+                bitsize = TAIL_BITS(size);
 
 		if (bitsize || !bytesize
 		    || !is_printable_ascii(bytep, bytesize, bitoffs)) {
@@ -770,6 +774,9 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
         }
 	case MATCHSTATE_DEF:
 	    PRINT_STRING(res, fn, arg, "#MatchState");
+	    break;
+	case BIN_REF_DEF:
+	    PRINT_STRING(res, fn, arg, "#BinRef");
 	    break;
         default:
 	    PRINT_STRING(res, fn, arg, "<unknown:");

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -274,7 +274,7 @@ dump_dist_ext(fmtfn_t to, void *to_arg, ErtsDistExternal *edep)
     if (!edep)
 	erts_print(to, to_arg, "D0:E0:");
     else {
-	byte *e;
+	const byte *e;
 	size_t sz;
         int i;
 
@@ -465,6 +465,70 @@ print_function_from_pc(fmtfn_t to, void *to_arg, ErtsCodePtr x)
 }
 
 static void
+dump_sub_bitstring(fmtfn_t to, void *to_arg, Uint br_flags, BinRef *br,
+                   const byte *base, Uint offset, Uint size) {
+    Binary *binary = br->val;
+
+    if (erts_atomic_xchg_nob(&binary->intern.refc, 0) > 0) {
+        binary->intern.flags = (UWord)all_binaries;
+        all_binaries = binary;
+    }
+
+    /* Emit bitstrings in the old sub-binary format which ignored bit offsets
+     * and truncated sizes to bytes (not even rounding up when required). This
+     * is not ideal but at least it contains most of the underlying data.
+     *
+     * When the BinRef hasn't been visited yet (header is still BIN_REF), we
+     * pretend that this is a BinRef because the crashdump viewer barfs on
+     * dumps where sub-binaries refer _directly_ to binaries that have been
+     * truncated. This will need to be revisited once crashdump viewer is made
+     * bitstring-aware. */
+    if (br->thing_word == HEADER_BIN_REF) {
+        erts_print(to, to_arg,
+                   "Yc" PTR_FMT ":" PTR_FMT ":" PTR_FMT "\n",
+                   binary, BYTE_OFFSET(offset), BYTE_SIZE(size));
+    } else {
+        Eterm br_term = (Eterm)br | br_flags;
+
+        erts_print(to, to_arg,
+                   "Ys" PTR_FMT ":" PTR_FMT ":" PTR_FMT "\n",
+                   br_term, BYTE_OFFSET(offset), BYTE_SIZE(size));
+    }
+}
+
+static void
+dump_heap_bitstring(fmtfn_t to, void *to_arg, byte *base,
+                    Uint offset, Uint size)
+{
+    /* We ignore trailing bits for now, the crashdump viewer has historically
+     * ignored bits altogether even for sub-binaries. */
+    erts_print(to, to_arg, "Yh%X:", BYTE_SIZE(size));
+    erts_print_base64(to, to_arg, &base[BYTE_OFFSET(offset)], BYTE_SIZE(size));
+    erts_putc(to, to_arg, '\n');
+}
+
+static void
+dump_bin_ref(fmtfn_t to, void *to_arg, BinRef *br)
+{
+    Binary *binary = br->val;
+
+    if (erts_atomic_xchg_nob(&binary->intern.refc, 0) > 0) {
+        binary->intern.flags = (UWord)all_binaries;
+        all_binaries = binary;
+    }
+
+    /* Dump the binary as-is, ignoring the fact that BIN_FLAG_MAGIC may keep
+     * the data elsewhere. This is incorrect but consistent with how things
+     * used to be done before bitstrings were refactored. We will need to
+     * revisit this. */
+    erts_print(to, to_arg,
+               "Yc" PTR_FMT ":" PTR_FMT ":" PTR_FMT "\n",
+               binary,
+               binary->orig_bytes,
+               binary->orig_size);
+}
+
+static void
 heap_dump(fmtfn_t to, void *to_arg, Eterm x)
 {
     DeclareTmpHeapNoproc(last,1);
@@ -543,63 +607,28 @@ heap_dump(fmtfn_t to, void *to_arg, Eterm x)
 		} else if (_is_bignum_header(hdr)) {
 		    erts_print(to, to_arg, "B%T\n", x);
 		    *ptr = OUR_NIL;
-		} else if (is_binary_header(hdr)) {
-		    Uint tag = thing_subtag(hdr);
-		    Uint size = binary_size(x);
+		} else if (is_bitstring_header(hdr)) {
+                    Uint offset, size;
+                    Eterm br_flags;
+                    byte *base;
+                    BinRef *br;
 
-		    if (tag == HEAP_BINARY_SUBTAG) {
-			byte* p;
+                    ERTS_GET_BITSTRING_REF(x, br_flags, br, base, offset, size);
 
-			erts_print(to, to_arg, "Yh%X:", size);
-			p = binary_bytes(x);
-                        erts_print_base64(to, to_arg, p, size);
-		    } else if (tag == REFC_BINARY_SUBTAG) {
-			ProcBin* pb = (ProcBin *) binary_val(x);
-			Binary* val = pb->val;
+                    if (br) {
+                        if (erts_is_literal(br_flags | (Eterm)br, (Eterm*)br)) {
+                            mark_literal((Eterm*)br);
+                        }
 
-			if (erts_atomic_xchg_nob(&val->intern.refc, 0) != 0) {
-			    val->intern.flags = (UWord) all_binaries;
-			    all_binaries = val;
-			}
-			erts_print(to, to_arg,
-				   "Yc" PTR_FMT ":" PTR_FMT ":" PTR_FMT,
-				   val,
-				   pb->bytes - (byte *)val->orig_bytes,
-				   size);
-		    } else if (tag == SUB_BINARY_SUBTAG) {
-			ErlSubBin* Sb = (ErlSubBin *) binary_val(x);
-			Eterm* real_bin;
-			void* val;
+                        dump_sub_bitstring(to, to_arg, br_flags, br,
+                                           base, offset, size);
+                    } else {
+                        dump_heap_bitstring(to, to_arg, base, offset, size);
+                    }
 
-			/*
-			 * Must use boxed_val() here, because the original
-			 * binary may have been visited and have had its
-			 * header word changed to OUR_NIL (in which case
-			 * binary_val() will cause an assertion failure in
-			 * the DEBUG emulator).
-			 */
-
-			real_bin = boxed_val(Sb->orig);
-
-			if (thing_subtag(*real_bin) == REFC_BINARY_SUBTAG) {
-			    /*
-			     * Unvisited REFC_BINARY: Point directly to
-			     * the binary.
-			     */
-			    ProcBin* pb = (ProcBin *) real_bin;
-			    val = pb->val;
-			} else {
-			    /*
-			     * Heap binary or visited REFC binary: Point
-			     * to heap binary or ProcBin on the heap.
-			     */
-			    val = real_bin;
-			}
-			erts_print(to, to_arg,
-				   "Ys" PTR_FMT ":" PTR_FMT ":" PTR_FMT,
-				   val, Sb->offs, size);
-		    }
-		    erts_putc(to, to_arg, '\n');
+                    *ptr = OUR_NIL;
+                } else if (hdr == HEADER_BIN_REF) {
+                    dump_bin_ref(to, to_arg, (BinRef*)ptr);
 		    *ptr = OUR_NIL;
 		} else if (is_external_pid_header(hdr)) {
 		    erts_print(to, to_arg, "P%T\n", x);
@@ -931,54 +960,22 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                 erts_print(to, to_arg, "F%X:%s\n", i, sbuf);
             } else if (_is_bignum_header(w)) {
                 erts_print(to, to_arg, "B%T\n", term);
-            } else if (is_binary_header(w)) {
-                Uint tag = thing_subtag(w);
-                Uint size = binary_size(term);
+            } else if (is_bitstring_header(w)) {
+                ERTS_DECLARE_DUMMY(Eterm br_flags);
+                Uint offset, size;
+                byte *base;
+                BinRef *br;
 
-                if (tag == HEAP_BINARY_SUBTAG) {
-                    byte* p;
+                ERTS_GET_BITSTRING_REF(term, br_flags, br, base, offset, size);
 
-                    erts_print(to, to_arg, "Yh%X:", size);
-                    p = binary_bytes(term);
-                    erts_print_base64(to, to_arg, p, size);
-                } else if (tag == REFC_BINARY_SUBTAG) {
-                    ProcBin* pb = (ProcBin *) binary_val(term);
-                    Binary* val = pb->val;
-
-                    if (erts_atomic_xchg_nob(&val->intern.refc, 0) != 0) {
-                        val->intern.flags = (UWord) all_binaries;
-                        all_binaries = val;
-                    }
-                    erts_print(to, to_arg,
-                               "Yc" PTR_FMT ":" PTR_FMT ":" PTR_FMT,
-                               val,
-                               pb->bytes - (byte *)val->orig_bytes,
-                               size);
-                } else if (tag == SUB_BINARY_SUBTAG) {
-                    ErlSubBin* Sb = (ErlSubBin *) binary_val(term);
-                    Eterm* real_bin;
-                    void* val;
-
-                    real_bin = boxed_val(Sb->orig);
-                    if (thing_subtag(*real_bin) == REFC_BINARY_SUBTAG) {
-                        /*
-                         * Unvisited REFC_BINARY: Point directly to
-                         * the binary.
-                         */
-                        ProcBin* pb = (ProcBin *) real_bin;
-                        val = pb->val;
-                    } else {
-                        /*
-                         * Heap binary or visited REFC binary: Point
-                         * to heap binary or ProcBin on the heap.
-                         */
-                        val = real_bin;
-                    }
-                    erts_print(to, to_arg,
-                               "Ys" PTR_FMT ":" PTR_FMT ":" PTR_FMT,
-                               val, Sb->offs, size);
+                if (br) {
+                    dump_sub_bitstring(to, to_arg, br_flags, br,
+                                       base, offset, size);
+                } else {
+                    dump_heap_bitstring(to, to_arg, base, offset, size);
                 }
-                erts_putc(to, to_arg, '\n');
+            } else if (w == HEADER_BIN_REF) {
+                dump_bin_ref(to, to_arg, (BinRef*)htop);
             } else if (is_map_header(w)) {
                 if (is_flatmap_header(w)) {
                     flatmap_t* fmp = (flatmap_t *) flatmap_val(term);
@@ -1032,6 +1029,7 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                 dump_externally(to, to_arg, term);
                 erts_putc(to, to_arg, '\n');
             }
+
             size = 1 + header_arity(w);
             switch (w & _HEADER_SUBTAG_MASK) {
             case FUN_SUBTAG:
@@ -1044,7 +1042,7 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                     size += hashmap_bitcount(MAP_HEADER_VAL(w));
                 }
                 break;
-            case SUB_BINARY_SUBTAG:
+            case SUB_BITS_SUBTAG:
                 size += 1;
                 break;
             }

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -92,25 +92,27 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 /*
  * HEADER representation:
  *
- *	aaaaaaaaaaaaaaaaaaaaaaaaaatttt00	arity:26, tag:4
+ *      aaaaaaaaaaaaaaaaaaaaaaaaaattttpp          arity:26, tag:4, ptag:2
+ *
+ * Where ptag is always TAG_PRIMARY_HEADER.
  *
  * HEADER tags:
  *
- *	0000	ARITYVAL
- *      0001    BINARY_AGGREGATE                |
- *	001x	BIGNUM with sign bit		|
- *	0100	REF				|
- *	0101	FUN				| THINGS
- *	0110	FLONUM				|
- *      0111    EXPORT                          |
- *	1000	REFC_BINARY	|		|
- *	1001	HEAP_BINARY	| BINARIES	|
- *	1010	SUB_BINARY	|		|
- *      1011    Not used; see comment below
- *      1100    EXTERNAL_PID  |                 |
- *      1101    EXTERNAL_PORT | EXTERNAL THINGS |
- *      1110    EXTERNAL_REF  |                 |
- *      1111    MAP
+ *      0000    ARITYVAL
+ *      0001    BINARY_AGGREGATE                  |
+ *      001x    BIGNUM with sign bit              |
+ *      0100    REF                               |
+ *      0101    FUN                               | THINGS
+ *      0110    FLONUM                            |
+ *      0111    -- FREE --                        |
+ *      1000    HEAP_BITS     | BITSTRINGS        |
+ *      1001    SUB_BITS      |                   |
+ *      1010    BIN_REF	                          |
+ *      1011    MAP                               |
+ *      1100    EXTERNAL_PID  | EXTERNAL THINGS   |
+ *      1101    EXTERNAL_PORT |                   |
+ *      1110    EXTERNAL_REF  |                   |
+ *      1111    -- FREE --    | Reserved external |
  *
  * COMMENTS:
  *
@@ -121,24 +123,25 @@ struct erl_node_; /* Declared in erl_node_tables.h */
  *
  * XXX: globally replace XXX_SUBTAG with TAG_HEADER_XXX
  */
-#define ARITYVAL_SUBTAG		(0x0 << _TAG_PRIMARY_SIZE) /* TUPLE */
-#define BIN_MATCHSTATE_SUBTAG	(0x1 << _TAG_PRIMARY_SIZE) 
-#define POS_BIG_SUBTAG		(0x2 << _TAG_PRIMARY_SIZE) /* BIG: tags 2&3 */
-#define NEG_BIG_SUBTAG		(0x3 << _TAG_PRIMARY_SIZE) /* BIG: tags 2&3 */
-#define _BIG_SIGN_BIT		(0x1 << _TAG_PRIMARY_SIZE)
-#define REF_SUBTAG		(0x4 << _TAG_PRIMARY_SIZE) /* REF */
-#define FUN_SUBTAG		(0x5 << _TAG_PRIMARY_SIZE) /* FUN */
-#define FLOAT_SUBTAG		(0x6 << _TAG_PRIMARY_SIZE) /* FLOAT */
-#define _BINARY_XXX_MASK	(0x3 << _TAG_PRIMARY_SIZE)
-#define REFC_BINARY_SUBTAG	(0x8 << _TAG_PRIMARY_SIZE) /* BINARY */
-#define HEAP_BINARY_SUBTAG	(0x9 << _TAG_PRIMARY_SIZE) /* BINARY */
-#define SUB_BINARY_SUBTAG	(0xA << _TAG_PRIMARY_SIZE) /* BINARY */
-/*   _BINARY_XXX_MASK depends on 0xB being unused */
-#define EXTERNAL_PID_SUBTAG	(0xC << _TAG_PRIMARY_SIZE) /* EXTERNAL_PID */
-#define EXTERNAL_PORT_SUBTAG	(0xD << _TAG_PRIMARY_SIZE) /* EXTERNAL_PORT */
-#define EXTERNAL_REF_SUBTAG	(0xE << _TAG_PRIMARY_SIZE) /* EXTERNAL_REF */
-#define MAP_SUBTAG		(0xF << _TAG_PRIMARY_SIZE) /* MAP */
-
+#define ARITYVAL_SUBTAG         (0x0 << _TAG_PRIMARY_SIZE) /* TUPLE */
+#define BIN_MATCHSTATE_SUBTAG   (0x1 << _TAG_PRIMARY_SIZE)
+#define _BIG_TAG_MASK           (~(0x1 << _TAG_PRIMARY_SIZE) & _TAG_HEADER_MASK)
+#define _BIG_SIGN_BIT           (0x1 << _TAG_PRIMARY_SIZE)
+#define POS_BIG_SUBTAG          (0x2 << _TAG_PRIMARY_SIZE) /* BIGNUM */
+#define NEG_BIG_SUBTAG          (0x3 << _TAG_PRIMARY_SIZE) /* BIGNUM */
+#define REF_SUBTAG              (0x4 << _TAG_PRIMARY_SIZE) /* REF */
+#define FUN_SUBTAG              (0x5 << _TAG_PRIMARY_SIZE) /* FUN */
+#define FLOAT_SUBTAG            (0x6 << _TAG_PRIMARY_SIZE) /* FLOAT */
+#define _BITSTRING_TAG_MASK     (~(0x1 << _TAG_PRIMARY_SIZE) & _TAG_HEADER_MASK)
+#define HEAP_BITS_SUBTAG        (0x8 << _TAG_PRIMARY_SIZE) /* BITSTRING */
+#define SUB_BITS_SUBTAG         (0x9 << _TAG_PRIMARY_SIZE) /* BITSTRING */
+#define BIN_REF_SUBTAG          (0xA << _TAG_PRIMARY_SIZE)
+#define MAP_SUBTAG              (0xB << _TAG_PRIMARY_SIZE) /* MAP */
+#define _EXTERNAL_TAG_MASK      (~(0x3 << _TAG_PRIMARY_SIZE) & _TAG_HEADER_MASK)
+#define EXTERNAL_PID_SUBTAG     (0xC << _TAG_PRIMARY_SIZE) /* EXTERNAL_PID */
+#define EXTERNAL_PORT_SUBTAG    (0xD << _TAG_PRIMARY_SIZE) /* EXTERNAL_PORT */
+#define EXTERNAL_REF_SUBTAG     (0xE << _TAG_PRIMARY_SIZE) /* EXTERNAL_REF */
+/* _EXTERNAL_TAG_MASK requires that 0xF is reserved for external terms. */
 
 #define _TAG_HEADER_ARITYVAL       (TAG_PRIMARY_HEADER|ARITYVAL_SUBTAG)
 #define _TAG_HEADER_FUN	           (TAG_PRIMARY_HEADER|FUN_SUBTAG)
@@ -146,9 +149,9 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 #define _TAG_HEADER_NEG_BIG        (TAG_PRIMARY_HEADER|NEG_BIG_SUBTAG)
 #define _TAG_HEADER_FLOAT          (TAG_PRIMARY_HEADER|FLOAT_SUBTAG)
 #define _TAG_HEADER_REF            (TAG_PRIMARY_HEADER|REF_SUBTAG)
-#define _TAG_HEADER_REFC_BIN       (TAG_PRIMARY_HEADER|REFC_BINARY_SUBTAG)
-#define _TAG_HEADER_HEAP_BIN       (TAG_PRIMARY_HEADER|HEAP_BINARY_SUBTAG)
-#define _TAG_HEADER_SUB_BIN        (TAG_PRIMARY_HEADER|SUB_BINARY_SUBTAG)
+#define _TAG_HEADER_BIN_REF        (TAG_PRIMARY_HEADER|BIN_REF_SUBTAG)
+#define _TAG_HEADER_HEAP_BITS      (TAG_PRIMARY_HEADER|HEAP_BITS_SUBTAG)
+#define _TAG_HEADER_SUB_BITS       (TAG_PRIMARY_HEADER|SUB_BITS_SUBTAG)
 #define _TAG_HEADER_EXTERNAL_PID   (TAG_PRIMARY_HEADER|EXTERNAL_PID_SUBTAG)
 #define _TAG_HEADER_EXTERNAL_PORT  (TAG_PRIMARY_HEADER|EXTERNAL_PORT_SUBTAG)
 #define _TAG_HEADER_EXTERNAL_REF   (TAG_PRIMARY_HEADER|EXTERNAL_REF_SUBTAG)
@@ -373,20 +376,15 @@ _ET_DECLARE_CHECKED(Uint,thing_subtag,Eterm)
 #define is_value(x)	((x) != THE_NON_VALUE)
 
 /* binary object access methods */
-#define is_binary_header(x) \
-	((((x) & (_TAG_HEADER_MASK)) == _TAG_HEADER_REFC_BIN) || \
-	 (((x) & (_TAG_HEADER_MASK)) == _TAG_HEADER_HEAP_BIN) || \
-	 (((x) & (_TAG_HEADER_MASK)) == _TAG_HEADER_SUB_BIN))
+#define is_bitstring_header(x)                                                \
+    (((x) & (_BITSTRING_TAG_MASK)) == _TAG_HEADER_HEAP_BITS)
 
-#define make_binary(x)	make_boxed((Eterm*)(x))
-#define is_binary(x)	(is_boxed((x)) && is_binary_header(*boxed_val((x))))
-#define is_not_binary(x) (!is_binary((x)))
-#define _unchecked_binary_val(x) _unchecked_boxed_val((x))
-_ET_DECLARE_CHECKED(Eterm*,binary_val,Wterm)
-#define binary_val(x)	_ET_APPLY(binary_val,(x))
-
-/* process binaries stuff (special case of binaries) */
-#define HEADER_PROC_BIN	_make_header(PROC_BIN_SIZE-1,_TAG_HEADER_REFC_BIN)
+#define make_bitstring(x)	make_boxed((Eterm*)(x))
+#define is_bitstring(x)	(is_boxed((x)) && is_bitstring_header(*boxed_val((x))))
+#define is_not_bitstring(x) (!is_bitstring((x)))
+#define _unchecked_bitstring_val(x) _unchecked_boxed_val((x))
+_ET_DECLARE_CHECKED(Eterm*,bitstring_val,Wterm)
+#define bitstring_val(x)	_ET_APPLY(bitstring_val,(x))
 
 /* Fun objects.
  *
@@ -427,7 +425,7 @@ _ET_DECLARE_CHECKED(Eterm*,fun_val,Wterm)
 /* bignum access methods */
 #define make_pos_bignum_header(sz)	_make_header((sz),_TAG_HEADER_POS_BIG)
 #define make_neg_bignum_header(sz)	_make_header((sz),_TAG_HEADER_NEG_BIG)
-#define _is_bignum_header(x)	(((x) & (_TAG_HEADER_MASK-_BIG_SIGN_BIT)) == _TAG_HEADER_POS_BIG)
+#define _is_bignum_header(x)	(((x) & _BIG_TAG_MASK) == _TAG_HEADER_POS_BIG)
 #define _unchecked_bignum_header_is_neg(x)	((x) & _BIG_SIGN_BIT)
 _ET_DECLARE_CHECKED(int,bignum_header_is_neg,Eterm)
 #define bignum_header_is_neg(x)	_ET_APPLY(bignum_header_is_neg,(x))
@@ -1162,8 +1160,7 @@ typedef struct external_thing_ {
   (((x) & _TAG_HEADER_MASK) == _TAG_HEADER_EXTERNAL_REF)
 
 #define is_external_header(x) \
-  (((x) & (_TAG_HEADER_MASK-_BINARY_XXX_MASK)) == _TAG_HEADER_EXTERNAL_PID \
-   && ((x) & _TAG_HEADER_MASK) != _TAG_HEADER_MAP)
+  (((x) & (_EXTERNAL_TAG_MASK)) == _TAG_HEADER_EXTERNAL_PID)
 
 #define is_external(x) (is_boxed((x)) && is_external_header(*boxed_val((x))))
 
@@ -1408,7 +1405,7 @@ _ET_DECLARE_CHECKED(Uint,loader_y_reg_index,Uint)
  *   of the tag_val_def() function
  */
 
-#define BINARY_DEF		0x0
+#define BITSTRING_DEF		0x0
 #define LIST_DEF		0x1
 #define NIL_DEF			0x2
 #define MAP_DEF			0x3
@@ -1425,8 +1422,9 @@ _ET_DECLARE_CHECKED(Uint,loader_y_reg_index,Uint)
 #define BIG_DEF			0xf
 #define SMALL_DEF		0x10
 #define MATCHSTATE_DEF          0x11   /* not a "real" term */
+#define BIN_REF_DEF             0x12   /* not a "real" term */
 
-#define FIRST_VACANT_TAG_DEF    0x12
+#define FIRST_VACANT_TAG_DEF    0x13
 
 #if ET_DEBUG
 ERTS_GLB_INLINE unsigned tag_val_def(Wterm, const char*, unsigned);
@@ -1491,9 +1489,9 @@ ERTS_GLB_INLINE unsigned tag_val_def(Wterm x)
 	    case (_TAG_HEADER_EXTERNAL_PORT >> _TAG_PRIMARY_SIZE):	return EXTERNAL_PORT_DEF;
 	    case (_TAG_HEADER_EXTERNAL_REF >> _TAG_PRIMARY_SIZE):	return EXTERNAL_REF_DEF;
 	    case (_TAG_HEADER_MAP >> _TAG_PRIMARY_SIZE):	return MAP_DEF;
-	    case (_TAG_HEADER_REFC_BIN >> _TAG_PRIMARY_SIZE):	return BINARY_DEF;
-	    case (_TAG_HEADER_HEAP_BIN >> _TAG_PRIMARY_SIZE):	return BINARY_DEF;
-	    case (_TAG_HEADER_SUB_BIN >> _TAG_PRIMARY_SIZE):	return BINARY_DEF;
+	    case (_TAG_HEADER_BIN_REF >> _TAG_PRIMARY_SIZE):	return BIN_REF_DEF;
+	    case (_TAG_HEADER_HEAP_BITS >> _TAG_PRIMARY_SIZE):	return BITSTRING_DEF;
+	    case (_TAG_HEADER_SUB_BITS >> _TAG_PRIMARY_SIZE):	return BITSTRING_DEF;
 	    case (_TAG_HEADER_BIN_MATCHSTATE >> _TAG_PRIMARY_SIZE): return MATCHSTATE_DEF;
 	  }
 

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -1172,25 +1172,39 @@ erts_call_trace(Process* p, ErtsCodeInfo *info, Binary *match_spec,
      */
     arity = info->mfa.arity;
     for (i = 0; i < arity; i++) {
-	Eterm arg = args[i];
-	if (is_boxed(arg) && header_is_bin_matchstate(*boxed_val(arg))) {
-	    ErlBinMatchState* ms = (ErlBinMatchState *) boxed_val(arg);
-	    ErlBinMatchBuffer* mb = &ms->mb;
-	    Uint bit_size;
-            ErlSubBin *sub_bin_heap = (ErlSubBin *)HAlloc(p, ERL_SUB_BIN_SIZE);
+        Eterm arg = args[i];
 
-	    bit_size = mb->size - mb->offset;
-	    sub_bin_heap->thing_word = HEADER_SUB_BIN;
-	    sub_bin_heap->size = BYTE_OFFSET(bit_size);
-	    sub_bin_heap->bitsize = BIT_OFFSET(bit_size);
-	    sub_bin_heap->offs = BYTE_OFFSET(mb->offset);
-	    sub_bin_heap->bitoffs = BIT_OFFSET(mb->offset);
-	    sub_bin_heap->is_writable = 0;
-	    sub_bin_heap->orig = mb->orig;
+        if (is_boxed(arg) && header_is_bin_matchstate(*boxed_val(arg))) {
+            ErlBinMatchState* ms = (ErlBinMatchState *)boxed_val(arg);
+            ErlBinMatchBuffer* mb = &ms->mb;
 
-	    arg = make_binary(sub_bin_heap);
-	}
-	transformed_args[i] = arg;
+            if (is_bitstring(mb->orig)) {
+                arg = erts_make_sub_bitstring(p,
+                                              mb->orig,
+                                              mb->offset,
+                                              mb->size - mb->offset);
+            } else {
+                Binary *refc_binary;
+                BinRef *br;
+                Eterm *hp;
+
+                br = (BinRef*)boxed_val(mb->orig);
+                refc_binary = br->val;
+
+                erts_refc_inctest(&refc_binary->intern.refc, 1);
+
+                hp = HAlloc(p, ERL_REFC_BITS_SIZE);
+                arg = erts_wrap_refc_bitstring(&MSO(p).first,
+                                               &MSO(p).overhead,
+                                               &hp,
+                                               refc_binary,
+                                               mb->base,
+                                               mb->offset,
+                                               mb->size - mb->offset);
+            }
+        }
+
+        transformed_args[i] = arg;
     }
     args = transformed_args;
 
@@ -1224,7 +1238,7 @@ erts_call_trace(Process* p, ErtsCodeInfo *info, Binary *match_spec,
     if (tracee_flags == &meta_flags) {
         /* Meta trace */
         if (pam_result == am_false) {
-            UnUseTmpHeap(ERL_SUB_BIN_SIZE,p);
+            UnUseTmpHeap(ERL_SUB_BITS_SIZE,p);
             ERTS_TRACER_CLEAR(&pre_ms_tracer);
             return return_flags;
         }
@@ -1232,12 +1246,12 @@ erts_call_trace(Process* p, ErtsCodeInfo *info, Binary *match_spec,
         /* Non-meta trace */
         if (*tracee_flags & F_TRACE_SILENT) {
             erts_match_set_release_result_trace(p, pam_result);
-            UnUseTmpHeap(ERL_SUB_BIN_SIZE,p);
+            UnUseTmpHeap(ERL_SUB_BITS_SIZE,p);
             ERTS_TRACER_CLEAR(&pre_ms_tracer);
             return 0;
         }
         if (pam_result == am_false) {
-            UnUseTmpHeap(ERL_SUB_BIN_SIZE,p);
+            UnUseTmpHeap(ERL_SUB_BITS_SIZE,p);
             ERTS_TRACER_CLEAR(&pre_ms_tracer);
             return return_flags;
         }
@@ -1690,28 +1704,30 @@ trace_port(Port *t_p, Eterm what, Eterm data) {
 
 
 static Eterm
-trace_port_tmp_binary(char *bin, Sint sz, Binary **bptrp, Eterm **hp)
+trace_port_tmp_binary(char *bin, Sint sz, Binary **bptrp, Eterm **hpp)
 {
-    if (sz <= ERL_ONHEAP_BIN_LIMIT) {
-        ErlHeapBin *hb = (ErlHeapBin *)*hp;
-        hb->thing_word = header_heap_bin(sz);
-        hb->size = sz;
-        sys_memcpy(hb->data, bin, sz);
-        *hp += heap_bin_size(sz);
-        return make_binary(hb);
+    Uint size_in_bits = NBITS(sz);
+
+    if (size_in_bits <= ERL_ONHEAP_BITS_LIMIT) {
+        Eterm result = HEAP_BITSTRING(*hpp, bin, 0, size_in_bits);
+        *hpp += heap_bits_size(size_in_bits);
+        return result;
     } else {
-        ProcBin* pb = (ProcBin *)*hp;
-        Binary *bptr = erts_bin_nrml_alloc(sz);
-        sys_memcpy(bptr->orig_bytes, bin, sz);
-        pb->thing_word = HEADER_PROC_BIN;
-        pb->size = sz;
-        pb->next = NULL;
-        pb->val = bptr;
-        pb->bytes = (byte*) bptr->orig_bytes;
-        pb->flags = 0;
-        *bptrp = bptr;
-        *hp += PROC_BIN_SIZE;
-        return make_binary(pb);
+        ErlOffHeap dummy_oh = {0};
+        Binary *refc_binary;
+
+        refc_binary = erts_bin_nrml_alloc(sz);
+
+        sys_memcpy(refc_binary->orig_bytes, bin, sz);
+        *bptrp = refc_binary;
+
+        return erts_wrap_refc_bitstring(&dummy_oh.first,
+                                        &dummy_oh.overhead,
+                                        hpp,
+                                        refc_binary,
+                                        (byte*)refc_binary->orig_bytes,
+                                        0,
+                                        size_in_bits);
     }
 }
 
@@ -1731,7 +1747,7 @@ trace_port_receive(Port *t_p, Eterm caller, Eterm what, ...)
     if (is_tracer_enabled(NULL, 0, &t_p->common, &tnif, TRACE_FUN_E_RECEIVE, am_receive)) {
         /* We can use a stack heap here, as the nif is called in the
            context of a port */
-#define LOCAL_HEAP_SIZE (3 + 3 + heap_bin_size(ERL_ONHEAP_BIN_LIMIT) + 3)
+#define LOCAL_HEAP_SIZE (3 + 3 + 3 + MAX(heap_bits_size(ERL_ONHEAP_BITS_LIMIT), ERL_REFC_BITS_SIZE))
         DeclareTmpHeapNoproc(local_heap,LOCAL_HEAP_SIZE);
 
         Eterm *hp, data, *orig_hp = NULL;
@@ -1774,9 +1790,9 @@ trace_port_receive(Port *t_p, Eterm caller, Eterm what, ...)
                 ErlIOVec *evp = va_arg(args, ErlIOVec*);
                 int i;
                 va_end(args);
-                if ((6 + evp->vsize * (2+PROC_BIN_SIZE+ERL_SUB_BIN_SIZE)) > LOCAL_HEAP_SIZE) {
+                if ((6 + evp->vsize * (2+ERL_REFC_BITS_SIZE)) > LOCAL_HEAP_SIZE) {
                     hp = erts_alloc(ERTS_ALC_T_TMP,
-                                    (6 + evp->vsize * (2+PROC_BIN_SIZE+ERL_SUB_BIN_SIZE)) * sizeof(Eterm));
+                                    (6 + evp->vsize * (2+ERL_REFC_BITS_SIZE)) * sizeof(Eterm));
                     orig_hp = hp;
                 }
                 arg = NIL;
@@ -1785,28 +1801,27 @@ trace_port_receive(Port *t_p, Eterm caller, Eterm what, ...)
                    the port task keeps the reference alive. */
                 for (i = evp->vsize-1; i >= 0; i--) {
                     if (evp->iov[i].iov_len) {
-                        ProcBin* pb = (ProcBin*)hp;
-                        ErlSubBin *sb;
-                        ASSERT(evp->binv[i]);
-                        pb->thing_word = HEADER_PROC_BIN;
-                        pb->val = ErlDrvBinary2Binary(evp->binv[i]);
-                        pb->size = pb->val->orig_size;
-                        pb->next = NULL;
-                        pb->bytes = (byte*) pb->val->orig_bytes;
-                        pb->flags = 0;
-                        hp += PROC_BIN_SIZE;
+                        ErlOffHeap dummy_oh = {0};
+                        Uint byte_offset;
+                        Eterm wrapped;
+                        Binary *bin;
 
-                        sb = (ErlSubBin*) hp;
-                        sb->thing_word = HEADER_SUB_BIN;
-                        sb->size = evp->iov[i].iov_len;
-                        sb->offs = (byte*)(evp->iov[i].iov_base) - pb->bytes;
-                        sb->orig = make_binary(pb);
-                        sb->bitoffs = 0;
-                        sb->bitsize = 0;
-                        sb->is_writable = 0;
-                        hp += ERL_SUB_BIN_SIZE;
+                        bin = ErlDrvBinary2Binary(evp->binv[i]);
 
-                        arg = CONS(hp, make_binary(sb), arg);
+                        ASSERT((char*)evp->iov[i].iov_base >= bin->orig_bytes);
+                        byte_offset =
+                            (char*)evp->iov[i].iov_base - bin->orig_bytes;
+
+                        wrapped =
+                            erts_wrap_refc_bitstring(&dummy_oh.first,
+                                                     &dummy_oh.overhead,
+                                                     &hp,
+                                                     bin,
+                                                     (byte*)bin->orig_bytes,
+                                                     NBITS(byte_offset),
+                                                     NBITS(evp->iov[i].iov_len));
+
+                        arg = CONS(hp, wrapped, arg);
                         hp += 2;
                     }
                 }
@@ -1859,12 +1874,11 @@ void trace_port_send_binary(Port *t_p, Eterm to, Eterm what, char *bin, Sint sz)
     if (is_tracer_enabled(NULL, 0, &t_p->common, &tnif, TRACE_FUN_E_SEND, am_send)) {
         Eterm msg;
         Binary* bptr = NULL;
-#define LOCAL_HEAP_SIZE (3 + 3 + heap_bin_size(ERL_ONHEAP_BIN_LIMIT))
+#define LOCAL_HEAP_SIZE (3 + 3 + MAX(heap_bits_size(ERL_ONHEAP_BITS_LIMIT), ERL_REFC_BITS_SIZE))
         DeclareTmpHeapNoproc(local_heap,LOCAL_HEAP_SIZE);
 
         Eterm *hp;
 
-        ERTS_CT_ASSERT(heap_bin_size(ERL_ONHEAP_BIN_LIMIT) >= PROC_BIN_SIZE);
         UseTmpHeapNoproc(LOCAL_HEAP_SIZE);
         hp = local_heap;
 

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -79,7 +79,7 @@ void erts_init_unicode(void)
     max_loop_limit = CONTEXT_REDS * LOOP_FACTOR;
     /* Non visual BIFs to trap to. */
     erts_init_trap_export(&characters_to_utf8_trap_exp,
-			  am_erlang, ERTS_MAKE_AM("characters_to_utf8_trap"), 3,
+			  am_erlang, ERTS_MAKE_AM("characters_to_utf8_trap"), 4,
 			  &characters_to_utf8_trap);
 
     erts_init_trap_export(&characters_to_list_trap_1_exp,
@@ -185,44 +185,35 @@ static ERTS_INLINE int simple_loops_to_common(int cost)
 
 static Sint aligned_binary_size(Eterm binary)
 {
-    ERTS_DECLARE_DUMMY(unsigned char *bytes);
-    ERTS_DECLARE_DUMMY(Uint bitoffs);
-    Uint bitsize;
-    
-    ERTS_GET_BINARY_BYTES(binary, bytes, bitoffs, bitsize);
-    if (bitsize != 0) {
-	return (Sint) -1;
+    Uint size = bitstring_size(binary);
+
+    if (TAIL_BITS(size) == 0 && size <= ERTS_SINT_MAX) {
+        return (Sint)size;
     }
-    return binary_size(binary);
+
+    return -1;
 }
 
 static Sint latin1_binary_need(Eterm binary)
 {
-    unsigned char *bytes;
-    byte *temp_alloc = NULL;
-    Uint bitoffs;
-    Uint bitsize;
+    const byte *temp_alloc = NULL, *bytes;
     Uint size;
-    Sint need = 0;
+    Sint need;
     Sint i;
-    
-    ERTS_GET_BINARY_BYTES(binary, bytes, bitoffs, bitsize);
-    if (bitsize != 0) {
-	return (Sint) -1;
+
+    bytes = erts_get_aligned_binary_bytes(binary, &size, &temp_alloc);
+    if (bytes == NULL) {
+        return -1;
     }
-    if (bitoffs != 0) {
-	bytes = erts_get_aligned_binary_bytes(binary, &temp_alloc);
-	/* The call to erts_get_aligned_binary_bytes cannot fail as 
-	   we'we already checked bitsize and that this is a binary */
+
+    for(i = 0, need = 0; i < size; ++i) {
+        if (bytes[i] & ((byte) 0x80)) {
+            need += 2;
+        } else {
+            need += 1;
+        }
     }
-    size = binary_size(binary);
-    for(i = 0; i < size; ++i) {
-	if (bytes[i] & ((byte) 0x80)) {
-	    need += 2;
-	} else {
-	    need += 1;
-	}
-    }
+
     erts_free_aligned_binary_bytes(temp_alloc);
     return need;
 }
@@ -241,16 +232,16 @@ static int utf8_len(byte first)
     return -1;
 }
 
-static Uint copy_utf8_bin(byte *target, byte *source, Uint size,
+static Uint copy_utf8_bin(byte *target, const byte *source, Uint size,
 			  byte *leftover, int *num_leftovers,
-			  byte **err_pos, Uint *characters)
+			  const byte **err_pos, Uint *characters)
 {
     Uint copied = 0;
     if (leftover != NULL && *num_leftovers) {
 	int need = utf8_len(leftover[0]);
 	int from_source = need - (*num_leftovers);
 	Uint c;
-	byte *tmp_err_pos = NULL;
+	const byte *tmp_err_pos = NULL;
 	ASSERT(need > 0);
 	ASSERT(from_source > 0);
 	if (size < from_source) {
@@ -359,7 +350,7 @@ static Sint utf8_need(Eterm ioterm, int latin1, Uint *costp)
 	*costp = 0;
 	return need;
     }
-    if(is_binary(ioterm)) {
+    if(is_bitstring(ioterm)) {
 	DESTROY_ESTACK(stack);
 	if (latin1) {
 	    Sint x = latin1_binary_need(ioterm);
@@ -427,7 +418,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    ESTACK_PUSH(stack,CDR(objp));
 		    ioterm = obj;
 		    goto L_Again;
-		} else if (is_binary(obj)) {
+		} else if (is_bitstring(obj)) {
 		    Sint x;
 
 		    if (latin1) { 
@@ -479,7 +470,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 	
 	if (!is_list(ioterm) && !is_nil(ioterm)) {
 	    /* improper list end */
-	    if (is_binary(ioterm)) {
+	    if (is_bitstring(ioterm)) {
 		Sint x; 
 		if (latin1) {
 		    x = latin1_binary_need(ioterm);
@@ -526,29 +517,19 @@ static Eterm do_build_utf8(Process *p, Eterm ioterm, Sint *left, int latin1,
 	DESTROY_ESTACK(stack);
 	return ioterm;
     }
-    if(is_binary(ioterm)) {
-	Uint bitoffs;
-	Uint bitsize;
-	Uint size;
-	Uint i;
-	Eterm res_term = NIL;
-	unsigned char *bytes;
-	byte *temp_alloc = NULL;
-	Uint orig_size;
-	
-	ERTS_GET_BINARY_BYTES(ioterm, bytes, bitoffs, bitsize);
-	if (bitsize != 0) {
-	    *err = 1;
-	    DESTROY_ESTACK(stack);
-	    return ioterm;
-	}
-	if (bitoffs != 0) {
-	    bytes = erts_get_aligned_binary_bytes(ioterm, &temp_alloc);
-	    /* The call to erts_get_aligned_binary_bytes cannot fail as 
-	       we'we already checked bitsize and that this is a binary */
-	}
+    if(is_bitstring(ioterm)) {
+        const byte *temp_alloc = NULL, *bytes;
+        Uint i, orig_size, size;
+        Eterm res_term = NIL;
 
-	orig_size = size = binary_size(ioterm);
+        bytes = erts_get_aligned_binary_bytes(ioterm, &orig_size, &temp_alloc);
+        if (bytes == NULL) {
+            *err = 1;
+            DESTROY_ESTACK(stack);
+            return ioterm;
+        }
+
+        size = orig_size;
 
 	/* This is done to avoid splitting binaries in two 
 	   and then create an unnecessary rest that eventually gives an error.
@@ -561,63 +542,37 @@ static Eterm do_build_utf8(Process *p, Eterm ioterm, Sint *left, int latin1,
 	    }
 	}
 
-	if (size > (*left)) {
-	    Eterm *hp;
-	    ErlSubBin *sb;
-	    Eterm orig;
-	    Uint offset;
-	    /* Split the binary in two parts, of which we 
-	       only process the first */
-	    hp = HAlloc(p, ERL_SUB_BIN_SIZE);
-	    sb = (ErlSubBin *) hp;
-	    ERTS_GET_REAL_BIN(ioterm, orig, offset, bitoffs, bitsize);
-	    sb->thing_word = HEADER_SUB_BIN;
-	    sb->size = size - (*left);
-	    sb->offs = offset + (*left);
-	    sb->orig = orig;
-	    sb->bitoffs = bitoffs;
-	    sb->bitsize = bitsize;
-	    sb->is_writable = 0;
-	    res_term = make_binary(sb);
-	    size = (*left);
-	}
+        if (size > (*left)) {
+            /* Split the binary in two parts, of which we only process the
+             * first */
+            res_term = erts_make_sub_binary(p, ioterm, (*left), size - (*left));
+            size = (*left);
+        }
 
 	if (!latin1) {
 	    Uint num;
-	    byte *err_pos = NULL;
+	    const byte *err_pos = NULL;
 	    num = copy_utf8_bin(target + (*pos), bytes, 
 				size, leftover, num_leftovers,&err_pos,characters);
 	    *pos += num;
 	    if (err_pos != NULL) {
-		int rest_bin_offset;
-		int rest_bin_size;
-		Eterm *hp;
-		ErlSubBin *sb;
-		Eterm orig;
-		Uint offset;
+                Uint rest_bin_offset, rest_bin_size;
 
-		*err = 1;
-		/* we have no real stack, just build a list of the binaries
-		   we have not decoded... */
-		DESTROY_ESTACK(stack);
+                *err = 1;
 
-		rest_bin_offset = (err_pos - bytes);
-		rest_bin_size = orig_size - rest_bin_offset;
-		
-		hp = HAlloc(p, ERL_SUB_BIN_SIZE);
-		sb = (ErlSubBin *) hp;
-		ERTS_GET_REAL_BIN(ioterm, orig, offset, bitoffs, bitsize);
-		sb->thing_word = HEADER_SUB_BIN;
-		sb->size = rest_bin_size;
-		sb->offs = offset + rest_bin_offset;
-		sb->orig = orig;
-		sb->bitoffs = bitoffs;
-		sb->bitsize = bitsize;
-		sb->is_writable = 0;
-		res_term = make_binary(sb);
-		erts_free_aligned_binary_bytes(temp_alloc);
-		return res_term;
-	    }
+                /* we have no real stack, just build a list of the binaries
+                 * we have not decoded... */
+                DESTROY_ESTACK(stack);
+
+                rest_bin_offset = (err_pos - bytes);
+                rest_bin_size = orig_size - rest_bin_offset;
+
+                erts_free_aligned_binary_bytes(temp_alloc);
+                return erts_make_sub_binary(p,
+                                            ioterm,
+                                            rest_bin_offset,
+                                            rest_bin_size);
+            }
 	} else {
 	    i = 0;
 	    while(i < size) {
@@ -726,7 +681,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 		    ESTACK_PUSH(stack,CDR(objp));
 		    ioterm = obj;
 		    goto L_Again;
-		} else if (is_binary(obj)) {
+		} else if (is_bitstring(obj)) {
 		    Eterm rest_term;
 		    rest_term = do_build_utf8(p,obj,left,latin1,target,pos, characters, err, 
 					      leftover, num_leftovers);
@@ -765,7 +720,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 
 	if ((*left) && !is_list(ioterm) && !is_nil(ioterm)) {
 	    /* improper list end */
-	    if (is_binary(ioterm)) {
+	    if (is_bitstring(ioterm)) {
 		ioterm = do_build_utf8(p,ioterm,left,latin1,target,pos,characters,err,leftover,num_leftovers);
 		if ((*err) != 0) {
 		    goto done;
@@ -791,7 +746,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 
 }
 
-static int check_leftovers(byte *source, int size) 
+static int check_leftovers(const byte *source, int size) 
 {
     if (((*source) & ((byte) 0xE0)) == 0xC0) {
 	return 0;
@@ -814,81 +769,87 @@ static int check_leftovers(byte *source, int size)
 
 
 static Eterm
-mk_utf8_result_bin(Process *p, Eterm bin)
-{
-    /*
-     * Don't let small refc-binaries escape out in the system
-     * when done. That is, convert such to heap binaries.
-     */
-    Uint size = binary_size(bin);
-
-    ASSERT(*binary_val(bin) == HEADER_PROC_BIN);
-    
-    if (size <= ERL_ONHEAP_BIN_LIMIT) {
-	ErlHeapBin* hb = (ErlHeapBin *) HAlloc(p, heap_bin_size(size));
-	hb->thing_word = header_heap_bin(size);
-	hb->size = size;
-        sys_memcpy(hb->data, binary_bytes(bin), size);
-	return make_binary(hb);
-    }
-    
-    return bin;
-}
-	 
-
-static BIF_RETTYPE build_utf8_return(Process *p,Eterm bin,Uint pos,
-			       Eterm rest_term,int err,
-			       byte *leftover,int num_leftovers,Eterm latin1)
-{
-    Eterm *hp;
-    Eterm ret;
-
-    binary_size(bin) = pos;
-    if (err) {
-	if (num_leftovers > 0) {
-	    Eterm leftover_bin = new_binary(p, leftover, num_leftovers);
-	    hp = HAlloc(p,8);
-	    rest_term = CONS(hp,rest_term,NIL);
-	    hp += 2;
-	    rest_term = CONS(hp,leftover_bin,rest_term);
-	    hp += 2;
-	} else {
-	   hp = HAlloc(p,4);
-	} 
-	ret = TUPLE3(hp,am_error,mk_utf8_result_bin(p,bin),rest_term);
-    } else if (rest_term == NIL && num_leftovers != 0) {
-	Eterm leftover_bin = new_binary(p, leftover, num_leftovers);
-	if (check_leftovers(leftover,num_leftovers) != 0) {
-	    hp = HAlloc(p,4);
-	    ret = TUPLE3(hp,am_error,mk_utf8_result_bin(p,bin),leftover_bin);
-	} else {
-	    hp = HAlloc(p,4);
-	    ret = TUPLE3(hp,am_incomplete,mk_utf8_result_bin(p,bin),leftover_bin);
-	}
-    } else { /* All OK */	    
-	if (rest_term != NIL) { /* Trap */
-	    if (num_leftovers > 0) {
-		Eterm rest_bin = new_binary(p, leftover, num_leftovers);
-		hp = HAlloc(p,2);
-		rest_term = CONS(hp,rest_bin,rest_term);
-	    }
-	    BUMP_ALL_REDS(p);
-	    BIF_TRAP3(&characters_to_utf8_trap_exp, p, bin, rest_term, latin1);
-	} else { /* Success */
-	    /*hp = HAlloc(p,5);
-	      ret = TUPLE4(hp,mk_utf8_result_bin(p,bin),rest_term,make_small(pos),make_small(err));*/
-	    ret = mk_utf8_result_bin(p,bin);
-	}
-    }
-    BIF_RET(ret);
-}
-
-
-static BIF_RETTYPE characters_to_utf8_trap(BIF_ALIST_3)
+mk_utf8_result_bin(Process *p, Eterm bin, Uint pos)
 {
 #ifdef DEBUG
-    Eterm *real_bin;
+    if (thing_subtag(*bitstring_val(bin)) == HEAP_BITS_SUBTAG) {
+        ASSERT(bitstring_size(bin) <= ERL_ONHEAP_BITS_LIMIT);
+    } else {
+        ASSERT(bitstring_size(bin) > ERL_ONHEAP_BITS_LIMIT);
+    }
 #endif
+
+    return erts_shrink_binary_term(bin, pos);
+}
+
+static BIF_RETTYPE build_utf8_return(Process *p, Eterm bin, Uint pos,
+                                     Eterm rest_term, int err,
+                                     byte *leftover, int num_leftovers,
+                                     Eterm latin1)
+{
+    Eterm result;
+    Eterm *hp;
+
+    if (err == 0 && rest_term == NIL && num_leftovers == 0) {
+        /* All done. */
+        result = mk_utf8_result_bin(p, bin, pos);
+    } else if (err == 0 && rest_term != NIL) {
+        /* Trap */
+        if (num_leftovers > 0) {
+            Eterm leftover_bin =
+                erts_new_binary_from_data(p,
+                                          num_leftovers,
+                                          leftover);
+            hp = HAlloc(p, 2);
+            rest_term = CONS(hp, leftover_bin, rest_term);
+        }
+
+        BUMP_ALL_REDS(p);
+        BIF_TRAP4(&characters_to_utf8_trap_exp,
+                  p,
+                  bin,
+                  erts_make_integer(pos, p),
+                  rest_term,
+                  latin1);
+    } else {
+        Eterm reason = am_error;
+
+        if (err != 0) {
+            if (num_leftovers > 0) {
+                Eterm leftover_bin = erts_new_binary_from_data(p,
+                                                               num_leftovers,
+                                                               leftover);
+
+                hp = HAlloc(p, 4);
+                rest_term = CONS(hp, rest_term, NIL);
+                hp += 2;
+                rest_term = CONS(hp, leftover_bin, rest_term);
+                hp += 2;
+            }
+        } else {
+            ASSERT(rest_term == NIL && num_leftovers > 0);
+
+            rest_term = erts_new_binary_from_data(p,
+                                                  num_leftovers,
+                                                  leftover);
+
+            if (check_leftovers(leftover, num_leftovers) == 0) {
+                reason = am_incomplete;
+            }
+        }
+
+        hp = HAlloc(p, 4);
+        result = TUPLE3(hp, reason, mk_utf8_result_bin(p, bin, pos), rest_term);
+    }
+
+    BIF_RET(result);
+}
+
+
+static BIF_RETTYPE characters_to_utf8_trap(BIF_ALIST_4)
+{
+    ERTS_DECLARE_DUMMY(Uint offset);
+    ERTS_DECLARE_DUMMY(Uint size);
     byte* bytes;
     Eterm rest_term;
     Sint left, sleft;
@@ -897,33 +858,35 @@ static BIF_RETTYPE characters_to_utf8_trap(BIF_ALIST_3)
     byte leftover[4]; /* used for temp buffer too, 
 			 otherwise 3 bytes would have been enough */
     int num_leftovers = 0;
-    int latin1 = 0;
+    int latin1;
     Uint characters = 0;
     
-    /*erts_printf("Trap %T!\r\n",BIF_ARG_2);*/
-    ASSERT(is_binary(BIF_ARG_1));
-#ifdef DEBUG
-    real_bin = binary_val(BIF_ARG_1);
-    ASSERT(*real_bin == HEADER_PROC_BIN);
-#endif
-    pos = binary_size(BIF_ARG_1);
-    bytes = binary_bytes(BIF_ARG_1);
+    /*erts_printf("Trap %T!\r\n",BIF_ARG_3);*/
+    ASSERT(is_bitstring(BIF_ARG_1));
+    ASSERT(is_integer(BIF_ARG_2));
+
+    ERTS_GET_BITSTRING(BIF_ARG_1, bytes, offset, size);
+    (void)term_to_Uint(BIF_ARG_2, &pos);
+    ASSERT(offset == 0 && TAIL_BITS(size) == 0 && pos <= BYTE_SIZE(size));
+
+    ASSERT(is_atom(BIF_ARG_4));
+    latin1 = (BIF_ARG_4 == am_latin1);
+
     sleft = left = allowed_iterations(BIF_P);
     err = 0;
-    if (BIF_ARG_3 == am_latin1) {
-	latin1 = 1;
-    } 
-    rest_term = do_build_utf8(BIF_P, BIF_ARG_2, &left, latin1,
-			      bytes, &pos, &characters, &err, leftover, &num_leftovers); 
+
+    rest_term = do_build_utf8(BIF_P, BIF_ARG_3, &left, latin1,
+                              bytes, &pos, &characters,
+                              &err, leftover, &num_leftovers); 
     cost_to_proc(BIF_P, sleft - left);
     return build_utf8_return(BIF_P,BIF_ARG_1,pos,rest_term,err,
-			      leftover,num_leftovers,BIF_ARG_3);
+                             leftover,num_leftovers, BIF_ARG_4);
 }
 
 BIF_RETTYPE unicode_bin_is_7bit_1(BIF_ALIST_1)
 {
     Sint need;
-    if(!is_binary(BIF_ARG_1)) {
+    if(!is_bitstring(BIF_ARG_1)) {
 	BIF_RET(am_false);
     }
     need = latin1_binary_need(BIF_ARG_1);
@@ -935,28 +898,22 @@ BIF_RETTYPE unicode_bin_is_7bit_1(BIF_ALIST_1)
 
 static int is_valid_utf8(Eterm orig_bin)
 {
-    Uint bitoffs;
-    Uint bitsize;
+    const byte *temp_alloc = NULL, *bytes;
     Uint size;
-    byte *temp_alloc = NULL;
-    const byte *endpos;
-    Uint numchar;
-    byte *bytes;
-    int ret;
 
-    ERTS_GET_BINARY_BYTES(orig_bin, bytes, bitoffs, bitsize);
-    if (bitsize != 0) {
-	return 0;
+    bytes = erts_get_aligned_binary_bytes(orig_bin, &size, &temp_alloc);
+    if (bytes != NULL) {
+        ERTS_DECLARE_DUMMY(const byte *endpos);
+        ERTS_DECLARE_DUMMY(Uint numchar);
+        int ret;
+
+        ret = erts_analyze_utf8(bytes, size, &endpos, &numchar, NULL);
+
+        erts_free_aligned_binary_bytes(temp_alloc);
+        return ret == ERTS_UTF8_OK;
     }
-    if (bitoffs != 0) {
-	bytes = erts_get_aligned_binary_bytes(orig_bin, &temp_alloc);
-    }
-    size = binary_size(orig_bin);
-    ret = erts_analyze_utf8(bytes,
-		       size,
-		       &endpos,&numchar,NULL);
-    erts_free_aligned_binary_bytes(temp_alloc);
-    return (ret == ERTS_UTF8_OK);
+
+    return 0;
 }
 
 BIF_RETTYPE unicode_characters_to_binary_2(BIF_ALIST_2)
@@ -983,7 +940,7 @@ BIF_RETTYPE unicode_characters_to_binary_2(BIF_ALIST_2)
     } else {
 	BIF_TRAP2(c_to_b_int_trap_exportp, BIF_P, BIF_ARG_1, BIF_ARG_2);
     }	
-    if (is_list(BIF_ARG_1) && is_binary(CAR(list_val(BIF_ARG_1))) && 
+    if (is_list(BIF_ARG_1) && is_bitstring(CAR(list_val(BIF_ARG_1))) && 
 	is_nil(CDR(list_val(BIF_ARG_1)))) {
 	subject = CAR(list_val(BIF_ARG_1));
     } else {
@@ -994,52 +951,57 @@ BIF_RETTYPE unicode_characters_to_binary_2(BIF_ALIST_2)
     if (need < 0) {
 	BIF_ERROR(BIF_P,BADARG);
     }
-    if (is_binary(subject) && need >= 0 && aligned_binary_size(subject) == need
+    if (is_bitstring(subject) && need >= 0 && aligned_binary_size(subject) == need
 	&& (latin1 || is_valid_utf8(subject))) {
 	cost_to_proc(BIF_P, simple_loops_to_common(cost_of_utf8_need)); 
 	    BIF_RET(subject);
     }
-	
 
-    bin = erts_new_mso_binary(BIF_P, (byte *)NULL, need);
-    bytes = binary_bytes(bin);
-    cost_to_proc(BIF_P, simple_loops_to_common(cost_of_utf8_need)); 
-    left = allowed_iterations(BIF_P) - 
-	simple_loops_to_common(cost_of_utf8_need);
-    if (left <= 0) {
-	/* simplified - let everything be setup by setting left to 1 */
-	left = 1;
+    bin = erts_new_binary(BIF_P, need, &bytes);
+    cost_to_proc(BIF_P, simple_loops_to_common(cost_of_utf8_need));
+    left = allowed_iterations(BIF_P) -
+        simple_loops_to_common(cost_of_utf8_need);
+
+    /* Simplified - ensure that we will not trap when the result is a heap
+     * binary. */
+    if (left <= ERL_ONHEAP_BINARY_LIMIT) {
+        left = ERL_ONHEAP_BINARY_LIMIT;
     }
+
     sleft = left;
     pos = 0;
     err = 0;
-
 
     rest_term = do_build_utf8(BIF_P, subject, &left, latin1,
 			      bytes, &pos, &characters, &err, leftover, &num_leftovers); 
 #ifdef HARDDEBUG
     if (left == 0) {
 	Eterm bin;
-	if (is_binary(subject)) {
+	if (is_bitstring(subject)) {
 	    bin = subject;
-	} else if(is_list(subject) && is_binary(CAR(list_val(subject)))) {
+	} else if(is_list(subject) && is_bitstring(CAR(list_val(subject)))) {
 	    bin = CAR(list_val(subject));
 	} else {
 	    bin = NIL;
 	}
-	if (is_binary(bin)) {
-	    byte *t = NULL;
-	    Uint sz = binary_size(bin);
-	    byte *by = erts_get_aligned_binary_bytes(bin,&t);
-	    Uint i;
-	    erts_printf("<<");
-	    for (i = 0;i < sz; ++i) {
-		erts_printf((i == sz -1) ? "0x%X" : "0x%X, ", (unsigned) by[i]);
-	    }
-	    erts_printf(">>: ");
-	    erts_free_aligned_binary_bytes(t);
-	}
-	erts_printf("%ld - %ld = %ld\n", sleft, left, sleft - left);
+	if (is_bitstring(bin)) {
+            byte *temp_alloc = NULL;
+            Uint i, size;
+            byte *data;
+
+            data = erts_get_aligned_binary_bytes(bin, &size, &temp_alloc);
+            ASSERT(data);
+
+            erts_printf("<<");
+            for (i = 0; i < sz; ++i) {
+                unsigned byte = data[i];
+                erts_printf((i == sz - 1) ? "0x%X" : "0x%X, ", data);
+            }
+            erts_printf(">>: ");
+
+            erts_free_aligned_binary_bytes(temp_alloc);
+        }
+        erts_printf("%ld - %ld = %ld\n", sleft, left, sleft - left);
     }
 #endif
     cost_to_proc(BIF_P, sleft - left); 
@@ -1059,8 +1021,11 @@ static BIF_RETTYPE build_list_return(Process *p, byte *bytes, Uint pos, Uint cha
     }
     
     if (err) {
-	if (num_leftovers > 0) {
-	    Eterm leftover_bin = new_binary(p, leftover, num_leftovers);
+        if (num_leftovers > 0) {
+            Eterm leftover_bin =
+                erts_new_binary_from_data(p,
+                                          num_leftovers,
+                                          leftover);
 	    hp = HAlloc(p,4);
 	    rest_term = CONS(hp,rest_term,NIL);
 	    hp += 2;
@@ -1068,7 +1033,11 @@ static BIF_RETTYPE build_list_return(Process *p, byte *bytes, Uint pos, Uint cha
 	}
 	BIF_RET(finalize_list_to_list(p, bytes, rest_term, 0U, pos, characters, ERTS_UTF8_ERROR, left, NIL));
     } else if (rest_term == NIL && num_leftovers != 0) {
-	Eterm leftover_bin = new_binary(p, leftover, num_leftovers);
+        Eterm leftover_bin =
+            erts_new_binary_from_data(p,
+                                      num_leftovers,
+                                      leftover);
+
 	if (check_leftovers(leftover,num_leftovers) != 0) {
 	    BIF_RET(finalize_list_to_list(p, bytes, leftover_bin, 0U, pos, characters, ERTS_UTF8_ERROR, 
 					  left, NIL));
@@ -1080,7 +1049,11 @@ static BIF_RETTYPE build_list_return(Process *p, byte *bytes, Uint pos, Uint cha
 	if (rest_term != NIL) { /* Trap */
 	    RestartContext rc;
 	    if (num_leftovers > 0) {
-		Eterm rest_bin = new_binary(p, leftover, num_leftovers);
+                Eterm rest_bin =
+                    erts_new_binary_from_data(p,
+                                              num_leftovers,
+                                              leftover);
+
 		hp = HAlloc(p,2);
 		rest_term = CONS(hp,rest_bin,rest_term);
 	    }
@@ -1108,13 +1081,16 @@ static BIF_RETTYPE characters_to_list_trap_1(BIF_ALIST_3)
     Eterm rest_term;
     Sint left, sleft;
 
-    int latin1 = 0;
+    int latin1;
     byte leftover[4]; /* used for temp buffer too, 
 			 otherwise 3 bytes would have been enough */
     int num_leftovers = 0;
     
 
     rc = get_rc_from_bin(BIF_ARG_1);
+
+    ASSERT(is_atom(BIF_ARG_3));
+    latin1 = (BIF_ARG_3 == am_latin1);
 
     bytes = rc->bytes;
     rc->bytes = NULL; /* to avoid free due to later GC */
@@ -1123,9 +1099,7 @@ static BIF_RETTYPE characters_to_list_trap_1(BIF_ALIST_3)
 
     sleft = left = allowed_iterations(BIF_P);
     err = 0;
-    if (BIF_ARG_3 == am_latin1) {
-	latin1 = 1;
-    } 
+
     rest_term = do_build_utf8(BIF_P, BIF_ARG_2, &left, latin1,
 			      bytes, &pos, &characters, &err, leftover, &num_leftovers); 
     cost_to_proc(BIF_P, sleft - left);
@@ -1155,7 +1129,7 @@ BIF_RETTYPE unicode_characters_to_list_2(BIF_ALIST_2)
     } else {
 	BIF_TRAP2(c_to_l_int_trap_exportp, BIF_P, BIF_ARG_1, BIF_ARG_2);
     }	
-    if (is_binary(BIF_ARG_1) && !latin1) { /* Optimized behaviour for this case */
+    if (is_bitstring(BIF_ARG_1) && !latin1) { /* Optimized behaviour for this case */
 	    return utf8_to_list(BIF_P,BIF_ARG_1);
     }
     need = utf8_need(BIF_ARG_1,latin1,&cost_of_utf8_need);
@@ -1353,9 +1327,9 @@ erts_make_list_from_utf8_buf(Eterm **hpp, Uint num,
 /*
  * No errors should be able to occur - no overlongs, no malformed, no nothing
  */
-static Eterm do_utf8_to_list(Process *p, Uint num, byte *bytes, Uint sz, 
-			     Uint left,
-			     Uint *num_built, Uint *num_eaten, Eterm tail)
+static Eterm do_utf8_to_list(Process *p, Uint num, const byte *bytes, Uint sz,
+                             Uint left, Uint *num_built, Uint *num_eaten,
+                             Eterm tail)
 {
     Eterm *hp;
 
@@ -1580,11 +1554,12 @@ static void handle_potential_norm(Eterm **hpp, Uint16 *savepoints, int *numpoint
     *retp = ret;
 } 
 
-static Eterm do_utf8_to_list_normalize(Process *p, Uint num, byte *bytes, Uint sz)
+static Eterm do_utf8_to_list_normalize(Process *p, Uint num, const byte *bytes,
+                                       Uint sz)
 {
+    const byte *source;
     Eterm *hp,*hp_end;
     Eterm ret;
-    byte *source;
     Uint unipoint;
     Uint16 savepoints[4];
     int numpoints = 0;
@@ -1747,15 +1722,12 @@ static BIF_RETTYPE do_bif_utf8_to_list(Process *p,
 				       Eterm tail) 
 {
     int left;
-    Uint bitoffs;
-    Uint bitsize;
     Uint size;
-    byte *bytes;
     Eterm converted = NIL;
     Eterm rest = NIL;
     Eterm *hp;
     Eterm ret;
-    byte *temp_alloc = NULL;
+    const byte *temp_alloc = NULL, *bytes;
     const byte *endpos;
     Uint numchar;
 
@@ -1763,20 +1735,15 @@ static BIF_RETTYPE do_bif_utf8_to_list(Process *p,
     Uint num_built; /* characters */
     Uint num_eaten; /* bytes */
 
-    ERTS_GET_BINARY_BYTES(orig_bin, bytes, bitoffs, bitsize);
-    if (bitsize != 0) {
-	converted = NIL;
-	rest = orig_bin;
-	goto error_return;
+    bytes = erts_get_aligned_binary_bytes(orig_bin, &size, &temp_alloc);
+    if (bytes == NULL) {
+        converted = NIL;
+        rest = orig_bin;
+        goto error_return;
     }
-    if (bitoffs != 0) {
-	bytes = erts_get_aligned_binary_bytes(orig_bin, &temp_alloc);
-    }
-    
-    size = binary_size(orig_bin);
 
     left = allowed_iterations(p);
-    
+
     if (state == ERTS_UTF8_ANALYZE_MORE) {
 	state = erts_analyze_utf8(bytes + num_bytes_to_process,
 			     size - num_bytes_to_process,
@@ -1835,23 +1802,11 @@ static BIF_RETTYPE do_bif_utf8_to_list(Process *p,
      */
 
     b_sz = size - (num_bytes_to_process + num_processed_bytes);
+    ASSERT((b_sz == 0) ^ (state != ERTS_UTF8_OK));
 
     if (b_sz) {
-	ErlSubBin *sb;
-	Eterm orig;
-	Uint offset;
-	ASSERT(state != ERTS_UTF8_OK);
-	hp = HAlloc(p, ERL_SUB_BIN_SIZE);
-	sb = (ErlSubBin *) hp;
-	ERTS_GET_REAL_BIN(orig_bin, orig, offset, bitoffs, bitsize);
-	sb->thing_word = HEADER_SUB_BIN;
-	sb->size = b_sz;
-	sb->offs = offset + num_bytes_to_process + num_processed_bytes;
-	sb->orig = orig;
-	sb->bitoffs = bitoffs;
-	sb->bitsize = bitsize;
-	sb->is_writable = 0;
-	rest = make_binary(sb);
+        Uint offset = num_bytes_to_process + num_processed_bytes;
+        rest = erts_make_sub_binary(p, orig_bin, offset, b_sz);
     } 
 
     /* Done */
@@ -1950,7 +1905,7 @@ static BIF_RETTYPE characters_to_list_trap_4(BIF_ALIST_1)
 
 static BIF_RETTYPE utf8_to_list(Process* p, Eterm arg)
 {
-    if (!is_binary(arg) || aligned_binary_size(arg) < 0) {
+    if (!is_bitstring(arg) || aligned_binary_size(arg) < 0) {
 	BIF_ERROR(p, BADARG);
     }
     return do_bif_utf8_to_list(p, arg, 0U, 0U, 0U,
@@ -1969,25 +1924,26 @@ BIF_RETTYPE atom_to_binary_2(BIF_ALIST_2)
     ap = atom_tab(atom_val(BIF_ARG_1));
 
     if (BIF_ARG_2 == am_latin1) {
-	Eterm bin_term;
+        Eterm bin_term;
 
-	if (ap->latin1_chars < 0) {
-	    goto error;
-	}
-	if (ap->latin1_chars == ap->len) {
-	    bin_term = new_binary(BIF_P, ap->name, ap->len);
-	}
-	else {
-	    byte* bin_p;
-	    int dbg_sz;
-	    bin_term = new_binary(BIF_P, 0, ap->latin1_chars);
-	    bin_p = binary_bytes(bin_term);
-	    dbg_sz = erts_utf8_to_latin1(bin_p, ap->name, ap->len);
-	    ASSERT(dbg_sz == ap->latin1_chars); (void)dbg_sz; 
-	}
-	BIF_RET(bin_term);
+        if (ap->latin1_chars < 0) {
+            goto error;
+        }
+
+        if (ap->latin1_chars == ap->len) {
+            bin_term = erts_new_binary_from_data(BIF_P, ap->len, ap->name);
+        } else {
+            byte* bin_p;
+            int dbg_sz;
+
+            bin_term = erts_new_binary(BIF_P, ap->latin1_chars, &bin_p);
+            dbg_sz = erts_utf8_to_latin1(bin_p, ap->name, ap->len);
+            ASSERT(dbg_sz == ap->latin1_chars); (void)dbg_sz;
+        }
+
+        BIF_RET(bin_term);
     } else if (BIF_ARG_2 == am_utf8 || BIF_ARG_2 == am_unicode) {
-	BIF_RET(new_binary(BIF_P, ap->name, ap->len));
+        BIF_RET(erts_new_binary_from_data(BIF_P, ap->len, ap->name));
     } else {
     error:
 	BIF_ERROR(BIF_P, BADARG);
@@ -1997,15 +1953,14 @@ BIF_RETTYPE atom_to_binary_2(BIF_ALIST_2)
 static BIF_RETTYPE
 binary_to_atom(Process* proc, Eterm bin, Eterm enc, int must_exist)
 {
-    byte* bytes;
-    byte *temp_alloc = NULL;
+    const byte *temp_alloc = NULL, *bytes;
     Uint bin_size;
     Eterm a;
 
-    if ((bytes = erts_get_aligned_binary_bytes(bin, &temp_alloc)) == 0) {
-	BIF_ERROR(proc, BADARG);
+    bytes = erts_get_aligned_binary_bytes(bin, &bin_size, &temp_alloc);
+    if (bytes == NULL) {
+        BIF_ERROR(proc, BADARG);
     }
-    bin_size = binary_size(bin);
 
     if (enc == am_latin1) {
 	if (!must_exist) {
@@ -2122,13 +2077,14 @@ char *erts_convert_filename_to_encoding(Eterm name, char *statbuf, size_t statbu
 	if (encoding == ERL_FILENAME_WIN_WCHAR) {
 	    name_buf[need-2] = 0;
 	}
-    } else if (is_binary(name)) {
-	byte *temp_alloc = NULL;
-	byte *bytes;
-	Uint size;
-	
-	size = binary_size(name);
-	bytes = erts_get_aligned_binary_bytes(name, &temp_alloc);
+    } else if (is_bitstring(name)) {
+        const byte *temp_alloc = NULL, *bytes;
+        Uint size;
+
+        bytes = erts_get_aligned_binary_bytes(name, &size, &temp_alloc);
+        if (bytes == NULL) {
+            return NULL;
+        }
 
 	if (encoding != ERL_FILENAME_WIN_WCHAR) {
 	    /*Add 0 termination only*/
@@ -2153,7 +2109,7 @@ char *erts_convert_filename_to_encoding(Eterm name, char *statbuf, size_t statbu
     return name_buf;
 }
 
-char* erts_convert_filename_to_wchar(byte* bytes, Uint size,
+char* erts_convert_filename_to_wchar(const byte* bytes, Uint size,
                                      char *statbuf, size_t statbuf_size,
                                      ErtsAlcType_t alloc_type, Sint* used,
                                      Uint extra_wchars)
@@ -2585,7 +2541,9 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
     DESTROY_ESTACK(stack);
     return;
 }
-void erts_copy_utf8_to_utf16_little(byte *target, byte *bytes, int num_chars)
+void erts_copy_utf8_to_utf16_little(byte *target,
+                                    const byte *bytes,
+                                    Uint num_chars)
 {
     Uint unipoint;
     
@@ -2675,38 +2633,44 @@ BIF_RETTYPE prim_file_internal_name2native_1(BIF_ALIST_1)
     if (is_atom(BIF_ARG_1)) {
 	BIF_ERROR(BIF_P,BADARG);
     }
-    if (is_binary(BIF_ARG_1)) {
-	byte *temp_alloc = NULL;
-	byte *bytes;
-	const byte *err_pos;
-	Uint size,num_chars;
-	/* Uninterpreted encoding except if windows widechar, in case we convert from 
-	   utf8 to win_wchar */
-	size = binary_size(BIF_ARG_1);
-	bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc);
-	if (encoding != ERL_FILENAME_WIN_WCHAR) {
+    if (is_bitstring(BIF_ARG_1)) {
+        const byte *temp_alloc = NULL, *bytes;
+        const byte *err_pos;
+        Uint size, num_chars;
+
+        /* Uninterpreted encoding except if windows widechar, in case we
+         * convert from utf8 to win_wchar */
+        bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+        if (bytes == NULL) {
+            BIF_ERROR(BIF_P, BADARG);
+        }
+
+        if (encoding != ERL_FILENAME_WIN_WCHAR) {
             Uint i;
-	    /*Add 0 termination only*/
-	    bin_term = new_binary(BIF_P, NULL, size+1);
-	    bin_p = binary_bytes(bin_term);
+            /*Add 0 termination only*/
+            bin_term = erts_new_binary(BIF_P, size+1, &bin_p);
+
             for (i = 0; i < size; i++) {
                 /* Don't allow null in the middle of filenames... */
                 if (bytes[i] == 0)
                     goto bin_name_error;
                 bin_p[i] = bytes[i];
             }
-	    bin_p[size]=0;
-	    erts_free_aligned_binary_bytes(temp_alloc);
-	    BIF_RET(bin_term);
-	} 
-	/* In a wchar world, the emulator flags only affect how
-	   binaries are interpreted when sent from the user. */
-	/* Determine real length and create a new binary */
-	if (erts_analyze_utf8(bytes,size,&err_pos,&num_chars,NULL) != ERTS_UTF8_OK || 
-	    erts_get_user_requested_filename_encoding() ==  ERL_FILENAME_LATIN1) {
-	    /* What to do now? Maybe latin1, so just take byte for byte instead */
-	    bin_term = new_binary(BIF_P, 0, (size+1)*2);
-	    bin_p = binary_bytes(bin_term);
+
+            bin_p[size]='\0';
+            erts_free_aligned_binary_bytes(temp_alloc);
+            BIF_RET(bin_term);
+        }
+
+        /* In a wchar world, the emulator flags only affect how
+         * binaries are interpreted when sent from the user.
+         *
+         * Determine real length and create a new binary */
+        if (erts_analyze_utf8(bytes,size,&err_pos,&num_chars,NULL) != ERTS_UTF8_OK || 
+            erts_get_user_requested_filename_encoding() ==  ERL_FILENAME_LATIN1) {
+            /* What to do now? Maybe latin1, so just take byte for byte instead */
+            bin_term = erts_new_binary(BIF_P, (size+1)*2, &bin_p);
+
 	    while (size--) {
                 /* Don't allow null in the middle of filenames... */
                 if (*bytes == 0)
@@ -2719,15 +2683,17 @@ BIF_RETTYPE prim_file_internal_name2native_1(BIF_ALIST_1)
 	    erts_free_aligned_binary_bytes(temp_alloc);
 	    BIF_RET(bin_term);
 	}
-	/* OK, UTF8 ok, number of characters is in num_chars */
-	bin_term = new_binary(BIF_P, 0, (num_chars+1)*2);
-	bin_p = binary_bytes(bin_term);
-	erts_copy_utf8_to_utf16_little(bin_p, bytes, num_chars);
-	/* zero termination */
-	bin_p[num_chars*2] = 0;
-	bin_p[num_chars*2+1] = 0;
-	erts_free_aligned_binary_bytes(temp_alloc);
-	BIF_RET(bin_term);
+
+        /* OK, UTF8 ok, number of characters is in num_chars */
+        bin_term = erts_new_binary(BIF_P, (num_chars+1)*2, &bin_p);
+        erts_copy_utf8_to_utf16_little(bin_p, bytes, num_chars);
+
+        /* zero termination */
+        bin_p[num_chars*2] = 0;
+        bin_p[num_chars*2+1] = 0;
+
+        erts_free_aligned_binary_bytes(temp_alloc);
+        BIF_RET(bin_term);
     bin_name_error:
         erts_free_aligned_binary_bytes(temp_alloc);
         BIF_ERROR(BIF_P,BADARG);
@@ -2742,27 +2708,23 @@ BIF_RETTYPE prim_file_internal_name2native_1(BIF_ALIST_1)
     } else {
 	++need;
     }
-    
-    bin_term = new_binary(BIF_P, 0, need);
-    bin_p = binary_bytes(bin_term);
-    erts_native_filename_put(BIF_ARG_1,encoding,bin_p); 
+
+    bin_term = erts_new_binary(BIF_P, need, &bin_p);
+    erts_native_filename_put(BIF_ARG_1, encoding, bin_p);
+
     bin_p[need-1] = 0;
     if (encoding == ERL_FILENAME_WIN_WCHAR) {
-	bin_p[need-2] = 0;
+        bin_p[need-2] = 0;
     }
+
     BIF_RET(bin_term);
 }
 
 BIF_RETTYPE prim_file_internal_native2name_1(BIF_ALIST_1)
 {
-    Eterm real_bin;
-    Uint offset;
     Uint size,num_chars;
-    Uint bitsize;
-    Uint bitoffs;
     Eterm *hp;
-    byte *temp_alloc = NULL;
-    byte *bytes;
+    const byte *temp_alloc = NULL, *bytes;
     const byte *err_pos;
     Uint num_built; /* characters */
     Uint num_eaten; /* bytes */
@@ -2773,28 +2735,30 @@ BIF_RETTYPE prim_file_internal_native2name_1(BIF_ALIST_1)
      * See comment on "Requirements on Raw Filename Format"
      * above.
      */
+    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (bytes == NULL) {
+        BIF_ERROR(BIF_P, BADARG);
+    } else if (size == 0) {
+        erts_free_aligned_binary_bytes(temp_alloc);
+        BIF_RET(NIL);
+    }
 
-    if (is_not_binary(BIF_ARG_1)) {
-	BIF_ERROR(BIF_P,BADARG);
-    }
-    size = binary_size(BIF_ARG_1);
-    ERTS_GET_REAL_BIN(BIF_ARG_1, real_bin, offset, bitoffs, bitsize);
-    if (bitsize != 0) {
-	BIF_ERROR(BIF_P,BADARG);
-    }
-    if (size == 0) {
-	BIF_RET(NIL);
-    }
     switch (erts_get_native_filename_encoding()) {
     case ERL_FILENAME_LATIN1:
-	hp = HAlloc(BIF_P, 2 * size);
-	bytes = binary_bytes(real_bin)+offset;
-    
-	BIF_RET(erts_bin_bytes_to_list(NIL, hp, bytes, size, bitoffs));
+        {
+            Eterm result;
+
+            hp = HAlloc(BIF_P, 2 * size);
+
+            result = erts_bin_bytes_to_list(NIL, hp, bytes, size, 0);
+            erts_free_aligned_binary_bytes(temp_alloc);
+
+            BIF_RET(result);
+        }
     case ERL_FILENAME_UTF8_MAC:
-	mac = 1;
+        mac = 1;
+        /* !! FALL THROUGH !! */
     case ERL_FILENAME_UTF8:
-	bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc);
 	if (erts_analyze_utf8(bytes,size,&err_pos,&num_chars,NULL) != ERTS_UTF8_OK) {
 	    Eterm *hp = HAlloc(BIF_P,3);
 	    Eterm warn_type = NIL;
@@ -2817,11 +2781,10 @@ BIF_RETTYPE prim_file_internal_native2name_1(BIF_ALIST_1)
 	    ret = do_utf8_to_list_normalize(BIF_P, num_chars, bytes, size);
 	} else {
 	    ret = do_utf8_to_list(BIF_P, num_chars, bytes, size, num_chars, &num_built, &num_eaten, NIL);
-	} 
+	}
 	erts_free_aligned_binary_bytes(temp_alloc);
 	BIF_RET(ret);
     case ERL_FILENAME_WIN_WCHAR:
-	bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc);
 	if ((size % 2) != 0) { /* Panic fixup to avoid crashing the emulator */
 	    size--;
 	    hp = HAlloc(BIF_P, size+2);
@@ -2838,93 +2801,88 @@ BIF_RETTYPE prim_file_internal_native2name_1(BIF_ALIST_1)
 	    size -= 2;
 	    ret = CONS(hp,make_small(x),ret);
 	    hp += 2;
-	}	    
+	}
 	erts_free_aligned_binary_bytes(temp_alloc);
 	BIF_RET(ret);
     default:
 	break;
     }
+
     BIF_RET(BIF_ARG_1);
 }
 
 BIF_RETTYPE prim_file_internal_normalize_utf8_1(BIF_ALIST_1)
 {
-    ERTS_DECLARE_DUMMY(Eterm real_bin);
-    ERTS_DECLARE_DUMMY(Uint offset);
-    Uint size,num_chars;
-    Uint bitsize;
-    ERTS_DECLARE_DUMMY(Uint bitoffs);
+    const byte *temp_alloc = NULL, *bytes;
+    Uint size;
     Eterm ret;
-    byte *temp_alloc = NULL;
-    byte *bytes;
-    const byte *err_pos;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	BIF_ERROR(BIF_P,BADARG);
+    ERTS_BIF_PREP_ERROR(ret, BIF_P, BADARG);
+
+    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (bytes != NULL) {
+        const byte *err_pos;
+        Uint num_chars;
+
+        if (erts_analyze_utf8(bytes,size,
+                              &err_pos,
+                              &num_chars,
+                              NULL) == ERTS_UTF8_OK) {
+            ret = do_utf8_to_list_normalize(BIF_P,
+                                            num_chars,
+                                            bytes,
+                                            size);
+        }
+
+        erts_free_aligned_binary_bytes(temp_alloc);
     }
-    size = binary_size(BIF_ARG_1);
-    ERTS_GET_REAL_BIN(BIF_ARG_1, real_bin, offset, bitoffs, bitsize);
-    if (bitsize != 0) {
-	BIF_ERROR(BIF_P,BADARG);
-    }
-    if (size == 0) {
-	BIF_RET(NIL);
-    }
-    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc);
-    if (erts_analyze_utf8(bytes,size,&err_pos,&num_chars,NULL) != ERTS_UTF8_OK) {
-	erts_free_aligned_binary_bytes(temp_alloc);
-	BIF_ERROR(BIF_P,BADARG);
-    }
-    ret = do_utf8_to_list_normalize(BIF_P, num_chars, bytes, size);
-    erts_free_aligned_binary_bytes(temp_alloc);
+
     BIF_RET(ret);
-}  
+}
 
 BIF_RETTYPE prim_file_is_translatable_1(BIF_ALIST_1)
 {
-    ERTS_DECLARE_DUMMY(Eterm real_bin);
-    ERTS_DECLARE_DUMMY(Uint offset);
+    const byte *temp_alloc = NULL, *bytes;
+    int translatable = 0;
     Uint size;
-    Uint num_chars;
-    Uint bitsize;
-    ERTS_DECLARE_DUMMY(Uint bitoffs);
-    byte *temp_alloc = NULL;
-    byte *bytes;
-    const byte *err_pos;
-    int status;
 
-    if (is_not_binary(BIF_ARG_1)) {
-	BIF_ERROR(BIF_P,BADARG);
-    }
-    size = binary_size(BIF_ARG_1);
-    ERTS_GET_REAL_BIN(BIF_ARG_1, real_bin, offset, bitoffs, bitsize);
-    if (bitsize != 0) {
-	BIF_ERROR(BIF_P,BADARG);
-    }
-    if (size == 0) {
-	BIF_RET(am_true);
+    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (bytes == NULL) {
+        BIF_ERROR(BIF_P,BADARG);
+    } else if (size == 0) {
+        translatable = 1;
+    } else {
+        /* If the encoding is latin1, the pathname is always translatable. */
+        switch (erts_get_native_filename_encoding()) {
+        case ERL_FILENAME_LATIN1:
+            translatable = 1;
+            break;
+        case ERL_FILENAME_WIN_WCHAR:
+            if (erts_get_user_requested_filename_encoding() == ERL_FILENAME_LATIN1) {
+                translatable = 1;
+                break;
+            }
+            /* !! FALL THROUGH !! */
+        case ERL_FILENAME_UTF8_MAC:
+        case ERL_FILENAME_UTF8:
+            {
+                /* Check whether the binary contains legal UTF-8 sequences. */
+                const byte *err_pos;
+                Uint num_chars;
+
+                translatable = (erts_analyze_utf8(bytes,
+                                                  size,
+                                                  &err_pos,
+                                                  &num_chars,
+                                                  NULL) == ERTS_UTF8_OK);
+                break;
+            }
+        }
     }
 
-    /*
-     * If the encoding is latin1, the pathname is always translatable.
-     */
-    switch (erts_get_native_filename_encoding()) {
-    case ERL_FILENAME_LATIN1:
-	BIF_RET(am_true);
-    case ERL_FILENAME_WIN_WCHAR:
-	if (erts_get_user_requested_filename_encoding() == ERL_FILENAME_LATIN1) {
-	    BIF_RET(am_true);
-	}
-    }
-
-    /*
-     * Check whether the binary contains legal UTF-8 sequences.
-     */
-    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &temp_alloc);
-    status = erts_analyze_utf8(bytes, size, &err_pos, &num_chars, NULL);
     erts_free_aligned_binary_bytes(temp_alloc);
-    BIF_RET(status == ERTS_UTF8_OK ? am_true : am_false);
-}  
+    BIF_RET(translatable ? am_true : am_false);
+}
 
 BIF_RETTYPE file_native_name_encoding_0(BIF_ALIST_0)
 {

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -897,14 +897,14 @@ erts_free_dist_ext_copy(ErtsDistExternal *edep)
 
 ErtsPrepDistExtRes
 erts_prepare_dist_ext(ErtsDistExternal *edep,
-		      byte *ext,
+		      const byte *ext,
 		      Uint size,
                       Binary *binp,
 		      DistEntry *dep,
                       Uint32 conn_id,
 		      ErtsAtomCache *cache)
 {
-    register byte *ep;
+    register const byte *ep;
 
     ASSERT(dep);
     erts_de_rlock(dep);
@@ -994,9 +994,9 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 	if (no_atoms) {
 	    int long_atoms = 0;
 #ifdef DEBUG
-	    byte *flgs_buf = ep;
+	    const byte *flgs_buf = ep;
 #endif
-	    byte *flgsp = ep;
+	    const byte *flgsp = ep;
 	    int flgs_size = ERTS_DIST_HDR_ATOM_CACHE_FLAG_BYTES(no_atoms);
 	    int byte_ix;
 	    int bit_ix;
@@ -1156,7 +1156,7 @@ bad_dist_ext(ErtsDistExternal *edep)
     if (edep->dep) {
 	DistEntry *dep = edep->dep;
 	erts_dsprintf_buf_t *dsbufp = erts_create_logger_dsbuf();
-	byte *ep;
+	const byte *ep;
 	erts_dsprintf(dsbufp,
 		      "%T got a corrupted external term from %T "
 		      "on distribution channel %d\n",
@@ -1185,24 +1185,27 @@ bad_dist_ext(ErtsDistExternal *edep)
 Sint
 erts_decode_dist_ext_size(ErtsDistExternal *edep, int kill_connection, int payload)
 {
+    const byte *ep;
     Sint res;
-    byte *ep;
 
     if (edep->data->frag_id > 1 && payload) {
         Uint sz = 0;
         Binary *bin;
+        byte *buf;
         int i;
-        byte *ep;
 
         for (i = 0; i < edep->data->frag_id; i++)
             sz += edep->data[i].ext_endp - edep->data[i].extp;
 
         bin = erts_bin_nrml_alloc(sz);
-        ep = (byte*)bin->orig_bytes;
+        buf = (byte*)bin->orig_bytes;
 
         for (i = 0; i < edep->data->frag_id; i++) {
-            sys_memcpy(ep, edep->data[i].extp, edep->data[i].ext_endp - edep->data[i].extp);
-            ep += edep->data[i].ext_endp - edep->data[i].extp;
+            sys_memcpy(buf,
+                       edep->data[i].extp,
+                       edep->data[i].ext_endp - edep->data[i].extp);
+
+            buf += edep->data[i].ext_endp - edep->data[i].extp;
             erts_bin_release(edep->data[i].binp);
             edep->data[i].binp = NULL;
             edep->data[i].extp = NULL;
@@ -1211,7 +1214,7 @@ erts_decode_dist_ext_size(ErtsDistExternal *edep, int kill_connection, int paylo
 
         edep->data->frag_id = 1;
         edep->data->extp = (byte*)bin->orig_bytes;
-        edep->data->ext_endp = ep;
+        edep->data->ext_endp = buf;
         edep->data->binp = bin;
     }
 
@@ -1343,11 +1346,8 @@ BIF_RETTYPE erts_debug_dist_ext_to_term_2(BIF_ALIST_2)
     ErtsDistExternal ede;
     ErtsDistExternalData ede_data;
     Eterm *tp;
-    Eterm real_bin;
-    Uint offset;
-    Uint size;
-    Uint bitsize;
-    Uint bitoffs;
+    Uint offset, size;
+    byte *base;
     Uint arity;
     int i;
 
@@ -1370,18 +1370,22 @@ BIF_RETTYPE erts_debug_dist_ext_to_term_2(BIF_ALIST_2)
 	ede.attab.atom[i-1] = tp[i];
     }
 
-    if (is_not_binary(BIF_ARG_2))
-	goto badarg;
+    if (is_not_bitstring(BIF_ARG_2)) {
+        goto badarg;
+    }
 
-    size = binary_size(BIF_ARG_2);
-    if (size == 0)
-	goto badarg;
-    ERTS_GET_REAL_BIN(BIF_ARG_2, real_bin, offset, bitoffs, bitsize);
-    if (bitsize != 0)
-	goto badarg;
+    ERTS_GET_BITSTRING(BIF_ARG_2, base, offset, size);
 
-    ede.data->extp = binary_bytes(real_bin)+offset;
-    ede.data->ext_endp = ede.data->extp + size;
+    if (size == 0 || TAIL_BITS(size) != 0) {
+        goto badarg;
+    }
+
+    ERTS_ASSERT(BIT_OFFSET(offset) == 0);
+    offset = BYTE_OFFSET(offset);
+    size = BYTE_SIZE(size);
+
+    ede.data->extp = &base[offset];
+    ede.data->ext_endp = &ede.data->extp[size];
     ede.data->frag_id = 1;
     ede.data->binp = NULL;
 
@@ -1692,7 +1696,7 @@ typedef struct {
 
 typedef struct B2TContext_t {
     Sint heap_size;
-    byte* aligned_alloc;
+    const byte *aligned_alloc;
     ErtsBinary2TermState b2ts;
     Uint32 flags;
     SWord reds;
@@ -1710,7 +1714,7 @@ typedef struct B2TContext_t {
 
 static B2TContext* b2t_export_context(Process*, B2TContext* src);
 
-static uLongf binary2term_uncomp_size(byte* data, Sint size)
+static uLongf binary2term_uncomp_size(const byte* data, Sint size)
 {
     z_stream stream;
     int err;
@@ -1740,10 +1744,11 @@ static uLongf binary2term_uncomp_size(byte* data, Sint size)
 }
 
 static ERTS_INLINE int
-binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size,
-		    B2TContext** ctxp, Process* p)
+binary2term_prepare(ErtsBinary2TermState *state,
+                    const byte *data, Sint data_size,
+                    B2TContext** ctxp, Process* p)
 {
-    byte *bytes = data;
+    const byte *bytes = data;
     Sint size = data_size;
 
     state->exttmp = 0;
@@ -1754,7 +1759,7 @@ binary2term_prepare(ErtsBinary2TermState *state, byte *data, Sint data_size,
     bytes++;
     size--;
     if (size < 5 || *bytes != COMPRESSED) {
-	state->extp = bytes;
+	state->extp = (byte*)bytes;
         if (ctxp)
 	    (*ctxp)->state = B2TSizeInit;
     }
@@ -1967,9 +1972,11 @@ static BIF_RETTYPE binary_to_term_int(Process* p, Eterm bin, B2TContext *ctx)
     do {
         switch (ctx->state) {
         case B2TPrepare: {
-	    byte* bytes;
+            const byte *bytes;
             Uint bin_size;
+
             bytes = erts_get_aligned_binary_bytes_extra(bin,
+                                                        &bin_size,
                                                         &ctx->aligned_alloc,
                                                         ERTS_ALC_T_EXT_TERM_DATA,
                                                         0);
@@ -1978,7 +1985,6 @@ static BIF_RETTYPE binary_to_term_int(Process* p, Eterm bin, B2TContext *ctx)
                 ctx->state = B2TBadArg;
                 break;
             }
-            bin_size = binary_size(bin);
             if (ctx->aligned_alloc) {
                 ctx->reds -= bin_size / 8;
             }
@@ -2272,27 +2278,26 @@ erts_term_to_binary_simple(Process* p, Eterm Term, Uint size, int level, Uint64 
 	} else {
 	    dest_len = real_size - 5;
 	}
-	bin = new_binary(p, NULL, real_size+1);
-	out_bytes = binary_bytes(bin);
-	out_bytes[0] = VERSION_MAGIC;
+        bin = erts_new_binary(p, real_size+1, &out_bytes);
+        out_bytes[0] = VERSION_MAGIC;
 	if (erl_zlib_compress2(out_bytes+6, &dest_len, bytes, real_size, level) != Z_OK) {
 	    sys_memcpy(out_bytes+1, bytes, real_size);
-	    bin = erts_realloc_binary(bin, real_size+1);
+	    bin = erts_shrink_binary_term(bin, real_size+1);
 	} else {
 	    out_bytes[1] = COMPRESSED;
 	    put_int32(real_size, out_bytes+2);
-	    bin = erts_realloc_binary(bin, dest_len+6);
+	    bin = erts_shrink_binary_term(bin, dest_len+6);
 	}
 	if (bytes != buf) {
 	    erts_free(ERTS_ALC_T_TMP, bytes);
 	}
 	return bin;
     } else {
-	byte* bytes;
+        byte* bytes;
 
-	bin = new_binary(p, (byte *)NULL, size);
-	bytes = binary_bytes(bin);
-	bytes[0] = VERSION_MAGIC;
+        bin = erts_new_binary(p, size, &bytes);
+        bytes[0] = VERSION_MAGIC;
+
 	if ((endp = enc_term(NULL, Term, bytes+1, dflags, NULL))
 	    == NULL) {
 	    erts_exit(ERTS_ERROR_EXIT, "%s, line %d: bad term: %x\n",
@@ -2303,7 +2308,7 @@ erts_term_to_binary_simple(Process* p, Eterm Term, Uint size, int level, Uint64 
 	    erts_exit(ERTS_ERROR_EXIT, "%s, line %d: buffer overflow: %d word(s)\n",
 		     __FILE__, __LINE__, endp - (bytes + size));
 	}
-	return erts_realloc_binary(bin, real_size);
+	return erts_shrink_binary_term(bin, real_size);
     }
 }
 
@@ -2342,11 +2347,13 @@ static int ttb_context_destructor(Binary *context_bin)
 	    break;
 	case TTBEncode:
 	    DESTROY_SAVED_WSTACK(&context->s.ec.wstack);
-	    if (context->s.ec.result_bin != NULL) { /* Set to NULL if ever made alive! */
-		ASSERT(erts_refc_read(&(context->s.ec.result_bin->intern.refc),1));
-		erts_bin_free(context->s.ec.result_bin);
-		context->s.ec.result_bin = NULL;
-	    }
+            /* Set to NULL if ever made alive! */
+            if (context->s.ec.result_bin != NULL) {
+                ASSERT(erts_refc_read(&(context->s.ec.result_bin->intern.refc),
+                        1) == 1);
+                erts_bin_free(context->s.ec.result_bin);
+                context->s.ec.result_bin = NULL;
+            }
             if (context->s.ec.map_array)
                 erts_free(ERTS_ALC_T_T2B_DETERMINISTIC, context->s.ec.map_array);
             if (context->s.ec.ycf_yield_state)
@@ -2357,17 +2364,23 @@ static int ttb_context_destructor(Binary *context_bin)
 	case TTBCompress:
 	    erl_zlib_deflate_finish(&(context->s.cc.stream));
 
-	    if (context->s.cc.destination_bin != NULL) { /* Set to NULL if ever made alive! */
-		ASSERT(erts_refc_read(&(context->s.cc.destination_bin->intern.refc),1));
-		erts_bin_free(context->s.cc.destination_bin);
-		context->s.cc.destination_bin = NULL;
-	    }
-	    
-	    if (context->s.cc.result_bin != NULL) { /* Set to NULL if ever made alive! */
-		ASSERT(erts_refc_read(&(context->s.cc.result_bin->intern.refc),1));
-		erts_bin_free(context->s.cc.result_bin);
-		context->s.cc.result_bin = NULL;
-	    }
+            /* Set to NULL if ever made alive! */
+            if (context->s.cc.destination_bin != NULL) {
+                ASSERT(
+                    erts_refc_read(&(context->s.cc.destination_bin->intern.refc),
+                                   1) == 1);
+                erts_bin_free(context->s.cc.destination_bin);
+                context->s.cc.destination_bin = NULL;
+            }
+
+            /* Set to NULL if ever made alive! */
+            if (context->s.cc.result_bin != NULL) {
+                ASSERT(
+                    erts_refc_read(&(context->s.cc.result_bin->intern.refc),
+                                   1) == 1);
+                erts_bin_free(context->s.cc.result_bin);
+                context->s.cc.result_bin = NULL;
+            }
 	    break;
 	}
     }
@@ -2517,7 +2530,7 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
                     vlen += 3*fragments;
                     ASSERT(vlen);
                 }
-                else if (size <= ERL_ONHEAP_BIN_LIMIT) {
+                else if (size <= ERL_ONHEAP_BINARY_LIMIT) {
 		    /* Finish in one go */
 		    res = erts_term_to_binary_simple(p, Term, size, 
 						     level, dflags);
@@ -2568,8 +2581,9 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
 		level = context->s.ec.level;
 		BUMP_REDS(p, (initial_reds - reds) / TERM_TO_BINARY_LOOP_FACTOR);
 		if (level == 0 || real_size < 6) { /* We are done */
-                    Sint cbin_refc_diff;
-                    Eterm result, rb_term, *hp, *hp_end;
+                    Eterm result, *hp, *hp_end;
+                    int referenced_cbin;
+                    BinRef *result_ref;
                     Uint hsz;
                     int ix;
                     SysIOVec *iov;
@@ -2582,13 +2596,20 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
 			erts_bin_free(context_b);
 		    }
                     if (!context->s.ec.iov) {
-                        hsz = PROC_BIN_SIZE + (iovec ? 2 : 0);
-                        hp = HAlloc(p, hsz);
-                        result = erts_build_proc_bin(&MSO(p), hp, result_bin);
+                        hp = HAlloc(p, ERL_REFC_BITS_SIZE + (iovec ? 2 : 0));
+
+                        result = erts_wrap_refc_bitstring(&MSO(p).first,
+                                                          &MSO(p).overhead,
+                                                          &hp,
+                                                          result_bin,
+                                                          (byte*)result_bin->orig_bytes,
+                                                          0,
+                                                          NBITS(result_bin->orig_size));
+
                         if (iovec) {
-                            hp += PROC_BIN_SIZE;
                             result = CONS(hp, result, NIL);
                         }
+
                         return result;
                     }
                     iovec = context->s.ec.iovec;
@@ -2602,86 +2623,111 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
                     ASSERT(!iov[0].iov_base && !iov[0].iov_len);
                     ASSERT(!iov[1].iov_base && !iov[1].iov_len);
 
-                    hsz = (2 /* cons */
-                           + (PROC_BIN_SIZE > ERL_SUB_BIN_SIZE
-                              ? PROC_BIN_SIZE
-                              : ERL_SUB_BIN_SIZE)); /* max size per vec */
-                    hsz *= context->s.ec.vlen - 2*fragments; /* number of vecs */
+                    /* Max per vec entry, cons + sub binary. */
+                    hsz = (2 + ERL_SUB_BITS_SIZE);
+                     /* Number of vecs */
+                    hsz *= context->s.ec.vlen - 2*fragments;
+                     /* BinRef for result bin. */
+                    hsz += ERL_BIN_REF_SIZE;
                     hp = HAlloc(p, hsz);
                     hp_end = hp + hsz;
-                    rb_term = THE_NON_VALUE;
                     result = NIL;
+
+                    /* Speculatively create a BinRef to hold any direct
+                     * references into the result_bin.
+                     *
+                     * Note that we do not link it into the off-heap list
+                     * until we know it will be used. */
                     ASSERT(erts_refc_read(&result_bin->intern.refc, 1) == 1);
-                    cbin_refc_diff = -1;
+                    result_ref = (BinRef*)hp;
+                    result_ref->thing_word = HEADER_BIN_REF;
+                    result_ref->val = result_bin;
+                    result_ref->bytes = (byte*)result_bin->orig_bytes;
+                    hp += ERL_BIN_REF_SIZE;
+                    referenced_cbin = 0;
+
                     for (ix = context->s.ec.vlen - 1; ix > 1; ix--) {
-                        Eterm bin_term, pb_term;
-                        Uint pb_size;
-                        ProcBin *pb;
                         SysIOVec *iovp = &iov[ix];
-                        if (!iovp->iov_base)
+                        Eterm segment;
+
+                        if (iovp->iov_base == NULL) {
                             continue; /* empty slot for header */
-                        pb_term = termv[ix];
-                        if (is_value(pb_term)) {
-                            pb_size = binary_size(pb_term);
-                            pb = (ProcBin *) binary_val(pb_term);
                         }
-                        else {
-                            iovp->iov_base = (void *) (((byte *) iovp->iov_base)
-                                                       + realloc_offset);
-                            pb_size = result_bin->orig_size;
-                            if (is_non_value(rb_term))
-                                pb = NULL;
-                            else {
-                                pb = (ProcBin *) binary_val(rb_term);
-                                pb_term = rb_term;
+
+                        ASSERT(IS_BINARY_SIZE_OK(iovp->iov_len));
+                        segment = termv[ix];
+
+                        if (is_value(segment)) {
+                            ErlSubBits *from_sb;
+
+                            from_sb = (ErlSubBits*)bitstring_val(segment);
+                            ASSERT(from_sb->thing_word == HEADER_SUB_BITS);
+
+                            /* If the term refers to the entire segment, we can
+                             * use it as is. Otherwise we need to return a
+                             * shrunken copy. */
+                            if (from_sb->size != NBITS(iovp->iov_len)) {
+                                ErlSubBits *to_sb = (ErlSubBits*)hp;
+
+                                segment = make_bitstring(to_sb);
+                                hp += ERL_SUB_BITS_SIZE;
+
+                                *to_sb = *from_sb;
+                                to_sb->size = NBITS(iovp->iov_len);
+
+                                ASSERT(to_sb->size < from_sb->size);
                             }
+                        } else {
+                            /* We don't have a term and need to create one now,
+                             * note that we intentionally avoid using heap
+                             * binaries since they will (most likely) need to
+                             * be converted to off-heap form when the result is
+                             * actually used.
+                             *
+                             * This wastes a bit of heap space for small
+                             * binaries, but that trade-off seems to be worth
+                             * it in most cases. */
+                            ErlSubBits *sb = (ErlSubBits*)hp;
+                            Uint iov_offset;
+
+                            iovp->iov_base =
+                                (void*)(((byte *)iovp->iov_base) + realloc_offset);
+                            iov_offset =
+                                (char*)iovp->iov_base - (char*)result_bin->orig_bytes;
+
+                            ASSERT(IS_BINARY_SIZE_OK(iov_offset));
+
+                            sb->thing_word = HEADER_SUB_BITS;
+                            ERTS_SET_SB_RANGE(sb,
+                                              NBITS(iov_offset),
+                                              NBITS(iovp->iov_len));
+                            sb->orig = make_bitstring(result_ref);
+
+                            segment = make_bitstring(sb);
+                            hp += ERL_SUB_BITS_SIZE;
+
+                            referenced_cbin = 1;
                         }
-                        /*
-                         * We intentionally avoid using sub binaries
-                         * since the GC might convert those to heap
-                         * binaries and by this ruin the nice preparation
-                         * for usage of this data as I/O vector in
-                         * nifs/drivers.
-                         */
-                        if (is_value(pb_term) && iovp->iov_len == pb_size)
-                            bin_term = pb_term;
-                        else {
-                            Binary *bin;
-                            if (is_value(pb_term)) {
-                                bin = ((ProcBin *) binary_val(pb_term))->val;
-                                erts_refc_inc(&bin->intern.refc, 2);
-                            }
-                            else {
-                                bin = result_bin;
-                                cbin_refc_diff++;
-                            }
-                            pb = (ProcBin *) (char *) hp;
-                            hp += PROC_BIN_SIZE;
-                            pb->thing_word = HEADER_PROC_BIN;
-                            pb->size = (Uint) iovp->iov_len;
-                            pb->next = MSO(p).first;
-                            MSO(p).first = (struct erl_off_heap_header*) pb;
-                            pb->val = bin;
-                            pb->bytes = (byte*) iovp->iov_base;
-                            pb->flags = 0;
-                            OH_OVERHEAD(&MSO(p), pb->size / sizeof(Eterm));
-                            bin_term = make_binary(pb);
-                        }
-                        result = CONS(hp, bin_term, result);
+
+                        result = CONS(hp, segment, result);
                         hp += 2;
                     }
+
                     ASSERT(hp <= hp_end);
                     HRelease(p, hp_end, hp);
                     context->s.ec.iov = NULL;
                     erts_free(ERTS_ALC_T_T2B_VEC, iov);
-                    if (cbin_refc_diff) {
-                        ASSERT(cbin_refc_diff >= -1);
-                        if (cbin_refc_diff > 0)
-                            erts_refc_add(&result_bin->intern.refc,
-                                          cbin_refc_diff, 1);
-                        else
-                            erts_bin_free(result_bin);
+
+                    if (referenced_cbin) {
+                        result_ref->next = MSO(p).first;
+                        MSO(p).first = (struct erl_off_heap_header*)result_ref;
+
+                        /* Ownership has been transferred to the result_ref, so
+                         * we do not need to bump refc. */
+                    } else {
+                        erts_bin_free(result_bin);
                     }
+
                     return result;
 		}
 		/* Continue with compression... */
@@ -2713,7 +2759,6 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
 		    TERM_TO_BINARY_COMPRESS_CHUNK : 
 		    left;
 		Binary *result_bin;
-		ProcBin *pb;
 		Uint max = (ERTS_BIF_REDS_LEFT(p) *  TERM_TO_BINARY_COMPRESS_CHUNK) / CONTEXT_REDS;
 
 		if (max < this_time) {
@@ -2747,37 +2792,57 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
 			if (context_b && erts_refc_read(&context_b->intern.refc,0) == 0) {
 			    erts_bin_free(context_b);
 			}
-			return erts_build_proc_bin(&MSO(p),
-						   HAlloc(p, PROC_BIN_SIZE),
-                                                   result_bin);
-		    }
-		default: /* Compression error, revert to uncompressed binary (still in 
-			    context) */
-		no_use_compressing:
-		    result_bin = context->s.cc.result_bin;
-		    context->s.cc.result_bin = NULL;
-		    pb = (ProcBin *) HAlloc(p, PROC_BIN_SIZE);
-		    pb->thing_word = HEADER_PROC_BIN;
-		    pb->size = context->s.cc.real_size;
-		    pb->next = MSO(p).first;
-		    MSO(p).first = (struct erl_off_heap_header*)pb;
-		    pb->val = result_bin;
-		    pb->bytes = (byte*) result_bin->orig_bytes;
-		    pb->flags = 0;
-		    OH_OVERHEAD(&(MSO(p)), pb->size / sizeof(Eterm));
-		    ASSERT(erts_refc_read(&result_bin->intern.refc, 1));
-		    erl_zlib_deflate_finish(&(context->s.cc.stream));
-		    erts_bin_free(context->s.cc.destination_bin);
-		    context->s.cc.destination_bin = NULL;
-		    context->alive = 0;
-		    BUMP_REDS(p, (this_time * CONTEXT_REDS) / TERM_TO_BINARY_COMPRESS_CHUNK);
-		    if (context_b && erts_refc_read(&context_b->intern.refc,0) == 0) {
-			erts_bin_free(context_b);
-		    }
-		    return make_binary(pb);
-		}
-	    }
-	}
+
+                        hp = HAlloc(p, ERL_REFC_BITS_SIZE);
+                        return erts_wrap_refc_bitstring(&MSO(p).first,
+                                                        &MSO(p).overhead,
+                                                        &hp,
+                                                        result_bin,
+                                                        (byte*)result_bin->orig_bytes,
+                                                        0,
+                                                        NBITS(result_bin->orig_size));
+                    }
+                default:
+                /* Revert to uncompressed binary (still in context) on
+                 * compression errors, and when compression grows the result.*/
+                no_use_compressing:
+                    {
+                        Uint result_size;
+
+                        ASSERT(IS_BINARY_SIZE_OK(context->s.cc.real_size));
+                        result_size = NBITS(context->s.cc.real_size);
+
+                        result_bin = context->s.cc.result_bin;
+                        context->s.cc.result_bin = NULL;
+
+                        ASSERT(erts_refc_read(&result_bin->intern.refc, 1));
+
+                        erl_zlib_deflate_finish(&(context->s.cc.stream));
+                        erts_bin_free(context->s.cc.destination_bin);
+                        context->s.cc.destination_bin = NULL;
+                        context->alive = 0;
+
+                        if (context_b &&
+                            erts_refc_read(&context_b->intern.refc,0) == 0) {
+                            erts_bin_free(context_b);
+                        }
+
+                        BUMP_REDS(p,
+                                  ((this_time * CONTEXT_REDS) /
+                                   TERM_TO_BINARY_COMPRESS_CHUNK));
+
+                        hp = HAlloc(p, ERL_REFC_BITS_SIZE);
+                        return erts_wrap_refc_bitstring(&MSO(p).first,
+                                                        &MSO(p).overhead,
+                                                        &hp,
+                                                        result_bin,
+                                                        (byte*)result_bin->orig_bytes,
+                                                        0,
+                                                        result_size);
+                    }
+                }
+            }
+        }
     }
 #undef EXPORT_CONTEXT
 #undef RETURN_STATE
@@ -3281,24 +3346,27 @@ enc_term_int(TTBEncodeContext* ctx, ErtsAtomCacheMap *acmp, Eterm obj, byte* ep,
 	    }
 	    goto outer_loop;
 	case ENC_BIN_COPY: {
-	    Uint bits = (Uint)obj;
-	    Uint bitoffs = WSTACK_POP(s);
-	    byte* bytes = (byte*) WSTACK_POP(s);
-	    byte* dst = (byte*) WSTACK_POP(s);
-	    if (bits > r * (TERM_TO_BINARY_MEMCPY_FACTOR * 8)) {
-		Uint n = r * TERM_TO_BINARY_MEMCPY_FACTOR;
-		WSTACK_PUSH5(s, (UWord)(dst + n), (UWord)(bytes + n), bitoffs,
-			     ENC_BIN_COPY, bits - 8*n);
-		bits = 8*n;
-		copy_binary_to_buffer(dst, 0, bytes, bitoffs, bits);
-		obj = THE_NON_VALUE;
-		r = 0; /* yield */
-		break;
-	    } else {
-		copy_binary_to_buffer(dst, 0, bytes, bitoffs, bits);
-		r -= bits / (TERM_TO_BINARY_MEMCPY_FACTOR * 8);
-		goto outer_loop;
-	    }
+            Uint size = (Uint)obj;
+            Uint src_offset = WSTACK_POP(s);
+            Uint dst_offset = WSTACK_POP(s);
+            byte* src = (byte*) WSTACK_POP(s);
+            byte* dst = (byte*) WSTACK_POP(s);
+            if (size > (r * TERM_TO_BINARY_MEMCPY_FACTOR)) {
+                Uint n = r * TERM_TO_BINARY_MEMCPY_FACTOR;
+                copy_binary_to_buffer(dst, dst_offset, src, src_offset, n);
+                src_offset += n;
+                dst_offset += n;
+                size -= n;
+                WSTACK_PUSH6(s, (UWord)dst, (UWord)src, dst_offset, src_offset,
+                             ENC_BIN_COPY, size);
+                obj = THE_NON_VALUE;
+                r = 0; /* yield */
+                break;
+            } else {
+                copy_binary_to_buffer(dst, dst_offset, src, src_offset, size);
+                r -= size / (TERM_TO_BINARY_MEMCPY_FACTOR);
+                goto outer_loop;
+            }
 	}
 	case ENC_MAP_PAIR: {
 	    Uint pairs_left = obj;
@@ -3760,132 +3828,123 @@ enc_term_int(TTBEncodeContext* ctx, ErtsAtomCacheMap *acmp, Eterm obj, byte* ep,
 	    }
 	    break;
 
-	case BINARY_DEF:
-	    {
-		Uint bitoffs;
-		Uint bitsize;
-		byte* bytes;
-		byte* data_dst;
-                Uint off_heap_bytesize = 0;
-                Uint off_heap_tail;
-                Eterm pb_term;
-                Binary *pb_val;
+	case BITSTRING_DEF:
+            {
+                ERTS_DECLARE_DUMMY(Eterm br_flags);
+                int encoding, copy_payload;
+                Uint offset, size;
+                Uint wire_size;
+                BinRef *br;
+                byte *base;
 
-                ASSERT(!(dflags & DFLAG_PENDING_CONNECT) || (ctx && ctx->iov));
-    
-		ERTS_GET_BINARY_BYTES(obj, bytes, bitoffs, bitsize);
-                if (use_iov) {
-                    if (bitoffs == 0) {
-                        ProcBin* pb = (ProcBin*) binary_val(obj);
-                        off_heap_bytesize = pb->size;
-                        if (off_heap_bytesize <= ERL_ONHEAP_BIN_LIMIT)
-                            off_heap_bytesize = 0;
-                        else {
-                            pb_term = obj;
-                            if (pb->thing_word == HEADER_SUB_BIN) {
-                                ErlSubBin* sub = (ErlSubBin*)pb;
-                                pb_term = sub->orig;
-                                pb = (ProcBin*) binary_val(pb_term);
-                            }
-                            if (pb->thing_word != HEADER_PROC_BIN)
-                                off_heap_bytesize = 0;
-                            else {
-                                if (pb->flags) {
-                                    char* before_realloc = pb->val->orig_bytes; 
-                                    erts_emasculate_writable_binary(pb);
-                                    bytes += (pb->val->orig_bytes - before_realloc);
-                                    ASSERT((byte *) &pb->val->orig_bytes[0] <= bytes
-                                           && bytes < ((byte *) &pb->val->orig_bytes[0]
-                                                       + pb->val->orig_size));
-                                }
-                                pb_val = pb->val;
-                            }
+                ERTS_PIN_BITSTRING(obj, br_flags, br, base, offset, size);
+                encoding = TAIL_BITS(size) ? BIT_BINARY_EXT : BINARY_EXT;
+                wire_size = NBYTES(size);
+
+                copy_payload =
+                    (size <= ERL_ONHEAP_BITS_LIMIT) ||
+                    (BIT_OFFSET(offset) != 0) ||
+                    !use_iov;
+
+                if ((dflags & DFLAG_ETS_COMPRESSED) && (br != NULL)) {
+                    const Binary *refc_binary = br->val;
+
+                    ASSERT(!use_iov);
+
+                    /* Use [BIT_]BINARY_INTERNAL_REF, copying the actual BinRef
+                     * and/or ErlSubBits whenever that is smaller than the data
+                     * itself. */
+                    if (wire_size >= sizeof(BinRef)) {
+                        if ((encoding == BINARY_EXT) &&
+                            (base == (byte*)refc_binary->orig_bytes) &&
+                            (size == refc_binary->orig_size * 8) &&
+                            (offset == 0)) {
+                            encoding = BINARY_INTERNAL_REF;
+                            copy_payload = 0;
+                        } else if (wire_size >= (sizeof(ErlSubBits) +
+                                                 sizeof(BinRef))) {
+                            encoding = BITSTRING_INTERNAL_REF;
+                            copy_payload = 0;
                         }
                     }
                 }
-		else if (dflags & DFLAG_ETS_COMPRESSED) {
-		    ProcBin* pb = (ProcBin*) binary_val(obj);
-		    Uint bytesize = pb->size;
-		    if (pb->thing_word == HEADER_SUB_BIN) {
-			ErlSubBin* sub = (ErlSubBin*)pb;
-			pb = (ProcBin*) binary_val(sub->orig);
-			ASSERT(bytesize == sub->size);
-			bytesize += (bitoffs + bitsize + 7) / 8;
-		    }
-		    if (pb->thing_word == HEADER_PROC_BIN
-			&& heap_bin_size(bytesize) > PROC_BIN_SIZE) {
-			ProcBin tmp;
-			if (bitoffs || bitsize) {
-			    *ep++ = BIT_BINARY_INTERNAL_REF;
-			    *ep++ = bitoffs;
-			    *ep++ = bitsize;
-			}
-			else {
-			    *ep++ = BINARY_INTERNAL_REF;
-			}
-			if (pb->flags) {
-			    char* before_realloc = pb->val->orig_bytes; 
-			    erts_emasculate_writable_binary(pb);
-			    bytes += (pb->val->orig_bytes - before_realloc);
-			}
-			erts_refc_inc(&pb->val->intern.refc, 2);
 
-			sys_memcpy(&tmp, pb, sizeof(ProcBin));
-			tmp.next = *off_heap;
-			tmp.bytes = bytes;
-			tmp.size = bytesize;
-			sys_memcpy(ep, &tmp, sizeof(ProcBin));
-			*off_heap = (struct erl_off_heap_header*) ep;
-			ep += sizeof(ProcBin);
-			break;
-		    }
-		}
-		if (bitsize == 0) {
-		    /* Plain old byte-sized binary. */
-		    *ep++ = BINARY_EXT;
-		    j = binary_size(obj);
-		    put_int32(j, ep);
-		    ep += 4;
-                    if (off_heap_bytesize)
-                        off_heap_tail = 0;
-                    else {
-                        data_dst = ep;
-                        ep += j;
+                ASSERT((copy_payload || use_iov) ^
+                       (encoding == BITSTRING_INTERNAL_REF ||
+                        encoding == BINARY_INTERNAL_REF));
+
+                *ep++ = encoding;
+                switch (encoding) {
+                case BITSTRING_INTERNAL_REF:
+                    sys_memcpy(ep, boxed_val(obj), sizeof(ErlSubBits));
+                    ep += sizeof(ErlSubBits);
+                    /* Fall through! */
+                case BINARY_INTERNAL_REF:
+                    {
+                        BinRef tmp_ref;
+
+                        erts_refc_inc(&(br->val)->intern.refc, 2);
+
+                        sys_memcpy(&tmp_ref, br, sizeof(BinRef));
+                        /* NOTE: this is only used by db_cleanup_offheap_comp
+                         * which handles potentially unaligned pointers. */
+                        tmp_ref.next = *off_heap;
+                        *off_heap = (struct erl_off_heap_header*)ep;
+                        sys_memcpy(ep, &tmp_ref, sizeof(BinRef));
+
+                        ep += sizeof(BinRef);
                     }
-		} else {
-		    /* Bit-level binary. */
-                    *ep++ = BIT_BINARY_EXT;
-                    j = binary_size(obj);
-                    put_int32((j+1), ep);
-                    ep += 4;
-                    *ep++ = bitsize;
-                    if (off_heap_bytesize) {
-                        /* trailing bits */
+                    break;
+                case BIT_BINARY_EXT:
+                    put_int32(wire_size, ep);
+                    ep[4] = TAIL_BITS(size);
+                    ep += 4 + 1;
+
+                    if (copy_payload) {
+                        /* To avoid information leakage, we have to clear the
+                         * unused bits at the end of the binary. The used bits
+                         * will be copied in later. */
+                        ep[wire_size - 1] = 0;
+                    } else {
+                        /* The bulk of the payload will be referenced directly
+                         * in the resulting iov, but the trailing bits will be
+                         * copied here since the iov can't address bits. */
+                        Uint trailing_bits = TAIL_BITS(size);
                         ep[0] = 0;
-                        copy_binary_to_buffer(ep, 0, bytes + j, 0, bitsize);
-                        off_heap_tail = 1;
+                        copy_binary_to_buffer(ep, 0, base,
+                                              offset + size - trailing_bits,
+                                              trailing_bits);
                     }
-                    else {
-                        ep[j] = 0;	/* Zero unused bits at end of binary */
-                        data_dst = ep;
-                        ep += j + 1;
-                    }
-		}
-                if (off_heap_bytesize) {
-                    ASSERT(pb_val);
-                    store_in_vec(ctx, ep, pb_val, pb_term,
-                                 bytes, off_heap_bytesize);
-                    ep += off_heap_tail;
+                    break;
+                case BINARY_EXT:
+                    put_int32(wire_size, ep);
+                    ep += 4;
+                    break;
                 }
-                else if (ctx && j > r * TERM_TO_BINARY_MEMCPY_FACTOR) {
-		    WSTACK_PUSH5(s, (UWord)data_dst, (UWord)bytes, bitoffs,
-				 ENC_BIN_COPY, 8*j + bitsize);
-		} else {
-		    copy_binary_to_buffer(data_dst, 0, bytes, bitoffs,
-					  8 * j + bitsize);
-		}
-	    }
-	    break;
+
+                if (copy_payload) {
+                    byte* data_dst = ep;
+                    ep += wire_size;
+
+                    if (ctx && wire_size > r * TERM_TO_BINARY_MEMCPY_FACTOR) {
+                        WSTACK_PUSH6(s, (UWord)data_dst, (UWord)base,
+                                     0, offset, ENC_BIN_COPY, size);
+                    } else {
+                        copy_binary_to_buffer(data_dst, 0, base, offset, size);
+                    }
+                } else if (use_iov) {
+                    /* Reference the stored data directly, omitting the
+                     * trailing bits which have been copied separately. */
+                    ASSERT(br != NULL && BIT_OFFSET(offset) == 0);
+                    base = &base[BYTE_OFFSET(offset)];
+                    store_in_vec(ctx, ep, br->val, obj, base, BYTE_SIZE(size));
+                    ep += (encoding == BIT_BINARY_EXT);
+                }
+
+                ASSERT(ctx == NULL || !use_iov ||
+                       (ep - ctx->cptr) <= (ctx->result_bin)->orig_size);
+            }
+            break;
         case FUN_DEF:
             {
                 ErlFunThing* funp = (ErlFunThing *) fun_val(obj);
@@ -4103,12 +4162,16 @@ store_in_vec_aux(TTBEncodeContext *ctx,
 static void
 store_in_vec(TTBEncodeContext *ctx,
              byte *ep,
-             Binary *ohbin,
-             Eterm ohpb,
-             byte *ohp,
-             Uint ohsz)
+             Binary *refc_binary,
+             Eterm binary,
+             byte *data,
+             Uint size)
 {
-    byte *cp = ctx->cptr;
+    byte *cp;
+
+    ASSERT((refc_binary == NULL) ^ is_value(binary));
+
+    cp = ctx->cptr;
     if (cp != ep) {
         /* save data in common binary... */
         store_in_vec_aux(ctx,
@@ -4120,13 +4183,15 @@ store_in_vec(TTBEncodeContext *ctx,
         ASSERT(ctx->frag_ix <= ctx->debug_fragments);
         ctx->cptr = ep;
     }
-    if (ohbin) {
+
+
+    if (refc_binary) {
         /* save off-heap binary... */
         store_in_vec_aux(ctx,
-                         ohbin,
-                         ohpb,
-                         ohp,
-                         ohsz);
+                         refc_binary,
+                         binary,
+                         data,
+                         size);
         ASSERT(ctx->vlen <= ctx->debug_vlen);
         ASSERT(ctx->frag_ix <= ctx->debug_fragments);
     }
@@ -4753,130 +4818,91 @@ dec_term_atom_common:
 	    }
 		break;
 	    }
-	case BINARY_EXT:
-	    {
-                Uint nu = get_uint32(ep);
-		ep += 4;
-	    
-                ASSERT(IS_BINARY_SIZE_OK(nu));
+        case BIT_BINARY_EXT:
+        case BINARY_EXT:
+            {
+                Uint size_in_bits, nu;
 
-		if (nu <= ERL_ONHEAP_BIN_LIMIT) {
-		    ErlHeapBin* hb = (ErlHeapBin *) hp;
+                nu = get_uint32(ep);
+                if (!IS_BINARY_SIZE_OK(nu)) {
+                    goto error;
+                }
 
-		    hb->thing_word = header_heap_bin(nu);
-		    hb->size = nu;
-		    hp += heap_bin_size(nu);
-		    sys_memcpy(hb->data, ep, nu);
-		    *objp = make_binary(hb);
-		} else if (edep && edep->data && edep->data->binp &&
-                           nu > (edep->data->binp->orig_size / 4)) {
+                size_in_bits = NBITS(nu);
+
+                if (ep[-1] == BIT_BINARY_EXT) {
+                    Uint trailing_bits = ep[4];
+
+                    if (((trailing_bits == 0) != (nu == 0)) ||
+                        trailing_bits > 8) {
+                        goto error;
+                    }
+
+                    size_in_bits -= 8 - trailing_bits;
+                    ep++;
+                }
+
+                ep += 4;
+
+                if (size_in_bits > ERL_ONHEAP_BITS_LIMIT &&
+                    edep &&
+                    edep->data &&
+                    (edep->data)->binp &&
+                    (nu > ((edep->data)->binp)->orig_size / 4)) {
                     /* If we decode a refc binary from a distribution data
-                       entry we know that it is a refc binary to begin with
-                       so we just increment it and use the reference. This
-                       means that the entire distribution data entry will
-                       remain until this binary is de-allocated so we only
-                       do it if a substantial part (> 25%) of the data
-                       is a binary. */
-                    ProcBin* pb = (ProcBin *) hp;
-                    Binary* bptr = edep->data->binp;
-                    erts_refc_inc(&bptr->intern.refc, 1);
-                    pb->thing_word = HEADER_PROC_BIN;
-                    pb->size = nu;
-                    pb->next = factory->off_heap->first;
-                    factory->off_heap->first = (struct erl_off_heap_header*)pb;
-                    pb->val = bptr;
-                    pb->bytes = (byte*) ep;
-                    ERTS_ASSERT((byte*)(bptr->orig_bytes) < ep &&
-                                ep+nu <= (byte*)(bptr->orig_bytes+bptr->orig_size));
-                    pb->flags = 0;
-                    OH_OVERHEAD(factory->off_heap, pb->size / sizeof(Eterm));
-                    hp += PROC_BIN_SIZE;
-                    *objp = make_binary(pb);
-		} else {
-		    Binary* dbin;
+                     * entry we know that it is a refc binary to begin with so
+                     * we just increment it and use the reference. This means
+                     * that the entire distribution data entry will remain
+                     * until this binary is de-allocated, so we'll only do it
+                     * when a substantial part (> 25%) of the data is a
+                     * binary. */
+                    Binary *refc_binary = (edep->data)->binp;
+                    byte *data;
 
-                    dbin = erts_bin_nrml_alloc(nu);
+                    erts_refc_inc(&refc_binary->intern.refc, 1);
 
-		    *objp = erts_build_proc_bin(factory->off_heap, hp, dbin);
-		    hp += PROC_BIN_SIZE;
-                    if (ctx) {
+                    data = (byte*)refc_binary->orig_bytes;
+                    ERTS_ASSERT(ErtsInArea(ep, data, refc_binary->orig_size));
+
+                    factory->hp = hp;
+                    *objp =
+                        erts_wrap_refc_bitstring(&(factory->off_heap)->first,
+                                                 &(factory->off_heap)->overhead,
+                                                 &factory->hp,
+                                                 refc_binary,
+                                                 data,
+                                                 NBITS(ep - data),
+                                                 size_in_bits);
+                    hp = factory->hp;
+                } else {
+                    byte *data;
+
+                    factory->hp = hp;
+                    *objp = erts_hfact_new_bitstring(factory,
+                                                     0,
+                                                     size_in_bits,
+                                                     &data);
+                    hp = factory->hp;
+
+                    if (ctx && size_in_bits > ERL_ONHEAP_BITS_LIMIT) {
                         unsigned int n_limit = reds * B2T_MEMCPY_FACTOR;
                         if (nu > n_limit) {
                             ctx->state = B2TDecodeBinary;
                             ctx->u.dc.remaining_n = nu - n_limit;
-                            ctx->u.dc.remaining_bytes = dbin->orig_bytes + n_limit;
+                            ctx->u.dc.remaining_bytes = (char*)&data[n_limit];
                             nu = n_limit;
                             reds = 0;
-                        }
-                        else
+                        } else {
                             reds -= nu / B2T_MEMCPY_FACTOR;
-                    }
-                    sys_memcpy(dbin->orig_bytes, ep, nu);
-                }
-		ep += nu;
-		break;
-	    }
-	case BIT_BINARY_EXT:
-	    {
-		Eterm bin;
-		ErlSubBin* sb;
-		Uint bitsize;
-                Uint nu = get_uint32(ep);
-
-                ASSERT(IS_BINARY_SIZE_OK(nu));
-
-		bitsize = ep[4];
-                if (((bitsize==0) != (nu==0)) || bitsize > 8)
-                    goto error;
-                ep += 5;
-		if (nu <= ERL_ONHEAP_BIN_LIMIT) {
-		    ErlHeapBin* hb = (ErlHeapBin *) hp;
-
-		    hb->thing_word = header_heap_bin(nu);
-		    hb->size = nu;
-		    sys_memcpy(hb->data, ep, nu);
-		    bin = make_binary(hb);
-		    hp += heap_bin_size(nu);
-                    ep += nu;
-		} else {
-		    Binary* dbin = erts_bin_nrml_alloc(nu);
-		    Uint n_copy = nu;
-
-		    bin = erts_build_proc_bin(factory->off_heap, hp, dbin);
-		    hp += PROC_BIN_SIZE;
-                    if (ctx) {
-                        int n_limit = reds * B2T_MEMCPY_FACTOR;
-                        if (nu > n_limit) {
-                            ctx->state = B2TDecodeBinary;
-                            ctx->u.dc.remaining_n = nu - n_limit;
-                            ctx->u.dc.remaining_bytes = dbin->orig_bytes + n_limit;
-                            n_copy = n_limit;
-                            reds = 0;
                         }
-                        else {
-                            reds -= nu / B2T_MEMCPY_FACTOR;
-			}
                     }
-                    sys_memcpy(dbin->orig_bytes, ep, n_copy);
-                    ep += n_copy;
+
+                    sys_memcpy(data, ep, nu);
                 }
 
-		if (bitsize == 8 || nu == 0) {
-		    *objp = bin;
-		} else {
-                    sb = (ErlSubBin *)hp;
-		    sb->thing_word = HEADER_SUB_BIN;
-		    sb->orig = bin;
-		    sb->size = nu - 1;
-		    sb->bitsize = bitsize;
-		    sb->bitoffs = 0;
-		    sb->offs = 0;
-		    sb->is_writable = 0;
-		    *objp = make_binary(sb);
-		    hp += ERL_SUB_BIN_SIZE;
-		}
-		break;
-	    }
+                ep += nu;
+                break;
+            }
         case EXPORT_EXT:
             {
                 ErlFunThing *funp;
@@ -5076,50 +5102,45 @@ dec_term_atom_common:
 	    *objp = make_atom(n);
 	    break;
 
-	case BINARY_INTERNAL_REF:
-	    {
-		ProcBin* pb = (ProcBin*) hp;
-		sys_memcpy(pb, ep, sizeof(ProcBin));
-		ep += sizeof(ProcBin);
+        case BITSTRING_INTERNAL_REF:
+        case BINARY_INTERNAL_REF:
+            {
+                const byte tag = ep[-1];
+                ErlSubBits *sb;
+                BinRef *br;
 
-		erts_refc_inc(&pb->val->intern.refc, 1);
-		hp += PROC_BIN_SIZE;
-		pb->next = factory->off_heap->first;
-		factory->off_heap->first = (struct erl_off_heap_header*)pb;
-		OH_OVERHEAD(factory->off_heap, pb->size / sizeof(Eterm));
-		pb->flags = 0;
-		*objp = make_binary(pb);
-		break;
-	    }
-	case BIT_BINARY_INTERNAL_REF:
-	    {
-		Sint bitoffs = *ep++;
-		Sint bitsize = *ep++;
-		ProcBin* pb = (ProcBin*) hp;
-		ErlSubBin* sub;
-		sys_memcpy(pb, ep, sizeof(ProcBin));
-		ep += sizeof(ProcBin);
+                sb = (ErlSubBits*)hp;
+                hp += ERL_SUB_BITS_SIZE;
+                br = (BinRef*)hp;
+                hp += ERL_BIN_REF_SIZE;
 
-		erts_refc_inc(&pb->val->intern.refc, 1);
-		hp += PROC_BIN_SIZE;
-		pb->next = factory->off_heap->first;
-		factory->off_heap->first = (struct erl_off_heap_header*)pb;
-                OH_OVERHEAD(factory->off_heap, pb->size / sizeof(Eterm));
-		pb->flags = 0;
+                if (tag == BITSTRING_INTERNAL_REF) {
+                    ASSERT(br == (BinRef*)&sb[1]);
 
-		sub = (ErlSubBin*)hp;
-		sub->thing_word = HEADER_SUB_BIN;
-		sub->size = pb->size - (bitoffs + bitsize + 7)/8;
-		sub->offs = 0;
-		sub->bitoffs = bitoffs;
-		sub->bitsize = bitsize;
-		sub->is_writable = 0;
-		sub->orig = make_binary(pb);
+                    sys_memcpy(sb, ep, sizeof(ErlSubBits) + sizeof(BinRef));
+                    ep += sizeof(ErlSubBits) + sizeof(BinRef);
+                } else {
+                    /* The encoded bitstring can be described entirely from the
+                     * wrapped Binary* object, so we've skipped encoding an
+                     * ErlSubBits here. We still need to create one however.*/
+                    sys_memcpy(br, ep, sizeof(BinRef));
+                    ep += sizeof(BinRef);
 
-		hp += ERL_SUB_BIN_SIZE;
-		*objp = make_binary(sub);
-		break;
-	    }
+                    sb->thing_word = HEADER_SUB_BITS;
+                    ERTS_SET_SB_RANGE(sb, 0, NBITS((br->val)->orig_size));
+                    sb->is_writable = 0;
+                }
+
+                erts_refc_inc(&(br->val)->intern.refc, 1);
+
+                br->next = (factory->off_heap)->first;
+                (factory->off_heap)->first = (struct erl_off_heap_header*)br;
+                ERTS_BR_OVERHEAD(factory->off_heap, br);
+
+                sb->orig = make_boxed((Eterm*)br);
+                *objp = make_bitstring(sb);
+                break;
+            }
         case MAGIC_REF_INTERNAL_REF:
             {
                 ErtsMRefThing* mrtp = (ErtsMRefThing*) hp;
@@ -5535,92 +5556,100 @@ encode_size_struct_int(TTBSizeContext* ctx, ErtsAtomCacheMap *acmp, Eterm obj,
 		result += 32;   /* Yes, including the tag */
 	    }
 	    break;
-	case BINARY_DEF: {
-            ProcBin* pb = (ProcBin*) binary_val(obj);
-            Uint bin_size = pb->size;
-            byte bitoffs = 0;
-            byte bitsize = 0;
-            if (dflags & DFLAG_ETS_COMPRESSED) {
-		ProcBin* pb = (ProcBin*) binary_val(obj);
-		Uint sub_extra = 0;
-		if (pb->thing_word == HEADER_SUB_BIN) {
-		    ErlSubBin* sub = (ErlSubBin*) pb;
-                    bitoffs = sub->bitoffs;
-                    bitsize = sub->bitsize;
-		    pb = (ProcBin*) binary_val(sub->orig);
-		    sub_extra = 2;  /* bitoffs and bitsize */
-		    bin_size += (bitoffs + bitsize + 7) / 8;
-		}
-		if (pb->thing_word == HEADER_PROC_BIN
-		    && heap_bin_size(bin_size) > PROC_BIN_SIZE) {
+	case BITSTRING_DEF: {
+            ERTS_DECLARE_DUMMY(Eterm br_flags);
+            int encoding, copy_payload;
+            Uint offset, size;
+            Uint wire_size;
+            byte *base;
+            BinRef *br;
 
-		    result += 1 + sub_extra + sizeof(ProcBin);
-		    break;
-		}
+            ERTS_PIN_BITSTRING(obj, br_flags, br, base, offset, size);
+            encoding = TAIL_BITS(size) ? BIT_BINARY_EXT : BINARY_EXT;
+            wire_size = NBYTES(size);
+
+            if (wire_size >= ERTS_UINT32_MAX) {
+                WSTACK_DESTROY(s);
+                return ERTS_EXT_SZ_SYSTEM_LIMIT;
             }
-            else {
-#ifdef ARCH_64
-                if (bin_size >= (Uint) 0xffffffff) {
-                    if (pb->thing_word == HEADER_SUB_BIN) {
-                        ErlSubBin* sub = (ErlSubBin*) pb;
-                        bin_size += (sub->bitoffs + sub->bitsize+ 7) / 8;
-                    }
-                    if (bin_size > (Uint) 0xffffffff) {
-                        WSTACK_DESTROY(s);
-                        return ERTS_EXT_SZ_SYSTEM_LIMIT;
+
+            copy_payload =
+                (size <= ERL_ONHEAP_BITS_LIMIT) ||
+                (BIT_OFFSET(offset) != 0) ||
+                (vlen < 0);
+
+            if ((dflags & DFLAG_ETS_COMPRESSED) && (br != NULL)) {
+                const Binary *refc_binary = br->val;
+
+                ASSERT(vlen < 0);
+
+                /* Use [BIT_]BINARY_INTERNAL_REF, copying the actual BinRef
+                 * and/or ErlSubBits whenever that is smaller than the data
+                 * itself. */
+                if (wire_size >= sizeof(BinRef)) {
+                    if ((encoding == BINARY_EXT) &&
+                        (base == (byte*)refc_binary->orig_bytes) &&
+                        (size == refc_binary->orig_size * 8) &&
+                        (offset == 0)) {
+                        encoding = BINARY_INTERNAL_REF;
+                    } else if (wire_size >= (sizeof(ErlSubBits) +
+                                             sizeof(BinRef))) {
+                        encoding = BITSTRING_INTERNAL_REF;
                     }
                 }
-#endif
-                if (pb->thing_word == HEADER_SUB_BIN) {
-                    ErlSubBin* sub = (ErlSubBin*) pb;
-                    bitoffs = sub->bitoffs;
-                    bitsize = sub->bitsize;
-                    pb = (ProcBin*) binary_val(sub->orig);
-                }
-                if (vlen >= 0) {
+            }
+
+            switch (encoding) {
+            case BITSTRING_INTERNAL_REF:
+                result += sizeof(ErlSubBits);
+                /* !! FALL THROUGH !! */
+            case BINARY_INTERNAL_REF:
+                result += 1 /* [BIT_]BINARY_INTERNAL_REF */
+                          + sizeof(BinRef);
+                break;
+            case BIT_BINARY_EXT:
+                result += 1; /* Trailing bit count. */
+                /* !! FALL THROUGH !! */
+            case BINARY_EXT:
+                result += 1   /* [BIT_]BINARY_EXT */
+                          + 4 /* Size in bytes */;
+
+                if (copy_payload) {
+                    result += wire_size;
+                } else {
                     Uint csz;
-                    if (pb->thing_word == HEADER_PROC_BIN
-                        && bitoffs == 0
-                        && bin_size > ERL_ONHEAP_BIN_LIMIT) {
-                        Uint trailing_result;
-                        if (bitsize == 0) {
-                            result += (1 /* BIT_BINARY_EXT */
-                                       + 4 /* size */);
-                            trailing_result = 0;
-                        }
-                        else {
-                            result += (1 /* BIT_BINARY_EXT */
-                                       + 4 /* size */
-                                       + 1 /* trailing bitsize */);
-                            trailing_result = 1 /* trailing bits */;
-                        }
-                        csz = result - ctx->last_result;
-                        ctx->last_result = result;
-                        result += trailing_result;
-                        vlen += 2; /* data leading up to binary and binary */
 
-                        /* potentially multiple elements leading up to binary */
-                        vlen += csz/MAX_SYSIOVEC_IOVLEN;
-                        /* potentially multiple elements for binary */
-                        vlen += bin_size/MAX_SYSIOVEC_IOVLEN;
-                        ctx->extra_size += bin_size;
-                        break;
-                    }
+                    /* The encode routine will set up an iovec pointing at the
+                     * actual data at this offset.
+                     *
+                     * In case of bit binaries, we grab the offset prior to
+                     * adding the trailing bits, as we want the iovec to
+                     * include the data prior to those. */
+                    csz = result - ctx->last_result;
+                    ctx->last_result = result;
+
+                    /* Trailing bits if any. */
+                    result += (encoding == BIT_BINARY_EXT);
+
+                    /* Data leading up to the binary, and the binary itself */
+                    vlen += 2;
+
+                    /* Potentially multiple elements leading up to binary */
+                    vlen += csz / MAX_SYSIOVEC_IOVLEN;
+
+                    /* Potentially multiple elements for binary.
+                     *
+                     * Note that we do not include the trailing bits in this
+                     * calculation as those have already been counted above. */
+                    size = BYTE_SIZE(size);
+                    vlen += size / MAX_SYSIOVEC_IOVLEN;
+
+                    ctx->extra_size += size;
                 }
-	    }
+                break;
+            }
 
-            if (bitsize == 0) {
-                result += (1     /* BINARY_EXT */
-                           + 4); /* size */
-            }
-            else {
-                result += (1     /* BIT_BINARY_EXT */
-                           + 4   /* size */
-                           + 1   /* bits */
-                           + 1); /* trailing bits */
-            }
-            result += bin_size;
-	    break;
+            break;
         }
         case FUN_DEF:
             {
@@ -6042,13 +6071,13 @@ init_done:
             if (!IS_BINARY_SIZE_OK(n))
                 goto error;
 #endif
-	    SKIP2(n, 4);
-	    if (n <= ERL_ONHEAP_BIN_LIMIT) {
-		heap_size += heap_bin_size(n);
-	    } else {
-		heap_size += PROC_BIN_SIZE;
-	    }
-	    break;
+            SKIP2(n, 4);
+            if (n <= ERL_ONHEAP_BINARY_LIMIT) {
+                heap_size += heap_bits_size(NBITS(n));
+            } else {
+                heap_size += ERL_REFC_BITS_SIZE;
+            }
+            break;
 	case BIT_BINARY_EXT:
 	    {
 		CHKSIZE(5);
@@ -6057,12 +6086,12 @@ init_done:
                 if (!IS_BINARY_SIZE_OK(n))
                     goto error;
 #endif
-		SKIP2(n, 5);
-		if (n <= ERL_ONHEAP_BIN_LIMIT) {
-		    heap_size += heap_bin_size(n) + ERL_SUB_BIN_SIZE;
-		} else {
-		    heap_size += PROC_BIN_SIZE + ERL_SUB_BIN_SIZE;
-		}
+                SKIP2(n, 5);
+                if (n <= ERL_ONHEAP_BINARY_LIMIT) {
+                    heap_size += heap_bits_size(NBITS(n));
+                } else {
+                    heap_size += ERL_REFC_BITS_SIZE;
+                }
 	    }
 	    break;
 	case EXPORT_EXT:
@@ -6103,21 +6132,24 @@ init_done:
 	    SKIP(3+atom_extra_skip);
 	    atom_extra_skip = 0;
 	    break;
+        case BITSTRING_INTERNAL_REF:
+            if (!internal_tags) {
+                goto error;
+            }
+            SKIP(sizeof(ErlSubBits));
+            /* !!! FALL THROUGH !!! */
+        case BINARY_INTERNAL_REF:
+            if (!internal_tags) {
+                goto error;
+            }
+            SKIP(sizeof(BinRef));
 
-	case BINARY_INTERNAL_REF:
-	    if (!internal_tags) {
-		goto error;
-	    }
-	    SKIP(sizeof(ProcBin));
-	    heap_size += PROC_BIN_SIZE;
-	    break;
-	case BIT_BINARY_INTERNAL_REF:
-	    if (!internal_tags) {
-		goto error;
-	    }
-	    SKIP(2+sizeof(ProcBin));
-	    heap_size += PROC_BIN_SIZE + ERL_SUB_BIN_SIZE;
-	    break;
+            /* While BITSTRING_INTERNAL_REF and BINARY_INTERNAL_REF are
+             * encoded differently, their on-heap size is the same since
+             * BinRefs are not valid terms and must be wrapped by an
+             * ErlSubBits. */
+            heap_size += ERL_REFC_BITS_SIZE;
+            break;
         case MAGIC_REF_INTERNAL_REF:
             if (!internal_tags)
                 goto error;

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -67,7 +67,7 @@
 #define ATOM_INTERNAL_REF2 'I'
 #define ATOM_INTERNAL_REF3 'K'
 #define BINARY_INTERNAL_REF 'J'
-#define BIT_BINARY_INTERNAL_REF 'L'
+#define BITSTRING_INTERNAL_REF 'L'
 #define MAGIC_REF_INTERNAL_REF 'N'
 #define COMPRESSED        'P'
 
@@ -136,8 +136,8 @@ typedef struct erl_dist_external_data ErtsDistExternalData;
 struct erl_dist_external_data {
     Uint64 seq_id;
     Uint64 frag_id;
-    byte *extp;
-    byte *ext_endp;
+    const byte *extp;
+    const byte *ext_endp;
     struct binary *binp;
 };
 
@@ -208,8 +208,15 @@ typedef enum {
     ERTS_PREP_DIST_EXT_CLOSED
 } ErtsPrepDistExtRes;
 
-ErtsPrepDistExtRes erts_prepare_dist_ext(ErtsDistExternal *, byte *, Uint, struct binary *,
-                                         DistEntry *, Uint32, ErtsAtomCache *);
+ErtsPrepDistExtRes
+erts_prepare_dist_ext(ErtsDistExternal *edep,
+                      const byte *ext,
+                      Uint size,
+                      struct binary *binp,
+                      DistEntry *dep,
+                      Uint32 conn_id,
+                      ErtsAtomCache *cache);
+
 Sint erts_decode_dist_ext_size(ErtsDistExternal *, int, int);
 Eterm erts_decode_dist_ext(ErtsHeapFactory*, ErtsDistExternal *, int);
 

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1231,9 +1231,9 @@ protected:
                               Uint bits,
                               const ArgRegister &Dst);
 
-    void emit_extract_binary(const arm::Gp bitdata,
-                             Uint bits,
-                             const ArgRegister &Dst);
+    void emit_extract_bitstring(const arm::Gp bitdata,
+                                Uint bits,
+                                const ArgRegister &Dst);
 
     UWord bs_get_flags(const ArgVal &val);
 

--- a/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
@@ -27,9 +27,7 @@ my @beam_global_funcs = qw(
     bif_nif_epilogue
     bif_export_trap
     bif_bit_size_body
-    bif_bit_size_guard
     bif_byte_size_body
-    bif_byte_size_guard
     bif_element_body_shared
     bif_element_guard_shared
     bif_is_eq_exact_shared
@@ -38,7 +36,6 @@ my @beam_global_funcs = qw(
     bif_tuple_size_guard
     bs_add_guard_shared
     bs_add_body_shared
-    bs_bit_size_shared
     bs_create_bin_error_shared
     bs_get_tail_shared
     bs_get_utf8_shared
@@ -196,7 +193,6 @@ $decl_emit_funcs
     void emit_raise_badarg(const ErtsCodeMFA *mfa);
 
     void emit_bif_bit_size_helper(Label fail);
-    void emit_bif_byte_size_helper(Label fail);
     void emit_bif_element_helper(Label fail);
     void emit_bif_tuple_size_helper(Label fail);
 

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -812,54 +812,46 @@ void beam_jit_bs_add_argument_error(Process *c_p, Eterm A, Eterm B) {
 Eterm beam_jit_bs_init(Process *c_p,
                        Eterm *reg,
                        ERL_BITS_DECLARE_STATEP,
-                       Eterm num_bytes,
+                       Uint num_bytes,
                        Uint alloc,
                        unsigned Live) {
+    const Uint num_bits = NBITS(num_bytes);
+
     erts_bin_offset = 0;
-    if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-        ErlHeapBin *hb;
+    if (num_bytes <= ERL_ONHEAP_BINARY_LIMIT) {
+        ErlHeapBits *hb;
         Uint bin_need;
 
-        bin_need = heap_bin_size(num_bytes);
-        gc_test(c_p, reg, 0, bin_need + alloc + ERL_SUB_BIN_SIZE, Live);
-        hb = (ErlHeapBin *)c_p->htop;
+        bin_need = heap_bits_size(num_bits);
+        gc_test(c_p, reg, 0, bin_need + alloc + ERL_SUB_BITS_SIZE, Live);
+
+        hb = (ErlHeapBits *)c_p->htop;
         c_p->htop += bin_need;
-        hb->thing_word = header_heap_bin(num_bytes);
-        hb->size = num_bytes;
+
+        hb->thing_word = header_heap_bits(num_bits);
+        ERTS_SET_HB_SIZE(hb, num_bits);
+
         erts_current_bin = (byte *)hb->data;
-        return make_binary(hb);
+        return make_bitstring(hb);
     } else {
-        Binary *bptr;
-        ProcBin *pb;
+        Binary *new_binary;
 
         test_bin_vheap(c_p,
                        reg,
                        num_bytes / sizeof(Eterm),
-                       alloc + PROC_BIN_SIZE,
+                       alloc + ERL_REFC_BITS_SIZE,
                        Live);
 
-        /*
-         * Allocate the binary struct itself.
-         */
-        bptr = erts_bin_nrml_alloc(num_bytes);
-        erts_current_bin = (byte *)bptr->orig_bytes;
+        new_binary = erts_bin_nrml_alloc(num_bytes);
+        erts_current_bin = (byte *)new_binary->orig_bytes;
 
-        /*
-         * Now allocate the ProcBin on the heap.
-         */
-        pb = (ProcBin *)c_p->htop;
-        c_p->htop += PROC_BIN_SIZE;
-        pb->thing_word = HEADER_PROC_BIN;
-        pb->size = num_bytes;
-        pb->next = MSO(c_p).first;
-        MSO(c_p).first = (struct erl_off_heap_header *)pb;
-        pb->val = bptr;
-        pb->bytes = (byte *)bptr->orig_bytes;
-        pb->flags = 0;
-
-        OH_OVERHEAD(&(MSO(c_p)), num_bytes / sizeof(Eterm));
-
-        return make_binary(pb);
+        return erts_wrap_refc_bitstring(&MSO(c_p).first,
+                                        &MSO(c_p).overhead,
+                                        &HEAP_TOP(c_p),
+                                        new_binary,
+                                        erts_current_bin,
+                                        0,
+                                        num_bits);
     }
 }
 
@@ -869,79 +861,43 @@ Eterm beam_jit_bs_init_bits(Process *c_p,
                             Uint num_bits,
                             Uint alloc,
                             unsigned Live) {
-    Eterm new_binary;
-    Uint num_bytes = ((Uint64)num_bits + (Uint64)7) >> 3;
-
-    if (num_bits & 7) {
-        alloc += ERL_SUB_BIN_SIZE;
-    }
-    if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-        alloc += heap_bin_size(num_bytes);
+    if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+        alloc += heap_bits_size(num_bits);
     } else {
-        alloc += PROC_BIN_SIZE;
+        alloc += ERL_REFC_BITS_SIZE;
     }
 
     erts_bin_offset = 0;
 
-    /* num_bits = Number of bits to build
-     * num_bytes = Number of bytes to allocate in the binary
-     * alloc = Total number of words to allocate on heap
-     * Operands: NotUsed NotUsed Dst
-     */
-    if (num_bytes <= ERL_ONHEAP_BIN_LIMIT) {
-        ErlHeapBin *hb;
+    if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
+        ErlHeapBits *hb;
 
         gc_test(c_p, reg, 0, alloc, Live);
-        hb = (ErlHeapBin *)c_p->htop;
-        c_p->htop += heap_bin_size(num_bytes);
-        hb->thing_word = header_heap_bin(num_bytes);
-        hb->size = num_bytes;
+        hb = (ErlHeapBits *)c_p->htop;
+
+        c_p->htop += heap_bits_size(num_bits);
+        hb->thing_word = header_heap_bits(num_bits);
+        ERTS_SET_HB_SIZE(hb, num_bits);
+
         erts_current_bin = (byte *)hb->data;
-        new_binary = make_binary(hb);
+        return make_bitstring(hb);
     } else {
-        Binary *bptr;
-        ProcBin *pb;
+        const Uint num_bytes = NBYTES(num_bits);
+        Binary *new_binary;
 
         test_bin_vheap(c_p, reg, num_bytes / sizeof(Eterm), alloc, Live);
 
-        /*
-         * Allocate the binary struct itself.
-         */
-        bptr = erts_bin_nrml_alloc(num_bytes);
-        erts_current_bin = (byte *)bptr->orig_bytes;
+        new_binary = erts_bin_nrml_alloc(num_bytes);
+        erts_current_bin = (byte *)new_binary->orig_bytes;
 
-        /*
-         * Now allocate the ProcBin on the heap.
-         */
-        pb = (ProcBin *)c_p->htop;
-        c_p->htop += PROC_BIN_SIZE;
-        pb->thing_word = HEADER_PROC_BIN;
-        pb->size = num_bytes;
-        pb->next = MSO(c_p).first;
-        MSO(c_p).first = (struct erl_off_heap_header *)pb;
-        pb->val = bptr;
-        pb->bytes = (byte *)bptr->orig_bytes;
-        pb->flags = 0;
-        OH_OVERHEAD(&(MSO(c_p)), pb->size / sizeof(Eterm));
-        new_binary = make_binary(pb);
+        return erts_wrap_refc_bitstring(&MSO(c_p).first,
+                                        &MSO(c_p).overhead,
+                                        &HEAP_TOP(c_p),
+                                        new_binary,
+                                        erts_current_bin,
+                                        0,
+                                        num_bits);
     }
-
-    if (num_bits & 7) {
-        ErlSubBin *sb;
-
-        sb = (ErlSubBin *)c_p->htop;
-        c_p->htop += ERL_SUB_BIN_SIZE;
-        sb->thing_word = HEADER_SUB_BIN;
-        sb->size = num_bytes - 1;
-        sb->bitsize = num_bits & 7;
-        sb->offs = 0;
-        sb->bitoffs = 0;
-        sb->is_writable = 0;
-        sb->orig = new_binary;
-        new_binary = make_binary(sb);
-    }
-
-    return new_binary;
 }
 
 Eterm beam_jit_bs_get_integer(Process *c_p,
@@ -994,7 +950,7 @@ void beam_jit_bs_construct_fail_info(Process *c_p,
     Eterm value = am_undefined;
 
     switch (op) {
-    case BSC_OP_BINARY:
+    case BSC_OP_BITSTRING:
         Op = am_binary;
         break;
     case BSC_OP_FLOAT:
@@ -1057,8 +1013,8 @@ void beam_jit_bs_construct_fail_info(Process *c_p,
         Info = am_unit;
         break;
     case BSC_INFO_DEPENDS:
-        ASSERT(op == BSC_OP_BINARY);
-        Info = is_binary(value) ? am_short : am_type;
+        ASSERT(op == BSC_OP_BITSTRING);
+        Info = is_bitstring(value) ? am_short : am_type;
         break;
     }
 
@@ -1077,10 +1033,13 @@ void beam_jit_bs_construct_fail_info(Process *c_p,
 }
 
 Sint beam_jit_bs_bit_size(Eterm term) {
-    if (is_binary(term)) {
+    if (is_bitstring(term)) {
+        Uint size = bitstring_size(term);
+
         ASSERT(sizeof(Uint) == 8); /* Only support 64-bit machines. */
-        Uint byte_size = binary_size(term);
-        return (Sint)((byte_size << 3) + binary_bitsize(term));
+        ASSERT(size <= ERTS_SINT_MAX);
+
+        return (Sint)size;
     }
 
     /* Signal error */

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -215,7 +215,7 @@ struct BeamModuleAssemblerCommon {
         switch (tag_val_def(constant)) {
         case ATOM_DEF:
             return BeamTypeId::Atom;
-        case BINARY_DEF:
+        case BITSTRING_DEF:
             return BeamTypeId::Bitstring;
         case FLOAT_DEF:
             return BeamTypeId::Float;
@@ -491,7 +491,7 @@ public:
 static const Uint BSC_SEGMENT_OFFSET = 10;
 
 typedef enum : Uint {
-    BSC_OP_BINARY = 0,
+    BSC_OP_BITSTRING = 0,
     BSC_OP_FLOAT = 1,
     BSC_OP_INTEGER = 2,
     BSC_OP_UTF8 = 3,

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1300,9 +1300,9 @@ protected:
                               Uint flags,
                               Uint bits,
                               const ArgRegister &Dst);
-    void emit_extract_binary(const x86::Gp bitdata,
-                             Uint bits,
-                             const ArgRegister &Dst);
+    void emit_extract_bitstring(const x86::Gp bitdata,
+                                Uint bits,
+                                const ArgRegister &Dst);
     void emit_read_integer(const x86::Gp bin_base,
                            const x86::Gp bin_position,
                            const x86::Gp tmp,

--- a/erts/emulator/beam/jit/x86/instr_float.cpp
+++ b/erts/emulator/beam/jit/x86/instr_float.cpp
@@ -114,7 +114,7 @@ void BeamGlobalAssembler::emit_fconv_shared() {
 
     auto boxed_ptr = emit_ptr_val(ARG2, ARG2);
     a.mov(ARG2, emit_boxed_val(boxed_ptr));
-    a.and_(ARG2, imm(_TAG_HEADER_MASK - _BIG_SIGN_BIT));
+    a.and_(ARG2, imm(_BIG_TAG_MASK));
     a.cmp(ARG2, imm(_TAG_HEADER_POS_BIG));
     a.short_().jne(error);
 

--- a/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
@@ -204,44 +204,16 @@ void BeamModuleAssembler::emit_bif_bit_size(const ArgWord &Bif,
         return;
     }
 
+    comment("inlined bit_size/1 because its argument is always a bitstring");
     mov_arg(ARG2, Src);
-
-    auto unit = getSizeUnit(Src);
-    bool is_bitstring = unit == 0 || std::gcd(unit, 8) != 8;
     x86::Gp boxed_ptr = emit_ptr_val(ARG2, ARG2);
 
-    if (is_bitstring) {
-        comment("inlined bit_size/1 because "
-                "its argument is a bitstring");
-    } else {
-        comment("inlined and simplified bit_size/1 because "
-                "its argument is a binary");
-    }
-
-    if (is_bitstring) {
-        a.mov(RETd, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
-    }
-
+    ERTS_CT_ASSERT(offsetof(ErlHeapBits, size) == sizeof(Eterm));
+    ERTS_CT_ASSERT(offsetof(ErlSubBits, size) == sizeof(Eterm));
     a.mov(ARG1, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
-    a.shl(ARG1, imm(3 + _TAG_IMMED1_SIZE));
-
-    if (is_bitstring) {
-        Label not_sub_bin = a.newLabel();
-        const auto diff_mask = _TAG_HEADER_SUB_BIN - _TAG_HEADER_REFC_BIN;
-        ERTS_CT_ASSERT((_TAG_HEADER_SUB_BIN & diff_mask) != 0 &&
-                       (_TAG_HEADER_REFC_BIN & diff_mask) == 0 &&
-                       (_TAG_HEADER_HEAP_BIN & diff_mask) == 0);
-        a.test(RETb, imm(diff_mask));
-        a.short_().jz(not_sub_bin);
-
-        a.mov(RETb, emit_boxed_val(boxed_ptr, offsetof(ErlSubBin, bitsize), 1));
-        a.shl(RETb, imm(_TAG_IMMED1_SIZE));
-        a.add(ARG1.r8(), RETb);
-
-        a.bind(not_sub_bin);
-    }
-
+    a.shl(ARG1, imm(_TAG_IMMED1_SIZE));
     a.or_(ARG1, imm(_TAG_IMMED1_SMALL));
+
     mov_arg(Dst, ARG1);
 }
 
@@ -260,46 +232,19 @@ void BeamModuleAssembler::emit_bif_byte_size(const ArgWord &Bif,
         return;
     }
 
+    comment("inlined byte_size/1 because its argument is always a bitstring");
     mov_arg(ARG2, Src);
-
-    auto unit = getSizeUnit(Src);
-    bool is_bitstring = unit == 0 || std::gcd(unit, 8) != 8;
     x86::Gp boxed_ptr = emit_ptr_val(ARG2, ARG2);
 
-    if (is_bitstring) {
-        comment("inlined byte_size/1 because "
-                "its argument is a bitstring");
-    } else {
-        comment("inlined and simplified byte_size/1 because "
-                "its argument is a binary");
-    }
-
-    if (is_bitstring) {
-        a.mov(RETd, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
-    }
-
+    ERTS_CT_ASSERT(offsetof(ErlHeapBits, size) == sizeof(Eterm));
+    ERTS_CT_ASSERT(offsetof(ErlSubBits, size) == sizeof(Eterm));
     a.mov(ARG1, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
 
-    if (is_bitstring) {
-        Label not_sub_bin = a.newLabel();
-        const auto diff_mask = _TAG_HEADER_SUB_BIN - _TAG_HEADER_REFC_BIN;
-        ERTS_CT_ASSERT((_TAG_HEADER_SUB_BIN & diff_mask) != 0 &&
-                       (_TAG_HEADER_REFC_BIN & diff_mask) == 0 &&
-                       (_TAG_HEADER_HEAP_BIN & diff_mask) == 0);
-        a.test(RETb, imm(diff_mask));
-        a.short_().jz(not_sub_bin);
-
-        a.mov(RETb, emit_boxed_val(boxed_ptr, offsetof(ErlSubBin, bitsize), 1));
-        a.test(RETb, RETb);
-        a.setne(RETb);
-        a.movzx(RETd, RETb);
-        a.add(ARG1, RET);
-
-        a.bind(not_sub_bin);
-    }
-
-    a.shl(ARG1, imm(_TAG_IMMED1_SIZE));
+    /* Round up to the nearest byte. */
+    a.add(ARG1, imm(7));
+    a.shl(ARG1, imm(_TAG_IMMED1_SIZE - 3));
     a.or_(ARG1, imm(_TAG_IMMED1_SMALL));
+
     mov_arg(Dst, ARG1);
 }
 

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -426,6 +426,7 @@ typedef long long          Sint  erts_align_attribute(sizeof(long long));
 typedef Uint UWord;
 typedef Sint SWord;
 #define ERTS_UINT_MAX ERTS_UWORD_MAX
+#define ERTS_SINT_MAX ERTS_SWORD_MAX
 
 typedef const void *ErtsCodePtr;
 typedef UWord BeamInstr;

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -1177,37 +1177,32 @@ tailrecur_ne:
 		    ++bb;
 		    goto term_array;
 		}
-	    case REFC_BINARY_SUBTAG:
-	    case HEAP_BINARY_SUBTAG:
-	    case SUB_BINARY_SUBTAG:
-		{
-		    byte* a_ptr;
-		    byte* b_ptr;
-		    size_t a_size;
-		    size_t b_size;
-		    Uint a_bitsize;
-		    Uint b_bitsize;
-		    Uint a_bitoffs;
-		    Uint b_bitoffs;
+	    case BIN_REF_SUBTAG:
+	    case HEAP_BITS_SUBTAG:
+	    case SUB_BITS_SUBTAG:
+                {
+                    Uint a_offset, a_size;
+                    byte* a_base;
+                    Uint b_offset, b_size;
+                    byte* b_base;
 
-		    if (!is_binary(b)) {
-			goto not_equal;
-		    }
-		    a_size = binary_size(a);
-		    b_size = binary_size(b);
-		    if (a_size != b_size) {
-			goto not_equal;
-		    }
-		    ERTS_GET_BINARY_BYTES(a, a_ptr, a_bitoffs, a_bitsize);
-		    ERTS_GET_BINARY_BYTES(b, b_ptr, b_bitoffs, b_bitsize);
-		    if ((a_bitsize | b_bitsize | a_bitoffs | b_bitoffs) == 0) {
-			if (sys_memcmp(a_ptr, b_ptr, a_size) == 0) goto pop_next;
-		    } else if (a_bitsize == b_bitsize) {
-			if (erts_cmp_bits(a_ptr, a_bitoffs, b_ptr, b_bitoffs,
-					  (a_size << 3) + a_bitsize) == 0) goto pop_next;
-		    }
-		    break; /* not equal */
-		}
+                    if (!is_bitstring(b)) {
+                        goto not_equal;
+                    }
+
+                    ERTS_GET_BITSTRING(a, a_base, a_offset, a_size);
+                    ERTS_GET_BITSTRING(b, b_base, b_offset, b_size);
+
+                    if (a_size == b_size) {
+                        if (erts_cmp_bits(a_base, a_offset,
+                                          b_base, b_offset,
+                                          a_size) == 0) {
+                            goto pop_next;
+                        }
+                    }
+
+                    break; /* not equal */
+                }
             case FUN_SUBTAG:
                 {
                     ErlFunThing* f1;
@@ -2202,45 +2197,34 @@ tailrecur_ne:
 		goto ref_common;
 	    default:
 		/* Must be a binary */
-		ASSERT(is_binary(a));
-		if (!is_binary(b)) {
-		    a_tag = BINARY_DEF;
+		ASSERT(is_bitstring(a));
+		if (!is_bitstring(b)) {
+		    a_tag = BITSTRING_DEF;
 		    goto mixed_types;
 		} else {
-		    Uint a_size = binary_size(a);
-		    Uint b_size = binary_size(b);
-		    Uint a_bitsize;
-		    Uint b_bitsize;
-		    Uint a_bitoffs;
-		    Uint b_bitoffs;
-		    Uint min_size;
-		    int cmp;
-		    byte* a_ptr;
-		    byte* b_ptr;
-		    if (eq_only && a_size != b_size) {
-		        RETURN_NEQ(a_size - b_size);
-		    }
-		    ERTS_GET_BINARY_BYTES(a, a_ptr, a_bitoffs, a_bitsize);
-		    ERTS_GET_BINARY_BYTES(b, b_ptr, b_bitoffs, b_bitsize);
-		    if ((a_bitsize | b_bitsize | a_bitoffs | b_bitoffs) == 0) {
-			min_size = (a_size < b_size) ? a_size : b_size;
-			if ((cmp = sys_memcmp(a_ptr, b_ptr, min_size)) != 0) {
-			    RETURN_NEQ(cmp);
-			}
-		    }
-		    else {
-			a_size = (a_size << 3) + a_bitsize;
-			b_size = (b_size << 3) + b_bitsize;
-			min_size = (a_size < b_size) ? a_size : b_size;
-			if ((cmp = erts_cmp_bits(a_ptr,a_bitoffs,
-						 b_ptr,b_bitoffs,min_size)) != 0) {
-			    RETURN_NEQ(cmp);
-			}
-		    }
-		    ON_CMP_GOTO((Sint)(a_size - b_size));
-		}
-	    }
-	}
+                    Uint a_offset, a_size;
+                    byte *a_base;
+                    Uint b_offset, b_size;
+                    byte *b_base;
+                    int cmp;
+
+                    ERTS_GET_BITSTRING(a, a_base, a_offset, a_size);
+                    ERTS_GET_BITSTRING(b, b_base, b_offset, b_size);
+
+                    if (!eq_only || a_size == b_size) {
+                        cmp = erts_cmp_bits(a_base, a_offset,
+                                            b_base, b_offset,
+                                            MIN(a_size, b_size));
+                        if (cmp != 0) {
+                            RETURN_NEQ(cmp);
+                        }
+                    }
+
+                    cmp = a_size < b_size ? -1 : (a_size == b_size ? 0 : 1);
+                    ON_CMP_GOTO(cmp);
+                }
+            }
+        }
     }
 
     /*
@@ -2948,484 +2932,6 @@ buf_to_intlist(Eterm** hpp, const char *buf, size_t len, Eterm tail)
 
     *hpp = hp;
     return tail;
-}
-
-/*
-** Write io list in to a buffer.
-**
-** An iolist is defined as:
-**
-** iohead ::= Binary
-**        |   Byte (i.e integer in range [0..255]
-**        |   iolist
-**        ;
-**
-** iotail ::= []
-**        |   Binary  (added by tony)
-**        |   iolist
-**        ;
-**
-** iolist ::= []
-**        |   Binary
-**        |   [ iohead | iotail]
-**        ;
-** 
-** Return remaining bytes in buffer on success
-**        ERTS_IOLIST_TO_BUF_OVERFLOW on overflow
-**        ERTS_IOLIST_TO_BUF_TYPE_ERROR on type error (including that result would not be a whole number of bytes)
-**
-** Note! 
-** Do not detect indata errors in this fiunction that are not detected by erts_iolist_size!
-**
-** A caller should be able to rely on a successful return from erts_iolist_to_buf
-** if erts_iolist_size is previously successfully called and erts_iolist_to_buf 
-** is called with a buffer at least as large as the value given by erts_iolist_size.
-** 
-*/
-
-typedef enum {
-    ERTS_IL2B_BCOPY_OK,
-    ERTS_IL2B_BCOPY_YIELD,
-    ERTS_IL2B_BCOPY_OVERFLOW,
-    ERTS_IL2B_BCOPY_TYPE_ERROR
-} ErtsIL2BBCopyRes;
-
-static ErtsIL2BBCopyRes
-iolist_to_buf_bcopy(ErtsIOList2BufState *state, Eterm obj, int *yield_countp);
-
-static ERTS_INLINE ErlDrvSizeT
-iolist_to_buf(const int yield_support,
-	      ErtsIOList2BufState *state,
-	      Eterm obj,
-	      char* buf,
-	      ErlDrvSizeT alloced_len)
-{
-#undef IOLIST_TO_BUF_BCOPY
-#define IOLIST_TO_BUF_BCOPY(CONSP)					\
-do {									\
-    size_t size = binary_size(obj);					\
-    if (size > 0) {							\
-	Uint bitsize;							\
-	byte* bptr;							\
-	Uint bitoffs;							\
-	Uint num_bits;							\
-	if (yield_support) {						\
-	    size_t max_size = ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;	\
-	    if (yield_count > 0)					\
-		max_size *= yield_count+1;				\
-	    if (size > max_size) {					\
-		state->objp = CONSP;					\
-		goto L_bcopy_yield;					\
-	    }								\
-	    if (size >= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT) {	\
-		int cost = (int) size;					\
-		cost /= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;	\
-		yield_count -= cost;					\
-	    }								\
-	}								\
-	if (len < size)							\
-	    goto L_overflow;						\
-	ERTS_GET_BINARY_BYTES(obj, bptr, bitoffs, bitsize);		\
-	if (bitsize != 0)						\
-	    goto L_type_error;						\
-	num_bits = 8*size;						\
-	copy_binary_to_buffer(buf, 0, bptr, bitoffs, num_bits);		\
-	buf += size;							\
-	len -= size;							\
-    }									\
-} while (0)
-
-    ErlDrvSizeT res, len;
-    Eterm* objp = NULL;
-    int init_yield_count;
-    int yield_count;
-    DECLARE_ESTACK(s);
-
-    len = (ErlDrvSizeT) alloced_len;
-
-    if (!yield_support) {
-	yield_count = init_yield_count = 0; /* Shut up faulty warning... >:-( */
-	goto L_again;
-    }
-    else {
-
-	if (state->iolist.reds_left <= 0)
-	    return ERTS_IOLIST_TO_BUF_YIELD;
-
-	ESTACK_CHANGE_ALLOCATOR(s, ERTS_ALC_T_SAVED_ESTACK);
-	init_yield_count = (ERTS_IOLIST_TO_BUF_YIELD_COUNT_PER_RED
-			   * state->iolist.reds_left);
-	yield_count = init_yield_count;
-
-	if (!state->iolist.estack.start)
-	    goto L_again;
-	else {
-	    int chk_stack;
-	    /* Restart; restore state... */
-	    ESTACK_RESTORE(s, &state->iolist.estack);
-
-	    if (!state->bcopy.bptr)
-		chk_stack = 0;
-	    else {
-		chk_stack = 1;
-		switch (iolist_to_buf_bcopy(state, THE_NON_VALUE, &yield_count)) {
-		case ERTS_IL2B_BCOPY_OK:
-		    break;
-		case ERTS_IL2B_BCOPY_YIELD:
-		    BUMP_ALL_REDS(state->iolist.c_p);
-		    state->iolist.reds_left = 0;
-		    ESTACK_SAVE(s, &state->iolist.estack);
-		    return ERTS_IOLIST_TO_BUF_YIELD;
-		case ERTS_IL2B_BCOPY_OVERFLOW:
-		    goto L_overflow;
-		case ERTS_IL2B_BCOPY_TYPE_ERROR:
-		    goto L_type_error;
-		}
-	    }
-
-	    obj = state->iolist.obj;
-	    buf = state->buf;
-	    len = state->len;
-	    objp = state->objp;
-	    state->objp = NULL;
-	    if (objp)
-		goto L_tail;
-	    if (!chk_stack)
-		goto L_again;
-	    /* check stack */
-	}
-    }
-
-    while (!ESTACK_ISEMPTY(s)) {
-	obj = ESTACK_POP(s);
-    L_again:
-	if (is_list(obj)) {
-	    while (1) { /* Tail loop */
-		while (1) { /* Head loop */
-		    if (yield_support && --yield_count <= 0)
-			goto L_yield;
-		    objp = list_val(obj);
-		    obj = CAR(objp);
-		    if (is_byte(obj)) {
-			if (len == 0) {
-			    goto L_overflow;
-			}
-			*buf++ = unsigned_val(obj);
-			len--;
-		    } else if (is_binary(obj)) {
-			IOLIST_TO_BUF_BCOPY(objp);
-		    } else if (is_list(obj)) {
-			ESTACK_PUSH(s, CDR(objp));
-			continue; /* Head loop */
-		    } else if (is_not_nil(obj)) {
-			goto L_type_error;
-		    }
-		    break;
-		}
-
-	    L_tail:
-
-		obj = CDR(objp);
-
-		if (is_list(obj)) {
-		    continue; /* Tail loop */
-		} else if (is_binary(obj)) {
-		    IOLIST_TO_BUF_BCOPY(NULL);
-		} else if (is_not_nil(obj)) {
-		    goto L_type_error;
-		}
-		break;
-	    }
-	} else if (is_binary(obj)) {
-	    IOLIST_TO_BUF_BCOPY(NULL);
-	} else if (is_not_nil(obj)) {
-	    goto L_type_error;
-	} else if (yield_support && --yield_count <= 0)
-	    goto L_yield;
-    }
-
-    res = len;
-
- L_return:
-
-    DESTROY_ESTACK(s);
-
-    if (yield_support) {
-	int reds;
-	CLEAR_SAVED_ESTACK(&state->iolist.estack);
-	reds = ((init_yield_count - yield_count - 1)
-		/ ERTS_IOLIST_TO_BUF_YIELD_COUNT_PER_RED) + 1;
-	BUMP_REDS(state->iolist.c_p, reds);
-	state->iolist.reds_left -= reds;
-	if (state->iolist.reds_left < 0)
-	    state->iolist.reds_left = 0;
-    }
-
-
-    return res;
-
- L_type_error:
-    res = ERTS_IOLIST_TO_BUF_TYPE_ERROR;
-    goto L_return;
-
- L_overflow:
-    res = ERTS_IOLIST_TO_BUF_OVERFLOW;
-    goto L_return;
-
- L_bcopy_yield:
-
-    state->buf = buf;
-    state->len = len;
-
-    switch (iolist_to_buf_bcopy(state, obj, &yield_count)) {
-    case ERTS_IL2B_BCOPY_OK:
-	ERTS_INTERNAL_ERROR("Missing yield");
-    case ERTS_IL2B_BCOPY_YIELD:
-	BUMP_ALL_REDS(state->iolist.c_p);
-	state->iolist.reds_left = 0;
-	ESTACK_SAVE(s, &state->iolist.estack);
-	return ERTS_IOLIST_TO_BUF_YIELD;
-    case ERTS_IL2B_BCOPY_OVERFLOW:
-	goto L_overflow;
-    case ERTS_IL2B_BCOPY_TYPE_ERROR:
-	goto L_type_error;
-    }
-
- L_yield:
-
-    BUMP_ALL_REDS(state->iolist.c_p);
-    state->iolist.reds_left = 0;
-    state->iolist.obj = obj;
-    state->buf = buf;
-    state->len = len;
-    ESTACK_SAVE(s, &state->iolist.estack);
-    return ERTS_IOLIST_TO_BUF_YIELD;
-
-#undef IOLIST_TO_BUF_BCOPY
-}
-
-static ErtsIL2BBCopyRes
-iolist_to_buf_bcopy(ErtsIOList2BufState *state, Eterm obj, int *yield_countp)
-{
-    ErtsIL2BBCopyRes res;
-    char *buf = state->buf;
-    ErlDrvSizeT len = state->len;
-    byte* bptr;
-    size_t size;
-    size_t max_size;
-    Uint bitoffs;
-    Uint num_bits;
-    int yield_count = *yield_countp;
-
-    if (state->bcopy.bptr) {
-	bptr = state->bcopy.bptr;
-	size = state->bcopy.size;
-	bitoffs = state->bcopy.bitoffs;
-	state->bcopy.bptr = NULL;
-    }
-    else {
-	Uint bitsize;
-
-	ASSERT(is_binary(obj));
-
-	size = binary_size(obj);
-	if (size <= 0)
-	    return ERTS_IL2B_BCOPY_OK;
-
-	if (len < size)
-	    return ERTS_IL2B_BCOPY_OVERFLOW;
-
-	ERTS_GET_BINARY_BYTES(obj, bptr, bitoffs, bitsize);
-	if (bitsize != 0)
-	    return ERTS_IL2B_BCOPY_TYPE_ERROR;
-    }
-
-    ASSERT(size > 0);
-    max_size = (size_t) ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;
-    if (yield_count > 0)
-	max_size *= (size_t) (yield_count+1);
-
-    if (size <= max_size) {
-	if (size >= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT) {
-	    int cost = (int) size;
-	    cost /= ERTS_IOLIST_TO_BUF_BYTES_PER_YIELD_COUNT;
-	    yield_count -= cost;
-	}
-	res = ERTS_IL2B_BCOPY_OK;
-    }
-    else {
-	ASSERT(0 < max_size && max_size < size);
-	yield_count = 0;
-	state->bcopy.bptr = bptr + max_size;
-	state->bcopy.bitoffs = bitoffs;
-	state->bcopy.size = size - max_size;
-	size = max_size;
-	res = ERTS_IL2B_BCOPY_YIELD;
-    }
-
-    num_bits = 8*size;
-    copy_binary_to_buffer(buf, 0, bptr, bitoffs, num_bits);
-    state->buf += size;
-    state->len -= size;
-    *yield_countp = yield_count;
-
-    return res;
-}
-
-ErlDrvSizeT erts_iolist_to_buf_yielding(ErtsIOList2BufState *state)
-{
-    return iolist_to_buf(1, state, state->iolist.obj, state->buf, state->len);
-}
-
-ErlDrvSizeT erts_iolist_to_buf(Eterm obj, char* buf, ErlDrvSizeT alloced_len)
-{
-    return iolist_to_buf(0, NULL, obj, buf, alloced_len);
-}
-
-/*
- * Return 0 if successful, and non-zero if unsuccessful.
- *
- * It is vital that if erts_iolist_to_buf would return an error for
- * any type of term data, this function should do so as well.
- * Any input term error detected in erts_iolist_to_buf should also
- * be detected in this function!
- */
-
-static ERTS_INLINE int
-iolist_size(const int yield_support, ErtsIOListState *state, Eterm obj, ErlDrvSizeT* sizep)
-{
-    int res, init_yield_count, yield_count;
-    Eterm* objp;
-    Uint size = (Uint) *sizep;
-    DECLARE_ESTACK(s);
-
-    if (!yield_support)
-	yield_count = init_yield_count = 0; /* Shut up faulty warning... >:-( */
-    else {
-	if (state->reds_left <= 0)
-	    return ERTS_IOLIST_YIELD;
-	ESTACK_CHANGE_ALLOCATOR(s, ERTS_ALC_T_SAVED_ESTACK);
-	init_yield_count = ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED;
-	init_yield_count *= state->reds_left;
-	yield_count = init_yield_count;
-	if (state->estack.start) {
-	    /* Restart; restore state... */
-	    ESTACK_RESTORE(s, &state->estack);
-	    size = (Uint) state->size;
-	    obj = state->obj;
-	}
-    }
-
-    goto L_again;
-
-#define SAFE_ADD(Var, Val)			\
-    do {					\
-        Uint valvar = (Val);			\
-	Var += valvar;				\
-	if (Var < valvar) {			\
-	    goto L_overflow_error;		\
-	}					\
-    } while (0)
-
-    while (!ESTACK_ISEMPTY(s)) {
-	obj = ESTACK_POP(s);
-    L_again:
-	if (is_list(obj)) {
-	    while (1) { /* Tail loop */
-		while (1) { /* Head loop */
-		    if (yield_support && --yield_count <= 0)
-			goto L_yield;
-		    objp = list_val(obj);
-		    /* Head */
-		    obj = CAR(objp);
-		    if (is_byte(obj)) {
-			size++;
-			if (size == 0) {
-			    goto L_overflow_error;
-			}
-		    } else if (is_binary(obj) && binary_bitsize(obj) == 0) {
-			SAFE_ADD(size, binary_size(obj));
-		    } else if (is_list(obj)) {
-			ESTACK_PUSH(s, CDR(objp));
-			continue; /* Head loop */
-		    } else if (is_not_nil(obj)) {
-			goto L_type_error;
-		    }
-		    break;
-		}
-		/* Tail */
-		obj = CDR(objp);
-		if (is_list(obj))
-		    continue; /* Tail loop */
-		else if (is_binary(obj) && binary_bitsize(obj) == 0) {
-		    SAFE_ADD(size, binary_size(obj));
-		} else if (is_not_nil(obj)) {
-		    goto L_type_error;
-		}
-		break;
-	    }
-	} else {
-	    if (yield_support && --yield_count <= 0)
-		goto L_yield;
-	    if (is_binary(obj) && binary_bitsize(obj) == 0) { /* Tail was binary */
-		SAFE_ADD(size, binary_size(obj));
-	    } else if (is_not_nil(obj)) {
-		goto L_type_error;
-	    }
-	}
-    }
-#undef SAFE_ADD
-
-    *sizep = (ErlDrvSizeT) size;
-
-    res = ERTS_IOLIST_OK;
-
- L_return:
-
-    DESTROY_ESTACK(s);
-
-    if (yield_support) {
-	int yc, reds;
-	CLEAR_SAVED_ESTACK(&state->estack);
-	yc = init_yield_count - yield_count;
-	reds = ((yc - 1) / ERTS_IOLIST_SIZE_YIELDS_COUNT_PER_RED) + 1;
-	BUMP_REDS(state->c_p, reds);
-	state->reds_left -= reds;
-	state->size = (ErlDrvSizeT) size;
-	state->have_size = 1;
-    }
-
-    return res;
-
- L_overflow_error:
-    res = ERTS_IOLIST_OVERFLOW;
-    size = 0;
-    goto L_return;
-
- L_type_error:
-    res = ERTS_IOLIST_TYPE;
-    size = 0;
-    goto L_return;
-
- L_yield:
-    BUMP_ALL_REDS(state->c_p);
-    state->reds_left = 0;
-    state->size = size;
-    state->obj = obj;
-    ESTACK_SAVE(s, &state->estack);
-    return ERTS_IOLIST_YIELD;
-}
-
-int erts_iolist_size_yielding(ErtsIOListState *state)
-{
-    ErlDrvSizeT size = state->size;
-    return iolist_size(1, state, state->obj, &size);
-}
-
-int erts_iolist_size(Eterm obj, ErlDrvSizeT* sizep)
-{
-    *sizep = 0;
-    return iolist_size(0, NULL, obj, sizep);
 }
 
 /* return 0 if item is not a non-empty flat list of bytes

--- a/erts/emulator/test/bs_match_int_SUITE.erl
+++ b/erts/emulator/test/bs_match_int_SUITE.erl
@@ -110,7 +110,7 @@ get_int_roundtrip(_, _) -> ok.
 
 get_int(Bin0) ->
     %% Note that it has become impossible to create a byte-sized sub
-    %% binary (see erts_extract_sub_binary() in erl_bits.c) of size 64
+    %% binary (see erts_build_sub_bitstring() in erl_bits.c) of size 64
     %% or less. Therefore, to be able to create an unaligned binary,
     %% we'll need to base it on on a binary with more than 64 bytes.
     Size = bit_size(Bin0),

--- a/erts/emulator/test/decode_packet_SUITE.erl
+++ b/erts/emulator/test/decode_packet_SUITE.erl
@@ -66,7 +66,7 @@ basic(Config) when is_list(Config) ->
 
     %% Run tests for different header types and bit offsets.
 
-    lists:foreach(fun({Type,Bits})->basic_pack(Type,Packet,Rest,Bits), 
+    lists:foreach(fun({Type,Bits})->basic_pack(Type,Packet,Rest,Bits),
                                     more_length(Type,Packet,Bits) end,
                   [{T,B} || T<-Types, B<-lists:seq(0,32)]),
     ok.
@@ -77,7 +77,7 @@ basic_pack(Type,Body,Rest,BitOffs) ->
     case Rest of
         <<>> -> ok;
         _ -> 
-            <<_:1,NRest/bits>> = Rest,
+            <<_, NRest/binary>> = Rest,
             basic_pack(Type,Body,NRest,BitOffs)
     end.
 
@@ -113,14 +113,16 @@ pack(Type,Packet,Rest) ->
 %    Orig = <<0:BitOffs,Body/binary,Rest/bits>>,
 %    <<_:BitOffs,Bin/bits>> = Orig,
 %    {Bin,<<Bin/binary,Rest/bits>>,Orig};
-pack(Type,Body,Rest,BitOffs) ->
-    {Packet,Unpacked} = pack(Type,Body),
+pack(Type, Body, Rest, BitOffs) ->
+    {Packet, Unpacked} = pack(Type, Body),
 
-    %% Make Bin a sub-bin with an arbitrary bitoffset within Orig
+    %% Make Bin a sub-binary with an arbitrary bitoffset within Orig. Note that
+    %% we do not tolerate the Rest to be a bitstring.
     Prefix = rand:uniform(1 bsl BitOffs) - 1,
-    Orig = <<Prefix:BitOffs,Packet/binary,Rest/bits>>,
-    <<_:BitOffs,Bin/bits>> = Orig,
-    {Bin,Unpacked,Orig}.
+    Orig = <<Prefix:BitOffs, Packet/binary, Rest/binary>>,
+    <<_:BitOffs, Bin/binary>> = Orig,
+
+    {Bin, Unpacked, Orig}.
 
 pack(1,Bin) ->
     Psz = byte_size(Bin),

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -122,9 +122,9 @@ test_size(Config) when is_list(Config) ->
 	{32, 18} -> ok;
 	{64, 10} -> ok
     end,
-    6 = do_test_size(<<0:(8*65)>>),    % ProcBin
-    8 = do_test_size(<<5:7>>),         % ErlSubBin + ErlHeapBin
-    11 = do_test_size(<<0:(8*80+1)>>), % ErlSubBin + ProcBin
+    9 = do_test_size(<<0:(8*65)>>),    % ErlSubBits + BinRef
+    3 = do_test_size(<<5:7>>),         % ErlHeapBits
+    9 = do_test_size(<<0:(8*80+1)>>),  % ErlSubBits + BinRef
 
     %% Test shared data structures.
     do_test_size([ConsCell1|ConsCell1],
@@ -186,8 +186,8 @@ term_type(Config) when is_list(Config) ->
           {hfloat, -1.0e18},
 
           {heap_binary, <<1,2,3>>},
-          {refc_binary, <<0:(8*80)>>},
-          {sub_binary,  <<5:7>>},
+          {sub_binary, <<0:(8*80)>>},
+          {heap_binary, <<5:7>>},
 
           {flatmap, #{ a => 1}},
           {hashmap, maps:from_list([{I,I}||I <- lists:seq(1,76)])},

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -130,7 +130,7 @@ define etp-1
 #
 # Reentrant
 #
-  if (($arg0) & 0x3) == 1
+  if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_list
     # Cons pointer
     if $etp_flat
       printf "<etpf-cons %p>", (($arg0) & etp_ptr_mask)
@@ -138,17 +138,17 @@ define etp-1
       etp-list-1 ($arg0) ($arg1)
     end
   else
-    if (($arg0) & 0x3) == 2
+    if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_boxed
       if $etp_flat
         printf "<etpf-boxed %p>", (($arg0) & etp_ptr_mask)
       else
         etp-boxed-1 ($arg0) ($arg1)
       end
     else
-      if (($arg0) & 0x3) == 3
+      if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_immed1
         etp-immediate-1 ($arg0)
       else
-        # (($arg0) & 0x3) == 0
+        # (($arg0) & etp_tag_primary_mask) == 0
         if (($arg0) == etp_the_non_value)
           printf "<the-non-value>"
         else
@@ -220,11 +220,11 @@ define etp-list-printable-1
     while ($etp_list_p != $etp_nil) && \
           ($etp_list_i < $etp_max_string_length) && \
           $etp_list_printable
-      if ($etp_list_p & 0x3) == 0x1
+      if ($etp_list_p & etp_tag_primary_mask) == etp_tag_primary_list
         # Cons pointer
         set $etp_list_n = ((Eterm*)($etp_list_p & etp_ptr_mask))[0]
-        if ($etp_list_n & 0xF) == 0xF
-          etp-ct-printable-1 ($etp_list_n>>4)
+        if ($etp_list_n & etp_tag_immed1_mask) == etp_tag_immed1_small
+          etp-ct-printable-1 ($etp_list_n>>etp_tag_immed1_size)
           if $etp_ct_printable
             # Printable
             set $etp_list_p = ((Eterm*)($etp_list_p & etp_ptr_mask))[1]
@@ -339,7 +339,8 @@ define etp-boxed-1
   if (($arg0) & 0x3) != 0x2
     printf "#NotBoxed<%p>", ($arg0)
   else
-    if (((Eterm*)(($arg0) & etp_ptr_mask))[0] & 0x3) != 0x0
+    if ((((Eterm*)(($arg0) & etp_ptr_mask))[0] & etp_tag_primary_mask) \
+        != etp_tag_primary_header)
       if $etp_chart
         etp-chart-entry-1 (($arg0)&etp_ptr_mask) ($arg1) 1
       end
@@ -347,14 +348,16 @@ define etp-boxed-1
     else
       if $etp_chart
         etp-chart-entry-1 (($arg0)&etp_ptr_mask) ($arg1) \
-                          ((((Eterm*)(($arg0)&etp_ptr_mask))[0]>>6)+1)
+                          ((((Eterm*)(($arg0)&etp_ptr_mask))[0]>>etp_header_arity_offs)+1)
       end
-      if (((Eterm*)(($arg0) & etp_ptr_mask))[0] & 0x3f) == 0x0
+      if ((((Eterm*)(($arg0) & etp_ptr_mask))[0] & etp_tag_header_mask) \
+          == etp_tag_header_arityval)
         printf "{"
         etp-array-1 ((Eterm*)(($arg0)&etp_ptr_mask)) ($arg1) ($arg1) \
-                    1 ((((Eterm*)(($arg0)&etp_ptr_mask))[0]>>6)+1) '}'
+                    1 ((((Eterm*)(($arg0)&etp_ptr_mask))[0]>>etp_header_arity_offs)+1) '}'
       else
-        if (((Eterm*)(($arg0) & etp_ptr_mask))[0] & 0x3c) == 0x3c
+        if ((((Eterm*)(($arg0) & etp_ptr_mask))[0] & etp_header_subtag_mask) \
+            == etp_tag_header_map)
 	  # A map
 	  if (((Eterm*)(($arg0) & etp_ptr_mask))[0] & 0xc0) == 0x0
 	    # Flat map
@@ -393,56 +396,58 @@ define etp-boxed-immediate-1
   if (($arg0) & 0x3) != 0x2
     printf "#NotBoxed<%p>", ($arg0)
   else
-    if (((Eterm*)(($arg0) & etp_ptr_mask))[0] & 0x3) != 0x0
+    if ((((Eterm*)(($arg0) & etp_ptr_mask))[0] & etp_tag_primary_mask) \
+        != etp_tag_primary_header)
       printf "#BoxedError<%p>", ($arg0)
     else
       set $etp_boxed_immediate_p = (Eterm*)(($arg0) & etp_ptr_mask)
-      set $etp_boxed_immediate_h = ($etp_boxed_immediate_p[0] >> 2) & 0xF
-      if $etp_boxed_immediate_h == 0xC
+      set $etp_boxed_immediate_h = ($etp_boxed_immediate_p[0] & etp_header_subtag_mask)
+      if $etp_boxed_immediate_h == etp_tag_header_external_pid
         etp-extpid-1 ($arg0)
       else
-        if $etp_boxed_immediate_h == 0xD
+        if $etp_boxed_immediate_h == etp_tag_header_external_port
           etp-extport-1 ($arg0)
         else
-          if ($etp_boxed_immediate_h == 0x2) || \
-             ($etp_boxed_immediate_h == 0x3)
+          if ($etp_boxed_immediate_h == etp_pos_big_subtag) || \
+             ($etp_boxed_immediate_h == etp_neg_big_subtag)
             etp-bignum-1 ($arg0)
           else
-            if ($etp_boxed_immediate_h == 0x6)
+            if ($etp_boxed_immediate_h == etp_float_subtag)
               etp-float-1 ($arg0)
             else
-              if ($etp_boxed_immediate_h == 0x4)
+              if ($etp_boxed_immediate_h == etp_ref_subtag)
                 etp-ref-1 ($arg0)
               else
-                if ($etp_boxed_immediate_h == 0xE)
+                if ($etp_boxed_immediate_h == etp_tag_header_external_ref)
                   etp-extref-1 ($arg0)
                 else
                   # Hexdump the rest
-                  if ($etp_boxed_immediate_h == 0x5)
+                  if ($etp_boxed_immediate_h == etp_fun_subtag)
                     printf "#Fun<"
                   else
-                    if ($etp_boxed_immediate_h == 0x8)
-                      printf "#RefcBinary<"
+                    if ($etp_boxed_immediate_h == etp_bin_ref_subtag)
+                      printf "#BinRef<"
                     else
-                    if ($etp_boxed_immediate_h == 0x9)
-                      printf "#HeapBinary<"
+                    if ($etp_boxed_immediate_h == etp_heap_bits_subtag)
+                      printf "#HeapBits<"
                     else
-                    if ($etp_boxed_immediate_h == 0xA)
-                      printf "#SubBinary<"
+                    if ($etp_boxed_immediate_h == etp_sub_bits_subtag)
+                      printf "#SubBits<"
                     else
                       printf "#Header%X<", $etp_boxed_immediate_h
                     end
 		  end
 		  end
                   end
-                  set $etp_boxed_immediate_arity = $etp_boxed_immediate_p[0]>>6
+                  set $etp_boxed_immediate_arity = \
+                    ($etp_boxed_immediate_p[0] >> etp_header_arity_offs)
                   while $etp_boxed_immediate_arity > 0
                     set $etp_boxed_immediate_p++
                     if $etp_boxed_immediate_arity > 1
                       printf "%p,", *$etp_boxed_immediate_p
                     else
                       printf "%p", *$etp_boxed_immediate_p
-        	      if ($etp_boxed_immediate_h == 0xA)
+        	      if ($etp_boxed_immediate_h == etp_sub_bits_subtag)
                         set $etp_boxed_immediate_p++
 			printf ":%p", *$etp_boxed_immediate_p
 		      end
@@ -558,24 +563,24 @@ define etp-immediate-1
 #
 # Reentrant capable
 #
-  if (($arg0) & 0x3) != 0x3
+  if (($arg0) & etp_tag_primary_immed1) != etp_tag_primary_immed1
     printf "#NotImmediate<%p>", ($arg0)
   else
-    if (($arg0) & 0xF) == 0x3 
+    if (($arg0) & etp_tag_immed1_mask) == etp_tag_immed1_pid
       etp-pid-1 ($arg0)
     else
-      if (($arg0) & 0xF) == 0x7
+      if (($arg0) & etp_tag_immed1_mask) == etp_tag_immed1_port
         etp-port-1 ($arg0)
       else
-        if (($arg0) & 0xF) == 0xf
+        if (($arg0) & etp_tag_immed1_mask) == etp_tag_immed1_small
           # Fixnum
-          printf "%ld", (long)((Sint)($arg0)>>4)
+          printf "%ld", (long)((Sint)($arg0)>>etp_tag_immed1_size)
         else
-          # Immediate2  - 0xB
-          if (($arg0) & 0x3f) == 0x0b
+          # Immediate2
+          if (($arg0) & etp_tag_immed2_mask) == etp_tag_immed2_atom
             etp-atom-1 ($arg0)
           else
-            if (($arg0) & 0x3f) == 0x1b
+            if (($arg0) & etp_tag_immed2_mask) == etp_tag_immed2_catch
               printf "#Catch<%d>", ($arg0)>>6
             else
               if (($arg0) == $etp_nil)
@@ -598,7 +603,7 @@ define etp-atom-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3f) != 0xb
+  if ((Eterm)($arg0) & etp_tag_immed2_mask) != etp_tag_immed2_atom
     printf "#NotAtom<%p>", ($arg0)
   else
     set $etp_atom_1_ap = (Atom*)erts_atom_table.seg_table[(Eterm)($arg0)>>16][((Eterm)($arg0)>>6)&0x3FF]
@@ -836,7 +841,7 @@ define etp-pid-1
 # Non-reentrant
 #
   set $etp_pid_1 = (Eterm)($arg0)
-  if ($etp_pid_1 & 0xF) == 0x3
+  if ($etp_pid_1 & etp_tag_immed1_mask) == etp_tag_immed1_pid
     if (etp_arch_bits == 64)
       if (etp_endianness > 0)
       	set $etp_pid_data = (unsigned) ((((Uint64) $etp_pid_1) >> 35) & 0x0fffffff)
@@ -858,11 +863,12 @@ define etp-extpid-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3) != 0x2
+  if ((Eterm)($arg0) & etp_tag_primary_mask) != etp_tag_primary_boxed
     printf "#NotBoxed<%p>", (Eterm)($arg0)
   else
     set $etp_extpid_1_p = (ExternalThing*)((Eterm)($arg0) & etp_ptr_mask)
-    if ($etp_extpid_1_p->header & 0x3f) != 0x30
+    if (($etp_extpid_1_p->header &etp_header_subtag_mask) \
+        != etp_external_pid_subtag)
       printf "#NotExternalPid<%p>", $etp_extpid_1_p->header
     else
       ## External pid
@@ -872,7 +878,7 @@ define etp-extpid-1
       set $etp_extpid_1_creation = $etp_extpid_1_np->creation
       set $etp_extpid_1_dep = $etp_extpid_1_np->dist_entry
       set $etp_extpid_1_node = $etp_extpid_1_np->sysname
-      if ($etp_extpid_1_node & 0x3f) != 0xb
+      if ($etp_extpid_1_node & etp_tag_immed2_mask) != etp_tag_immed2_atom
         # Should be an atom
         printf "#ExternalPidError<%p>", ($arg0)
       else
@@ -896,7 +902,7 @@ define etp-port-1
 # Non-reentrant
 #
   set $etp_port_1 = (Eterm)($arg0)
-  if ($etp_port_1 & 0xF) == 0x7
+  if ($etp_port_1 & etp_tag_immed1_mask) == etp_tag_immed1_port
     if (etp_arch_bits == 64)
       if (etp_endianness > 0)
       	set $etp_port_data = (unsigned) ((((Uint64) $etp_port_1) >> 36) & 0x0fffffff)
@@ -918,24 +924,26 @@ define etp-extport-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3) != 0x2
+  if ((Eterm)($arg0) & etp_tag_primary_mask) != etp_tag_primary_boxed
     printf "#NotBoxed<%p>", (Eterm)($arg0)
   else
     set $etp_extport_1_p = (ExternalThing*)((Eterm)($arg0) & etp_ptr_mask)
-    if ($etp_extport_1_p->header & 0x3F) != 0x34
+    if (($etp_extport_1_p->header & etp_tag_header_mask) \
+        != etp_tag_header_external_port)
       printf "#NotExternalPort<%p>", $etp_extport_1->header
     else
       ## External port
       if $etp_arch64
-	set $etp_extport_1_number = $etp_extport_1_p->data.port.id
+        set $etp_extport_1_number = $etp_extport_1_p->data.port.id
       else
-	set $etp_extport_1_number = $etp_extport_1_p->data.port.low | (((Uint64)$etp_extport_1_p->data.port.high) << 32)
+        set $etp_extport_1_number = ($etp_extport_1_p->data.port.low |
+                            (((Uint64)$etp_extport_1_p->data.port.high) << 32))
       end
       set $etp_extport_1_np = $etp_extport_1_p->node
       set $etp_extport_1_creation = $etp_extport_1_np->creation
       set $etp_extport_1_dep = $etp_extport_1_np->dist_entry
       set $etp_extport_1_node = $etp_extport_1_np->sysname
-      if ($etp_extport_1_node & 0x3f) != 0xb
+      if ($etp_extport_1_node & etp_tag_immed2_mask) != etp_tag_immed2_atom
         # Should be an atom
         printf "#ExternalPortError<%p>", ($arg0)
       else
@@ -958,18 +966,18 @@ define etp-bignum-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3) != 0x2
+  if ((Eterm)($arg0) & etp_tag_primary_mask) != etp_tag_primary_boxed
     printf "#NotBoxed<%p>", (Eterm)($arg0)
   else
     set $etp_bignum_1_p = (Eterm*)((Eterm)($arg0) & etp_ptr_mask)
-    if ($etp_bignum_1_p[0] & 0x3b) != 0x08
+    if ($etp_bignum_1_p[0] & etp_big_tag_mask) != etp_pos_big_subtag
       printf "#NotBignum<%p>", $etp_bignum_1_p[0]
     else
-      set $etp_bignum_1_i = ($etp_bignum_1_p[0] >> 6)
+      set $etp_bignum_1_i = ($etp_bignum_1_p[0] >> etp_header_arity_offs)
       if $etp_bignum_1_i < 1
         printf "#BignumError<%p>", (Eterm)($arg0)
       else
-        if $etp_bignum_1_p[0] & 0x04
+        if $etp_bignum_1_p[0] & etp_big_sign_bit
           printf "-"
         end
         set $etp_bignum_1_p = (ErtsDigit *)($etp_bignum_1_p + 1)
@@ -997,11 +1005,11 @@ define etp-float-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3) != 0x2
+  if ((Eterm)($arg0) & etp_tag_primary_mask) != etp_tag_primary_boxed
     printf "#NotBoxed<%p>", (Eterm)($arg0)
   else
     set $etp_float_1_p = (Eterm*)((Eterm)($arg0) & etp_ptr_mask)
-    if ($etp_float_1_p[0] & 0x3f) != 0x18
+    if ($etp_float_1_p[0] & etp_tag_header_mask) != etp_tag_header_float
       printf "#NotFloat<%p>", $etp_float_1_p[0]
     else
       printf "%f", *(double*)($etp_float_1_p+1)
@@ -1016,11 +1024,12 @@ define etp-ref-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3) != 0x2
+  if ((Eterm)($arg0) & etp_tag_primary_mask) != etp_tag_primary_boxed
     printf "#NotBoxed<%p>", (Eterm)($arg0)
   else
     set $etp_ref_1_p = (ErtsORefThing *)((Eterm)($arg0) & etp_ptr_mask)
-    if ($etp_ref_1_p->header & 0x3b) != 0x10
+    if (($etp_ref_1_p->header & etp_external_tag_mask) \
+        != etp_external_pid_subtag)
       printf "#NotRef<%p>", $etp_ref_1_p->header
     else
       if $etp_ref_1_p->header != etp_ref_header && $etp_ref_1_p->header != etp_magic_ref_header
@@ -1063,11 +1072,12 @@ define etp-extref-1
 #
 # Non-reentrant
 #
-  if ((Eterm)($arg0) & 0x3) != 0x2
+  if ((Eterm)($arg0) & etp_tag_primary_mask) != etp_tag_primary_boxed
     printf "#NotBoxed<%p>", (Eterm)($arg0)
   else
     set $etp_extref_1_p = (ExternalThing*)((Eterm)($arg0) & etp_ptr_mask)
-    if ($etp_extref_1_p->header & 0x3F) != 0x38
+    if (($etp_extref_1_p->header & etp_header_subtag_mask) \
+        != etp_external_ref_subtag)
       printf "#NotExternalRef<%p>", $etp_extref_1->header
     else
       ## External ref
@@ -1078,7 +1088,8 @@ define etp-extref-1
       set $etp_extref_1_creation = $etp_extref_1_np->creation
       set $etp_extref_1_dep = $etp_extref_1_np->dist_entry
       set $etp_extref_1_node = $etp_extref_1_np->sysname
-      if ($etp_extref_1_node & 0x3f) != 0xb || $etp_extref_1_i < 3
+      if ((($etp_extref_1_node & etp_tag_immed2_mask) != etp_tag_immed2_atom)
+          || $etp_extref_1_i < 3)
         # Node should be an atom
 	set $etp_extref_1_error = 1
       else
@@ -2016,10 +2027,10 @@ end
 
 define etp-term-dump
 # Args: Eterm
-  if (($arg0) & 0x3) == 0
+  if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_header
     etp-term-dump-header ($arg0)
   else
-    if (($arg0) & 0x3) == 1
+    if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_list
       # Cons pointer
       set $etp_term_dump_cons_p = ((Eterm*)(($arg0) & etp_ptr_mask))
       if $etp_term_dump_cons_p > $etp_heapdump_heap &&  $etp_term_dump_cons_p < $etp_heapdump_end
@@ -2029,11 +2040,11 @@ define etp-term-dump
         printf "| C:0x%08x ", $etp_term_dump_cons_p
       end
     else
-      if (($arg0) & 0x3) == 2
+      if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_boxed
         # Box pointer
         printf "| B:0x%08x ", ($arg0)
       else
-        if (($arg0) & 0x3) == 3
+        if (($arg0) & etp_tag_primary_mask) == etp_tag_primary_immed1
           # immediate
           etp-term-dump-immediate ($arg0)
         else
@@ -2046,30 +2057,29 @@ end
 
 define etp-term-dump-immediate
 # Args: immediate term
-  if (($arg0) & 0xF) == 0xf
+  if (($arg0) & etp_tag_immed1_mask) == etp_tag_immed1_small
     # Fixnum
-    etp-ct-printable-1 ((long)((Sint)($arg0)>>4))
+    etp-ct-printable-1 ((long)((Sint)($arg0)>>etp_tag_immed1_size))
       if $etp_ct_printable
         if $etp_ct_printable < 0
-	  printf "| I:   %c (%3ld) ", (long)((Sint)($arg0)>>4), (long)((Sint)($arg0)>>4)
+          printf "| I:   %c (%3ld) ", (long)((Sint)($arg0)>>etp_tag_immed1_size), (long)((Sint)($arg0)>>etp_tag_immed1_size)
         else
-	  printf "| I:  \\%c (%3ld) ", (long)((Sint)($arg0)>>4), (long)((Sint)($arg0)>>4)
+          printf "| I:  \\%c (%3ld) ", (long)((Sint)($arg0)>>etp_tag_immed1_size), (long)((Sint)($arg0)>>etp_tag_immed1_size)
         end
       else
-      printf "| I:%10ld ", (long)((Sint)($arg0)>>4)
+      printf "| I:%10ld ", (long)((Sint)($arg0)>>etp_tag_immed1_size)
     end
   else
-    if (($arg0) & 0xF) == 0x3
+    if (($arg0) & etp_tag_immed1_mask) == etp_tag_immed1_pid
       etp-term-dump-pid ($arg0)
     else
-      if (($arg0) & 0xF) == 0x7
+      if (($arg0) & etp_tag_immed1_mask) == etp_tag_immed1_port
         printf "| port:0x%05x ", ($arg0)
        else
-         # Immediate2  - 0xB
-         if (($arg0) & 0x3f) == 0x0b
+         if (($arg0) & etp_tag_immed2_mask) == etp_tag_immed2_atom
 	   etp-term-dump-atom ($arg0)
          else
-           if (($arg0) & 0x3f) == 0x1b
+           if (($arg0) & etp_tag_immed2_mask) == etp_tag_immed2_catch
 	     printf "| #Catch<%06d> ", ($arg0)>>6
            else
              if (($arg0) == $etp_nil)
@@ -2157,7 +2167,7 @@ define etp-term-dump-pid
 # Non-reentrant
 #
   set $etp_pid_1 = (Eterm)($arg0)
-  if ($etp_pid_1 & 0xF) == 0x3
+  if ($etp_pid_1 & etp_tag_immed1_mask) == etp_tag_immed1_pid
     if (etp_arch_bits == 64)
       if (etp_endianness > 0)
         set $etp_pid_data = (unsigned) ((((Uint64) $etp_pid_1) >> 36) & 0x0fffffff)
@@ -2176,38 +2186,41 @@ end
 
 define etp-term-dump-header
   # Args: Header term
-  if (($arg0) & 0x3f) == 0
-    printf  "| H:%4u-tuple ", ($arg0) >> 6
+  if (($arg0) & etp_tag_header_mask) == etp_tag_header_arityval
+    printf  "| H:%4u-tuple ", ($arg0) >> etp_header_arity_offs
   else
-    set $etp_heapdump_skips = ($arg0) >> 6
-    if ((($arg0) & 0x3f) == 0x18)
-      printf  "| H: float %3u ", ($arg0) >> 6
+    set $etp_heapdump_skips = ($arg0) >> etp_header_arity_offs
+    if ((($arg0) & etp_tag_header_mask) == etp_tag_header_float)
+      printf  "| H: float %3u ", ($arg0) >> etp_header_arity_offs
     else
-      if ((($arg0) & 0x3f) == 0x28)
-        printf  "| H:   sub-bin "
+      if ((($arg0) & etp_tag_header_mask) == etp_tag_header_sub_bits)
+        printf  "| H:   sub-bits "
       else
-        if ((($arg0) & 0x3f) == 0x24)
-          printf  "| H:  heap-bin "
+        if ((($arg0) & etp_tag_header_mask) == etp_tag_header_heap_bits)
+          printf  "| H:  heap-bits "
         else
-          if ((($arg0) & 0x3f) == 0x20)
-            printf  "| H:  refc-bin "
+          if ((($arg0) & etp_tag_header_mask) == etp_tag_header_bin_ref)
+            printf  "| H:  bin-ref "
           else
-            if ((($arg0) & 0x3f) == 0x8)
+            if ((($arg0) & etp_tag_header_mask) == etp_tag_header_pos_big)
               # pos-bignum
-              printf  "| H:bignum %3u ", ($arg0) >> 6
+              printf  "| H:bignum %3u ", ($arg0) >> etp_header_arity_offs
             else
-              if ((($arg0) & 0x3f) == 0x14)
-                printf  "| H:fun %6u ", ($arg0) >> 6
+              if ((($arg0) & etp_tag_header_mask) == etp_tag_header_fun)
+                printf  "| H:fun %6u ", ($arg0) >> etp_header_arity_offs
               else
-                if ((($arg0) & 0xbc) == 0x3c)
-                  set $etp_heapdump_skips = (($arg0)>>(6+2)) & 0xff
+                if ((($arg0) & etp_header_map_subtag_mask) \
+                    == etp_map_subtag_head_flatmap)
+                  set $etp_heapdump_skips = (($arg0)>>(etp_header_arity_offs+2)) & 0xff
                   printf  "| flatmap %5u ", $etp_heapdump_skips
                 else
-                  if ((($arg0) & 0xbc) == 0xbc)
-                    set $etp_heapdump_skips = (($arg0)>>(6+2)) & 0xff
+                  if ((($arg0) & etp_header_map_hashmap_head_mask) \
+                      == etp_map_subtag_head_array)
+                    # Matches both bitmap and array.
+                    set $etp_heapdump_skips = (($arg0)>>(etp_header_arity_offs+2)) & 0xff
                     printf  "| hashmap %4u ", $etp_heapdump_skips
                   else
-                    printf  "| header %5u ", ($arg0) >> 6
+                    printf  "| header %5u ", ($arg0) >> etp_header_arity_offs
                   end
                 end
               end

--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -291,17 +291,15 @@ def eterm_summary(valobj, internal_dict):
 def eterm(valobj, depth = float('inf')):
     val = valobj.unsigned
     valobj = strip_literal_tag(valobj)
-    tag = val & 0x3
-    if tag == 0x1:
+    tag = val & c('TAG_PRIMARY_MASK')
+    if tag == c('TAG_PRIMARY_LIST'):
         return cons(valobj, depth)
-    elif tag == 0x2:
+    elif tag == c('TAG_PRIMARY_BOXED'):
         return boxed(valobj, depth)
-    elif tag == 0x3:
+    elif tag == c('TAG_PRIMARY_IMMED1'):
         return imm(valobj)
-    elif val == 0x0:
+    elif val == c('THE_NON_VALUE'):
         return '<the non-value>'
-    elif val == 0x4:
-        return '<the non-value debug>'
     else:
         return cp(valobj)
 
@@ -314,7 +312,7 @@ def cons(valobj, depth = float('inf')):
 
     ptr = cdr.CreateValueFromData(
         "unconsed",
-        lldb.SBData.CreateDataFromInt(cdr.unsigned - 1),
+        lldb.SBData.CreateDataFromInt(cdr.unsigned - c('TAG_PRIMARY_LIST')),
         EtermPtr(cdr.target))
     if ptr.deref.error.fail:
         return "#ConsError<%x>" % cdr.unsigned;
@@ -323,7 +321,7 @@ def cons(valobj, depth = float('inf')):
         cdr = strip_literal_tag(cdr)
         ptr = cdr.CreateValueFromData(
             "unconsed",
-            lldb.SBData.CreateDataFromInt(cdr.unsigned - 1),
+            lldb.SBData.CreateDataFromInt(cdr.unsigned - c('TAG_PRIMARY_LIST')),
             EtermPtr(cdr.target))
         items.append((ptr.deref, depth // 20)); # Append depth, car
         if ptr.deref.unsigned & 0xF == 0xF:
@@ -333,7 +331,7 @@ def cons(valobj, depth = float('inf')):
         cdr = offset(1,ptr).deref
         if is_nil(cdr):
             break
-        if cdr.unsigned & 0x1 == 0:
+        if cdr.unsigned & c('TAG_PRIMARY_LIST') == 0:
             improper = True
             break
         if depth <= 1:
@@ -347,13 +345,15 @@ def cons(valobj, depth = float('inf')):
     chars = ''
     isprintable = True
     for car, car_depth in items:
-        if car.unsigned & 0xF == 0xF:
-            if car.unsigned >> 4 == 10:
+        if ((car.unsigned & c('TAG_IMMED1_MASK'))
+             == c('TAG_IMMED1_SMALL')):
+            if car.unsigned >> c('TAG_IMMED1_SIZE') == 10:
                 chars += '\\n'
-            elif car.unsigned >> 4 == 9:
+            elif car.unsigned >> c('TAG_IMMED1_SIZE') == 9:
                 chars += '\\t'
             else:
-                chars += f'{car.unsigned >> 4:c}'
+                shift = c('TAG_IMMED1_SIZE')
+                chars += f'{car.unsigned >> shift:c}'
         else:
             isprintable = False
             break
@@ -377,14 +377,14 @@ def cons(valobj, depth = float('inf')):
 def boxed(valobj, depth = float('inf')):
     ptr = valobj.CreateValueFromData(
         "unboxed",
-        lldb.SBData.CreateDataFromInt(valobj.unsigned - 2),
+        lldb.SBData.CreateDataFromInt(valobj.unsigned - c('TAG_PRIMARY_BOXED')),
         EtermPtr(valobj.target))
     boxed_hdr = ptr.deref
     if boxed_hdr.error.fail:
-        return "#BoxedError<%x>" % valobj.unsigned;
+        return "#BoxedError<%x>" % valobj.unsigned
     boxed_hdr = boxed_hdr.unsigned
-    if boxed_hdr & 0x3f == 0x00:
-        arity = (boxed_hdr >> 6)
+    if boxed_hdr & c('TAG_HEADER_MASK') == c('TAG_HEADER_ARITYVAL'):
+        arity = (boxed_hdr >> c('HEADER_ARITY_OFFS'))
         terms = []
         for x in range(1, arity+1):
             if depth <= 1:
@@ -394,51 +394,50 @@ def boxed(valobj, depth = float('inf')):
             terms.append(eterm(offset(x, ptr).deref, depth))
         res = ','.join(terms)
         return F"{{{res}}}"
-    if boxed_hdr & 0x3c == 0x3c:
-        if boxed_hdr & 0xc0 == 0x0:
+    masked_hdr = boxed_hdr & c('HEADER_SUBTAG_MASK')
+    if masked_hdr == c('MAP_SUBTAG'):
+        if ((boxed_hdr & c('HEADER_MAP_SUBTAG_MASK'))
+             == c('MAP_SUBTAG_HEAD_FLATMAP')):
             return "#FlatMap"
         else:
             return "#HashMap"
-    boxed_type = (boxed_hdr >> 2) & 0xF
-    if boxed_type == 0xC:
+    if masked_hdr == c('EXTERNAL_PID_SUBTAG'):
         return '#ExternalPid'
-    if boxed_type == 0xD:
+    if masked_hdr == c('EXTERNAL_PORT_SUBTAG'):
         return '#ExternalPort'
-    if boxed_type == 0x2 or boxed_type == 0x3:
-        return '#Bignum'
-    if boxed_type == 0x6:
-        return '#Float'
-    if boxed_type == 0x4:
-        return '#Ref'
-    if boxed_type == 0xE:
+    if masked_hdr == c('EXTERNAL_REF_SUBTAG'):
         return '#ExternalRef'
-    if boxed_type == 0x5:
+    if (masked_hdr & BIG_TAG_MASK) == c('POS_BIG_SUBTAG'):
+        return '#Bignum'
+    if masked_hdr == c('FLOAT_SUBTAG'):
+        return '#Float'
+    if masked_hdr == c('REF_SUBTAG'):
+        return '#Ref'
+    if masked_hdr == c('FUN_SUBTAG'):
         return '#Fun'
-    if boxed_type == 0x8:
-        return '#RefcBin'
-    if boxed_type == 0x9:
-        return '#HeapBin'
-    if boxed_type == 0xA:
-        return '#SubBin'
+    if masked_hdr == c('HEAP_BITS_SUBTAG'):
+        return '#HeapBits'
+    if masked_hdr == c('SUB_BITS_SUBTAG'):
+        return '#SubBits'
     return F'#Boxed<{valobj.unsigned}>'
 
 def imm(valobj):
     val = valobj.unsigned
-    if (val & 0x3) != 3:
+    if (val & c('TAG_PRIMARY_MASK')) != c('TAG_PRIMARY_IMMED1'):
         return '#NotImmediate<%#x>' % val
-    tag = val & 0xF
-    if tag == 0x3:
+    tag = val & c('TAG_IMMED1_MASK')
+    if tag == c('TAG_IMMED1_PID'):
         return pid(valobj)
-    elif tag == 0x7:
+    elif tag == c('TAG_IMMED1_PORT'):
         return port(valobj)
-    elif tag == 0xF:
-        return str(val >> 4)
-    elif tag == 0xB:
+    elif tag == c('TAG_IMMED1_SMALL'):
+        return str(val >> c('TAG_IMMED1_SIZE'))
+    elif tag == c('TAG_IMMED1_IMMED2'):
         # Immediate2
-        tag2 = val & 0x3F
-        if tag2 == 0x0B:
+        tag2 = val & c('TAG_IMMED2_MASK')
+        if tag2 == c('TAG_IMMED2_ATOM'):
             return atom(valobj)
-        elif tag2 == 0x1B:
+        elif tag2 == c('TAG_IMMED2_CATCH'):
             return F'#Catch<{val>>6:#x}>'
         elif is_nil(valobj):
             return '[]'
@@ -461,13 +460,14 @@ def cp(valobj):
 
 def pid(valobj):
     val = valobj.unsigned
-    if (val & 0xF) == 0x3:
+    if (val & c('TAG_IMMED1_MASK')) == c('TAG_IMMED1_PID'):
         target = valobj.target
         if etp_arch_bits(target) == 64:
+            val = val >> c('TAG_IMMED1_SIZE')
             if etp_big_endian(target):
-                data = (val >> 35) & 0x0FFFFFFF
+                data = (val >> 31) & 0x0FFFFFFF
             else:
-                data = (val >> 4) & 0x0FFFFFFF
+                data = val & 0x0FFFFFFF
         else:
             data = pixdata2data(valobj)
         return '<0.%u.%u>' % (data & 0x7FFF, (data >> 15) & 0x1FFF)
@@ -476,13 +476,14 @@ def pid(valobj):
 
 def port(valobj):
     val = valobj.unsigned
-    if (val & 0xF) == 0x7:
+    if (val & c('TAG_IMMED1_MASK')) == c('TAG_IMMED1_PORT'):
         target = valobj.target
         if etp_arch_bits(target) == 64 and not etp_halfword(target):
+            val = val >> c('TAG_IMMED1_SIZE')
             if etp_big_endian(target):
-                data = (val >> 36) & 0x0FFFFFFF
+                data = (val >> 32) & 0x0FFFFFFF
             else:
-                data = (val >> 4) & 0x0FFFFFFF
+                data = val & 0x0FFFFFFF
         else:
             data = pixdata2data(valobj)
         return '#Port<0.%u>' % data
@@ -493,7 +494,7 @@ def port(valobj):
 
 def atom(valobj):
     val = valobj.unsigned
-    if (val & 0x3F) == 0x0B:
+    if (val & c('TAG_IMMED2_MASK')) == c('TAG_IMMED2_ATOM'):
         name = atom_name(atom_tab(valobj))
         if unquoted_atom_re.match(name):
             return str(name)
@@ -540,9 +541,7 @@ MI_FUNCTIONS = 13
 MI_NUM_FUNCTIONS = 0
 
 def is_nil(value):
-    ## We handle both -5 and 0x3b as NIL values so that this script
-    ## works with more versions
-    return value.signed == -5 or value.unsigned == 0x3b
+    return (value.unsigned & c('TAG_IMMED2_MASK')) == c('TAG_IMMED2_NIL')
 
 # Types
 
@@ -677,12 +676,15 @@ def strip_literal_tag(valobj):
         return valobj
 
     # Strip literal tags from list and boxed terms.
-    primary_tag = valobj.unsigned & 0x03
-    if (primary_tag == 1 or primary_tag == 2) and valobj.unsigned & 0x04:
+    primary_tag = valobj.unsigned & c('TAG_PRIMARY_MASK')
+    if ((primary_tag == c('TAG_PRIMARY_LIST') or
+         primary_tag == c('TAG_PRIMARY_BOXED')) and
+         (valobj.unsigned & c('TAG_LITERAL_PTR'))):
         valobj = valobj.CreateValueFromData(
             valobj.name,
-            lldb.SBData.CreateDataFromInt(valobj.unsigned - 0x04),
+            lldb.SBData.CreateDataFromInt(valobj.unsigned & c('PTR_MASK')),
             Eterm(valobj.target))
+
     return valobj
 
 def init(target):
@@ -692,6 +694,20 @@ def init(target):
              'beam_exception_trace', 'beam_call_trace_return']
     for name in names:
         code_pointers[global_var(name, target).unsigned] = name
+
+# Lookup function for constants reflected in erl_etp.c, saving us from the
+# massive headache of having to update this script every time the tag scheme
+# changes.
+constants = {}
+def c(name):
+    constant = constants.get(name)
+    if constant != None:
+        return constant
+    else:
+        target = lldb.debugger.GetSelectedTarget()
+        constant = global_var('etp_' + name.lower(), target).unsigned
+        constants[name] = constant
+        return constant
 
 # LLDB utils
 

--- a/lib/crypto/c_src/api_ng.c
+++ b/lib/crypto/c_src/api_ng.c
@@ -551,7 +551,6 @@ static int get_final_args(ErlNifEnv* env,
 
                     else if (ctx_res->padding == atom_none)
                         {
-                            ASSERT(pad_size == 0);
                             ctx_res->padded_size = pad_size;
                             pad_offset = 0;
                         }


### PR DESCRIPTION
By reducing the difference between match states and sub-binaries, this PR sets the stage for massive improvements in the bit syntax implementation, where we plan to allow returning matched tails from functions without any loss of performance relative to continuation-passing-style.

This PR also simplifies the handling of off-heap `Binary` objects. `ProcBin` (now called `BinRef`) is no longer exposed directly as a term, with off-heap bitstrings instead being represented by an `ErlSubBits` that references the `BinRef`. While this results in slightly more on-heap usage, it reduces complexity and makes it easy to determine which regions in a binary a process refers to during a GC, giving us the opportunity to shed references or shrink them to fit.

Needless to say this is a _massive_ diff, the bulk of it in a single commit that proved very difficult to break into small components that still made sense. External review would be much appreciated. :-)