### PR TITLE
otp: Fix build on Yocto

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -24349,15 +24349,6 @@ else $as_nop
 /* end confdefs.h.  */
 
 /* gethrvtime procfs ioctl test */
-/* These need to be undef:ed to not break activation of
- * micro level process accounting on /proc/self
- */
-#ifdef _LARGEFILE_SOURCE
-#  undef _LARGEFILE_SOURCE
-#endif
-#ifdef _FILE_OFFSET_BITS
-#  undef _FILE_OFFSET_BITS
-#endif
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/erts/emulator/sys/unix/sys_time.c
+++ b/erts/emulator/sys/unix/sys_time.c
@@ -22,16 +22,6 @@
 #  include "config.h"
 #endif
 
-/* These need to be undef:ed to not break activation of
- * micro level process accounting on /proc/self 
- */
-#ifdef _LARGEFILE_SOURCE
-#  undef _LARGEFILE_SOURCE
-#endif
-#ifdef _FILE_OFFSET_BITS
-#  undef _FILE_OFFSET_BITS
-#endif
-
 #include <stdlib.h>
 #include "sys.h"
 #include "global.h"

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -2705,15 +2705,6 @@ dnl
 AC_MSG_CHECKING([if gethrvtime works and how to use it])
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
 /* gethrvtime procfs ioctl test */
-/* These need to be undef:ed to not break activation of
- * micro level process accounting on /proc/self 
- */
-#ifdef _LARGEFILE_SOURCE
-#  undef _LARGEFILE_SOURCE
-#endif
-#ifdef _FILE_OFFSET_BITS
-#  undef _FILE_OFFSET_BITS
-#endif
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>


### PR DESCRIPTION
A workaround to avoid breaking "micro level process accounting on /proc/self" broke the build on Yocto. As this is a really ancient
workaround (pre-2009) and the comment is unclear about what actually breaks, we'll try removing it to see if this is still a problem.