### PR TITLE
Fix log format just trim leading and trailing whitespaces

### DIFF
--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -85,13 +85,12 @@ format(#{level:=Level,msg:=Msg0,meta:=Meta},Config0)
                 MsgStr0 = format_msg(Msg0,Meta1,Config1),
                 case maps:get(single_line,Config) of
                     true ->
-                        %% Trim leading and trailing whitespaces, and replace
-                        %% newlines with ", "
+                        %% Trim leading and trailing whitespaces
                         T = lists:reverse(
                               trim(
                                 lists:reverse(
                                   trim(MsgStr0,false)),true)),
-                        re:replace(T,",?\r?\n\s*",", ",
+                        re:replace(T,"\r?\n\s*"," ",
                                    [{return,list},global,unicode]);
                     _false ->
                         MsgStr0

--- a/lib/kernel/test/logger_formatter_SUITE.erl
+++ b/lib/kernel/test/logger_formatter_SUITE.erl
@@ -427,6 +427,12 @@ format_msg(_Config) ->
     ct:log(String12),
     "string" = String12,
 
+    Map = {#{292 => <<5,174,250,106>>,observe => 0,uri_path => [<<"ps">>,<<"coap">>,<<"test">>],uri_query => #{<<"clientid">> => <<"0622ff402c06010122ff">>,<<"token">> => <<"129493754">>}}},
+    MapStr = io_lib:format("~p", [Map]),
+    String13 = format(info,{string, MapStr},#{},#{template=>Template}),
+    ct:log(String13),
+    "{#{292 => <<5,174,250,106>>, observe => 0, uri_path => [<<\"ps\">>,<<\"coap\">>,<<\"test\">>], uri_query => #{<<\"clientid\">> => <<\"0622ff402c06010122ff\">>, <<\"token\">> => <<\"129493754\">>}}}" = String13,
+
     ok.
 
 report_cb(_Config) ->


### PR DESCRIPTION
Fix [https://github.com/erlang/otp/issues/7837](https://github.com/erlang/otp/issues/7837)

It seems that the original regular expression may match newlines, and then replace and add one `,`.