### PR TITLE
lib/crypto/c_src/openssl_config.h: fix build without DES

### DIFF
--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -202,14 +202,14 @@
 
 #ifndef OPENSSL_NO_DES
 # define HAVE_DES
-#endif
 
-#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION(0,9,7,'e')
-# define HAVE_DES_ede3_cfb
-#endif
+# if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION(0,9,7,'e')
+#  define HAVE_DES_ede3_cfb
+# endif
 
-#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION(0,9,7,'e')
-# define HAVE_DES_ede3_cbc
+# if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION(0,9,7,'e')
+#  define HAVE_DES_ede3_cbc
+# endif
 #endif
 
 #ifndef OPENSSL_NO_DH


### PR DESCRIPTION
Fix the following build failure without DES:

```
cipher.c:51:42: error: 'EVP_des_ede3_cbc' undeclared here (not in a function); did you mean 'SN_des_ede3_cbc'?
   51 |     {{"des_ede3_cbc"}, "des-ede3-cbc", {&EVP_des_ede3_cbc}, 0, 0},
      |                                          ^~~~~~~~~~~~~~~~
      |                                          SN_des_ede3_cbc
```

Fixes:
 - http://autobuild.buildroot.org/results/1aace0ee738f8ec4aa2c9a739fc7535c3b6bf884