### PR TITLE
Fix #7811, SSL not working on FIPS enabled OTP 26.1 

### DIFF
--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -1842,7 +1842,7 @@ ec_curve_spec({namedCurve, ed25519 = Name}) ->
 ec_curve_spec({namedCurve, ed448 = Name}) ->
     Name;
 ec_curve_spec({namedCurve, Name}) when is_atom(Name) ->
-    crypto:ec_curve(Name).
+   (Name).
 
 ec_curve_type(ed25519) ->
     eddsa;


### PR DESCRIPTION
To reproduce see:
https://github.com/erlang/otp/issues/7811

In our case the error is when calling from elixir:
"TLS :client: In state :certify at tls_dtls_connection.erl:705 generated CLIENT ALERT: Fatal - Handshake Failure\n - :malformed_handshake_data".

Only when fips mode enabled.