### PR TITLE
Docs: list 'else' as a reserved word

### DIFF
--- a/system/doc/reference_manual/reference_manual.md
+++ b/system/doc/reference_manual/reference_manual.md
@@ -74,7 +74,7 @@ manual page in ERTS.
 
 The following are reserved words in Erlang:
 
-`after and andalso band begin bnot bor bsl bsr bxor case catch cond div end fun if let maybe not of or orelse receive rem try when xor`
+`after and andalso band begin bnot bor bsl bsr bxor case catch cond div else end fun if let maybe not of or orelse receive rem try when xor`
 
 **Note**: `cond` and `let`, while reserved, are currently not used by the
 language.


### PR DESCRIPTION
Since it's part of `maybe` expressions, its use as an unquoted atom fails to compile on OTP 27.0-rc1 with a default setup.