### PR TITLE
jit: Unregister unloaded code with GDB integration

### DIFF
--- a/erts/emulator/beam/beam_bif_load.c
+++ b/erts/emulator/beam/beam_bif_load.c
@@ -2066,6 +2066,7 @@ BIF_RETTYPE erts_internal_purge_module_2(BIF_ALIST_2)
                 __lsan_unregister_root_region(modp->old.code_hdr,
                                               modp->old.code_length);
 #   endif
+                beamasm_unregister_metadata(modp->old.metadata);
                 beamasm_purge_module(modp->old.executable_region,
                                      modp->old.writable_region,
                                      modp->old.code_length);

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1105,7 +1105,7 @@ public:
 
     void codegen(char *buff, size_t len);
 
-    void register_metadata(const BeamCodeHeader *header);
+    void *register_metadata(const BeamCodeHeader *header);
 
     ErtsCodePtr getCode(unsigned label);
     ErtsCodePtr getLambda(unsigned index);
@@ -1829,9 +1829,9 @@ protected:
     }
 };
 
-void beamasm_metadata_update(std::string module_name,
-                             ErtsCodePtr base_address,
-                             size_t code_size,
-                             const std::vector<AsmRange> &ranges);
+void *beamasm_metadata_insert(std::string module_name,
+                              ErtsCodePtr base_address,
+                              size_t code_size,
+                              const std::vector<AsmRange> &ranges);
 void beamasm_metadata_early_init();
 void beamasm_metadata_late_init();

--- a/erts/emulator/beam/jit/arm/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.cpp
@@ -79,10 +79,10 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
                           .name = code.labelEntry(labels[val.first])->name()});
     }
 
-    beamasm_metadata_update("global",
-                            (ErtsCodePtr)getBaseAddress(),
-                            code.codeSize(),
-                            ranges);
+    (void)beamasm_metadata_insert("global",
+                                  (ErtsCodePtr)getBaseAddress(),
+                                  code.codeSize(),
+                                  ranges);
 
     /* `this->get_xxx` are populated last to ensure that we crash if we use
      * them instead of labels in global code. */

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -1133,7 +1133,7 @@ void beam_load_finalize_code(LoaderState *stp,
     }
 
     /* Register debug / profiling info with external tools. */
-    beamasm_register_metadata(stp->ba, stp->code_hdr);
+    inst_p->metadata = beamasm_register_metadata(stp->ba, stp->code_hdr);
 
     erts_seal_module(inst_p);
 

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -59,7 +59,8 @@ void beamasm_codegen(void *ba,
                      const BeamCodeHeader *in_hdr,
                      const BeamCodeHeader **out_exec_hdr,
                      BeamCodeHeader **out_rw_hdr);
-void beamasm_register_metadata(void *ba, const BeamCodeHeader *hdr);
+void *beamasm_register_metadata(void *ba, const BeamCodeHeader *header);
+void beamasm_unregister_metadata(void *handle);
 void beamasm_purge_module(const void *executable_region,
                           void *writable_region,
                           size_t size);

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -357,7 +357,7 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *_ga,
     }
 }
 
-void BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
+void *BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
 #ifndef WIN32
     const BeamCodeLineTab *line_table = header->line_table;
 
@@ -472,10 +472,12 @@ void BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
              .stop = (ErtsCodePtr)(code.baseAddress() + code.codeSize()),
              .name = module_name + "::codeFooter"});
 
-    beamasm_metadata_update(module_name,
-                            (ErtsCodePtr)code.baseAddress(),
-                            code.codeSize(),
-                            ranges);
+    return beamasm_metadata_insert(module_name,
+                                   (ErtsCodePtr)code.baseAddress(),
+                                   code.codeSize(),
+                                   ranges);
+#else
+    return NULL;
 #endif
 }
 

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -623,9 +623,10 @@ extern "C"
                     out_rw_hdr);
     }
 
-    void beamasm_register_metadata(void *instance, const BeamCodeHeader *hdr) {
+    void *beamasm_register_metadata(void *instance,
+                                    const BeamCodeHeader *header) {
         BeamModuleAssembler *ba = static_cast<BeamModuleAssembler *>(instance);
-        ba->register_metadata(hdr);
+        return ba->register_metadata(header);
     }
 
     Uint beamasm_get_header(void *instance, const BeamCodeHeader **hdr) {

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1186,7 +1186,7 @@ public:
 
     void codegen(char *buff, size_t len);
 
-    void register_metadata(const BeamCodeHeader *header);
+    void *register_metadata(const BeamCodeHeader *header);
 
     ErtsCodePtr getCode(unsigned label);
     ErtsCodePtr getLambda(unsigned index);
@@ -1663,9 +1663,9 @@ protected:
     }
 };
 
-void beamasm_metadata_update(std::string module_name,
-                             ErtsCodePtr base_address,
-                             size_t code_size,
-                             const std::vector<AsmRange> &ranges);
+void *beamasm_metadata_insert(std::string module_name,
+                              ErtsCodePtr base_address,
+                              size_t code_size,
+                              const std::vector<AsmRange> &ranges);
 void beamasm_metadata_early_init();
 void beamasm_metadata_late_init();

--- a/erts/emulator/beam/jit/x86/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.cpp
@@ -80,10 +80,10 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
                           .name = code.labelEntry(labels[val.first])->name()});
     }
 
-    beamasm_metadata_update("global",
-                            (ErtsCodePtr)getBaseAddress(),
-                            code.codeSize(),
-                            ranges);
+    (void)beamasm_metadata_insert("global",
+                                  (ErtsCodePtr)getBaseAddress(),
+                                  code.codeSize(),
+                                  ranges);
 #endif
 
     /* `this->get_xxx` are populated last to ensure that we crash if we use them

--- a/erts/emulator/beam/module.h
+++ b/erts/emulator/beam/module.h
@@ -34,6 +34,7 @@ struct erl_module_instance {
 
     const void *executable_region;
     void *writable_region;
+    void *metadata;
 
     /* Protected by code modification permission. */
     int unsealed;


### PR DESCRIPTION
This resolves some random crashes when stepping backwards under `rr` (but sadly not all).