### PR TITLE
Update ei_x_encode_long documentation to indicate variable length encoding.

### DIFF
--- a/lib/erl_interface/doc/references/ei.md
+++ b/lib/erl_interface/doc/references/ei.md
@@ -735,6 +735,7 @@ int ei_x_encode_long(ei_x_buff* x, long p);
 
 Encodes a long integer in the binary format. If the code is 64 bits, the
 function `ei_encode_long()` is the same as `ei_encode_longlong()`.
+This is a variable length encoding.
 
 ## ei_encode_longlong()
 


### PR DESCRIPTION
The `ei_x_encode_long` function does not encode the passed value to the fixed length of a long. Updating the documentation to make that more obvious.