### PR TITLE
inets: Fix httpd_serve_SUITE failing on OpenBSD

### DIFF
--- a/lib/inets/test/httpd_serve_SUITE.erl
+++ b/lib/inets/test/httpd_serve_SUITE.erl
@@ -105,12 +105,17 @@ run_server_assertions({ok, {Ip0, Port, Path}}, Assertions) when is_integer(Port)
     ok = verify_assertions(Assertions, ServerInfo),
     ct:comment("Ran ~w assertion(s).", [length(Assertions)]).
 
-maybe_convert_to_localhost(Ip = {0, 0, 0, 0}) ->
-    case os:type() of
-         {win32, _} -> {127, 0, 0, 1};
-         _ -> Ip
-    end;
 maybe_convert_to_localhost(Ip) ->
+    case os:type() of
+        {unix, linux} -> Ip;
+        _Other -> convert_to_localhost(Ip)
+    end.
+
+convert_to_localhost({0, 0, 0, 0}) ->
+    {127, 0, 0, 1};
+convert_to_localhost({0, 0, 0, 0, 0, 0, 0, 0}) ->
+    {0, 0, 0, 0, 0, 0, 0, 1};
+convert_to_localhost(Ip) ->
     Ip.
 
 %%


### PR DESCRIPTION
The test previously tried to connect via 0.0.0.0 and ::, which may not work depending on the network configuration. Since this to seems to be a Linux specific feature that was relied on on the original machine used to implement this feature, and it so far has caused problems with multipel platforms, change the code to simply always convert into 127.0.0.1 and ::1 on systems except from Linux to prevent compatibility issues. (Converting for any host would fail CI for Linux).

Tested on Debian, FreeBSD and OpenBSD :-)