### PR TITLE
Optimise ETS usage in code_server

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -78,7 +78,7 @@ init(Ref, Parent, [Root,Mode]) ->
     register(?MODULE, self()),
     process_flag(trap_exit, true),
 
-    Db = ets:new(?moddb, [named_table, protected]),
+    Db = ets:whereis(ets:new(?moddb, [named_table, protected])),
     foreach(fun (M) ->
 		    %% Pre-loaded modules are always sticky.
 		    ets:insert(Db, [{M,preloaded},{{sticky,M},true}])
@@ -802,7 +802,7 @@ normalize(Other) ->
 %% The priv_dir/1 and lib_dir/1 functions will have
 %% an O(1) lookup.
 create_namedb(Path, Root) ->
-    Db = ets:new(code_names,[named_table, public]),
+    Db = ets:new(code_names,[]),
     init_namedb(lists:reverse(Path), Db),
 
     case lookup_name("erts", Db) of


### PR DESCRIPTION
Since the code_server state already holds a reference to the code_server table that is meticulously passed around, we can look up the direct reference with `ets:whereis`, rather than passing the name around. ETS operations with a refrence are faster than with the name.

Additionally, for the `code_names` table, we can make it private and unnamed completely, since it's only used directly from the server, there's no access to it from outside the process.