### PR TITLE
add application:ensure_all_stopped/1,2 with concurrent and serial option

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -23,7 +23,7 @@
 -export([start/1, 
 	 load_application/1, unload_application/1, 
 	 start_application/2, start_application_request/2,
-	 start_boot_application/2, stop_application/1,
+	 start_boot_application/2, stop_application/1, stop_application_request/1,
 	 control_application/1, is_running/1,
 	 change_application_data/2, prep_config_change/0, config_change/1,
 	 which_applications/0, which_applications/1,
@@ -280,6 +280,9 @@ start_boot_application(Application, RestartType) ->
 
 stop_application(AppName) ->
     gen_server:call(?AC, {stop_application, AppName}, infinity).
+
+stop_application_request(AppName) ->
+	gen_server:send_request(?AC, {stop_application, AppName}).
 
 %%-----------------------------------------------------------------
 %% Returns: [{Name, Descr, Vsn}]


### PR DESCRIPTION
(edited)

This PR adds the following user-facing application API:
- `application:ensure_all_stopped/1`
- `application:ensure_all_stopped/2`

These are the inverse operations to `application:ensure_all_started/1,2,3` that take a set of applications, construct the dependency graph, and then stops them in the correct order. The API supports serial, as well as concurrent stop as the existing `application:ensure_all_started/3`.

There are a couple of changes in here to achieve this:
- The application_controller now supports async stop, meaning stop operations don't block the controller anymore. The flow is essentially identical to starts.
- I added `application_controller:application_stop_request/1` to make use of this capability. This also allows the application_controller to process multiple stop operations concurrently.
- I refactored how application:ensure_all_started works, and split the flow in (1) building the dependency graph, and (2) traversing the graph. The same graph is used by the stop operation. This is mainly used to avoid a bunch of code duplication when handling start and stop operations.
- added the API for ensure_all_stopped