### PR TITLE
Fix timeout overflow

### DIFF
--- a/erts/emulator/beam/time.c
+++ b/erts/emulator/beam/time.c
@@ -613,7 +613,22 @@ find_next_timeout(ErtsSchedulerData *esdp, ErtsTimerWheel *tiw)
     }
 
 done: {
-        ErtsMonotonicTime min_timeout;
+        ErtsMonotonicTime min_timeout, timeout_pos_limit;
+
+        timeout_pos_limit = tiw->pos + ERTS_CLKTCKS_WEEK;
+        if (min_timeout_pos > timeout_pos_limit) {
+            /*
+             * We never expose a timeout larger than a week in order to avoid
+             * issues with primitives that have a limited maximum timeout
+             * time (for example, poll() with a timeout in milliseconds passed
+             * in a variable of type 'int' which is around 3,5 weeks). The
+             * overhead, in case all timers are very far in the future, will
+             * be that the scheduler once a week will have to check if we got
+             * any timeouts closer in time than a week...
+             */
+            min_timeout_pos = timeout_pos_limit;
+            true_min_timeout = 0;
+        }
 
         min_timeout = ERTS_CLKTCKS_TO_MONOTONIC(min_timeout_pos);
         tiw->next_timeout_pos = min_timeout_pos;

--- a/erts/emulator/sys/common/erl_poll.c
+++ b/erts/emulator/sys/common/erl_poll.c
@@ -1809,8 +1809,15 @@ get_timeout_timespec(ErtsPollSet *ps,
     }
     else {
 	ErtsMonotonicTime sec = timeout/(1000*1000*1000);
-	tsp->tv_sec = sec;
-	tsp->tv_nsec = timeout - sec*(1000*1000*1000);
+        if (sizeof(tsp->tv_sec) == 8
+            || sec <= (ErtsMonotonicTime) INT_MAX) {
+            tsp->tv_sec = sec;
+            tsp->tv_nsec = timeout - sec*(1000*1000*1000);
+        }
+        else {
+            tsp->tv_sec = INT_MAX;
+            tsp->tv_nsec = 0;
+        }
 
 	ASSERT(tsp->tv_sec >= 0);
 	ASSERT(tsp->tv_nsec >= 0);

--- a/erts/emulator/sys/win32/erl_poll.c
+++ b/erts/emulator/sys/win32/erl_poll.c
@@ -1015,6 +1015,8 @@ ErtsPollEvents erts_poll_control(ErtsPollSet *ps,
     return result;
 }
 
+#define MILLISECONDS_PER_WEEK__ (7*24*60*60*1000)
+
 int erts_poll_wait(ErtsPollSet *ps,
 		   ErtsPollResFd pr[],
 		   int *len,
@@ -1022,13 +1024,20 @@ int erts_poll_wait(ErtsPollSet *ps,
                    Sint64 timeout_in)
 {
     int no_fds;
-    DWORD timeout = timeout_in == -1 ? INFINITE : timeout_in;
+    DWORD timeout;
     EventData* ev;
     int res = 0;
     int num = 0;
     int n; 
     int i;
     int break_state;
+
+    if (timeout_in < 0)
+        timeout = INFINITE;
+    else if (timeout_in > MILLISECONDS_PER_WEEK__)
+        timeout = MILLISECONDS_PER_WEEK__;
+    else
+        timeout = (DWORD) timeout_in;
 
     HARDTRACEF(("In erts_poll_wait"));
     ERTS_POLLSET_LOCK(ps);

--- a/erts/emulator/test/timer_bif_SUITE.erl
+++ b/erts/emulator/test/timer_bif_SUITE.erl
@@ -32,7 +32,8 @@
 %	 same_time_yielding_with_cancel_other_accessor/1,
 	 auto_cancel_yielding/1,
          suspended_scheduler_timeout/1,
-         multizero_timeout_in_timeout/1]).
+         multizero_timeout_in_timeout/1,
+         huge_timeout/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -72,7 +73,8 @@ all() ->
 %     same_time_yielding_with_cancel_other_accessor,
      auto_cancel_yielding,
      suspended_scheduler_timeout,
-     multizero_timeout_in_timeout].
+     multizero_timeout_in_timeout,
+     huge_timeout].
 
 
 %% Basic start_timer/3 functionality
@@ -771,8 +773,51 @@ multizero_timeout_in_timeout(Config) when is_list(Config) ->
     io:format("Time=~p~n", [Time]),
     true = Time < Timeout + MaxTimeoutDiff,
     ok.
-            
-        
+
+huge_timeout(Config) when is_list(Config) ->
+    %% More than 2^31 seconds...
+    huge_timeout_test((1 bsl 31)*1000 + 1000),
+    %% More than 2^32 seconds...
+    huge_timeout_test((1 bsl 32)*1000 + 1000),
+    %% More than 2^31 milliseconds...
+    huge_timeout_test((1 bsl 31) + 1000),
+    %% More than 2^32 milliseconds...
+    huge_timeout_test((1 bsl 32) + 1000),
+    ok.
+
+huge_timeout_test(HugeTmo) ->
+    SOnln = erlang:system_info(schedulers_online),
+    process_flag(trap_exit, true),
+    %% Likely to hit the bug if we set a huge timeout in an
+    %% empty timer wheel, then set a small timeout
+    %% and let the small timeout trigger. The huge timeout
+    %% will then be found as the next timeout in the wheel.
+    %% Just setting a huge timeout wont trigger the bug
+    %% since an empty wheel have a fake timeout of one week.
+    Ps = lists:map(
+           fun (N) ->
+                   spawn_opt(
+                     fun () ->
+                             erlang:send_after(HugeTmo, self(), hej),
+                             erlang:send_after(2, self(), hej),
+                             receive after infinity -> ok end
+                     end, [{scheduler,N}, link])
+           end, lists:seq(1, erlang:system_info(schedulers))),
+    %% If we have schedulers offline, those timer wheels are likely
+    %% empty, so set them online increasing the chanse of hitting
+    %% a bug.
+    try
+        erlang:system_flag(schedulers_online, erlang:system_info(schedulers)),
+        receive after 1000 -> ok end
+    after
+        lists:foreach(fun (P) ->
+                              unlink(P),
+                              exit(P, kill),
+                              false = is_process_alive(P)
+                      end, Ps),
+        erlang:system_flag(schedulers_online, SOnln),
+        process_flag(trap_exit, false)
+    end.
 
 process_is_cleaned_up(P) when is_pid(P) ->
     undefined == erts_debug:get_internal_state({process_status, P}).

--- a/erts/include/internal/erl_errno.h
+++ b/erts/include/internal/erl_errno.h
@@ -47,6 +47,9 @@
 #  ifndef ETIMEDOUT
 #    define ETIMEDOUT EAGAIN
 #  endif
+#  ifndef EINTR
+#    define EINTR (INT_MAX-1)
+#  endif
 #endif
 
 #endif

--- a/erts/lib_src/pthread/ethr_event.c
+++ b/erts/lib_src/pthread/ethr_event.c
@@ -52,6 +52,7 @@
 
 #include <sched.h>
 #include <errno.h>
+#include <limits.h>
 
 #define ETHR_YIELD_AFTER_BUSY_LOOPS 50
 
@@ -92,6 +93,7 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 #ifdef ETHR_HAVE_ETHR_GET_MONOTONIC_TIME
     ethr_sint64_t start = 0; /* SHUT UP annoying faulty warning... */
 #endif
+    int timeout_res = ETIMEDOUT;
 
     if (spincount < 0)
 	ETHR_FATAL_ERROR__(EINVAL);
@@ -131,6 +133,7 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 	}
 
 	if (timeout >= 0) {
+            ethr_sint64_t sec, nsec;
 #ifdef ETHR_HAVE_ETHR_GET_MONOTONIC_TIME
 	    time = timeout - (ethr_get_monotonic_time() - start);
 #endif
@@ -141,8 +144,18 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 		    goto return_event_on;
 		return ETIMEDOUT;
 	    }
-	    ts.tv_sec = time / (1000*1000*1000);
-	    ts.tv_nsec = time % (1000*1000*1000);
+            sec = time / (1000*1000*1000);
+            nsec = time % (1000*1000*1000);
+            if (sizeof(ts.tv_sec) == 8
+                || sec <= (ethr_sint64_t) INT_MAX) {
+                ts.tv_sec = sec;
+                ts.tv_nsec = nsec;
+            }
+            else {
+                ts.tv_sec = INT_MAX;
+                ts.tv_nsec = 0;
+                timeout_res = EINTR;
+            }
 	}
 
 	if (val != ETHR_EVENT_OFF_WAITER__) {
@@ -160,8 +173,10 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 			   ETHR_EVENT_OFF_WAITER__,
 			   tsp);
 	switch (res) {
-	case EINTR:
 	case ETIMEDOUT:
+            res = timeout_res;
+            /* Fall through... */
+	case EINTR:
 	    return res;
 	case 0:
 	case EWOULDBLOCK:
@@ -189,6 +204,7 @@ return_event_on:
 #include <sys/select.h>
 #include <errno.h>
 #include <string.h>
+#include <limits.h>
 
 #include "erl_misc_utils.h"
 
@@ -358,6 +374,7 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 #ifdef ETHR_HAVE_ETHR_GET_MONOTONIC_TIME
     ethr_sint64_t timeout_time = 0; /* SHUT UP annoying faulty warning... */
 #endif
+    int timeout_res = ETIMEDOUT;
 
     val = ethr_atomic32_read(&e->state);
     if (val == ETHR_EVENT_ON__)
@@ -452,6 +469,7 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 #ifdef ETHR_HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC
 	    if (timeout > 0) {
 		if (time != timeout_time) {
+                    ethr_sint64_t sec, nsec;
 		    time = timeout_time;
 
 #if ERTS_USE_PREMATURE_TIMEOUT
@@ -467,11 +485,22 @@ wait__(ethr_event *e, int spincount, ethr_sint64_t timeout)
 			time -= ERTS_PREMATURE_TIMEOUT(rtmo, 1000*1000*1000);
 		    }
 #endif
-
-		    cond_timeout.tv_sec = time / (1000*1000*1000);
-		    cond_timeout.tv_nsec = time % (1000*1000*1000);
+                    sec = time / (1000*1000*1000);
+                    nsec = time % (1000*1000*1000);
+                    if (sizeof(cond_timeout.tv_sec) == 8
+                        || sec <= (ethr_sint64_t) INT_MAX) {
+                        cond_timeout.tv_sec = sec;
+                        cond_timeout.tv_nsec = nsec;
+                    }
+                    else {
+                        cond_timeout.tv_sec = INT_MAX;
+                        cond_timeout.tv_nsec = 0;
+                        timeout_res = EINTR;
+                    }
 		}
 		res = pthread_cond_timedwait(&e->cnd, &e->mtx, &cond_timeout);
+                if (res == ETIMEDOUT)
+                    res = timeout_res;
 		if (res == EINTR
 		    || (res == ETIMEDOUT
 #if ERTS_USE_PREMATURE_TIMEOUT

--- a/erts/lib_src/win/ethr_event.c
+++ b/erts/lib_src/win/ethr_event.c
@@ -71,11 +71,14 @@ ethr_event_reset(ethr_event *e)
     ethr_event_reset__(e);
 }
 
+#define MILLISECONDS_PER_WEEK__ (7*24*60*60*1000)
+
 static ETHR_INLINE int
 wait(ethr_event *e, int spincount, ethr_sint64_t timeout)
 {
     DWORD code, tmo;
     int sc, res, until_yield = ETHR_YIELD_AFTER_BUSY_LOOPS;
+    int timeout_res = ETIMEDOUT;
 
     if (timeout < 0)
 	tmo = INFINITE;
@@ -88,11 +91,19 @@ wait(ethr_event *e, int spincount, ethr_sint64_t timeout)
 	return ETIMEDOUT;
     }	    
     else {
+        ethr_sint64_t tmo_ms;
 	/*
 	 * Timeout in nano-seconds, but we can only
 	 * wait for milli-seconds...
 	 */
-	tmo = (DWORD) (timeout - 1) / (1000*1000) + 1;
+	tmo_ms = (timeout - 1) / (1000*1000) + 1;
+        if (tmo_ms <= MILLISECONDS_PER_WEEK__) {
+            tmo = (DWORD) tmo_ms;
+        }
+        else {
+            tmo = MILLISECONDS_PER_WEEK__;
+            timeout_res = EINTR;
+        }
     }
 
     if (spincount < 0)
@@ -131,7 +142,7 @@ wait(ethr_event *e, int spincount, ethr_sint64_t timeout)
 
 	code = WaitForSingleObject(e->handle, tmo);
         if (code == WAIT_TIMEOUT)
-            return ETIMEDOUT;
+            return timeout_res;
 	if (code != WAIT_OBJECT_0)
 	    ETHR_FATAL_ERROR__(ethr_win_get_errno__());
     }


### PR DESCRIPTION
32-bit runtime systems on most Unix like platforms could crash if a BIF timer was set with a huge timeout of more than 68 years into the future. In order for the crash to occur, the huge timer (at a later time than when it was set) had to become the nearest active timer set on the specific scheduler on which it was set. This could not happen on a system with only one scheduler since there would always be shorter timers in the system.

Setting a timer larger than 49 days on Windows could under rare circumstances cause the timeout to be delayed.