### PR TITLE
Simplify application startup

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -1388,26 +1388,25 @@ do_start(AppName, RT, Type, From, S) ->
     end.
     
 spawn_starter(From, Appl, S, Type) ->
-    spawn_link(?MODULE, init_starter, [From, Appl, S, Type]).
+    spawn_link(?MODULE, init_starter, [From, Appl, S#state.running, Type]).
 
-init_starter(_From, Appl, S, Type) ->
+init_starter(_From, Appl, Running, Type) ->
     process_flag(trap_exit, true),
     AppName = Appl#appl.name,
-    gen_server:cast(?AC, {application_started, AppName, 
-			  catch start_appl(Appl, S, Type)}).
+    gen_server:cast(?AC, {application_started, AppName,
+			  catch start_appl(Appl, Running, Type)}).
 
 reply(undefined, _Reply) -> 
     ok;
 reply(From, Reply) -> gen_server:reply(From, Reply).
 
-start_appl(Appl, S, Type) ->
+start_appl(Appl, Running, Type) ->
     ApplData = Appl#appl.appl_data,
     case ApplData#appl_data.mod of
 	[] ->
 	    {ok, undefined};
 	_ ->
 	    %% Name = ApplData#appl_data.name,
-	    Running = S#state.running,
 	    foreach(
 		fun(AppName) ->
 		    case lists:keymember(AppName, 1, Running) orelse

--- a/lib/kernel/src/application_master.erl
+++ b/lib/kernel/src/application_master.erl
@@ -24,7 +24,7 @@
 -export([get_child/1]).
 
 %% Internal exports
--export([init/4, start_it/4]).
+-export([init/3, start_it/4]).
 
 -include("application_master.hrl").
 
@@ -39,9 +39,8 @@
 %% Returns: {ok, Pid} | {error, Reason} (Pid is unregistered)
 %%-----------------------------------------------------------------
 start_link(ApplData, Type) ->
-    Parent = whereis(application_controller),
     proc_lib:start_link(application_master, init,
-			[Parent, self(), ApplData, Type]).
+			[self(), ApplData, Type]).
 
 start_type() ->
     group_leader() ! {start_type, self()},
@@ -114,8 +113,9 @@ call(AppMaster, Req) ->
 %%%-----------------------------------------------------------------
 %%% Internal functions
 %%%-----------------------------------------------------------------
-init(Parent, Starter, ApplData, Type) ->
-    link(Parent),
+init(Parent, ApplData, Type) ->
+    %% Unblock the parent process as soon as possible
+    proc_lib:init_ack(Parent, {ok, self()}),
     process_flag(trap_exit, true),
     OldGleader =
         case group_leader() == whereis(init) of
@@ -135,12 +135,13 @@ init(Parent, Starter, ApplData, Type) ->
     case start_it(State, Type) of
 	{ok, Pid} ->          % apply(M,F,A) returned ok
 	    ok = set_timer(ApplData#appl_data.maxT),
-	    unlink(Starter),
-	    proc_lib:init_ack(Starter, {ok,self()}),
+	    gen_server:cast(Parent, {application_started, Name, {ok, self()}}),
 	    main_loop(Parent, State#state{child = Pid});
 	{error, Reason} ->    % apply(M,F,A) returned error
+	    gen_server:cast(Parent, {application_started, Name, {error, Reason}}),
 	    exit(Reason);
 	Else ->               % apply(M,F,A) returned erroneous
+	    gen_server:cast(Parent, {application_started, Name, {error, Else}}),
 	    exit(Else)
     end.
 


### PR DESCRIPTION
This is a proposal to simplify application startup procedure. In particular, it removes one process from the stack. In the current scenario an application startup looks like this:
```
┌──────┐   ┌───────────┐   ┌──────┐   ┌───────────┐   ┌──────────────┐
│  AC  ├──►│ (starter) ├──►│  AM  ├──►│ (spawner) ├──►│ App:start()  │
└──────┘   └───────────┘   └──────┘   └───────────┘   └──────────────┘
```
After the change it's:
```
┌──────┐   ┌──────┐   ┌───────────┐   ┌──────────────┐
│  AC  ├──►│  AM  ├──►│ (spawner) ├──►│ App:start()  │
└──────┘   └──────┘   └───────────┘   └──────────────┘
```
with the `application_master` process started directly by the `application_controller`. The change does not affect the fact that the startup procedure is similarly asynchronous as before (moving the coordination from the separate process, directly into `application_master`) moving only small amount of extra work to the critical path - this should be well offset by avoiding copying large data structures into the intermediary process.

The change is done in many, small commits to simplify review (and my implementation). I'd be happy to squash if accepted.