### PR TITLE
Exit process immediately when the max heap size is exceeded

### DIFF
--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -700,6 +700,8 @@ i_bs_append(Fail, ExtraHeap, Live, Unit, Size, Dst) {
     res = erts_bs_append(c_p, reg, live, $Size, $ExtraHeap, $Unit);
     HEAVY_SWAPIN;
     if (is_non_value(res)) {
+        $MAYBE_EXIT_AFTER_GC();
+
         /* c_p->freason is already set (to BADARG or SYSTEM_LIMIT). */
         $FAIL_HEAD_OR_BODY($Fail);
     }
@@ -1057,6 +1059,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         new_binary = erts_bs_append_checked(c_p, reg, live, num_bits, alloc, unit);
         HEAVY_SWAPIN;
         if (is_non_value(new_binary)) {
+            $MAYBE_EXIT_AFTER_GC();
             $BS_FAIL_INFO($Fail, c_p->freason, c_p->fvalue, reg[live]);
         }
         p_start += BSC_NUM_ARGS;

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1461,6 +1461,19 @@ build_writable_bitstring(Process *p,
     *sbp = sb;
 }
 
+/*
+ * This function either returns a term or THE_NON_VALUE.
+ *
+ * If THE_NON_VALUE is returned, it can mean one of two things:
+ *
+ * - The max_heap_size limit for the process was exceeded and the
+ *   process was killed. This situation can be recognized by calling
+ *   the ERTS_PROC_IS_EXITING(P) macro. The caller must immediately
+ *   pass control to the scheduler.
+ *
+ * - A BADARG or SYSTEM_LIMIT exception happened. The caller must
+ *   raise an exception.
+ */
 Eterm
 erts_bs_append(Process* c_p, Eterm* reg, Uint live, Eterm build_size_term,
                Uint extra_words, Uint unit)
@@ -1488,6 +1501,9 @@ erts_bs_append(Process* c_p, Eterm* reg, Uint live, Eterm build_size_term,
                                   extra_words, unit);
 }
 
+/*
+ * See erts_bs_append().
+ */
 Eterm
 erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
                        Uint build_size_in_bits, Uint extra_words,
@@ -1552,6 +1568,9 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
     if (build_size_in_bits == 0) {
         if (HeapWordsLeft(c_p) < extra_words) {
             (void) erts_garbage_collect(c_p, extra_words, reg, live+1);
+            if (ERTS_PROC_IS_EXITING(c_p)) {
+                return THE_NON_VALUE;
+            }
             bin = reg[live];
         }
 	return bin;
@@ -1590,6 +1609,9 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
     heap_need = ERL_SUB_BITS_SIZE + extra_words;
     if (HeapWordsLeft(c_p) < heap_need) {
         (void)erts_garbage_collect(c_p, heap_need, reg, live + 1);
+        if (ERTS_PROC_IS_EXITING(c_p)) {
+            return THE_NON_VALUE;
+        }
     }
 
     sb = (ErlSubBits*)c_p->htop;
@@ -1619,6 +1641,9 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
         heap_need = ERL_REFC_BITS_SIZE + extra_words;
         if (HeapWordsLeft(c_p) < heap_need) {
             (void) erts_garbage_collect(c_p, heap_need, reg, live+1);
+            if (ERTS_PROC_IS_EXITING(c_p)) {
+                return THE_NON_VALUE;
+            }
             bin = reg[live];
         }
 

--- a/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
@@ -40,6 +40,7 @@ my @beam_global_funcs = qw(
     bs_get_tail_shared
     bs_get_utf8_shared
     bs_get_utf8_short_shared
+    bs_init_bits_shared
     bs_size_check_shared
     call_bif_shared
     call_light_bif_shared

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -121,22 +121,7 @@ void BeamModuleAssembler::emit_i_bs_init_heap(const ArgWord &Size,
                                               const ArgWord &Heap,
                                               const ArgWord &Live,
                                               const ArgRegister &Dst) {
-    mov_arg(ARG4, Size);
-    mov_arg(ARG5, Heap);
-    mov_arg(ARG6, Live);
-
-    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
-                       Update::eReductions>(Live.get());
-
-    a.mov(ARG1, c_p);
-    load_x_reg_array(ARG2);
-    load_erl_bits_state(ARG3);
-    runtime_call<6>(beam_jit_bs_init);
-
-    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
-                       Update::eReductions>(Live.get());
-
-    mov_arg(Dst, ARG1);
+    emit_i_bs_init_bits_heap(ArgWord(Size.get() * 8), Heap, Live, Dst);
 }
 
 /* Set the error reason when a size check has failed. */
@@ -168,20 +153,10 @@ void BeamModuleAssembler::emit_i_bs_init_fail_heap(const ArgSource &Size,
     }
 
     if (emit_bs_get_field_size(Size, 1, fail, ARG4) >= 0) {
+        a.lsr(ARG4, ARG4, imm(3));
         mov_arg(ARG5, Heap);
         mov_arg(ARG6, Live);
-
-        emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
-                           Update::eReductions>(Live.get());
-
-        a.mov(ARG1, c_p);
-        load_x_reg_array(ARG2);
-        load_erl_bits_state(ARG3);
-        runtime_call<6>(beam_jit_bs_init);
-
-        emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
-                           Update::eReductions>(Live.get());
-
+        fragment_call(ga->get_bs_init_bits_shared());
         mov_arg(Dst, ARG1);
     }
 
@@ -229,18 +204,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_heap(const ArgWord &NumBits,
     mov_arg(ARG4, NumBits);
     mov_arg(ARG5, Alloc);
     mov_arg(ARG6, Live);
-
-    emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
-                       Update::eReductions>(Live.get());
-
-    a.mov(ARG1, c_p);
-    load_x_reg_array(ARG2);
-    load_erl_bits_state(ARG3);
-    runtime_call<6>(beam_jit_bs_init_bits);
-
-    emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
-                       Update::eReductions>(Live.get());
-
+    fragment_call(ga->get_bs_init_bits_shared());
     mov_arg(Dst, ARG1);
 }
 
@@ -270,18 +234,7 @@ void BeamModuleAssembler::emit_i_bs_init_bits_fail_heap(
     if (emit_bs_get_field_size(NumBits, 1, fail, ARG4) >= 0) {
         mov_arg(ARG5, Alloc);
         mov_arg(ARG6, Live);
-
-        emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
-                           Update::eReductions>(Live.get());
-
-        a.mov(ARG1, c_p);
-        load_x_reg_array(ARG2);
-        load_erl_bits_state(ARG3);
-        runtime_call<6>(beam_jit_bs_init_bits);
-
-        emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
-                           Update::eReductions>(Live.get());
-
+        fragment_call(ga->get_bs_init_bits_shared());
         mov_arg(Dst, ARG1);
     }
 
@@ -680,15 +633,16 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
         int unit = Unit.get();
 
         if (emit_bs_get_field_size(Sz, unit, fail, ARG5) >= 0) {
-            /* This operation can be expensive if a bignum can be
-             * created because there can be a garbage collection. */
+            /* If there cannot possibly be a GC in the code that
+             * follows, we can avoid loading registers that will never
+             * be used. */
             auto max = std::get<1>(getClampedRange(Sz));
-            bool potentially_expensive =
+            bool potential_gc =
                     max >= SMALL_BITS || (max * Unit.get()) >= SMALL_BITS;
 
             mov_arg(ARG3, Ctx);
             mov_imm(ARG4, flags);
-            if (potentially_expensive) {
+            if (potential_gc) {
                 mov_arg(ARG6, Live);
             } else {
 #ifdef DEBUG
@@ -697,7 +651,7 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
 #endif
             }
 
-            if (potentially_expensive) {
+            if (potential_gc) {
                 emit_enter_runtime<Update::eHeapAlloc | Update::eXRegs |
                                    Update::eReductions>(Live.get());
             } else {
@@ -707,7 +661,7 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             }
 
             a.mov(ARG1, c_p);
-            if (potentially_expensive) {
+            if (potential_gc) {
                 load_x_reg_array(ARG2);
             } else {
 #ifdef DEBUG
@@ -717,7 +671,7 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             }
             runtime_call<6>(beam_jit_bs_get_integer);
 
-            if (potentially_expensive) {
+            if (potential_gc) {
                 emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                                    Update::eReductions>(Live.get());
             } else {
@@ -725,6 +679,13 @@ void BeamModuleAssembler::emit_bs_get_integer2(const ArgLabel &Fail,
             }
 
             emit_branch_if_not_value(ARG1, fail);
+            if (potential_gc) {
+                /* Test for max heap size exceeded. */
+                emit_is_not_cons(
+                        resolve_fragment(ga->get_do_schedule(), dispUnknown),
+                        ARG1);
+            }
+
             mov_arg(Dst, ARG1);
         }
     }
@@ -1599,6 +1560,8 @@ void BeamModuleAssembler::emit_i_bs_append(const ArgLabel &Fail,
                                            const ArgSource &Size,
                                            const ArgSource &Bin,
                                            const ArgRegister &Dst) {
+    Label next = a.newLabel();
+
     mov_arg(ARG3, Live);
     mov_arg(ARG4, Size);
     mov_arg(ARG5, ExtraHeap);
@@ -1616,18 +1579,24 @@ void BeamModuleAssembler::emit_i_bs_append(const ArgLabel &Fail,
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(Live.get() + 1);
 
-    if (Fail.get() != 0) {
-        emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
-    } else {
-        Label next = a.newLabel();
+    emit_branch_if_value(ARG1, next);
 
-        emit_branch_if_value(ARG1, next);
+    if (Fail.get() != 0) {
+        /* Test whether the max_heap_size limit has been exceeded. */
+        a.ldr(TMP1.w(), arm::Mem(c_p, offsetof(Process, state.value)));
+        a.tst(TMP1, imm(ERTS_PSFLG_EXITING));
+        a.b_eq(resolve_beam_label(Fail, disp1MB));
+        a.b(resolve_fragment(ga->get_do_schedule(), disp128MB));
+    } else {
+        a.ldr(TMP1.w(), arm::Mem(c_p, offsetof(Process, state.value)));
+        a.tst(TMP1, imm(ERTS_PSFLG_EXITING));
+        a.b_ne(resolve_fragment(ga->get_do_schedule(), disp1MB));
+
         /* The error has been prepared in `erts_bs_append` */
         emit_raise_exception();
-
-        a.bind(next);
     }
 
+    a.bind(next);
     mov_arg(Dst, ARG1);
 }
 
@@ -2193,6 +2162,40 @@ void BeamGlobalAssembler::emit_store_unaligned() {
     a.ret(a64::x30);
 }
 
+/*
+ * In:
+ *   ARG4 = Size of binary in bits.
+ *   ARG5 = Extra words to allocate.
+ *   ARG6 = Number of live X registers.
+ *
+ * Out:
+ *   ARG1 = Allocated binary object.
+ */
+
+void BeamGlobalAssembler::emit_bs_init_bits_shared() {
+    emit_enter_runtime_frame();
+
+    load_erl_bits_state(ARG3);
+    load_x_reg_array(ARG2);
+    a.mov(ARG1, c_p);
+
+    emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
+                       Update::eXRegs>();
+
+    runtime_call<6>(beam_jit_bs_init_bits);
+
+    emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
+                       Update::eXRegs>();
+
+    emit_leave_runtime_frame();
+
+    a.ldr(TMP1.w(), arm::Mem(c_p, offsetof(Process, state.value)));
+    a.tst(TMP1, imm(ERTS_PSFLG_EXITING));
+    a.b_ne(labels[do_schedule]);
+
+    a.ret(a64::x30);
+}
+
 void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                const ArgWord &Alloc,
                                                const ArgWord &Live0,
@@ -2605,6 +2608,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
     /* Allocate the binary. */
     if (segments[0].type == am_append) {
         BscSegment seg = segments[0];
+        Label schedule = resolve_fragment(ga->get_do_schedule(), dispUnknown);
+
         comment("append to binary");
         mov_arg(ARG3, Live);
         if (sizeReg.isValid()) {
@@ -2627,9 +2632,16 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         if (exact_type<BeamTypeId::Bitstring>(seg.src) &&
             std::gcd(seg.unit, getSizeUnit(seg.src)) == seg.unit) {
             /* There is no way the call can fail with a system_limit
-             * exception on a 64-bit architecture. */
+             * exception on a 64-bit architecture. However, it can
+             * fail because the max_heap_size limit has been
+             * exceeded. */
             comment("skipped test for success because units are compatible");
+            emit_branch_if_not_value(ARG1, schedule);
         } else {
+            Label all_good = a.newLabel();
+
+            emit_branch_if_value(ARG1, all_good);
+
             if (Fail.get() == 0) {
                 mov_arg(ARG3, ArgXRegister(Live.get()));
                 mov_imm(ARG4,
@@ -2638,7 +2650,14 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                                         BSC_INFO_FVALUE,
                                                         BSC_VALUE_ARG3));
             }
-            emit_branch_if_not_value(ARG1, resolve_label(error, dispUnknown));
+
+            /* Test whether the max_heap_size limit has been exceeded. */
+            a.ldr(TMP1.w(), arm::Mem(c_p, offsetof(Process, state.value)));
+            a.tst(TMP1, imm(ERTS_PSFLG_EXITING));
+            a.b_eq(resolve_label(error, disp1MB));
+            a.b(resolve_fragment(ga->get_do_schedule(), disp128MB));
+
+            a.bind(all_good);
         }
     } else if (segments[0].type == am_private_append) {
         BscSegment seg = segments[0];
@@ -2736,17 +2755,9 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         }
     } else {
         comment("allocate binary");
-        mov_arg(ARG5, Alloc);
-        mov_arg(ARG6, Live);
-        load_erl_bits_state(ARG3);
-        load_x_reg_array(ARG2);
-        a.mov(ARG1, c_p);
-        emit_enter_runtime<Update::eReductions | Update::eHeapAlloc |
-                           Update::eXRegs>(Live.get());
         if (sizeReg.isValid()) {
             comment("(size in bits)");
             a.mov(ARG4, sizeReg);
-            runtime_call<6>(beam_jit_bs_init_bits);
         } else {
             allocated_size = NBYTES(num_bits);
             if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
@@ -2756,10 +2767,10 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                                  ~((sizeof(Eterm) - 1));
             }
             mov_imm(ARG4, num_bits);
-            runtime_call<6>(beam_jit_bs_init_bits);
         }
-        emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
-                           Update::eXRegs>(Live.get());
+        mov_arg(ARG5, Alloc);
+        mov_arg(ARG6, Live);
+        fragment_call(ga->get_bs_init_bits_shared());
     }
     a.str(ARG1, TMP_MEM1q);
 

--- a/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
@@ -34,6 +34,8 @@ my @beam_global_funcs = qw(
     bs_get_tail_shared
     bs_get_utf8_shared
     bs_get_utf8_short_shared
+    bs_init_bits_shared
+    bs_init_bits_legacy_shared
     call_bif_shared
     call_light_bif_shared
     call_nif_early

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -98,6 +98,7 @@ MODULES= \
 	prim_eval_SUITE \
 	persistent_term_SUITE \
 	process_SUITE \
+	process_max_heap_size_SUITE \
 	pseudoknot_SUITE \
 	receive_SUITE \
 	ref_SUITE \
@@ -152,6 +153,9 @@ NO_OPT= bs_bincomp \
 	guard \
 	map
 
+R24= \
+	process_max_heap_size
+
 R25= \
 	bs_bincomp \
 	bs_construct \
@@ -177,6 +181,9 @@ NO_OPT_ERL_FILES= $(NO_OPT_MODULES:%=%.erl)
 
 NATIVE_MODULES= $(NATIVE:%=%_native_SUITE)
 NATIVE_ERL_FILES= $(NATIVE_MODULES:%=%.erl)
+
+R24_MODULES= $(R24:%=%_r24_SUITE)
+R24_ERL_FILES= $(R24_MODULES:%=%.erl)
 
 R25_MODULES= $(R25:%=%_r25_SUITE)
 R25_ERL_FILES= $(R25_MODULES:%=%.erl)
@@ -217,13 +224,15 @@ ERL_COMPILE_FLAGS := $(filter-out +deterministic,$($(ERL_COMPILE_FLAGS)))
 # ----------------------------------------------------
 
 make_emakefile: $(NO_OPT_ERL_FILES) $(NATIVE_ERL_FILES) \
-  $(KERNEL_ERL_FILES) $(R25_ERL_FILES) $(STRIPPED_TYPES_ERL_FILES)
+  $(KERNEL_ERL_FILES) $(R24_ERL_FILES) $(R25_ERL_FILES) $(STRIPPED_TYPES_ERL_FILES)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) +compressed -o$(EBIN) \
 	$(MODULES) $(KERNEL_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +no_copt +no_postopt +no_ssa_opt +no_bsm_opt \
         $(ERL_COMPILE_FLAGS) -o$(EBIN) $(NO_OPT_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) \
 	-o$(EBIN) $(NATIVE_MODULES) >> $(EMAKEFILE)
+	$(ERL_TOP)/make/make_emakefile +r24 \
+        $(ERL_COMPILE_FLAGS) -o$(EBIN) $(R24_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +r25 \
         $(ERL_COMPILE_FLAGS) -o$(EBIN) $(R25_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +strip_types \
@@ -252,6 +261,9 @@ targets: $(TARGET_FILES)
 %_native_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
+%_r24_SUITE.erl: %_SUITE.erl
+	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
+
 %_r25_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
@@ -272,6 +284,7 @@ release_tests_spec: make_emakefile
 	$(INSTALL_DATA) $(NO_OPT_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(NATIVE_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(KERNEL_ERL_FILES) "$(RELSYSDIR)"
+	$(INSTALL_DATA) $(R24_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(R25_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(STRIPPED_TYPES_ERL_FILES) "$(RELSYSDIR)"
 	chmod -R u+w "$(RELSYSDIR)"

--- a/erts/emulator/test/process_max_heap_size_SUITE.erl
+++ b/erts/emulator/test/process_max_heap_size_SUITE.erl
@@ -1,0 +1,320 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(process_max_heap_size_SUITE).
+
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
+	 init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2,
+         immediate_termination/1]).
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]},
+     {timetrap, {minutes, 10}}].
+
+all() ->
+    [immediate_termination].
+
+groups() ->
+    [].
+
+init_per_suite(Config) ->
+    _ = id(Config),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
+    [{testcase, Func}|Config].
+
+end_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
+    %% Restore max_heap_size to default value.
+    erlang:system_flag(max_heap_size,
+                       #{size => 0,
+                         kill => true,
+                         include_shared_binaries => false,
+                         error_logger => true}),
+    ok.
+
+%% Make sure that when maximum allowed heap size is exceeded, the
+%% process will actually terminate.
+%%
+%% Despite the timetrap and limit of number of iterations, bugs
+%% provoked by the test case can cause the runtime system to hang in
+%% this test case.
+immediate_termination(_Config) ->
+    ct:timetrap({minutes,1}),
+    do_more_spawn_opt_max_heap_size(fun(F) -> F end),
+
+    %% save_calls will cause all calls to BIFs to go through their
+    %% exports entries, which will test a different code path.
+    Wrapper1 = fun(F) ->
+                       fun() ->
+                               process_flag(save_calls, 10),
+                               F()
+                       end
+               end,
+    do_more_spawn_opt_max_heap_size(Wrapper1),
+
+    %% Make sure that the kill signal can't be caught.
+    Wrapper2 = fun(F) ->
+                       fun() ->
+                               process_flag(save_calls, 10),
+                               catch F()
+                       end
+               end,
+    do_more_spawn_opt_max_heap_size(Wrapper2),
+
+    ok.
+
+do_more_spawn_opt_max_heap_size(Wrap) ->
+    Funs = [fun build_and_bif/0,
+            fun build_bin_and_bif/0,
+            fun build_bin_on_heap_known_size/0,
+            fun build_bin_on_heap_unknown_small_size/0,
+            fun build_bin_on_heap_unknown_size/0,
+            fun build_bin_append_known_binary/0,
+            fun build_bin_append_unknown_binary/0,
+            fun build_bin_append_unknown_binary_guard/0,
+            fun build_bin_append_writable_binary_extra/0,
+            fun build_bin_append_unknown_binary_extra/0,
+            fun build_and_recv_timeout/0,
+            fun build_and_recv_msg/0,
+            fun bif_and_recv_timeout/0,
+            fun bif_and_recv_msg/0,
+            fun bs_match_integer_known_size/0,
+            fun bs_match_integer_unknown_size/0
+           ],
+    _ = [begin
+             {name,Name} = erlang:fun_info(F0, name),
+             F = Wrap(F0),
+             {Pid,Ref} = spawn_opt(F, [{max_heap_size,
+                                        #{size => 233, kill => true,
+                                          error_logger => false}},
+                                       monitor]),
+             io:format("~p ~p ~p/0\n", [Pid,F,Name]),
+             receive
+                 {'DOWN',Ref,process,Pid,Reason} ->
+                     killed = Reason
+             end
+         end || F0 <- Funs],
+    ok.
+
+%% This number should be greater than the default heap size.
+-define(MANY_ITERATIONS, 10_000).
+
+build_and_bif() ->
+    build_and_bif(?MANY_ITERATIONS, []).
+
+build_and_bif(0, Acc0) ->
+    Acc0;
+build_and_bif(N, Acc0) ->
+    Acc = [0|Acc0],
+    _ = erlang:crc32(Acc),
+    build_and_bif(N-1, Acc).
+
+build_bin_on_heap_known_size() ->
+    Data = id(1),
+    A = erlang:make_tuple(233 - 3 * 8, a),
+
+    %% Each created binary will be a heap binary.
+    B = <<Data:64/unit:8>>,
+    C = <<Data:64/unit:8>>,
+    D = <<Data:64/unit:8>>,
+    E = <<Data:64/unit:8>>,
+
+    %% This code should never be reached.
+    exit({A,B,C,D,E}).
+
+build_bin_on_heap_unknown_small_size() ->
+    Size = id(64),
+
+    %% Make it known to the JIT that the maximum size is 64 bytes,
+    %% so that the JIT will know that each of binaries below are
+    %% heap binaries.
+    true = is_integer(Size) andalso Size =< 64,
+
+    A = erlang:make_tuple(233 - 3 * 8, a),
+    B = <<0:Size/unit:8>>,
+    C = <<0:Size/unit:8>>,
+    D = <<0:Size/unit:8>>,
+    E = <<0:Size/unit:8>>,
+    exit({A,B,C,D,E}).
+
+build_bin_on_heap_unknown_size() ->
+    Size = id(64),
+    A = erlang:make_tuple(233 - 3 * 8, a),
+
+    %% Each created binary will be a heap binary, but the JIT will
+    %% not know that beforehand.
+    B = <<0:Size/unit:8>>,
+    C = <<0:Size/unit:8>>,
+    D = <<0:Size/unit:8>>,
+    E = <<0:Size/unit:8>>,
+    exit({A,B,C,D,E}).
+
+build_bin_append_known_binary() ->
+    A = erlang:make_tuple(233 - 3 * 8, a),
+    Bin = id(<<>>),
+    true = is_binary(Bin),
+
+    B = <<Bin/binary,"abc">>,
+    C = <<B/binary,"abc">>,
+    D = <<C/binary,"abc">>,
+    E = <<D/binary,"abc">>,
+    exit({A,B,C,D,E}).
+
+build_bin_append_unknown_binary() ->
+    A = erlang:make_tuple(233 - 3 * 8, a),
+    Bin = id(<<>>),
+
+    B = <<Bin/binary,"abc">>,
+    C = <<(id(B))/binary,"abc">>,
+    D = <<(id(C))/binary,"abc">>,
+    E = <<(id(D))/binary,"abc">>,
+    exit({A,B,C,D,E}).
+
+build_bin_append_unknown_binary_guard() ->
+    A = erlang:make_tuple(233 - 3 * 8, a),
+    Bin = id(<<>>),
+
+    if
+        byte_size(<<Bin/binary,"abc">>) =:= 0 ->
+            ok;
+        byte_size(<<Bin/binary,"abc">>) =:= 0 ->
+            ok;
+        byte_size(<<Bin/binary,"abc">>) =:= 0 ->
+            ok;
+        byte_size(<<Bin/binary,"abc">>) =:= 0 ->
+            ok;
+        true ->
+            exit(A)
+    end.
+
+build_bin_append_writable_binary_extra() ->
+    A = erlang:make_tuple(233 - 3 * 8, a),
+    Bin = id(<<>>),
+    Size = id(0),
+
+    B = <<Bin/binary,1:8>>,
+
+    %% Cover handling of special case for append of zero bits. The heap space
+    %% needed for the tuple will cause a GC.
+    C = <<B/binary,0:Size>>,
+    exit({A,B,C,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}).
+
+build_bin_append_unknown_binary_extra() ->
+    A = erlang:make_tuple(233 - 3 * 8, a),
+    Bin = id(<<>>),
+
+    %% Try appending zero bits.
+    B = <<Bin/binary,0:0>>,
+    exit({A,B,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24}).
+
+build_bin_and_bif() ->
+    build_bin_and_bif(?MANY_ITERATIONS, <<>>).
+
+build_bin_and_bif(0, Acc0) ->
+    Acc0;
+build_bin_and_bif(N, Acc0) ->
+    Acc = <<0, Acc0/binary>>,
+    _ = erlang:crc32(Acc),
+    build_bin_and_bif(N-1, Acc).
+
+build_and_recv_timeout() ->
+    build_and_recv_timeout(?MANY_ITERATIONS, []).
+
+build_and_recv_timeout(0, Acc0) ->
+    Acc0;
+build_and_recv_timeout(N, Acc0) ->
+    Acc = [0|Acc0],
+    receive
+    after 1 ->
+            ok
+    end,
+    build_and_recv_timeout(N-1, Acc).
+
+build_and_recv_msg() ->
+    build_and_recv_msg(?MANY_ITERATIONS, []).
+
+build_and_recv_msg(0, Acc0) ->
+    Acc0;
+build_and_recv_msg(N, Acc0) ->
+    Acc = [0|Acc0],
+    receive
+        _ ->
+            ok
+    after 0 ->
+            ok
+    end,
+    build_and_recv_msg(N-1, Acc).
+
+bif_and_recv_timeout() ->
+    Bin = <<0:?MANY_ITERATIONS/unit:8>>,
+    bif_and_recv_timeout(Bin).
+
+bif_and_recv_timeout(Bin) ->
+    List = binary_to_list(Bin),
+    receive
+    after 1 ->
+            ok
+    end,
+    List.
+
+bif_and_recv_msg() ->
+    Bin = <<0:?MANY_ITERATIONS/unit:8>>,
+    bif_and_recv_msg(Bin).
+
+bif_and_recv_msg(Bin) ->
+    List = binary_to_list(Bin),
+    receive
+        _ ->
+            ok
+    after 0 ->
+            ok
+    end,
+    List.
+
+bs_match_integer_known_size() ->
+    Size = 233 * 8,
+    Bin = id(<<255:Size/little-unit:8>>),
+    <<N:Size/big-unit:8>> = Bin,
+    exit(N).
+
+bs_match_integer_unknown_size() ->
+    Size = id(233 * 8),
+    Bin = id(<<255:Size/little-unit:8>>),
+    <<N:Size/big-unit:8>> = Bin,
+    exit(N).
+
+
+%%%
+%%% Common utilities.
+%%%
+
+id(I) ->
+    I.


### PR DESCRIPTION
When exceeding the `max_heap_size` limit in a garbage collection initatied by some bit syntax operations, the process would not always terminate immediately.