### PR TITLE
erts: Unify ErlSubBits with match contexts

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -1230,19 +1230,21 @@ any_heap_refs(Eterm* start, Eterm* end, char* mod_start, Uint mod_size)
 	    break;
 	case TAG_PRIMARY_HEADER:
 	    if (!header_is_transparent(val)) {
-		Eterm* new_p;
-                if (header_is_bin_matchstate(val)) {
-                    ErlBinMatchState *ms = (ErlBinMatchState*) p;
-                    ErlBinMatchBuffer *mb = &(ms->mb);
-                    if (ErtsInArea(mb->orig, mod_start, mod_size)) {
+                Eterm* new_p;
+
+                if (val == HEADER_SUB_BITS) {
+                    ErlSubBits *sb = (ErlSubBits*) p;
+
+                    if (ErtsInArea(sb->orig, mod_start, mod_size)) {
                         return 1;
                     }
                 }
-		new_p = p + thing_arityval(val);
-		ASSERT(start <= new_p && new_p < end);
-		p = new_p;
-	    }
-	}
+
+                new_p = p + thing_arityval(val);
+                ASSERT(start <= new_p && new_p < end);
+                p = new_p;
+            }
+        }
     }
     return 0;
 }

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -148,14 +148,15 @@ i_bs_get_binary_all2.fetch(Ctx) {
 }
 
 i_bs_get_binary_all2.execute(Fail, Live, Unit, Dst) {
-    ErlBinMatchBuffer *_mb;
+    ErlSubBits *sb;
     Eterm _result;
 
     $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
-    _mb = ms_matchbuffer(context);
-    if (((_mb->size - _mb->offset) % $Unit) == 0) {
+    sb = (ErlSubBits*)bitstring_val(context);
+
+    if (((sb->end - sb->start) % $Unit) == 0) {
         LIGHT_SWAPOUT;
-        _result = erts_bs_get_binary_all_2(c_p, _mb);
+        _result = erts_bs_get_binary_all_2(c_p, sb);
         LIGHT_SWAPIN;
         HEAP_SPACE_VERIFIED(0);
         ASSERT(is_value(_result));
@@ -177,14 +178,14 @@ i_bs_get_binary2.fetch(Ctx) {
 }
 
 i_bs_get_binary2.execute(Fail, Live, Sz, Flags, Dst) {
-    ErlBinMatchBuffer *_mb;
+    ErlSubBits *sb;
     Eterm _result;
     Uint _size;
     $BS_GET_FIELD_SIZE($Sz, (($Flags) >> 3), $FAIL($Fail), _size);
     $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
-    _mb = ms_matchbuffer(context);
+    sb = (ErlSubBits*)bitstring_val(context);
     LIGHT_SWAPOUT;
-    _result = erts_bs_get_binary_2(c_p, _size, $Flags, _mb);
+    _result = erts_bs_get_binary_2(c_p, _size, $Flags, sb);
     LIGHT_SWAPIN;
     HEAP_SPACE_VERIFIED(0);
     if (is_non_value(_result)) {
@@ -206,12 +207,12 @@ i_bs_get_binary_imm2.fetch(Ctx) {
 }
 
 i_bs_get_binary_imm2.execute(Fail, Live, Sz, Flags, Dst) {
-    ErlBinMatchBuffer *_mb;
+    ErlSubBits *sb;
     Eterm _result;
     $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
-    _mb = ms_matchbuffer(context);
+    sb = (ErlSubBits*)bitstring_val(context);
     LIGHT_SWAPOUT;
-    _result = erts_bs_get_binary_2(c_p, $Sz, $Flags, _mb);
+    _result = erts_bs_get_binary_2(c_p, $Sz, $Flags, sb);
     LIGHT_SWAPIN;
     HEAP_SPACE_VERIFIED(0);
     if (is_non_value(_result)) {
@@ -232,7 +233,7 @@ i_bs_get_float2.fetch(Ctx) {
 }
 
 i_bs_get_float2.execute(Fail, Live, Sz, Flags, Dst) {
-    ErlBinMatchBuffer *_mb;
+    ErlSubBits *sb;
     Eterm _result;
     Sint _size;
 
@@ -241,9 +242,9 @@ i_bs_get_float2.execute(Fail, Live, Sz, Flags, Dst) {
     }
     _size *= (($Flags) >> 3);
     $GC_TEST_PRESERVE(FLOAT_SIZE_OBJECT, $Live, context);
-    _mb = ms_matchbuffer(context);
+    sb = (ErlSubBits*)bitstring_val(context);
     LIGHT_SWAPOUT;
-    _result = erts_bs_get_float_2(c_p, _size, ($Flags), _mb);
+    _result = erts_bs_get_float_2(c_p, _size, ($Flags), sb);
     LIGHT_SWAPIN;
     HEAP_SPACE_VERIFIED(0);
     if (is_non_value(_result)) {
@@ -266,27 +267,25 @@ i_bs_skip_bits2.fetch(Ctx, Bits) {
 }
 
 i_bs_skip_bits2.execute(Fail, Unit) {
-    ErlBinMatchBuffer *_mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     size_t new_offset;
     Uint _size;
 
-    _mb = ms_matchbuffer(context);
     $BS_GET_FIELD_SIZE(bits, $Unit, $FAIL($Fail), _size);
-    new_offset = _mb->offset + _size;
-    if (new_offset <= _mb->size) {
-        _mb->offset = new_offset;
+    new_offset = sb->start + _size;
+    if (new_offset <= sb->end) {
+        sb->start = new_offset;
     } else {
         $FAIL($Fail);
     }
 }
 
 i_bs_skip_bits_imm2(Fail, Ms, Bits) {
-    ErlBinMatchBuffer *_mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ms);
     size_t new_offset;
-    _mb = ms_matchbuffer($Ms);
-    new_offset = _mb->offset + ($Bits);
-    if (new_offset <= _mb->size) {
-        _mb->offset = new_offset;
+    new_offset = sb->start + ($Bits);
+    if (new_offset <= sb->end) {
+        sb->start = new_offset;
     } else {
         $FAIL($Fail);
     }
@@ -446,7 +445,7 @@ bs_init.execute(Live, Dst) {
         HTOP += bin_need;
 
         hb->thing_word = header_heap_bits(num_bits);
-        ERTS_SET_HB_SIZE(hb, num_bits);
+        hb->size = num_bits;
         erts_current_bin = (byte *) hb->data;
 
         new_binary = make_bitstring(hb);
@@ -554,7 +553,7 @@ bs_init_bits.execute(Live, Dst) {
         HTOP += heap_bits_size(num_bits);
         hb->thing_word = header_heap_bits(num_bits);
 
-        ERTS_SET_HB_SIZE(hb, num_bits);
+        hb->size = num_bits;
 
         erts_current_bin = (byte*)hb->data;
         new_binary = make_bitstring(hb);
@@ -808,12 +807,10 @@ i_bs_validate_unicode_retract(Fail, Src, Ms) {
     Eterm i = $Src;
     if (is_not_small(i) || i > make_small(0x10FFFFUL) ||
         (make_small(0xD800UL) <= i && i <= make_small(0xDFFFUL))) {
-        Eterm ms = $Ms;		/* Match context */
-        ErlBinMatchBuffer* mb;
+        ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ms);
 
         /* Invalid value. Retract the position in the binary. */
-        mb = ms_matchbuffer(ms);
-        mb->offset -= 32;
+        sb->start -= 32;
         $BADARG($Fail);
     }
 }
@@ -1096,7 +1093,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             hb = (ErlHeapBits *) HTOP;
             HTOP += heap_bits_size(num_bits);
             hb->thing_word = header_heap_bits(num_bits);
-            ERTS_SET_HB_SIZE(hb, num_bits);
+            hb->size = num_bits;
             erts_current_bin = (byte *) hb->data;
             new_binary = make_bitstring(hb);
         } else {
@@ -1240,33 +1237,29 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
 //
 
 bs_test_zero_tail2(Fail, Ctx) {
-    ErlBinMatchBuffer *_mb;
-    _mb = (ErlBinMatchBuffer*) ms_matchbuffer($Ctx);
-    if (_mb->size != _mb->offset) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
+    if (sb->end != sb->start) {
         $FAIL($Fail);
     }
 }
 
 bs_test_tail_imm2(Fail, Ctx, Offset) {
-    ErlBinMatchBuffer *_mb;
-    _mb = ms_matchbuffer($Ctx);
-    if (_mb->size - _mb->offset != $Offset) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
+    if (sb->end - sb->start != $Offset) {
         $FAIL($Fail);
     }
 }
 
 bs_test_unit(Fail, Ctx, Unit) {
-    ErlBinMatchBuffer *_mb;
-    _mb = ms_matchbuffer($Ctx);
-    if ((_mb->size - _mb->offset) % $Unit) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
+    if ((sb->end - sb->start) % $Unit) {
         $FAIL($Fail);
     }
 }
 
 bs_test_unit8(Fail, Ctx) {
-    ErlBinMatchBuffer *_mb;
-    _mb = ms_matchbuffer($Ctx);
-    if ((_mb->size - _mb->offset) & 7) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
+    if ((sb->end - sb->start) & 7) {
         $FAIL($Fail);
     }
 }
@@ -1282,17 +1275,18 @@ i_bs_get_integer_8.fetch(Ctx) {
 }
 
 i_bs_get_integer_8.execute(Fail, Dst) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Eterm _result;
-    ErlBinMatchBuffer* _mb = ms_matchbuffer(context);
 
-    if (_mb->size - _mb->offset < 8) {
+    if (sb->end - sb->start < 8) {
         $FAIL($Fail);
     }
-    if (BIT_OFFSET(_mb->offset) != 0) {
-        _result = erts_bs_get_integer_2(c_p, 8, 0, _mb);
+    if (BIT_OFFSET(sb->start) != 0) {
+        _result = erts_bs_get_integer_2(c_p, 8, 0, sb);
     } else {
-        _result = make_small(_mb->base[BYTE_OFFSET(_mb->offset)]);
-        _mb->offset += 8;
+        _result = make_small(*(erl_sub_bits_get_base(sb) +
+                                BYTE_OFFSET(sb->start)));
+        sb->start += 8;
     }
     $Dst = _result;
 }
@@ -1308,17 +1302,18 @@ i_bs_get_integer_16.fetch(Ctx) {
 }
 
 i_bs_get_integer_16.execute(Fail, Dst) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Eterm _result;
-    ErlBinMatchBuffer* _mb = ms_matchbuffer(context);
 
-    if (_mb->size - _mb->offset < 16) {
+    if (sb->end - sb->start < 16) {
         $FAIL($Fail);
     }
-    if (BIT_OFFSET(_mb->offset) != 0) {
-        _result = erts_bs_get_integer_2(c_p, 16, 0, _mb);
+    if (BIT_OFFSET(sb->start) != 0) {
+        _result = erts_bs_get_integer_2(c_p, 16, 0, sb);
     } else {
-        _result = make_small(get_int16(_mb->base+BYTE_OFFSET(_mb->offset)));
-        _mb->offset += 16;
+        _result = make_small(get_int16(erl_sub_bits_get_base(sb) +
+                                        BYTE_OFFSET(sb->start)));
+        sb->start += 16;
     }
     $Dst = _result;
 }
@@ -1335,18 +1330,19 @@ i_bs_get_integer_32.fetch(Ctx) {
 }
 
 i_bs_get_integer_32.execute(Fail, Dst) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Uint32 _integer;
-    ErlBinMatchBuffer* _mb = ms_matchbuffer(context);
 
-    if (_mb->size - _mb->offset < 32) {
+    if (sb->end - sb->start < 32) {
         $FAIL($Fail);
     }
-    if (BIT_OFFSET(_mb->offset) != 0) {
-        _integer = erts_bs_get_unaligned_uint32(_mb);
+    if (BIT_OFFSET(sb->start) != 0) {
+        _integer = erts_bs_get_unaligned_uint32(sb);
     } else {
-        _integer = get_int32(_mb->base + _mb->offset/8);
+        _integer = get_int32(erl_sub_bits_get_base(sb) +
+                              BYTE_OFFSET(sb->start));
     }
-    _mb->offset += 32;
+    sb->start += 32;
     $Dst = make_small(_integer);
 }
 %endif
@@ -1359,8 +1355,8 @@ bs_get_integer.head() {
 }
 
 bs_get_integer.fetch(Ctx, Size, Live) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
     Uint wordsneeded;
-    ErlBinMatchBuffer* mb;
     Ms = $Ctx;
     Sz = $Size;
     wordsneeded = 1+WSIZE(NBYTES(Sz));
@@ -1369,8 +1365,7 @@ bs_get_integer.fetch(Ctx, Size, Live) {
      * and then realize we don't need the allocated space (if the
      * op fails).
      */
-    mb = ms_matchbuffer(Ms);
-    if (mb->size - mb->offset >= Sz) {
+    if (sb->end - sb->start >= Sz) {
         $GC_TEST_PRESERVE(wordsneeded, $Live, Ms);
     }
 }
@@ -1381,12 +1376,11 @@ bs_get_integer.fetch_small(Ctx, Size) {
 }
 
 bs_get_integer.execute(Fail, Flags, Dst) {
-    ErlBinMatchBuffer* mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(Ms);
     Eterm result;
 
-    mb = ms_matchbuffer(Ms);
     LIGHT_SWAPOUT;
-    result = erts_bs_get_integer_2(c_p, Sz, $Flags, mb);
+    result = erts_bs_get_integer_2(c_p, Sz, $Flags, sb);
     LIGHT_SWAPIN;
     HEAP_SPACE_VERIFIED(0);
     if (is_non_value(result)) {
@@ -1406,9 +1400,9 @@ i_bs_get_integer.fetch(Ctx) {
 }
 
 i_bs_get_integer.execute(Fail, Live, FlagsAndUnit, Sz, Dst) {
+    ErlSubBits *sb;
     Uint flags;
     Uint size;
-    ErlBinMatchBuffer* mb;
     Eterm result;
 
     flags = $FlagsAndUnit;
@@ -1419,21 +1413,24 @@ i_bs_get_integer.execute(Fail, Live, FlagsAndUnit, Sz, Dst) {
          * We do not want a gc and then realize we don't need
          * the allocated space (i.e. if the op fails).
          *
-         * Remember to re-acquire the matchbuffer after gc.
+         * Remember to re-acquire the match context after gc.
          */
 
-        mb = ms_matchbuffer(context);
-        if (mb->size - mb->offset < size) {
+        sb = (ErlSubBits*)bitstring_val(context);
+        if (sb->end - sb->start < size) {
             $FAIL($Fail);
         }
         wordsneeded = 1+WSIZE(NBYTES((Uint) size));
         $GC_TEST_PRESERVE(wordsneeded, $Live, context);
         $REFRESH_GEN_DEST();
     }
-    mb = ms_matchbuffer(context);
+
+    sb = (ErlSubBits*)bitstring_val(context);
+
     LIGHT_SWAPOUT;
-    result = erts_bs_get_integer_2(c_p, size, flags, mb);
+    result = erts_bs_get_integer_2(c_p, size, flags, sb);
     LIGHT_SWAPIN;
+
     HEAP_SPACE_VERIFIED(0);
     if (is_non_value(result)) {
         $FAIL($Fail);
@@ -1452,21 +1449,21 @@ i_bs_get_utf8.fetch(Ctx) {
 }
 
 i_bs_get_utf8.execute(Fail, Dst) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Eterm result;
-    ErlBinMatchBuffer* mb = ms_matchbuffer(context);
 
-    if (mb->size - mb->offset < 8) {
+    if (sb->end - sb->start < 8) {
         $FAIL($Fail);
     }
-    if (BIT_OFFSET(mb->offset) != 0) {
-        result = erts_bs_get_utf8(mb);
+    if (BIT_OFFSET(sb->start) != 0) {
+        result = erts_bs_get_utf8(sb);
     } else {
-        byte b = mb->base[BYTE_OFFSET(mb->offset)];
+        byte b = *(erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start));
         if (b < 128) {
             result = make_small(b);
-            mb->offset += 8;
+            sb->start += 8;
         } else {
-            result = erts_bs_get_utf8(mb);
+            result = erts_bs_get_utf8(sb);
         }
     }
     if (is_non_value(result)) {
@@ -1487,8 +1484,8 @@ i_bs_get_utf16.fetch(Ctx) {
 }
 
 i_bs_get_utf16.execute(Fail, Flags, Dst) {
-    ErlBinMatchBuffer* mb = ms_matchbuffer(context);
-    Eterm result = erts_bs_get_utf16(mb, $Flags);
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
+    Eterm result = erts_bs_get_utf16(sb, $Flags);
 
     if (is_non_value(result)) {
         $FAIL($Fail);
@@ -1498,24 +1495,28 @@ i_bs_get_utf16.execute(Fail, Flags, Dst) {
 }
 
 i_bs_match_string(Ctx, Fail, Bits, Ptr) {
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
     byte* bytes = (byte *) $Ptr;
-    Uint bits = $Bits;
-    ErlBinMatchBuffer* mb;
+    Uint size = $Bits;
     Uint offs;
 
-    mb = ms_matchbuffer($Ctx);
-    if (mb->size - mb->offset < bits) {
+    if (sb->end - sb->start < size) {
         $FAIL($Fail);
     }
-    offs = mb->offset & 7;
-    if (offs == 0 && (bits & 7) == 0) {
-        if (sys_memcmp(bytes, mb->base+(mb->offset>>3), bits>>3)) {
+    offs = BIT_OFFSET(sb->start);
+    if (offs == 0 && TAIL_BITS(size) == 0) {
+        if (sys_memcmp(bytes,
+                       erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start),
+                       BYTE_SIZE(size))) {
             $FAIL($Fail);
         }
-    } else if (erts_cmp_bits(bytes, 0, mb->base+(mb->offset>>3), mb->offset & 7, bits)) {
+    } else if (erts_cmp_bits(bytes, 0,
+                             erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start),
+                             BIT_OFFSET(sb->start),
+                             size)) {
         $FAIL($Fail);
     }
-    mb->offset += bits;
+    sb->start += size;
 }
 
 bs_get_tail := bs_get_tail.fetch.execute;
@@ -1529,23 +1530,21 @@ bs_get_tail.fetch(Src) {
 }
 
 bs_get_tail.execute(Dst, Live) {
-    ErlBinMatchBuffer* mb;
     Eterm bin, *htop;
-
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
+    ErlSubBits *sb;
 
     $GC_TEST_PRESERVE(BUILD_SUB_BITSTRING_HEAP_NEED, $Live, context);
 
     htop = HTOP;
 
-    mb = ms_matchbuffer(context);
+    sb = (ErlSubBits*)bitstring_val(context);
 
     bin = erts_build_sub_bitstring(&htop,
-                                   mb->orig & TAG_PTR_MASK__,
-                                   (BinRef*)boxed_val(mb->orig),
-                                   mb->base,
-                                   mb->offset,
-                                   mb->size - mb->offset);
+                                   sb->orig & TAG_PTR_MASK__,
+                                   (BinRef*)boxed_val(sb->orig),
+                                   erl_sub_bits_get_base(sb),
+                                   sb->start,
+                                   sb->end - sb->start);
     HTOP = htop;
 
     $REFRESH_GEN_DEST();
@@ -1566,8 +1565,8 @@ i_bs_start_match3_gp.fetch(Src) {
 }
 
 i_bs_start_match3_gp.execute(Live, Fail, Dst, Pos) {
-    Eterm header;
     Uint position, live;
+    Eterm header;
 
     live = $Live;
 
@@ -1577,30 +1576,32 @@ i_bs_start_match3_gp.execute(Live, Fail, Dst, Pos) {
 
     header = *boxed_val(context);
 
-    if (header_is_bin_matchstate(header)) {
-        ErlBinMatchBuffer *mb;
+    if (is_bitstring_header(header)) {
+        ErlSubBits *sb;
+        int reuse = 0;
 
-        ASSERT(HEADER_NUM_SLOTS(header) == 0);
+        if (header == HEADER_SUB_BITS) {
+            sb = (ErlSubBits*)bitstring_val(context);
+            reuse = erl_sub_bits_is_match_context(sb);
+        }
 
-        mb = ms_matchbuffer(context);
-        position = mb->offset;
+        if (!reuse) {
+            $GC_TEST_PRESERVE(ERL_SUB_BITS_SIZE, live, context);
 
-        $Dst = context;
-    } else if (is_bitstring_header(header)) {
-        ErlBinMatchState *ms;
-
-        $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(0), live, context);
-        HEAP_TOP(c_p) = HTOP;
+            HEAP_TOP(c_p) = HTOP;
 #ifdef DEBUG
-        c_p->stop = E;	/* Needed for checking in HeapOnlyAlloc(). */
+            c_p->stop = E;        /* Needed for checking in HeapOnlyAlloc(). */
 #endif
-        ms = erts_bs_start_match_3(c_p, context);
-        HTOP = HEAP_TOP(c_p);
-        HEAP_SPACE_VERIFIED(0);
+            sb = erts_bs_start_match_3(c_p, context);
+            HTOP = HEAP_TOP(c_p);
+            HEAP_SPACE_VERIFIED(0);
 
-        $REFRESH_GEN_DEST();
-        $Dst = make_matchstate(ms);
-        position = ms->mb.offset;
+            $REFRESH_GEN_DEST();
+            context = make_bitstring(sb);
+        }
+
+        position = sb->start;
+        $Dst = context;
     } else {
         $FAIL($Fail);
     }
@@ -1609,84 +1610,18 @@ i_bs_start_match3_gp.execute(Live, Fail, Dst, Pos) {
     $Pos = make_small(position);
 }
 
-i_bs_start_match3 := i_bs_start_match3.fetch.execute;
-
-i_bs_start_match3.head() {
-    Eterm context;
-}
-
-i_bs_start_match3.fetch(Src) {
-    context = $Src;
-}
-
-i_bs_start_match3.execute(Live, Fail, Dst) {
-    Eterm header;
-    Uint live;
-
-    live = $Live;
-
-    if (!is_boxed(context)) {
-        $FAIL($Fail);
-    }
-
-    header = *boxed_val(context);
-
-    if (header_is_bin_matchstate(header)) {
-        ASSERT(HEADER_NUM_SLOTS(header) == 0);
-        $Dst = context;
-    } else if (is_bitstring_header(header)) {
-        ErlBinMatchState *ms;
-
-        $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(0), live, context);
-        HEAP_TOP(c_p) = HTOP;
-#ifdef DEBUG
-        c_p->stop = E;	/* Needed for checking in HeapOnlyAlloc(). */
-#endif
-        ms = erts_bs_start_match_3(c_p, context);
-        HTOP = HEAP_TOP(c_p);
-        HEAP_SPACE_VERIFIED(0);
-
-        $REFRESH_GEN_DEST();
-        $Dst = make_matchstate(ms);
-    } else {
-        $FAIL($Fail);
-    }
-}
-
 bs_set_position(Ctx, Pos) {
-    ErlBinMatchBuffer* mb;
-    Eterm context;
-
-    context = $Ctx;
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-
-    mb = ms_matchbuffer(context);
-    mb->offset = unsigned_val($Pos);
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
+    sb->start = unsigned_val($Pos);
 }
 
 i_bs_get_position(Ctx, Dst) {
-    ErlBinMatchBuffer* mb;
-    Eterm context;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
 
-    context = $Ctx;
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-
-    mb = ms_matchbuffer(context);
-    $Dst = make_small(mb->offset);
+    $Dst = make_small(sb->start);
 }
 
 %else
-
-#
-# Unlike their 64-bit counterparts, the 32-bit position instructions operate on
-# an offset from the "base position" of the context because storing raw
-# positions would lead to the creation of far too many bigints.
-#
-# When a match context is reused we check whether its position fits into an
-# immediate, and create a new match context if it does not. This means we only
-# have to allocate stuff roughly once every 16MB rather than every time we
-# match at a position beyond 16MB.
-#
 
 bs_set_position := bs_set_position.fetch.execute;
 
@@ -1700,16 +1635,13 @@ bs_set_position.fetch(Ctx, Pos) {
 }
 
 bs_set_position.execute() {
-    ErlBinMatchState *ms;
-
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-    ms = (ErlBinMatchState*)boxed_val(context);
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
 
     if (ERTS_LIKELY(is_small(position))) {
-        ms->mb.offset = ms->save_offset[0] + unsigned_val(position);
+        sb->start = unsigned_val(position);
     } else {
         ASSERT(is_big(position));
-        ms->mb.offset = ms->save_offset[0] + *BIG_V(big_val(position));
+        sb->start = *BIG_V(big_val(position));
     }
 }
 
@@ -1724,13 +1656,8 @@ bs_get_position.fetch(Ctx) {
 }
 
 bs_get_position.execute(Dst, Live) {
-    ErlBinMatchState *ms;
-    Uint position;
-
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-    ms = (ErlBinMatchState*)boxed_val(context);
-
-    position = ms->mb.offset - ms->save_offset[0];
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
+    Uint position = sb->start;
 
     if (ERTS_LIKELY(IS_USMALL(0, position))) {
         $Dst = make_small(position);
@@ -1750,6 +1677,8 @@ bs_get_position.execute(Dst, Live) {
     }
 }
 
+%endif
+
 i_bs_start_match3 := i_bs_start_match3.fetch.execute;
 
 i_bs_start_match3.head() {
@@ -1772,59 +1701,35 @@ i_bs_start_match3.execute(Live, Fail, Dst) {
 
     header = *boxed_val(context);
 
-    if (header_is_bin_matchstate(header)) {
-        ErlBinMatchState *current_ms;
-        Uint position;
+    if (is_bitstring_header(header)) {
+        ErlSubBits *sb;
+        int reuse = 0;
 
-        ASSERT(HEADER_NUM_SLOTS(header) == 1);
+        if (header == HEADER_SUB_BITS) {
+            sb = (ErlSubBits*)bitstring_val(context);
+            reuse = erl_sub_bits_is_match_context(sb);
+        }
 
-        current_ms = (ErlBinMatchState*)boxed_val(context);
-        position = current_ms->mb.offset - current_ms->save_offset[0];
+        if (!reuse) {
+            $GC_TEST_PRESERVE(ERL_SUB_BITS_SIZE, live, context);
 
-        if (ERTS_LIKELY(IS_USMALL(0, position))) {
-            $Dst = context;
-        } else {
-            ErlBinMatchState *new_ms;
-
-            $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(1), live, context);
-            current_ms = (ErlBinMatchState*)boxed_val(context);
-
-            new_ms = (ErlBinMatchState*)HTOP;
-            HTOP += ERL_BIN_MATCHSTATE_SIZE(1);
-
-            new_ms->thing_word = HEADER_BIN_MATCHSTATE(1);
-            new_ms->save_offset[0] = current_ms->mb.offset;
-            new_ms->mb = current_ms->mb;
+            HEAP_TOP(c_p) = HTOP;
+#ifdef DEBUG
+            c_p->stop = E;        /* Needed for checking in HeapOnlyAlloc(). */
+#endif
+            sb = erts_bs_start_match_3(c_p, context);
+            HTOP = HEAP_TOP(c_p);
+            HEAP_SPACE_VERIFIED(0);
 
             $REFRESH_GEN_DEST();
-            $Dst = make_matchstate(new_ms);
+            context = make_bitstring(sb);
         }
-    } else if (is_bitstring_header(header)) {
-        Eterm result;
 
-        $GC_TEST_PRESERVE(ERL_BIN_MATCHSTATE_SIZE(1), live, context);
-        HEAP_TOP(c_p) = HTOP;
-
-#ifdef DEBUG
-        c_p->stop = E;	/* Needed for checking in HeapOnlyAlloc(). */
-#endif
-
-        /* We intentionally use erts_bs_start_match_2 so that we can use
-         * save_offset as a base for all saved positions on this context,
-         * allowing us to avoid bigints for much longer. */
-        result = erts_bs_start_match_2(c_p, context, 1);
-
-        HTOP = HEAP_TOP(c_p);
-        HEAP_SPACE_VERIFIED(0);
-
-        $REFRESH_GEN_DEST();
-        $Dst = result;
+        $Dst = context;
     } else {
         $FAIL($Fail);
     }
 }
-
-%endif
 
 //
 // New instructions introduced in OTP 26 for matching of integers and
@@ -1846,9 +1751,9 @@ i_bs_ensure_bits.fetch(Src) {
 }
 
 i_bs_ensure_bits.execute(NumBits, Fail) {
-    ErlBinMatchBuffer* mb = ms_matchbuffer(context);
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Uint size = $NumBits;
-    if (mb->size - mb->offset < size) {
+    if (sb->end - sb->start < size) {
         $FAIL($Fail);
     }
 }
@@ -1868,11 +1773,11 @@ i_bs_ensure_bits_unit.fetch(Src) {
 }
 
 i_bs_ensure_bits_unit.execute(NumBits, Unit, Fail) {
-    ErlBinMatchBuffer* mb = ms_matchbuffer(context);
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Uint size = $NumBits;
     Uint diff;
 
-    if ((diff = mb->size - mb->offset) < size) {
+    if ((diff = sb->end - sb->start) < size) {
         $FAIL($Fail);
     }
     if ((diff - size) % $Unit != 0) {
@@ -1889,24 +1794,24 @@ i_bs_read_bits := i_bs_read_bits.fetch.execute;
 i_bs_ensure_bits_read := i_bs_read_bits.fetch.ensure_bits.execute;
 
 i_bs_read_bits.head() {
-    ErlBinMatchBuffer* mb;
+    ErlSubBits *sb;
     Uint size;
 }
 
 i_bs_read_bits.fetch(Src, NumBits) {
-    mb = ms_matchbuffer($Src);
+    sb = (ErlSubBits*)bitstring_val($Src);
     size = $NumBits;
 }
 
 i_bs_read_bits.ensure_bits(Fail) {
-    if (mb->size - mb->offset < size) {
+    if (sb->end - sb->start < size) {
         $FAIL($Fail);
     }
 }
 
 i_bs_read_bits.execute() {
-    byte *byte_ptr;
-    Uint bit_offset = mb->offset % 8;
+    const byte *byte_ptr;
+    Uint bit_offset = sb->start % 8;
     Uint num_bytes_to_read = (size + 7) / 8;
     Uint num_partial = size % 8;
 
@@ -1916,8 +1821,8 @@ i_bs_read_bits.execute() {
     }
 
     bitdata = 0;
-    byte_ptr = mb->base + (mb->offset >> 3);
-    mb->offset += size;
+    byte_ptr = erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start);
+    sb->start += size;
     switch (num_bytes_to_read) {
 #ifdef ARCH_64
     case 9:
@@ -1975,13 +1880,13 @@ i_bs_extract_integer(NumBits, Dst) {
 
 // i_bs_read_integer_8 Ctx Dst
 i_bs_read_integer_8(Ctx, Dst) {
-    ErlBinMatchBuffer* mb = ms_matchbuffer($Ctx);
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val($Ctx);
     byte *byte_ptr;
-    Uint bit_offset = mb->offset % 8;
+    Uint bit_offset = sb->start % 8;
     Eterm result;
 
-    byte_ptr = mb->base + (mb->offset >> 3);
-    mb->offset += 8;
+    byte_ptr = erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start);
+    sb->start += 8;
     result = byte_ptr[0];
     if (bit_offset != 0) {
         result = result << 8 | byte_ptr[1];
@@ -2006,15 +1911,15 @@ i_bs_get_fixed_integer.fetch(Src) {
 }
 
 i_bs_get_fixed_integer.execute(Size, Flags, Dst) {
-    ErlBinMatchBuffer* mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Uint size = $Size;
     Eterm result;
 
-    mb = ms_matchbuffer(context);
     LIGHT_SWAPOUT;
-    result = erts_bs_get_integer_2(c_p, size, $Flags, mb);
+    result = erts_bs_get_integer_2(c_p, size, $Flags, sb);
     LIGHT_SWAPIN;
     HEAP_SPACE_VERIFIED(0);
+
     $Dst = result;
 }
 
@@ -2033,24 +1938,21 @@ i_bs_get_fixed_binary.fetch(Src) {
 }
 
 i_bs_get_fixed_binary.execute(Size, Dst) {
-    ErlBinMatchBuffer* mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Uint size = $Size;
     Eterm* htop;
     Eterm result;
 
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-
     htop = HTOP;
-    mb = ms_matchbuffer(context);
     result = erts_build_sub_bitstring(&htop,
-                                      mb->orig & TAG_PTR_MASK__,
-                                      (BinRef*)boxed_val(mb->orig),
-                                      mb->base,
-                                      mb->offset,
+                                      sb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(sb->orig),
+                                      erl_sub_bits_get_base(sb),
+                                      sb->start,
                                       size);
     HTOP = htop;
 
-    mb->offset += size;
+    sb->start += size;
 
     $Dst = result;
 }
@@ -2070,20 +1972,17 @@ i_bs_get_tail.fetch(Src) {
 }
 
 i_bs_get_tail.execute(Dst) {
-    ErlBinMatchBuffer* mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Eterm* htop;
     Eterm result;
 
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-
     htop = HTOP;
-    mb = ms_matchbuffer(context);
     result = erts_build_sub_bitstring(&htop,
-                                      mb->orig & TAG_PTR_MASK__,
-                                      (BinRef*)boxed_val(mb->orig),
-                                      mb->base,
-                                      mb->offset,
-                                      mb->size - mb->offset);
+                                      sb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(sb->orig),
+                                      erl_sub_bits_get_base(sb),
+                                      sb->start,
+                                      sb->end - sb->start);
     HTOP = htop;
 
     $Dst = result;
@@ -2104,12 +2003,10 @@ i_bs_skip.fetch(Src) {
 }
 
 i_bs_skip.execute(Size) {
-    ErlBinMatchBuffer* mb;
+    ErlSubBits *sb = (ErlSubBits*)bitstring_val(context);
     Uint size = $Size;
 
-    ASSERT(header_is_bin_matchstate(*boxed_val(context)));
-    mb = ms_matchbuffer(context);
-    mb->offset += size;
+    sb->start += size;
 }
 
 // i_bs_drop Size

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1793,7 +1793,7 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
 
     erts_current_bin = br->bytes;
 
-    return bin;
+    return make_bitstring(sb);
 }
 
 Eterm

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -98,81 +98,58 @@ static byte get_bit(byte b, size_t a_offs);
 	}					\
   }while(0)					\
 
-Eterm
-erts_bs_start_match_2(Process *p, Eterm bin, Uint Max)
+ErlSubBits *erts_bs_start_match_3(Process *p, Eterm bin)
 {
-    ErlBinMatchState *ms;
+    ErlSubBits *sb;
     Uint offset, size;
     byte *base;
     Eterm br_flags;
     BinRef *br;
-    Uint* hp;
+    Uint *hp;
 
     ASSERT(is_bitstring(bin));
 
-    hp = HeapOnlyAlloc(p, ERL_BIN_MATCHSTATE_SIZE(Max));
-    ms = (ErlBinMatchState *) hp;
+    hp = HeapOnlyAlloc(p, ERL_SUB_BITS_SIZE);
+    sb = (ErlSubBits *) hp;
 
     ERTS_PIN_BITSTRING(bin, br_flags, br, base, offset, size);
 
-    ms->thing_word = HEADER_BIN_MATCHSTATE(Max);
-    (ms->mb).orig = br ? ((Eterm)br | br_flags) : bin;
-    (ms->mb).base = base;
-    (ms->mb).offset = ms->save_offset[0] = offset;
-    (ms->mb).size = offset + size;
+    erl_sub_bits_init(sb,
+                      ERL_SUB_BITS_FLAGS_MATCH_CONTEXT,
+                      br ? ((Eterm)br | br_flags) : bin,
+                      base,
+                      offset,
+                      size);
 
-    return make_matchstate(ms);
-}
-
-ErlBinMatchState *erts_bs_start_match_3(Process *p, Eterm bin)
-{
-    ErlBinMatchState *ms;
-    Uint offset, size;
-    byte *base;
-    Eterm br_flags;
-    BinRef *br;
-    Uint* hp;
-
-    ASSERT(is_bitstring(bin));
-
-    hp = HeapOnlyAlloc(p, ERL_BIN_MATCHSTATE_SIZE(0));
-    ms = (ErlBinMatchState *) hp;
-
-    ERTS_PIN_BITSTRING(bin, br_flags, br, base, offset, size);
-
-    ms->thing_word = HEADER_BIN_MATCHSTATE(0);
-    (ms->mb).orig = br ? ((Eterm)br | br_flags) : bin;
-    (ms->mb).base = base;
-    (ms->mb).offset = offset;
-    (ms->mb).size = offset + size;
-
-    return ms;
+    return sb;
 }
 
 #ifdef DEBUG
 # define CHECK_MATCH_BUFFER(MB) check_match_buffer(MB)
 
-static void check_match_buffer(const ErlBinMatchBuffer *mb)
+static void check_match_buffer(const ErlSubBits *sb)
 {
-    Eterm *unboxed = boxed_val(mb->orig);
-    const byte *base;
+    Eterm *unboxed = boxed_val(sb->orig);
+    const byte *match_base = erl_sub_bits_get_base(sb);
+    const byte *orig_base;
     Uint size;
 
     if (*unboxed == HEADER_BIN_REF) {
         const BinRef *br = (BinRef*)unboxed;
-        size = NBITS((br->val)->orig_size);
-        base = (byte*)br->bytes;
         ASSERT(!((br->val)->intern.flags &
                  (BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)));
+        size = NBITS((br->val)->orig_size);
+        orig_base = (byte*)(sb->base_flags & ~ERL_SUB_BITS_FLAG_MASK);
     } else {
         const ErlHeapBits *hb = (ErlHeapBits*)unboxed;
         size = hb->size;
-        base = (byte*)hb->data;
+        orig_base = (byte*)hb->data;
     }
 
-    ASSERT(mb->size <= size);
-    ASSERT(mb->base >= base && mb->base <= (base + NBYTES(size)));
-    ASSERT(mb->offset <= (size - NBITS(mb->base - base)));
+    ASSERT(sb->end >= sb->start);
+    ASSERT(size >= (sb->end - sb->start));
+    ASSERT(match_base >= orig_base && match_base <= (orig_base + NBYTES(size)));
+    ASSERT(sb->start <= (size - NBITS(match_base - orig_base)));
 }
 #else
 # define CHECK_MATCH_BUFFER(MB)
@@ -180,7 +157,7 @@ static void check_match_buffer(const ErlBinMatchBuffer *mb)
 
 Eterm
 erts_bs_get_integer_2(
-Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
+Process *p, Uint num_bits, unsigned flags, ErlSubBits *sb)
 {
     Uint bytes;
     Uint bits;
@@ -199,8 +176,8 @@ Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
 	return SMALL_ZERO;
     }
     
-    CHECK_MATCH_BUFFER(mb);
-    if (mb->size - mb->offset < num_bits) {	/* Asked for too many bits.  */
+    CHECK_MATCH_BUFFER(sb);
+    if (sb->end - sb->start < num_bits) {	/* Asked for too many bits.  */
 	return THE_NON_VALUE;
     }
 
@@ -208,14 +185,14 @@ Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
      * Special cases for field sizes up to the size of Uint.
      */
 
-    if (num_bits <= 8-(offs = BIT_OFFSET(mb->offset))) {
+    if (num_bits <= 8-(offs = BIT_OFFSET(sb->start))) {
 	/*
 	 * All bits are in one byte in the binary. We only need
 	 * shift them right and mask them.
 	 */
-	Uint b = mb->base[BYTE_OFFSET(mb->offset)];
+	Uint b = *(erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start));
 	Uint mask = MAKE_MASK(num_bits);
-	mb->offset += num_bits;
+	sb->start += num_bits;
 	b >>= 8 - offs - num_bits;
 	b &= mask;
 	if ((flags & BSF_SIGNED) && b >> (num_bits-1)) {
@@ -228,10 +205,11 @@ Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
 	 * combine the bytes to a word first, and then shift right and
 	 * mask to extract the bits.
 	 */
-	Uint byte_offset = BYTE_OFFSET(mb->offset);
-	Uint w = mb->base[byte_offset] << 8 | mb->base[byte_offset+1];
+	Uint byte_offset = BYTE_OFFSET(sb->start);
+	const byte* bp = erl_sub_bits_get_base(sb) + byte_offset;
+	Uint w = bp[0] << 8 | bp[1];
 	Uint mask = MAKE_MASK(num_bits);
-	mb->offset += num_bits;
+	sb->start += num_bits;
 	w >>= 16 - offs - num_bits;
 	w &= mask;
 	if ((flags & BSF_SIGNED) && w >> (num_bits-1)) {
@@ -243,12 +221,12 @@ Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
 	 * Handle field sizes from 9 up to SMALL_BITS-1 bits, big-endian,
 	 * stored in at least two bytes.
 	 */
-	byte* bp = mb->base + BYTE_OFFSET(mb->offset);
+	const byte* bp = erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start);
 	Uint n;
 	Uint w;
 
 	n = num_bits;
-	mb->offset += num_bits;
+	sb->start += num_bits;
 
 	/*
 	 * Handle the most signicant byte if it contains 1 to 7 bits.
@@ -326,13 +304,15 @@ Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
      */
     
     if (flags & BSF_LITTLE) {
-	erts_copy_bits(mb->base, mb->offset, 1, LSB, 0, 1, num_bits);
+	erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1,
+                       LSB, 0, 1, num_bits);
 	*MSB >>= offs;		/* adjust msb */
     } else {
 	*MSB = 0;
-	erts_copy_bits(mb->base, mb->offset, 1, MSB, offs, -1, num_bits);
+	erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1,
+                       MSB, offs, -1, num_bits);
     }
-    mb->offset += num_bits;
+    sb->start += num_bits;
 
     /*
      * Get the sign bit.
@@ -436,12 +416,12 @@ Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
 }
 
 Eterm
-erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
+erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlSubBits *sb)
 {
     Eterm result;
 
-    CHECK_MATCH_BUFFER(mb);
-    if (mb->size - mb->offset < num_bits) {
+    CHECK_MATCH_BUFFER(sb);
+    if (sb->end - sb->start < num_bits) {
         /* Asked for too many bits.  */
         return THE_NON_VALUE;
     }
@@ -451,18 +431,18 @@ erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffe
      */
 
     result = erts_build_sub_bitstring(&HEAP_TOP(p),
-                                      mb->orig & TAG_PTR_MASK__,
-                                      (BinRef*)boxed_val(mb->orig),
-                                      mb->base,
-                                      mb->offset, num_bits);
+                                      sb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(sb->orig),
+                                      erl_sub_bits_get_base(sb),
+                                      sb->start, num_bits);
 
-    mb->offset += num_bits;
+    sb->start += num_bits;
 
     return result;
 }
 
 Eterm
-erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer* mb)
+erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlSubBits *sb)
 {
     Eterm* hp;
     erlfp16 f16;
@@ -471,14 +451,14 @@ erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer
     byte* fptr;
     FloatDef f;
 
-    CHECK_MATCH_BUFFER(mb);
+    CHECK_MATCH_BUFFER(sb);
     if (num_bits == 0) {
 	f.fd = 0.0;
 	hp = HeapOnlyAlloc(p, FLOAT_SIZE_OBJECT);
 	PUT_DOUBLE(f, hp);
 	return make_float(hp);
     }
-    if (mb->size - mb->offset < num_bits) {	/* Asked for too many bits.  */
+    if (sb->end - sb->start < num_bits) {	/* Asked for too many bits.  */
 	return THE_NON_VALUE;
     }
     if (num_bits == 16) {
@@ -492,11 +472,11 @@ erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer
     }
 
     if (BIT_IS_MACHINE_ENDIAN(flags)) {
-	erts_copy_bits(mb->base, mb->offset, 1,
+	erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1,
 		  fptr, 0, 1,
 		  num_bits);
     } else {
-	erts_copy_bits(mb->base, mb->offset, 1,
+	erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1,
 		  fptr + NBYTES(num_bits) - 1, 0, -1,
 		  num_bits);
     }
@@ -519,28 +499,28 @@ erts_bs_get_float_2(Process *p, Uint num_bits, unsigned flags, ErlBinMatchBuffer
 	f.fd = f64;
 #endif
     }
-    mb->offset += num_bits;
+    sb->start += num_bits;
     hp = HeapOnlyAlloc(p, FLOAT_SIZE_OBJECT);
     PUT_DOUBLE(f, hp);
     return make_float(hp);
 }
 
 Eterm
-erts_bs_get_binary_all_2(Process *p, ErlBinMatchBuffer* mb)
+erts_bs_get_binary_all_2(Process *p, ErlSubBits *sb)
 {
     Uint bit_size;
     Eterm result;
 
-    CHECK_MATCH_BUFFER(mb);
-    bit_size = mb->size - mb->offset;
+    CHECK_MATCH_BUFFER(sb);
+    bit_size = sb->end - sb->start;
 
     result = erts_build_sub_bitstring(&HEAP_TOP(p),
-                                      mb->orig & TAG_PTR_MASK__,
-                                      (BinRef*)boxed_val(mb->orig),
-                                      mb->base,
-                                      mb->offset, bit_size);
+                                      sb->orig & TAG_PTR_MASK__,
+                                      (BinRef*)boxed_val(sb->orig),
+                                      erl_sub_bits_get_base(sb),
+                                      sb->start, bit_size);
 
-    mb->offset = mb->size;
+    sb->start = sb->end;
 
     return result;
 }
@@ -1448,6 +1428,7 @@ static void
 build_writable_bitstring(Process *p,
                          Eterm **hpp,
                          Binary *bin,
+                         Uint current_size,
                          Uint apparent_size,
                          BinRef **brp,
                          ErlSubBits **sbp)
@@ -1469,11 +1450,12 @@ build_writable_bitstring(Process *p,
 
     MSO(p).overhead += apparent_size / (sizeof(Eterm) * 8);
 
-    br->bytes = (byte*)bin->orig_bytes;
-
-    sb->thing_word = HEADER_SUB_BITS;
-    sb->is_writable = 1;
-    sb->orig = make_bitstring(br);
+    erl_sub_bits_init(sb,
+                      ERL_SUB_BITS_FLAGS_WRITABLE,
+                      make_boxed((Eterm*)br),
+                      &bin->orig_bytes[0],
+                      0,
+                      current_size);
 
     *brp = br;
     *sbp = sb;
@@ -1542,8 +1524,8 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
 	goto not_writable;
     }
     sb = (ErlSubBits*)ptr;
-    if (!sb->is_writable) {
-	goto not_writable;
+    if (!erl_sub_bits_is_writable(sb)) {
+        goto not_writable;
     }
 
     br = (BinRef *) boxed_val(sb->orig);
@@ -1557,8 +1539,8 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
     /*
      * OK, the binary is writable.
      */
-
-    erts_bin_offset = sb->size;
+    ASSERT(sb->start == 0);
+    erts_bin_offset = sb->end;
     if (unit > 1) {
 	if ((unit == 8 && (erts_bin_offset & 7) != 0) ||
 	    (unit != 8 && (erts_bin_offset % unit) != 0)) {
@@ -1584,9 +1566,9 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
     used_size_in_bits = erts_bin_offset + build_size_in_bits;
 
     /* Make sure that no one else can append to the incoming bitstring. */
-    sb->is_writable = 0;
+    erl_sub_bits_clear_writable(sb);
 
-    update_wb_overhead(c_p, br, sb->size, used_size_in_bits);
+    update_wb_overhead(c_p, br, sb->end, used_size_in_bits);
     binp->intern.flags |= BIN_FLAG_ACTIVE_WRITER;
 
     /* Reallocate the underlying binary if it is too small. */
@@ -1595,13 +1577,12 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
 
         binp = erts_bin_realloc(binp, new_size);
         br->val = binp;
-        br->bytes = (byte*)binp->orig_bytes;
 
         BUMP_REDS(c_p, erts_bin_offset / BITS_PER_REDUCTION);
     }
 
     binp->intern.apparent_size = NBYTES(used_size_in_bits);
-    erts_current_bin = br->bytes;
+    erts_current_bin = (byte*)binp->orig_bytes;
 
     /* Allocate heap space and build a new sub binary. */
     reg[live] = sb->orig;
@@ -1611,12 +1592,15 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
         (void)erts_garbage_collect(c_p, heap_need, reg, live + 1);
     }
 
-    sb = (ErlSubBits *) c_p->htop;
+    sb = (ErlSubBits*)c_p->htop;
     c_p->htop += ERL_SUB_BITS_SIZE;
-    sb->thing_word = HEADER_SUB_BITS;
-    ERTS_SET_SB_RANGE(sb, 0, used_size_in_bits);
-    sb->is_writable = 1;
-    sb->orig = reg[live];
+
+    erl_sub_bits_init(sb,
+                      ERL_SUB_BITS_FLAGS_WRITABLE,
+                      reg[live],
+                      erts_current_bin,
+                      0,
+                      used_size_in_bits);
 
     return make_bitstring(sb);
 
@@ -1638,7 +1622,7 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
             bin = reg[live];
         }
 
-        /* Calculate sizes. The size of the new binary, is the sum of the
+        /* Calculate sizes. The size of the new binary is the sum of the
          * build size and the size of the old binary. Allow some room
          * for growing. */
         ERTS_GET_BITSTRING(bin, src_bytes, src_offset, src_size);
@@ -1671,6 +1655,7 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
                                  &c_p->htop,
                                  erts_bin_nrml_alloc(MAX(alloc_size, 256)),
                                  used_size_in_bits,
+                                 used_size_in_bits,
                                  &br,
                                  &sb);
 
@@ -1683,8 +1668,6 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
                               src_offset,
                               src_size);
         BUMP_REDS(c_p, src_size / BITS_PER_REDUCTION);
-
-        ERTS_SET_SB_RANGE(sb, 0, used_size_in_bits);
 
         return make_bitstring(sb);
     }
@@ -1732,7 +1715,8 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
     ASSERT(br->thing_word == HEADER_BIN_REF);
 
     /* Calculate new size in bits. */
-    erts_bin_offset = sb->size;
+    ASSERT(sb->start == 0);
+    erts_bin_offset = sb->end;
 
     if((ERTS_UINT_MAX - build_size_in_bits) < erts_bin_offset) {
         p->fvalue = am_size;
@@ -1743,7 +1727,7 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
     refc_binary = br->val;
 
     new_position = erts_bin_offset + build_size_in_bits;
-    update_wb_overhead(p, br, sb->size, new_position);
+    update_wb_overhead(p, br, sb->end, new_position);
 
     used_size = NBYTES(new_position);
     new_size = GROW_PROC_BIN_SIZE(used_size);
@@ -1752,15 +1736,20 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
         /* This is the normal case - the binary is writable. There are no other
          * references to the binary, so it is safe to reallocate it when it's
          * too small. */
-        ASSERT(sb->is_writable);
+        ASSERT(erl_sub_bits_is_writable(sb));
         ASSERT(erts_refc_read(&refc_binary->intern.refc, 1) == 1);
         if (refc_binary->orig_size < used_size) {
             refc_binary = erts_bin_realloc(refc_binary, new_size);
             br->val = refc_binary;
-            br->bytes = (byte*)refc_binary->orig_bytes;
 
             BUMP_REDS(p, erts_bin_offset / BITS_PER_REDUCTION);
         }
+
+        ASSERT(sb->start == 0);
+        sb->end = new_position;
+
+        refc_binary->intern.flags |= BIN_FLAG_ACTIVE_WRITER;
+        refc_binary->intern.apparent_size = used_size;
     } else {
         /* The binary is NOT writable. The only way that this can happen is
          * when call tracing is turned on, which means that a trace process now
@@ -1776,7 +1765,13 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
         Binary *new_binary = erts_bin_nrml_alloc(new_size);
         Eterm *hp = HeapFragOnlyAlloc(p, ERL_REFC_BITS_SIZE);
 
-        build_writable_bitstring(p, &hp, new_binary, new_position, &br, &sb);
+        build_writable_bitstring(p,
+                                 &hp,
+                                 new_binary,
+                                 new_position,
+                                 new_position,
+                                 &br,
+                                 &sb);
 
         sys_memcpy(new_binary->orig_bytes,
                    refc_binary->orig_bytes,
@@ -1786,12 +1781,8 @@ erts_bs_private_append_checked(Process* p, Eterm bin, Uint build_size_in_bits, U
         refc_binary = new_binary;
     }
 
-    refc_binary->intern.flags = BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER;
-    refc_binary->intern.apparent_size = used_size;
-
-    ERTS_SET_SB_RANGE(sb, 0, new_position);
-
-    erts_current_bin = br->bytes;
+    ASSERT(refc_binary->intern.flags & BIN_FLAG_WRITABLE);
+    erts_current_bin = (byte*)&refc_binary->orig_bytes[0];
 
     return make_bitstring(sb);
 }
@@ -1800,6 +1791,7 @@ Eterm
 erts_bs_init_writable(Process* p, Eterm sz)
 {
     Uint bin_size = 1024;
+    Binary *refc_binary;
     ErlSubBits *sb;
     BinRef *br;
 
@@ -1814,50 +1806,51 @@ erts_bs_init_writable(Process* p, Eterm sz)
         (void)erts_garbage_collect(p, ERL_REFC_BITS_SIZE, NULL, 0);
     }
 
+    refc_binary = erts_bin_nrml_alloc(bin_size);
     build_writable_bitstring(p,
                              &p->htop,
-                             erts_bin_nrml_alloc(bin_size),
+                             refc_binary,
+                             0,
                              bin_size * 8,
                              &br, &sb);
-    ERTS_SET_SB_RANGE(sb, 0, 0);
     (void)br;
 
     return make_bitstring(sb);
 }
 
-int erts_pin_writable_binary(BinRef *br) {
-    enum binary_flags flags;
-    Binary *refc_binary;
+void erts_pin_writable_binary(ErlSubBits *sb, BinRef *br) {
+    if (erl_sub_bits_was_writable(sb)) {
+        enum binary_flags flags;
+        Binary *refc_binary;
 
-    refc_binary = br->val;
-    flags = refc_binary->intern.flags;
+        refc_binary = br->val;
+        flags = refc_binary->intern.flags;
 
-    if (flags & (BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)) {
-        Uint apparent_size = refc_binary->intern.apparent_size;
+        if (flags & (BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)) {
+            Uint apparent_size = refc_binary->intern.apparent_size;
 
-        ASSERT(refc_binary->orig_size >= apparent_size);
-        ASSERT((flags & ~(BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)) == 0);
-        ASSERT(erts_refc_read(&refc_binary->intern.refc, 1) == 1);
+            ASSERT(refc_binary->orig_size >= apparent_size);
+            ASSERT(!(flags & ~(BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)));
+            ASSERT(erts_refc_read(&refc_binary->intern.refc, 1) == 1);
 
-        refc_binary->intern.flags = 0;
+            refc_binary->intern.flags = 0;
 
-        /* Our allocators are 8 byte aligned, i.e., shrinking with less than 8
-         * bytes will have no real effect */
-        if (refc_binary->orig_size - apparent_size >= 8) {
-            refc_binary = erts_bin_realloc(refc_binary, apparent_size);
-
-            br->val = refc_binary;
-            br->bytes = (byte*)refc_binary->orig_bytes;
-
-            return 1;
+            /* Our allocators are 8 byte aligned, i.e., shrinking with less
+             * than 8 bytes will have no real effect */
+            if (refc_binary->orig_size - apparent_size >= 8) {
+                refc_binary = erts_bin_realloc(refc_binary, apparent_size);
+                br->val = refc_binary;
+            }
         }
+
+        sb->base_flags = (UWord)refc_binary->orig_bytes;
     }
 
-    return 0;
+    ASSERT(erl_sub_bits_is_normal(sb));
 }
 
 Uint32
-erts_bs_get_unaligned_uint32(ErlBinMatchBuffer* mb)
+erts_bs_get_unaligned_uint32(ErlSubBits* sb)
 {
     Uint bytes;
     Uint offs;
@@ -1865,9 +1858,9 @@ erts_bs_get_unaligned_uint32(ErlBinMatchBuffer* mb)
     byte* LSB;
     byte* MSB;
 	
-    CHECK_MATCH_BUFFER(mb);
-    ASSERT((mb->offset & 7) != 0);
-    ASSERT(mb->size - mb->offset >= 32);
+    CHECK_MATCH_BUFFER(sb);
+    ASSERT((sb->start & 7) != 0);
+    ASSERT(sb->end - sb->start >= 32);
 
     bytes = 4;
     offs = 0;
@@ -1876,14 +1869,14 @@ erts_bs_get_unaligned_uint32(ErlBinMatchBuffer* mb)
     MSB = LSB + bytes - 1;
 
     *MSB = 0;
-    erts_copy_bits(mb->base, mb->offset, 1, MSB, offs, -1, 32);
+    erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1, MSB, offs, -1, 32);
     return LSB[0] | (LSB[1]<<8) | (LSB[2]<<16) | (LSB[3]<<24);
 }
 
 static void
-erts_align_utf8_bytes(ErlBinMatchBuffer* mb, byte* buf)
+erts_align_utf8_bytes(ErlSubBits *sb, byte* buf)
 {
-    Uint bits = mb->size - mb->offset;
+    Uint bits = sb->end - sb->start;
 
     /*
      * Copy up to 4 bytes into the supplied buffer.
@@ -1899,15 +1892,15 @@ erts_align_utf8_bytes(ErlBinMatchBuffer* mb, byte* buf)
     } else {
 	bits = 16;
     }
-    erts_copy_bits(mb->base, mb->offset, 1, buf, 0, 1, bits);
+    erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1, buf, 0, 1, bits);
 }
 
 Eterm
-erts_bs_get_utf8(ErlBinMatchBuffer* mb)
+erts_bs_get_utf8(ErlSubBits *sb)
 {
     Eterm result;
     Uint remaining_bits;
-    byte* pos;
+    const byte *pos;
     byte tmp_buf[4];
     Eterm a, b, c;
 
@@ -1925,22 +1918,22 @@ erts_bs_get_utf8(ErlBinMatchBuffer* mb)
 	2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,9,9,9,9,9,9,9,9
     };
 
-    CHECK_MATCH_BUFFER(mb);
+    CHECK_MATCH_BUFFER(sb);
 
-    if ((remaining_bits = mb->size - mb->offset) < 8) {
+    if ((remaining_bits = sb->end - sb->start) < 8) {
 	return THE_NON_VALUE;
     }
-    if (BIT_OFFSET(mb->offset) == 0) {
-	pos = mb->base + BYTE_OFFSET(mb->offset);
+    if (BIT_OFFSET(sb->start) == 0) {
+	pos = erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start);
     } else {
-	erts_align_utf8_bytes(mb, tmp_buf);
+	erts_align_utf8_bytes(sb, tmp_buf);
 	pos = tmp_buf;
     }
     result = pos[0];
     switch (erts_trailing_bytes_for_utf8[result]) {
       case 0:
 	/* One byte only */
-	mb->offset += 8;
+	sb->start += 8;
 	break;
       case 1:
 	/* Two bytes */
@@ -1952,7 +1945,7 @@ erts_bs_get_utf8(ErlBinMatchBuffer* mb)
 	    return THE_NON_VALUE;
 	}
 	result = (result << 6) + a - (Eterm) 0x00003080UL;
-	mb->offset += 16;
+	sb->start += 16;
 	break;
       case 2:
 	/* Three bytes */
@@ -1969,7 +1962,7 @@ erts_bs_get_utf8(ErlBinMatchBuffer* mb)
 	if (0xD800 <= result && result <= 0xDFFF) {
 	    return THE_NON_VALUE;
 	}
-	mb->offset += 24;
+	sb->start += 24;
 	break;
       case 3:
 	/* Four bytes */
@@ -1989,7 +1982,7 @@ erts_bs_get_utf8(ErlBinMatchBuffer* mb)
 	if (result > 0x10FFFF) {
 	    return THE_NON_VALUE;
 	}
-	mb->offset += 32;
+	sb->start += 32;
 	break;
       default:
 	return THE_NON_VALUE;
@@ -1998,10 +1991,10 @@ erts_bs_get_utf8(ErlBinMatchBuffer* mb)
 }
 
 Eterm
-erts_bs_get_utf16(ErlBinMatchBuffer* mb, Uint flags)
+erts_bs_get_utf16(ErlSubBits *sb, Uint flags)
 {
     Uint bit_offset;
-    Uint num_bits = mb->size - mb->offset;
+    Uint num_bits = sb->end - sb->start;
     byte* src;
     byte tmp_buf[4];
     Uint16 w1;
@@ -2011,20 +2004,21 @@ erts_bs_get_utf16(ErlBinMatchBuffer* mb, Uint flags)
 	return THE_NON_VALUE;
     }
 
-    CHECK_MATCH_BUFFER(mb);
+    CHECK_MATCH_BUFFER(sb);
     /*
      * Set up the pointer to the source bytes.
      */
-    if ((bit_offset = BIT_OFFSET(mb->offset)) == 0) {
+    if ((bit_offset = BIT_OFFSET(sb->start)) == 0) {
 	/* We can access the binary directly because the bytes are aligned. */
-	src = mb->base + BYTE_OFFSET(mb->offset);
+	src = erl_sub_bits_get_base(sb) + BYTE_OFFSET(sb->start);
     } else {
 	/*
 	 * We must copy the data to a temporary buffer. If possible,
 	 * get 4 bytes, otherwise two bytes.
 	 */
 	Uint n = num_bits < 32 ? 16 : 32;
-	erts_copy_bits(mb->base, mb->offset, 1, tmp_buf, 0, 1, n);
+	erts_copy_bits(erl_sub_bits_get_base(sb), sb->start, 1,
+                       tmp_buf, 0, 1, n);
 	src = tmp_buf;
     }
     
@@ -2037,7 +2031,7 @@ erts_bs_get_utf16(ErlBinMatchBuffer* mb, Uint flags)
 	w1 = (src[0] << 8) | src[1];
     }
     if (w1 < 0xD800 || w1 > 0xDFFF) {
-	mb->offset += 16;
+	sb->start += 16;
 	return make_small(w1);
     } else if (w1 > 0xDBFF) {
 	return THE_NON_VALUE;
@@ -2056,7 +2050,7 @@ erts_bs_get_utf16(ErlBinMatchBuffer* mb, Uint flags)
     if (!(0xDC00 <= w2 && w2 <= 0xDFFF)) {
 	return THE_NON_VALUE;
     }
-    mb->offset += 32;
+    sb->start += 32;
     return make_small((((w1 & 0x3FF) << 10) | (w2 & 0x3FF)) + 0x10000UL);
 }
 
@@ -2304,15 +2298,25 @@ Eterm erts_build_sub_bitstring(Eterm **hp,
         return result;
     } else {
         ErlSubBits *sb = (ErlSubBits*)*hp;
-        *hp += ERL_SUB_BITS_SIZE;
+        UWord flags = 0;
 
         ASSERT(br && ((br_flags & _TAG_PRIMARY_MASK) == TAG_PRIMARY_BOXED));
 
-        sb->thing_word = HEADER_SUB_BITS;
-        ERTS_SET_SB_RANGE(sb, offset, size);
-        sb->orig = ((Eterm)br) | br_flags;
-        sb->is_writable = 0;
+        /* If the underlying binary is writable, we have to mark the result as
+         * volatile. We can skip this indirection once the flags move into
+         * br_flags. */
+        if ((br->val)->intern.flags & BIN_FLAG_WRITABLE) {
+            flags |= ERL_SUB_BITS_FLAG_VOLATILE;
+        }
 
+        erl_sub_bits_init(sb,
+                          flags,
+                          ((Eterm)br) | br_flags,
+                          base,
+                          offset,
+                          size);
+
+        *hp += ERL_SUB_BITS_SIZE;
         return make_bitstring(sb);
     }
 }
@@ -2327,18 +2331,26 @@ Eterm erts_wrap_refc_bitstring(struct erl_off_heap_header **oh,
 {
     ErlSubBits *sb = (ErlSubBits*)&(*hpp)[ERL_BIN_REF_SIZE];
     BinRef *br = (BinRef*)*hpp;
+    UWord flags = 0;
 
     ASSERT(bin != NULL);
 
     br->thing_word = HEADER_BIN_REF;
     br->next = (*oh);
     br->val = bin;
-    br->bytes = bytes;
 
-    sb->thing_word = HEADER_SUB_BITS;
-    sb->is_writable = 0;
-    sb->orig = make_boxed((Eterm*)br);
-    ERTS_SET_SB_RANGE(sb, offset, size);
+    /* If the underlying binary is writable, we have to mark the result as
+     * volatile. */
+    if (bin->intern.flags & BIN_FLAG_WRITABLE) {
+        flags |= ERL_SUB_BITS_FLAG_VOLATILE;
+    }
+
+    erl_sub_bits_init(sb,
+                      flags,
+                      make_boxed((Eterm*)br),
+                      bytes,
+                      offset,
+                      size);
 
     *oh = (struct erl_off_heap_header*)br;
     *overhead += size / NBITS(sizeof(Eterm));
@@ -2400,7 +2412,7 @@ erts_hfact_new_bitstring(ErtsHeapFactory *hfact, Uint reserve_size,
                                                           reserve_size);
 
         hb->thing_word = header_heap_bits(size);
-        ERTS_SET_HB_SIZE(hb, size);
+        hb->size = size;
 
         *datap = (byte*)hb->data;
 
@@ -2451,7 +2463,7 @@ erts_new_bitstring_refc(Process *p, Uint size, Binary **binp, byte **datap)
 
         hb = (ErlHeapBits *)HAlloc(p, heap_bits_size(size));
         hb->thing_word = header_heap_bits(size);
-        ERTS_SET_HB_SIZE(hb, size);
+        hb->size = size;
 
         *datap = (byte*)hb->data;
 
@@ -2521,19 +2533,21 @@ erts_shrink_binary_term(Eterm binary, size_t size)
     if (thing_subtag(*ptr) == HEAP_BITS_SUBTAG) {
         ErlHeapBits *hb = (ErlHeapBits*)ptr;
         ASSERT(TAIL_BITS(hb->size) == 0 && hb->size >= NBITS(size));
-        ERTS_SET_HB_SIZE(hb, NBITS(size));
+        hb->size = NBITS(size);
     } else {
         ErlSubBits *sb = (ErlSubBits*)ptr;
         BinRef *br = (BinRef*)boxed_val(sb->orig);
 
-        ASSERT(TAIL_BITS(sb->size) == 0 && sb->size >= NBITS(size));
-        ERTS_SET_SB_RANGE(sb, sb->offs, NBITS(size));
+        ASSERT(erl_sub_bits_is_normal(sb));
+        ASSERT(TAIL_BITS(sb->end) == 0 && sb->end >= NBITS(size));
+        ASSERT(sb->start == 0);
+        sb->end = NBITS(size);
 
         /* Our allocators are 8-byte aligned, so don't bother reallocating for
          * differences smaller than that. */
-        if (size < (NBYTES(sb->size) + 8)) {
+        if (size < (NBYTES(sb->end) + 8)) {
             br->val = erts_bin_realloc(br->val, size);
-            br->bytes = (byte*)(br->val)->orig_bytes;
+            sb->base_flags = (UWord)&(br->val)->orig_bytes[0];
         }
     }
 

--- a/erts/emulator/beam/erl_debug.c
+++ b/erts/emulator/beam/erl_debug.c
@@ -189,9 +189,6 @@ pdisplay1(fmtfn_t to, void *to_arg, Process* p, Eterm obj)
     case BITSTRING_DEF:
 	erts_print(to, to_arg, "#Bin");
 	break;
-    case MATCHSTATE_DEF:
-        erts_print(to, to_arg, "#Matchstate");
-        break;
     case BIN_REF_DEF:
         erts_print(to, to_arg, "#BinRef");
         break;

--- a/erts/emulator/beam/erl_etp.c
+++ b/erts/emulator/beam/erl_etp.c
@@ -92,7 +92,6 @@ const Eterm etp_hole_marker = 0;
 #endif
 
 const Eterm etp_arityval_subtag = ARITYVAL_SUBTAG;
-const Eterm etp_bin_matchstate_subtag = BIN_MATCHSTATE_SUBTAG;
 const Eterm etp_big_tag_mask = _BIG_TAG_MASK;
 const Eterm etp_big_sign_bit = _BIG_SIGN_BIT;
 const Eterm etp_pos_big_subtag = POS_BIG_SUBTAG;
@@ -122,7 +121,6 @@ const Eterm etp_tag_header_sub_bits = _TAG_HEADER_SUB_BITS;
 const Eterm etp_tag_header_external_pid = _TAG_HEADER_EXTERNAL_PID;
 const Eterm etp_tag_header_external_port = _TAG_HEADER_EXTERNAL_PORT;
 const Eterm etp_tag_header_external_ref = _TAG_HEADER_EXTERNAL_REF;
-const Eterm etp_tag_header_bin_matchstate = _TAG_HEADER_BIN_MATCHSTATE;
 const Eterm etp_tag_header_map = _TAG_HEADER_MAP;
 
 const Eterm etp_tag_header_mask = _TAG_HEADER_MASK;

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -66,9 +66,6 @@ ERTS_GLB_INLINE Eterm* move_boxed(Eterm *ERTS_RESTRICT ptr, Eterm hdr, Eterm **h
     ASSERT(is_header(hdr));
     nelts = header_arity(hdr);
     switch ((hdr) & _HEADER_SUBTAG_MASK) {
-    case SUB_BITS_SUBTAG:
-        nelts++;
-        break;
     case MAP_SUBTAG:
         if (is_flatmap_header(hdr)) nelts+=flatmap_get_size(ptr) + 1;
         else nelts += hashmap_bitcount(MAP_HEADER_VAL(hdr));

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -3383,8 +3383,6 @@ BIF_RETTYPE erts_internal_term_type_1(BIF_ALIST_1) {
                     BIF_RET(ERTS_MAKE_AM("heap_binary"));
                 case SUB_BITS_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("sub_binary"));
-                case BIN_MATCHSTATE_SUBTAG:
-                    BIF_RET(ERTS_MAKE_AM("matchstate"));
                 case POS_BIG_SUBTAG:
                 case NEG_BIG_SUBTAG:
                     BIF_RET(ERTS_MAKE_AM("bignum"));

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -4160,10 +4160,7 @@ static int fill_iovec_with_slice(ErlNifEnv *env,
             br->next = MSO(env->proc).first;
             MSO(env->proc).first = (struct erl_off_heap_header*)br;
             br->val = bin;
-            br->bytes = (byte*) bin->orig_bytes;
             ERTS_BR_OVERHEAD(&MSO(env->proc), br);
-
-            return make_bitstring(br);
         }
     }
 

--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -772,9 +772,6 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
             }
             break;
         }
-	case MATCHSTATE_DEF:
-	    PRINT_STRING(res, fn, arg, "#MatchState");
-	    break;
 	case BIN_REF_DEF:
 	    PRINT_STRING(res, fn, arg, "#BinRef");
 	    break;

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -7284,12 +7284,11 @@ area_literal_size(Eterm* start, Eterm* end, char* lit_start, Uint lit_size)
             break;
         case TAG_PRIMARY_HEADER:
             if (!header_is_transparent(val)) {
-                Eterm* new_p;
-                if (header_is_bin_matchstate(val)) {
-                    ErlBinMatchState *ms = (ErlBinMatchState*) p;
-                    ErlBinMatchBuffer *mb = &(ms->mb);
-                    if (ErtsInArea(mb->orig, lit_start, lit_size)) {
-                        sz += size_object(mb->orig);
+                Eterm *new_p;
+                if (val == HEADER_SUB_BITS) {
+                    ErlSubBits *sb = (ErlSubBits*) p;
+                    if (ErtsInArea(sb->orig, lit_start, lit_size)) {
+                        sz += size_object(sb->orig);
                     }
                 }
                 new_p = p + thing_arityval(val);
@@ -7323,16 +7322,20 @@ area_literal_copy(Eterm **hpp, ErlOffHeap *ohp,
         case TAG_PRIMARY_HEADER:
             if (!header_is_transparent(val)) {
                 Eterm* new_p;
-                /* matchstate in message, not possible. */
-                if (header_is_bin_matchstate(val)) {
-                    ErlBinMatchState *ms = (ErlBinMatchState*) p;
-                    ErlBinMatchBuffer *mb = &(ms->mb);
-                    if (ErtsInArea(mb->orig, lit_start, lit_size)) {
-                        sz = size_object(mb->orig);
-                        mb->orig = copy_struct(mb->orig, sz, hpp, ohp);
-                    }
+
+                if (val == HEADER_SUB_BITS) {
+                    /* Match contexts and writable binaries should never be
+                     * present in signals. */
+                    ASSERT(erl_sub_bits_is_normal((ErlSubBits*)p));
+
+                    /* Make sure to copy the `orig` field if needed. It's the
+                     * last field inside the thing structure so we can handle
+                     * it by pretending it's not part of the thing. */
+                    new_p = p + thing_arityval(val) - 1;
+                } else {
+                    new_p = p + thing_arityval(val);
                 }
-                new_p = p + thing_arityval(val);
+
                 ASSERT(start <= new_p && new_p < end);
                 p = new_p;
             }

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -1042,9 +1042,6 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                     size += hashmap_bitcount(MAP_HEADER_VAL(w));
                 }
                 break;
-            case SUB_BITS_SUBTAG:
-                size += 1;
-                break;
             }
             break;
         default:

--- a/erts/emulator/beam/erl_term.c
+++ b/erts/emulator/beam/erl_term.c
@@ -115,7 +115,6 @@ erts_term_init(void)
         /* Check that the tag masks cannot confuse tags outside of their
          * category. */
         const Eterm tags[] = {ARITYVAL_SUBTAG,
-                              BIN_MATCHSTATE_SUBTAG,
                               POS_BIG_SUBTAG,
                               NEG_BIG_SUBTAG,
                               REF_SUBTAG,

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -124,7 +124,7 @@ struct erl_node_; /* Declared in erl_node_tables.h */
  * XXX: globally replace XXX_SUBTAG with TAG_HEADER_XXX
  */
 #define ARITYVAL_SUBTAG         (0x0 << _TAG_PRIMARY_SIZE) /* TUPLE */
-#define BIN_MATCHSTATE_SUBTAG   (0x1 << _TAG_PRIMARY_SIZE)
+/* (0x1 << _TAG_PRIMARY_SIZE)                                 FREE  */
 #define _BIG_TAG_MASK           (~(0x1 << _TAG_PRIMARY_SIZE) & _TAG_HEADER_MASK)
 #define _BIG_SIGN_BIT           (0x1 << _TAG_PRIMARY_SIZE)
 #define POS_BIG_SUBTAG          (0x2 << _TAG_PRIMARY_SIZE) /* BIGNUM */
@@ -155,7 +155,6 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 #define _TAG_HEADER_EXTERNAL_PID   (TAG_PRIMARY_HEADER|EXTERNAL_PID_SUBTAG)
 #define _TAG_HEADER_EXTERNAL_PORT  (TAG_PRIMARY_HEADER|EXTERNAL_PORT_SUBTAG)
 #define _TAG_HEADER_EXTERNAL_REF   (TAG_PRIMARY_HEADER|EXTERNAL_REF_SUBTAG)
-#define _TAG_HEADER_BIN_MATCHSTATE (TAG_PRIMARY_HEADER|BIN_MATCHSTATE_SUBTAG)
 #define _TAG_HEADER_MAP	           (TAG_PRIMARY_HEADER|MAP_SUBTAG)
 
 
@@ -167,7 +166,6 @@ struct erl_node_; /* Declared in erl_node_tables.h */
  (((x) & (_HEADER_SUBTAG_MASK)) == ARITYVAL_SUBTAG)
 #define header_is_arityval(x)	(((x) & _HEADER_SUBTAG_MASK) == ARITYVAL_SUBTAG)
 #define header_is_thing(x)	(!header_is_transparent((x)))
-#define header_is_bin_matchstate(x)	((((x) & (_HEADER_SUBTAG_MASK)) == BIN_MATCHSTATE_SUBTAG))
 
 #define _CPMASK		0x3
 
@@ -1421,8 +1419,7 @@ _ET_DECLARE_CHECKED(Uint,loader_y_reg_index,Uint)
 #define FLOAT_DEF		0xe
 #define BIG_DEF			0xf
 #define SMALL_DEF		0x10
-#define MATCHSTATE_DEF          0x11   /* not a "real" term */
-#define BIN_REF_DEF             0x12   /* not a "real" term */
+#define BIN_REF_DEF             0x11   /* not a "real" term */
 
 #define FIRST_VACANT_TAG_DEF    0x13
 
@@ -1492,7 +1489,6 @@ ERTS_GLB_INLINE unsigned tag_val_def(Wterm x)
 	    case (_TAG_HEADER_BIN_REF >> _TAG_PRIMARY_SIZE):	return BIN_REF_DEF;
 	    case (_TAG_HEADER_HEAP_BITS >> _TAG_PRIMARY_SIZE):	return BITSTRING_DEF;
 	    case (_TAG_HEADER_SUB_BITS >> _TAG_PRIMARY_SIZE):	return BITSTRING_DEF;
-	    case (_TAG_HEADER_BIN_MATCHSTATE >> _TAG_PRIMARY_SIZE): return MATCHSTATE_DEF;
 	  }
 
 	  break;

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -2642,7 +2642,6 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
                     result_ref = (BinRef*)hp;
                     result_ref->thing_word = HEADER_BIN_REF;
                     result_ref->val = result_bin;
-                    result_ref->bytes = (byte*)result_bin->orig_bytes;
                     hp += ERL_BIN_REF_SIZE;
                     referenced_cbin = 0;
 
@@ -2666,16 +2665,17 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
                             /* If the term refers to the entire segment, we can
                              * use it as is. Otherwise we need to return a
                              * shrunken copy. */
-                            if (from_sb->size != NBITS(iovp->iov_len)) {
+                            if (NBITS(iovp->iov_len) != (from_sb->end -
+                                                         from_sb->start)) {
                                 ErlSubBits *to_sb = (ErlSubBits*)hp;
 
                                 segment = make_bitstring(to_sb);
                                 hp += ERL_SUB_BITS_SIZE;
 
                                 *to_sb = *from_sb;
-                                to_sb->size = NBITS(iovp->iov_len);
+                                to_sb->end = to_sb->start + NBITS(iovp->iov_len);
 
-                                ASSERT(to_sb->size < from_sb->size);
+                                ASSERT(to_sb->end < from_sb->end);
                             }
                         } else {
                             /* We don't have a term and need to create one now,
@@ -2697,11 +2697,12 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
 
                             ASSERT(IS_BINARY_SIZE_OK(iov_offset));
 
-                            sb->thing_word = HEADER_SUB_BITS;
-                            ERTS_SET_SB_RANGE(sb,
+                            erl_sub_bits_init(sb,
+                                              0,
+                                              make_boxed((Eterm*)result_ref),
+                                              result_bin->orig_bytes,
                                               NBITS(iov_offset),
                                               NBITS(iovp->iov_len));
-                            sb->orig = make_bitstring(result_ref);
 
                             segment = make_bitstring(sb);
                             hp += ERL_SUB_BITS_SIZE;
@@ -5119,6 +5120,8 @@ dec_term_atom_common:
 
                     sys_memcpy(sb, ep, sizeof(ErlSubBits) + sizeof(BinRef));
                     ep += sizeof(ErlSubBits) + sizeof(BinRef);
+
+                    sb->orig = make_boxed((Eterm*)br);
                 } else {
                     /* The encoded bitstring can be described entirely from the
                      * wrapped Binary* object, so we've skipped encoding an
@@ -5126,9 +5129,12 @@ dec_term_atom_common:
                     sys_memcpy(br, ep, sizeof(BinRef));
                     ep += sizeof(BinRef);
 
-                    sb->thing_word = HEADER_SUB_BITS;
-                    ERTS_SET_SB_RANGE(sb, 0, NBITS((br->val)->orig_size));
-                    sb->is_writable = 0;
+                    erl_sub_bits_init(sb,
+                                      0,
+                                      make_boxed((Eterm*)br),
+                                      &(br->val)->orig_bytes[0],
+                                      0,
+                                      NBITS((br->val)->orig_size));
                 }
 
                 erts_refc_inc(&(br->val)->intern.refc, 1);
@@ -5136,8 +5142,6 @@ dec_term_atom_common:
                 br->next = (factory->off_heap)->first;
                 (factory->off_heap)->first = (struct erl_off_heap_header*)br;
                 ERTS_BR_OVERHEAD(factory->off_heap, br);
-
-                sb->orig = make_boxed((Eterm*)br);
                 *objp = make_bitstring(sb);
                 break;
             }

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -842,8 +842,9 @@ class BeamModuleAssembler : public BeamAssembler,
     /* Save the last known unreachable position. */
     size_t last_unreachable_offset = 0;
 
-    /* Mark this point unreachable. Use at the end of a BEAM
-     * instruction. */
+    /* Mark this point unreachable. This must be placed at the very end when
+     * used in a BEAM instruction, and should not be used in helper
+     * functions. */
     void mark_unreachable() {
         last_unreachable_offset = a.offset();
     }

--- a/erts/emulator/beam/jit/arm/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.cpp
@@ -247,8 +247,6 @@ void BeamModuleAssembler::emit_raise_exception(const ErtsCodeMFA *exp) {
         fragment_call(ga->get_raise_exception_null_exp());
     }
 
-    mark_unreachable();
-
     /* `line` instructions need to know the latest offset that may throw an
      * exception. See the `line` instruction for details. */
     last_error_offset = a.offset();

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -2322,22 +2322,27 @@ void BeamModuleAssembler::emit_is_int_ge(ArgLabel const &Fail,
 
 void BeamModuleAssembler::emit_badmatch(const ArgSource &Src) {
     emit_error(BADMATCH, Src);
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_case_end(const ArgSource &Src) {
     emit_error(EXC_CASE_CLAUSE, Src);
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_system_limit_body() {
     emit_error(SYSTEM_LIMIT);
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_if_end() {
     emit_error(EXC_IF_CLAUSE);
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_badrecord(const ArgSource &Src) {
     emit_error(EXC_BADRECORD, Src);
+    mark_unreachable();
 }
 
 void BeamModuleAssembler::emit_catch(const ArgYRegister &Y,

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -973,24 +973,26 @@ void BeamModuleAssembler::emit_is_binary(const ArgLabel &Fail,
     auto src = load_source(Src, ARG1);
 
     emit_is_boxed(resolve_beam_label(Fail, dispUnknown), Src, src.reg);
+    emit_untag_ptr(ARG1, src.reg);
+
+    ERTS_CT_ASSERT_FIELD_PAIR(ErlHeapBits, thing_word, size);
+    a.ldp(TMP1, TMP2, arm::Mem(ARG1));
+
+    Label not_sub_bits = a.newLabel();
+    a.cmp(TMP1, imm(HEADER_SUB_BITS));
+    a.b_ne(not_sub_bits);
+    {
+        ERTS_CT_ASSERT_FIELD_PAIR(ErlSubBits, start, end);
+        a.ldp(TMP2, TMP3, arm::Mem(ARG1, offsetof(ErlSubBits, start)));
+        a.sub(TMP2, TMP3, TMP2);
+    }
+    a.bind(not_sub_bits);
 
     if (masked_types<BeamTypeId::MaybeBoxed>(Src) == BeamTypeId::Bitstring) {
-        arm::Gp boxed_ptr = emit_ptr_val(ARG1, src.reg);
-
         comment("skipped header test since we know it's a bitstring when "
                 "boxed");
-
-        ERTS_CT_ASSERT(offsetof(ErlHeapBits, size) == sizeof(Eterm));
-        ERTS_CT_ASSERT(offsetof(ErlSubBits, size) == sizeof(Eterm));
-        a.ldur(TMP2, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
         a.tst(TMP2, imm(7));
     } else {
-        emit_untag_ptr(ARG1, src.reg);
-
-        ERTS_CT_ASSERT_FIELD_PAIR(ErlHeapBits, thing_word, size);
-        ERTS_CT_ASSERT_FIELD_PAIR(ErlSubBits, thing_word, size);
-        a.ldp(TMP1, TMP2, arm::Mem(ARG1));
-
         const auto mask = _BITSTRING_TAG_MASK & ~_TAG_PRIMARY_MASK;
         ERTS_CT_ASSERT(TAG_PRIMARY_HEADER == 0);
         ERTS_CT_ASSERT(_TAG_HEADER_HEAP_BITS == (_TAG_HEADER_HEAP_BITS & mask));
@@ -1449,19 +1451,6 @@ void BeamModuleAssembler::emit_is_eq_exact(const ArgLabel &Fail,
                                            const ArgSource &Y) {
     auto x = load_source(X, ARG1);
 
-    if (exact_type<BeamTypeId::Bitstring>(X) && Y.isLiteral()) {
-        Eterm literal = beamfile_get_literal(beam, Y.as<ArgLiteral>().get());
-
-        if (is_bitstring(literal) && bitstring_size(literal) == 0) {
-            comment("simplified equality test with empty binary");
-
-            arm::Gp boxed_ptr = emit_ptr_val(ARG1, x.reg);
-            a.ldur(TMP1, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
-            a.cbnz(TMP1, resolve_beam_label(Fail, disp1MB));
-            return;
-        }
-    }
-
     /* If either argument is known to be an immediate, we can fail immediately
      * if they're not equal. */
     if (always_immediate(X) || always_immediate(Y)) {
@@ -1521,20 +1510,6 @@ void BeamModuleAssembler::emit_is_ne_exact(const ArgLabel &Fail,
                                            const ArgSource &X,
                                            const ArgSource &Y) {
     auto x = load_source(X, ARG1);
-
-    if (exact_type<BeamTypeId::Bitstring>(X) && Y.isLiteral()) {
-        Eterm literal = beamfile_get_literal(beam, Y.as<ArgLiteral>().get());
-
-        if (is_bitstring(literal) && bitstring_size(literal) == 0) {
-            arm::Gp boxed_ptr = emit_ptr_val(ARG1, x.reg);
-
-            comment("simplified non-equality test with empty binary");
-            a.ldur(TMP1, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
-            a.cbz(TMP1, resolve_beam_label(Fail, disp1MB));
-
-            return;
-        }
-    }
 
     /* If either argument is known to be an immediate, we can fail immediately
      * if they're equal. */

--- a/erts/emulator/beam/jit/arm/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/instr_trace.cpp
@@ -215,4 +215,5 @@ void BeamModuleAssembler::emit_i_hibernate() {
 
     a.bind(error);
     emit_raise_exception(&BIF_TRAP_EXPORT(BIF_hibernate_3)->info.mfa);
+    mark_unreachable();
 }

--- a/erts/emulator/test/bs_bincomp_SUITE.erl
+++ b/erts/emulator/test/bs_bincomp_SUITE.erl
@@ -141,7 +141,7 @@ random_binary() ->
     << <<($a + rand:uniform($z - $a)):8>> || _ <- Seq >>.
 
 random_binaries(N) when N > 0 ->
-    random_binary(),
+    80 = bit_size(random_binary()),
     random_binaries(N - 1);
 random_binaries(_) -> ok.
 

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -122,9 +122,9 @@ test_size(Config) when is_list(Config) ->
 	{32, 18} -> ok;
 	{64, 10} -> ok
     end,
-    9 = do_test_size(<<0:(8*65)>>),    % ErlSubBits + BinRef
+    8 = do_test_size(<<0:(8*65)>>),    % ErlSubBits + BinRef
     3 = do_test_size(<<5:7>>),         % ErlHeapBits
-    9 = do_test_size(<<0:(8*80+1)>>),  % ErlSubBits + BinRef
+    8 = do_test_size(<<0:(8*80+1)>>),  % ErlSubBits + BinRef
 
     %% Test shared data structures.
     do_test_size([ConsCell1|ConsCell1],


### PR DESCRIPTION
This is a continuation of https://github.com/erlang/otp/pull/7828, unifying `ErlSubBits` and match contexts so that the compiler can treat the latter as an ordinary term that happens to be mutable. It will now be fine to pass them to functions like `bit_size/1` or even `binary:part/2,3`, as long the function doesn't alias the match context _itself_ it will work without a hitch.

It also means that if we _know_ that a term returned from a function won't be aliased (e.g. if it's immediately deconstructed), it will be safe to place a match context in there. We'll make the related changes to the compiler in a later PR.

(There's also a few things that have become slightly less efficient as a result of this. The plan is to fix them before RC1 but it'll take some time, and we want to get this out the door so that we can start work on the compiler in parallel.)