### PR TITLE
Fix deterministic build for preloaded beams

### DIFF
--- a/erts/preloaded/src/Makefile
+++ b/erts/preloaded/src/Makefile
@@ -86,7 +86,7 @@ STDLIB_INCLUDE=$(ERL_TOP)/lib/stdlib/include
 ERL_COMPILE_FLAGS += -I$(KERNEL_SRC) -I$(KERNEL_INCLUDE)
 
 ifeq ($(ERL_DETERMINISTIC),yes)
-	ERL_COMPILE_FLAGS += deterministic
+	ERL_COMPILE_FLAGS += +deterministic
 endif
 
 DIA_PLT      = erts-preloaded.plt


### PR DESCRIPTION
Hi,

When building with the flag '--enable-deterministic-build', I got the following errors:

```
| cd erts/preloaded/src && \                                                                                
|   ERL_TOP=/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git PATH=/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/bootstrap/bin:"${PATH}" \
|       make opt ERL_COMPILE_WARNINGS_AS_ERRORS=yes                                                         
| make[1]: Entering directory '/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src'                                                                                                               
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin erl_prim_loader.erl                          
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin init.erl                                     
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin prim_buffer.erl
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin prim_file.erl           
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin prim_inet.erl               
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin socket_registry.erl          
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin prim_socket.erl                                                                                       
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin prim_net.erl       
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin zlib.erl                                                                                              
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin prim_zip.erl   
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin erl_init.erl                                                                                          
| erlc -W  -Werror +debug_info +deterministic -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/src -I/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/lib/kernel/include deterministic -o../..
/ebin erts_code_purger.erl
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/socket_registry.beam] Error 1
| make[1]: *** Waiting for unfinished jobs....
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/prim_socket.beam] Error 1
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/prim_file.beam] Error 1
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/prim_buffer.beam] Error 1
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/prim_inet.beam] Error 1
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/prim_zip.beam] Error 1
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/erts_code_purger.beam] Error 1
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/erl_init.beam] Error 1
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/erl_prim_loader.beam] Error 1
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/prim_net.beam] Error 1
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/init.beam] Error 1
| File has no extension: /build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src/deterministic                                                                                                        
| make[1]: Leaving directory '/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/erts/preloaded/src'                                                                                                                
| make[1]: *** [/build/tmp/work/core2-64-poky-linux/erlang/27.0-rc1/git/make/x86_64-poky-linux-gnu/otp.mk:136: ../../ebin/zlib.beam] Error 1
```

The issue was a missing '+' to 'deterministic'