### PR TITLE
Make alias analysis less conservative with calls

### DIFF
--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -1116,10 +1116,12 @@ aa_call(_Dst, [#b_remote{mod=#b_literal{val=erlang},
     %% The function will never return, so nothing that happens after
     %% this can influence the aliasing status.
     {SS, AAS};
-aa_call(Dst, [_Callee|Args], _Anno, SS, AAS) ->
+aa_call(Dst, [_Callee|Args], _Anno, SS0, AAS) ->
     %% This is either a call to a fun or to an external function,
-    %% assume that all arguments and the result escape.
-    {aa_set_aliased([Dst|Args], SS), AAS}.
+    %% assume that result always escapes and
+    %% all arguments escape, if they survive.
+    SS = aa_alias_surviving_args(Args, Dst, SS0, AAS),
+    {aa_set_aliased([Dst], SS), AAS}.
 
 %% Incorporate aliasing information for the arguments to a call when
 %% analysing the body of a function into the global state.

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -487,7 +487,7 @@ aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, AAS0) ->
                 [#b_literal{val=Hint},_Size,Src|Updates] = Args,
                 RecordType = maps:get(arg_types, Anno0, #{}),
                 ?DP("UPDATE RECORD dst: ~p, src: ~p, type:~p~n",
-                    [Dst,_Src,RecordType]),
+                    [Dst,Src,RecordType]),
                 Values = aa_update_record_get_vars(Updates),
                 ?DP("values: ~p~n", [Values]),
                 Types = aa_map_arg_to_type(Args, RecordType),
@@ -555,7 +555,7 @@ aa_is([I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0, AAS0) ->
             _ ->
                 exit({unknown_instruction, I})
         end,
-    ?DP("Post I: ~p.~p~n", [I, SS]),
+    ?DP("Post I: ~p.~n      ~p~n", [I, SS]),
     aa_is(Is, SS, AAS);
 aa_is([], SS, AAS) ->
     {SS, AAS}.

--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -842,6 +842,9 @@ assert_variable_exists(#b_var{}=V, State) ->
             State
     end.
 
+-endif.
+-ifdef(DEBUG).
+
 dump(State) ->
     io:format("~p~n", [State]).
 

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -770,6 +770,17 @@ transformable33() ->
 transformable33_inner(V) ->
     << <<C>> || <<C:4>> <= V >>.
 
+%% Check that calling an external function with append result doesn't
+%% prevent private_append optimization.
+transformable34() ->
+    transformable34a(<<>>).
+
+transformable34a(Acc) ->
+%ssa% (Arg1) when post_ssa_opt ->
+%ssa% _ = bs_create_bin(private_append, _, Arg1, ...).
+    Value = <<Acc/binary, 1>>,
+    ex:escape(Value).
+
 % Should not be transformed as we can't know the alias status of Acc
 not_transformable1([H|T], Acc) ->
 %ssa% (_, Arg1) when post_ssa_opt ->


### PR DESCRIPTION
Even if we don't know anything about the callee, we can skip marking
arguments as aliased, if they are killed by the call - since we'll
never use them again. This allows the optimisation to apply in
many more cases.

Closes #8106