### PR TITLE
Fix error message for invalid replacement args in `binary:replace/3,4`

### DIFF
--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -162,7 +162,7 @@ format_binary_error(split, [Subject, Pattern, _Options], _) ->
 format_binary_error(replace, [Subject, Pattern, Replacement], _) ->
     [must_be_binary(Subject),
      must_be_pattern(Pattern),
-     must_be_binary(Replacement)];
+     must_be_binary_replacement(Replacement)];
 format_binary_error(replace, [Subject, Pattern, Replacement, _Options], Cause) ->
     Errors = format_binary_error(replace, [Subject, Pattern, Replacement], Cause),
     case Cause of
@@ -1014,6 +1014,10 @@ must_be_pattern(P) ->
         error:badarg ->
             bad_binary_pattern
     end.
+
+must_be_binary_replacement(R) when is_binary(R) -> [];
+must_be_binary_replacement(R) when is_function(R, 1) -> [];
+must_be_binary_replacement(_R) -> bad_replacement.
 
 must_be_position(Pos) when is_integer(Pos), Pos >= 0 -> [];
 must_be_position(Pos) when is_integer(Pos) -> range;


### PR DESCRIPTION
In the previous PRs #6197 and #7590, the `replace/3,4` functions in the `re` and `binary` modules were changed to also accept a function as third (replacement) parameters. However, the error message formatting facility in `erl_stdlib_errors` was not adapted, and in the case that an invalid parameter (like and atom for instance) is passed in, it would say that argument 3 is not a binary/iodata, whereas functions would also be possible.

This PR corrects the error reporting such that, if an invalid term is given as replacement, it will say that argument 3 is not a valid replacement.

EDIT: Fix for the `re` part has been moved into #7925 to be merged into `maint`.