### PR TITLE
compiler: beam_ssa_ss: Enforce cutoff for list literals

### DIFF
--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -593,6 +593,11 @@ merge_in_arg(#b_var{}=V, Status, Cutoff, State) ->
                        end,
             merge_elements(InEdges, Elements, Cutoff, State)
     end;
+merge_in_arg(#b_literal{}, _, 0, _State) ->
+    %% We have reached the cutoff while traversing a larger construct,
+    %% as we're not looking deeper down into the structure we indicate
+    %% that we have no information.
+    no_info;
 merge_in_arg(#b_literal{val=[Hd|Tl]}, Status, Cutoff, State) ->
     {HdS,TlS,Elements0} = case Status of
                               {unique,#{hd:=HdS0,tl:=TlS0}=All} ->


### PR DESCRIPTION
The alias analysis pass tracks the structure and aliasing status of values given as arguments and returned from functions. The information is kept in the graph provided by the beam_ssa_ss module and is built when the alias analysis processes instructions constructing terms. When a literal is given as an argument to a function, the graph is extended to have the same structure as if the literal was constructed programmatically.

To handle self-recursive functions which, for example builds a list, there is a cutoff which limits the depth to which the graph is constructed. This allows a fixpoint to be reached without implementing a solver for recurrence equations about the structure of the arguments, but also limits the size of the graph.

This patch corrects an omission in the beam_ssa_ss:merge_in_arg/4 function where the cutoff was not enforced for list literals.

Closes #8140