### PR TITLE
yecc: Emit .yrl file around -module attribute

### DIFF
--- a/lib/parsetools/src/yecc.erl
+++ b/lib/parsetools/src/yecc.erl
@@ -2048,9 +2048,11 @@ rule_pos({Line, Column}) when is_integer(Line), is_integer(Column) ->
 output_prelude(Outport, Inport, St0) when St0#yecc.includefile =:= [] ->
     St5 = output_header(St0),
     #yecc{infile = Infile, module = Module} = St5,
-    St10 = fwrite(St5, <<"-module(~w).\n">>, [Module]),
+    St8 = output_file_directive(St5, Infile, 0),
+    St10 = fwrite(St8, <<"-module(~w).\n">>, [Module]),
+    St15 = output_file_directive(St10, St10#yecc.outfile, St10#yecc.line),
     St20 = 
-        fwrite(St10,
+        fwrite(St15,
                <<"-export([parse/1, parse_and_scan/1, format_error/1]).\n">>,
                []),
     {St25, N_lines_1, LastErlangCodeLine} = 

--- a/lib/parsetools/test/yecc_SUITE.erl
+++ b/lib/parsetools/test/yecc_SUITE.erl
@@ -346,8 +346,8 @@ syntax(Config) when is_list(Config) ->
                         {{_,_},_,{undefined_function,{yeccpars2_2_,1}}},
                         {{_,_},_,{bad_nowarn_unused_function,{yeccpars2_2_,1}}}]}],
              []} = compile:file(Parserfile1, [basic_validation,return]),
-            L1 = 36 + SzYeccPre,
-            L2 = 45 + SzYeccPre
+            ?assertEqual(L1, 38 + SzYeccPre),
+            ?assertEqual(L2, 47 + SzYeccPre)
     end(),
 
     %% Bad macro in action. OTP-7224.
@@ -366,8 +366,8 @@ syntax(Config) when is_list(Config) ->
                         {{_,_},_,{undefined_function,{yeccpars2_2_,1}}},
                         {{_,_},_,{bad_nowarn_unused_function,{yeccpars2_2_,1}}}]}],
              []} = compile:file(Parserfile1, [basic_validation,return]),
-            L1 = 36 + SzYeccPre,
-            L2 = 45 + SzYeccPre
+            ?assertEqual(L1, 38 + SzYeccPre),
+            ?assertEqual(L2, 47 + SzYeccPre)
     end(),
 
     %% Check line numbers. OTP-7224.
@@ -1697,8 +1697,8 @@ otp_7292(Config) when is_list(Config) ->
                         {{_,_},_,{bad_nowarn_unused_function,{yeccpars2_2_,1}}}]}],
              [{_,[{{16,20},_,{unused_function,{foo,0}}}]}]} =
                 compile:file(Parserfile1, [basic_validation, return]),
-            L1 = 46 + SzYeccPre,
-            L2 = 55 + SzYeccPre
+            ?assertEqual(L1, 48 + SzYeccPre),
+            ?assertEqual(L2, 57 + SzYeccPre)
     end(),
 
     YeccPre = filename:join(Dir, "yeccpre.hrl"),
@@ -1717,8 +1717,8 @@ otp_7292(Config) when is_list(Config) ->
                         {{_,_},_,{bad_nowarn_unused_function,{yeccpars2_2_,1}}}]}],
                    [{_,[{{16,20},_,{unused_function,{foo,0}}}]}]} =
                 compile:file(Parserfile1, [basic_validation, return]),
-            L1 = 45 + SzYeccPre,
-            L2 = 54 + SzYeccPre
+            ?assertEqual(L1, 45 + SzYeccPre),
+            ?assertEqual(L2, 54 + SzYeccPre)
     end(),
 
     file:delete(YeccPre),


### PR DESCRIPTION
We do this so that tools that want to know what the source of a generated file is, can look at the -file of the -module attribute.