### PR TITLE
stdlib: add auto formatting to the shell

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -527,9 +527,10 @@ get_chars_apply(Pbs, M, F, Xa, Drv, Shell, Buf, State0, LineCont, Encoding) ->
             %% Prompt was valid expression, clear the prompt in user_drv
             %% First redraw without the multi line prompt
             FormattedLine = format_expression(LineCont, Drv),
-            case lists:reverse(string:split(FormattedLine, "\n", all)) of
-                [CL|LB] when is_list(CL) ->
-                    LineCont1 = {LB,{lists:reverse(CL++"\n"), []},[]},
+            case LineCont of
+                {[_|_], _, _} ->
+                    [CL1|LB1] = lists:reverse(string:split(FormattedLine, "\n", all)),
+                    LineCont1 = {LB1,{lists:reverse(CL1++"\n"), []},[]},
                     MultiLinePrompt = lists:duplicate(shell:prompt_width(Pbs), $\s),
                     send_drv_reqs(Drv, [{redraw_prompt, Pbs, MultiLinePrompt, LineCont1},new_prompt]);
                 _ -> skip %% oldshell mode
@@ -944,7 +945,7 @@ format_expression(Cont, Drv) ->
         end
     catch _:_ ->
             send_drv_reqs(Drv, [{put_chars, unicode, io_lib:format("* Bad format function: ~tp~n", [FormatingCommand])}]),
-            shell:format_shell_func(default),
+            _ = shell:format_shell_func(default),
             Buffer
     end.
 format_expression1(Buffer, FormatingCommand) ->

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -502,6 +502,16 @@ shell_format(Config) ->
         timer:sleep(1000),
         send_tty(Term1, "Up"),
         check_content(Term1, "fun\\(X\\) ->\\s*..         X\\s*.. end."),
+        send_tty(Term1, "Down"),
+        send_stdin(Term1, "shell:format_shell_func({bad,format}).\n"),
+        send_tty(Term1, "Up"),
+        send_tty(Term1, "Up"),
+        send_tty(Term1, "\n"),
+        timer:sleep(1000),
+        check_content(Term1, "\\Q* Bad format function: {bad,format}\\E"),
+        send_tty(Term1, "Up"),
+        %% No modifications should be made, when default format function is used
+        check_content(Term1, "fun\\(X\\) ->\\s*..         X\\s*.. end."),
         ok
     after
         stop_tty(Term1)

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -59,6 +59,7 @@
          shell_update_window_unicode_wrap/1,
          shell_receive_standard_out/1,
          shell_standard_error_nlcr/1, shell_clear/1,
+         shell_format/1, format_func/1,
          remsh_basic/1, remsh_error/1, remsh_longnames/1, remsh_no_epmd/1,
          remsh_expand_compatibility_25/1, remsh_expand_compatibility_later_version/1,
          external_editor/1, external_editor_visual/1,
@@ -129,7 +130,7 @@ groups() ->
      {tty_latin1,[],[{group,tty_tests}]},
      {tty_tests, [parallel],
       [shell_navigation, shell_multiline_navigation, shell_multiline_prompt,
-       shell_xnfix, shell_delete,
+       shell_xnfix, shell_delete, shell_format,
        shell_transpose, shell_search, shell_insert,
        shell_update_window, shell_small_window_multiline_navigation, shell_huge_input,
        shell_support_ansi_input,
@@ -475,6 +476,35 @@ shell_multiline_navigation(Config) ->
         ok
     after
         stop_tty(Term)
+    end.
+
+format_func(String) ->
+    lists:flatten(string:replace(String, "  ", " ", all)).
+
+shell_format(Config) ->
+    Term1 = start_tty([{args,["-stdlib","format_shell_func","{interactive_shell_SUITE,format_func}"]}|Config]),
+    DataDir = proplists:get_value(data_dir, Config),
+    EmacsFormat = "\""++DataDir ++ "emacs-format-file\"\n",
+    try
+        send_tty(Term1,"fun(X) ->\n  X\nend.\n"),
+        send_tty(Term1,"Up"),
+        check_content(Term1, "fun\\(X\\) ->\\s*..  X\\s*.. end."),
+        send_tty(Term1, "Down"),
+        tmux(["resize-window -t ",tty_name(Term1)," -x ",200]),
+        timer:sleep(1000),
+        send_stdin(Term1, "shell:format_shell_func(\"emacs -batch \${file} -l \"\n"),
+        send_stdin(Term1, EmacsFormat),
+        send_stdin(Term1, "\" -f emacs-format-function\").\n"),
+        check_content(Term1, "{interactive_shell_SUITE,format_func}"),
+        send_tty(Term1, "Up"),
+        send_tty(Term1, "Up"),
+        send_tty(Term1, "\n"),
+        timer:sleep(1000),
+        send_tty(Term1, "Up"),
+        check_content(Term1, "fun\\(X\\) ->\\s*..         X\\s*.. end."),
+        ok
+    after
+        stop_tty(Term1)
     end.
 
 shell_multiline_prompt(Config) ->

--- a/lib/stdlib/doc/src/shell.xml
+++ b/lib/stdlib/doc/src/shell.xml
@@ -1043,6 +1043,24 @@ q                 - quit erlang
     </func>
 
     <func>
+      <name name="format_shell_func" arity="1" since="OTP @OTP-18848@"/>
+      <fsummary>Set the formatting function for submitted shell commands.</fsummary>
+      <desc>
+        <p>Can be used to set the formatting of the Erlang shell output. This have an effect
+        on commands that have been submitted, and how it is saved in history. Or if the
+        formatting hotkey is pressed while editing an expression (Alt-f by default). You can specify a Mod:Func/1 that
+        expects the whole expression as a string and returns a formatted expressions as a string.
+        See <seeapp marker="STDLIB_app#format_shell_func"><c>stdlib app config</c></seeapp>
+        for how to set it before shell started.</p>
+        <p>If instead a string is provided, it will be used as a shell command.
+        Your command must include <c>${file}</c>
+        somewhere in the string, for the shell to know where the file goes in the command.
+        </p>
+        <code>shell:format_shell_func("\"emacs -batch \${file} -l ~/erlang-format/emacs-format-file -f emacs-format-function\"").</code>
+      </desc>
+    </func>
+
+    <func>
       <name name="results" arity="1" since=""/>
       <fsummary>Set the number of previous results to keep.</fsummary>
       <desc>

--- a/lib/stdlib/doc/src/shell.xml
+++ b/lib/stdlib/doc/src/shell.xml
@@ -1057,6 +1057,18 @@ q                 - quit erlang
         somewhere in the string, for the shell to know where the file goes in the command.
         </p>
         <code>shell:format_shell_func("\"emacs -batch \${file} -l ~/erlang-format/emacs-format-file -f emacs-format-function\"").</code>
+        <code>shell:format_shell_func({shell, erl_pp_format_func}).</code>
+      </desc>
+    </func>
+
+    <func>
+      <name name="erl_pp_format_func" arity="1" since="OTP @OTP-18848@"/>
+      <fsummary>A formatting function that makes use of erl_pp.</fsummary>
+      <desc>
+        <p>A formatting function that can be set with <seemfa marker="#format_shell_func/1"><c>format_shell_func/1</c></seemfa>
+        that will make expressions submitted to the shell prettier.
+        </p>
+        <note><p>This formatting function filter comments away from the expressions.</p></note>
       </desc>
     </func>
 

--- a/lib/stdlib/doc/src/stdlib_app.xml
+++ b/lib/stdlib/doc/src/stdlib_app.xml
@@ -74,8 +74,8 @@
       </item>
       <tag><marker id="format_shell_func"/><c>format_shell_func = {Mod, Func} | string() | default</c></tag>
       <item>
-        <p>Can be used to set the formatting of the Erlang shell output. This have an effect
-        on commands that have been submitted, and how it is saved in history. Or if the
+        <p>Can be used to set the formatting of the Erlang shell output. This has an effect
+        on commands that have been submitted and how it is saved in history or if the
         formatting hotkey is pressed while editing an expression (Alt-f by default). You can specify a Mod:Func/1 that
         expects the whole expression as a string and returns a formatted expressions as a string.
         See <seemfa marker="shell#format_shell_func/1"><c>shell:format_shell_func/1</c></seemfa>

--- a/lib/stdlib/doc/src/stdlib_app.xml
+++ b/lib/stdlib/doc/src/stdlib_app.xml
@@ -85,6 +85,7 @@
         somewhere in the string, for the shell to know where the file goes in the command.
         </p>
         <code>-stdlib format_shell_func "\"emacs -batch \${file} -l ~/erlang-format/emacs-format-file -f emacs-format-function\""</code>
+        <code>-stdlib format_shell_func "{shell, erl_pp_format_func}"</code>
       </item>
       <tag><marker id="shell_prompt_func"/><c>shell_prompt_func = {Mod, Func} | default</c></tag>
       <item>

--- a/lib/stdlib/doc/src/stdlib_app.xml
+++ b/lib/stdlib/doc/src/stdlib_app.xml
@@ -72,6 +72,20 @@
       <item>
         <p>Can be used to override the default keymap configuration for the shell.</p>
       </item>
+      <tag><marker id="format_shell_func"/><c>format_shell_func = {Mod, Func} | string() | default</c></tag>
+      <item>
+        <p>Can be used to set the formatting of the Erlang shell output. This have an effect
+        on commands that have been submitted, and how it is saved in history. Or if the
+        formatting hotkey is pressed while editing an expression (Alt-f by default). You can specify a Mod:Func/1 that
+        expects the whole expression as a string and returns a formatted expressions as a string.
+        See <seemfa marker="shell#format_shell_func/1"><c>shell:format_shell_func/1</c></seemfa>
+        for how to set it from inside the shell.</p>
+        <p>If instead a string is provided, it will be used as a shell command.
+        Your command must include <c>${file}</c>
+        somewhere in the string, for the shell to know where the file goes in the command.
+        </p>
+        <code>-stdlib format_shell_func "\"emacs -batch \${file} -l ~/erlang-format/emacs-format-file -f emacs-format-function\""</code>
+      </item>
       <tag><marker id="shell_prompt_func"/><c>shell_prompt_func = {Mod, Func} | default</c></tag>
       <item>
         <p>where</p>

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -683,6 +683,8 @@ current_chars({line,_,MultiLine,_}) ->
 current_line({line,_,MultiLine,_}) ->
     current_line(MultiLine) ++ "\n";
 %% Convert a multiline tuple into a string with new lines
+current_line(SingleLine) when is_list(SingleLine) ->
+    SingleLine;
 current_line({LinesBefore, {Before, After}, LinesAfter}) ->
     CurrentLine = lists:reverse(Before, After),
     unicode:characters_to_list(lists:flatten(

--- a/lib/stdlib/src/edlin_key.erl
+++ b/lib/stdlib/src/edlin_key.erl
@@ -236,6 +236,7 @@ normal_map() ->
         "\^[d" => kill_word,
         "\^[F" => forward_word,
         "\^[f" => forward_word,
+        "\^[r" => format_expression,
         "\^[h" => help,
         "\^[L" => redraw_line,
         "\^[l" => redraw_line,
@@ -310,6 +311,7 @@ valid_functions() ->
      clear_line,           %% Clear the current expression
      end_of_expression,    %% Move to the end of the expression
      end_of_line,          %% Move to the end of the line
+     format_expression,    %% Format the current expression
      forward_char,         %% Move forward one character
      forward_delete_char,  %% Delete the character under the cursor
      forward_delete_word,  %% Delete the characters until the closest non-word character

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -23,7 +23,8 @@
 -export([get_state/0, get_function/2]).
 -export([start_restricted/1, stop_restricted/0]).
 -export([local_func/0, local_func/1, local_allowed/3, non_local_allowed/3]).
--export([catch_exception/1, prompt_func/1, multiline_prompt_func/1, format_shell_func/1, strings/1]).
+-export([catch_exception/1, prompt_func/1, multiline_prompt_func/1, strings/1]).
+-export([format_shell_func/1, erl_pp_format_func/1]).
 -export([start_interactive/0, start_interactive/1]).
 -export([read_and_add_records/5]).
 -export([default_multiline_prompt/1, inverted_space_prompt/1]).
@@ -1872,6 +1873,31 @@ multiline_prompt_func(PromptFunc) ->
       ShellFormatFunc2 :: 'default' | {module(),function()} | string().
 format_shell_func(ShellFormatFunc) ->
     set_env(stdlib, format_shell_func, ShellFormatFunc, default).
+
+-spec erl_pp_format_func(String) -> String2 when
+      String :: string(),
+      String2 :: string().
+erl_pp_format_func(String) ->
+    %% A simple pretty printer function of shell expressions.
+    %% 
+    %% Comments will be filtered.
+    %% If you add return_comments to the option list,
+    %% parsing will fail, and we will end up with the original string.
+    Options = [text,{reserved_word_fun,fun erl_scan:reserved_word/1}],
+    case erl_scan:tokens([], String, {1,1}, Options) of
+        {done, {ok, Toks, _}, _} ->
+            try
+                case erl_parse:parse_form(Toks) of
+                    {ok, Def} -> lists:flatten(erl_pp:form(Def))
+                end
+            catch
+                _:_ -> case erl_parse:parse_exprs(Toks) of
+                          {ok, Def1} -> lists:flatten(erl_pp:exprs(Def1))++".";
+                          _ -> String
+                      end
+            end;
+        _ -> String
+    end.
 
 -spec strings(Strings) -> Strings2 when
       Strings :: boolean(),

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -23,7 +23,7 @@
 -export([get_state/0, get_function/2]).
 -export([start_restricted/1, stop_restricted/0]).
 -export([local_func/0, local_func/1, local_allowed/3, non_local_allowed/3]).
--export([catch_exception/1, prompt_func/1, multiline_prompt_func/1, strings/1]).
+-export([catch_exception/1, prompt_func/1, multiline_prompt_func/1, format_shell_func/1, strings/1]).
 -export([start_interactive/0, start_interactive/1]).
 -export([read_and_add_records/5]).
 -export([default_multiline_prompt/1, inverted_space_prompt/1]).
@@ -1866,6 +1866,12 @@ prompt_func(PromptFunc) ->
 
 multiline_prompt_func(PromptFunc) ->
     set_env(stdlib, shell_multiline_prompt, PromptFunc, ?DEF_PROMPT_FUNC).
+
+-spec format_shell_func(ShellFormatFunc) -> ShellFormatFunc2 when
+      ShellFormatFunc :: 'default' | {module(),function()} | string(),
+      ShellFormatFunc2 :: 'default' | {module(),function()} | string().
+format_shell_func(ShellFormatFunc) ->
+    set_env(stdlib, format_shell_func, ShellFormatFunc, default).
 
 -spec strings(Strings) -> Strings2 when
       Strings :: boolean(),


### PR DESCRIPTION
Adds an option for users to provide a formatter for submitted shell statements.
