### PR TITLE
Optimize the `timer`module by using a private table

### DIFF
--- a/lib/stdlib/src/timer.erl
+++ b/lib/stdlib/src/timer.erl
@@ -479,7 +479,7 @@ start_link() ->
 -spec init([]) -> {'ok', ets:tid()}.
 init([]) ->
     process_flag(trap_exit, true),
-    Tab = ets:new(?MODULE, []),
+    Tab = ets:new(?MODULE, [private]),
     {ok, Tab}.
 
 %% server calls


### PR DESCRIPTION
The current implementation of the `timer` module uses the default protection level of `protected` for its internal "bookkeeping" `ets` table. However, since the timer server process is the only one using this table, `private` is a better choice because operations can then skip any otherwise necessary locking.