### PR TITLE
argparse: Correct argparse tuple help docs

### DIFF
--- a/lib/stdlib/doc/src/argparse.xml
+++ b/lib/stdlib/doc/src/argparse.xml
@@ -199,9 +199,10 @@ cli() ->
       <desc>
         <p>User-defined help template to print in the command usage. First element of
           a tuple must be a string. It is printed as a part of the usage header. Second
-          element of the tuple can be either a string printed as-is, a list
-          containing strings, <c>type</c> and <c>default</c> atoms, or a user-defined
-          function that must return a string.</p>
+          element of the tuple can be either a list containing strings, <c>type</c>
+          and <c>default</c> atoms, or a user-defined function that must return a
+          string. A plain string should be wrapped as a list such as
+          <c>["string is nested"]</c>.</p>
       </desc>
     </datatype>
 

--- a/lib/stdlib/test/argparse_SUITE.erl
+++ b/lib/stdlib/test/argparse_SUITE.erl
@@ -999,6 +999,9 @@ validator_exception(Config) when is_list(Config) ->
         argparse:validate(#{arguments => [#{name => one, required => ok}]})),
     ?assertException(error, {argparse, argument, Prg, help, _},
         argparse:validate(#{arguments => [#{name => one, help => ok}]})),
+    %% tuple form of help must not have string as second argument
+    ?assertException(error, {argparse, argument, Prg, help, _},
+        argparse:validate(#{arguments => [#{name => one, help => {"one", "1"}}]})),
     %% broken commands
     try argparse:help(#{}, #{progname => 123}), ?assert(false)
     catch error:badarg:Stack ->


### PR DESCRIPTION
The second argument must not be a string as-is. Add a testcase to
validate that it throws a validation error.