### PR TITLE
stdlib: Include process label in gen_statem, gen_server, gent_event, gen_fsm crash messages

### DIFF
--- a/lib/stdlib/test/gen_event_SUITE.erl
+++ b/lib/stdlib/test/gen_event_SUITE.erl
@@ -33,6 +33,7 @@
          undef_init/1, undef_handle_call/1, undef_handle_event/1,
          undef_handle_info/1, undef_code_change/1, undef_terminate/1,
          undef_in_terminate/1, format_log_1/1, format_log_2/1,
+         format_log_with_process_label/1,
          send_request_receive_reqid_collection/1, send_request_wait_reqid_collection/1,
          send_request_check_reqid_collection/1]).
 
@@ -43,7 +44,7 @@ all() ->
      call_format_status, call_format_status_anon, error_format_status,
      get_state, replace_state,
      start_opt, {group, undef_callbacks}, undef_in_terminate,
-     format_log_1, format_log_2,
+     format_log_1, format_log_2, format_log_with_process_label,
      send_request_receive_reqid_collection, send_request_wait_reqid_collection,
      send_request_check_reqid_collection].
 
@@ -1325,7 +1326,8 @@ format_log_1(_Config) ->
                name=>Name,
                last_message=>Term,
                state=>Term,
-               reason=>Term},
+               reason=>Term,
+               process_label=>undefined},
     {F1, A1} = gen_event:format_log(Report),
     FExpected1 = "** gen_event handler ~tp crashed.\n"
         "** Was installed in ~tp\n"
@@ -1361,7 +1363,8 @@ format_log_1(_Config) ->
                                      name=>Name,
                                      last_message=>LastMsg,
                                      state=>State,
-                                     reason=>Reason}),
+                                     reason=>Reason,
+                                     process_label=>undefined}),
     FExpected2 = "** gen_event handler ~tP crashed.\n"
         "** Was installed in ~tP\n"
         "** Last event was: ~tP\n"
@@ -1398,7 +1401,8 @@ format_log_2(_Config) ->
                name=>Name,
                last_message=>Term,
                state=>Term,
-               reason=>Term},
+               reason=>Term,
+               process_label=>undefined},
     FormatOpts1 = #{},
     Str1 = flatten_format_log(Report, FormatOpts1),
     L1 = length(Str1),
@@ -1522,6 +1526,85 @@ format_log_2(_Config) ->
     true = lists:prefix(WExpected6, WStr6),
     true = WL6 < WL4,
 
+    ok.
+
+format_log_with_process_label(_Config) ->
+    %% Previous test cases test with process_label set to undefined,
+    %% so in this test case, test setting it, and test:
+    %% * multiple and single line line
+    %% * depth-limited and unlimited
+
+    FD = application:get_env(kernel, error_logger_format_depth),
+    application:unset_env(kernel, error_logger_format_depth),
+    Term = lists:seq(1,15),
+    Handler = my_handler,
+    Name = self(),
+    NameStr = pid_to_list(Name),
+    ProcessLabel = {some_id, #{term => Term}},
+    LastMsg = dummy_msg,
+    Reason = dummy_reason,
+    State = dummy_state,
+    Report = #{label=>{gen_event,terminate},
+               handler=>Handler,
+               name=>Name,
+               last_message=>LastMsg,
+               state=>State,
+               reason=>Reason,
+               process_label=>ProcessLabel},
+
+    %% multiple and single line (unlimited depth)
+
+    {F1, A1} = gen_event:format_log(Report),
+    FExpected1 = "** gen_event handler ~tp crashed.\n"
+        "** Was installed in ~tp\n"
+        "** Process label == ~tp\n"
+        "** Last event was: ~tp\n"
+        "** When handler state == ~tp\n"
+        "** Reason == ~tp\n",
+    ct:log("F1: ~ts~nA1: ~tp", [F1,A1]),
+    FExpected1 = F1,
+    [Handler,Name,ProcessLabel,LastMsg,State,Reason] = A1,
+
+    FormatOpts2 = #{single_line=>true},
+    Str2 = flatten_format_log(Report, FormatOpts2),
+    Expected2 = "Generic event handler my_handler crashed. "
+        "Installed: "++NameStr++". "
+        "Label: {some_id,#{term => [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}}. "
+        "Last event: dummy_msg. "
+        "State: dummy_state. "
+        "Reason: dummy_reason.",
+    ct:log("Str2: ~ts", [Str2]),
+    true = Expected2 =:= Str2,
+
+    %% multiple and single line (depth-limited)
+
+    Depth = 10,
+    FormatOpts3 = #{depth=>Depth},
+    Str3 = flatten_format_log(Report, FormatOpts3),
+    Expected3 = "** gen_event handler my_handler crashed.\n"
+        "** Was installed in " ++ NameStr ++ "\n"
+        "** Process label == {some_id,#{term => [1,2,3,4,5,6|...]}}\n"
+        "** Last event was: ",
+    ct:log("Str3: ~ts",[Str3]),
+    true = lists:prefix(Expected3,Str3),
+
+    FormatOpts4 = #{single_line=>true, depth=>Depth},
+    Str4 = flatten_format_log(Report, FormatOpts4),
+    Expected4 = "Generic event handler my_handler crashed. "
+        "Installed: "++NameStr++". "
+        "Label: {some_id,#{term => [1,2,3,4,5,6|...]}}. "
+        "Last event: dummy_msg. "
+        "State: dummy_state. "
+        "Reason: dummy_reason.",
+    ct:log("Str4: ~ts", [Str4]),
+    true = Expected4 =:= Str4,
+
+    case FD of
+        undefined ->
+            application:unset_env(kernel, error_logger_format_depth);
+        _ ->
+            application:set_env(kernel, error_logger_format_depth, FD)
+    end,
     ok.
 
 flatten_format_log(Report, Format) ->

--- a/lib/stdlib/test/gen_fsm_SUITE.erl
+++ b/lib/stdlib/test/gen_fsm_SUITE.erl
@@ -46,7 +46,7 @@
 
 -export([hibernate/1,auto_hibernate/1,hiber_idle/3,hiber_wakeup/3,hiber_idle/2,hiber_wakeup/2]).
 
--export([format_log_1/1, format_log_2/1]).
+-export([format_log_1/1, format_log_2/1, format_log_with_process_label/1]).
 
 -export([reply_by_alias_with_payload/1]).
 
@@ -89,7 +89,8 @@ groups() ->
      {undef_callbacks, [],
       [undef_handle_event, undef_handle_sync_event, undef_handle_info,
        undef_init, undef_code_change, undef_terminate1, undef_terminate2]},
-     {format_log, [], [format_log_1, format_log_2]}].
+     {format_log, [], [format_log_1, format_log_2,
+                       format_log_with_process_label]}].
 
 init_per_suite(Config) ->
     Config.
@@ -1032,7 +1033,8 @@ format_log_1(_Config) ->
                state_data=>Term,
                log=>[Term],
                reason=>Term,
-               client_info=>{self(),{clientname,[]}}},
+               client_info=>{self(),{clientname,[]}},
+               process_label=>undefined},
     {F1,A1} = gen_fsm:format_log(Report),
     FExpected1 = "** State machine ~tp terminating \n"
         "** Last message in was ~tp~n"
@@ -1066,7 +1068,8 @@ format_log_1(_Config) ->
                                    state_data=>Term,
                                    log=>[Term],
                                    reason=>Term,
-                                   client_info=>{self(),{clientname,[]}}}),
+                                   client_info=>{self(),{clientname,[]}},
+                                   process_label=>undefined}),
     FExpected2 =  "** State machine ~tP terminating \n"
         "** Last message in was ~tP~n"
         "** When State == ~tP~n"
@@ -1107,7 +1110,8 @@ format_log_2(_Config) ->
                state_data=>Term,
                log=>[Term],
                reason=>Term,
-               client_info=>{self(),{clientname,[]}}},
+               client_info=>{self(),{clientname,[]}},
+               process_label=>undefined},
     FormatOpts1 = #{},
     Str1 = flatten_format_log(Report, FormatOpts1),
     L1 = length(Str1),
@@ -1244,6 +1248,96 @@ format_log_2(_Config) ->
     true = lists:prefix(WExpected6, WStr6),
     true = WL6 < WL4,
 
+    ok.
+
+format_log_with_process_label(_Config) ->
+    %% Previous test cases test with process_label set to undefined,
+    %% so in this test case, test setting it, and test:
+    %% * multiple and single line line
+    %% * depth-limited and unlimited
+
+    FD = application:get_env(kernel, error_logger_format_depth),
+    application:unset_env(kernel, error_logger_format_depth),
+    Term = lists:seq(1,15),
+    Name = self(),
+    NameStr = pid_to_list(Name),
+    ProcessLabel = {some_id, #{term => Term}},
+    LastMsg = dummy_msg,
+    Reason = dummy_reason,
+    StateName = dummy_state_name,
+    StateData = dummy_state_data,
+    Report = #{label=>{gen_fsm,terminate},
+               name=>Name,
+               last_message=>LastMsg,
+               state_name=>StateName,
+               state_data=>StateData,
+               log=>[],
+               reason=>Reason,
+               client_info=>{self(),{clientname,[]}},
+               process_label=>ProcessLabel},
+
+    %% multiple and single line (unlimited depth)
+
+    {F1,A1} = gen_fsm:format_log(Report),
+    FExpected1 = "** State machine ~tp terminating \n"
+        "** Process label == ~tp~n"
+        "** Last message in was ~tp~n"
+        "** When State == ~tp~n"
+        "**      Data  == ~tp~n"
+        "** Reason for termination ==~n** ~tp~n"
+        "** Client ~tp stacktrace~n** ~tp~n",
+    ct:log("F1: ~ts~nA1: ~tp", [F1,A1]),
+    FExpected1=F1,
+
+    [Name,ProcessLabel,LastMsg,StateName,StateData,Reason,clientname,[]] = A1,
+
+    FormatOpts2 = #{single_line=>true},
+    Str2 = flatten_format_log(Report, FormatOpts2),
+    Expected2 = "State machine "++NameStr++" terminating. "
+        "Label: {some_id,#{term => [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}}. "
+        "Reason: dummy_reason. "
+        "Last event: [dummy_msg]. "
+        "State: dummy_state_name. "
+        "Data: dummy_state_data. "
+        "Client clientname stacktrace: [].",
+    ct:log("Str2: ~ts", [Str2]),
+    true = Expected2 =:= Str2,
+
+    %% multiple and single line (depth-limited)
+
+    Depth = 10,
+    FormatOpts3 = #{depth=>Depth},
+    Str3 = flatten_format_log(Report, FormatOpts3),
+    Expected3 = "** State machine "++NameStr++" terminating \n"
+        "** Process label == {some_id,#{term => [1,2,3,4,5,6|...]}}\n"
+        "** Last message in was dummy_msg\n"
+        "** When State == dummy_state_name\n"
+        "**      Data  == dummy_state_data\n"
+        "** Reason for termination ==\n"
+        "** dummy_reason\n"
+        "** Client clientname stacktrace\n"
+        "** []\n",
+    ct:log("Str3: ~ts", [Str3]),
+    true = lists:prefix(Expected3,Str3),
+
+    FormatOpts4 = #{single_line=>true, depth=>Depth},
+    Str4 = flatten_format_log(Report, FormatOpts4),
+    Expected4 = "State machine "++NameStr++" terminating. "
+        "Label: {some_id,#{term => [1,2,3,4,5,6|...]}}. "
+        "Reason: dummy_reason. "
+        "Last event: [dummy_msg]. "
+        "State: dummy_state_name. "
+        "Data: dummy_state_data. "
+        "Client clientname stacktrace: [].",
+    ct:log("Str4: ~ts", [Str4]),
+    true = Expected4 =:= Str4,
+
+    case FD of
+        undefined ->
+            application:unset_env(kernel, error_logger_format_depth);
+        _ ->
+            application:set_env(kernel, error_logger_format_depth, FD)
+    end,
     ok.
 
 flatten_format_log(Report, Format) ->


### PR DESCRIPTION
The #7720 added process labels and the `proc_lib:set_label/1` and `get_label/1` functions. This PR includes a process label printout in crash message printouts from gen_statems, gen_servers, gen_events and gen_fsms, to make it easier to identify the crashing process.

Below is an example of what it may look like for a gen_statem. The "Process label" on the second line is new.
```
  ** State machine <0.1386.0> terminating
  ** Process label = {some_label, ...}
  ** When server state  = #{...}
  ** Reason for termination = error:...
  ** Callback modules = [...]
  ** Callback mode = state_functions
```
If no label has been set, then that process label line will not be included, and the printout will look like it did before this commit.