### PR TITLE
Remove unused field from appl record in application_controller

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -159,7 +159,7 @@
 %% Env         = [{Key, Value}]
 %%-----------------------------------------------------------------
 
--record(appl, {name, appl_data, descr, id, vsn, restart_type, inc_apps, opt_apps, apps}).
+-record(appl, {name, appl_data, descr, id, vsn, inc_apps, opt_apps, apps}).
 
 %%-----------------------------------------------------------------
 %% Func: start/1


### PR DESCRIPTION
This field is not set or read. It seems that the restart_type is stored in the running field of the controller's state.