### PR TITLE
ssh: do not start acceptor for client

### DIFF
--- a/lib/ssh/src/ssh_system_sup.erl
+++ b/lib/ssh/src/ssh_system_sup.erl
@@ -51,8 +51,10 @@
 
 start_system(Role, Address0, Options) ->
     case find_system_sup(Role, Address0) of
-        {ok,{SysPid,Address}} ->
+        {ok,{SysPid,Address}} when Role =:= server->
             restart_acceptor(SysPid, Address, Options);
+        {ok,{SysPid,_}}->
+            {ok,SysPid};
         {error,not_found} ->
             supervisor:start_child(sup(Role),
                                    #{id       => {?MODULE,Address0},


### PR DESCRIPTION
- don't start acceptor nor acceptor_sup for ssh client