### PR TITLE
Avoid mixed usage of ebin directories on build

### DIFF
--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -186,7 +186,6 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 
 ERL_COMPILE_FLAGS += -Werror
 ERL_COMPILE_FLAGS += -I../include
-ERL_COMPILE_FLAGS += -pa ../ebin
 
 
 # ----------------------------------------------------


### PR DESCRIPTION
This has come up here: https://github.com/erlang/otp/pull/7755#issuecomment-1786825281