### PR TITLE
Fix loss of state in code_server

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -1132,11 +1132,11 @@ try_finish_module(File, Mod, PC, EnsureLoaded, From, St) ->
             fun(_, S0) ->
                 case erlang:module_loaded(Mod) of
                     true ->
-                        reply_loading(EnsureLoaded, Mod, {module, Mod}, St);
+                        reply_loading(EnsureLoaded, Mod, {module, Mod}, S0);
                     false when S0#state.mode =:= interactive ->
                         try_finish_module_1(File, Mod, PC, From, EnsureLoaded, S0);
                     false ->
-                        reply_loading(EnsureLoaded, Mod, {error, embedded}, St)
+                        reply_loading(EnsureLoaded, Mod, {error, embedded}, S0)
                 end
             end
     end,


### PR DESCRIPTION
We were accidentally returning the old closed
over state, which lead to loss of information,
causing the code_server to crash.

This was introduced in #7503.

This pull request is for maint only. #8007 already fixes it in master.
Reproducing the failure is a bit tricky as it requires concurrent
loading of modules (some with pending on load callbacks).