### PR TITLE
Add `string:jaro_distance/2`

### DIFF
--- a/lib/stdlib/doc/src/string.xml
+++ b/lib/stdlib/doc/src/string.xml
@@ -245,6 +245,28 @@ true</pre>
     </func>
 
     <func>
+      <name name="jaro_distance" arity="2" since="OTP 27.0"/>
+      <fsummary>Find the Jaro similarity of two strings.</fsummary>
+      <desc>
+        <p>Returns a float between <c>+0.0</c> and <c>1.0</c> representing the
+        <url href="https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance">
+        Jaro similarity</url> of the given strings. Strings with many letters
+        in common relative to their lengths will score closer to <c>1.0</c>.
+        </p>
+        <p><em>Example:</em></p>
+        <pre>
+1> <input>string:jaro_distance("ditto", "ditto").</input>
+1.0
+2> <input>string:jaro_distance("foo", "bar").</input>
++0.0
+3> <input>string:jaro_distance("michelle", "michael").</input>
+0.8690476190476191
+4> <input>string:jaro_distance(&lt;&lt;"Édouard"/utf8>>, &lt;&lt;"Claude">>).</input>
+0.746031746031746</pre>
+      </desc>
+    </func>
+
+    <func>
       <name name="length" arity="1" since="OTP 20.0"/>
       <fsummary>Calculate length of the string.</fsummary>
       <desc>

--- a/lib/stdlib/test/string_SUITE.erl
+++ b/lib/stdlib/test/string_SUITE.erl
@@ -956,14 +956,14 @@ test_1(Line, Func, Str, Args, Exp) ->
         check_types(Line, Func, Args, Res),
         case res(Res, Exp) of
             true -> ok;
-            {Res1,Exp1} when is_tuple(Exp1) ->
+            {Res1,Exp1} when is_binary(Exp1) orelse is_list(Exp1) ->
+                io:format("~p:~p: ~ts~w =>~n  :~ts~w:~ts~w~n",
+                          [Func,Line, Str,Str, Res1,Res1, Exp1,Exp1]),
+                exit({error, Func});
+            {Res1,Exp1} ->
                 io:format("~p~n",[Args]),
                 io:format("~p:~p: ~ts~w =>~n  :~w:~w~n",
                           [Func,Line, Str,Str,Res1,Exp1]),
-                exit({error, Func});
-            {Res1,Exp1} ->
-                io:format("~p:~p: ~ts~w =>~n  :~ts~w:~ts~w~n",
-                          [Func,Line, Str,Str, Res1,Res1, Exp1,Exp1]),
                 exit({error, Func})
         end
     catch


### PR DESCRIPTION
@garazdawi mentioned this might be a nice addition to `string` (https://github.com/erlang/rebar3/issues/2844#issuecomment-1803478622). It's a translation from Elixir's `String.jaro_distance/2` adapted to allow `unicode:chardata()` rather than only binaries.

@garazdawi also mentioned someone from the Erlang/OTP team was interested in working on this so I am submitting what I have now - please feel free to take it over or supersede this PR if you'd like!