### PR TITLE
otp: Fix links and lists after markdown convertion

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -26,66 +26,64 @@ Crypto Functions
 
 This module provides a set of cryptographic functions.
 
-- **Hash functions** - \* **SHA1, SHA2** - [Secure Hash Standard \[FIPS PUB
-  180-4]](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)
+- **Hash functions** -
 
-  - **SHA3** - [SHA-3 Standard: Permutation-Based Hash and Extendable-Output
-    Functions \[FIPS PUB
-    202]](https://www.nist.gov/publications/sha-3-standard-permutation-based-hash-and-extendable-output-functions?pub_id=919061)
+  - **SHA1, SHA2** - [Secure Hash Standard \[FIPS PUB180-4\]](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf)
+  - **SHA3** - [SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions \[FIPS PUB 202\]](https://www.nist.gov/publications/sha-3-standard-permutation-based-hash-and-extendable-output-functions?pub_id=919061)
 
   - **BLAKE2** - [BLAKE2 — fast secure hashing](https://blake2.net/)
 
-  - **MD5** - [The MD5 Message Digest Algorithm \[RFC
-    1321]](http://www.ietf.org/rfc/rfc1321.txt)
+  - **MD5** - [The MD5 Message Digest Algorithm \[RFC 1321\]](http://www.ietf.org/rfc/rfc1321.txt)
 
-  - **MD4** - [The MD4 Message Digest Algorithm \[RFC
-    1320]](http://www.ietf.org/rfc/rfc1320.txt)
+  - **MD4** - [The MD4 Message Digest Algorithm \[RFC 1320\]](http://www.ietf.org/rfc/rfc1320.txt)
 
-- **MACs - Message Authentication Codes** - \* **Hmac functions** -
-  [Keyed-Hashing for Message Authentication \[RFC
-  2104]](http://www.ietf.org/rfc/rfc2104.txt)
+- **MACs - Message Authentication Codes** -
 
-  - **Cmac functions** - [The AES-CMAC Algorithm \[RFC
-    4493]](http://www.ietf.org/rfc/rfc4493.txt)
+  - **Hmac functions** - [Keyed-Hashing for Message Authentication \[RFC 2104\]](http://www.ietf.org/rfc/rfc2104.txt)
 
-  - **POLY1305** - [ChaCha20 and Poly1305 for IETF Protocols \[RFC
-    7539]](http://www.ietf.org/rfc/rfc7539.txt)
+  - **Cmac functions** - [The AES-CMAC Algorithm \[RFC 4493\]](http://www.ietf.org/rfc/rfc4493.txt)
 
-- **Symmetric Ciphers** - \* **DES, 3DES and AES** - [Block Cipher Techniques
-  \[NIST]](https://csrc.nist.gov/projects/block-cipher-techniques)
+  - **POLY1305** - [ChaCha20 and Poly1305 for IETF Protocols \[RFC 7539\]](http://www.ietf.org/rfc/rfc7539.txt)
+
+- **Symmetric Ciphers** - 
+
+  - **DES, 3DES and AES** - [Block Cipher Techniques \[NIST\]](https://csrc.nist.gov/projects/block-cipher-techniques)
 
   - **Blowfish** -
     [Fast Software Encryption, Cambridge Security Workshop Proceedings (December 1993), Springer-Verlag, 1994, pp. 191-204.](https://www.schneier.com/academic/archives/1994/09/description_of_a_new.html)
 
-  - **Chacha20** - [ChaCha20 and Poly1305 for IETF Protocols \[RFC
-    7539]](http://www.ietf.org/rfc/rfc7539.txt)
+  - **Chacha20** - [ChaCha20 and Poly1305 for IETF Protocols \[RFC 7539\]](http://www.ietf.org/rfc/rfc7539.txt)
 
   - **Chacha20_poly1305** - [ChaCha20 and Poly1305 for IETF Protocols \[RFC
-    7539]](http://www.ietf.org/rfc/rfc7539.txt)
+    7539\]](http://www.ietf.org/rfc/rfc7539.txt)
 
-- **Modes** - \* **ECB, CBC, CFB, OFB and CTR** - [Recommendation for Block
-  Cipher Modes of Operation: Methods and Techniques \[NIST SP
-  800-38A]](https://csrc.nist.gov/publications/detail/sp/800-38a/final)
+- **Modes**
+
+  - **ECB, CBC, CFB, OFB and CTR** - [Recommendation for Block
+    Cipher Modes of Operation: Methods and Techniques \[NIST SP
+    800-38A\]](https://csrc.nist.gov/publications/detail/sp/800-38a/final)
 
   - **GCM** - [Recommendation for Block Cipher Modes of Operation:
     Galois/Counter Mode (GCM) and GMAC \[NIST SP
-    800-38D]](https://csrc.nist.gov/publications/detail/sp/800-38d/final)
+    800-38D\]](https://csrc.nist.gov/publications/detail/sp/800-38d/final)
 
   - **CCM** - [Recommendation for Block Cipher Modes of Operation: The CCM Mode
     for Authentication and Confidentiality \[NIST SP
-    800-38C]](https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38c.pdf)
+    800-38C\]](https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38c.pdf)
 
-- **Asymmetric Ciphers - Public Key Techniques** - \* **RSA** - [PKCS #1: RSA
-  Cryptography Specifications \[RFC 3447]](http://www.ietf.org/rfc/rfc3447.txt)
+- **Asymmetric Ciphers - Public Key Techniques** -
+
+  - **RSA** - [PKCS #1: RSA
+    Cryptography Specifications \[RFC 3447\]](http://www.ietf.org/rfc/rfc3447.txt)
 
   - **DSS** - [Digital Signature Standard (DSS) \[FIPS
-    186-4]](https://csrc.nist.gov/publications/detail/fips/186/4/final)
+    186-4\]](https://csrc.nist.gov/publications/detail/fips/186/4/final)
 
   - **ECDSA** - [Elliptic Curve Digital Signature Algorithm
-    \[ECDSA]](http://csrc.nist.gov/groups/STM/cavp/documents/dss2/ecdsa2vs.pdf)
+    \[ECDSA\]](http://csrc.nist.gov/groups/STM/cavp/documents/dss2/ecdsa2vs.pdf)
 
   - **SRP** - [The SRP Authentication and Key Exchange System \[RFC
-    2945]](http://www.ietf.org/rfc/rfc2945.txt)
+    2945\]](http://www.ietf.org/rfc/rfc2945.txt)
 
 > #### Note {: .info }
 >
@@ -2473,7 +2471,7 @@ Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 Encrypts the `PlainText` (message digest) using the `PublicKey` and returns the
 `CipherText`. This is a low level signature operation used for instance by older
 versions of the SSL protocol. See also
-[public_key:encrypt_public/\[2,3]](`public_key:encrypt_public/2`)
+[public_key:encrypt_public/2,3](`public_key:encrypt_public/2`)
 """.
 -doc(#{since => <<"OTP R16B01">>}).
 -spec public_encrypt(Algorithm, PlainText, PublicKey, Options) ->
@@ -2494,7 +2492,7 @@ Decrypts the `CipherText`, encrypted with `public_encrypt/4` (or equivalent
 function) using the `PrivateKey`, and returns the plaintext (message digest).
 This is a low level signature verification operation used for instance by older
 versions of the SSL protocol. See also
-[public_key:decrypt_private/\[2,3]](`public_key:decrypt_private/2`)
+[public_key:decrypt_private/2,3](`public_key:decrypt_private/2`)
 """.
 -doc(#{since => <<"OTP R16B01">>}).
 -spec private_decrypt(Algorithm, CipherText, PrivateKey, Options) ->
@@ -2514,7 +2512,7 @@ Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 Encrypts the `PlainText` using the `PrivateKey` and returns the ciphertext. This
 is a low level signature operation used for instance by older versions of the
 SSL protocol. See also
-[public_key:encrypt_private/\[2,3]](`public_key:encrypt_private/2`)
+[public_key:encrypt_private/2,3](`public_key:encrypt_private/2`)
 """.
 -doc(#{since => <<"OTP R16B01">>}).
 -spec private_encrypt(Algorithm, PlainText, PrivateKey, Options) ->
@@ -2535,7 +2533,7 @@ Decrypts the `CipherText`, encrypted with `private_encrypt/4`(or equivalent
 function) using the `PrivateKey`, and returns the plaintext (message digest).
 This is a low level signature verification operation used for instance by older
 versions of the SSL protocol. See also
-[public_key:decrypt_public/\[2,3]](`public_key:decrypt_public/2`)
+[public_key:decrypt_public/2,3](`public_key:decrypt_public/2`)
 """.
 -doc(#{since => <<"OTP R16B01">>}).
 -spec public_decrypt(Algorithm, CipherText, PublicKey, Options) ->

--- a/lib/inets/doc/notes.md
+++ b/lib/inets/doc/notes.md
@@ -1793,7 +1793,7 @@ limitations under the License.
 - Better handling of errorI(s) during update of the session database.
 
   Also added and updated some debugging functions
-  [which_sessions/\[0,1]](`httpc:which_sessions/0`) and
+  [which_sessions/0,1](`httpc:which_sessions/0`) and
   [info/0](`httpc:info/0`).
 
   Own Id: OTP-10093
@@ -1846,7 +1846,7 @@ limitations under the License.
   Own Id: OTP-9960
 
 - \[httpc] Add function for retrieving current options,
-  [get_options/\[1,2]](`httpc:get_options/1`).
+  [get_options/1,2](`httpc:get_options/1`).
 
   Own Id: OTP-9979
 
@@ -2034,7 +2034,7 @@ limitations under the License.
 - \[httpc] Add support for upload body streaming (PUT and POST).
 
   For more info, see the definition of the `Body` argument of the
-  [request/\[4,5]](`httpc:request/4`) function.
+  [request/4,5](`httpc:request/4`) function.
 
   Filipe David Manana
 
@@ -2080,7 +2080,7 @@ limitations under the License.
   `ossl` will work for as long as the ssl application supports it.
 
   See the httpd [socket_type](`m:httpd#props_comm`) communication property or
-  the httpc [request/\[4,5]](`httpc:request/4`) function for more info.
+  the httpc [request/4,5](`httpc:request/4`) function for more info.
 
   Own Id: OTP-9230
 
@@ -2213,7 +2213,7 @@ limitations under the License.
 - \[httpc|httpd] - Now allow the use of the "new" ssl, by using the `essl` tag
   instead.
 
-  See the `http_option` option in the [request/\[4,5]](`httpc:request/4`) or the
+  See the `http_option` option in the [request/4,5](`httpc:request/4`) or the
   [socket-type](`m:httpd#props_comm`) section of the Communication properties
   chapter for more info,
 
@@ -2323,7 +2323,7 @@ limitations under the License.
   making requests.
 
   See the `socket_opts` option in the [request/4](`httpc:request/4`) or
-  [set_options/\[1,2]](`httpc:set_options/1`) for more info,
+  [set_options/1,2](`httpc:set_options/1`) for more info,
 
   Own Id: OTP-8352
 
@@ -2516,7 +2516,7 @@ limitations under the License.
   `connect_timeout` option is used for the initial request, when the client
   connects to the server. Default value is that of the `timeout` option.
 
-  See the [request/\[4,5]](`httpc:request/4`) function for more info.
+  See the [request/4,5](`httpc:request/4`) function for more info.
 
   Own Id: OTP-7298
 
@@ -2586,7 +2586,7 @@ limitations under the License.
   As a side-effect of this, the option `ipv6` has been removed and replaced by
   the `ipfamily` option.
 
-  See [http:set_options/\[1,2]](`httpc:set_options/1`) for more info.
+  See [http:set_options/1,2](`httpc:set_options/1`) for more info.
 
   \*** POTENTIAL INCOMPATIBILITY \***
 

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -280,7 +280,7 @@ HTTP options:
 
   Default value is obtained by calling
   [`httpc:ssl_verify_host_options(true)`. ](`ssl_verify_host_options/1`). See
-  [ssl:connect/\[2,3,4]](`m:ssl`) for available options.
+  [ssl:connect/2,3,4](`m:ssl`) for available options.
 
 - **`autoredirect`** - The client automatically retrieves the information from
   the new URI and returns that as the result, instead of a 30X-result code.
@@ -368,7 +368,7 @@ Options details:
   > options.
 
   By default the socket options set by function
-  [set_options/\[1,2]](`set_options/1`) are used when establishing a connection.
+  [set_options/1,2](`set_options/1`) are used when establishing a connection.
 
 - **`receiver`** - Defines how the client delivers the result of an asynchronous
   request (`sync` has the value `false`).
@@ -873,7 +873,7 @@ Returns the cookie header that would have been sent when making a request to
 is used.
 
 Option `ipv6_host_with_bracket` deals with how to parse IPv6 addresses. For
-details, see argument `Options` of [request/\[4,5]](`request/4`).
+details, see argument `Options` of [request/4,5](`request/4`).
 """.
 -doc(#{since => <<"OTP R13B04">>}).
 -spec cookie_header(Url, ProfileOrOpts) -> HttpHeader | {error, Reason} when
@@ -900,7 +900,7 @@ Returns the cookie header that would have been sent when making a request to
 is used.
 
 Option `ipv6_host_with_bracket` deals with how to parse IPv6 addresses. For
-details, see argument `Options` of [request/\[4,5]](`request/4`).
+details, see argument `Options` of [request/4,5](`request/4`).
 """.
 -doc(#{since => <<"OTP R15B">>}).
 -spec cookie_header(Url, Opts, Profile) -> HttpHeader | {error, Reason} when

--- a/lib/kernel/src/gen_sctp.erl
+++ b/lib/kernel/src/gen_sctp.erl
@@ -72,9 +72,10 @@ Options can be changed when calling [`connect/4,5`](`connect/4`).
 
   [](){: #option-active }
 
-- **`{active, true|false|once|N}`** - \* If `false` (passive mode, the default),
-  the caller must do an explicit [`recv`](`recv/1`) call to retrieve the
-  available data from the socket.
+- **`{active, true|false|once|N}`**
+
+  - If `false` (passive mode, the default), the caller must do an explicit
+    [`recv`](`recv/1`) call to retrieve the available data from the socket.
 
   - If `true|once|N` (active modes) received data or events are sent to the
     owning process. See [`open/0..2`](`open/0`) for the message format.

--- a/lib/mnesia/doc/guides/mnesia_chap4.md
+++ b/lib/mnesia/doc/guides/mnesia_chap4.md
@@ -848,7 +848,7 @@ collect.
 
 > #### Warning {: .warning }
 >
-> There is a severe performance penalty in using `mnesia:select/[1|2|3|4]` after
+> There is a severe performance penalty in using `mnesia:select/1,2,3,4` after
 > any modifying operation is done on that table in the same transaction. That
 > is, avoid using `mnesia:write/1` or `mnesia:delete/1` before `mnesia:select`
 > in the same transaction.
@@ -861,7 +861,7 @@ remedied with indexes (see [Indexing](mnesia_chap5.md#indexing)) if the function
 [mnesia:match_object](`mnesia:match_object/1`) is used.
 
 QLC queries can also be used to search `Mnesia` tables. By using the function
-[mnesia:table/\[1|2]](`mnesia:table/1`) as the generator inside a QLC query, you
+[mnesia:table/1,2](`mnesia:table/1`) as the generator inside a QLC query, you
 let the query operate on a `Mnesia` table. `Mnesia`\-specific options to
 `mnesia:table/2` are `{lock, Lock}`, `{n_objects,Integer}`, and
 `{traverse, SelMethod}`:

--- a/lib/observer/doc/guides/etop_ug.md
+++ b/lib/observer/doc/guides/etop_ug.md
@@ -59,8 +59,10 @@ Pid            Name or Initial Func    Time    Reds  Memory    MsgQ Current Func
 
 The header includes some system information:
 
-- **`Load`** - \* **`cpu`** - `Runtime/Wallclock`, that is, the percentage of
-  time where the node has been active.
+- **`Load`**
+
+  - **`cpu`** - `Runtime/Wallclock`, that is, the percentage of time where the
+    node has been active.
 
   - **`procs`** - The number of processes on the node.
 

--- a/lib/odbc/doc/guides/databases.md
+++ b/lib/odbc/doc/guides/databases.md
@@ -85,7 +85,7 @@ format as they are part of an SQL-query. Example:
 > odbc:sql_query(Ref, "INSERT INTO EMPLOYEE VALUES(1, 'Jane', 'Doe', 'F')").
 > ```
 
-You may also input data using [param_query/\[3,4]](`m:odbc#param_query`) and
+You may also input data using [param_query/3,4](`m:odbc#param_query`) and
 then the input data will have the Erlang type corresponding to the ODBC type of
 the column.[See ODBC to Erlang mapping](databases.md#type)
 
@@ -134,7 +134,7 @@ the Erlang application._
 > #### Note {: .info }
 >
 > To find out which data types will be returned for the columns in a table use
-> the function [describe_table/\[2,3]](`m:odbc#describe_table`)
+> the function [describe_table/2,3](`m:odbc#describe_table`)
 
 ## Batch handling
 

--- a/lib/ssh/doc/guides/introduction.md
+++ b/lib/ssh/doc/guides/introduction.md
@@ -67,7 +67,7 @@ supports user authentication as follows:
   password is encrypted before sent over the network.
 
 Several configuration options for authentication handling are available in
-[ssh:connect/\[3,4]](`ssh:connect/3`) and [ssh:daemon/\[2,3]](`ssh:daemon/2`).
+[ssh:connect/3,4](`ssh:connect/3`) and [ssh:daemon/2,3](`ssh:daemon/2`).
 
 The public key handling can be customized by implementing the following
 behaviours from `ssh`:

--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -1,4 +1,4 @@
-%
+%%
 %% %CopyrightBegin%
 %%
 %% Copyright Ericsson AB 2004-2024. All Rights Reserved.
@@ -333,7 +333,7 @@ As an alternative, an already open TCP socket could be passed to the function in
 with the SSH that should be at the other end.
 
 No channel is started. This is done by calling
-[ssh_connection:session_channel/\[2, 4]](`ssh_connection:session_channel/2`).
+[ssh_connection:session_channel/2,4](`ssh_connection:session_channel/2`).
 
 The `NegotiationTimeout` is in milli-seconds. The default value is `infinity` or
 the value of the [`connect_timeout`](`t:connect_timeout_client_option/0`)

--- a/lib/ssh/src/ssh_client_channel.erl
+++ b/lib/ssh/src/ssh_client_channel.erl
@@ -78,7 +78,7 @@ For more detailed information on time-outs, see Section
     {ok, State :: term()} | {ok, State :: term(), timeout() | hibernate} |
     {stop, Reason :: term()} | ignore.
 -doc """
-Handles messages sent by calling [call/\[2,3]](`call/2`)
+Handles messages sent by calling [call/2,3](`call/2`)
 
 For more detailed information on time-outs,, see Section
 [Callback timeouts](`m:ssh_client_channel#module-callback-timeouts`).

--- a/lib/ssh/src/ssh_client_key_api.erl
+++ b/lib/ssh/src/ssh_client_key_api.erl
@@ -43,7 +43,7 @@ this behavior with help of the standard OpenSSH files, see the
 %%% is called, the term() will be {hi,{there}}
 
 -doc """
-Options provided to [ssh:connect/\[3,4]](`ssh:connect/3`).
+Options provided to [ssh:connect/3,4](`ssh:connect/3`).
 
 The option list given in the [`key_cb`](`t:ssh:key_cb_common_option/0`) option
 is available with the key `key_cb_private`.

--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -184,7 +184,7 @@ Messages that include a `WantReply` expect the channel handling process to call
 
 -doc """
 Data has arrived on the channel. This event is sent as a result of calling
-[ssh_connection:send/\[3,4,5]](`send/3`).
+[ssh_connection:send/3,4,5](`send/3`).
 """.
 -doc(#{title => <<"Data Transfer (RFC 4254, section 5.2)">>}).
 -type data_ch_msg() :: {data,

--- a/lib/ssh/src/ssh_sftp.erl
+++ b/lib/ssh/src/ssh_sftp.erl
@@ -800,7 +800,7 @@ write_file_info(Pid, Name, Info) ->
 
 -doc """
 Writes file information from a `file_info` record to the file specified by
-`Name`. See [file:write_file_info/\[2,3]](`file:write_file_info/2`) for
+`Name`. See [file:write_file_info/2,3](`file:write_file_info/2`) for
 information about the record.
 """.
 -spec write_file_info(ChannelPid, Name, FileInfo, Timeout) -> ok | Error when

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1431,7 +1431,7 @@ For futher description of customize options see
 -doc """
 Specify the hostname to be used in TLS Server Name Indication extension. If not
 specified it will default to the `Host` argument of
-[connect/\[3,4]](`connect/3`) unless it is of type inet:ipaddress().
+[connect/3,4](`connect/3`) unless it is of type inet:ipaddress().
 
 The `HostName` will also be used in the hostname verification of the peer
 certificate using `public_key:pkix_verify_hostname/2`.
@@ -1964,7 +1964,7 @@ transport_accept(ListenSocket) ->
 -doc """
 Accepts an incoming connection request on a listen socket. `ListenSocket` must
 be a socket returned from `listen/2`. The socket returned is to be passed to
-[handshake/\[2,3]](`handshake/2`) to complete handshaking, that is, establishing
+[handshake/2,3](`handshake/2`) to complete handshaking, that is, establishing
 the TLS/DTLS connection.
 
 > #### Warning {: .warning }
@@ -2945,14 +2945,14 @@ and testing purposes.
 
 - **`supported`** - TLS versions supported with current application environment
   and crypto library configuration. Overridden by a version option on
-  [connect/\[2,3,4]](`connect/2`), `listen/2`, and
-  [handshake/\[2,3]](`handshake/2`). For the negotiated TLS version, see
+  [connect/2,3,4](`connect/2`), `listen/2`, and
+  [handshake/2,3](`handshake/2`). For the negotiated TLS version, see
   [connection_information/1 ](`connection_information/1`).
 
 - **`supported_dtls`** - DTLS versions supported with current application
   environment and crypto library configuration. Overridden by a version option
-  on [connect/\[2,3,4]](`connect/2`), `listen/2`, and
-  [handshake/\[2,3]](`handshake/2`). For the negotiated DTLS version, see
+  on [connect/2,3,4](`connect/2`), `listen/2`, and
+  [handshake/2,3](`handshake/2`). For the negotiated DTLS version, see
   [connection_information/1 ](`connection_information/1`).
 
 - **`available`** - All TLS versions supported with the linked crypto library.

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -1227,7 +1227,9 @@ well-defined value for that key.
 Each entry in the resulting list contains the following corresponding
 information about the program forms:
 
-- **`{attributes, Attributes}`** - \* `Attributes = [{atom(), term()}]`
+- **`{attributes, Attributes}`**
+
+  - `Attributes = [{atom(), term()}]`
 
   `Attributes` is a list of pairs representing the names and corresponding
   values of all so-called "wild" attributes (as e.g. "`-compile(...)`")
@@ -1236,13 +1238,16 @@ information about the program forms:
   that each name occurs at most once in the list. The order of listing is not
   defined.
 
-- **`{errors, Errors}`** - \* `Errors = [term()]`
+- **`{errors, Errors}`**
+
+  - `Errors = [term()]`
 
   `Errors` is the list of error descriptors of all `error_marker` nodes that
   occur in `Forms`. The order of listing is not defined.
 
-- **`{exports, Exports}`** - \* `Exports = [FunctionName]`
+- **`{exports, Exports}`**
 
+  - `Exports = [FunctionName]`
   - `FunctionName = atom() | {atom(), integer()} | {ModuleName, FunctionName}`
   - `ModuleName = atom()`
 
@@ -1252,15 +1257,18 @@ information about the program forms:
   guarantee that each name occurs at most once in the list. The order of listing
   is not defined.
 
-- **`{functions, Functions}`** - \* `Functions = [{atom(), integer()}]`
+- **`{functions, Functions}`**
+
+  - `Functions = [{atom(), integer()}]`
 
   `Functions` is a list of the names of the functions that are defined in
   `Forms` (cf. [`analyze_function/1`](`analyze_function/1`)). We do not
   guarantee that each name occurs at most once in the list. The order of listing
   is not defined.
 
-- **`{imports, Imports}`** - \* `Imports = [{Module, Names}]`
+- **`{imports, Imports}`**
 
+  - `Imports = [{Module, Names}]`
   - `Module = atom()`
   - `Names = [FunctionName]`
   - `FunctionName = atom() | {atom(), integer()} | {ModuleName, FunctionName}`
@@ -1273,15 +1281,18 @@ information about the program forms:
   occurs at most once in the lists of function names. The order of listing is
   not defined.
 
-- **`{module, ModuleName}`** - \* `ModuleName = atom()`
+- **`{module, ModuleName}`**
+
+  - `ModuleName = atom()`
 
   `ModuleName` is the name declared by a module attribute in `Forms`. If no
   module name is defined in `Forms`, the result will contain no entry for the
   `module` key. If multiple module name declarations should occur, all but the
   first will be ignored.
 
-- **`{records, Records}`** - \* `Records = [{atom(), Fields}]`
+- **`{records, Records}`**
 
+  - `Records = [{atom(), Fields}]`
   - `Fields = [{atom(), {Default, Type}}]`
   - `Default = none | syntaxTree()`
   - `Type = none | syntaxTree()`
@@ -1295,7 +1306,9 @@ information about the program forms:
   guarantee that each record name occurs at most once in the list. The order of
   listing is not defined.
 
-- **`{warnings, Warnings}`** - \* `Warnings = [term()]`
+- **`{warnings, Warnings}`**
+
+  - `Warnings = [term()]`
 
   `Warnings` is the list of error descriptors of all `warning_marker` nodes that
   occur in `Forms`. The order of listing is not defined.


### PR DESCRIPTION
Bullet lists as the first item in a tag list was incorrectly converted by placing the first item as a header to the tag list.

Also links with [] in the name were properly escaped.