### PR TITLE
erl: Set -noshell when -S is used

### DIFF
--- a/erts/doc/src/erl_cmd.xml
+++ b/erts/doc/src/erl_cmd.xml
@@ -636,6 +636,7 @@ $ <input>erl \
           <c><![CDATA[[Arg1,Arg2,...]]]></c> as argument, or an empty list
           if no arguments are passed. All further arguments occurring after
           this option are passed to the specified function as strings.
+          Implies <c><![CDATA[-noshell]]></c>.
           See <seeerl marker="init"> <c>init(3)</c></seeerl>.</p>
       </item>
       <tag><c><![CDATA[-run Mod [Func [Arg1, Arg2, ...]]]]></c> (init

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -1035,6 +1035,7 @@ int main(int argc, char **argv)
                         /* This is a -S passed on command line */
 			process_args = 0;
 			ADD_BOOT_CONFIG;
+			add_arg("-noshell");
 			add_arg("-S");
                     } else {
 			add_arg(argv[i]);

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -534,7 +534,7 @@ do_serve(#{address := Address, port := Port, directory := Path}) ->
     ),
     % This is needed to support random port assignment (--port 0)
     [{port, ActualPort}] = info(Pid, [port]),
-    io:fwrite("~nStarted HTTP server on http://~s:~w at ~s~n",
+    io:fwrite("Started HTTP server on http://~s:~w at ~s~n",
               [inet:ntoa(Address), ActualPort, AbsPath]),
     receive
         {From, shutdown} ->

--- a/lib/inets/test/httpd_serve_SUITE.erl
+++ b/lib/inets/test/httpd_serve_SUITE.erl
@@ -222,7 +222,7 @@ wait_for_startup_line([], Unexpected, Tries) when Tries > 0 ->
     end,
     timer:sleep(?STARTUP_WAIT_NAPTIME_MS),
     wait_for_startup_line(ct:capture_get(), Unexpected, Tries - 1);
-wait_for_startup_line(["\nStarted HTTP" ++ _Rest = Line | _Lines], _Unexpected, _Tries) ->
+wait_for_startup_line(["Started HTTP" ++ _Rest = Line | _Lines], _Unexpected, _Tries) ->
     {ok, Line};
 wait_for_startup_line([Line | Lines], Unexpected, Tries) ->
     wait_for_startup_line(Lines, [Line | Unexpected], Tries).
@@ -232,7 +232,7 @@ wait_for_startup_line([Line | Lines], Unexpected, Tries) ->
 %%   Started HTTP server on http://127.0.0.1:8000 at /path/to/lib/inets/make_test_dir/ct_logs/ct_run.test_server@zulu.2023-06-06_12.07.27\n"
 parse_startup_line(Line) ->
     {match, [_, RawIp, RawPort, Path]} = re:run(
-        Line, "^\nStarted HTTP server on http://(.+):(\\d+) at (.*)\\n$", [{capture, all, list}]
+        Line, "^Started HTTP server on http://(.+):(\\d+) at (.*)\\n$", [{capture, all, list}]
     ),
     {ok, Ip} = inet:parse_address(RawIp),
     Port = list_to_integer(RawPort),


### PR DESCRIPTION
Since the primary intended usecase for -S is command-line scripts such as the new "httpd serve", automatically add the "-noshell" flag to simplify noninteractive use.

Remove a leading newline from the httpd serve startup output that was used to separate it from the shell prompt.

As suggested in #7470.