### PR TITLE
Globally define the type mfargs

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -99,7 +99,7 @@
 -type maybe_improper_list() :: maybe_improper_list(any(), any()).
 -type maybe_improper_list(ContentType, TerminationType) :: maybe_improper_list(ContentType, TerminationType).
 -type mfa() :: {module(),atom(),arity()}.
--type mfargs() :: {M :: module(), F :: atom(), A :: [term()]}.
+-type mfargs() :: {Module :: module(), Function :: atom(), Args :: [term()]}.
 -type module() :: atom().
 -type neg_integer() :: neg_integer().
 -type nil() :: [].

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -99,6 +99,7 @@
 -type maybe_improper_list() :: maybe_improper_list(any(), any()).
 -type maybe_improper_list(ContentType, TerminationType) :: maybe_improper_list(ContentType, TerminationType).
 -type mfa() :: {module(),atom(),arity()}.
+-type mfargs() :: {M :: module(), F :: atom(), A :: [term()]}.
 -type module() :: atom().
 -type neg_integer() :: neg_integer().
 -type nil() :: [].


### PR DESCRIPTION
This is defined in lib/stdlib/src/supervisor.erl but would be a useful type to define more generally.

For example, [this function in the Elixir codebase accepts an mfargs](https://github.com/elixir-lang/elixir/blob/main/lib/elixir/lib/registry.ex#L544). I've personally defined `mfargs` as a custom type because it wasn't defined and `mfa` wasn't what I needed, despite the common nomenclature of "mfa tuple".