### PR TITLE
Use code_server path cache in code:where_is_file/1

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -1773,8 +1773,7 @@ locate application resource files.
       Filename :: file:filename(),
       Absname :: file:filename().
 where_is_file(File) when is_list(File) ->
-    Path = get_path(),
-    where_is_file(Path, File).
+    call({where_is_file, File}).
 
 %% To avoid unnecessary work when looking at many modules, this also
 %% accepts pairs of directories and pre-fetched contents in the path

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -1751,7 +1751,8 @@ file containing object code for `Module` and returns the absolute filename.
 which(Module) when is_atom(Module) ->
     case is_loaded(Module) of
 	false ->
-            which(Module, get_path());
+            File = atom_to_list(Module) ++ objfile_extension(),
+            where_is_file(File);
 	{file, File} ->
 	    File
     end.


### PR DESCRIPTION
`application:load/1` slows down as the number of directories in the code path increases because the call to `code:where_is_file/1` for the '.app' file must scan each directory for the app. The code_server maintains a cache of the contents of directories in the path depending on their `code:cache()` setting since https://github.com/erlang/otp/pull/6729 / https://github.com/erlang/otp/pull/8049. Re-using and updating that cache when searching for '.app' files in `application:load/1` can improve its runtime, especially when loading multiple applications.

~Internally to make this possible I've added a `code_server:where_is_file/1` function that the application_controller uses instead of `code:where_is_file/1`. This re-uses the code_server's existing cache helper functions to find the file and update the caches along the way, respecting the `code:cache()` option for each dir.~

For a reasonably large project (RabbitMQ) with a high number of code path dirs (111 at time of writing), loading an application might take upwards of 20ms. With the code_server's cache, loading each application takes at most around half of a millisecond instead. `application:load/1` is used for loading plugins in Rabbit's CLI for example, and this change can save as much as 750ms for a run of `rabbitmqctl --help` (30% of the total run time). It also improves boot time for the broker since `application:load/1` is used by `application:start/2`.