### PR TITLE
ssl: Get dhfile ssl option

### DIFF
--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -331,7 +331,7 @@ init_diffie_hellman(DbHandle, Opts, server) ->
         Bin when is_binary(Bin) ->
             public_key:der_decode('DHParameter', Bin);
         _ ->
-            case maps:get(dh, Opts, undefined) of
+            case maps:get(dhfile, Opts, undefined) of
                 undefined ->
                     ?DEFAULT_DIFFIE_HELLMAN_PARAMS;
                 DHParamFile ->

--- a/lib/ssl/test/ssl_api_SUITE_data/dHParam-invalid.pem
+++ b/lib/ssl/test/ssl_api_SUITE_data/dHParam-invalid.pem
@@ -1,0 +1,2 @@
+-----BEGIN DH PARAMETERS-----
+-----END DH PARAMETERS-----


### PR DESCRIPTION
The fallback after "dh" ssl option was undefined was to get "dh" from
ssl options again. This is clearly wrong and now changed to the
documented fallback "dhfile" ssl option.

Add test for passing an invalid dhparams file to server ssl options.