### PR TITLE
Fix enif_binary_to_term function declaration mismatch warning

### DIFF
--- a/erts/doc/src/erl_nif.xml
+++ b/erts/doc/src/erl_nif.xml
@@ -1112,7 +1112,7 @@ typedef struct {
     <func>
       <name since="OTP 19.0"><ret>size_t</ret><nametext>enif_binary_to_term(ErlNifEnv *env,
         const unsigned char* data, size_t size, ERL_NIF_TERM *term,
-        ErlNifBinaryToTerm opts)</nametext></name>
+        unsigned int opts)</nametext></name>
       <fsummary>Create a term from the external format.</fsummary>
       <desc>
         <p>Creates a term that is the result of decoding the binary data at

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1477,7 +1477,7 @@ size_t enif_binary_to_term(ErlNifEnv *dst_env,
                            const unsigned char* data,
                            size_t data_sz,
                            ERL_NIF_TERM *term,
-                           ErlNifBinaryToTerm opts)
+                           unsigned int opts)
 {
     Sint size;
     ErtsHeapFactory factory;

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2558,8 +2558,7 @@ static ERL_NIF_TERM binary_to_term(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
     /* build dummy heap term first to provoke OTP-15080 */
     dummy = enif_make_list_cell(msg_env, atom_true, atom_false);
 
-    ret = enif_binary_to_term(msg_env, bin.data, bin.size, &term,
-			      (ErlNifBinaryToTerm)opts);
+    ret = enif_binary_to_term(msg_env, bin.data, bin.size, &term, opts);
     if (!ret)
 	return atom_false;
 


### PR DESCRIPTION
Fix function declaration mismatch warning with gcc-13/14:

```
beam/erl_nif.c:1476:8: warning: conflicting types for 'enif_binary_to_term' due to enum/integer mismatch; have 'size_t(ErlNifEnv *, const unsigned char *, size_t,  ERL_NIF_TERM *, ErlNifBinaryToTerm)' {aka 'long unsigned int(struct enif_environment_t *, const unsigned char *, long unsigned int,  long unsigned int *, ErlNifBinaryToTerm)'} [-Wenum-int-mismatch]
 1476 | size_t enif_binary_to_term(ErlNifEnv *dst_env,
      |        ^~~~~~~~~~~~~~~~~~~
In file included from beam/erl_nif.c:44:
beam/erl_nif_api_funcs.h:174:31: note: previous declaration of 'enif_binary_to_term' with type 'size_t(ErlNifEnv *, const unsigned char *, size_t,  ERL_NIF_TERM *, unsigned int)' {aka 'long unsigned int(struct enif_environment_t *, const unsigned char *, long unsigned int,  long unsigned int *, unsigned int)'}
  174 | ERL_NIF_API_FUNC_DECL(size_t, enif_binary_to_term, (ErlNifEnv *env, const unsigned char* data, size_t sz, ERL_NIF_TERM *term, unsigned int opts));
      |                               ^~~~~~~~~~~~~~~~~~~
beam/erl_nif.h:369:71: note: in definition of macro 'ERL_NIF_API_FUNC_DECL'
  369 | #  define ERL_NIF_API_FUNC_DECL(RET_TYPE, NAME, ARGS) extern RET_TYPE NAME ARGS
      |                                                                       ^~~~
```

The function definition uses an enum type so I updated the extern declaration to do the same.