### PR TITLE
ssl: Correct default value

### DIFF
--- a/lib/ssl/src/dtls_record.erl
+++ b/lib/ssl/src/dtls_record.erl
@@ -377,7 +377,7 @@ supported_protocol_versions([_|_] = Vsns) ->
 	false ->
 	    case Vsns -- ['dtlsv1.2'] of
 		[] ->
-		    ?MIN_SUPPORTED_VERSIONS;
+		    ?MIN_DATAGRAM_SUPPORTED_VERSIONS;
 		NewVsns ->
 		    NewVsns
 	    end


### PR DESCRIPTION
I guess this seldom has an practical meaning (this code will only be executed with very using very old cryptolibs), but correct should be correct. 

Closes #8079

