### PR TITLE
Fix error message for erlang:phash*/2

### DIFF
--- a/lib/kernel/src/erl_erts_errors.erl
+++ b/lib/kernel/src/erl_erts_errors.erl
@@ -683,9 +683,9 @@ format_erlang_error(open_port, [Name, Settings], Cause) ->
             must_be_tuple(Name)
     end;
 format_erlang_error(phash, [_,N], _) ->
-    [must_be_pos_int(N)];
+    [[], must_be_pos_int(N)];
 format_erlang_error(phash2, [_,N], _) ->
-    [must_be_pos_int(N)];
+    [[], must_be_pos_int(N)];
 format_erlang_error(posixtime_to_universaltime, [_], _) ->
     [not_integer];
 format_erlang_error(pid_to_list, [_], _) ->


### PR DESCRIPTION
Before this patch, it would say:

    1> erlang:phash2(nil, 0).
    ** exception error: bad argument
        in function  erlang:phash2/2
            called as erlang:phash2(nil,0)
            *** argument 1: out of range