### PR TITLE
Remove indirection on set primary archive

### DIFF
--- a/erts/preloaded/src/erl_prim_loader.erl
+++ b/erts/preloaded/src/erl_prim_loader.erl
@@ -49,7 +49,7 @@
 -export([prim_init/0, prim_get_file/2, prim_list_dir/2,
          prim_read_file_info/3, prim_get_cwd/2]).
 
-%% Used by escript and code
+%% Used by escript
 -export([set_primary_archive/4]).
 
 %% Used by test suites

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -73,7 +73,6 @@
          get_doc/2,
 	 where_is_file/1,
 	 where_is_file/2,
-	 set_primary_archive/4,
 	 clash/0,
          module_status/0,
          module_status/1,
@@ -1028,28 +1027,6 @@ get_function_docs_from_ast({function,Anno,Name,Arity,_Code}, AST) ->
       [unicode:characters_to_binary(Signature)], none, SpecMd}];
 get_function_docs_from_ast(_, _) ->
     [].
-
--spec set_primary_archive(ArchiveFile :: file:filename(),
-			  ArchiveBin :: binary(),
-			  FileInfo :: file:file_info(),
-			  ParserFun :: fun())
-			 -> 'ok' | {'error', atom()}.
-
-set_primary_archive(ArchiveFile0, ArchiveBin, #file_info{} = FileInfo,
-		    ParserFun)
-  when is_list(ArchiveFile0), is_binary(ArchiveBin) ->
-    ArchiveFile = filename:absname(ArchiveFile0),
-    case call({set_primary_archive, ArchiveFile, ArchiveBin, FileInfo,
-	       ParserFun}) of
-	{ok, []} ->
-	    ok;
-	{ok, _Mode, Ebins} ->
-	    %% Prepend the code path with the ebins found in the archive
-	    Ebins2 = [filename:join([ArchiveFile, E]) || E <- Ebins],
-	    add_pathsa(Ebins2, cache); % Returns ok
-	{error, _Reason} = Error ->
-	    Error
-    end.
 
 %% Search the entire path system looking for name clashes
 

--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -358,16 +358,6 @@ handle_call({get_object_code_for_loading,Mod}, From, St0) when is_atom(Mod) ->
 handle_call(stop,_From, S) ->
     {stop,normal,stopped,S};
 
-handle_call({set_primary_archive, File, ArchiveBin, FileInfo, ParserFun},
-	    _From, S=#state{mode=Mode}) ->
-    case erl_prim_loader:set_primary_archive(File, ArchiveBin, FileInfo,
-					     ParserFun) of
-	{ok, Files} ->
-	    {reply, {ok, Mode, Files}, S};
-	{error, _Reason} = Error ->
-	    {reply, Error, S}
-    end;
-
 handle_call(get_mode, _From, S=#state{mode=Mode}) ->
     {reply, Mode, S};
 


### PR DESCRIPTION
The previous code called code, which then called the code server,
but none of those calls rely directly on the code server (or its state).