### PR TITLE
compiler: Rewrite swap to move

### DIFF
--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -63,7 +63,8 @@ norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
     {put_map,F,Op,S,D,R,{list,Puts}};
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],{line,_}=Line}) -> Line;
-norm({set,[],[],{executable_line,_}=Line}) -> Line.
+norm({set,[],[],{executable_line,_}=Line}) -> Line;
+norm({set,[D1,D2],[D1,D2],swap})   -> {swap,D1,D2}.
 
 norm_allocate({_Zero,nostack,Nh,[]}, Regs) ->
     [{test_heap,Nh,Regs}];

--- a/lib/compiler/src/beam_trim.erl
+++ b/lib/compiler/src/beam_trim.erl
@@ -292,9 +292,6 @@ remap([{recv_marker_clear,Ref}|Is], Remap) ->
 remap([{recv_marker_reserve,Mark}|Is], Remap) ->
     I = {recv_marker_reserve,remap_arg(Mark, Remap)},
     [I|remap(Is, Remap)];
-remap([{swap,Reg1,Reg2}|Is], Remap) ->
-    I = {swap,remap_arg(Reg1, Remap),remap_arg(Reg2, Remap)},
-    [I|remap(Is, Remap)];
 remap([{test,Name,Fail,Ss}|Is], Remap) ->
     I = {test,Name,Fail,remap_args(Ss, Remap)},
     [I|remap(Is, Remap)];
@@ -547,12 +544,6 @@ do_usage([{recv_marker_clear,Src}|Is], Safe, Regs0, Ns, Acc) ->
     do_usage(Is, Safe, Regs, Ns, [U|Acc]);
 do_usage([{recv_marker_reserve,Src}|Is], Safe, Regs0, Ns, Acc) ->
     Regs = ordsets:union(Regs0, yregs([Src])),
-    U = {Regs,Ns},
-    do_usage(Is, Safe, Regs, Ns, [U|Acc]);
-do_usage([{swap,R1,R2}|Is], Safe, Regs0, Ns0, Acc) ->
-    Ds = yregs([R1,R2]),
-    Regs = ordsets:union(Regs0, Ds),
-    Ns = ordsets:union(Ns0, Ds),
     U = {Regs,Ns},
     do_usage(Is, Safe, Regs, Ns, [U|Acc]);
 do_usage([{test,_,Fail,Ss}|Is], Safe, Regs0, Ns, Acc) ->


### PR DESCRIPTION
When a simple instruction such as building a tuple or calling a non-garbage-collecting BIF is followed by a `swap` instruction, it is sometimes possible to replace the `swap` instruction with a `move` placed **before** the other instruction.

Here is an example of a guard BIF call:

    {bif,self,{f,0},[],{x,2}}.
    {swap,{x,1},{x,2}}.

which can be rewritten like so:

    {move,{x,1},{x,2}}.
    {bif,self,{f,0},[],{x,1}}.

The `make_fun3` instruction for creating a fun is frequently followed by a `swap` instruction:

    {make_fun3, ...}.
    {swap,{x,0},{x,2}}.

which can be replaced with a `move` instruction:

    {move,{x,0},{x,2}}.
    {make_fun3, ...}.

This optimization is worthwhile because a `move` instruction is generally cheaper than a `swap` instruction.