### PR TITLE
erts: Share external funs globally

### DIFF
--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -4152,8 +4152,6 @@ BIF_RETTYPE ref_to_list_1(BIF_ALIST_1)
 
 BIF_RETTYPE make_fun_3(BIF_ALIST_3)
 {
-    ErlFunThing *funp;
-    Eterm *hp;
     Export *ep;
     Sint arity;
 
@@ -4168,12 +4166,8 @@ BIF_RETTYPE make_fun_3(BIF_ALIST_3)
         BIF_ERROR(BIF_P, BADARG);
     }
 
-    hp = HAlloc(BIF_P, ERL_FUN_SIZE);
-
     ep = erts_export_get_or_make_stub(BIF_ARG_1, BIF_ARG_2, (Uint) arity);
-    funp = erts_new_export_fun_thing(&hp, ep, arity);
-
-    BIF_RET(make_fun(funp));
+    BIF_RET(ep->lambda);
 }
 
 BIF_RETTYPE fun_to_list_1(BIF_ALIST_1)

--- a/erts/emulator/beam/erl_fun.c
+++ b/erts/emulator/beam/erl_fun.c
@@ -296,28 +296,6 @@ erts_fun_purge_complete(ErlFunEntry **funs, Uint no)
     ERTS_THR_WRITE_MEMORY_BARRIER;
 }
 
-
-ErlFunThing *erts_new_export_fun_thing(Eterm **hpp, Export *exp, int arity)
-{
-    ErlFunThing *funp;
-
-    funp = (ErlFunThing*)(*hpp);
-    *hpp += ERL_FUN_SIZE;
-
-    funp->thing_word = MAKE_FUN_HEADER(arity, 0, 1);
-    funp->entry.exp = exp;
-    funp->next = NULL;
-
-#ifdef DEBUG
-    {
-        const ErtsCodeMFA *mfa = &exp->info.mfa;
-        ASSERT(arity == mfa->arity);
-    }
-#endif
-
-    return funp;
-}
-
 ErlFunThing *erts_new_local_fun_thing(Process *p, ErlFunEntry *fe,
                                       int arity, int num_free)
 {

--- a/erts/emulator/beam/erl_fun.h
+++ b/erts/emulator/beam/erl_fun.h
@@ -89,7 +89,6 @@ typedef struct erl_fun_thing {
  * C99-style flexible array */
 #define ERL_FUN_SIZE ((sizeof(ErlFunThing)/sizeof(Eterm)))
 
-ErlFunThing *erts_new_export_fun_thing(Eterm **hpp, Export *exp, int arity);
 ErlFunThing *erts_new_local_fun_thing(Process *p,
                                       ErlFunEntry *fe,
                                       int arity,

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -900,6 +900,12 @@ dump_literals(fmtfn_t to, void *to_arg)
     for (idx = 0; idx < erts_num_persistent_areas; idx++) {
         dump_module_literals(to, to_arg, erts_persistent_areas[idx]);
     }
+
+    for (ErtsLiteralArea *lambda_area = erts_get_next_lambda_lit_area(NULL);
+         lambda_area != NULL;
+         lambda_area = erts_get_next_lambda_lit_area(lambda_area)) {
+        dump_module_literals(to, to_arg, lambda_area);
+    }
 }
 
 static void

--- a/erts/emulator/beam/export.c
+++ b/erts/emulator/beam/export.c
@@ -34,6 +34,14 @@
 
 #define EXPORT_HASH(m,f,a) ((atom_val(m) * atom_val(f)) ^ (a))
 
+#ifndef DEBUG
+#  define SHARED_LAMBDA_INITIAL_SIZE EXPORT_INITIAL_SIZE
+#  define SHARED_LAMBDA_EXPAND_SIZE 512
+#else
+#  define SHARED_LAMBDA_INITIAL_SIZE 256
+#  define SHARED_LAMBDA_EXPAND_SIZE 16
+#endif
+
 #ifdef DEBUG
 #  define IF_DEBUG(x) x
 #else
@@ -48,6 +56,18 @@ static erts_atomic_t total_entries_bytes;
  * AND it protects the staging table from becoming active.
  */
 erts_mtx_t export_staging_lock;
+
+/* Bump allocator for globally shared external funs, allocating them in
+ * reasonably large chunks to simplify crash dumping and avoid fragmenting the
+ * literal heap too much.
+ *
+ * This is protected by the export staging lock. */
+struct lambda_chunk {
+    struct lambda_chunk *next;
+    Eterm *hp;
+
+    ErtsLiteralArea area;
+} *lambda_chunk = NULL;
 
 struct export_entry
 {
@@ -109,6 +129,72 @@ export_cmp(struct export_entry* tmpl_e, struct export_entry* obj_e)
 	     tmpl->info.mfa.arity == obj->info.mfa.arity);
 }
 
+ErtsLiteralArea *erts_get_next_lambda_lit_area(ErtsLiteralArea *prev)
+{
+    struct lambda_chunk *next;
+
+    ASSERT(ERTS_IS_CRASH_DUMPING);
+
+    if (prev != NULL) {
+        struct lambda_chunk *chunk = ErtsContainerStruct(prev,
+                                                         struct lambda_chunk,
+                                                         area);
+        next = chunk->next;
+
+        if (next == NULL) {
+            return NULL;
+        }
+    } else {
+        next = lambda_chunk;
+    }
+
+    next->area.end = next->hp;
+    return &next->area;
+}
+
+static void expand_shared_lambda_area(Uint count)
+{
+    struct lambda_chunk *chunk;
+    Uint heap_size;
+
+    ERTS_LC_ASSERT(erts_lc_mtx_is_locked(&export_staging_lock));
+
+    heap_size = count * ERL_FUN_SIZE;
+    chunk = erts_alloc(ERTS_ALC_T_LITERAL,
+                       sizeof(struct lambda_chunk) +
+                        (heap_size - 1) * sizeof(Eterm));
+    chunk->hp = &chunk->area.start[0];
+    chunk->area.end = &chunk->hp[heap_size];
+    chunk->area.off_heap = NULL;
+    chunk->next = lambda_chunk;
+
+    lambda_chunk = chunk;
+}
+
+static void create_shared_lambda(Export *export)
+{
+    ErlFunThing *lambda;
+
+    ERTS_LC_ASSERT(erts_lc_mtx_is_locked(&export_staging_lock));
+
+    ASSERT((lambda_chunk->hp <= lambda_chunk->area.end &&
+            lambda_chunk->hp >= lambda_chunk->area.start) &&
+           ((lambda_chunk->area.end - lambda_chunk->hp) % ERL_FUN_SIZE) == 0);
+    if (lambda_chunk->hp == lambda_chunk->area.end) {
+        expand_shared_lambda_area(SHARED_LAMBDA_EXPAND_SIZE);
+    }
+
+    lambda = (ErlFunThing*)lambda_chunk->hp;
+    lambda_chunk->hp += ERL_FUN_SIZE;
+
+    lambda->thing_word = MAKE_FUN_HEADER(export->info.mfa.arity, 0, 1);
+    lambda->entry.exp = export;
+    lambda->next = NULL;
+
+    export->lambda = make_fun(lambda);
+
+    erts_set_literal_tag(&export->lambda, (Eterm*)lambda, ERL_FUN_SIZE);
+}
 
 static struct export_entry*
 export_alloc(struct export_entry* tmpl_e)
@@ -130,6 +216,8 @@ export_alloc(struct export_entry* tmpl_e)
 	obj->info.mfa.arity = tmpl->info.mfa.arity;
         obj->bif_number = -1;
         obj->is_bif_traced = 0;
+
+        create_shared_lambda(obj);
 
         sys_memset(&obj->trampoline, 0, sizeof(obj->trampoline));
 
@@ -197,6 +285,16 @@ init_export_table(void)
 	erts_index_init(ERTS_ALC_T_EXPORT_TABLE, &export_tables[i], "export_list",
 			EXPORT_INITIAL_SIZE, EXPORT_LIMIT, f);
     }
+
+#ifdef ERTS_ENABLE_LOCK_CHECK
+    export_staging_lock();
+#endif
+
+    expand_shared_lambda_area(SHARED_LAMBDA_INITIAL_SIZE);
+
+#ifdef ERTS_ENABLE_LOCK_CHECK
+    export_staging_unlock();
+#endif
 }
 
 static struct export_entry* init_template(struct export_templ* templ,

--- a/erts/emulator/beam/export.h
+++ b/erts/emulator/beam/export.h
@@ -57,6 +57,10 @@ typedef struct export_
     /* Non-zero if this is a BIF that's traced. */
     int is_bif_traced;
 
+    /* Globally shared external fun for this export entry. This is always a
+     * literal. */
+    Eterm lambda;
+
     /* This is a small trampoline function that can be used for lazy code
      * loading, global call tracing, and so on. It's only valid when
      * addresses points to it and should otherwise be left zeroed.

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1005,6 +1005,12 @@ void erts_lookup_function_info(FunctionInfo* fi,
 extern ErtsLiteralArea** erts_dump_lit_areas;
 extern Uint erts_dump_num_lit_areas;
 
+/* export.c */
+
+/** @brief Iterates through the literal areas for canonical lambdas. This is
+ * destructive and can only be used for crash dumping. */
+ErtsLiteralArea *erts_get_next_lambda_lit_area(ErtsLiteralArea *prev);
+
 /* break.c */
 void init_break_handler(void);
 void erts_set_ignore_break(void);


### PR DESCRIPTION
By storing external funs in a dedicated literal area shared by all modules and keeping a reference to them in the export entry they refer to, they will no longer be tied to the lifetime of the module that created them. `make_fun/3` will also use this reference so that dynamic creation of an external fun also results in a shared literal. This opens up for optimizations in, for example, `gen_statem` where there will no longer be any drawbacks to caching the event function when in `state_functions` mode.