### PR TITLE
ChildSpecs

### DIFF
--- a/system/doc/design_principles/sup_princ.xml
+++ b/system/doc/design_principles/sup_princ.xml
@@ -433,7 +433,7 @@ child_spec() = #{id => child_id(),             % mandatory
            signal back. If no exit signal is received within
            the specified time, the child process is unconditionally
            terminated using <c>exit(Child, kill)</c>.</item>
-          <item>If the child process is another supervisor, it must be
+          <item>If the child process is another supervisor, it should be
            set to <c>infinity</c> to give the subtree enough time to
            shut down. It is also allowed to set it to <c>infinity</c>,
            if the child process is a worker. See the warning below:</item>


### PR DESCRIPTION
line 436:
It is better to use "should" instead of "must". 
Because, "For children that are supervisors themselves, ... it is common but not mandatory to select infinity, giving them the time they need to shut down their potentially large subtree." (Designing for Scalability with Erlang/OTP, Francesco Cesarini and Steve Vinoski)