### PR TITLE
Improve caching of BEAM registers

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -958,98 +958,95 @@ class BeamModuleAssembler : public BeamAssembler,
      * fragments as if they were local. */
     std::unordered_map<void (*)(), Label> _dispatchTable;
 
-    /* Skip unnecessary moves in load_source(), load_sources(), and
-     * mov_arg(). Don't use these variables directly. */
-    size_t last_destination_offset = 0;
-    a64::Gp last_destination_from1, last_destination_from2;
-    arm::Mem last_destination_to1, last_destination_to2;
+    RegisterCache<16, arm::Mem, a64::Gp> reg_cache =
+            RegisterCache<16, arm::Mem, a64::Gp>(scheduler_registers, E, {});
 
-    /* Private helper. */
-    void preserve__cache(a64::Gp dst) {
-        last_destination_offset = a.offset();
-        invalidate_cache(dst);
+    void reg_cache_put(arm::Mem mem, a64::Gp src) {
+        if (src != SUPER_TMP) {
+            reg_cache.put(mem, src);
+        }
     }
 
-    bool is_cache_valid() {
-        return a.offset() == last_destination_offset;
+    a64::Gp find_cache(arm::Mem mem) {
+        return reg_cache.find(a.offset(), mem);
     }
 
     /* Works as the STR instruction, but also updates the cache. */
-    void str_cache(a64::Gp src, arm::Mem dst) {
-        if (a.offset() == last_destination_offset &&
-            dst != last_destination_to1) {
-            /* Something is already cached in the first slot. Use the
-             * second slot. */
-            a.str(src, dst);
-            last_destination_offset = a.offset();
-            last_destination_to2 = dst;
-            last_destination_from2 = src;
-        } else {
-            /* Nothing cached yet, or the first slot has the same
-             * memory address as we will store into. Use the first
-             * slot and invalidate the second slot. */
-            a.str(src, dst);
-            last_destination_offset = a.offset();
-            last_destination_to1 = dst;
-            last_destination_from1 = src;
-            last_destination_to2 = arm::Mem();
-        }
+    void str_cache(a64::Gp src, arm::Mem mem_dst) {
+        reg_cache.consolidate(a.offset());
+        reg_cache.invalidate(src);
+
+        a.str(src, mem_dst);
+
+        reg_cache_put(mem_dst, src);
+        reg_cache.update(a.offset());
     }
 
     /* Works as the STP instruction, but also updates the cache. */
-    void stp_cache(a64::Gp src1, a64::Gp src2, arm::Mem dst) {
-        safe_stp(src1, src2, dst);
-        last_destination_offset = a.offset();
-        last_destination_to1 = dst;
-        last_destination_from1 = src1;
-        last_destination_to2 =
-                arm::Mem(a64::GpX(dst.baseId()), dst.offset() + 8);
-        last_destination_from2 = src2;
-    }
+    void stp_cache(a64::Gp src1, a64::Gp src2, arm::Mem mem_dst) {
+        arm::Mem next_dst =
+                arm::Mem(a64::GpX(mem_dst.baseId()), mem_dst.offset() + 8);
 
-    void invalidate_cache(a64::Gp dst) {
-        if (dst == last_destination_from1) {
-            last_destination_to1 = arm::Mem();
-            last_destination_from1 = a64::Gp();
-        }
-        if (dst == last_destination_from2) {
-            last_destination_to2 = arm::Mem();
-            last_destination_from2 = a64::Gp();
-        }
+        reg_cache.consolidate(a.offset());
+
+        reg_cache.invalidate(src1);
+        reg_cache.invalidate(src2);
+
+        safe_stp(src1, src2, mem_dst);
+
+        reg_cache_put(mem_dst, src1);
+        reg_cache_put(next_dst, src2);
+
+        reg_cache.update(a.offset());
     }
 
     /* Works like LDR, but looks in the cache first. */
     void ldr_cached(a64::Gp dst, arm::Mem mem) {
-        if (a.offset() == last_destination_offset) {
-            a64::Gp cached_reg;
-            if (mem == last_destination_to1) {
-                cached_reg = last_destination_from1;
-            } else if (mem == last_destination_to2) {
-                cached_reg = last_destination_from2;
-            }
+        a64::Gp cached_reg = find_cache(mem);
 
-            if (cached_reg.isValid()) {
-                /* This memory location is cached. */
-                if (cached_reg != dst) {
-                    comment("simplified fetching of BEAM register");
-                    a.mov(dst, cached_reg);
-                    preserve__cache(dst);
-                } else {
-                    comment("skipped fetching of BEAM register");
-                    invalidate_cache(dst);
-                }
+        if (cached_reg.isValid()) {
+            /* This memory location is cached. */
+            if (cached_reg == dst) {
+                comment("skipped fetching of BEAM register");
             } else {
-                /* Not cached. Load and preserve the cache. */
-                a.ldr(dst, mem);
-                preserve__cache(dst);
+                comment("simplified fetching of BEAM register");
+                a.mov(dst, cached_reg);
+                reg_cache.invalidate(dst);
+                reg_cache.update(a.offset());
             }
         } else {
-            /* The cache is invalid. */
+            /* Not cached. Load and update cache. */
             a.ldr(dst, mem);
-            last_destination_offset = a.offset();
-            last_destination_to1 = mem;
-            last_destination_from1 = dst;
-            last_destination_to2 = arm::Mem();
+            reg_cache.invalidate(dst);
+            reg_cache_put(mem, dst);
+            reg_cache.update(a.offset());
+        }
+    }
+
+    template<typename L, typename... Any>
+    void preserve_cache(L generate, Any... clobber) {
+        bool valid = reg_cache.validAt(a.offset());
+
+        generate();
+
+        if (valid) {
+            if (sizeof...(clobber) > 0) {
+                reg_cache.invalidate(clobber...);
+            }
+
+            reg_cache.update(a.offset());
+        }
+    }
+
+    void trim_preserve_cache(const ArgWord &Words) {
+        if (Words.get() > 0) {
+            ASSERT(Words.get() <= 1023);
+
+            preserve_cache([&]() {
+                auto offset = Words.get() * sizeof(Eterm);
+                add(E, E, offset);
+                reg_cache.trim_yregs(-offset);
+            });
         }
     }
 
@@ -1058,21 +1055,19 @@ class BeamModuleAssembler : public BeamAssembler,
     }
 
     void mov_preserve_cache(a64::Gp dst, a64::Gp src) {
-        if (a.offset() == last_destination_offset) {
-            a.mov(dst, src);
-            preserve__cache(dst);
-        } else {
-            a.mov(dst, src);
-        }
+        preserve_cache(
+                [&]() {
+                    a.mov(dst, src);
+                },
+                dst);
     }
 
-    void mov_imm_preserve_cache(a64::Gp dst, UWord value) {
-        if (a.offset() == last_destination_offset) {
-            mov_imm(dst, value);
-            preserve__cache(dst);
-        } else {
-            mov_imm(dst, value);
-        }
+    void untag_ptr_preserve_cache(a64::Gp dst, a64::Gp src) {
+        preserve_cache(
+                [&]() {
+                    emit_untag_ptr(dst, src);
+                },
+                dst);
     }
 
     arm::Mem embed_label(const Label &label, enum Displacement disp);
@@ -1150,8 +1145,31 @@ protected:
     a64::Gp emit_call_fun(bool skip_box_test = false,
                           bool skip_header_test = false);
 
+    void emit_is_cons(Label Fail, a64::Gp Src) {
+        preserve_cache([&]() {
+            BeamAssembler::emit_is_cons(Fail, Src);
+        });
+    }
+
+    void emit_is_not_cons(Label Fail, a64::Gp Src) {
+        preserve_cache([&]() {
+            BeamAssembler::emit_is_not_cons(Fail, Src);
+        });
+    }
+
+    void emit_is_list(Label Fail, a64::Gp Src) {
+        preserve_cache([&]() {
+            a.tst(Src, imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
+            a.mov(SUPER_TMP, NIL);
+            a.ccmp(Src, SUPER_TMP, imm(NZCV::kEqual), imm(arm::CondCode::kNE));
+            a.b_ne(Fail);
+        });
+    }
+
     void emit_is_boxed(Label Fail, a64::Gp Src) {
-        BeamAssembler::emit_is_boxed(Fail, Src);
+        preserve_cache([&]() {
+            BeamAssembler::emit_is_boxed(Fail, Src);
+        });
     }
 
     void emit_is_boxed(Label Fail, const ArgVal &Arg, a64::Gp Src) {
@@ -1160,7 +1178,9 @@ protected:
             return;
         }
 
-        BeamAssembler::emit_is_boxed(Fail, Src);
+        preserve_cache([&]() {
+            BeamAssembler::emit_is_boxed(Fail, Src);
+        });
     }
 
     /* Copies `count` words from the address at `from`, to the address at `to`.
@@ -1446,13 +1466,17 @@ protected:
         ASSERT(tmp.isGpX());
 
         if (arg.isLiteral()) {
-            a.ldr(tmp, embed_constant(arg, disp32K));
+            preserve_cache(
+                    [&]() {
+                        a.ldr(tmp, embed_constant(arg, disp32K));
+                    },
+                    tmp);
             return Variable(tmp);
         } else if (arg.isRegister()) {
             if (isRegisterBacked(arg)) {
                 auto index = arg.as<ArgXRegister>().get();
                 a64::Gp reg = register_backed_xregs[index];
-                invalidate_cache(reg);
+                reg_cache.invalidate(reg);
                 return Variable(reg);
             }
 
@@ -1465,13 +1489,52 @@ protected:
                                          : arg.as<ArgWord>().get();
 
                 if (Support::isIntOrUInt32(val)) {
-                    mov_imm_preserve_cache(tmp, val);
+                    preserve_cache(
+                            [&]() {
+                                mov_imm(tmp, val);
+                            },
+                            tmp);
                     return Variable(tmp);
                 }
             }
 
-            a.ldr(tmp, embed_constant(arg, disp32K));
+            preserve_cache(
+                    [&]() {
+                        a.ldr(tmp, embed_constant(arg, disp32K));
+                    },
+                    tmp);
             return Variable(tmp);
+        }
+    }
+
+    /*
+     * Load the argument into ANY register, using the
+     * cache to avoid reloading the value.
+     *
+     * Because it is not possible to predict into which register
+     * the value will end up, the following code is UNSAFE:
+     *
+     *    auto src = load_source(Src);
+     *    a.tst(src.reg, ...);
+     *    a.mov(TMP2, NIL);
+     *    a.ccmp(src.reg, TMP2, ..., ...);
+     *
+     * If the value of Src happens to end up in TMP2, it will be
+     * overwritten before its second use.
+     *
+     * Basically, the only safe way to use this function is when the
+     * register is used immediately and only once. For example:
+     *
+     *    a.and_(TMP1, load_source(Src), imm(...));
+     *    a.cmp(TMP1, imm(...));
+     */
+    Variable<a64::Gp> load_source(const ArgVal &arg) {
+        a64::Gp cached_reg = find_cache(getArgRef(arg));
+
+        if (cached_reg.isValid()) {
+            return load_source(arg, cached_reg);
+        } else {
+            return load_source(arg, TMP1);
         }
     }
 
@@ -1559,6 +1622,8 @@ protected:
     void flush_var(const Variable<a64::Gp> &to) {
         if (to.mem.hasBase()) {
             str_cache(to.reg, to.mem);
+        } else {
+            reg_cache.invalidate(to.reg);
         }
     }
 
@@ -1707,11 +1772,11 @@ protected:
         ASSERT(gp.isGpX());
 
         if (abs_offset <= sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
-            bool valid_cache = is_cache_valid();
-            a.ldr(gp, mem);
-            if (valid_cache) {
-                preserve__cache(gp);
-            }
+            preserve_cache(
+                    [&]() {
+                        a.ldr(gp, mem);
+                    },
+                    gp);
         } else {
             add(SUPER_TMP, a64::GpX(mem.baseId()), offset);
             a.ldr(gp, arm::Mem(SUPER_TMP));
@@ -1751,12 +1816,12 @@ protected:
         ASSERT(gp1 != gp2);
 
         if (abs_offset <= sizeof(Eterm) * MAX_LDP_STP_DISPLACEMENT) {
-            bool valid_cache = is_cache_valid();
-            a.ldp(gp1, gp2, mem);
-            if (valid_cache) {
-                preserve__cache(gp1);
-                preserve__cache(gp2);
-            }
+            preserve_cache(
+                    [&]() {
+                        a.ldp(gp1, gp2, mem);
+                    },
+                    gp1,
+                    gp2);
         } else if (abs_offset < sizeof(Eterm) * MAX_LDR_STR_DISPLACEMENT) {
             /* Note that we used `<` instead of `<=`, as we're loading two
              * elements rather than one. */

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1618,7 +1618,7 @@ protected:
         }
     }
 
-    void mov_arg(const ArgVal &To, const ArgVal &From) {
+    void mov_arg(const ArgRegister &To, const ArgVal &From) {
         if (isRegisterBacked(To)) {
             auto to = init_destination(To, SUPER_TMP);
             auto from = load_source(From, to.reg);
@@ -1632,7 +1632,7 @@ protected:
         }
     }
 
-    void mov_arg(const ArgVal &To, arm::Mem From) {
+    void mov_arg(const ArgRegister &To, arm::Mem From) {
         auto to = init_destination(To, SUPER_TMP);
         a.ldr(to.reg, From);
         flush_var(to);

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -367,7 +367,7 @@ void BeamModuleAssembler::emit_label(const ArgLabel &Label) {
     current_label = rawLabels[Label.get()];
     bind_veneer_target(current_label);
 
-    last_destination_offset = ~0;
+    reg_cache.invalidate();
 }
 
 void BeamModuleAssembler::emit_aligned_label(const ArgLabel &Label,

--- a/erts/emulator/beam/jit/arm/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/instr_arith.cpp
@@ -152,7 +152,7 @@ void BeamModuleAssembler::emit_i_plus(const ArgLabel &Fail,
     if (always_small(LHS) && always_small(RHS) && is_small_result) {
         auto dst = init_destination(Dst, ARG1);
         if (rhs_is_arm_literal) {
-            auto lhs = load_source(LHS, ARG2);
+            auto lhs = load_source(LHS);
             Uint cleared_tag = RHS.as<ArgSmall>().get() & ~_TAG_IMMED1_MASK;
             comment("add small constant without overflow check");
             a.add(dst.reg, lhs.reg, imm(cleared_tag));
@@ -341,7 +341,7 @@ void BeamModuleAssembler::emit_i_minus(const ArgLabel &Fail,
     if (always_small(LHS) && always_small(RHS) && is_small_result) {
         auto dst = init_destination(Dst, ARG1);
         if (rhs_is_arm_literal) {
-            auto lhs = load_source(LHS, ARG2);
+            auto lhs = load_source(LHS);
             Uint cleared_tag = RHS.as<ArgSmall>().get() & ~_TAG_IMMED1_MASK;
             comment("subtract small constant without overflow check");
             a.sub(dst.reg, lhs.reg, imm(cleared_tag));
@@ -1175,7 +1175,7 @@ void BeamModuleAssembler::emit_i_band(const ArgLabel &Fail,
                                          &ignore)) {
             comment("skipped test for small operands since they are always "
                     "small");
-            auto lhs = load_source(LHS, ARG2);
+            auto lhs = load_source(LHS);
             auto dst = init_destination(Dst, ARG1);
 
             /* TAG & TAG = TAG, so we don't need to tag it again. */
@@ -1269,7 +1269,7 @@ void BeamModuleAssembler::emit_i_bor(const ArgLabel &Fail,
         if (a64::Utils::encodeLogicalImm(rhs, 64, &ignore)) {
             comment("skipped test for small operands since they are always "
                     "small");
-            auto lhs = load_source(LHS, ARG2);
+            auto lhs = load_source(LHS);
             auto dst = init_destination(Dst, ARG1);
 
             a.orr(dst.reg, lhs.reg, rhs);
@@ -1624,7 +1624,7 @@ void BeamModuleAssembler::emit_i_bsl(const ArgLabel &Fail,
     if (is_bsl_small(LHS, RHS)) {
         comment("skipped tests because operands and result are always small");
         if (RHS.isSmall()) {
-            auto lhs = load_source(LHS, ARG2);
+            auto lhs = load_source(LHS);
             a.and_(TMP1, lhs.reg, imm(~_TAG_IMMED1_MASK));
             a.lsl(TMP1, TMP1, imm(RHS.as<ArgSmall>().getSigned()));
         } else {

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -109,7 +109,7 @@ void BeamModuleAssembler::emit_i_bif1(const ArgSource &Src1,
                                       const ArgLabel &Fail,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
-    auto src1 = load_source(Src1, TMP1);
+    auto src1 = load_source(Src1);
 
     a.str(src1.reg, getXRef(0));
 
@@ -169,7 +169,7 @@ void BeamModuleAssembler::emit_i_bif(const ArgLabel &Fail,
 void BeamModuleAssembler::emit_nofail_bif1(const ArgSource &Src1,
                                            const ArgWord &Bif,
                                            const ArgRegister &Dst) {
-    auto src1 = load_source(Src1, TMP1);
+    auto src1 = load_source(Src1);
 
     a.str(src1.reg, getXRef(0));
 

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -632,7 +632,7 @@ void BeamModuleAssembler::emit_i_bs_match_string(const ArgRegister &Ctx,
 void BeamModuleAssembler::emit_i_bs_get_position(const ArgRegister &Ctx,
                                                  const ArgRegister &Dst) {
     const int start_offset = offsetof(ErlSubBits, start);
-    auto ctx_reg = load_source(Ctx, TMP1);
+    auto ctx_reg = load_source(Ctx);
     auto dst_reg = init_destination(Dst, TMP2);
 
     /* Match contexts can never be literals, so we can skip clearing literal

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -272,29 +272,31 @@ void BeamModuleAssembler::emit_continue_exit() {
 void BeamModuleAssembler::emit_get_list(const ArgRegister &Src,
                                         const ArgRegister &Hd,
                                         const ArgRegister &Tl) {
-    auto src = load_source(Src, TMP1);
-    auto hd = init_destination(Hd, TMP2);
-    auto tl = init_destination(Tl, TMP3);
-    a64::Gp cons_ptr = emit_ptr_val(TMP1, src.reg);
+    auto src = load_source(Src);
 
     /* The `ldp` instruction does not accept a negative offset, so we
-     * will need subtract the LIST tag beforehand. (This also nicely
-     * take care of the potential overwriting issue when Src == Hd.) */
-    a.sub(TMP1, cons_ptr, imm(TAG_PRIMARY_LIST));
+     * need to get rid of tag bits beforehand. */
+    untag_ptr_preserve_cache(TMP1, src.reg);
+
+    auto hd = init_destination(Hd, TMP2);
+    auto tl = init_destination(Tl, TMP3);
+
     if (hd.reg == tl.reg) {
         /* ldp with two identical registers is an illegal
-         * instruction. Produce the same result at the interpreter. */
+         * instruction. Produce the same result as the interpreter. */
         a.ldr(tl.reg, arm::Mem(TMP1, sizeof(Eterm)));
         flush_var(tl);
     } else {
-        a.ldp(hd.reg, tl.reg, arm::Mem(TMP1));
+        preserve_cache([&]() {
+            a.ldp(hd.reg, tl.reg, arm::Mem(TMP1));
+        });
         flush_vars(hd, tl);
     }
 }
 
 void BeamModuleAssembler::emit_get_hd(const ArgRegister &Src,
                                       const ArgRegister &Hd) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
     auto hd = init_destination(Hd, TMP2);
     a64::Gp cons_ptr = emit_ptr_val(TMP1, src.reg);
 
@@ -304,7 +306,7 @@ void BeamModuleAssembler::emit_get_hd(const ArgRegister &Src,
 
 void BeamModuleAssembler::emit_get_tl(const ArgRegister &Src,
                                       const ArgRegister &Tl) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
     auto tl = init_destination(Tl, TMP2);
     a64::Gp cons_ptr = emit_ptr_val(TMP1, src.reg);
 
@@ -344,8 +346,9 @@ void BeamModuleAssembler::emit_i_get_hash(const ArgConstant &Src,
 
 /* Store the untagged pointer to a tuple in ARG1. */
 void BeamModuleAssembler::emit_load_tuple_ptr(const ArgSource &Src) {
-    auto src = load_source(Src, ARG1);
-    emit_untag_ptr(ARG1, src.reg);
+    auto src = load_source(Src);
+
+    untag_ptr_preserve_cache(ARG1, src.reg);
 }
 
 #ifdef DEBUG
@@ -504,11 +507,7 @@ void BeamModuleAssembler::emit_init_yregs(const ArgWord &Size,
 
 void BeamModuleAssembler::emit_trim(const ArgWord &Words,
                                     const ArgWord &Remaining) {
-    ASSERT(Words.get() <= 1023);
-
-    if (Words.get() > 0) {
-        add(E, E, Words.get() * sizeof(Eterm));
-    }
+    trim_preserve_cache(Words);
 }
 
 void BeamModuleAssembler::emit_i_move(const ArgSource &Src,
@@ -558,10 +557,7 @@ void BeamModuleAssembler::emit_move_two_trim(const ArgYRegister &Src1,
         } else {
             flush_vars(dst1, dst2);
 
-            ASSERT(Words.get() <= 1023);
-            if (Words.get() > 0) {
-                add(E, E, Words.get() * sizeof(Eterm));
-            }
+            trim_preserve_cache(Words);
         }
     }
 }
@@ -597,9 +593,7 @@ void BeamModuleAssembler::emit_move_trim(const ArgSource &Src,
 
     /* Fallback. */
     mov_arg(Dst, Src);
-    if (Words.get() > 0) {
-        add(E, E, trim);
-    }
+    trim_preserve_cache(Words);
 }
 
 void BeamModuleAssembler::emit_store_two_values(const ArgSource &Src1,
@@ -711,10 +705,14 @@ void BeamModuleAssembler::emit_put_list(const ArgSource &Hd,
                                         const ArgSource &Tl,
                                         const ArgRegister &Dst) {
     auto [hd, tl] = load_sources(Hd, TMP1, Tl, TMP2);
+    auto hd_reg = hd.reg;
+    auto tl_reg = tl.reg;
     auto dst = init_destination(Dst, TMP3);
 
-    a.stp(hd.reg, tl.reg, arm::Mem(HTOP).post(sizeof(Eterm[2])));
-    a.sub(dst.reg, HTOP, imm(sizeof(Eterm[2]) - TAG_PRIMARY_LIST));
+    preserve_cache([&]() {
+        a.stp(hd_reg, tl_reg, arm::Mem(HTOP).post(sizeof(Eterm[2])));
+        a.sub(dst.reg, HTOP, imm(sizeof(Eterm[2]) - TAG_PRIMARY_LIST));
+    });
 
     flush_var(dst);
 }
@@ -1006,7 +1004,7 @@ void BeamModuleAssembler::emit_set_tuple_element(const ArgSource &Element,
 
 void BeamModuleAssembler::emit_is_nonempty_list(const ArgLabel &Fail,
                                                 const ArgRegister &Src) {
-    auto list_ptr = load_source(Src, TMP1);
+    auto list_ptr = load_source(Src);
     emit_is_cons(resolve_beam_label(Fail, dispUnknown), list_ptr.reg);
 }
 
@@ -1017,11 +1015,15 @@ void BeamModuleAssembler::emit_jump(const ArgLabel &Fail) {
 
 void BeamModuleAssembler::emit_is_atom(const ArgLabel &Fail,
                                        const ArgSource &Src) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
 
-    a.and_(TMP1, src.reg, imm(_TAG_IMMED2_MASK));
-    a.cmp(TMP1, imm(_TAG_IMMED2_ATOM));
-    a.b_ne(resolve_beam_label(Fail, disp1MB));
+    preserve_cache(
+            [&]() {
+                a.and_(TMP1, src.reg, imm(_TAG_IMMED2_MASK));
+                a.cmp(TMP1, imm(_TAG_IMMED2_ATOM));
+                a.b_ne(resolve_beam_label(Fail, disp1MB));
+            },
+            TMP1);
 }
 
 void BeamModuleAssembler::emit_is_boolean(const ArgLabel &Fail,
@@ -1237,17 +1239,14 @@ void BeamModuleAssembler::emit_is_integer(const ArgLabel &Fail,
 
 void BeamModuleAssembler::emit_is_list(const ArgLabel &Fail,
                                        const ArgSource &Src) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
 
-    a.tst(src.reg, imm(_TAG_PRIMARY_MASK - TAG_PRIMARY_LIST));
-    a.mov(TMP2, NIL);
-    a.ccmp(src.reg, TMP2, imm(NZCV::kEqual), imm(arm::CondCode::kNE));
-    a.b_ne(resolve_beam_label(Fail, disp1MB));
+    emit_is_list(resolve_beam_label(Fail, dispUnknown), src.reg);
 }
 
 void BeamModuleAssembler::emit_is_map(const ArgLabel &Fail,
                                       const ArgSource &Src) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
 
     emit_is_boxed(resolve_beam_label(Fail, dispUnknown), Src, src.reg);
 
@@ -1256,23 +1255,29 @@ void BeamModuleAssembler::emit_is_map(const ArgLabel &Fail,
     if (masked_types<BeamTypeId::MaybeBoxed>(Src) == BeamTypeId::Map) {
         comment("skipped header test since we know it's a map when boxed");
     } else {
-        a64::Gp boxed_ptr = emit_ptr_val(TMP1, src.reg);
-        a.ldur(TMP1, emit_boxed_val(boxed_ptr));
-        a.and_(TMP1, TMP1, imm(_TAG_HEADER_MASK));
-        a.cmp(TMP1, imm(_TAG_HEADER_MAP));
-        a.b_ne(resolve_beam_label(Fail, disp1MB));
+        preserve_cache(
+                [&]() {
+                    a64::Gp boxed_ptr = emit_ptr_val(TMP3, src.reg);
+                    a.ldur(TMP3, emit_boxed_val(boxed_ptr));
+                    a.and_(TMP3, TMP3, imm(_TAG_HEADER_MASK));
+                    a.cmp(TMP3, imm(_TAG_HEADER_MAP));
+                    a.b_ne(resolve_beam_label(Fail, disp1MB));
+                },
+                TMP3);
     }
 }
 
 void BeamModuleAssembler::emit_is_nil(const ArgLabel &Fail,
                                       const ArgRegister &Src) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
 
     if (always_one_of<BeamTypeId::List>(Src)) {
         emit_is_not_cons(resolve_beam_label(Fail, dispUnknown), src.reg);
     } else {
-        a.cmp(src.reg, imm(NIL));
-        a.b_ne(resolve_beam_label(Fail, disp1MB));
+        preserve_cache([&]() {
+            a.cmp(src.reg, imm(NIL));
+            a.b_ne(resolve_beam_label(Fail, disp1MB));
+        });
     }
 }
 
@@ -1723,8 +1728,10 @@ void BeamModuleAssembler::emit_is_eq_exact(const ArgLabel &Fail,
             comment("simplified check since one argument is an immediate");
         }
 
-        cmp_arg(x.reg, Y);
-        a.b_ne(resolve_beam_label(Fail, disp1MB));
+        preserve_cache([&]() {
+            cmp_arg(x.reg, Y);
+            a.b_ne(resolve_beam_label(Fail, disp1MB));
+        });
 
         return;
     }
@@ -1875,8 +1882,10 @@ void BeamModuleAssembler::emit_is_ne_exact(const ArgLabel &Fail,
             comment("simplified check since one argument is an immediate");
         }
 
-        cmp_arg(x.reg, Y);
-        a.b_eq(resolve_beam_label(Fail, disp1MB));
+        preserve_cache([&]() {
+            cmp_arg(x.reg, Y);
+            a.b_eq(resolve_beam_label(Fail, disp1MB));
+        });
 
         return;
     }
@@ -2568,23 +2577,27 @@ void BeamModuleAssembler::emit_is_ge_lt(ArgLabel const &Fail1,
     mov_arg(ARG2, A);
     mov_arg(ARG3, B);
 
-    a.and_(TMP1, src.reg, imm(_TAG_IMMED1_MASK));
-    a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
-    a.b_ne(generic);
+    preserve_cache(
+            [&]() {
+                a.and_(TMP1, src.reg, imm(_TAG_IMMED1_MASK));
+                a.cmp(TMP1, imm(_TAG_IMMED1_SMALL));
+                a.b_ne(generic);
 
-    a.cmp(src.reg, ARG2);
-    a.b_lt(resolve_beam_label(Fail1, disp1MB));
-    a.cmp(ARG3, src.reg);
-    a.b_ge(resolve_beam_label(Fail2, disp1MB));
-    a.b(next);
+                a.cmp(src.reg, ARG2);
+                a.b_lt(resolve_beam_label(Fail1, disp1MB));
+                a.cmp(ARG3, src.reg);
+                a.b_ge(resolve_beam_label(Fail2, disp1MB));
+                a.b(next);
 
-    a.bind(generic);
-    mov_var(ARG1, src);
-    fragment_call(ga->get_is_ge_lt_shared());
-    a.b_lt(resolve_beam_label(Fail1, disp1MB));
-    a.b_gt(resolve_beam_label(Fail2, disp1MB));
+                a.bind(generic);
+                mov_var(ARG1, src);
+                fragment_call(ga->get_is_ge_lt_shared());
+                a.b_lt(resolve_beam_label(Fail1, disp1MB));
+                a.b_gt(resolve_beam_label(Fail2, disp1MB));
 
-    a.bind(next);
+                a.bind(next);
+            },
+            TMP1);
 }
 
 /*
@@ -2604,10 +2617,15 @@ void BeamModuleAssembler::emit_is_ge_ge(ArgLabel const &Fail1,
     }
 
     auto src = load_source(Src, ARG1);
-    subs(TMP1, src.reg, A.as<ArgImmed>().get());
-    a.b_lt(resolve_beam_label(Fail1, disp1MB));
-    cmp(TMP1, B.as<ArgImmed>().get() - A.as<ArgImmed>().get());
-    a.b_lo(resolve_beam_label(Fail2, disp1MB));
+
+    preserve_cache(
+            [&]() {
+                subs(TMP1, src.reg, A.as<ArgImmed>().get());
+                a.b_lt(resolve_beam_label(Fail1, disp1MB));
+                cmp(TMP1, B.as<ArgImmed>().get() - A.as<ArgImmed>().get());
+                a.b_lo(resolve_beam_label(Fail2, disp1MB));
+            },
+            TMP1);
 }
 
 /*
@@ -2624,16 +2642,20 @@ void BeamModuleAssembler::emit_is_int_in_range(ArgLabel const &Fail,
                                                ArgConstant const &Max) {
     auto src = load_source(Src, ARG1);
 
-    sub(TMP1, src.reg, Min.as<ArgImmed>().get());
+    preserve_cache(
+            [&]() {
+                sub(TMP1, src.reg, Min.as<ArgImmed>().get());
 
-    /* Since we have subtracted the (tagged) lower bound, the
-     * tag bits of the difference is 0 if and only if Src is
-     * a small. */
-    ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
-    a.tst(TMP1, imm(_TAG_IMMED1_MASK));
-    a.b_ne(resolve_beam_label(Fail, disp1MB));
-    cmp(TMP1, Max.as<ArgImmed>().get() - Min.as<ArgImmed>().get());
-    a.b_hi(resolve_beam_label(Fail, disp1MB));
+                /* Since we have subtracted the (tagged) lower bound, the tag
+                 * bits of the difference is 0 if and only if Src is a
+                 * small. */
+                ERTS_CT_ASSERT(_TAG_IMMED1_SMALL == _TAG_IMMED1_MASK);
+                a.tst(TMP1, imm(_TAG_IMMED1_MASK));
+                a.b_ne(resolve_beam_label(Fail, disp1MB));
+                cmp(TMP1, Max.as<ArgImmed>().get() - Min.as<ArgImmed>().get());
+                a.b_hi(resolve_beam_label(Fail, disp1MB));
+            },
+            TMP1);
 }
 
 /*
@@ -2649,25 +2671,33 @@ void BeamModuleAssembler::emit_is_int_ge(ArgLabel const &Fail,
         comment("simplified small test since all other types are boxed");
         emit_is_boxed(small, Src, src.reg);
     } else {
-        a.and_(TMP2, src.reg, imm(_TAG_IMMED1_MASK));
-        a.cmp(TMP2, imm(_TAG_IMMED1_SMALL));
-        a.b_eq(small);
+        preserve_cache(
+                [&]() {
+                    a.and_(TMP2, src.reg, imm(_TAG_IMMED1_MASK));
+                    a.cmp(TMP2, imm(_TAG_IMMED1_SMALL));
+                    a.b_eq(small);
+                },
+                TMP2);
 
         emit_is_boxed(resolve_beam_label(Fail, dispUnknown), Src, TMP2);
     }
 
-    a64::Gp boxed_ptr = emit_ptr_val(TMP1, src.reg);
-    a.ldur(TMP1, emit_boxed_val(boxed_ptr));
-    a.and_(TMP1, TMP1, imm(_TAG_HEADER_MASK));
-    a.cmp(TMP1, imm(_TAG_HEADER_POS_BIG));
-    a.b_ne(resolve_beam_label(Fail, disp1MB));
-    a.b(next);
+    preserve_cache(
+            [&]() {
+                a64::Gp boxed_ptr = emit_ptr_val(TMP1, src.reg);
+                a.ldur(TMP1, emit_boxed_val(boxed_ptr));
+                a.and_(TMP1, TMP1, imm(_TAG_HEADER_MASK));
+                a.cmp(TMP1, imm(_TAG_HEADER_POS_BIG));
+                a.b_ne(resolve_beam_label(Fail, disp1MB));
+                a.b(next);
 
-    a.bind(small);
-    cmp(src.reg, Min.as<ArgImmed>().get());
-    a.b_lt(resolve_beam_label(Fail, disp1MB));
+                a.bind(small);
+                cmp(src.reg, Min.as<ArgImmed>().get());
+                a.b_lt(resolve_beam_label(Fail, disp1MB));
 
-    a.bind(next);
+                a.bind(next);
+            },
+            TMP1);
 }
 
 void BeamModuleAssembler::emit_badmatch(const ArgSource &Src) {

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -603,24 +603,30 @@ void BeamModuleAssembler::emit_move_trim(const ArgSource &Src,
 }
 
 void BeamModuleAssembler::emit_store_two_values(const ArgSource &Src1,
-                                                const ArgYRegister &Dst1,
+                                                const ArgRegister &Dst1,
                                                 const ArgSource &Src2,
-                                                const ArgYRegister &Dst2) {
+                                                const ArgRegister &Dst2) {
     auto [src1, src2] = load_sources(Src1, TMP1, Src2, TMP2);
     auto dst1 = init_destination(Dst1, src1.reg);
     auto dst2 = init_destination(Dst2, src2.reg);
 
+    ASSERT(!isRegisterBacked(Dst1));
+    ASSERT(!isRegisterBacked(Dst2));
+
     flush_vars(dst1, dst2);
 }
 
-void BeamModuleAssembler::emit_load_two_xregs(const ArgYRegister &Src1,
+void BeamModuleAssembler::emit_load_two_xregs(const ArgRegister &Src1,
                                               const ArgXRegister &Dst1,
-                                              const ArgYRegister &Src2,
+                                              const ArgRegister &Src2,
                                               const ArgXRegister &Dst2) {
     ASSERT(ArgVal::memory_relation(Src1, Src2) ==
            ArgVal::Relation::consecutive);
     auto dst1 = init_destination(Dst1, TMP1);
     auto dst2 = init_destination(Dst2, TMP2);
+
+    ASSERT(!isRegisterBacked(Src1));
+    ASSERT(!isRegisterBacked(Src2));
 
     safe_ldp(dst1.reg, dst2.reg, Src1, Src2);
     flush_vars(dst1, dst2);

--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -143,7 +143,7 @@ void BeamModuleAssembler::emit_cmp_immed_to_bool(arm::CondCode cc,
                                                  const ArgSource &RHS,
                                                  const ArgRegister &Dst) {
     if (RHS.isImmed()) {
-        auto lhs = load_source(LHS, TMP1);
+        auto lhs = load_source(LHS);
         cmp_arg(lhs.reg, RHS);
     } else {
         auto [lhs, rhs] = load_sources(LHS, TMP1, RHS, TMP2);

--- a/erts/emulator/beam/jit/arm/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/instr_map.cpp
@@ -358,8 +358,10 @@ void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
                                                  const ArgRegister &Src,
                                                  const ArgRegister &Key,
                                                  const ArgRegister &Dst) {
-    mov_arg(ARG1, Src);
-    mov_arg(ARG2, Key);
+    auto [src, key] = load_sources(Src, ARG1, Key, ARG2);
+
+    mov_var(ARG1, src);
+    mov_var(ARG2, key);
 
     if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key)) {
         fragment_call(ga->get_i_get_map_element_shared());

--- a/erts/emulator/beam/jit/arm/instr_msg.cpp
+++ b/erts/emulator/beam/jit/arm/instr_msg.cpp
@@ -43,8 +43,10 @@ void BeamModuleAssembler::emit_recv_marker_reserve(const ArgRegister &Dst) {
 
 void BeamModuleAssembler::emit_recv_marker_bind(const ArgRegister &Marker,
                                                 const ArgRegister &Reference) {
-    mov_arg(ARG2, Marker);
-    mov_arg(ARG3, Reference);
+    auto [marker, reference] = load_sources(Marker, ARG2, Reference, ARG3);
+
+    mov_var(ARG2, marker);
+    mov_var(ARG3, reference);
 
     emit_enter_runtime();
 

--- a/erts/emulator/beam/jit/arm/instr_select.cpp
+++ b/erts/emulator/beam/jit/arm/instr_select.cpp
@@ -256,7 +256,7 @@ void BeamModuleAssembler::emit_i_select_tuple_arity(const ArgRegister &Src,
                                                     const ArgLabel &Fail,
                                                     const ArgWord &Size,
                                                     const Span<ArgVal> &args) {
-    auto src = load_source(Src, TMP1);
+    auto src = load_source(Src);
 
     emit_is_boxed(resolve_beam_label(Fail, dispUnknown), Src, src.reg);
 

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -163,8 +163,7 @@ is_number f s
 jump f
 
 #
-# List matching instructions. The combination of test for a nonempty list
-# followed by get_{list/hd/tl} are common, so we will optimize that.
+# List matching instructions.
 #
 is_nonempty_list Fail nqia => jump Fail
 

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -340,17 +340,29 @@ move S1=y D1=x | move S2=y D2=x |
   distinct(D1, D2) =>
     load_two_xregs S1 D1 S2 D2
 
+move S1=x D1=x | move S2=x D2=x |
+  consecutive_xregs(S1, S2) |
+  distinct(D1, D2) =>
+    load_two_xregs S1 D1 S2 D2
+
 move S1=y D1=x | move S2=y D2=x |
   consecutive_words(S2, S1) |
+  distinct(D1, S2) |
+  distinct(D1, D2) =>
+    load_two_xregs S2 D2 S1 D1
+
+move S1=x D1=x | move S2=x D2=x |
+  consecutive_xregs(S2, S1) |
+  distinct(D1, S2) |
   distinct(D1, D2) =>
     load_two_xregs S2 D2 S1 D1
 
 # Optimize storing two values in Y registers when destination Y
 # registers are consecutive.
 
-move S1 D1=y | move S2 D2=y | consecutive_words(D1, D2) =>
+move S1 D1=y | move S2 D2=y | consecutive_words(D1, D2) | distinct(D1, S2) =>
     store_two_values S1 D1 S2 D2
-move S1 D1=y | move S2 D2=y | consecutive_words(D2, D1) =>
+move S1 D1=y | move S2 D2=y | consecutive_words(D2, D1) | distinct(D1, S2) =>
     store_two_values S2 D2 S1 D1
 
 move S1=y D1 | move S2=y D2 | consecutive_words(S1, S2) | trim N u =>
@@ -358,6 +370,12 @@ move S1=y D1 | move S2=y D2 | consecutive_words(S1, S2) | trim N u =>
 
 move S2=y D2 | move S1=y D1 | consecutive_words(S1, S2) | trim N u =>
     move_two_trim S1 D1 S2 D2 N
+
+move S1 D1=x | move S2 D2=x | consecutive_xregs(D1, D2) | distinct(D1, S2) =>
+    store_two_values S1 D1 S2 D2
+
+move S1 D1=x | move S2 D2=x | consecutive_xregs(D2, D1) | distinct(D1, S2) =>
+    store_two_values S2 D2 S1 D1
 
 move Src Dst | trim N u => move_trim Src Dst N
 
@@ -368,8 +386,8 @@ move_trim s d t
 move Src Dst => i_move Src Dst
 
 i_move s d
-store_two_values s y s y
-load_two_xregs y x y x
+store_two_values s d s d
+load_two_xregs d x d x
 
 #
 # Swap instructions.

--- a/erts/emulator/beam/jit/arm/predicates.tab
+++ b/erts/emulator/beam/jit/arm/predicates.tab
@@ -82,7 +82,10 @@ pred.never_fails(Bif) {
 }
 
 pred.consecutive_xregs(A1, A2) {
-    return A1.type == TAG_x && A2.type == TAG_x && A1.val + 1 == A2.val && A1.val >= 6;
+    /* The following value must be the same as in beam_asm.hpp. */
+    const Uint num_register_backed_xregs = 6;
+    return A1.type == TAG_x && A2.type == TAG_x &&
+        A1.val + 1 == A2.val && A1.val >= num_register_backed_xregs;
 }
 
 pred.consecutive_words(A1, A2) {

--- a/erts/emulator/beam/jit/arm/predicates.tab
+++ b/erts/emulator/beam/jit/arm/predicates.tab
@@ -81,6 +81,10 @@ pred.never_fails(Bif) {
     return 0;
 }
 
+pred.consecutive_xregs(A1, A2) {
+    return A1.type == TAG_x && A2.type == TAG_x && A1.val + 1 == A2.val && A1.val >= 6;
+}
+
 pred.consecutive_words(A1, A2) {
     return A1.type == A2.type && A1.val + 1 == A2.val;
 }

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -51,6 +51,7 @@ extern "C"
 
 #include "beam_jit_args.hpp"
 #include "beam_jit_types.hpp"
+#include "beam_jit_register_cache.hpp"
 
 using namespace asmjit;
 

--- a/erts/emulator/beam/jit/beam_jit_register_cache.hpp
+++ b/erts/emulator/beam/jit/beam_jit_register_cache.hpp
@@ -1,0 +1,201 @@
+/*
+ * %CopyrightBegin%
+ *
+ * Copyright Ericsson AB 2024. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#ifndef __BEAM_JIT_REGISTER_CACHE_HPP__
+#define __BEAM_JIT_REGISTER_CACHE_HPP__
+
+#include <algorithm>
+#include <limits>
+
+template<int Size, typename Mem, typename Reg>
+class RegisterCache {
+    struct CacheEntry {
+        Mem mem;
+        Reg reg;
+    };
+
+    CacheEntry cache[Size];
+    int entries;
+    size_t position;
+    const std::vector<Reg> temporaries;
+    const Reg xregs_base;
+    const Reg yregs_base;
+
+    CacheEntry *begin() {
+        return std::begin(cache);
+    }
+
+    CacheEntry *end() {
+        return begin() + entries;
+    }
+
+    bool isCached(const Reg &reg) {
+        return std::any_of(begin(), end(), [&](const auto &entry) {
+            return reg == entry.reg;
+        });
+    }
+
+public:
+    RegisterCache(Reg xregs, Reg yregs, std::initializer_list<Reg> &&tmps)
+            : entries(0), position(std::numeric_limits<size_t>::max()),
+              temporaries(tmps), xregs_base(xregs), yregs_base(yregs) {
+    }
+
+    void consolidate(size_t offset) {
+        if (!validAt(offset)) {
+            invalidate();
+        }
+
+        position = offset;
+    }
+
+    Reg find(size_t offset, Mem mem) {
+        ASSERT(mem.hasBase());
+        consolidate(offset);
+
+        auto it = std::find_if(begin(), end(), [&](const auto &entry) {
+            return mem == entry.mem;
+        });
+
+        if (it != end()) {
+            ASSERT(it->reg.isValid());
+            return it->reg;
+        }
+
+        return Reg();
+    }
+
+    void invalidate(Mem mem) {
+        ASSERT(mem.hasBase());
+
+        auto i = 0;
+        while (i < entries) {
+            auto &entry = cache[i];
+
+            if (entry.mem == mem) {
+                entry = cache[entries - 1];
+                entries--;
+                break;
+            }
+
+            i++;
+        }
+    }
+
+    void invalidate(Reg reg) {
+        ASSERT(reg.isValid());
+
+        auto i = 0;
+        while (i < entries) {
+            auto &entry = cache[i];
+
+            if (reg == entry.reg) {
+                entry = cache[entries - 1];
+                entries--;
+                continue;
+            }
+
+            i++;
+        }
+    }
+
+    void invalidate() {
+        position = std::numeric_limits<size_t>::max();
+        entries = 0;
+    }
+
+    void trim_yregs(int64_t offset) {
+        for (int i = 0; i < entries; i++) {
+            auto &entry = cache[i];
+
+            if (entry.mem.hasBase() && entry.mem.baseReg() == yregs_base) {
+                entry.mem = entry.mem.cloneAdjusted(offset);
+            }
+        }
+    }
+
+    template<typename Operand, typename... Operands>
+    void invalidate(Operand op, Operands... rest) {
+        invalidate(op);
+        invalidate(rest...);
+    }
+
+    /* Pick a temporary register among the list passed to our constructor,
+     * preferring those not present in the cache. */
+    Reg allocate(size_t offset) {
+        consolidate(offset);
+
+        auto it = std::find_if(temporaries.cbegin(),
+                               temporaries.cend(),
+                               [&](const auto &reg) {
+                                   return !isCached(reg);
+                               });
+
+        if (it != temporaries.cend()) {
+            ASSERT(std::none_of(begin(), end(), [&](const auto &entry) {
+                return (*it == entry.reg) ||
+                       (entry.mem.hasBase() && entry.mem.baseReg() == *it);
+            }));
+
+            return *it;
+        }
+
+        return temporaries.front();
+    }
+
+    void put(Mem mem, Reg reg) {
+        ASSERT(mem.hasBase());
+
+        /* Only allow caching of X and Y registers. */
+        auto base = mem.baseReg();
+        if (base != xregs_base && base != yregs_base) {
+            return;
+        }
+
+        ASSERT(mem.baseReg() != reg);
+
+        auto it = std::find_if(begin(), end(), [&](const auto &entry) {
+            return mem == entry.mem;
+        });
+
+        if (it == end()) {
+            if (it == std::end(cache)) {
+                ASSERT(entries == Size);
+                it = std::begin(cache);
+            } else {
+                ASSERT(entries < Size);
+                entries++;
+            }
+        }
+
+        it->reg = reg;
+        it->mem = mem;
+    }
+
+    bool validAt(size_t offset) {
+        return position == offset;
+    }
+
+    void update(size_t offset) {
+        position = offset;
+    }
+};
+
+#endif

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <unordered_map>
 #include <map>
+#include <functional>
 #include <algorithm>
 #include <cmath>
 
@@ -117,6 +118,9 @@ protected:
     const x86::Gp ARG5 = x86::r10;
     const x86::Gp ARG6 = x86::r11;
 
+    const x86::Gp TMP1 = x86::rdi;
+    const x86::Gp TMP2 = x86::rsi;
+
     const x86::Gp ARG1d = x86::ecx;
     const x86::Gp ARG2d = x86::edx;
     const x86::Gp ARG3d = x86::r8d;
@@ -130,6 +134,9 @@ protected:
     const x86::Gp ARG4 = x86::rcx;
     const x86::Gp ARG5 = x86::r8;
     const x86::Gp ARG6 = x86::r9;
+
+    const x86::Gp TMP1 = x86::r10;
+    const x86::Gp TMP2 = x86::r11;
 
     const x86::Gp ARG1d = x86::edi;
     const x86::Gp ARG2d = x86::esi;
@@ -1033,125 +1040,113 @@ class BeamModuleAssembler : public BeamAssembler,
     /* Save the last PC for an error. */
     size_t last_error_offset = 0;
 
-    /* Skip unnecessary moves in mov_arg() and cmp_arg(). */
-    size_t last_movarg_offset = 0;
-    x86::Gp last_movarg_from1, last_movarg_from2;
-    x86::Mem last_movarg_to1, last_movarg_to2;
+    /* ARG2 is excluded as it is used to point to the currently active tuple. */
+    RegisterCache<20, x86::Mem, x86::Gp> reg_cache =
+            RegisterCache<20, x86::Mem, x86::Gp>(
+                    registers,
+                    E,
+                    {TMP1, TMP2, ARG3, ARG4, ARG5, ARG6, ARG1, RET});
 
-    /* Private helper. */
-    void preserve__cache(x86::Gp dst) {
-        last_movarg_offset = a.offset();
-        invalidate_cache(dst);
-    }
-
-    void preserve__cache(x86::Mem mem) {
-        last_movarg_offset = a.offset();
-        invalidate_cache(mem);
-    }
-
-    bool is_cache_valid() {
-        return a.offset() == last_movarg_offset;
-    }
-
-    void preserve_cache(x86::Gp dst, bool cache_valid) {
-        if (cache_valid) {
-            preserve__cache(dst);
-        }
-    }
-
-    void preserve_cache(x86::Mem mem, bool cache_valid) {
-        if (cache_valid) {
-            preserve__cache(mem);
-        }
+    x86::Gp find_cache(x86::Mem mem) {
+        return reg_cache.find(a.offset(), mem);
     }
 
     /* Store CPU register into memory and update the cache. */
-    void store_cache(x86::Gp src, x86::Mem dst) {
-        if (is_cache_valid() && dst != last_movarg_to1) {
-            /* Something is already cached in the first slot. Use the
-             * second slot. */
-            a.mov(dst, src);
-
-            last_movarg_offset = a.offset();
-            last_movarg_to2 = dst;
-            last_movarg_from2 = src;
-        } else {
-            /* Nothing cached yet, or the first slot has the same
-             * memory address as we will store into. Use the first
-             * slot and invalidate the second slot. */
-            a.mov(dst, src);
-
-            last_movarg_offset = a.offset();
-            last_movarg_to1 = dst;
-            last_movarg_from1 = src;
-
-            last_movarg_to2 = x86::Mem();
-        }
-    }
-
-    void invalidate_cache(x86::Gp dst) {
-        if (dst == last_movarg_from1) {
-            last_movarg_to1 = x86::Mem();
-            last_movarg_from1 = x86::Gp();
-        }
-        if (dst == last_movarg_from2) {
-            last_movarg_to2 = x86::Mem();
-            last_movarg_from2 = x86::Gp();
-        }
-    }
-
-    void invalidate_cache(x86::Mem mem) {
-        if (mem == last_movarg_to1) {
-            last_movarg_to1 = x86::Mem();
-            last_movarg_from1 = x86::Gp();
-        }
-        if (mem == last_movarg_to2) {
-            last_movarg_to2 = x86::Mem();
-            last_movarg_from2 = x86::Gp();
-        }
-    }
-
-    x86::Gp cached_reg(x86::Mem mem) {
-        if (is_cache_valid()) {
-            if (mem == last_movarg_to1) {
-                return last_movarg_from1;
-            }
-            if (mem == last_movarg_to2) {
-                return last_movarg_from2;
-            }
-        }
-        return x86::Gp();
+    void store_cache(x86::Gp src, x86::Mem mem_dst) {
+        reg_cache.consolidate(a.offset());
+        a.mov(mem_dst, src);
+        reg_cache.put(mem_dst, src);
+        reg_cache.update(a.offset());
     }
 
     void load_cached(x86::Gp dst, x86::Mem mem) {
-        if (a.offset() == last_movarg_offset) {
-            x86::Gp reg = cached_reg(mem);
+        x86::Gp cached_reg = find_cache(mem);
 
-            if (reg.isValid()) {
-                /* This memory location is cached. */
-                if (reg != dst) {
-                    comment("simplified fetching of BEAM register");
-                    a.mov(dst, reg);
-                    preserve__cache(dst);
-                } else {
-                    comment("skipped fetching of BEAM register");
-                    invalidate_cache(dst);
-                }
+        if (cached_reg.isValid()) {
+            /* This memory location is cached. */
+            if (cached_reg == dst) {
+                comment("skipped fetching of BEAM register");
             } else {
-                /* Not cached. Load and preserve the cache. */
-                a.mov(dst, mem);
-                preserve__cache(dst);
+                comment("simplified fetching of BEAM register");
+                a.mov(dst, cached_reg);
+                reg_cache.invalidate(dst);
+                reg_cache.update(a.offset());
             }
         } else {
-            /* The cache is invalid. */
+            /* Not cached. Load and update cache. */
             a.mov(dst, mem);
-
-            last_movarg_offset = a.offset();
-            last_movarg_to1 = mem;
-            last_movarg_from1 = dst;
-
-            last_movarg_to2 = x86::Mem();
+            reg_cache.invalidate(dst);
+            reg_cache.put(mem, dst);
+            reg_cache.update(a.offset());
         }
+    }
+
+    template<typename L, typename... Any>
+    void preserve_cache(L generate, Any... clobber) {
+        bool valid = reg_cache.validAt(a.offset());
+
+        generate();
+
+        if (valid) {
+            if (sizeof...(clobber) > 0) {
+                reg_cache.invalidate(clobber...);
+            }
+
+            reg_cache.update(a.offset());
+        }
+    }
+
+    void trim_preserve_cache(const ArgWord &Words) {
+        if (Words.get() > 0) {
+            ASSERT(Words.get() <= 1023);
+            preserve_cache([&]() {
+                auto offset = Words.get() * sizeof(Eterm);
+                a.add(E, imm(offset));
+                reg_cache.trim_yregs(-offset);
+            });
+        }
+    }
+
+    void mov_preserve_cache(x86::Mem dst, x86::Gp src) {
+        preserve_cache(
+                [&]() {
+                    a.mov(dst, src);
+                },
+                dst);
+    }
+
+    void mov_preserve_cache(x86::Gp dst, x86::Gp src) {
+        preserve_cache(
+                [&]() {
+                    a.mov(dst, src);
+                },
+                dst);
+    }
+
+    void mov_preserve_cache(x86::Gp dst, x86::Mem src) {
+        preserve_cache(
+                [&]() {
+                    a.mov(dst, src);
+                },
+                dst);
+    }
+
+    void cmp_preserve_cache(x86::Gp reg1, x86::Gp reg2) {
+        preserve_cache([&]() {
+            a.cmp(reg1, reg2);
+        });
+    }
+
+    void cmp_preserve_cache(x86::Mem mem, x86::Gp reg) {
+        preserve_cache([&]() {
+            a.cmp(mem, reg);
+        });
+    }
+
+    /* Pick a temporary register, preferring a register not present in
+     * the cache. */
+    x86::Gp alloc_temp_reg() {
+        return reg_cache.allocate(a.offset());
     }
 
     /* Maps code pointers to thunks that jump to them, letting us treat global
@@ -1231,7 +1226,9 @@ protected:
                           bool skip_header_test = false);
 
     void emit_is_boxed(Label Fail, x86::Gp Src, Distance dist = dLong) {
-        BeamAssembler::emit_is_boxed(Fail, Src, dist);
+        preserve_cache([&]() {
+            BeamAssembler::emit_is_boxed(Fail, Src, dist);
+        });
     }
 
     void emit_is_boxed(Label Fail,
@@ -1243,7 +1240,31 @@ protected:
             return;
         }
 
-        BeamAssembler::emit_is_boxed(Fail, Src, dist);
+        preserve_cache([&]() {
+            BeamAssembler::emit_is_boxed(Fail, Src, dist);
+        });
+    }
+
+    void emit_is_cons(Label Fail, x86::Gp Src, Distance dist = dLong) {
+        preserve_cache([&]() {
+            emit_test_cons(Src);
+            if (dist == dShort) {
+                a.short_().jne(Fail);
+            } else {
+                a.jne(Fail);
+            }
+        });
+    }
+
+    void emit_is_not_cons(Label Fail, x86::Gp Src, Distance dist = dLong) {
+        preserve_cache([&]() {
+            emit_test_cons(Src);
+            if (dist == dShort) {
+                a.short_().je(Fail);
+            } else {
+                a.je(Fail);
+            }
+        });
     }
 
     void emit_get_list(const x86::Gp boxed_ptr,
@@ -1439,7 +1460,7 @@ protected:
     }
 
     void cmp_arg(x86::Mem mem, const ArgVal &val, const x86::Gp &spill) {
-        x86::Gp reg = cached_reg(mem);
+        x86::Gp reg = find_cache(mem);
 
         if (reg.isValid()) {
             /* Note that the cast to Sint is necessary to handle
@@ -1447,82 +1468,118 @@ protected:
             if (val.isImmed() &&
                 Support::isInt32((Sint)val.as<ArgImmed>().get())) {
                 comment("simplified compare of BEAM register");
-                a.cmp(reg, imm(val.as<ArgImmed>().get()));
+                preserve_cache([&]() {
+                    a.cmp(reg, imm(val.as<ArgImmed>().get()));
+                });
             } else if (reg != spill) {
                 comment("simplified compare of BEAM register");
                 mov_arg(spill, val);
-                a.cmp(reg, spill);
+                cmp_preserve_cache(reg, spill);
             } else {
                 mov_arg(spill, val);
-                a.cmp(mem, spill);
+                cmp_preserve_cache(mem, spill);
             }
         } else {
             /* Note that the cast to Sint is necessary to handle
              * negative numbers such as NIL. */
             if (val.isImmed() &&
                 Support::isInt32((Sint)val.as<ArgImmed>().get())) {
-                a.cmp(mem, imm(val.as<ArgImmed>().get()));
+                preserve_cache([&]() {
+                    a.cmp(mem, imm(val.as<ArgImmed>().get()));
+                });
             } else {
                 mov_arg(spill, val);
-                a.cmp(mem, spill);
+                cmp_preserve_cache(mem, spill);
             }
         }
     }
 
     void cmp_arg(x86::Gp gp, const ArgVal &val, const x86::Gp &spill) {
         if (val.isImmed() && Support::isInt32((Sint)val.as<ArgImmed>().get())) {
-            a.cmp(gp, imm(val.as<ArgImmed>().get()));
+            preserve_cache([&]() {
+                a.cmp(gp, imm(val.as<ArgImmed>().get()));
+            });
         } else {
             mov_arg(spill, val);
-            a.cmp(gp, spill);
+            cmp_preserve_cache(gp, spill);
         }
     }
 
     void cmp(x86::Gp gp, int64_t val, const x86::Gp &spill) {
         if (Support::isInt32(val)) {
-            a.cmp(gp, imm(val));
+            preserve_cache([&]() {
+                a.cmp(gp, imm(val));
+            });
         } else if (gp.isGpd()) {
             mov_imm(spill, val);
-            a.cmp(gp, spill.r32());
+            preserve_cache([&]() {
+                a.cmp(gp, spill.r32());
+            });
         } else {
             mov_imm(spill, val);
-            a.cmp(gp, spill);
+            cmp_preserve_cache(gp, spill);
         }
     }
 
     void sub(x86::Gp gp, int64_t val, const x86::Gp &spill) {
         if (Support::isInt32(val)) {
-            a.sub(gp, imm(val));
+            preserve_cache(
+                    [&]() {
+                        a.sub(gp, imm(val));
+                    },
+                    gp);
         } else {
-            mov_imm(spill, val);
-            a.sub(gp, spill);
+            preserve_cache(
+                    [&]() {
+                        mov_imm(spill, val);
+                        a.sub(gp, spill);
+                    },
+                    gp,
+                    spill);
         }
     }
 
     /* Note: May clear flags. */
     void mov_arg(x86::Gp to, const ArgVal &from, const x86::Gp &spill) {
-        bool valid_cache = is_cache_valid();
-
         if (from.isBytePtr()) {
             make_move_patch(to, strings, from.as<ArgBytePtr>().get());
         } else if (from.isExport()) {
             make_move_patch(to, imports[from.as<ArgExport>().get()].patches);
         } else if (from.isImmed()) {
-            mov_imm(to, from.as<ArgImmed>().get());
+            preserve_cache(
+                    [&]() {
+                        mov_imm(to, from.as<ArgImmed>().get());
+                    },
+                    to);
         } else if (from.isLambda()) {
-            make_move_patch(to, lambdas[from.as<ArgLambda>().get()].patches);
+            preserve_cache(
+                    [&]() {
+                        make_move_patch(
+                                to,
+                                lambdas[from.as<ArgLambda>().get()].patches);
+                    },
+                    to);
         } else if (from.isLiteral()) {
-            make_move_patch(to, literals[from.as<ArgLiteral>().get()].patches);
+            preserve_cache(
+                    [&]() {
+                        make_move_patch(
+                                to,
+                                literals[from.as<ArgLiteral>().get()].patches);
+                    },
+                    to);
         } else if (from.isRegister()) {
             auto mem = getArgRef(from.as<ArgRegister>());
             load_cached(to, mem);
         } else if (from.isWord()) {
-            mov_imm(to, from.as<ArgWord>().get());
+            preserve_cache(
+                    [&]() {
+                        mov_imm(to, from.as<ArgWord>().get());
+                    },
+                    to);
         } else {
             ASSERT(!"mov_arg with incompatible type");
         }
 
-        preserve_cache(to, valid_cache);
 #ifdef DEBUG
         /* Explicitly clear flags to catch bugs quicker, it may be very rare
          * for a certain instruction to load values that would otherwise cause
@@ -1534,33 +1591,43 @@ protected:
     void mov_arg(x86::Mem to, const ArgVal &from, const x86::Gp &spill) {
         if (from.isImmed()) {
             auto val = from.as<ArgImmed>().get();
-            bool cache_valid = is_cache_valid();
 
             if (Support::isInt32((Sint)val)) {
-                a.mov(to, imm(val));
+                preserve_cache(
+                        [&]() {
+                            a.mov(to, imm(val));
+                        },
+                        to);
             } else {
-                a.mov(spill, imm(val));
-                a.mov(to, spill);
-                preserve_cache(spill, cache_valid);
+                preserve_cache(
+                        [&]() {
+                            a.mov(spill, imm(val));
+                            a.mov(to, spill);
+                        },
+                        to,
+                        spill);
             }
-            preserve_cache(to, cache_valid);
         } else if (from.isWord()) {
             auto val = from.as<ArgWord>().get();
-            bool cache_valid = is_cache_valid();
 
             if (Support::isInt32((Sint)val)) {
-                a.mov(to, imm(val));
+                preserve_cache(
+                        [&]() {
+                            a.mov(to, imm(val));
+                        },
+                        to);
             } else {
-                a.mov(spill, imm(val));
-                a.mov(to, spill);
-                preserve_cache(spill, cache_valid);
+                preserve_cache(
+                        [&]() {
+                            a.mov(spill, imm(val));
+                            a.mov(to, spill);
+                        },
+                        to,
+                        spill);
             }
-            preserve_cache(to, cache_valid);
         } else {
             mov_arg(spill, from);
-            bool cache_valid = is_cache_valid();
-            a.mov(to, spill);
-            preserve_cache(to, cache_valid);
+            mov_preserve_cache(to, spill);
         }
     }
 
@@ -1577,20 +1644,34 @@ protected:
     }
 
     void mov_arg(const ArgRegister &to, BeamInstr from, const x86::Gp &spill) {
-        if (Support::isInt32((Sint)from)) {
-            a.mov(getArgRef(to), imm(from));
-        } else {
-            a.mov(spill, imm(from));
-            mov_arg(to, spill);
-        }
+        preserve_cache(
+                [&]() {
+                    if (Support::isInt32((Sint)from)) {
+                        a.mov(getArgRef(to), imm(from));
+                    } else {
+                        a.mov(spill, imm(from));
+                        mov_arg(to, spill);
+                    }
+                },
+                getArgRef(to),
+                spill);
     }
 
-    void mov_arg(const ArgRegister &to, const ArgVal &from, const x86::Gp &spill) {
-        if (from.isRegister()) {
-            mov_arg(spill, from);
-            mov_arg(to, spill);
-        } else {
+    void mov_arg(const ArgRegister &to,
+                 const ArgVal &from,
+                 const x86::Gp &spill) {
+        if (!from.isRegister()) {
             mov_arg(getArgRef(to), from);
+        } else {
+            x86::Gp from_reg = find_cache(getArgRef(from));
+
+            if (from_reg.isValid()) {
+                comment("skipped fetching of BEAM register");
+            } else {
+                from_reg = spill;
+                mov_arg(from_reg, from);
+            }
+            mov_arg(to, from_reg);
         }
     }
 

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1564,19 +1564,19 @@ protected:
         }
     }
 
-    void mov_arg(const ArgVal &to, x86::Gp from, const x86::Gp &spill) {
+    void mov_arg(const ArgRegister &to, x86::Gp from, const x86::Gp &spill) {
         (void)spill;
 
         auto mem = getArgRef(to);
         store_cache(from, mem);
     }
 
-    void mov_arg(const ArgVal &to, x86::Mem from, const x86::Gp &spill) {
+    void mov_arg(const ArgRegister &to, x86::Mem from, const x86::Gp &spill) {
         a.mov(spill, from);
         a.mov(getArgRef(to), spill);
     }
 
-    void mov_arg(const ArgVal &to, BeamInstr from, const x86::Gp &spill) {
+    void mov_arg(const ArgRegister &to, BeamInstr from, const x86::Gp &spill) {
         if (Support::isInt32((Sint)from)) {
             a.mov(getArgRef(to), imm(from));
         } else {
@@ -1585,7 +1585,7 @@ protected:
         }
     }
 
-    void mov_arg(const ArgVal &to, const ArgVal &from, const x86::Gp &spill) {
+    void mov_arg(const ArgRegister &to, const ArgVal &from, const x86::Gp &spill) {
         if (from.isRegister()) {
             mov_arg(spill, from);
             mov_arg(to, spill);

--- a/erts/emulator/beam/jit/x86/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_module.cpp
@@ -333,7 +333,7 @@ void BeamModuleAssembler::emit_label(const ArgLabel &Label) {
     current_label = rawLabels[Label.get()];
     a.bind(current_label);
 
-    last_movarg_offset = ~0;
+    reg_cache.invalidate();
 }
 
 void BeamModuleAssembler::emit_aligned_label(const ArgLabel &Label,

--- a/erts/emulator/beam/jit/x86/instr_float.cpp
+++ b/erts/emulator/beam/jit/x86/instr_float.cpp
@@ -100,7 +100,11 @@ void BeamModuleAssembler::emit_fstore(const ArgFRegister &Src,
     a.lea(ARG1, x86::qword_ptr(HTOP, make_float(0)));
     mov_arg(Dst, ARG1);
 
-    a.add(HTOP, imm(FLOAT_SIZE_OBJECT * sizeof(Eterm)));
+    preserve_cache(
+            [&]() {
+                a.add(HTOP, imm(FLOAT_SIZE_OBJECT * sizeof(Eterm)));
+            },
+            HTOP);
 }
 
 /* ARG2 = source term */

--- a/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
@@ -740,9 +740,13 @@ void BeamModuleAssembler::emit_bif_map_size(const ArgLabel &Fail,
     a.bind(good_map);
     {
         ERTS_CT_ASSERT(offsetof(flatmap_t, size) == sizeof(Eterm));
-        a.mov(RET, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
-        a.shl(RET, imm(4));
-        a.or_(RETb, imm(_TAG_IMMED1_SMALL));
+        preserve_cache(
+                [&]() {
+                    a.mov(RET, emit_boxed_val(boxed_ptr, sizeof(Eterm)));
+                    a.shl(RET, imm(4));
+                    a.or_(RETb, imm(_TAG_IMMED1_SMALL));
+                },
+                RET);
         mov_arg(Dst, RET);
     }
 }


### PR DESCRIPTION
This pull request improves the caching mechanism introduced in #6298.

For x86_64, 170,752 loads of BEAM registers from memory are now eliminated, compared to 115,998 loads before this PR.

For AArch64/ARM64, 21,109 load of BEAM registers are now eliminated, compared to 15,098 loads before this PR. (The six first X registers are kept in CPU registers, and therefore the caching only applies to Y registers and `{x,6}` and above.)