### PR TITLE
typo fixes in alt_dist.xml

### DIFF
--- a/erts/doc/src/alt_dist.xml
+++ b/erts/doc/src/alt_dist.xml
@@ -162,7 +162,7 @@
     <marker id="distribution_module"/>
     <title>Distribution Module</title>
     <p>
-      The distribution module expose an API that <c>net_kernel</c> call
+      The distribution module exposes an API that <c>net_kernel</c> calls
       in order to manage connections to other nodes. The module name
       should have the suffix <c>_dist</c>.
     </p>
@@ -1152,7 +1152,7 @@
         callbacks although it has marked itself as busy. This has always been a
         requirement on drivers used by the distribution, but no capability
         information has been available about this previously. For more
-        information. see <seecref marker="erl_driver#set_busy_port">
+        information, see <seecref marker="erl_driver#set_busy_port">
         <c>erl_driver:set_busy_port()</c></seecref>).</p>
 
       <p>This driver was written before the runtime system had SMP support.


### PR DESCRIPTION
Thank you for working on OTP, I've been thoroughly enjoying it for the past few months.

I have other more extensive typo fixes that I'm working through https://github.com/erlang/otp/compare/maint..ivanov:otp:pi/doc-fix-typos-and-repeated-words?diff=unified , but wanted to start off with this changeset that brought me here today to begin with. The other changeset is currently up to 50 files, and I'm only about a 10th of the way through.