### PR TITLE
Ingela/ssl/custom sign fun

### DIFF
--- a/lib/public_key/doc/src/public_key.xml
+++ b/lib/public_key/doc/src/public_key.xml
@@ -145,6 +145,14 @@
       </desc>
     </datatype>
 
+     <datatype>
+      <name name="custom_key_opts"/>
+      <desc>
+	<p>Can be provided together with a custom private key, that specifies a key fun,
+	to provide additional options understood by the fun.</p>
+      </desc>
+    </datatype>
+
     <datatype>
       <name name="ed_oid_name"/>
       <desc>
@@ -390,9 +398,14 @@
     <name name="encrypt_private" arity="3" since="OTP 21.1"/>
     <fsummary>Public-key encryption using the private key.</fsummary>
   <desc> 
-    <p>Public-key encryption using the private key.
-     See also <seemfa
-	marker="crypto:crypto#private_encrypt/4">crypto:private_encrypt/4</seemfa>.</p> 
+    <p>Public-key encryption using the private key.  See also <seemfa
+    marker="crypto:crypto#private_encrypt/4">crypto:private_encrypt/4</seemfa>.
+    The key, can besides a standard RSA key, be a map specifing the
+    key algorithm <c>rsa</c> and a fun to handle the encryption
+    operation. This may be used for customized the encryption
+    operation with for instance hardware security modules (HSM) or
+    trusted platform modules (TPM).
+    </p>
   </desc> 
   </func>   
 
@@ -1006,7 +1019,11 @@ end
     <p>Creates a digital signature.</p> 
     <p>The <c>Msg</c> is either the binary "plain text" data to be
     signed or it is the hashed value of "plain text", that is, the
-    digest.</p>
+    digest. The key, can besides a standard key, be a map specifing
+    a key algorithm and a fun that should handle the signing. This may
+    be used for customized signing with for instance hardware security
+    modules (HSM) or trusted platform modules (TPM).
+    </p>
   </desc> 
   </func>   
 

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -112,10 +112,21 @@
               test_root_cert/0
              ]).
 
--type public_key()           ::  rsa_public_key() | rsa_pss_public_key() | dsa_public_key() | ec_public_key() | ed_public_key() .
--type private_key()          ::  rsa_private_key() | rsa_pss_private_key() | dsa_private_key() | ec_private_key() | ed_private_key() .
+-type public_key()           ::  rsa_public_key() |
+                                 rsa_pss_public_key() |
+                                 dsa_public_key() |
+                                 ec_public_key() |
+                                 ed_public_key() .
+-type private_key()          ::  rsa_private_key() |
+                                 rsa_pss_private_key() |
+                                 dsa_private_key() |
+                                 ec_private_key() |
+                                 ed_private_key() |
+                                 #{algorithm := eddsa | rsa_pss_pss | ecdsa | rsa | dsa,
+                                   sign_fun => fun()} .
 -type rsa_public_key()       ::  #'RSAPublicKey'{}.
--type rsa_private_key()      ::  #'RSAPrivateKey'{}. 
+-type rsa_private_key()      ::  #'RSAPrivateKey'{} | #{algorithm := rsa,
+                                                        encrypt_fun => fun()}.
 -type dss_public_key()       :: integer().
 -type rsa_pss_public_key()   ::  {rsa_pss_public_key(), #'RSASSA-PSS-params'{}}.
 -type rsa_pss_private_key()  ::  { #'RSAPrivateKey'{}, #'RSASSA-PSS-params'{}}.
@@ -637,14 +648,14 @@ encrypt_private(PlainText, Key) ->
                                        Key :: rsa_private_key(),
                                        Options :: crypto:pk_encrypt_decrypt_opts(),
                                        CipherText :: binary() .
-encrypt_private(PlainText,
-		#'RSAPrivateKey'{modulus = N, publicExponent = E,
-				 privateExponent = D} = Key,
-		Options)
+encrypt_private(PlainText, Key, Options)
   when is_binary(PlainText),
-       is_integer(N), is_integer(E), is_integer(D),
        is_list(Options) ->
-    crypto:private_encrypt(rsa, PlainText, format_rsa_private_key(Key), default_options(Options)).
+    Opts = default_options(Options),
+    case format_sign_key(Key) of
+        {extern, Fun} -> Fun(PlainText, Opts);
+        {rsa, CryptoKey} -> crypto:private_encrypt(rsa, PlainText, CryptoKey, Opts)
+    end.
 
 %%--------------------------------------------------------------------
 %% Description: List available group sizes among the pre-computed dh groups
@@ -840,6 +851,8 @@ sign(DigestOrPlainText, DigestType, Key, Options) ->
     case format_sign_key(Key) of
 	badarg ->
 	    erlang:error(badarg, [DigestOrPlainText, DigestType, Key, Options]);
+        {extern, Fun} when is_function(Fun) ->
+            Fun(DigestOrPlainText, DigestType, Options);
 	{Algorithm, CryptoKey} ->
 	    try crypto:sign(Algorithm, DigestType, DigestOrPlainText, CryptoKey, Options)
             catch %% Compatible with old error schema
@@ -1505,7 +1518,16 @@ format_pkix_sign_key({#'RSAPrivateKey'{} = Key, _}) ->
     Key;
 format_pkix_sign_key(Key) ->
     Key.
+
+format_sign_key(#{encrypt_fun := KeyFun}) ->
+    {extern, KeyFun};
+format_sign_key(#{sign_fun := KeyFun}) ->
+    {extern, KeyFun};
 format_sign_key(Key = #'RSAPrivateKey'{}) ->
+    {rsa, format_rsa_private_key(Key)};
+format_sign_key({#'RSAPrivateKey'{} = Key, _}) ->
+    %% Params are handled in options arg
+    %% provided by caller.
     {rsa, format_rsa_private_key(Key)};
 format_sign_key(#'DSAPrivateKey'{p = P, q = Q, g = G, x = X}) ->
     {dss, [P, Q, G, X]};

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -124,6 +124,7 @@
                                  ed_private_key() |
                                  #{algorithm := eddsa | rsa_pss_pss | ecdsa | rsa | dsa,
                                    sign_fun => fun()} .
+-type custom_key_opts()      :: [term()].
 -type rsa_public_key()       ::  #'RSAPublicKey'{}.
 -type rsa_private_key()      ::  #'RSAPrivateKey'{} | #{algorithm := rsa,
                                                         encrypt_fun => fun()}.
@@ -646,7 +647,7 @@ encrypt_private(PlainText, Key) ->
 			     CipherText
                                  when  PlainText :: binary(),
                                        Key :: rsa_private_key(),
-                                       Options :: crypto:pk_encrypt_decrypt_opts(),
+                                       Options :: crypto:pk_encrypt_decrypt_opts() | custom_key_opts(),
                                        CipherText :: binary() .
 encrypt_private(PlainText, Key, Options)
   when is_binary(PlainText),
@@ -842,7 +843,7 @@ sign(DigestOrPlainText, DigestType, Key) ->
                   Signature when Msg ::  binary() | {digest,binary()},
                                  DigestType :: digest_type(),
                                  Key :: private_key(),
-                                 Options :: crypto:pk_sign_verify_opts(),
+                                 Options :: crypto:pk_sign_verify_opts() | custom_key_opts(),
                                  Signature :: binary() .
 sign(Digest, none, Key = #'DSAPrivateKey'{}, Options) when is_binary(Digest) ->
     %% Backwards compatible

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -344,11 +344,13 @@
       <name name="key"/>
       <desc>
 
-	<p>The user's private key. The map formats referring to a
-	crypto engine/provider (with key reference information) or Erlang fun,
-	can both be used for customized signing with
-	for instance hardware security modules (HSM) or trusted
-	platform modules (TPM). </p>
+	<p>The user's private key.  Either the key can be provided
+	directly as DER encoded entity, or indirectly using a crypto
+	engine/provider (with key reference information) or an Erlang
+	fun (with possible custom options).  The latter two options
+	can both be used for customized signing with for instance
+	hardware security modules (HSM) or trusted platform modules
+	(TPM). </p>
 
 	<list>
 	  <item><p>A DER encoded key will need to specify the ASN-1 type used to

--- a/lib/ssl/doc/src/ssl.xml
+++ b/lib/ssl/doc/src/ssl.xml
@@ -343,11 +343,33 @@
     <datatype>
       <name name="key"/>
       <desc>
-	<p>The DER-encoded user's private key or a map referring to a crypto
-	engine and its key reference that optionally can be password protected,
-	see also <seemfa marker="crypto:crypto#engine_load/3"> crypto:engine_load/3
-	</seemfa> and <seeguide marker="crypto:engine_load"> Crypto's Users Guide</seeguide>. If this option 
-	is supplied, it overrides option <c>keyfile</c>.</p>
+
+	<p>The user's private key. The map formats referring to a
+	crypto engine/provider (with key reference information) or Erlang fun,
+	can both be used for customized signing with
+	for instance hardware security modules (HSM) or trusted
+	platform modules (TPM). </p>
+
+	<list>
+	  <item><p>A DER encoded key will need to specify the ASN-1 type used to
+	  create the encoding.</p></item>
+
+	  <item><p>An engine/provider needs to specify specific
+	  information to support this concept and can optionally be
+	  password protected, see also <seemfa
+	  marker="crypto:crypto#engine_load/3"> crypto:engine_load/3
+	  </seemfa> and <seeguide marker="crypto:engine_load">
+	  Crypto's Users Guide</seeguide>. </p></item>
+
+	  <item><p>A fun option should include a fun that mimics <seemfa
+	  marker="public_key:public_key#sign/4">public_key:sign/4</seemfa>
+	  and possibly <seemfa
+	  marker="public_key:public_key#encrypt_private/3">public_key:private_encrypt/4</seemfa>
+	  if legacy versions TLS-1.0 and TLS-1.1 should be supported. </p></item>
+	</list>
+
+	<p>If this option is supplied, it overrides option <c>keyfile</c>.
+	</p>
       </desc>
     </datatype>
     
@@ -616,7 +638,7 @@ version.
       ROOT-CA, and so on. The default value is 10.</p>
       </desc>
     </datatype>
-    
+
     <datatype>
       <name name="custom_verify"/>
       <desc>

--- a/lib/ssl/src/ssl.app.src
+++ b/lib/ssl/src/ssl.app.src
@@ -88,6 +88,6 @@
     {applications, [crypto, public_key, kernel, stdlib]},
     {env, []},
     {mod, {ssl_app, []}},
-    {runtime_dependencies, ["stdlib-4.1","public_key-1.11.3","kernel-9.0",
+    {runtime_dependencies, ["stdlib-4.1","public_key-@OTP-18876@","kernel-9.0",
                             "erts-14.0","crypto-5.0", "inets-5.10.7",
                             "runtime_tools-1.15.1"]}]}.

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -357,7 +357,9 @@
                                        password => crypto:password()} |
                                      #{algorithm := sign_algo(),
                                        sign_fun := fun(),
-                                       encrypt_fun => fun() %% Only TLS-1.0, TLS-1.1 and rsa-key
+                                       sign_opts => list(),
+                                       encrypt_fun => fun(), %% Only TLS-1.0, TLS-1.1 and rsa-key
+                                       encrypt_opts => list()
                                       }. % exported
 -type key_pem()                   :: file:filename().
 -type key_pem_password()          :: iodata() | fun(() -> iodata()).

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -84,7 +84,7 @@
          signature_algs/2,
          eccs/0, 
          eccs/1, 
-         versions/0, 
+         versions/0,
          groups/0, 
          groups/1,
          format_error/1, 
@@ -111,9 +111,9 @@
 -removed({cipher_suites, 1, 
           "use cipher_suites/2,3 instead"}).
 -removed([{negotiated_next_protocol,1,
-          "use ssl:negotiated_protocol/1 instead"}]).
+           "use ssl:negotiated_protocol/1 instead"}]).
 -removed([{connection_info,1,
-          "use ssl:connection_information/[1,2] instead"}]).
+           "use ssl:connection_information/[1,2] instead"}]).
 
 -export_type([socket/0,
               sslsocket/0,
@@ -193,7 +193,7 @@
 
 -type legacy_hash()             :: sha224 | sha | md5.
 
--type sign_algo()               :: rsa | dsa | ecdsa | eddsa. % exported
+-type sign_algo()               :: rsa | rsa_pss_pss | dsa | ecdsa | eddsa. % exported
 
 -type sign_schemes()            :: [sign_scheme()].
 
@@ -233,8 +233,8 @@
                                    }.  
 
 -type old_cipher_suite() :: {kex_algo(), cipher(), hash()} % Pre TLS 1.2 
-                             %% TLS 1.2, internally PRE TLS 1.2 will use default_prf
-                           | {kex_algo(), cipher(), hash() | aead, hash()}. 
+                            %% TLS 1.2, internally PRE TLS 1.2 will use default_prf
+                          | {kex_algo(), cipher(), hash() | aead, hash()}.
 
 -type named_curve()           :: sect571r1 |
                                  sect571k1 |
@@ -350,11 +350,15 @@
 -type cert()                      :: public_key:der_encoded().
 -type cert_pem()                  :: file:filename().
 -type key()                       :: {'RSAPrivateKey'| 'DSAPrivateKey' | 'ECPrivateKey' |'PrivateKeyInfo', 
-                                           public_key:der_encoded()} | 
-                                     #{algorithm := rsa | dss | ecdsa, 
+                                      public_key:der_encoded()} |
+                                     #{algorithm := sign_algo(),
                                        engine := crypto:engine_ref(), 
                                        key_id := crypto:key_id(), 
-                                       password => crypto:password()}. % exported
+                                       password => crypto:password()} |
+                                     #{algorithm := sign_algo(),
+                                       sign_fun := fun(),
+                                       encrypt_fun => fun() %% Only TLS-1.0, TLS-1.1 and rsa-key
+                                      }. % exported
 -type key_pem()                   :: file:filename().
 -type key_pem_password()          :: iodata() | fun(() -> iodata()).
 -type certs_keys()                :: [cert_key_conf()].
@@ -367,12 +371,11 @@
 -type ciphers()                   :: [erl_cipher_suite()] |
                                      string(). % (according to old API) exported
 -type cipher_filters()            :: list({key_exchange | cipher | mac | prf,
-                                        algo_filter()}). % exported
+                                           algo_filter()}). % exported
 -type algo_filter()               :: fun((kex_algo()|cipher()|hash()|aead|default_prf) -> true | false).
 -type keep_secrets()              :: boolean().
 -type secure_renegotiation()      :: boolean(). 
 -type allowed_cert_chain_length() :: integer().
-
 -type custom_verify()               ::  {Verifyfun :: fun(), InitialUserState :: any()}.
 -type crl_check()                :: boolean() | peer | best_effort.
 -type crl_cache_opts()           :: {Module :: atom(),
@@ -430,9 +433,9 @@
                                 {use_ticket, use_ticket()} |
                                 {early_data, client_early_data()} |
                                 {use_srtp, use_srtp()}.
-                                %% {ocsp_stapling, ocsp_stapling()} |
-                                %% {ocsp_responder_certs, ocsp_responder_certs()} |
-                                %% {ocsp_nonce, ocsp_nonce()}.
+%% {ocsp_stapling, ocsp_stapling()} |
+%% {ocsp_responder_certs, ocsp_responder_certs()} |
+%% {ocsp_nonce, ocsp_nonce()}.
 
 -type client_verify_type()       :: verify_type().
 -type client_reuse_session()     :: session_id() | {session_id(), SessionData::binary()}.
@@ -578,9 +581,9 @@ stop() ->
 %%--------------------------------------------------------------------
 
 -spec connect(TCPSocket, TLSOptions) ->
-                     {ok, sslsocket()} |
-                     {error, reason()} |
-                     {option_not_a_key_value_tuple, any()} when
+          {ok, sslsocket()} |
+          {error, reason()} |
+          {option_not_a_key_value_tuple, any()} when
       TCPSocket :: socket(),
       TLSOptions :: [tls_client_option()].
 
@@ -588,22 +591,22 @@ connect(Socket, SslOptions) ->
     connect(Socket, SslOptions, infinity).
 
 -spec connect(TCPSocket, TLSOptions, Timeout) ->
-                     {ok, sslsocket()} | {error, reason()} when
+          {ok, sslsocket()} | {error, reason()} when
       TCPSocket :: socket(),
       TLSOptions :: [tls_client_option()],
       Timeout :: timeout();
              (Host, Port, TLSOptions) ->
-                     {ok, sslsocket()} |
-                     {ok, sslsocket(),Ext :: protocol_extensions()} |
-                     {error, reason()} |
-                     {option_not_a_key_value_tuple, any()} when
+          {ok, sslsocket()} |
+          {ok, sslsocket(),Ext :: protocol_extensions()} |
+          {error, reason()} |
+          {option_not_a_key_value_tuple, any()} when
       Host :: host(),
       Port :: inet:port_number(),
       TLSOptions :: [tls_client_option()].
 
 connect(Socket, SslOptions0, Timeout) when is_list(SslOptions0) andalso 
                                            (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
-    
+
     try
         CbInfo = handle_option_cb_info(SslOptions0, tls),
         Transport = element(1, CbInfo),
@@ -617,10 +620,10 @@ connect(Host, Port, Options) ->
     connect(Host, Port, Options, infinity).
 
 -spec connect(Host, Port, TLSOptions, Timeout) ->
-                     {ok, sslsocket()} |
-                     {ok, sslsocket(),Ext :: protocol_extensions()} |
-                     {error, reason()} |
-                     {option_not_a_key_value_tuple, any()} when
+          {ok, sslsocket()} |
+          {ok, sslsocket(),Ext :: protocol_extensions()} |
+          {error, reason()} |
+          {option_not_a_key_value_tuple, any()} when
       Host :: host(),
       Port :: inet:port_number(),
       TLSOptions :: [tls_client_option()],
@@ -664,7 +667,7 @@ listen(Port, Options0) ->
 %% Description: Performs transport accept on an ssl listen socket
 %%--------------------------------------------------------------------
 -spec transport_accept(ListenSocket) -> {ok, SslSocket} |
-					{error, reason()} when
+          {error, reason()} when
       ListenSocket :: sslsocket(),
       SslSocket :: sslsocket().
 
@@ -672,7 +675,7 @@ transport_accept(ListenSocket) ->
     transport_accept(ListenSocket, infinity).
 
 -spec transport_accept(ListenSocket, Timeout) -> {ok, SslSocket} |
-					{error, reason()} when
+          {error, reason()} when
       ListenSocket :: sslsocket(),
       Timeout :: timeout(),
       SslSocket :: sslsocket().
@@ -686,7 +689,7 @@ transport_accept(#sslsocket{pid = {ListenSocket,
 	dtls_gen_connection ->
 	    dtls_socket:accept(ListenSocket, Config, Timeout)
     end.
-  
+
 %%--------------------------------------------------------------------
 %%
 %% Description: Performs accept on an ssl listen socket. e.i. performs
@@ -729,9 +732,9 @@ handshake(#sslsocket{} = Socket, Timeout) when  (is_integer(Timeout) andalso Tim
 handshake(ListenSocket, SslOptions) ->
     handshake(ListenSocket, SslOptions, infinity).
 -spec handshake(Socket, Options, Timeout) ->
-                       {ok, SslSocket} |
-                       {ok, SslSocket, Ext} |
-                       {error, Reason} when
+          {ok, SslSocket} |
+          {ok, SslSocket, Ext} |
+          {error, Reason} when
       Socket :: socket() | sslsocket(),
       SslSocket :: sslsocket(),
       Options :: [server_option()],
@@ -782,7 +785,7 @@ handshake(Socket, SslOptions, Timeout) when (is_integer(Timeout) andalso Timeout
 
 %%--------------------------------------------------------------------
 -spec handshake_continue(HsSocket, Options) ->
-                                {ok, SslSocket} | {error, Reason} when
+          {ok, SslSocket} | {error, Reason} when
       HsSocket :: sslsocket(),
       Options :: [tls_client_option() | tls_server_option()],
       SslSocket :: sslsocket(),
@@ -795,7 +798,7 @@ handshake_continue(Socket, SSLOptions) ->
     handshake_continue(Socket, SSLOptions, infinity).
 %%--------------------------------------------------------------------
 -spec handshake_continue(HsSocket, Options, Timeout) ->
-                                {ok, SslSocket} | {error, Reason} when
+          {ok, SslSocket} | {error, Reason} when
       HsSocket :: sslsocket(),
       Options :: [tls_client_option() | tls_server_option()],
       Timeout :: timeout(),
@@ -850,7 +853,7 @@ close(#sslsocket{pid = [TLSPid|_]},
             Other
     end;
 close(#sslsocket{pid = [TLSPid|_]}, Timeout) when is_pid(TLSPid),
-					      (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
+                                                  (is_integer(Timeout) andalso Timeout >= 0) or (Timeout == infinity) ->
     ssl_gen_statem:close(TLSPid, {close, Timeout});
 close(#sslsocket{pid = {dtls = ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
     dtls_socket:close(Transport, ListenSocket);    
@@ -963,7 +966,7 @@ connection_information(#sslsocket{pid = [Pid|_]}, Items) when is_pid(Pid) ->
 
 %%--------------------------------------------------------------------
 -spec peername(SslSocket) -> {ok, {Address, Port}} |
-                             {error, reason()} when
+          {error, reason()} when
       SslSocket :: sslsocket(),
       Address :: inet:ip_address(),
       Port :: inet:port_number().
@@ -1021,12 +1024,12 @@ negotiated_protocol(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
 %% TLS/DTLS version
 %%--------------------------------------------------------------------
 cipher_suites(Description, Version) when Version == 'tlsv1.3';
-                                  Version == 'tlsv1.2';
-                                  Version == 'tlsv1.1';
-                                  Version == tlsv1 ->
+                                         Version == 'tlsv1.2';
+                                         Version == 'tlsv1.1';
+                                         Version == tlsv1 ->
     cipher_suites(Description, tls_record:protocol_version_name(Version));
 cipher_suites(Description, Version)  when Version == 'dtlsv1.2';
-                                   Version == 'dtlsv1'->
+                                          Version == 'dtlsv1'->
     cipher_suites(Description, dtls_record:protocol_version_name(Version));
 cipher_suites(Description, Version) ->
     [ssl_cipher_format:suite_bin_to_map(Suite) || Suite <- supported_suites(Description, Version)].
@@ -1040,12 +1043,12 @@ cipher_suites(Description, Version) ->
 %% TLS/DTLS version
 %%--------------------------------------------------------------------
 cipher_suites(Description, Version, StringType) when  Version == 'tlsv1.3';
-                                               Version == 'tlsv1.2';
-                                               Version == 'tlsv1.1';
-                                               Version == tlsv1 ->
+                                                      Version == 'tlsv1.2';
+                                                      Version == 'tlsv1.1';
+                                                      Version == tlsv1 ->
     cipher_suites(Description, tls_record:protocol_version_name(Version), StringType);
 cipher_suites(Description, Version, StringType)  when Version == 'dtlsv1.2';
-                                               Version == 'dtlsv1'->
+                                                      Version == 'dtlsv1'->
     cipher_suites(Description, dtls_record:protocol_version_name(Version), StringType);
 cipher_suites(Description, Version, rfc) ->
     [ssl_cipher_format:suite_map_to_str(ssl_cipher_format:suite_bin_to_map(Suite))
@@ -1125,8 +1128,8 @@ signature_algs(default, 'tlsv1.3') ->
 signature_algs(default, 'tlsv1.2') ->
     tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.2')]);
 signature_algs(all, 'tlsv1.3') ->
-   tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.3'), 
-                                  tls_record:protocol_version_name('tlsv1.2')]) ++ 
+    tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.3'),
+                                   tls_record:protocol_version_name('tlsv1.2')]) ++
         tls_v1:legacy_signature_algs_pre_13();
 signature_algs(all, 'tlsv1.2') ->
     tls_v1:default_signature_algs([tls_record:protocol_version_name('tlsv1.2')]) ++ 
@@ -1194,7 +1197,7 @@ groups(default) ->
 
 %%--------------------------------------------------------------------
 -spec getopts(SslSocket, OptionNames) ->
-		     {ok, [gen_tcp:option()]} | {error, reason()} when
+          {ok, [gen_tcp:option()]} | {error, reason()} when
       SslSocket :: sslsocket(),
       OptionNames :: [gen_tcp:option_name()].
 %%
@@ -1286,18 +1289,18 @@ setopts(#sslsocket{}, Options) ->
 
 %%---------------------------------------------------------------
 -spec getstat(SslSocket) ->
-                     {ok, OptionValues} | {error, inet:posix()} when
+          {ok, OptionValues} | {error, inet:posix()} when
       SslSocket :: sslsocket(),
       OptionValues :: [{inet:stat_option(), integer()}].
 %%
 %% Description: Get all statistic options for a socket.
 %%--------------------------------------------------------------------
 getstat(Socket) ->
-	getstat(Socket, inet:stats()).
+    getstat(Socket, inet:stats()).
 
 %%---------------------------------------------------------------
 -spec getstat(SslSocket, Options) ->
-                     {ok, OptionValues} | {error, inet:posix()} when
+          {ok, OptionValues} | {error, inet:posix()} when
       SslSocket :: sslsocket(),
       Options :: [inet:stat_option()],
       OptionValues :: [{inet:stat_option(), integer()}].
@@ -1350,7 +1353,7 @@ shutdown(#sslsocket{pid = [Pid|_]}, How) when is_pid(Pid) ->
 
 %%--------------------------------------------------------------------
 -spec sockname(SslSocket) ->
-                      {ok, {Address, Port}} | {error, reason()} when
+          {ok, {Address, Port}} | {error, reason()} when
       SslSocket :: sslsocket(),
       Address :: inet:ip_address(),
       Port :: inet:port_number().
@@ -1381,18 +1384,18 @@ versions() ->
     ImplementedTLSVsns =  ?ALL_AVAILABLE_VERSIONS,
     ImplementedDTLSVsns = ?ALL_AVAILABLE_DATAGRAM_VERSIONS,
 
-     TLSCryptoSupported = fun(Vsn) -> 
-                                  tls_record:sufficient_crypto_support(Vsn)
+    TLSCryptoSupported = fun(Vsn) ->
+                                 tls_record:sufficient_crypto_support(Vsn)
+                         end,
+    DTLSCryptoSupported = fun(Vsn) ->
+                                  tls_record:sufficient_crypto_support(dtls_v1:corresponding_tls_version(Vsn))
                           end,
-     DTLSCryptoSupported = fun(Vsn) -> 
-                                   tls_record:sufficient_crypto_support(dtls_v1:corresponding_tls_version(Vsn))  
-                           end,
     SupportedTLSVsns = [tls_record:protocol_version(Vsn) || Vsn <- ConfTLSVsns,  TLSCryptoSupported(Vsn)],
     SupportedDTLSVsns = [dtls_record:protocol_version(Vsn) || Vsn <- ConfDTLSVsns, DTLSCryptoSupported(Vsn)],
 
     AvailableTLSVsns = [Vsn || Vsn <- ImplementedTLSVsns, TLSCryptoSupported(tls_record:protocol_version_name(Vsn))],
     AvailableDTLSVsns = [Vsn || Vsn <- ImplementedDTLSVsns, DTLSCryptoSupported(dtls_record:protocol_version_name(Vsn))],
-                                    
+
     [{ssl_app, ?VSN}, 
      {supported, SupportedTLSVsns}, 
      {supported_dtls, SupportedDTLSVsns}, 
@@ -1409,7 +1412,7 @@ versions() ->
 %% Description: Initiates a renegotiation.
 %%--------------------------------------------------------------------
 renegotiate(#sslsocket{pid = [Pid, Sender |_]} = Socket) when is_pid(Pid),
-                                                     is_pid(Sender) ->
+                                                              is_pid(Sender) ->
     case ssl:connection_information(Socket, [protocol]) of
         {ok, [{protocol, 'tlsv1.3'}]} ->
             {error, notsup};
@@ -1451,7 +1454,7 @@ update_keys(_, Type) ->
 
 %%--------------------------------------------------------------------
 -spec prf(SslSocket, Secret, Label, Seed, WantedLength) ->
-                 {ok, binary()} | {error, reason()} when
+          {ok, binary()} | {error, reason()} when
       SslSocket :: sslsocket(),
       Secret :: binary() | 'master_secret',
       Label::binary(),
@@ -1533,7 +1536,7 @@ str_to_suite(CipherSuiteName) ->
         _:_ ->
             {error, {not_recognized, CipherSuiteName}}
     end.
-           
+
 %%%--------------------------------------------------------------
 %%% Internal functions
 %%%--------------------------------------------------------------------
@@ -1810,21 +1813,21 @@ opt_verify_fun(UserOpts, Opts, _Env) ->
     Opts#{verify_fun => VerifyFun}.
 
 none_verify_fun() ->
-     fun(_, {bad_cert, _}, UserState) ->
-             {valid, UserState};
-        (_, {extension, #'Extension'{critical = true}}, UserState) ->
-             %% This extension is marked as critical, so
-             %% certificate verification should fail if we don't
-             %% understand the extension.  However, this is
-             %% `verify_none', so let's accept it anyway.
-             {valid, UserState};
-        (_, {extension, _}, UserState) ->
-             {unknown, UserState};
-        (_, valid, UserState) ->
+    fun(_, {bad_cert, _}, UserState) ->
             {valid, UserState};
-        (_, valid_peer, UserState) ->
-             {valid, UserState}
-     end.
+       (_, {extension, #'Extension'{critical = true}}, UserState) ->
+            %% This extension is marked as critical, so
+            %% certificate verification should fail if we don't
+            %% understand the extension.  However, this is
+            %% `verify_none', so let's accept it anyway.
+            {valid, UserState};
+       (_, {extension, _}, UserState) ->
+            {unknown, UserState};
+       (_, valid, UserState) ->
+            {valid, UserState};
+       (_, valid_peer, UserState) ->
+            {valid, UserState}
+    end.
 
 convert_verify_fun() ->
     fun(_,{bad_cert, _} = Reason, OldFun) ->
@@ -1840,7 +1843,7 @@ convert_verify_fun() ->
             {valid, UserState}
     end.
 
-opt_certs(UserOpts, #{log_level := LogLevel} = Opts0, Env) ->
+opt_certs(UserOpts, #{log_level := LogLevel, versions := Versions} = Opts0, Env) ->
     case get_opt_list(certs_keys, [], UserOpts, Opts0) of
         {Where, []} when Where =/= new ->
             opt_old_certs(UserOpts, #{}, Opts0, Env);
@@ -1848,11 +1851,11 @@ opt_certs(UserOpts, #{log_level := LogLevel} = Opts0, Env) ->
             opt_old_certs(UserOpts, CertKey, Opts0, Env);
         {Where, CKs} when is_list(CKs) ->
             warn_override(Where, UserOpts, certs_keys, [cert,certfile,key,keyfile,password], LogLevel),
-            Opts0#{certs_keys => [check_cert_key(CK, #{}, LogLevel) || CK <- CKs]}
+            Opts0#{certs_keys => [check_cert_key(Versions, CK, #{}, LogLevel) || CK <- CKs]}
     end.
 
-opt_old_certs(UserOpts, CertKeys, #{log_level := LogLevel}=SSLOpts, _Env) ->
-    CK = check_cert_key(UserOpts, CertKeys, LogLevel),
+opt_old_certs(UserOpts, CertKeys, #{log_level := LogLevel, versions := Versions}=SSLOpts, _Env) ->
+    CK = check_cert_key(Versions, UserOpts, CertKeys, LogLevel),
     case maps:keys(CK) =:= [] of
         true ->
             SSLOpts#{certs_keys => []};
@@ -1860,7 +1863,7 @@ opt_old_certs(UserOpts, CertKeys, #{log_level := LogLevel}=SSLOpts, _Env) ->
             SSLOpts#{certs_keys => [CK]}
     end.
 
-check_cert_key(UserOpts, CertKeys, LogLevel) ->
+check_cert_key(Versions, UserOpts, CertKeys, LogLevel) ->
     CertKeys0 = case get_opt(cert, undefined, UserOpts, CertKeys) of
                     {Where, Cert} when is_binary(Cert) ->
                         warn_override(Where, UserOpts, cert, [certfile], LogLevel),
@@ -1895,7 +1898,15 @@ check_cert_key(UserOpts, CertKeys, LogLevel) ->
                            KF == 'RSAPrivateKey'; KF == 'DSAPrivateKey';
                            KF == 'ECPrivateKey'; KF == 'PrivateKeyInfo' ->
                         CertKeys0#{key => Key};
-                    {_, #{engine := _, key_id := _, algorithm := _} = Key} ->
+                    {_, #{engine := _, key_id := _, algorithm := Algo} = Key} ->
+                        check_key_algo_version_dep(Versions, Algo),
+                        CertKeys0#{key => Key};
+                    {_, #{sign_fun := _, algorithm := Algo} = Key} ->
+                        check_key_algo_version_dep(Versions, Algo),
+                        check_key_legacy_version_dep(Versions, Key, Algo),
+                        CertKeys0#{key => Key};
+                    {_, #{encrypt_fun := _, algorithm := rsa} = Key} ->
+                        check_key_legacy_version_dep(Versions, Key),
                         CertKeys0#{key => Key};
                     {new, Err1} ->
                         option_error(key, Err1)
@@ -1911,6 +1922,29 @@ check_cert_key(UserOpts, CertKeys, LogLevel) ->
                         option_error(password, Err2)
                 end,
     CertKeys2.
+
+check_key_algo_version_dep(Versions, eddsa) ->
+    assert_version_dep(key, Versions, ['tlsv1.3']);
+check_key_algo_version_dep(Versions, rsa_pss_pss) ->
+    assert_version_dep(key, Versions, ['tlsv1.3', 'tlsv1.2']);
+check_key_algo_version_dep(Versions, dsa) ->
+    assert_version_dep(key, Versions, ['tlsv1.2', 'tlsv1.1', 'tlsv1']);
+check_key_algo_version_dep(_,_) ->
+    true.
+
+check_key_legacy_version_dep(Versions, Key, rsa) ->
+    check_key_legacy_version_dep(Versions, Key);
+check_key_legacy_version_dep(_,_,_) ->
+    true.
+
+check_key_legacy_version_dep(Versions, Key) ->
+    EncryptFun = maps:get(encrypt_fun, Key, undefined),
+    case EncryptFun of
+        undefined ->
+            assert_version_dep(key, Versions, ['tlsv1.3', 'tlsv1.2']);
+        _  ->
+            assert_version_dep(key, Versions, ['tlsv1.1', 'tlsv1'])
+    end.
 
 opt_cacerts(UserOpts, #{verify := Verify, log_level := LogLevel, versions := Versions} = Opts,
             #{role := Role}) ->
@@ -2244,7 +2278,7 @@ opt_identity(UserOpts, #{versions := Versions} = Opts, _Env) ->
                   PSKSize = byte_size(PSK1),
                   assert_version_dep(psk_identity, Versions, ['tlsv1','tlsv1.1','tlsv1.2']),
                   option_error(not (0 < PSKSize andalso PSKSize < 65536),
-                                psk_identity, {psk_identity, PSK0}),
+                               psk_identity, {psk_identity, PSK0}),
                   PSK1;
               {_, PSK0} ->
                   PSK0
@@ -2256,7 +2290,7 @@ opt_identity(UserOpts, #{versions := Versions} = Opts, _Env) ->
                   UserSize = byte_size(User),
                   assert_version_dep(srp_identity, Versions, ['tlsv1','tlsv1.1','tlsv1.2']),
                   option_error(not (0 < UserSize andalso UserSize < 65536),
-                                srp_identity, {srp_identity, PSK0}),
+                               srp_identity, {srp_identity, PSK0}),
                   {User, unicode:characters_to_binary(S2)};
               {new, Err} ->
                   option_error(srp_identity, Err);
@@ -2702,7 +2736,7 @@ all_suites([?TLS_1_3, Version1 |_]) ->
         ssl_cipher:all_suites(Version1) ++
         ssl_cipher:anonymous_suites(Version1);
 all_suites([Version|_]) ->
-      ssl_cipher:all_suites(Version) ++
+    ssl_cipher:all_suites(Version) ++
         ssl_cipher:anonymous_suites(Version).
 
 tuple_to_map({Kex, Cipher, Mac}) ->
@@ -2868,7 +2902,7 @@ connection_cb(tls) ->
 connection_cb(dtls) ->
     dtls_gen_connection;
 connection_cb(Opts) ->
-   connection_cb(proplists:get_value(protocol, Opts, tls)).
+    connection_cb(proplists:get_value(protocol, Opts, tls)).
 
 
 %% Assert that basic options are on the format {Key, Value}
@@ -2952,4 +2986,4 @@ format_ocsp_params(Map) ->
     Nonce = maps:get(ocsp_nonce, Map, '?'),
     Certs = maps:get(ocsp_responder_certs, Map, '?'),
     io_lib:format("Stapling = ~W Nonce = ~W Certs = ~W",
-                   [Stapling, 5, Nonce, 5, Certs, 5]).
+                  [Stapling, 5, Nonce, 5, Certs, 5]).

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -2503,7 +2503,17 @@ options_cert(Config) -> %% cert[file] cert_keys keys password
         [{key, {rsa, <<>>}}], client, Old),
     ?OK(#{certs_keys := [#{key := #{}}]},
         [{key, #{engine => foo, algorithm => foo, key_id => foo}}], client, Old),
-
+    ?OK(#{certs_keys := [#{key := #{}}]},
+        [{key, #{algorithm => eddsa, sign_fun => fun(_,_,_,_) -> << "dummy signature">> end}},
+         {versions, ['tlsv1.3']}], client, Old),
+    ?OK(#{certs_keys := [#{key := #{}}]},
+        [{key, #{algorithm => ecdsa, sign_fun => fun(_,_,_,_) -> << "dummy signature">> end}}],
+        client, Old),
+    ?OK(#{certs_keys := [#{key := #{}}]},
+        [{key, #{algorithm => rsa,
+                  sign_fun => fun(_,_,_,_) -> << "dummy signature">> end,
+                 encrypt_fun => fun(_,_,_) -> << "dummy encrypt">> end}},
+         {versions, ['tlsv1.3', 'tlsv1.2', 'tlsv1.1']}], client, Old),
     ?OK(#{certs_keys := [#{password := _}]}, [{password, "foobar"}], client, Old),
     ?OK(#{certs_keys := [#{password := _}]}, [{password, <<"foobar">>}], client, Old),
     Pwd = fun() -> "foobar" end,
@@ -2517,6 +2527,14 @@ options_cert(Config) -> %% cert[file] cert_keys keys password
         client, Old),
 
     %% Errors
+    ?ERR({options,incompatible,[key,{versions,['tlsv1.2']}]},
+         [{key, #{algorithm => eddsa, sign_fun => fun(_,_,_,_) -> << "dummy signature">> end}},
+          {versions, ['tlsv1.2']}], client),
+    ?ERR({options,incompatible,[key,{versions,['tlsv1.3','tlsv1.2']}]},
+         [{key, #{algorithm => rsa,
+                  sign_fun => fun(_,_,_,_) -> << "dummy signature">> end,
+                  encrypt_fun => fun(_,_,_) -> << "dummy encrypt">> end
+                 }}], client),
     ?ERR({cert, #{}}, [{cert, #{}}], client),
     ?ERR({certfile, cert}, [{certfile, cert}], client),
     ?ERR({certs_keys, #{}}, [{certs_keys, #{}}], client),

--- a/lib/ssl/test/ssl_cert_SUITE.erl
+++ b/lib/ssl/test/ssl_cert_SUITE.erl
@@ -43,6 +43,8 @@
          no_auth/1,
          auth/0,
          auth/1,
+         client_auth_custom_key/0,
+         client_auth_custom_key/1,
          client_auth_empty_cert_accepted/0,
          client_auth_empty_cert_accepted/1,
          client_auth_empty_cert_rejected/0,
@@ -228,6 +230,7 @@ all_version_tests() ->
     [
      no_auth,
      auth,
+     client_auth_custom_key,
      client_auth_empty_cert_accepted,
      client_auth_empty_cert_rejected,
      client_auth_use_partial_chain,
@@ -458,6 +461,11 @@ auth() ->
     ssl_cert_tests:auth().
 auth(Config) ->
     ssl_cert_tests:auth(Config).
+%%--------------------------------------------------------------------
+client_auth_custom_key() ->
+    ssl_cert_tests:client_auth_custom_key().
+client_auth_custom_key(Config) ->
+    ssl_cert_tests:client_auth_custom_key(Config).
 %%--------------------------------------------------------------------
 client_auth_empty_cert_accepted() ->
     ssl_cert_tests:client_auth_empty_cert_accepted().

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -29,6 +29,8 @@
          no_auth/1,
          auth/0,
          auth/1,
+         client_auth_custom_key/0,
+         client_auth_custom_key/1,
          client_auth_empty_cert_accepted/0,
          client_auth_empty_cert_accepted/1,
          client_auth_empty_cert_rejected/0,
@@ -97,7 +99,35 @@ auth(Config) ->
                   end,
     ServerOpts =  [{verify, verify_peer} | ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config)],
     ssl_test_lib:basic_test(ClientOpts, ServerOpts, Config).
+%%--------------------------------------------------------------------
+client_auth_custom_key() ->
+    [{doc,"Test that client and server can connect using their own signature function"}].
 
+client_auth_custom_key(Config) when is_list(Config) ->
+    Version = proplists:get_value(version,Config),
+    ClientOpts0 =  case Version of
+                      'tlsv1.3' ->
+                          [{verify, verify_peer},
+                           {certificate_authorities, true} |
+                           ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)];
+                      _ ->[{verify, verify_peer} | ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)]
+                  end,
+    ClientKeyFilePath =  proplists:get_value(keyfile, ClientOpts0),
+    [ClientKeyEntry] = ssl_test_lib:pem_to_der(ClientKeyFilePath),
+    ClientKey = ssl_test_lib:public_key(public_key:pem_entry_decode(ClientKeyEntry)),
+    ClientCustomKey = choose_custom_key(ClientKey, Version),
+
+    ClientOpts = [ ClientCustomKey | proplists:delete(key, proplists:delete(keyfile, ClientOpts0))],
+
+    ServerOpts0 = ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config),
+    ServerKeyFilePath =  proplists:get_value(keyfile, ServerOpts0),
+    [ServerKeyEntry] = ssl_test_lib:pem_to_der(ServerKeyFilePath),
+    ServerKey = ssl_test_lib:public_key(public_key:pem_entry_decode(ServerKeyEntry)),
+    ServerCustomKey = choose_custom_key(ServerKey, Version),
+
+    ServerOpts = [ ServerCustomKey, {verify, verify_peer} | ServerOpts0],
+
+    ssl_test_lib:basic_test(ClientOpts, ServerOpts, Config).
 %%--------------------------------------------------------------------
 client_auth_empty_cert_accepted() ->
     [{doc,"Client sends empty cert chain as no cert is configured and server allows it"}].
@@ -517,3 +547,30 @@ group_config(Config, ServerOpts, ClientOpts) ->
                 {[{supported_groups, [x448, x25519]} | ServerOpts],
                  [{groups,"P-256:X25519"} | ClientOpts]}
         end.
+
+choose_custom_key(#'RSAPrivateKey'{} = Key, Version)
+  when (Version == 'dtlsv1') or (Version == 'tlsv1') or (Version == 'tlsv1.1') ->
+    EFun = fun (PlainText, Options) ->
+                   public_key:encrypt_private(PlainText, Key, Options)
+          end,
+    SFun = fun (Msg, HashAlgo, Options) ->
+                   public_key:sign(Msg, HashAlgo, Key, Options)
+           end,
+    {key, #{algorithm => rsa, sign_fun => SFun, encrypt_fun => EFun}};
+choose_custom_key(Key, _) ->
+    Fun = fun (Msg, HashAlgo, Options) ->
+                  public_key:sign(Msg, HashAlgo, Key, Options)
+          end,
+    {key, #{algorithm => alg_key(Key), sign_fun => Fun}}.
+
+alg_key(#'RSAPrivateKey'{}) ->
+    rsa;
+alg_key({#'RSAPrivateKey'{}, #'RSASSA-PSS-params'{}}) ->
+    rsa_pss_pss;
+alg_key(#'DSAPrivateKey'{}) ->
+    dsa;
+alg_key(#'ECPrivateKey'{parameters = {namedCurve, CurveOId}}) when CurveOId == ?'id-Ed25519' orelse
+                                                                   CurveOId == ?'id-Ed448' ->
+    eddsa;
+alg_key(#'ECPrivateKey'{}) ->
+    ecdsa.

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -89,28 +89,28 @@ auth() ->
 
 auth(Config) ->
     Version = proplists:get_value(version,Config),
+    CommonClientOpts = [{verify, verify_peer} | ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)],
     ClientOpts =  case Version of
                       'tlsv1.3' ->
-                          [{verify, verify_peer},
-                           {certificate_authorities, true} |
-                           ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)];
+                          [{certificate_authorities, true} | CommonClientOpts];
                       _ ->
-                          [{verify, verify_peer} | ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)]
+                          CommonClientOpts
                   end,
     ServerOpts =  [{verify, verify_peer} | ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config)],
     ssl_test_lib:basic_test(ClientOpts, ServerOpts, Config).
+
 %%--------------------------------------------------------------------
 client_auth_custom_key() ->
     [{doc,"Test that client and server can connect using their own signature function"}].
 
 client_auth_custom_key(Config) when is_list(Config) ->
     Version = proplists:get_value(version,Config),
+    CommonClientOpts = [{verify, verify_peer} | ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)],
     ClientOpts0 =  case Version of
                       'tlsv1.3' ->
-                          [{verify, verify_peer},
-                           {certificate_authorities, true} |
-                           ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)];
-                      _ ->[{verify, verify_peer} | ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config)]
+                           [{certificate_authorities, true} | CommonClientOpts];
+                      _ ->
+                           CommonClientOpts
                   end,
     ClientKeyFilePath =  proplists:get_value(keyfile, ClientOpts0),
     [ClientKeyEntry] = ssl_test_lib:pem_to_der(ClientKeyFilePath),


### PR DESCRIPTION
Last commit show what we like the API to look like in #7475  (Commits now squashed and this PR replaces #7475)

Design decisions:  

Keep all engine stuff in ssl, although it is a corner case of the more general
customization added, it has nothing to do with the functionality in public_key. 

Keep options sign/encrypt_private options  explicit in ssl, where the knowledge of correct options belong, do not rely on public_key defaults that are not even documented.

There has to be a legacy fun option for TLS legacy versions using encrypt_private as new version and legacy version can be supported in the same time and is negotiated. 

We do not want to support funs on format {Module, Fun}.  fun() is sufficient and you can
use` fun(X,Y) ...` or fun M:F/2



