### PR TITLE
 jit: Optimize reference counting of local funs

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -1730,7 +1730,12 @@ call_fun(Process* p,    /* Current process. */
 
     if (ERTS_LIKELY(code_ptr != beam_unloaded_fun &&
                     fun_arity(funp) == arity)) {
-        for (int i = 0, num_free = fun_num_free(funp); i < num_free; i++) {
+        /* Copy the free variables, skipping the FunRef in the environment.
+         *
+         * Note that we avoid using fun_num_free as it asserts that the
+         * argument is a local function, which we don't need to care about
+         * here. */
+        for (int i = 0, num_free = fun_env_size(funp) - 1; i < num_free; i++) {
             reg[i + arity] = funp->env[i];
         }
 
@@ -1739,7 +1744,6 @@ call_fun(Process* p,    /* Current process. */
             DTRACE_LOCAL_CALL(p, erts_code_to_codemfa(code_ptr));
         } else {
             Export *ep = funp->entry.exp;
-            ASSERT(is_external_fun(funp) && funp->next == NULL);
             DTRACE_GLOBAL_CALL(p, &ep->info.mfa);
         }
 #endif

--- a/erts/emulator/beam/code_ix.h
+++ b/erts/emulator/beam/code_ix.h
@@ -277,12 +277,8 @@ int erts_has_code_stage_permission(void);
 int erts_has_code_mod_permission(void);
 #endif
 
-/* module/function/arity can be NIL/NIL/-1 when the MFA is pointing to some
-   invalid code, for instance unloaded_fun. */
 #define ASSERT_MFA(MFA)                                                 \
-    ASSERT((is_atom((MFA)->module) || is_nil((MFA)->module)) &&         \
-           (is_atom((MFA)->function) || is_nil((MFA)->function)) &&     \
-           (((MFA)->arity >= 0 && (MFA)->arity < 1024) || (MFA)->arity == -1))
+    ASSERT(is_atom((MFA)->module) && is_atom((MFA)->function))
 
 extern erts_atomic32_t the_active_code_index;
 extern erts_atomic32_t the_staging_code_index;

--- a/erts/emulator/beam/emu/instrs.tab
+++ b/erts/emulator/beam/emu/instrs.tab
@@ -541,16 +541,35 @@ i_init3(Y1, Y2, Y3) {
 }
 
 i_make_fun3(FunP, Dst, Arity, NumFree) {
-    ErlFunThing* funp;
     ErlFunEntry *fe = (ErlFunEntry *) $FunP;
     int i, num_free = $NumFree;
+    ErlFunThing* funp;
     //| -no_next
-    SWAPOUT;
-    funp = erts_new_local_fun_thing(c_p, fe, $Arity, num_free);
-    SWAPIN;
+
+    /* We add one word to account for the `FunRef` keeping our fun entry
+     * alive, it's kept as part of the environment. */
+    funp = (ErlFunThing*)HTOP;
+    HTOP += ERL_FUN_SIZE + num_free + 1;
+
+    funp->thing_word = MAKE_FUN_HEADER($Arity, num_free, 0);
+    funp->entry.fun = fe;
+
+#ifdef DEBUG
+    {
+        /* Note that `mfa` may be NULL if the fun is currently being purged. We
+         * ignore this since it's not an error and we only need `mfa` to
+         * sanity-check the arity at this point. If the fun is called while in
+         * this state, the `error_handler` module will take care of it. */
+        const ErtsCodeMFA *mfa = erts_get_fun_mfa(fe, erts_active_code_ix());
+        ASSERT(!mfa || fun_arity(funp) == mfa->arity - num_free);
+        ASSERT($Arity == fe->arity);
+    }
+#endif
+
     I = $NEXT_INSTRUCTION;
-    for (i = 0; i < num_free; i++) {
-	Eterm term = *I++;
+
+    for (i = 0; i < (num_free + 1); i++) {
+        Eterm term = *I++;
         switch (loader_tag(term)) {
         case LOADER_X_REG:
             term = x(loader_x_reg_index(term));
@@ -559,8 +578,9 @@ i_make_fun3(FunP, Dst, Arity, NumFree) {
             term = y(loader_y_reg_index(term));
             break;
         }
-	funp->env[i] = term;
+        funp->env[i] = term;
     }
+
     $Dst = make_fun(funp);
     Goto(*I);
 }

--- a/erts/emulator/beam/emu/load.h
+++ b/erts/emulator/beam/emu/load.h
@@ -142,10 +142,11 @@ struct LoaderState_ {
     unsigned int current_li;	/* Current line instruction */
     unsigned int* func_line;	/* Mapping from function to first line instr */
 
-    /* Translates lambda indexes to their literals, if any. Lambdas that lack
-     * a literal (for example if they have an environment) are represented by
-     * ERTS_SWORD_MAX. */
-    SWord *lambda_literals;
+    /* Translates lambda indexes to the literal holding their FunRef.
+     *
+     * Lambdas that lack an environment are represented by an ErlFunThing that
+     * is immediately followed by an FunRef. */
+    SWord *fun_refs;
 
     int otp_20_or_higher;
 

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -3815,7 +3815,6 @@ fun_info_2(BIF_ALIST_2)
         fe = funp->entry.fun;
         mfa = erts_get_fun_mfa(fe, erts_active_code_ix());
     } else {
-        ASSERT(is_external_fun(funp) && funp->next == NULL);
         mfa = &(funp->entry.exp)->info.mfa;
         fe = NULL;
     }
@@ -3855,13 +3854,12 @@ fun_info_2(BIF_ALIST_2)
         break;
     case am_env:
         {
-            Uint num_free = fun_num_free(funp);
-            int i;
+            int num_free = is_local_fun(funp) ? fun_num_free(funp) : 0;
 
             hp = HAlloc(p, 3 + 2 * num_free);
             val = NIL;
 
-            for (i = num_free - 1; i >= 0; i--) {
+            for (int i = num_free - 1; i >= 0; i--) {
                 val = CONS(hp, funp->env[i], val);
                 hp += 2;
             }
@@ -3919,7 +3917,6 @@ fun_info_mfa_1(BIF_ALIST_1)
                                make_small(fun_arity(funp))));
             }
         } else {
-            ASSERT(is_external_fun(funp) && funp->next == NULL);
             mfa = &(funp->entry.exp)->info.mfa;
         }
 

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -3743,12 +3743,9 @@ void db_cleanup_offheap_comp(DbTerm* obj)
         case BIN_REF_SUBTAG:
             erts_bin_release(u.br->val);
             break;
-        case FUN_SUBTAG:
-            /* We _KNOW_ that this is a local fun, otherwise it would not
-             * be part of the off-heap list. */
-            ASSERT(is_local_fun(u.fun));
-            if (erts_refc_dectest(&u.fun->entry.fun->refc, 0) == 0) {
-                erts_erase_fun_entry(u.fun->entry.fun);
+        case FUN_REF_SUBTAG:
+            if (erts_refc_dectest(&(u.fref->entry)->refc, 0) == 0) {
+                erts_erase_fun_entry(u.fref->entry);
             }
             break;
         case REF_SUBTAG:

--- a/erts/emulator/beam/erl_debug.c
+++ b/erts/emulator/beam/erl_debug.c
@@ -192,6 +192,9 @@ pdisplay1(fmtfn_t to, void *to_arg, Process* p, Eterm obj)
     case BIN_REF_DEF:
         erts_print(to, to_arg, "#BinRef");
         break;
+    case FUN_REF_DEF:
+        erts_print(to, to_arg, "#FunRef");
+        break;
     default:
 	erts_print(to, to_arg, "unknown object %x", obj);
     }

--- a/erts/emulator/beam/erl_etp.c
+++ b/erts/emulator/beam/erl_etp.c
@@ -98,6 +98,7 @@ const Eterm etp_pos_big_subtag = POS_BIG_SUBTAG;
 const Eterm etp_neg_big_subtag = NEG_BIG_SUBTAG;
 const Eterm etp_ref_subtag = REF_SUBTAG;
 const Eterm etp_fun_subtag = FUN_SUBTAG;
+const Eterm etp_fun_ref_subtag = FUN_REF_SUBTAG;
 const Eterm etp_float_subtag = FLOAT_SUBTAG;
 const Eterm etp_bitstring_tag_mask = _BITSTRING_TAG_MASK;
 const Eterm etp_heap_bits_subtag = HEAP_BITS_SUBTAG;

--- a/erts/emulator/beam/erl_fun.c
+++ b/erts/emulator/beam/erl_fun.c
@@ -379,9 +379,7 @@ fun_cmp(ErlFunEntryContainer* obj1, ErlFunEntryContainer* obj2)
     ErlFunEntry* fe1 = &obj1->entry;
     ErlFunEntry* fe2 = &obj2->entry;
 
-    return !(fe1->old_index == fe2->old_index &&
-             fe1->old_uniq == fe2->old_uniq &&
-             fe1->module == fe2->module &&
+    return !(fe1->module == fe2->module &&
              fe1->index == fe2->index &&
              fe1->arity == fe2->arity &&
              !sys_memcmp(fe1->uniq, fe2->uniq, sizeof(fe1->uniq)));

--- a/erts/emulator/beam/erl_fun.c
+++ b/erts/emulator/beam/erl_fun.c
@@ -147,7 +147,8 @@ erts_put_fun_entry2(Eterm mod, int old_uniq, int old_index,
     return &fc->entry;
 }
 
-const ErtsCodeMFA *erts_get_fun_mfa(const ErlFunEntry *fe, ErtsCodeIndex ix) {
+const ErtsCodeMFA *erts_get_fun_mfa(const ErlFunEntry *fe, ErtsCodeIndex ix)
+{
     ErtsCodePtr address = fe->dispatch.addresses[ix];
 
     if (address != beam_unloaded_fun) {
@@ -157,13 +158,15 @@ const ErtsCodeMFA *erts_get_fun_mfa(const ErlFunEntry *fe, ErtsCodeIndex ix) {
     return NULL;
 }
 
-void erts_set_fun_code(ErlFunEntry *fe, ErtsCodeIndex ix, ErtsCodePtr address) {
+void erts_set_fun_code(ErlFunEntry *fe, ErtsCodeIndex ix, ErtsCodePtr address)
+{
     /* Fun entries MUST NOT be updated during a purge! */
     ASSERT(fe->pend_purge_address == NULL);
     fe->dispatch.addresses[ix] = address;
 }
 
-int erts_is_fun_loaded(const ErlFunEntry* fe, ErtsCodeIndex ix) {
+int erts_is_fun_loaded(const ErlFunEntry* fe, ErtsCodeIndex ix)
+{
     return fe->dispatch.addresses[ix] != beam_unloaded_fun;
 }
 
@@ -295,37 +298,6 @@ erts_fun_purge_complete(ErlFunEntry **funs, Uint no)
 
     ERTS_THR_WRITE_MEMORY_BARRIER;
 }
-
-ErlFunThing *erts_new_local_fun_thing(Process *p, ErlFunEntry *fe,
-                                      int arity, int num_free)
-{
-    ErlFunThing *funp;
-
-    funp = (ErlFunThing*) p->htop;
-    p->htop += ERL_FUN_SIZE + num_free;
-    erts_refc_inc(&fe->refc, 2);
-
-    funp->thing_word = MAKE_FUN_HEADER(arity, num_free, 0);
-    funp->entry.fun = fe;
-
-    funp->next = MSO(p).first;
-    MSO(p).first = (struct erl_off_heap_header*) funp;
-
-#ifdef DEBUG
-    {
-        /* Note that `mfa` may be NULL if the fun is currently being purged. We
-         * ignore this since it's not an error and we only need `mfa` to
-         * sanity-check the arity at this point. If the fun is called while in
-         * this state, the `error_handler` module will take care of it. */
-        const ErtsCodeMFA *mfa = erts_get_fun_mfa(fe, erts_active_code_ix());
-        ASSERT(!mfa || fun_arity(funp) == mfa->arity - num_free);
-        ASSERT(arity == fe->arity);
-    }
-#endif
-
-    return funp;
-}
-
 
 struct dump_fun_foreach_args {
     fmtfn_t to;

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -67,16 +67,25 @@ ERTS_GLB_INLINE Eterm* move_boxed(Eterm *ERTS_RESTRICT ptr, Eterm hdr, Eterm **h
     nelts = header_arity(hdr);
     switch ((hdr) & _HEADER_SUBTAG_MASK) {
     case MAP_SUBTAG:
-        if (is_flatmap_header(hdr)) nelts+=flatmap_get_size(ptr) + 1;
-        else nelts += hashmap_bitcount(MAP_HEADER_VAL(hdr));
-    break;
-    case FUN_SUBTAG: nelts+=fun_num_free((ErlFunThing*)(ptr)); break;
+        if (is_flatmap_header(hdr)) {
+            nelts += flatmap_get_size(ptr) + 1;
+        } else {
+            nelts += hashmap_bitcount(MAP_HEADER_VAL(hdr));
+        }
+        break;
+    case FUN_SUBTAG:
+        nelts += fun_env_size((ErlFunThing*)(ptr));
+        break;
     }
+
     gval    = make_boxed(htop);
     *orig   = gval;
     *htop++ = hdr;
     *ptr++  = gval;
-    while (nelts--) *htop++ = *ptr++;
+
+    while (nelts--) {
+        *htop++ = *ptr++;
+    }
 
     *hpp = htop;
     return ptr;

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -3361,7 +3361,6 @@ BIF_RETTYPE erts_internal_term_type_1(BIF_ALIST_1) {
                         if (is_local_fun(funp)) {
                             BIF_RET(ERTS_MAKE_AM("fun"));
                         } else {
-                            ASSERT(is_external_fun(funp) && funp->next == NULL);
                             BIF_RET(ERTS_MAKE_AM("export"));
                         }
                     }

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -170,12 +170,9 @@ erts_cleanup_offheap_list(struct erl_off_heap_header* first)
 	case BIN_REF_SUBTAG:
             erts_bin_release(u.br->val);
 	    break;
-	case FUN_SUBTAG:
-            /* We _KNOW_ that this is a local fun, otherwise it would not
-             * be part of the off-heap list. */
-            ASSERT(is_local_fun(u.fun));
-            if (erts_refc_dectest(&u.fun->entry.fun->refc, 0) == 0) {
-                erts_erase_fun_entry(u.fun->entry.fun);
+	case FUN_REF_SUBTAG:
+            if (erts_refc_dectest(&(u.fref->entry)->refc, 0) == 0) {
+                erts_erase_fun_entry(u.fref->entry);
             }
 	    break;
 	case REF_SUBTAG:

--- a/erts/emulator/beam/erl_node_tables.c
+++ b/erts/emulator/beam/erl_node_tables.c
@@ -1570,7 +1570,7 @@ insert_offheap(ErlOffHeap *oh, int type, Eterm id)
             }
 	    break;
 	case BIN_REF_SUBTAG:
-	case FUN_SUBTAG:
+	case FUN_REF_SUBTAG:
 	    break; /* No need to */
 	default:
 	    ASSERT(is_external_header(u.hdr->thing_word));

--- a/erts/emulator/beam/erl_printf_term.c
+++ b/erts/emulator/beam/erl_printf_term.c
@@ -670,8 +670,6 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
                     long tdcount;
                     int tres;
 
-                    ASSERT(is_external_fun(funp) && funp->next == NULL);
-
                     PRINT_STRING(res, fn, arg, "fun ");
 
                     /* We pass a temporary 'dcount' and adjust the real one
@@ -772,9 +770,12 @@ print_term(fmtfn_t fn, void* arg, Eterm obj, long *dcount) {
             }
             break;
         }
-	case BIN_REF_DEF:
-	    PRINT_STRING(res, fn, arg, "#BinRef");
-	    break;
+        case BIN_REF_DEF:
+            PRINT_STRING(res, fn, arg, "#BinRef");
+            break;
+        case FUN_REF_DEF:
+            PRINT_STRING(res, fn, arg, "#FunRef");
+            break;
         default:
 	    PRINT_STRING(res, fn, arg, "<unknown:");
 	    PRINT_POINTER(res, fn, arg, wobj);

--- a/erts/emulator/beam/erl_term.c
+++ b/erts/emulator/beam/erl_term.c
@@ -118,6 +118,7 @@ erts_term_init(void)
                               POS_BIG_SUBTAG,
                               NEG_BIG_SUBTAG,
                               REF_SUBTAG,
+                              FUN_REF_SUBTAG,
                               FUN_SUBTAG,
                               FLOAT_SUBTAG,
                               HEAP_BITS_SUBTAG,

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -99,7 +99,7 @@ struct erl_node_; /* Declared in erl_node_tables.h */
  * HEADER tags:
  *
  *      0000    ARITYVAL
- *      0001    BINARY_AGGREGATE                  |
+ *      0001    FUN_REF                           |
  *      001x    BIGNUM with sign bit              |
  *      0100    REF                               |
  *      0101    FUN                               | THINGS
@@ -124,7 +124,7 @@ struct erl_node_; /* Declared in erl_node_tables.h */
  * XXX: globally replace XXX_SUBTAG with TAG_HEADER_XXX
  */
 #define ARITYVAL_SUBTAG         (0x0 << _TAG_PRIMARY_SIZE) /* TUPLE */
-/* (0x1 << _TAG_PRIMARY_SIZE)                                 FREE  */
+#define FUN_REF_SUBTAG          (0x1 << _TAG_PRIMARY_SIZE) /* FUN_REF */
 #define _BIG_TAG_MASK           (~(0x1 << _TAG_PRIMARY_SIZE) & _TAG_HEADER_MASK)
 #define _BIG_SIGN_BIT           (0x1 << _TAG_PRIMARY_SIZE)
 #define POS_BIG_SUBTAG          (0x2 << _TAG_PRIMARY_SIZE) /* BIGNUM */
@@ -144,7 +144,8 @@ struct erl_node_; /* Declared in erl_node_tables.h */
 /* _EXTERNAL_TAG_MASK requires that 0xF is reserved for external terms. */
 
 #define _TAG_HEADER_ARITYVAL       (TAG_PRIMARY_HEADER|ARITYVAL_SUBTAG)
-#define _TAG_HEADER_FUN	           (TAG_PRIMARY_HEADER|FUN_SUBTAG)
+#define _TAG_HEADER_FUN_REF        (TAG_PRIMARY_HEADER|FUN_REF_SUBTAG)
+#define _TAG_HEADER_FUN            (TAG_PRIMARY_HEADER|FUN_SUBTAG)
 #define _TAG_HEADER_POS_BIG        (TAG_PRIMARY_HEADER|POS_BIG_SUBTAG)
 #define _TAG_HEADER_NEG_BIG        (TAG_PRIMARY_HEADER|NEG_BIG_SUBTAG)
 #define _TAG_HEADER_FLOAT          (TAG_PRIMARY_HEADER|FLOAT_SUBTAG)
@@ -377,6 +378,8 @@ _ET_DECLARE_CHECKED(Uint,thing_subtag,Eterm)
 #define is_bitstring_header(x)                                                \
     (((x) & (_BITSTRING_TAG_MASK)) == _TAG_HEADER_HEAP_BITS)
 
+#define is_bin_ref(x)                                                         \
+    (is_boxed((x)) && *boxed_val(x) == HEADER_BIN_REF)
 #define make_bitstring(x)	make_boxed((Eterm*)(x))
 #define is_bitstring(x)	(is_boxed((x)) && is_bitstring_header(*boxed_val((x))))
 #define is_not_bitstring(x) (!is_bitstring((x)))
@@ -391,27 +394,31 @@ _ET_DECLARE_CHECKED(Eterm*,bitstring_val,Wterm)
  *
  *     aaaaaaaaaaaaaaaa aaaaaaaaaatttt00       arity:26, tag:4
  *
- * Since the arity and number of free variables are both limited to 255, and we
- * only need one bit to signify whether the fun is local or external, we can
- * fit all of that information in the header word.
+ * Since the arity and number of free variables are both limited to 255, we can
+ * fit them both into the header word.
  *
- *     0000000effffffff aaaaaaaa00010100       external:1, free:8, arity:8
+ *     0000000eeeeeeeee aaaaaaaa00010100       environment_size:9, arity:8
  *
  * Note that the lowest byte contains only the function subtag, and the next
  * byte after that contains only the arity. This lets us combine the type
  * and/or arity check into a single comparison without masking, by using 8- or
- * 16-bit operations on the header word. */
+ * 16-bit operations on the header word.
+ *
+ * Furthermore, as local funs always have at least one environment variable as
+ * the `FunRef` is treated as part of the environment, we can distinguish
+ * them by checking whether the environment size is zero. */
 
 #define FUN_HEADER_ARITY_OFFS (_HEADER_ARITY_OFFS + 2)
-#define FUN_HEADER_NUM_FREE_OFFS (FUN_HEADER_ARITY_OFFS + 8)
-#define FUN_HEADER_EXTERNAL_OFFS (FUN_HEADER_NUM_FREE_OFFS + 8)
+#define FUN_HEADER_ENV_SIZE_OFFS (FUN_HEADER_ARITY_OFFS + 8)
 
 #define MAKE_FUN_HEADER(Arity, NumFree, External)                             \
-    (_TAG_HEADER_FUN |                                                        \
+    (ASSERT((!(External)) || ((NumFree) == 0)),                               \
+     (_TAG_HEADER_FUN |                                                       \
      (((Arity)) << FUN_HEADER_ARITY_OFFS) |                                   \
-     (((NumFree)) << FUN_HEADER_NUM_FREE_OFFS) |                              \
-     ((!!(External)) << FUN_HEADER_EXTERNAL_OFFS))
+     (((NumFree + !External)) << FUN_HEADER_ENV_SIZE_OFFS)))
 
+#define is_fun_ref(x)                                                         \
+    (is_boxed((x)) && *boxed_val(x) == HEADER_FUN_REF)
 #define is_fun_header(x)        (((x) & _HEADER_SUBTAG_MASK) == FUN_SUBTAG)
 #define make_fun(x)             make_boxed((Eterm*)(x))
 #define is_any_fun(x)           (is_boxed((x)) && is_fun_header(*boxed_val((x))))
@@ -1420,6 +1427,7 @@ _ET_DECLARE_CHECKED(Uint,loader_y_reg_index,Uint)
 #define BIG_DEF			0xf
 #define SMALL_DEF		0x10
 #define BIN_REF_DEF             0x11   /* not a "real" term */
+#define FUN_REF_DEF             0x12   /* not a "real" term */
 
 #define FIRST_VACANT_TAG_DEF    0x13
 
@@ -1487,6 +1495,7 @@ ERTS_GLB_INLINE unsigned tag_val_def(Wterm x)
 	    case (_TAG_HEADER_EXTERNAL_REF >> _TAG_PRIMARY_SIZE):	return EXTERNAL_REF_DEF;
 	    case (_TAG_HEADER_MAP >> _TAG_PRIMARY_SIZE):	return MAP_DEF;
 	    case (_TAG_HEADER_BIN_REF >> _TAG_PRIMARY_SIZE):	return BIN_REF_DEF;
+	    case (_TAG_HEADER_FUN_REF >> _TAG_PRIMARY_SIZE):	return FUN_REF_DEF;
 	    case (_TAG_HEADER_HEAP_BITS >> _TAG_PRIMARY_SIZE):	return BITSTRING_DEF;
 	    case (_TAG_HEADER_SUB_BITS >> _TAG_PRIMARY_SIZE):	return BITSTRING_DEF;
 	  }

--- a/erts/emulator/beam/erl_term_hashing.c
+++ b/erts/emulator/beam/erl_term_hashing.c
@@ -257,8 +257,6 @@ tail_recur:
             } else {
                 const ErtsCodeMFA *mfa = &funp->entry.exp->info.mfa;
 
-                ASSERT(is_external_fun(funp) && funp->next == NULL);
-
                 hash = hash * FUNNY_NUMBER11 + mfa->arity;
                 hash = hash*FUNNY_NUMBER1 +
                        (atom_tab(atom_val(mfa->module))->slot.bucket.hvalue);
@@ -1189,8 +1187,6 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
                 } else {
                     Export *ep = funp->entry.exp;
 
-                    ASSERT(is_external_fun(funp) && funp->next == NULL);
-
                     UINT32_HASH_2
                         (ep->info.mfa.arity,
                          atom_tab(atom_val(ep->info.mfa.module))->slot.bucket.hvalue,
@@ -1924,8 +1920,6 @@ make_internal_hash(Eterm term, erts_ihash_t salt)
 
                     goto pop_next;
                 } else {
-                    ASSERT(is_external_fun(funp) && funp->next == NULL);
-
                     /* Assumes Export entries never move */
                     IHASH_MIX_ALPHA(IHASH_TYPE_EXTERNAL_FUN);
                     IHASH_MIX_BETA((UWord)funp->entry.exp);

--- a/erts/emulator/beam/export.c
+++ b/erts/emulator/beam/export.c
@@ -189,7 +189,6 @@ static void create_shared_lambda(Export *export)
 
     lambda->thing_word = MAKE_FUN_HEADER(export->info.mfa.arity, 0, 1);
     lambda->entry.exp = export;
-    lambda->next = NULL;
 
     export->lambda = make_fun(lambda);
 

--- a/erts/emulator/beam/generators.tab
+++ b/erts/emulator/beam/generators.tab
@@ -301,38 +301,75 @@ gen.skip_bits2(Fail, Ms, Size, Unit, Flags) {
 }
 
 // Creates an instruction that moves a literal lambda to a register.
-MakeLiteralLambda(Op, Index, DstType, DstVal) {
-    BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[Idx.val];
+MakeLiteralFun(Op, Index, Arity, Dst) {
     SWord literal;
-
-    ASSERT(entry->num_free == 0);
 
     /* If we haven't already done so, we need to create a placeholder for the
      * lambda. */
-    if (S->lambda_literals[$Index] == ERTS_SWORD_MAX) {
-        Eterm tmp_hp[ERL_FUN_SIZE];
+    literal = S->fun_refs[$Index];
+    if (literal == ERTS_SWORD_MAX) {
+        Eterm tmp_hp[ERL_FUN_SIZE + ERL_FUN_REF_SIZE + 1];
         ErlFunThing *funp;
+        FunRef *refp;
 
-        /* The placeholder is an external fun with the export field set to
-         * NULL, preventing it from colliding with external fun literals
-         * created by the user. We also disable deduplication to prevent it
-         * from colliding with other placeholder lambdas of the same arity. */
+        /* +1 to skip funp->env[0] */
+        refp = (FunRef*)&tmp_hp[ERL_FUN_SIZE + 1];
+        refp->thing_word = HEADER_FUN_REF;
+        refp->entry = NULL;
+        refp->next = NULL;
+
         funp = (ErlFunThing*)tmp_hp;
-        funp->thing_word = MAKE_FUN_HEADER(entry->arity, 0, 1);
+        funp->thing_word = MAKE_FUN_HEADER($Arity, 0, 0);
         funp->entry.exp = NULL;
-        funp->next = NULL;
+        funp->env[0] = make_boxed((Eterm*)refp);
 
-        literal = beamfile_add_literal(&S->beam, make_fun(tmp_hp), 0);
-        S->lambda_literals[$Index] = literal;
-    } else {
-        literal = S->lambda_literals[$Index];
+        literal = beamfile_add_literal(&S->beam, make_fun((Eterm*)funp), 0);
+        S->fun_refs[$Index] = literal;
     }
 
     $BeamOpNameArity($Op, move, 2);
     ($Op)->a[0].type = TAG_q;
     ($Op)->a[0].val = literal;
-    ($Op)->a[1].type = $DstType;
-    ($Op)->a[1].val = $DstVal;
+    ($Op)->a[1] = $Dst;
+}
+
+MakeFun(Op, Index, Arity, NumFree, Env, Dst) {
+    SWord literal;
+
+    $BeamOpNameArity(op, i_make_fun3, 4);
+    $BeamOpArity(op, 5 + $NumFree);
+
+    op->a[0].type = TAG_u;
+    op->a[0].val = $Index;
+    op->a[1] = $Dst;
+    op->a[2].type = TAG_u;
+    op->a[2].val = $Arity - $NumFree;
+    op->a[3].type = TAG_u;
+    op->a[3].val = $NumFree;
+
+    for (int i = 0; i < $NumFree; i++) {
+        op->a[4 + i] = $Env[i];
+    }
+
+    /* Create a FunRef if we haven't already done so (may be shared with other
+     * make_fun3 instructions). */
+    literal = S->fun_refs[$Index];
+    if (literal == ERTS_SWORD_MAX) {
+        Eterm tmp_hp[ERL_FUN_REF_SIZE];
+        FunRef *refp = (FunRef*)tmp_hp;
+
+        refp->thing_word = HEADER_FUN_REF;
+        refp->entry = NULL;
+        refp->next = NULL;
+
+        literal = beamfile_add_literal(&S->beam, make_boxed((Eterm*)refp), 0);
+        S->fun_refs[$Index] = literal;
+    }
+
+    /* Add the FunRef as part of the environment, just past the free
+     * variables. */
+    op->a[4 + $NumFree].type = TAG_q;
+    op->a[4 + $NumFree].val = literal;
 }
 
 gen.make_fun3(Idx, Dst, NumFree, Env) {
@@ -344,25 +381,10 @@ gen.make_fun3(Idx, Dst, NumFree, Env) {
         BeamFile_LambdaEntry *entry = &S->beam.lambdas.entries[Idx.val];
 
         if (NumFree.val == entry->num_free) {
-            int i;
-
-            if (NumFree.val == 0) {
-                $MakeLiteralLambda(op, Idx.val, Dst.type, Dst.val);
+            if (entry->num_free == 0) {
+                $MakeLiteralFun(op, Idx.val, entry->arity, Dst);
             } else {
-                $BeamOpNameArity(op, i_make_fun3, 4);
-                $BeamOpArity(op, 4 + NumFree.val);
-
-                op->a[0].type = TAG_u;
-                op->a[0].val = Idx.val;
-                op->a[1] = Dst;
-                op->a[2].type = TAG_u;
-                op->a[2].val = entry->arity - entry->num_free;
-                op->a[3].type = TAG_u;
-                op->a[3].val = entry->num_free;
-
-                for (i = 0; i < NumFree.val; i++) {
-                    op->a[i+4] = Env[i];
-                }
+                $MakeFun(op, Idx.val, entry->arity, entry->num_free, Env, Dst);
             }
 
             return op;

--- a/erts/emulator/beam/generators.tab
+++ b/erts/emulator/beam/generators.tab
@@ -346,7 +346,7 @@ gen.make_fun3(Idx, Dst, NumFree, Env) {
         if (NumFree.val == entry->num_free) {
             int i;
 
-            if (NumFree.val == 0 && erts_init_process_id != ERTS_INVALID_PID) {
+            if (NumFree.val == 0) {
                 $MakeLiteralLambda(op, Idx.val, Dst.type, Dst.val);
             } else {
                 $BeamOpNameArity(op, i_make_fun3, 4);

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -273,7 +273,7 @@ extern Eterm erts_ddll_monitor_driver(Process *p,
 union erl_off_heap_ptr {
     struct erl_off_heap_header* hdr;
     BinRef *br;
-    struct erl_fun_thing* fun;
+    struct erl_fun_ref* fref;
     struct external_thing_* ext;
     ErtsMRefThing *mref;
     Eterm* ep;

--- a/erts/emulator/beam/jit/load.h
+++ b/erts/emulator/beam/jit/load.h
@@ -88,10 +88,11 @@ struct LoaderState_ {
     void *coverage;
     byte *line_coverage_valid;
 
-    /* Translates lambda indexes to their literals, if any. Lambdas that lack
-     * a literal (for example if they have an environment) are represented by
-     * ERTS_SWORD_MAX. */
-    SWord *lambda_literals;
+    /* Translates lambda indexes to the literal holding their FunRef.
+     *
+     * Lambdas that lack an environment are represented by an ErlFunThing that
+     * is immediately followed by an FunRef. */
+    SWord *fun_refs;
 
     void *ba; /* Assembler used to create x86 assembly */
 

--- a/erts/emulator/test/erts_debug_SUITE.erl
+++ b/erts/emulator/test/erts_debug_SUITE.erl
@@ -82,7 +82,10 @@ test_size(Config) when is_list(Config) ->
 
     %% Fun environment size = 0 (the smallest fun possible)
     SimplestFun = fun() -> ok end,
-    FunSz0 = 3,
+
+    %% 2 words for the fun, 1 word to point at the off-heap reference, and
+    %% 3 words for the off-heap reference itself. The actual on-heap size is 3.
+    FunSz0 = 6,
     FunSz0 = do_test_size(SimplestFun),
 
     %% Fun environment size = 1
@@ -95,8 +98,9 @@ test_size(Config) when is_list(Config) ->
 
     FunSz1 = do_test_size(fun() -> ConsCell1 end) - do_test_size(ConsCell1),
 
-    %% External funs are the same size as local ones without environment
-    FunSz0 = do_test_size(fun lists:sort/1),
+    %% External funs are always 2 words (they're also always stored off-heap,
+    %% so the effective size is zero).
+    2 = do_test_size(fun lists:sort/1),
 
     Arch = 8 * erlang:system_info({wordsize, external}),
     case {Arch, do_test_size(mk_ext_pid({a@b, 1}, 17, 42))} of

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -425,16 +425,20 @@ define etp-boxed-immediate-1
                   if ($etp_boxed_immediate_h == etp_fun_subtag)
                     printf "#Fun<"
                   else
-                    if ($etp_boxed_immediate_h == etp_bin_ref_subtag)
-                      printf "#BinRef<"
+                    if ($etp_boxed_immediate_h == etp_fun_ref_subtag)
+                      printf "#FunRef<"
                     else
-                    if ($etp_boxed_immediate_h == etp_heap_bits_subtag)
-                      printf "#HeapBits<"
-                    else
-                    if ($etp_boxed_immediate_h == etp_sub_bits_subtag)
-                      printf "#SubBits<"
-                    else
-                      printf "#Header%X<", $etp_boxed_immediate_h
+                      if ($etp_boxed_immediate_h == etp_bin_ref_subtag)
+                        printf "#BinRef<"
+                      else
+                      if ($etp_boxed_immediate_h == etp_heap_bits_subtag)
+                        printf "#HeapBits<"
+                      else
+                      if ($etp_boxed_immediate_h == etp_sub_bits_subtag)
+                        printf "#SubBits<"
+                      else
+                        printf "#Header%X<", $etp_boxed_immediate_h
+                      end
                     end
 		  end
 		  end

--- a/erts/etc/unix/etp.py
+++ b/erts/etc/unix/etp.py
@@ -415,6 +415,8 @@ def boxed(valobj, depth = float('inf')):
         return '#Ref'
     if masked_hdr == c('FUN_SUBTAG'):
         return '#Fun'
+    if masked_hdr == c('FUN_REF_SUBTAG'):
+        return '#FunRef'
     if masked_hdr == c('HEAP_BITS_SUBTAG'):
         return '#HeapBits'
     if masked_hdr == c('SUB_BITS_SUBTAG'):

--- a/lib/observer/src/crashdump_viewer.erl
+++ b/lib/observer/src/crashdump_viewer.erl
@@ -2894,7 +2894,12 @@ parse_heap_term("Mh"++Line0, Addr, DecodeOpts, D0) -> %Head node in a hashmap.
     {Map,Line,D};
 parse_heap_term("Mn"++Line0, Addr, DecodeOpts, D) -> %Interior node in a hashmap.
     {N,":"++Line} = get_hex(Line0),
-    parse_tuple(N, Line, Addr, DecodeOpts, D, []).
+    parse_tuple(N, Line, Addr, DecodeOpts, D, []);
+parse_heap_term("Rf"++Line0, Addr, _DecodeOpts, D0) -> %Fun reference
+    {N,[]} = get_hex(Line0),
+    Term = {'#CDVFRef', N},
+    D = gb_trees:insert(Addr, Term, D0),
+    {Term,[],D}.
 
 parse_tuple(0, Line, Addr, _, D0, Acc) ->
     Tuple = list_to_tuple(lists:reverse(Acc)),


### PR DESCRIPTION
This is a far better way to speed up fun creation than https://github.com/erlang/otp/pull/7946.

In the most common cases, creating or sending a fun to another process will cost no more than a tuple, and their garbage collection is greatly sped up as they no longer need to be part of the process off-heap list.

There are a few exceptions such as during fun purging or if they're received over distribution, in which cases they will work just like before. Optimizing the latter is possible through keeping canonical `FunRef`s in their corresponding `ErlFunEntry`, but it's probably not worth the time investment at the moment.