### PR TITLE
ct: Introduce replace mode to cth_log_redirect

### DIFF
--- a/lib/common_test/doc/src/ct_hooks_chapter.xml
+++ b/lib/common_test/doc/src/ct_hooks_chapter.xml
@@ -511,6 +511,25 @@ results(State) ->
         use another level either change the <c>default</c> handler level before
         starting common_test, or use the <seemfa marker="kernel:logger#set_handler_config/3">
         <c>logger:set_handler_config/3</c></seemfa> API.</p>
+        <p>This hook supports the following options:</p>
+        <taglist>
+          <tag><c>{mode, add}</c></tag>
+          <item>
+            <p>Add <c>cth_log_redirect</c> to the default logging handler:
+              Logs will be emitted to both standard output via the
+              default handler, and into the Common Test HTML logs.
+              This is the default behaviour.</p>
+          </item>
+          <tag><c>{mode, replace}</c></tag>
+          <item>
+            <p>Replace the <c>default</c> logging handler with <c>cth_log_redirect</c>
+              instead of logging to both the default handler and this handler.
+              This effectively silences any logger output which would normally be printed
+              to standard output during test runs. To enable this mode, you can pass
+              the following options to <c>ct_run</c>:</p>
+            <p><c>-enable_builtin_hooks false -ct_hooks cth_log_redirect [{mode,replace}]</c></p>
+          </item>
+        </taglist>
        </item>
        <tag><c>cth_surefire</c></tag>
        <item>


### PR DESCRIPTION
In addition to the existing way of logging to both the CT HTML logs and console, allow users to completely replace the standard logging handler with the log redirect hook, effectively silencing console logging output during Common Test runs.

Mostly taken from #7375, with the caveat that "add" mode continues being the default, and no changes outside of the hook take place.

Additionally, group cth_log_redirect test cases together to allow for easier module verification.

As suggested in https://github.com/erlang/otp/pull/7375#issuecomment-1818801029