### PR TITLE
Optimise ets:fold* functions

### DIFF
--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -2105,22 +2105,17 @@ the traversal.
 
 foldl(F, Accu, T) ->
     ets:safe_fixtable(T, true),
-    First = ets:first(T),
+    First = ets:first_lookup(T),
     try
         do_foldl(F, Accu, First, T)
     after
 	ets:safe_fixtable(T, false)
     end.
 
-do_foldl(F, Accu0, Key, T) ->
-    case Key of
-	'$end_of_table' ->
-	    Accu0;
-	_ ->
-	    do_foldl(F,
-		     lists:foldl(F, Accu0, ets:lookup(T, Key)),
-		     ets:next(T, Key), T)
-    end.
+do_foldl(_F, Accu, '$end_of_table', _T) -> Accu;
+do_foldl(F, Accu0, {Key, Objects}, T) ->
+    Accu = lists:foldl(F, Accu0, Objects),
+    do_foldl(F, Accu, ets:next_lookup(T, Key), T).
 
 -doc """
 `Acc0` is returned if the table is empty. This function is similar to
@@ -2141,22 +2136,17 @@ the traversal.
 
 foldr(F, Accu, T) ->
     ets:safe_fixtable(T, true),
-    Last = ets:last(T),
+    Last = ets:last_lookup(T),
     try
         do_foldr(F, Accu, Last, T)
-    after 
+    after
         ets:safe_fixtable(T, false)
     end.
 
-do_foldr(F, Accu0, Key, T) ->
-    case Key of
-	'$end_of_table' ->
-	    Accu0;
-	_ ->
-	    do_foldr(F,
-		     lists:foldr(F, Accu0, ets:lookup(T, Key)),
-		     ets:prev(T, Key), T)
-    end.
+do_foldr(_F, Accu, '$end_of_table', _T) -> Accu;
+do_foldr(F, Accu0, {Key, Objects}, T) ->
+    Accu = lists:foldr(F, Accu0, Objects),
+    do_foldr(F, Accu, ets:prev_lookup(T, Key), T).
 
 -doc """
 Fills an already created ETS table with the objects in the already opened Dets

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -2103,7 +2103,8 @@ the traversal.
       AccIn :: term(),
       AccOut :: term().
 
-foldl(F, Accu, T) ->
+foldl(F, Accu, Tab) ->
+    T = soft_whereis(Tab),
     ets:safe_fixtable(T, true),
     First = ets:first_lookup(T),
     try
@@ -2134,7 +2135,8 @@ the traversal.
       AccIn :: term(),
       AccOut :: term().
 
-foldr(F, Accu, T) ->
+foldr(F, Accu, Tab) ->
+    T = soft_whereis(Tab),
     ets:safe_fixtable(T, true),
     Last = ets:last_lookup(T),
     try
@@ -2147,6 +2149,13 @@ do_foldr(_F, Accu, '$end_of_table', _T) -> Accu;
 do_foldr(F, Accu0, {Key, Objects}, T) ->
     Accu = lists:foldr(F, Accu0, Objects),
     do_foldr(F, Accu, ets:prev_lookup(T, Key), T).
+
+soft_whereis(Table) when is_atom(Table) ->
+    case ets:whereis(Table) of
+        undefined -> error(badarg, [Table], [{error_info, #{cause => id, module => erl_stdlib_errors}}]);
+        Ref -> Ref
+    end;
+soft_whereis(Table) -> Table.
 
 -doc """
 Fills an already created ETS table with the objects in the already opened Dets

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -42,7 +42,8 @@
 	 tabfile_ext2/1, tabfile_ext3/1, tabfile_ext4/1, badfile/1]).
 -export([heavy_lookup/1, heavy_lookup_element/1, heavy_concurrent/1]).
 -export([lookup_element_mult/1, lookup_element_default/1]).
--export([foldl_ordered/1, foldr_ordered/1, foldl/1, foldr/1, fold_empty/1]).
+-export([foldl_ordered/1, foldr_ordered/1, foldl/1, foldr/1, fold_empty/1,
+         fold_badarg/1]).
 -export([t_delete_object/1, t_init_table/1, t_whitebox/1,
          select_bound_chunk/1, t_delete_all_objects/1, t_test_ms/1,
          t_delete_all_objects_trap/1,
@@ -118,6 +119,7 @@
 -export([t_select_reverse/1]).
 
 -include_lib("stdlib/include/ms_transform.hrl"). % ets:fun2ms
+-include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("common_test/include/ct_event.hrl").
 
@@ -219,7 +221,7 @@ groups() ->
       [heavy_lookup, heavy_lookup_element, heavy_concurrent]},
      {fold, [],
       [foldl_ordered, foldr_ordered, foldl, foldr,
-       fold_empty]},
+       fold_empty, fold_badarg]},
      {meta_smp, [],
       [meta_lookup_unnamed_read, meta_lookup_unnamed_write,
        meta_lookup_named_read, meta_lookup_named_write,
@@ -6426,6 +6428,11 @@ fold_empty(Config) when is_list(Config) ->
               verify_etsmem(EtsMem)
       end),
     ok.
+
+fold_badarg(Config) when is_list(Config) ->
+    F = fun(_, _) -> ok end,
+    ?assertError(badarg, ets:foldl(F, [], non_existing)),
+    ?assertError(badarg, ets:foldr(F, [], non_existing)).
 
 foldl(Config) when is_list(Config) ->
     repeat_for_opts_all_table_types(


### PR DESCRIPTION
This implements two optimisations for `ets:foldr` and `ets:foldl` functions.

* Using the new `ets:*_lookup` functions introduced in #6791 cuts the number of ETS operations in half
* Using `ets:whereis` on the table to resolve named table before the loop, speeds up the whole thing for named tables since resolving named tables is expensive on a system with a lot of tables.

This was measured with a simple benchmark:
```elixir
for i <- 1..10000 do
  :ets.new(:"tab#{i}", [:named_table])
end

:ets.new(:test, [:named_table])
table = :ets.whereis(:test)
for i <- 1..10000 do
  :ets.insert(:test, {i, i})
end

benches = %{
  "foldl named" => fn -> :ets.foldl(fn x, acc -> [x | acc] end, [], :test) end,
  "foldl ref" => fn -> :ets.foldl(fn x, acc -> [x | acc] end, [], table) end,
  "foldr named" => fn -> :ets.foldr(fn x, acc -> [x | acc] end, [], :test) end,
  "foldr ref" => fn -> :ets.foldr(fn x, acc -> [x | acc] end, [], table) end
}

Benchee.run(benches,
  warmup: 1,
  time: 5,
  memory_time: 0.01
)

```

I run the benchmarks on my M1 Max laptop.

Before, I could notice about 25-30% difference between the "named" and "ref" variants, after the change there's no difference, suggesting point 2 holds.

Overall, the "ref" variants, after the changes are about 20% faster, and the "named" variants are about 50% faster.

Raw data: https://gist.github.com/michalmuskala/3aa3fa2db2ad4ba524b32bbb9915b28b

This has an additional side-effect that a key matching `'$end_of_table'` won't mess up the iteration anymore, since the successful return value of `*_lookup` functions is a tuple.
