### PR TITLE
stdlib: markdown conversor to erlang+html

### DIFF
--- a/erts/doc/src/erlang_system_info.md
+++ b/erts/doc/src/erlang_system_info.md
@@ -270,7 +270,7 @@ Returns information about the default process heap settings:
   `garbage_collection` described below.
 
 - `garbage_collection`{: #system_info_garbage_collection } - Returns
-  `t:garbage_collection_defaults()` describing the default garbage collection settings.
+  `t:garbage_collection_defaults/0` describing the default garbage collection settings.
   A process spawned on the local node by a `spawn` or `spawn_link` uses these
   garbage collection settings. The default settings can be changed by using
   [`erlang:system_flag/2`](`erlang:system_flag/2`).

--- a/lib/compiler/src/beam_doc.erl
+++ b/lib/compiler/src/beam_doc.erl
@@ -1077,10 +1077,10 @@ fetch_doc_and_anno(#docs{docs = DocsMap}=State, {Attr, Anno0, F, A, _Args}) ->
         {_, {Doc1, Anno}} -> {Doc1, Anno}
     end.
 
--spec fun_to_varargs(tuple() | term()) -> list(term()).
+-spec fun_to_varargs(tuple() | term()) -> dynamic().
 fun_to_varargs({type, _, bounded_fun, [T|_]}) ->
    fun_to_varargs(T);
-fun_to_varargs({type, _, 'fun', [{type,_,product,Args}|_] }) ->
+fun_to_varargs({type, _, 'fun', [{type,_,product,Args}|_] }) when is_list(Args) ->
    map(fun fun_to_varargs/1, Args);
 fun_to_varargs({ann_type, _, [Name|_]}) ->
    Name;

--- a/lib/compiler/src/cerl.erl
+++ b/lib/compiler/src/cerl.erl
@@ -50,7 +50,7 @@ function `type/1`.
 > we do not give any guarantees on how an abstract syntax tree may or may not be
 > represented, _with the following exceptions_: no syntax tree is represented by a
 > single atom, such as `none`, by a list constructor `[X | Y]`, or by the empty
->list `[]`. This can be relied on when writing functions that operate on syntax
+> list `[]`. This can be relied on when writing functions that operate on syntax
 > trees.
 """.
 

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -121,6 +121,7 @@ MODULES= \
 	shell \
 	shell_default \
 	shell_docs \
+	shell_docs_markdown \
 	slave \
 	sofs \
 	string \

--- a/lib/stdlib/src/shell_docs_markdown.erl
+++ b/lib/stdlib/src/shell_docs_markdown.erl
@@ -1,0 +1,897 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(shell_docs_markdown).
+
+-moduledoc false.
+%% this module is expected to be consumed by `shell_docs.erl`.
+%% any output from `process_md/1` may not correspond 1-to-1 to
+%% a common conversion from markdown to Erlang+HTML.
+%% the end goal is that the output can be pretty printed correctly.
+
+-export([parse_md/1]).
+
+%% Valid inline prefixes, e.g., t:my_type()
+-define(INLINE_PREFIX(X), (X =:= $t orelse X =:= $m orelse X =:= $e orelse X =:= $c)).
+
+%% Allowed lists and their ways to capture them
+-define(IS_BULLET(X), (X =:= $* orelse X =:= $- orelse X =:= $+)).
+-define(IS_NUMBERED(X), (is_integer(X) andalso min(0, X) =:= 0)).
+
+%% Parsing format symbols and symbols separators between formats
+-define(VALID_BREAK(Symb), (Symb =:= $\s orelse Symb =:= $\n orelse Symb =:= <<>>)).
+-define(VALID_SEPARATOR(Symb), (?VALID_BREAK(Symb) orelse ?VALID_PUNCTUATION(Symb))).
+-define(VALID_FORMAT(Format), (Format =:= $* orelse Format =:= $_)).
+-define(VALID_ESCAPED(Char),
+        ((Char) =:= $! orelse (Char) =:= $" orelse (Char) =:= $# orelse (Char) =:= $$
+         orelse (Char) =:= $% orelse (Char) =:= $& orelse (Char) =:= $' orelse (Char) =:= $(
+         orelse (Char) =:= $\) orelse (Char) =:= $* orelse (Char) =:= $+ orelse (Char) =:= $,
+         orelse (Char) =:= $- orelse (Char) =:= $. orelse (Char) =:= $/ orelse (Char) =:= $:
+         orelse (Char) =:= $; orelse (Char) =:= $< orelse (Char) =:= $= orelse (Char) =:= $>
+         orelse (Char) =:= $? orelse (Char) =:= $@ orelse (Char) =:= $[ orelse (Char) =:= $\\
+         orelse (Char) =:= $] orelse (Char) =:= $^ orelse (Char) =:= $_ orelse (Char) =:= $`
+         orelse (Char) =:= ${ orelse (Char) =:= $| orelse (Char) =:= $} orelse (Char) =:= $~
+       )).
+-define(VALID_PUNCTUATION(Symb),
+        (Symb =:= $. orelse Symb =:= $, orelse
+         Symb =:= $( orelse Symb =:= $) orelse
+         Symb =:= $: orelse Symb =:= $;)).
+
+-spec parse_md(Doc0 :: binary()) -> Doc1 :: shell_docs:chunk_elements().
+parse_md(Doc) when is_binary(Doc) ->
+    %% remove links from [this form][1] to [this form].
+    Doc1 = re:replace(Doc, ~b"\\[([^\\]]*?)\\]\\[(.*?)\\]", "\\1", [{return, binary}, global]),
+
+    Lines = binary:split(Doc1, [<<"\r\n">>, <<"\n">>], [global]),
+    AST = parse_md(Lines, []),
+    format_line(AST).
+
+%% Formats a line
+-spec format_line(Input :: shell_docs:chunk_elements()) -> Result :: shell_docs:chunk_elements().
+format_line(Ls) ->
+    format_line(Ls, sets:new()).
+
+-spec format_line(Input, OmissionSet) -> Result when
+      Input :: shell_docs:chunk_elements(),
+      Result :: shell_docs:chunk_elements(),
+      OmissionSet :: sets:set(atom()).
+format_line([], _BlockSet0) ->
+    [];
+format_line([{Tag, [], List} | Rest], BlockSet0) ->
+    case format_line(List, sets:add_element(Tag, BlockSet0)) of
+        [] ->
+            format_line(Rest, BlockSet0);
+        Ls ->
+            [{Tag, [], Ls}] ++ format_line(Rest, BlockSet0)
+    end;
+format_line([Bin | Rest], BlockSet0) when is_binary(Bin) ->
+    %% Ignores formatting these elements
+    Restriction = sets:from_list([h1, h2, h3, h4, h5, h6, pre]),
+
+    case sets:is_disjoint(Restriction, BlockSet0) of
+        true ->
+            case format_inline(create_paragraph(Bin)) of
+                {p, [], []} ->
+                    %% ignore empty paragraphs
+                    %% they can happen if the line only contains links
+                    %% that are removed, so no content exists
+                    format_line(Rest, BlockSet0);
+                B ->
+                    [B | format_line(Rest, BlockSet0)]
+            end;
+        false ->
+            [Bin | format_line(Rest, BlockSet0)]
+    end.
+
+
+-spec parse_md(Markdown, HtmlErlang) -> HtmlErlang when
+      Markdown :: [binary()],
+      HtmlErlang :: shell_docs:chunk_elements().
+parse_md([], Block) ->
+    Block;
+
+parse_md([<<"    ", Line/binary>> | Rest], Block) ->
+   Block ++ process_code([<<"    ", Line/binary>> | Rest], []);
+
+%%
+%% Lists and paragraphs
+%%
+parse_md(Rest, Block) when is_list(Rest) ->
+    process_rest(Rest, Block).
+
+process_table([<<$|, _Data/binary>>=Header, Delimiter | Rest]) ->
+    maybe
+        {true, Fields} ?= check_start_closing_table(Header),
+        {true, Fields} ?= is_delimiter(Delimiter),
+        {DataRows, NotTable} ?= extract_body(Rest, Fields),
+        Table = lists:map(fun(Line) -> <<Line/binary, "\n">> end, [Header, Delimiter | DataRows]),
+        {[create_table(Table)], NotTable}
+    else
+        false ->
+            error;
+        {true, _DiffFieldNumber} ->
+            error
+    end;
+process_table(_) ->
+    %% The table either misses a delimiter or data rows,
+    %% which makes it an invalid table
+    error.
+
+
+is_delimiter(<<$|, Line/binary>>) ->
+    NoSpacesBin = re:replace(Line, ~b"(\s|:)", <<>>, [{return, binary}, global]),
+    is_delimiter(NoSpacesBin, 0);
+is_delimiter(_A) ->
+    false.
+
+is_delimiter(<<>>, Count) ->
+    {true, Count};
+is_delimiter(<<$|, Line/binary>>, Count) ->
+    is_delimiter(Line, Count + 1);
+is_delimiter(<<$-, Line/binary>>, Count) ->
+    is_delimiter(Line, Count);
+is_delimiter(_Bin, _Count) ->
+    false.
+
+extract_body([], _Fields) ->
+    {[], []};
+extract_body([<<>> | Rest], _Fields) ->
+    {[], Rest};
+extract_body([<<$|, _/binary>>=Line | Rest], Fields) ->
+    maybe
+        {true, Fields} ?= check_start_closing_table(Line),
+        {Row, Rest1} ?= extract_body(Rest, Fields),
+        {[Line | Row], Rest1}
+    else
+        _E ->
+            false
+    end;
+extract_body(Rest, _Fields) when is_list(Rest) ->
+    {[], Rest}.
+
+
+check_start_closing_table(Line) ->
+    Line1 = re:replace(Line, ~b"(\s)", <<>>, [{return, binary}, global]),
+    FirstBar = binary:first(Line1),
+    LastBar = binary:last(Line1),
+    case FirstBar =:= $| andalso LastBar =:= $| of
+        true ->
+            SkipVerbatimSlash = length(binary:matches(Line, ~"\\|")),
+            {true, length(binary:matches(Line, ~"|")) - SkipVerbatimSlash - 1};
+        false ->
+            false
+    end.
+
+process_rest([P | Rest], Block) ->
+    process_list_or_p(P, Rest, Block).
+
+detect_rest(<<BulletList, $\s, _Line/binary>>) when ?IS_BULLET(BulletList) ->
+    ul;
+detect_rest(<<NumberedList, $., $\s, _Line/binary>>) when ?IS_NUMBERED(NumberedList) ->
+    ol;
+detect_rest(_) ->
+    p.
+
+process_list_or_p(P, Rest, Block) ->
+    {StrippedP, SpaceCount} = strip_spaces(P, 0, infinity),
+    case detect_rest(StrippedP) of
+        List when List =:= ul;
+                  List =:= ol ->
+            {Content, Rest1} = process_list(List, P, Rest, SpaceCount, Block),
+            Content ++ parse_md(Rest1, []);
+        _ ->
+            %% Note: It could be that some text has been indented
+            %% further than normal. If there is some rendering issue,
+            %% maybe here we need to strip P from spaces and re-run parse_md(P).
+            %% Not an issue, so far.
+            process_kind_block([StrippedP | Rest], Block)
+    end.
+
+process_list(Format, LineContent, Rest, SpaceCount, Block) ->
+    {Content, Rest1} = create_list(Format, [LineContent | Rest], SpaceCount, Block),
+    {Block ++ [create_item_list(Format, lists:reverse(Content))], Rest1}.
+
+create_item_list(ul, Items) when is_list(Items) ->
+    ul(Items);
+create_item_list(ol, Items) when is_list(Items) ->
+    ol(Items).
+
+ul(Items) when is_list(Items) ->
+    {ul, [], Items}.
+
+ol(Items) when is_list(Items) ->
+    {ol, [], Items}.
+
+li(Items) when is_list(Items)->
+    {li, [], Items}.
+
+create_list(Format, [Line | Rest], SpaceCount, Acc) ->
+    process_block(Format, [Line | Rest], SpaceCount, Acc).
+
+process_block(_Format, [], _SpaceCount, Acc) ->
+    {lists:reverse(Acc), []};
+process_block(Format, [Line | Rest], SpaceCount, Acc) ->
+    {Content, RemainingRest, Done} = get_next_block(Format, [Line | Rest], SpaceCount, Acc),
+    Items = case Content of
+                L when L =:= []; L =:= Acc ->
+                    [];
+                _ ->
+                    [li(parse_md(lists:reverse(Content), [])) | Acc]
+            end,
+    case Done of
+        true ->
+            {Items, RemainingRest};
+        false ->
+            {Items2, Rest2} = process_block(Format, RemainingRest, SpaceCount, []),
+            {Items2 ++ Items, Rest2}
+    end.
+
+get_next_block(_Format, [], _SpaceCount, Acc) ->
+    {Acc, [], true};
+get_next_block(Format, [Line | Rest], SpaceCount, Acc) ->
+    {Stripped, NextCount} = strip_spaces(Line, 0, infinity),
+    case detect_next_kind(Format, Stripped, Rest, SpaceCount, NextCount) of
+        next ->
+            {NewLine, _} = strip_spaces(Line, 0, min(NextCount, 2)),
+            %% Try to remove extra space padding from line, so that when
+            %% the accumulated lines are processed by process_md,
+            %% there is no extra space to take into account.
+            %%
+            %% Example:
+            %%
+            %% ~"- ```erlang
+            %%     foo() -> ok.
+            %%     ```"
+            %% is seen by process_md later on as
+            %% ~"```erlang
+            %%     foo() -> ok.
+            %%   ```"
+            %% This step tries to to always remove extra space padding.
+            %% This is because markdown is not consistent in the spacing rules
+            %% and when we mix positioning of list blocks where the space
+            %% matters with places where space does not, it becomes ambiguous
+            %% to parse correctly.
+            %%
+            %% Example 2:
+            %%
+            %% ~" -  First line in list
+            %%          second line in list
+            %%    and continue here"
+            %%
+            get_next_block(Format, Rest, SpaceCount, [NewLine | Acc]);
+        done ->
+            {Acc, [Line | Rest], true};
+        list ->
+            {Acc, [strip_list_line(Stripped) | Rest], false}
+    end.
+
+detect_list_format_change(State, ExpectedFormat, Line, SpaceCount, NextCount) ->
+    ListType = detect_rest(Line),
+    case ExpectedFormat =:= ListType orelse ListType =:= p of
+        false when NextCount =< SpaceCount ->
+            done;
+        _ ->
+            State
+    end.
+
+detect_next_kind(Format, Line, Rest, SpaceCount, NextCount) ->
+    State = process_next_kind(Line, Rest, SpaceCount, NextCount),
+    detect_list_format_change(State, Format, Line, SpaceCount, NextCount).
+
+process_next_kind(<<BulletFormat>>, _, _SpaceCount, _NextCount)
+  when ?IS_BULLET(BulletFormat) ->
+    %% Important: otherwise it may consider the symbol to mean
+    %%            a setext heading underline, when it was a mistake to ignore
+    list;
+process_next_kind(<<BulletFormat, $\s, _/binary>>, _, SpaceCount, NextCount)
+  when ?IS_BULLET(BulletFormat) andalso (NextCount =< SpaceCount) ->
+    list;
+process_next_kind(<<OrderedFormat, $., $\s, _/binary>>, _, SpaceCount, NextCount)
+  when ?IS_NUMBERED(OrderedFormat) andalso  (NextCount =< SpaceCount) ->
+    list;
+process_next_kind(<<>>, [<<$\s, _/binary>> | _], _SpaceCount, _NextCount) ->
+    next;
+process_next_kind(<<>>, _, _, _) ->
+    done;
+process_next_kind(_A, _B, _C, _D) ->
+    next.
+
+strip_list_line(Line) ->
+    case Line of
+        <<BulletFormat>>
+          when ?IS_BULLET(BulletFormat) ->
+            %% Important: otherwise it may consider the symbol to mean
+            %%            a setext heading underline, when it was a mistake to ignore
+            <<>>;
+        <<BulletFormat, $\s, Continuation/binary>>
+          when ?IS_BULLET(BulletFormat) ->
+            strip_list_line(Continuation);
+        <<OrderedFormat, $., Continuation/binary>>
+          when ?IS_NUMBERED(OrderedFormat) ->
+            strip_list_line(Continuation);
+        <<OrderedFormat, $\s, Continuation/binary>>
+          when ?IS_NUMBERED(OrderedFormat) ->
+            strip_list_line(Continuation);
+        _ ->
+            Line
+    end.
+
+%%
+%% Headings
+%%
+process_kind_block([<<" ", Line/binary>> | Rest], Block) ->
+    process_kind_block([Line | Rest], Block);
+process_kind_block([<<"# ", Heading/binary>> | Rest], Block) ->
+    HeadingLevel = 1,
+    Block ++ process_heading(HeadingLevel, Heading, Rest);
+process_kind_block([<<"## ", Heading/binary>> | Rest], Block) ->
+    HeadingLevel = 2,
+    Block ++ process_heading(HeadingLevel, Heading, Rest);
+process_kind_block([<<"### ", Heading/binary>> | Rest], Block) ->
+    HeadingLevel = 3,
+    Block ++ process_heading(HeadingLevel, Heading, Rest);
+process_kind_block([<<"#### ", Heading/binary>> | Rest], Block) ->
+    HeadingLevel = 4,
+    Block ++ process_heading(HeadingLevel, Heading, Rest);
+process_kind_block([<<"##### ", Heading/binary>> | Rest], Block) ->
+    HeadingLevel = 5,
+    Block ++ process_heading(HeadingLevel, Heading, Rest);
+process_kind_block([<<"###### ", Heading/binary>> | Rest], Block) ->
+    HeadingLevel = 6,
+    Block ++ process_heading(HeadingLevel, Heading, Rest);
+
+%%
+%% Quotes where
+%%
+process_kind_block([<<">", _/binary>>=Line | Rest], Block) ->
+    Block ++ process_quote([Line | Rest], []);
+
+%%
+%% process block code
+%%
+process_kind_block([<<"```", _Line/binary>> | Rest], Block) ->
+    Block ++ process_fence_code(Rest, []);
+%%
+%% New line
+%%
+process_kind_block([<<"">> | Rest], Block) ->
+    Block ++ parse_md(Rest, []);
+%%
+%% Comments
+%%
+process_kind_block([<<"<!--", Line/binary>> | Rest], Block) ->
+    Block ++ parse_md(process_comment([Line | Rest]), []);
+%%
+%% Tables
+%%
+process_kind_block([<<$|, _/binary>> | _]=Lines, Block) ->
+    maybe
+        {Table, Rest1} ?= process_table(Lines),
+        Block ++ Table ++ parse_md(Rest1, [])
+    else
+        error ->
+            %% looked like a table but it was not
+            %% process as per the remaining option: paragraph
+            process_paragraph(Lines, Block)
+    end;
+
+process_kind_block([P | Rest], Block) ->
+    process_paragraph([P | Rest], Block).
+
+process_paragraph([P | Rest], Block) ->
+    case process_p([P | Rest], Block) of
+        {[_ | _]=Rest1, Block1} ->
+            process_setext_header({Rest1, Block1});
+        {Rest2, Block2} ->
+            parse_md(Rest2, Block2)
+    end.
+
+process_setext_header({[Line | Remaining]=Rest1, [H]=Block1}) ->
+    case strip_spaces(Line, 0, infinity) of
+        {Stripped, SpaceCount} when SpaceCount =:= 4; Stripped == <<>> ->
+            %% new code block, example:
+            %%
+            %%     foo() -> ok.
+            %%
+            parse_md(Rest1, Block1);
+        {Stripped, _} ->
+            HeaderSymbol = binary:first(Stripped),
+            maybe
+                true ?= repeated_bin_char(Stripped, HeaderSymbol),
+                <<$#, _/binary>>=Header ?= header_bin_level(HeaderSymbol),
+                HeaderBlock = parse_md([<<Header/binary, H/binary>>], []),
+                HeaderBlock ++ parse_md(Remaining, [])
+            else
+                _ ->
+                    parse_md(Rest1, Block1)
+            end
+    end.
+
+header_bin_level($=) -> <<"# ">>;
+header_bin_level($-) -> <<"## ">>;
+header_bin_level(_) -> error.
+
+repeated_bin_char(<<>>, _) ->
+    true;
+repeated_bin_char(<<Char, RestLine/binary>>, Char) ->
+    repeated_bin_char(RestLine, Char);
+repeated_bin_char(_, _) ->
+    false.
+
+process_p([<<>>], Block) when is_list(Block) ->
+    {[], Block};
+process_p([P | Rest], []) when is_binary(P) ->
+    {Rest, [P]};
+process_p([<<$\s, P/binary>> | Rest], [Bin | RestBlock]) when is_binary(Bin) ->
+    process_p([P | Rest], [Bin | RestBlock]);
+process_p([P | Rest], [Bin | RestBlock]) when is_binary(Bin), is_binary(P) ->
+    %% merge lines and add space, if required.
+    case binary:last(Bin) of
+        $\s ->
+            {Rest, [<<Bin/binary, P/binary>> | RestBlock]};
+        _ ->
+            {Rest, [<<Bin/binary, $\s, P/binary>> | RestBlock]}
+    end.
+
+strip_spaces(<<" ", Rest/binary>>, Acc, Max) when Max =:= infinity; Acc < Max ->
+    strip_spaces(Rest, Acc + 1, Max);
+strip_spaces(Rest, Acc, _) ->
+    {Rest, Acc}.
+
+-type chunk_element_type() :: a | code | em | strong | i | b|
+                              p | 'div' | br | pre | ul |
+                              ol | li | dl | dt | dd |
+                              h1 | h2 | h3 | h4 | h5 | h6.
+-type chunk_element_attrs() :: [].
+-type quote() :: {blockquote,[], shell_docs:chunk_elements()}.
+-type code() :: {pre, chunk_element_attrs(), [{code,[], shell_docs:chunk_elements()}]}.
+-type p() :: {p, chunk_element_attrs(), shell_docs:chunk_elements()}.
+-type i() :: {i, chunk_element_attrs(), shell_docs:chunk_elements()}.
+-type em() :: {em, chunk_element_attrs(), shell_docs:chunk_elements()}.
+-type code_inline() :: {code, chunk_element_attrs(), shell_docs:chunk_elements()}.
+-type header() :: {h1 | h2 | h3 | h4 | h5 | h6, chunk_element_attrs(), shell_docs:chunk_elements() | [binary()]}.
+
+-spec process_heading(Level, Heading, Rest) -> HtmlErlang when
+      Level         :: 1..6,
+      Heading       :: binary(),
+      Rest          :: [binary()],
+      HtmlErlang    :: shell_docs:chunk_elements().
+process_heading(Level, Text, Rest) ->
+    Header = create_header(Level, Text),
+    [format_inline(Header) | parse_md(Rest, [])].
+
+-spec create_header(Level, Header) -> header() when
+      Level  :: 1..6,
+      Header :: binary().
+create_header(Level, Heading) ->
+    {header_level(Level), [], [Heading]}.
+
+%% this function makes it easier for type checker
+%% to understand the meaning.
+header_level(1) -> h1;
+header_level(2) -> h2;
+header_level(3) -> h3;
+header_level(4) -> h4;
+header_level(5) -> h5;
+header_level(6) -> h6.
+
+-spec process_quote(Line, PrevLines) -> HtmlErlang when
+      Line       :: [binary()],  %% Represents current parsing line.
+      PrevLines  :: [binary()],  %% Represent unprocessed lines.
+      HtmlErlang :: shell_docs:chunk_elements().
+process_quote([<<">">> | Rest], PrevLines) ->
+    process_quote(Rest, PrevLines);
+process_quote([<<"> ", Line/binary>> | Rest], PrevLines) ->
+    process_quote(Rest, [Line | PrevLines]);
+process_quote([<<">> ", Line/binary>> | Rest], PrevLines) ->
+    process_quote([<<"> ", Line/binary>> | Rest], PrevLines);
+process_quote([<<">", Line/binary>> | Rest], PrevLines) ->
+    process_quote([<<"> ", Line/binary>> | Rest], PrevLines);
+process_quote(Rest, PrevLines) ->
+    [quote(parse_md(lists:reverse(PrevLines), []))] ++ parse_md(Rest, []).
+
+-spec format_inline(Inline) -> Inline :: {chunk_element_type(), [], shell_docs:chunk_elements()} when
+      Inline :: {chunk_element_type(), [], [binary()]}.
+format_inline({Tag, [], Ls}) when is_list(Ls) ->
+    F = fun (Bin, Acc) when is_list(Acc), is_binary(Bin) ->
+                L = case format_link(Bin) of
+                        <<>> ->
+                            %% ignore empty lines if we remove {: .text }\n
+                            [];
+                        Text ->
+                            Format = [], % existing format to match on closing
+                            Buffer = [], % tracks the current thing to put within a specific format
+                            process_inline(Text, Format, Buffer)
+                    end,
+                L ++ Acc
+        end,
+    FormattedLines = lists:foldr(F, [], Ls),
+    {Tag, [], lists:reverse(FormattedLines)}.
+
+format_link(Bin) when is_binary(Bin) ->
+    Options = [{return, binary}, global],
+
+    %% replace using greedy search, works on
+    %% [foo bar](etc)
+    %% thanks to Elixir folks:
+    %% https://github.com/elixir-lang/elixir/blob/30db5d91fbe54f066776840a9f09116e6f1ea81b/lib/elixir/lib/io/ansi/docs.ex#L623
+    R1 = re:replace(Bin, ~b"\\[([^\\]]*?)\\]\\((.*?)\\)", "\\1", Options),
+
+    %% replace using lazy search, useful when there are [] symbols
+    %% e.g., [`foo([ok])`](etc)
+    R2 = re:replace(R1, ~b"\\[(.*)\\]\\((.*?)\\)", "\\1", Options),
+
+    %% remove anchors
+    R3 = re:replace(R2, ~b"{:[^}]*}", <<>>, Options),
+
+    %% remove links of the form: `[foo]: erlang.org`
+    re:replace(R3, ~b"\\[([^\\]]*?)\\]: (.*?)", "", [{return, binary}, global]).
+
+-spec process_inline(Line, Format, Buffer) -> Result when
+      Line :: binary(),
+      Format :: [binary()],
+      Buffer :: shell_docs:chunk_elements(),
+      Result :: shell_docs:chunk_elements().
+process_inline(Bin, Fs, Buffer) ->
+    case process_format(Bin, Fs, Buffer) of
+        {not_closed, Buffer1} ->
+            Buffer1;
+        {ok, Buffer1} ->
+            Buffer1;
+        {Continuation, Buffer1} when is_binary(Continuation)->
+            process_inline(Continuation, [], Buffer1)
+    end.
+
+-spec process_format(Text, Format, Buffer) -> {Continuation, ResultBuffer} when
+      Text :: binary(),
+      Format :: [binary()],
+      Buffer :: shell_docs:chunk_elements(),
+      ResultBuffer :: shell_docs:chunk_elements(),
+      Continuation :: not_closed | ok | binary().
+%%
+%% Handle inline code
+%%
+process_format(<<$`, Continuation/binary>>, Fs, Buffer) ->
+    {Buffer1, Continuation2} = code_inliner(Continuation, []),
+    process_format(Continuation2, Fs, merge_buffers(Buffer1, Buffer));
+
+
+process_format(<<$\\, Char, Rest/binary>>, Fs, Buffer)
+  when ?VALID_ESCAPED(Char) ->
+    process_format(Rest, Fs, merge_buffers([<<Char>>],  Buffer));
+
+%% This case deals with closing of formatting code on special characters,
+%% e.g.,"_Keys (ssh)_," should understand the last underscore as the closing
+%% of italics. This is not the general case, see example "ssh_added_here"
+%% which must not be considered italics
+process_format(<<Char, Format, Format, Char2, Rest/binary>>, [<<Format>>, <<Format>>]=Fs, Buffer)
+  when (Char =/= Format andalso not ?VALID_FORMAT(Char) andalso ?VALID_PUNCTUATION(Char)) andalso
+       ?VALID_FORMAT(Format) andalso
+       (Char2 =/= Format andalso not ?VALID_FORMAT(Char2) andalso ?VALID_SEPARATOR(Char2)) ->
+    close_format(<<Char2, Rest/binary>>, Fs, merge_buffers([<<Char>>],  Buffer));
+process_format(<<Char, Format, Char2, Rest/binary>>, [<<Format>>], Buffer)
+  when (Char =/= Format andalso not ?VALID_FORMAT(Char) andalso ?VALID_PUNCTUATION(Char)) andalso
+       ?VALID_FORMAT(Format) andalso
+       (Char2 =/= Format andalso not ?VALID_FORMAT(Char2) andalso ?VALID_SEPARATOR(Char2)) ->
+    close_format(<<Char2, Rest/binary>>, [<<Format>>], merge_buffers([<<Char>>],  Buffer));
+
+%% This case deals with ssh_added_here to not be consider italics,
+%% so no formatting of code should happen
+process_format(<<Char, Format, Char2, Rest/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) andalso
+       (Char  =/= Format andalso Char  =/= $\s andalso Char  =/= $\n andalso not ?VALID_FORMAT(Char)) andalso
+       (Char2 =/= Format andalso Char2 =/= $\s andalso Char2 =/= $\n andalso not ?VALID_FORMAT(Char2) andalso
+        not ?VALID_PUNCTUATION(Char2)) ->
+    process_format(Rest, Fs, merge_buffers([<<Char, Format, Char2>>],  Buffer));
+process_format(<<Char, Format, Format, Char2, Rest/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) andalso
+       (Char  =/= Format andalso Char  =/= $\s andalso Char  =/= $\n andalso not ?VALID_FORMAT(Char)) andalso
+       (Char2 =/= Format andalso Char2 =/= $\s andalso Char2 =/= $\n andalso not ?VALID_FORMAT(Char2) andalso
+        not ?VALID_PUNCTUATION(Char2)) ->
+    process_format(Rest, Fs, merge_buffers([<<Char, Format, Char2>>],  Buffer));
+
+%%
+%% Handle closing of bold / italics
+%%
+process_format(<<Format, Format, Symb/binary>>, [<<Format>>, <<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(Symb, [<<Format>>, <<Format>>], Buffer);
+process_format(<<Format, Format, Symb, Continuation/binary>>, [<<Format>>, <<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<Symb, Continuation/binary>>, [<<Format>>, <<Format>>], Buffer);
+process_format(<<Format, Format, $\r, $\n, Continuation/binary>>, [<<Format>>, <<Format>>], Buffer) ->
+    close_format(<<$\r, $\n, Continuation/binary>>, [<<Format>>, <<Format>>], Buffer);
+process_format(<<Format, Format, Continuation/binary>>, [<<Format>>, <<Format>>], Buffer) ->
+    close_format(Continuation, [<<Format>>, <<Format>>], Buffer);
+
+
+process_format(<<Symb, Format, Format>>, [<<Format>>, <<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<>>, [<<Format>>, <<Format>>], merge_buffers([<<Symb>>], Buffer));
+process_format(<<Symb, Format, Format, Continuation/binary>>, [<<Format>>, <<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<Continuation/binary>>, [<<Format>>, <<Format>>], merge_buffers([<<Symb>>], Buffer));
+
+
+process_format(<<Format, Symb/binary>>, [<<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<>>, [<<Format>>], Buffer);
+process_format(<<Format, Symb, Continuation/binary>>, [<<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<Symb, Continuation/binary>>, [<<Format>>], Buffer);
+process_format(<<Format, $\r, $\n, Continuation/binary>>, [<<Format>>], Buffer) ->
+    close_format(<<$\r, $\n, Continuation/binary>>, [<<Format>>], Buffer);
+process_format(<<Format, Continuation/binary>>, [<<Format>>], Buffer) ->
+    close_format(Continuation, [<<Format>>], Buffer);
+
+process_format(<<Symb, Format>>, [<<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<>>, [<<Format>>], merge_buffers([<<Symb>>], Buffer));
+process_format(<<Symb, Format, Continuation/binary>>, [<<Format>>], Buffer)
+  when ?VALID_SEPARATOR(Symb) ->
+    close_format(<<Continuation/binary>>, [<<Format>>], merge_buffers([<<Symb>>], Buffer));
+
+%%
+%% Handle opening blocks of bold / italics
+%%
+process_format(<<Format, Format>>, [<<Format2>>, <<Format2>>]=Fs, Buffer)
+  when ?VALID_FORMAT(Format) andalso Format =/= Format2 ->
+    %% open a new format that will never be matched because
+    %% the Continuation has ended <<>>.
+    process_format(<<>>, Fs, merge_buffers([<<Format>>, <<Format>>], Buffer));
+process_format(<<Symb, Format, Format, Continuation/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) andalso ?VALID_SEPARATOR(Symb) ->
+    open_format(Continuation, [<<Format>>, <<Format>>], Fs, merge_buffers([<<Symb>>], Buffer));
+process_format(<<$\r, $\n, Format, Format, Continuation/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) ->
+    open_format(Continuation, [<<Format>>, <<Format>>], Fs, merge_buffers([<<$\r, $\n>>], Buffer));
+process_format(<<Format, Format, Continuation/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) ->
+    open_format(Continuation, [<<Format>>, <<Format>>], Fs, Buffer);
+
+
+process_format(<<Format>>, [<<Format2>>]=Fs, Buffer)
+  when ?VALID_FORMAT(Format) andalso Format =/= Format2 ->
+    %% open a new format that will never be matched
+    process_format(<<>>, Fs, merge_buffers([<<Format>>], Buffer));
+process_format(<<Symb, Format, Continuation/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) andalso ?VALID_SEPARATOR(Symb) ->
+    open_format(Continuation, [<<Format>>], Fs, merge_buffers([<<Symb>>], Buffer));
+process_format(<< $\r, $\n, Format, Continuation/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) ->
+    open_format(Continuation, [<<Format>>], Fs, merge_buffers([<<$\r, $\n>>], Buffer));
+process_format(<<Format, Continuation/binary>>, Fs, Buffer)
+  when ?VALID_FORMAT(Format) ->
+    open_format(Continuation, [<<Format>>], Fs, Buffer);
+
+
+%%
+%% Handle non-formatting characters
+%%
+process_format(<<Char, Rest/binary>>, Format, Buffer) ->
+    process_format(Rest, Format, merge_buffers([<<Char>>],  Buffer));
+process_format(<<>>, [], Buffer) ->
+    {ok, Buffer};
+process_format(<<>>, _Format, Buffer) ->
+    {not_closed, Buffer}.
+
+%%
+%% Parses text until it finds a closing $`
+-spec code_inliner(Line, Buffer) -> {ReturnedBuffer, Rest} when
+      Line :: binary(),
+      Buffer :: shell_docs:chunk_elements(),
+      ReturnedBuffer :: shell_docs:chunk_elements(),
+      Rest :: binary().
+code_inliner(Line, Buffer0) ->
+    F = fun Inliner(<<$\\, $`, Rest/binary>>, Buffer) ->
+                %% append chars to buffer
+                Inliner(Rest, merge_buffers([<<$`>>], Buffer));
+            Inliner(<<$`, Rest/binary>>, Buffer) ->
+                %% close inline
+                {[code_inline(Buffer)], Rest};
+            Inliner(<<Char, Rest/binary>>, Buffer) ->
+                %% append chars to buffer
+                Inliner(Rest, merge_buffers([<<Char>>], Buffer));
+            Inliner(<<>>, Buffer) ->
+                %% end without closing inline
+                {Buffer, <<>>}
+        end,
+    case Line of
+       <<Prefix, $:, Rest/binary>> when ?INLINE_PREFIX(Prefix) ->
+         F(Rest, Buffer0);
+      _ ->
+         F(Line, Buffer0)
+    end.
+
+-spec open_format(Continuation, NewFormat, PrevFormat, Buffer) -> Result when
+      Continuation :: binary(),
+      NewFormat    :: [binary()], % list of the following binary chars $* | $_ | $`,
+      PrevFormat   :: [binary()], % same as above
+      Buffer       :: shell_docs:chunk_elements(),
+      Result       :: dynamic().
+open_format(Continuation, NewFormat, PrevFormat, Buffer) ->
+    case process_format(Continuation, NewFormat, []) of
+        {not_closed, _LastBufferedResult} ->
+            %% the 'NewFormat' could not find a closing match when
+            %% processing, thus one must prepend 'NewFormat'
+            %% to whatever the buffer at that time had, so that
+            %% we add the symbols in 'NewFormat' at their opening place
+            %% if they are a binary:
+            %%
+            %% Example:
+            %%
+            %% Buffer = [<<"Here">>] and NewFormat = [<<"*">>]
+            %% merge_buffers(Buffer, NewFormat) = [<<"*Here">>].
+            %%
+            %% Buffer = [{em, [], X}] and Buffer2 = [<<"Zzz">>]
+            %% merge_buffers(Buffer, Buffer2) = [{em, [], X}, <<"Zzz">>].
+            %%
+            PrependToBuffer = merge_buffers(NewFormat, Buffer),
+            process_format(Continuation, PrevFormat, PrependToBuffer);
+        {ok, Buffer1} ->
+            %% There is no more continuation, i.e., nothing to process,
+            %% so we are finished.
+            {ok, merge_buffers(Buffer1, Buffer)};
+        {Continuation1, LastBufferedResult} when is_binary(Continuation1) ->
+            %% The NewFormat was closed, so we continue processing
+            %% the resulting continuation
+            process_format(Continuation1, PrevFormat, merge_buffers(LastBufferedResult, Buffer))
+    end.
+
+-spec close_format(Continuation, ClosingFormat, Buffer) -> Result when
+      Continuation  :: binary(),
+      ClosingFormat :: [binary()], % list of the following binary chars $* | $_ | $`,
+      Buffer        :: shell_docs:chunk_elements(),
+      Result        :: dynamic().
+close_format(Continuation, ClosingFormat, Buffer) ->
+    {Continuation, format(ClosingFormat, Buffer)}.
+
+%% assume that buffers have their elements in reverse order.
+%% i.e., [{p, [], [<<"Here ">>, {em, [], <<"there">>}]}] will appear here as
+%% [{p, [], [{em, [], <<"there">>}, <<"Here ">>]}]
+%% the reversal operation is taking care of once, in another place.
+merge_buffers(EndBuffer, BeginningBuffer) ->
+    lists:foldr(fun compact_buffers/2, [], EndBuffer ++ BeginningBuffer).
+
+compact_buffers(X, []) when is_binary(X); is_tuple(X) ->
+    [X];
+compact_buffers(X, Acc) when is_tuple(X) ->
+    [X | Acc];
+compact_buffers(X, [LastEntry | Beginning]) when is_tuple(LastEntry) ->
+    [X, LastEntry | Beginning];
+compact_buffers(<<X/binary>>, [<<LastEntry/binary>> | Beginning]) ->
+    [<<LastEntry/binary, X/binary>> | Beginning].
+
+-spec format(Format, Line) -> Result when
+      Line :: shell_docs:chunk_elements(),
+      Result :: [{chunk_element_type(), chunk_element_attrs(), shell_docs:chunk_elements()}],
+      Format :: [binary()].
+format(Format, Line0) when is_list(Line0)->
+    Line1 = lists:reverse(Line0),
+    Formatted = case Format of
+                    [<<"*">>, <<"*">>] ->
+                        em(Line1);
+                    [<<"_">>, <<"_">>] ->
+                        em(Line1);
+                    [<<"_">>] ->
+                        i(Line1);
+                    [<<"*">>] ->
+                        i(Line1);
+                    [<<"`">>] ->
+                        code_inline(Line1)
+                end,
+    [Formatted].
+
+-spec process_code(Line, PrevLines) -> HtmlErlang when
+      Line       :: [binary()],  %% Represents current parsing line.
+      PrevLines  :: [binary()],  %% Represent unprocessed lines.
+      HtmlErlang :: shell_docs:chunk_elements().
+process_code([], Block) ->
+    [create_code(Block)];
+process_code([<<"    ", Line/binary>> | Rest], Block) ->
+    %% process blank line followed by code
+    process_code(Rest, [Line | Block]);
+process_code(Rest, Block) ->
+    process_code([], Block) ++ parse_md(Rest, []).
+
+process_fence_code([], Block) ->
+    [create_code(Block)];
+process_fence_code([<<"```">> | Rest], Block) ->
+    %% close block
+    process_fence_code([], Block) ++ parse_md(Rest, []);
+process_fence_code([Line | Rest], Block) ->
+    {Stripped, _} = strip_spaces(Line, 0, infinity),
+    maybe
+        <<"```", RestLine/binary>> ?= Stripped,
+        {<<>>, _} ?= strip_spaces(RestLine, 0, infinity),
+        process_fence_code([<<"```">> | Rest], Block)
+    else
+        _ ->
+            process_fence_code(Rest, [Line | Block])
+    end.
+
+-spec process_comment(Line :: [binary()]) -> [binary()].
+process_comment([]) ->
+    [];
+process_comment([Line | Rest]) ->
+    case binary:split(Line, <<"-->">>) of
+        [_] ->
+            % Line is just comment, process next line
+            case process_comment(Rest) of
+                [] ->
+                    %% closing comment not found
+                    error(missing_close_comment);
+                Result ->
+                    Result
+            end;
+        [_Comment, Text] ->
+            % Skip comment, return text plus continuation line
+            [Text | Rest]
+    end.
+
+-spec create_paragraph(Line) -> P when
+      Line :: binary(),
+      P :: p().
+create_paragraph(<<$\s, Line/binary>>) ->
+    create_paragraph(Line);
+create_paragraph(Line) when is_binary(Line) ->
+    p(Line).
+
+-spec create_code(Lines :: [binary()]) -> code().
+create_code(CodeBlocks) when is_list(CodeBlocks) ->
+    %% assumes that the code block is in reverse order
+    Bin = trim_and_add_new_line(CodeBlocks),
+    {pre,[], [{code,[], [Bin]}]}.
+
+create_table(Table) when is_list(Table) ->
+    {pre,[], [{code,[], Table}]}.
+
+
+-spec quote(Quote :: list()) -> quote().
+quote(List) when is_list(List) ->
+    {blockquote, [], List}.
+
+-spec p(Line :: binary()) -> p().
+p(X) when is_binary(X) ->
+    {p, [], [X]}.
+
+-spec code_inline(Text :: shell_docs:chunk_elements()) -> code_inline().
+code_inline(X) when is_list(X) ->
+    {code, [], X}.
+
+-spec i(Text :: shell_docs:chunk_elements()) -> i().
+i(X) when is_list(X) ->
+    {i, [], X}.
+
+-spec em(Text :: shell_docs:chunk_elements()) -> em().
+em(X) when is_list(X) ->
+    {em, [], X}.
+
+%% Assumes that the list is reversed, so Last is the last element.
+-spec trim_and_add_new_line([binary()]) -> binary().
+trim_and_add_new_line([]) ->
+    ~"\n";
+trim_and_add_new_line(Lines) when is_list(Lines) ->
+    trim_and_add_new_line(Lines, <<>>).
+
+trim_and_add_new_line([], Acc) when is_binary(Acc) ->
+    Acc;
+trim_and_add_new_line([Line | Rest], Acc) when is_binary(Line), is_binary(Acc) ->
+    Line1 = re:replace(Line, ~b"(\n|\r\n)", <<>>, [{return, binary}, global]),
+    trim_and_add_new_line(Rest, <<Line1/binary, "\n", Acc/binary>>).

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -101,6 +101,7 @@
 	     shell,
 	     shell_default,
 	     shell_docs,
+         shell_docs_markdown,
 	     slave,
 	     sofs,
 	     string,

--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -88,6 +88,7 @@ MODULES= \
 	naughty_child \
 	shell_SUITE \
 	shell_docs_SUITE \
+	shell_docs_markdown_SUITE \
 	sigils_SUITE \
 	supervisor_SUITE \
 	supervisor_bridge_SUITE \

--- a/lib/stdlib/test/shell_docs_SUITE.erl
+++ b/lib/stdlib/test/shell_docs_SUITE.erl
@@ -133,26 +133,30 @@ render_smoke(_Config) ->
                             E(shell_docs:render(Mod, D, Config)),
                             E(shell_docs:render_type(Mod, D, Config)),
                             E(shell_docs:render_callback(Mod, D, Config)),
+
                             Exports = try Mod:module_info(exports)
                                       catch _:undef -> []
                                       end, %% nif file not available on this platform
 
+                            DHTML = markdown_to_shelldoc(D),
                             [try
-                                 E(shell_docs:render(Mod, F, A, D, Config))
+                                 E(shell_docs:render(Mod, F, A, DHTML, Config))
                              catch _E:R:ST ->
                                      io:format("Failed to render ~p:~p/~p~n~p:~p~n~p~n",
                                                [Mod,F,A,R,ST,shell_docs:get_doc(Mod,F,A)]),
                                      erlang:raise(error,R,ST)
                              end || {F,A} <- Exports],
+
                             [try
-                                 E(shell_docs:render_type(Mod, T, A, D, Config))
+                                 E(shell_docs:render_type(Mod, T, A, DHTML, Config))
                              catch _E:R:ST ->
                                      io:format("Failed to render type ~p:~p/~p~n~p:~p~n~p~n",
                                                [Mod,T,A,R,ST,shell_docs:get_type_doc(Mod,T,A)]),
                                      erlang:raise(error,R,ST)
                              end || {{type,T,A},_,_,_,_} <- Docs],
+
                             [try
-                                 E(shell_docs:render_callback(Mod, T, A, D, Config))
+                                 E(shell_docs:render_callback(Mod, T, A, DHTML, Config))
                              catch _E:R:ST ->
                                      io:format("Failed to render callback ~p:~p/~p~n~p:~p~n~p~n",
                                                [Mod,T,A,R,ST,shell_docs:get_callback_doc(Mod,T,A)]),
@@ -171,6 +175,38 @@ render_smoke(_Config) ->
                       #{ encoding => latin1 }])
       end),
     ok.
+
+markdown_to_shelldoc(#docs_v1{format = Format}=Docs) ->
+    DefaultFormat = <<"text/markdown">>,
+    DFormat = binary_to_list(DefaultFormat),
+    case Format of
+        _ when Format =:= DefaultFormat orelse Format =:= DFormat ->
+            ModuleDoc = Docs#docs_v1.module_doc,
+            Doc = Docs#docs_v1.docs,
+            Docs#docs_v1{format = ?NATIVE_FORMAT,
+                         module_doc = process_moduledoc(ModuleDoc),
+                         docs = process_doc_attr(Doc)};
+        _  ->
+            Docs
+    end.
+
+-spec process_moduledoc(Doc :: map() | none | hidden) -> map() | none | hidden.
+process_moduledoc(Doc) when Doc =:= none orelse Doc =:= hidden ->
+    Doc;
+process_moduledoc(Doc) when is_map(Doc) ->
+    maps:map(fun (_K, V) -> shell_docs_markdown:parse_md(V) end, Doc).
+
+process_doc_attr(Doc) ->
+    lists:map(fun process_doc/1, Doc).
+
+process_doc(Docs) when is_list(Docs) ->
+    lists:map(fun process_doc/1, Docs);
+process_doc({_At, _A, _S, Doc, _M}=Entry) when Doc =:= none orelse Doc =:= hidden ->
+    Entry;
+process_doc({Attributes, Anno, Signature, Doc, Metadata}) ->
+    Docs = maps:map(fun (_K, V) -> shell_docs_markdown:parse_md(V) end, Doc),
+    {Attributes, Anno, Signature, Docs, Metadata}.
+
 
 render_prop(Config) ->
 %    dbg:tracer(),dbg:p(all,c),dbg:tpl(shell_docs_prop,[]),

--- a/lib/stdlib/test/shell_docs_markdown_SUITE.erl
+++ b/lib/stdlib/test/shell_docs_markdown_SUITE.erl
@@ -1,0 +1,1123 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 1996-2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(shell_docs_markdown_SUITE).
+
+%% callbacks
+-export([all/0, groups/0, init_per_group/2, end_per_group/2]).
+
+%% test format
+-export([convert_erlang_html/1, convert_unknown_format/1]).
+
+%% test non-existing moduledoc
+-export([non_existing_moduledoc/1,hidden_moduledoc/1,existing_moduledoc/1]).
+
+%% test non-existing docs
+-export([non_existing_doc/1, hidden_doc/1, existing_doc/1]).
+
+%% headings
+-export([h1_test/1, h2_test/1, h3_test/1, h4_test/1, h5_test/1, h6_test/1,
+         setext_h1/1, setext_h2/1]).
+
+%% quotes
+-export([single_line_quote_test/1, double_char_for_quote_test/1,
+         ignore_three_spaces_before_quote/1, multiple_line_quote_test/1,
+         paragraph_in_between_test/1, quote_with_anchor_test/1, quote_without_space/1]).
+
+%% paragraph
+-export([paragraph_after_heading_test/1, quote_before_and_after_paragraph_test/1]).
+
+%% inline code
+-export([single_line_code_test/1, multiple_line_code_test/1, paragraph_between_code_test/1]).
+
+%% fence code
+-export([single_line_fence_code_test/1, multiple_line_fence_code_test/1,
+         paragraph_between_fence_code_test/1, fence_code_ignores_link_format_test/1,
+         fence_code_with_spaces/1]).
+
+%% br
+-export([start_with_br_test/1, multiple_br_followed_by_paragraph_test/1,
+         multiple_lines_of_a_paragraph_test/1, ending_br_test/1]).
+
+%% Comments
+-export([begin_comment_test/1, after_paragraph_comment/1, forget_closing_comment/1 ]).
+
+%% Format
+-export([format_heading_test/1, format_paragraph_test/1, format_multiple_inline/1,
+         format_multiple_inline_format_short/1, format_multiple_inline_format_long/1,
+         format_multiple_inline_format_mixed/1, unmatched_format_simple/1,
+         unmatched_format_with_inline/1, unmatched_complex_format_with_inline/1,
+         format_inline_link_with_inline/1, complex_inline_format/1, skip_symbols_in_inline/1,
+         format_header_identifier/1, italic_in_middle_word_test/1, italic_with_colons/1,
+         list_format_with_italics_in_sentence/1, list_format_with_bold_in_sentence/1,
+         new_lines_test/1, format_separator_test/1, list_with_format/1, multi_word_format_test/1,
+         multiline_link/1, multiline_link_not_allowed/1, inline_mfa_link/1,
+         escaped_character/1]).
+
+%% Bullet lists
+-export([singleton_bullet_list/1, singleton_bullet_list_followed_new_paragraph/1, singleton_bullet_list_with_format/1,
+         singleton_bullet_list_followed_inner_paragraph/1, singleton_bullet_list_followed_inner_paragraph2/1,
+         singleton_bullet_list_followed_inner_paragraph3/1, multiline_bullet_indented_list/1, multiline_bullet_indented_list2/1,
+         multiline_bullet_list/1, even_nested_bullet_list/1, odd_nested_bullet_list/1,
+         complex_nested_bullet_list/1, complex_nested_bullet_list2/1, complex_nested_bullet_list3/1,
+         bullet_list_mix_with_number_list/1, inline_code_list/1, bullet_list_with_anchor/1]).
+
+%% Numbered lists
+-export([singleton_numbered_list/1, singleton_numbered_list_followed_new_paragraph/1,
+         singleton_numbered_list_with_format/1, singleton_numbered_list_followed_inner_paragraph/1,
+         singleton_numbered_list_followed_inner_paragraph2/1, multiline_numbered_indented_list/1,
+         multiline_numbered_indented_list2/1, multiline_numbered_list/1, even_nested_numbered_list/1,
+         odd_nested_numbered_list/1]).
+
+-export([table_with_rows/1, table_with_escaped_bars/1, fake_table_test/1]).
+
+-define(ERLANG_HTML, ~"application/erlang+html").
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("kernel/include/eep48.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+
+-define(EXPECTED_FUN(Expected), {{function, foo, 0}, [], [], Expected, #{}}).
+
+all() ->
+    [{group, different_format_generator},
+     {group, module_generator},
+     {group, doc_generator},
+     {group, header_generator},
+     {group, quote_generator},
+     {group, paragraph_generator},
+     {group, code_generator},
+     {group, fence_code_generator},
+     {group, br_generator},
+     {group, comment_generator},
+     {group, format_generator},
+     {group, bullet_list_generator},
+     {group, numbered_list_generator},
+     {group, table_generator}
+    ].
+
+groups() ->
+    [{different_format_generator, [sequence], different_format_conversion_tests()},
+     {module_generator, [sequence], moduledoc_tests()},
+     {doc_generator, [sequence], doc_tests()},
+     {header_generator, [sequence], header_tests()},
+     {quote_generator, [sequence], quote_tests()},
+     {paragraph_generator, [sequence], paragraph_tests()},
+     {code_generator, [sequence], code_tests()},
+     {fence_code_generator, [sequence], fence_code_tests()},
+     {br_generator, [sequence], br_tests()},
+     {comment_generator, [sequence], comment_tests()},
+     {format_generator, [sequence], format_tests()},
+     {bullet_list_generator, [sequence], bullet_list_tests()},
+     {numbered_list_generator, [sequence], numbered_list_tests()},
+     {table_generator, [sequence], table_tests()}
+    ].
+
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, _Config) ->
+    ok.
+
+different_format_conversion_tests() ->
+    [ convert_erlang_html,
+      convert_unknown_format
+    ].
+
+moduledoc_tests() ->
+    [ non_existing_moduledoc,
+      hidden_moduledoc,
+      existing_moduledoc
+    ].
+
+doc_tests() ->
+    [ non_existing_doc,
+      hidden_doc,
+      existing_doc
+    ].
+
+header_tests() ->
+    [ h1_test,
+      h2_test,
+      h3_test,
+      h4_test,
+      h5_test,
+      h6_test,
+      setext_h1,
+      setext_h2
+    ].
+
+quote_tests() ->
+    [ single_line_quote_test,
+      double_char_for_quote_test,
+      ignore_three_spaces_before_quote,
+      multiple_line_quote_test,
+      paragraph_in_between_test,
+      quote_with_anchor_test,
+      quote_without_space
+    ].
+
+paragraph_tests() ->
+    [ paragraph_after_heading_test,
+      quote_before_and_after_paragraph_test
+    ].
+
+code_tests() ->
+    [ single_line_code_test,
+      multiple_line_code_test,
+      paragraph_between_code_test
+    ].
+
+fence_code_tests() ->
+  [single_line_fence_code_test,
+   multiple_line_fence_code_test,
+   paragraph_between_fence_code_test,
+   fence_code_ignores_link_format_test,
+   fence_code_with_spaces
+  ].
+
+br_tests() ->
+    [ start_with_br_test,
+      multiple_br_followed_by_paragraph_test,
+      multiple_lines_of_a_paragraph_test,
+      ending_br_test
+    ].
+
+comment_tests() ->
+    [ begin_comment_test,
+      after_paragraph_comment,
+      forget_closing_comment
+    ].
+
+format_tests() ->
+    [ format_heading_test,
+      format_paragraph_test,
+      format_multiple_inline,
+      format_multiple_inline_format_long,
+      format_multiple_inline_format_short,
+      format_multiple_inline_format_mixed,
+      unmatched_format_simple,
+      unmatched_format_with_inline,
+      unmatched_complex_format_with_inline,
+      format_inline_link_with_inline,
+      complex_inline_format,
+      skip_symbols_in_inline,
+      format_header_identifier,
+      italic_in_middle_word_test,
+      italic_with_colons,
+      list_format_with_italics_in_sentence,
+      list_format_with_bold_in_sentence,
+      new_lines_test,
+      format_separator_test,
+      list_with_format,
+      multi_word_format_test,
+      multiline_link,
+      multiline_link_not_allowed,
+      inline_mfa_link,
+      escaped_character
+    ].
+
+bullet_list_tests() ->
+    [ singleton_bullet_list,
+      singleton_bullet_list_followed_new_paragraph,
+      singleton_bullet_list_with_format,
+      singleton_bullet_list_followed_inner_paragraph,
+      singleton_bullet_list_followed_inner_paragraph2,
+      singleton_bullet_list_followed_inner_paragraph3,
+      multiline_bullet_indented_list,
+      multiline_bullet_indented_list2,
+      multiline_bullet_list,
+      even_nested_bullet_list,
+      odd_nested_bullet_list,
+      complex_nested_bullet_list,
+      complex_nested_bullet_list2,
+      complex_nested_bullet_list3,
+      bullet_list_mix_with_number_list,
+      inline_code_list,
+      bullet_list_with_anchor
+    ].
+
+numbered_list_tests() ->
+    [ singleton_numbered_list,
+      singleton_numbered_list_followed_new_paragraph,
+      singleton_numbered_list_with_format,
+      singleton_numbered_list_followed_inner_paragraph,
+      singleton_numbered_list_followed_inner_paragraph2,
+      multiline_numbered_indented_list,
+      multiline_numbered_indented_list2,
+      multiline_numbered_list,
+      even_nested_numbered_list,
+      odd_nested_numbered_list
+    ].
+
+table_tests() ->
+  [ table_with_rows,
+    table_with_escaped_bars,
+    fake_table_test].
+
+convert_erlang_html(_Conf) ->
+    Doc = #{~"en" => [{p, [], [~"Test"]}]},
+    Functions = [{{function, foo, 0}, [], [], Doc, #{}}],
+
+    Docs = create_eep48(erlang, ?ERLANG_HTML, none, #{}, Functions),
+    ok = shell_docs:validate(Docs),
+    ok.
+
+convert_unknown_format(_Conf) ->
+    Doc = #{~"en" => ~"<text>Here</text>"},
+    Functions = create_fun(Doc),
+
+    Docs = create_eep48(erlang, ~"xml", Doc, #{},Functions),
+    ok = try
+           shell_docs:validate(Docs)
+         catch
+           error:function_clause ->
+             ok
+         end,
+    ok.
+
+non_existing_moduledoc(_Conf) ->
+    Docs = create_eep48(erlang, ~"application/erlang+html", none, #{}, []),
+    _ = compile(Docs),
+    ok.
+
+hidden_moduledoc(_Conf) ->
+    Docs = create_eep48(erlang, ~"application/erlang+html", hidden, #{}, []),
+    _ = compile(Docs),
+    ok.
+
+existing_moduledoc(_Conf) ->
+    Docs = create_eep48_doc(~"# Here"),
+    HtmlDocs = compile(Docs),
+    #{~"en" := HtmlModDoc} = extract_moduledoc(HtmlDocs),
+    H1 = header(1, ~"Here"),
+    [H1] = HtmlModDoc,
+    ok.
+
+non_existing_doc(_Conf) ->
+    Docs = create_eep48(erlang, ~"application/erlang+html", none, #{}, create_fun(none)),
+    ok = shell_docs:validate(Docs),
+    ok.
+
+hidden_doc(_Conf) ->
+    Docs = create_eep48(erlang, ~"application/erlang+html", none, #{}, create_fun(hidden)),
+    ok = shell_docs:validate(Docs),
+    ok.
+
+existing_doc(_Conf) ->
+    Docs = create_eep48_doc(~"Test"),
+    ok = shell_docs:validate(Docs),
+    ok.
+
+h1_test(_Conf) ->
+    Input = ~"# Here",
+    Result = [header(1, ~"Here")],
+    compile_and_compare(Input, Result).
+
+h2_test(_Conf) ->
+    Input = ~"# Here\n## Header 2",
+    Result = [header(1, ~"Here"), header(2,~"Header 2")],
+    compile_and_compare(Input, Result).
+
+h3_test(_Conf) ->
+    Input = ~"# Here\n### Header 3",
+    Result = [header(1, ~"Here"), header(3, ~"Header 3")],
+    compile_and_compare(Input, Result).
+
+h4_test(_Conf) ->
+    Input = ~"### Here\n#### Header 4",
+    Result = [header(3, ~"Here"), header(4, ~"Header 4")],
+    compile_and_compare(Input, Result).
+
+h5_test(_Conf) ->
+    Convert = fun shell_docs_markdown:parse_md/1,
+    Doc = #{~"en" => Convert(~"### Here\n#### Header 4\n##### H5")},
+    DocH5 = #{~"en" => Convert(~"##### H5")},
+    Functions = [{{function, foo, 0}, [], [], Doc, #{}},
+                 {{function, bar, 0}, [], [], DocH5, #{}}],
+    Docs = create_eep48(erlang, ~"application/erlang+html", Doc, #{}, Functions),
+
+    HtmlDocs = compile(Docs),
+    ExpectedH3 = #{~"en" => [ header(3, ~"Here"),
+                              header(4, ~"Header 4"),
+                              header(5, ~"H5")]},
+    ExpectedH5 = #{~"en" => [ header(5, ~"H5") ]},
+    ExpectedH3 = extract_moduledoc(HtmlDocs),
+    [ E1, E2 ] = extract_doc(HtmlDocs),
+    {{function, foo, 0}, [], [], ExpectedH3, #{}} = E1,
+    {{function, bar, 0}, [], [], ExpectedH5, #{}} = E2,
+    ok.
+
+h6_test(_Conf) ->
+    Convert = fun shell_docs_markdown:parse_md/1,
+    Doc = #{~"en" => Convert(~"### Here\n#### Header 4\n##### H5")},
+    DocH6 = #{~"en" => Convert(~"###### H6\n## H2")},
+    Functions = [{{function, foo, 0}, [], [], Doc, #{}},
+                 {{function, bar, 0}, [], [], DocH6, #{}}],
+    Docs = create_eep48(erlang, ~"application/erlang+html", Doc, #{}, Functions),
+
+    HtmlDocs = compile(Docs),
+    ExpectedH3 = #{~"en" => [ header(3, ~"Here"),
+                              header(4, ~"Header 4"),
+                              header(5, ~"H5")]},
+    ExpectedH6 = #{~"en" => [ header(6, ~"H6"),
+                              header(2, ~"H2")]},
+    ExpectedH3 = extract_moduledoc(HtmlDocs),
+    [ E1, E2 ] = extract_doc(HtmlDocs),
+    {{function, foo, 0}, [], [], ExpectedH3, #{}} = E1,
+    {{function, bar, 0}, [], [], ExpectedH6, #{}} = E2,
+    ok.
+
+setext_h1(_Config) ->
+    Input = ~"Here\n===\n\nNew text",
+    Result = [ header(1, ~"Here"),
+               p(~"New text")],
+    compile_and_compare(Input, Result).
+
+setext_h2(_Config) ->
+    Input = ~"Here\n--\n\nNew text",
+    Result = [ header(2, ~"Here"),
+               p(~"New text")],
+    compile_and_compare(Input, Result).
+
+single_line_quote_test(_Conf) ->
+    Input = ~"# Here\n> This is a quote",
+    Result = [ header(1, ~"Here"),
+               blockquote(p(~"This is a quote"))],
+    compile_and_compare(Input, Result).
+
+double_char_for_quote_test(_Conf) ->
+    Input = ~"# Here\n>> This is a quote",
+    Result = [ header(1, ~"Here"),
+               blockquote(p(~"This is a quote"))],
+    compile_and_compare(Input, Result).
+
+ignore_three_spaces_before_quote(_Conf) ->
+    Input = ~"   > # Here",
+    Result = blockquote([header(1, ~"Here")]),
+    compile_and_compare(Input, Result).
+
+multiple_line_quote_test(_Conf) ->
+    Input = ~"> # Here\n> This is a quote",
+    Result = [ blockquote([header(1, ~"Here"),
+                           p(~"This is a quote")])],
+  compile_and_compare(Input, Result).
+
+paragraph_in_between_test(_Conf) ->
+    Input = ~"# Header 1\nThis is text\n> A quote\n> continues\n## Header 2\nBody content",
+    Result = [ header(1, ~"Header 1"),
+               p(~"This is text"),
+               blockquote([p(~"A quote continues")]),
+               header(2, ~"Header 2"),
+               p(~"Body content")],
+    compile_and_compare(Input, Result).
+
+quote_with_anchor_test(_Config) ->
+    Input =
+~"> #### Note{: .info }
+>
+> The [User's Guide](index.html) has examples and a
+> [Getting Started](using_ssh.md) section.",
+    Result = [blockquote([header(4,~"Note"),
+                                     p([~"The User's Guide has examples and a Getting Started section."])])],
+    compile_and_compare(Input, Result).
+
+quote_without_space(_Config) ->
+    Input =
+~"> #### Note{: .info }
+>
+>The [User's Guide](index.html) has examples and a
+> [Getting Started](using_ssh.md) section.",
+    Result = [blockquote([header(4,~"Note"),
+                                     p([~"The User's Guide has examples and a Getting Started section."])])],
+    compile_and_compare(Input, Result).
+
+paragraph_after_heading_test(_Conf) ->
+    Input = ~"# Header 1\nThis is text\n\nBody content",
+    Result = [ header(1, ~"Header 1"),
+               p(~"This is text"),
+               p(~"Body content")],
+    compile_and_compare(Input, Result).
+
+quote_before_and_after_paragraph_test(_Conf) ->
+    Input = ~"> Quote 1\nThis is text\n> Quote 2\nBody content",
+    Result = [ blockquote(p(~"Quote 1")),
+               p(~"This is text"),
+               blockquote(p(~"Quote 2")),
+               p(~"Body content")],
+    compile_and_compare(Input, Result).
+
+single_line_code_test(_Conf) ->
+    Input = ~"# Here\n    This is code",
+    Result = [ header(1, ~"Here"),
+               code(~"This is code\n")],
+    compile_and_compare(Input, Result).
+
+multiple_line_code_test(_Conf) ->
+    Input = ~"    # Here\n    This is code\n        Nested Line",
+    Result = code(~"# Here\nThis is code\n    Nested Line\n"),
+    compile_and_compare(Input, Result).
+
+paragraph_between_code_test(_Conf) ->
+    Input = <<"This is a paragraph\n",
+              "\n",
+              "    # Here\n",
+              "    This is code\n",
+              "        Nested Line\n",
+              "Another paragraph">>,
+    Result = [ p(~"This is a paragraph"),
+               code(~"# Here\nThis is code\n    Nested Line\n"),
+               p(~"Another paragraph")],
+    compile_and_compare(Input, Result).
+
+single_line_fence_code_test(_Conf) ->
+    Input = ~"
+```erlang
+test() -> ok.
+```",
+    Result = [ code(~"test() -> ok.\n")],
+    compile_and_compare(Input, Result).
+
+multiple_line_fence_code_test(_Conf) ->
+    Input = ~"
+```erlang
+test() ->
+  ok.
+```",
+    Result = [ code(~"test() ->\n  ok.\n")],
+    compile_and_compare(Input, Result).
+
+
+paragraph_between_fence_code_test(_Conf) ->
+    Input = ~"This is a test:
+```erlang
+test() ->
+  ok.
+```",
+    Result = [p(~"This is a test:"),
+                         code(~"test() ->\n  ok.\n")],
+    compile_and_compare(Input, Result).
+
+fence_code_ignores_link_format_test(_Conf) ->
+    Input = ~"This is a test:
+```erlang
+[foo](bar)
+```",
+    Result = [p(~"This is a test:"),
+              code(~"[foo](bar)\n")],
+    compile_and_compare(Input, Result).
+
+fence_code_with_spaces(_Config) ->
+    Input =
+~"  ```erlang
+  [foo](bar)
+```",
+    Result = [code(~"  [foo](bar)\n")],
+    compile_and_compare(Input, Result).
+
+start_with_br_test(_Conf) ->
+    Input = ~"\n\nAnother paragraph",
+    Result = [ p(~"Another paragraph")],
+    compile_and_compare(Input, Result).
+
+multiple_br_followed_by_paragraph_test(_Conf) ->
+    Input = ~"\nAnother paragraph\n\nAnother paragraph",
+    Result = [ p(~"Another paragraph"),
+               p(~"Another paragraph")],
+    compile_and_compare(Input, Result).
+
+multiple_lines_of_a_paragraph_test(_Conf) ->
+  Input = ~"""
+Returns a new list `List3`, which is made from the elements of `List1` followed
+by the elements of `List2`.
+""",
+    Result = [p([~"Returns a new list ",
+                 inline_code(~"List3"),
+                 ~", which is made from the elements of ",
+                 inline_code(~"List1"), ~" followed by the elements of ",
+                 inline_code(~"List2"), ~"."])],
+    compile_and_compare(Input, Result).
+
+ending_br_test(_Conf) ->
+    Input = ~"Test\n",
+    Result = [ p(~"Test")],
+    compile_and_compare(Input, Result).
+
+begin_comment_test(_Conf) ->
+    Input = ~"<!-- Ignore -->Test",
+    Result = [ p(~"Test")],
+    compile_and_compare(Input, Result).
+
+after_paragraph_comment(_Conf) ->
+    Input = ~"Test\n<!-- Ignore -->Test",
+    Result = [ p(~"Test"), p(~"Test")],
+    compile_and_compare(Input, Result).
+
+forget_closing_comment(_Conf) ->
+    ok = try
+           create_eep48_doc(~"Test\n<!-- Ignore Test")
+         catch
+           error:missing_close_comment ->
+             ok
+         end,
+    ok.
+
+format_heading_test(_Conf) ->
+    Input = ~"# **H1**\n## _H2_\n### `H3`",
+    Result = [ header(1, em(~"H1")),
+               header(2, it(~"H2")),
+               header(3, inline_code(~"H3"))
+             ],
+    compile_and_compare(Input, Result).
+
+format_paragraph_test(_Conf) ->
+    Input = ~"**H1** *HH* _H2_ __H3__ `code`",
+    Result = [ p([ em(~"H1"),
+                   ~" ",
+                   it(~"HH"),
+                   ~" ",
+                   it(~"H2"),
+                   ~" ",
+                   em(~"H3"),
+                   ~" ",
+                   inline_code(~"code")
+                 ])
+             ],
+    compile_and_compare(Input, Result).
+
+format_multiple_inline(_Conf) ->
+    Input = ~"**H1 *HH***",
+    Result = [ p([ em([~"H1 ", it(~"HH")])]) ],
+    compile_and_compare(Input, Result).
+
+format_multiple_inline_format_long(_Conf) ->
+    Input = ~"**H1 __HH__**",
+    Result = [ p([ em([~"H1 ", em(~"HH")])]) ],
+    compile_and_compare(Input, Result).
+
+format_multiple_inline_format_short(_Conf) ->
+    Input = ~"_H1 *HH*_",
+    Result = [ p([ it([~"H1 ", it(~"HH")])])],
+    compile_and_compare(Input, Result).
+
+format_multiple_inline_format_mixed(_Conf) ->
+    Input = ~"__H1 *HH* _test_ **test2**__ _there_",
+    Result = [ p([ em([~"H1 ", it(~"HH"), ~" ", it(~"test"), ~" ", em(~"test2")]),
+                   ~" ",
+                   it(~"there")])
+             ],
+    compile_and_compare(Input, Result).
+
+unmatched_format_simple(_Conf) ->
+    Input = ~"**Bold*",
+    Result = [ p([~"**Bold*" ])],
+    compile_and_compare(Input, Result).
+
+unmatched_format_with_inline(_Conf) ->
+    Input = ~"**Bold *Italics*",
+    Result = p([~"**Bold ", it(~"Italics") ]),
+    compile_and_compare(Input, Result).
+
+unmatched_complex_format_with_inline(_Conf) ->
+    Input = ~"__H1 *HH* _test_ **test2** _there_ ",
+    Result = [ p([ ~"__H1 ", it(~"HH"), ~" ", it(~"test"), ~" ",
+                   em(~"test2"),
+                   ~" ",
+                   it(~"there"), ~" "])
+             ],
+    compile_and_compare(Input, Result).
+
+format_inline_link_with_inline(_Config) ->
+    Input = ~"[`splitwith/2`](`splitwith/2`) behaves as if",
+    Result = [ p([inline_code(~"splitwith/2"),~" behaves as if"])],
+    compile_and_compare(Input, Result).
+
+complex_inline_format(_Config) ->
+  %% The complexity here comes from the _, where the alg needs to backtrack
+  %% add the _ to an existing buffer, and continue where it left off using  %% any previous opening format characters, in this case **.
+  Input = ~"**`{set_alarm, {AlarmId, AlarmDescr}}`**",
+  Result = p(em(inline_code(~"{set_alarm, {AlarmId, AlarmDescr}}"))),
+  compile_and_compare(Input, Result).
+
+italic_in_middle_word_test(_Config) ->
+  Input = ~"this ssh_daemon_channel is not in italics",
+  Result = p(~"this ssh_daemon_channel is not in italics"),
+  compile_and_compare(Input, Result).
+
+italic_with_colons(_Config) ->
+  Input = ~"_This is ok:_ **test:**",
+  Result = p([it(~"This is ok:"), ~" ", em(~"test:")]),
+  compile_and_compare(Input, Result).
+
+list_format_with_italics_in_sentence(_Config) ->
+  Input = ~"- Mandatory: one or more _Host key(s)_. Default is `/etc/ssh`",
+  Result = ul([li(p([~"Mandatory: one or more ",
+                     it(~"Host key(s)"),
+                     ~". Default is ",
+                     inline_code(~"/etc/ssh")]))]),
+  compile_and_compare(Input, Result).
+
+list_format_with_bold_in_sentence(_Config) ->
+  Input = ~"- Mandatory: one or more __Host key(s)__. Default is `/etc/ssh`",
+  Result = ul([li(p([~"Mandatory: one or more ",
+                     em(~"Host key(s)"),
+                     ~". Default is ",
+                     inline_code(~"/etc/ssh")]))]),
+  compile_and_compare(Input, Result).
+
+format_separator_test(_Config) ->
+  Input = ~"**This is a Test,**, including _a parens)_ and **This is a Test**, end",
+  Result = p([em(~"This is a Test,"),
+              ~", including ",
+              it(~"a parens)"),
+              ~" and ",
+              em(~"This is a Test"),
+              ~", end"
+             ]),
+  compile_and_compare(Input, Result).
+
+multi_word_format_test(_Config) ->
+  Input = ~"**`--help` (or `-h`)** - Print this message and exit.",
+  Result = p([em([inline_code(~"--help"),
+                  ~" (or ",
+                  inline_code(~"-h"),
+                  ~")"]),
+              ~" - Print this message and exit."]),
+  compile_and_compare(Input, Result).
+
+
+multiline_link(_Config) ->
+  Input = ~"this is a [link with\nnew line](erlang.com)",
+  Result = p([~"this is a link with new line"]),
+  compile_and_compare(Input, Result).
+
+%% As per commonmark.js-0.28.1, Github Flavoured Markdown 0.23.10
+multiline_link_not_allowed(_Config) ->
+  Input = ~"this is a [link with new line]\n(erlang.com)",
+  Result = p([~"this is a [link with new line] (erlang.com)"]),
+  compile_and_compare(Input, Result).
+
+inline_mfa_link(_Config) ->
+  Input = ~"See `t:count()`, and `c:arith:plus/1`, `e:math:sum/2`, and `m:extra:here/1`",
+  Result = p([~"See ", inline_code(~"count()"), ~", and ",
+              inline_code(~"arith:plus/1"), ~", ",
+              inline_code(~"math:sum/2"), ~", and ",
+              inline_code(~"extra:here/1")]),
+  compile_and_compare(Input, Result).
+
+escaped_character(_Config) ->
+  Input = ~B"Here \*not bold\* and \`not code\` and \_means_nothing_ `\`test\``",
+  Result = p([~"Here *not bold* and `not code` and _means_nothing_ ",
+              inline_code(~"`test`")]),
+  compile_and_compare(Input, Result).
+
+list_with_format(_Config) ->
+  Input = ~"- **`--help` (or `-h`)** - Print this message and exit.",
+  Result = ul([li(p([em([inline_code(~"--help"),
+                         ~" (or ",
+                         inline_code(~"-h"),
+                         ~")"]),
+                     ~" - Print this message and exit."]))]),
+  compile_and_compare(Input, Result).
+
+new_lines_test(_Config) ->
+  Input = ~"Render in
+the same line",
+  Result = p([~"Render in the same line"]),
+  compile_and_compare(Input, Result).
+
+skip_symbols_in_inline(_Config) ->
+  Input = ~"**`{the_beginning, the_end}`**",
+  Result = p(em(inline_code(~"{the_beginning, the_end}"))),
+  compile_and_compare(Input, Result).
+
+format_header_identifier(_Config) ->
+  Input = ~"## Test {: #id .class} there",
+  Result = header(2, ~"Test  there"),
+  compile_and_compare(Input, Result).
+
+singleton_bullet_list(_Config) ->
+    Input = ~"* One liner",
+    Result = [ul([li(p(~"One liner"))])],
+    compile_and_compare(Input, Result).
+
+singleton_bullet_list_followed_new_paragraph(_Config) ->
+    Input = ~"* One liner\n\nThis is a new paragraph",
+    Result = [ul([li(p(~"One liner"))]), p(~"This is a new paragraph")],
+    compile_and_compare(Input, Result).
+
+singleton_bullet_list_followed_inner_paragraph(_Config) ->
+    Input = ~"* One liner\n  This is a new paragraph",
+    Result = [ul([li([p([~"One liner This is a new paragraph"])])])],
+    compile_and_compare(Input, Result).
+
+singleton_bullet_list_followed_inner_paragraph2(_Config) ->
+    Input = ~"* One liner.\nThis is a new paragraph",
+    Result = [ul([li([p([~"One liner. This is a new paragraph"])])])],
+    compile_and_compare(Input, Result).
+
+singleton_bullet_list_followed_inner_paragraph3(_Config) ->
+    Input = ~"* One liner\n\n  This is a new paragraph\n  continue here\n\n  and this one follows\n\nNew text",
+    Result = [ul([li([p(~"One liner"),
+                      p([~"This is a new paragraph continue here"]),
+                      p(~"and this one follows")])]),
+              p(~"New text")],
+    compile_and_compare(Input, Result).
+
+singleton_bullet_list_with_format(_Config) ->
+    Input = ~"* *One* __liner__",
+    Result = [ul([li(p([it(~"One"), ~" ",  em(~"liner")]))])],
+    compile_and_compare(Input, Result).
+
+multiline_bullet_list(_Config) ->
+    Input = ~"* One liner\n* Second line",
+    Result = [ul([li(p(~"One liner")), li(p(~"Second line"))])],
+    compile_and_compare(Input, Result).
+
+multiline_bullet_indented_list(_Config) ->
+    Input = ~"  * One liner\n  * Second line",
+    Result = [ul([li(p(~"One liner")), li(p(~"Second line"))])],
+    compile_and_compare(Input, Result).
+
+multiline_bullet_indented_list2(_Config) ->
+    Input = ~"  * _One liner_\n  * _Second_ `line`",
+    Result = [ul([li(p(it(~"One liner"))),
+                  li(p([it(~"Second"), ~" ",  inline_code(~"line")]))])],
+    compile_and_compare(Input, Result).
+
+even_nested_bullet_list(_Config) ->
+    Input = ~"* One liner\n  * First nested line\n  * Second nested line",
+    Result = [ul([
+                  li([ p(~"One liner"),
+                       ul([ li(p(~"First nested line")),
+                            li(p(~"Second nested line"))
+                          ])
+                     ])
+                 ])],
+    compile_and_compare(Input, Result).
+
+odd_nested_bullet_list(_Config) ->
+    Input = ~"* One liner\n  * First nested line\n  * Second nested line\n  * Third nested line",
+    Result = [ul([
+                  li([ p(~"One liner"),
+                       ul([ li(p(~"First nested line")),
+                            li(p(~"Second nested line")),
+                            li(p(~"Third nested line"))
+                          ])
+                     ])
+                 ])],
+    compile_and_compare(Input, Result).
+
+complex_nested_bullet_list(_Config) ->
+    Input = ~"* One liner\n  * First nested line\n* Second line",
+    Result = [ul([
+                  li([ p(~"One liner"),
+                       ul([ li(p(~"First nested line")) ])
+                     ]),
+                  li([p(~"Second line")])
+                 ])],
+    compile_and_compare(Input, Result).
+
+complex_nested_bullet_list2(_Config) ->
+    Input = ~"
+* One liner
+  * First nested line
+    * Second level nested line
+  * Second nested line
+    * Another nested line
+* Second one liner",
+    Result = [ul([
+                  li([ p(~"One liner"),
+                       ul([ li([
+                                p(~"First nested line"),
+                                ul([ li([p(~"Second level nested line")])])
+                               ]),
+                            li([
+                                p(~"Second nested line"),
+                                ul([ li([p(~"Another nested line")])])
+                               ])
+                          ])
+                     ]),
+                  li([ p(~"Second one liner")])
+                 ])],
+    compile_and_compare(Input, Result).
+
+complex_nested_bullet_list3(_Config) ->
+    Input = ~"
+- Optional: one or more _User's private key(s)_ in case of `publickey`
+  authorization. The default files are
+  - `id_dsa` and `id_dsa.pub`
+  - `id_rsa` and `id_rsa.pub`
+  - `id_ecdsa` and `id_ecdsa.pub`
+",
+    Result = [ul([ li([p([~"Optional: one or more ",
+                          it(~"User's private key(s)"),
+                          ~" in case of ",
+                          inline_code(~"publickey"),
+                           ~" authorization. The default files are"]),
+                      ul([ li( [p([inline_code(~"id_dsa"),
+                                ~" and ",
+                                inline_code(~"id_dsa.pub")])]),
+                           li( [p([inline_code(~"id_rsa"),
+                                  ~" and ",
+                                  inline_code(~"id_rsa.pub")])]),
+                           li( [p([inline_code(~"id_ecdsa"),
+                                ~" and ",
+                               inline_code(~"id_ecdsa.pub")])])])])])],
+    compile_and_compare(Input, Result).
+
+bullet_list_mix_with_number_list(_Config) ->
+    Input = ~"* Bullet list\n1. Numbered list",
+    Result = [ul([li([ p(~"Bullet list")])]),
+              ol([li([ p(~"Numbered list")])])],
+    compile_and_compare(Input, Result).
+
+inline_code_list(_Config) ->
+    Input = ~"""
+* ```
+  Code block
+    More code
+  ```
+  {: .class }
+""",
+    Result = [ul([li([ code(~"Code block\n  More code\n")])])],
+    compile_and_compare(Input, Result).
+
+%% this example could render the last line within the inner ul.
+%% the end result looks exactly the same, and the fix is non-trivial.
+bullet_list_with_anchor(_Config) ->
+    Input = ~"""
+- **`+c true | false`**{: #+c } - Enables or disables
+  [time correction](time_correction.md#time-correction):
+
+  - **`true`** - Enables time correction.
+  - another example
+
+  - **`false`** - Disables time correction.
+""",
+    Result = [ul([li([ p([em(inline_code(~"+c true | false")),
+                          ~" - Enables or disables time correction:"]),
+                       ul([li([ p([ em(inline_code(~"true")), ~" - Enables time correction."])]),
+                           li([ p(~"another example")])]),
+                       ul([li(p([ em(inline_code(~"false")), ~" - Disables time correction."]))])])])],
+    compile_and_compare(Input, Result).
+
+singleton_numbered_list(_Config) ->
+    Input = ~"1. One liner",
+    Result = [ol([li(p(~"One liner"))])],
+    compile_and_compare(Input, Result).
+
+singleton_numbered_list_followed_new_paragraph(_Config) ->
+    Input = ~"1. One liner\n\nThis is a new paragraph",
+    Result = [ol([li(p(~"One liner"))]), p(~"This is a new paragraph")],
+    compile_and_compare(Input, Result).
+
+singleton_numbered_list_followed_inner_paragraph(_Config) ->
+    Input = ~"1. One liner\n  This is a new paragraph",
+    Result = [ol([li([p([~"One liner This is a new paragraph"])])])],
+    compile_and_compare(Input, Result).
+
+singleton_numbered_list_followed_inner_paragraph2(_Config) ->
+    Input = ~"1. One liner.\nThis is a new paragraph",
+    Result = [ol([li([p([~"One liner. This is a new paragraph"])])])],
+    compile_and_compare(Input, Result).
+
+singleton_numbered_list_with_format(_Config) ->
+    Input = ~"1. *One* __liner__",
+    Result = [ol([li(p([it(~"One"), ~" ",  em(~"liner")]))])],
+    compile_and_compare(Input, Result).
+
+multiline_numbered_indented_list(_Config) ->
+    Input = ~"  1. One liner\n  2. Second line",
+    Result = [ol([li(p(~"One liner")), li(p(~"Second line"))])],
+    compile_and_compare(Input, Result).
+
+multiline_numbered_indented_list2(_Config) ->
+    Input = ~"  1. _One liner_\n  2. _Second_ `line`",
+    Result = [ol([li(p(it(~"One liner"))),
+                  li(p([it(~"Second"), ~" ",  inline_code(~"line")]))])],
+    compile_and_compare(Input, Result).
+
+multiline_numbered_list(_Config) ->
+    Input = ~"1. One liner\n2. Second line",
+    Result = [ol([li(p(~"One liner")), li(p(~"Second line"))])],
+    compile_and_compare(Input, Result).
+
+even_nested_numbered_list(_Config) ->
+    Input = ~"1. One liner\n  1. First nested line\n  2. Second nested line",
+    Result = [ol([
+                  li([ p(~"One liner"),
+                       ol([ li(p(~"First nested line")),
+                            li(p(~"Second nested line"))
+                          ])
+                     ])
+                 ])],
+    compile_and_compare(Input, Result).
+
+odd_nested_numbered_list(_Config) ->
+    Input = ~"1. One liner\n  1. First nested line\n  2. Second nested line\n  3. Third nested line",
+    Result = [ol([
+                  li([ p(~"One liner"),
+                       ol([ li(p(~"First nested line")),
+                            li(p(~"Second nested line")),
+                            li(p(~"Third nested line"))
+                          ])
+                     ])
+                 ])],
+    compile_and_compare(Input, Result).
+
+
+table_with_rows(_Config) ->
+    Input = ~"""
+| H1 | H2 | H3 |
+|:-----|:--:|----|
+|D1   | D2 | D3 |
+""",
+    Result = table([~"| H1 | H2 | H3 |\n",
+                                ~"|:-----|:--:|----|\n",
+                                ~"|D1   | D2 | D3 |\n"]),
+    compile_and_compare(Input, Result).
+
+table_with_escaped_bars(_Config) ->
+    Input = ~"""
+| **JSON** | **Erlang**             |
+|----------|------------------------|
+| Number   | `integer() \| float()` |
+""",
+    Result = table([~"| **JSON** | **Erlang**             |\n",
+                    ~"|----------|------------------------|\n",
+                    ~"| Number   | `integer() \\| float()` |\n"]),
+    compile_and_compare(Input, Result).
+
+fake_table_test(_Config) ->
+    NotTable = ~"""
+| **JSON** | **Erlang**
+""",
+    Result = [p([~"| ", em(~"JSON"), ~" | ", em(~"Erlang")])],
+    compile_and_compare(NotTable, Result).
+
+header(Level, Text) when is_integer(Level) ->
+    HeadingLevel = integer_to_list(Level),
+    HeadingLevelAtom = list_to_existing_atom("h" ++ HeadingLevel),
+    {HeadingLevelAtom, [], [Text]}.
+
+code(X) ->
+    {pre,[],[inline_code(X)]}.
+
+table(Table) when is_list(Table) ->
+    {pre,[], [inline_code(Table)]}.
+
+inline_code(X) when is_list(X) ->
+    {code,[],X};
+inline_code(X) ->
+    {code,[],[X]}.
+
+p(X) when is_list(X) ->
+    {p, [], X};
+p(X) when is_tuple(X); is_binary(X) ->
+    p([X]).
+
+blockquote(X) when is_list(X) ->
+  {blockquote, [], X};
+blockquote(Tuple) when is_tuple(Tuple) ->
+    {blockquote, [], [Tuple]}.
+
+em(X) when is_list(X) ->
+    {em, [], X};
+em(X) when is_binary(X); is_tuple(X) ->
+    em([X]).
+
+it(X) when is_list(X) ->
+    {i, [], X};
+it(X) when is_binary(X); is_tuple(X) ->
+    it([X]).
+
+ul(Items) when is_list(Items) ->
+    {ul, [], Items}.
+
+ol(Items) when is_list(Items) ->
+    {ol, [], Items}.
+
+li(Item) when is_tuple(Item); is_binary(Item) ->
+    li([Item]);
+li(Items) when is_list(Items) ->
+    {li, [], Items}.
+
+-spec create_eep48(Language, Mime, ModuleDoc, Metadata, Docs) -> #docs_v1{} when
+      Language  :: atom(),
+      Mime      :: binary(),
+      ModuleDoc :: #{DocLanguage := DocValue} | none | hidden,
+      Metadata  :: map(),
+      Docs      :: [{{Kind, Name, Arity},
+                     Anno :: erl_anno:anno(),
+                     Signature :: [binary()],
+                     Doc :: #{DocLanguage := DocValue} | none | hidden,
+                     Metadata :: map()
+                    }],
+      Kind      :: function | type | callback,
+      Name      :: atom(),
+      Arity     :: non_neg_integer(),
+      DocLanguage :: binary(),
+      DocValue :: binary() | term().
+create_eep48(Language, Mime, ModuleDoc, Metadata, Docs) ->
+    #docs_v1{anno = [],
+             beam_language = Language,
+             format = Mime,
+             module_doc = ModuleDoc,
+             metadata = maps:merge(#{ otp_doc_vsn => ?CURR_DOC_VERSION }, Metadata),
+             docs = Docs}.
+
+extract_moduledoc(Docs) ->
+    Docs#docs_v1.module_doc.
+
+extract_doc(Docs) ->
+    Docs#docs_v1.docs.
+
+extract_format(Docs) ->
+    Docs#docs_v1.format.
+
+create_eep48_doc(Doc) when is_binary(Doc) ->
+    create_eep48_doc(Doc, ~"application/erlang+html").
+
+create_eep48_doc(Doc, Format) when is_binary(Doc) ->
+    Docs = #{~"en" => shell_docs_markdown:parse_md(Doc)},
+    create_eep48(erlang, Format, Docs, #{}, create_fun(Docs)).
+
+create_fun(Docs) ->
+    [{{function, foo, 0}, [], [], Docs, #{}}].
+
+expected(X) when is_list(X)->
+    #{~"en" => X};
+expected(X) when is_tuple(X) ->
+    expected([X]).
+
+compile(Docs) ->
+    ok = shell_docs:validate(Docs),
+    ?NATIVE_FORMAT = extract_format(Docs),
+    Docs.
+
+compile_and_compare(Input, Result) ->
+    Docs = create_eep48_doc(Input),
+    HtmlDocs = compile(Docs),
+
+    Expected = expected(Result),
+    Expected = extract_moduledoc(HtmlDocs),
+    [ ?EXPECTED_FUN(Expected) ] = extract_doc(HtmlDocs),
+    ok.


### PR DESCRIPTION
conversor from markdown to `erlang+html`. `shell_docs` needs documentation in `erlang+html` format, so that it can render the documentation attributes correctly in the shell. documentation attributes are written in markdown and, with this `erlang+html` conversion tool, `shell_docs` can interpret documentation attributes.
