### PR TITLE
beam/external: don't blow assert on encounter with a magic binary

### DIFF
--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -4015,8 +4015,12 @@ store_in_vec_aux(TTBEncodeContext *ctx,
     Uint iov_len;
     ErlIOVec *feiovp;
 
-    ASSERT(((byte *) &bin->orig_bytes[0]) <= ptr);
-    ASSERT(ptr + len <= ((byte *) &bin->orig_bytes[0]) + bin->orig_size);
+#ifdef DEBUG
+    if (!(bin->intern.flags & BIN_FLAG_MAGIC)) {
+        ASSERT(((byte *) &bin->orig_bytes[0]) <= ptr);
+        ASSERT(ptr + len <= ((byte *) &bin->orig_bytes[0]) + bin->orig_size);
+    }
+#endif
 
     if (ctx->frag_ix >= 0) {
         feiovp = &ctx->fragment_eiovs[ctx->frag_ix];


### PR DESCRIPTION
Magic binaries might have data outside their actual Binary struct so we shouldn't try to assert about where their data is here.

Encountered this while testing a NIF that generates magic binaries via `enif_make_resource_binary` with `-emu_type debug`.