### PR TITLE
make: remove not needed error message part

### DIFF
--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -99,12 +99,9 @@ print_on_error_note () {
         cat << EOM
 NOTE:
 
-Some test cases do not work correctly when run through "make test" as
-they are designed to be run through the method that is described in
-the "$ERL_TOP/HOWTO/TESTING.md" text file. You may want to check this
-text file if you encounter strange errors. Note also that you can
-rerun a specific test case by passing parameters to ct_run as in the
-example below:
+You may want to check "$ERL_TOP/HOWTO/TESTING.md" text file if you
+encounter strange errors. Note also that you can rerun a specific test
+case by passing parameters to ct_run as in the example below:
 
 make ARGS="-suite asn1_SUITE -case ticket_7407" test
 


### PR DESCRIPTION
- adjust error message reported by test_target_script.sh
- "make test" is expected to work nowadays