### PR TITLE
crypto: add support for SM4 block cipher algorithm

### DIFF
--- a/lib/crypto/c_src/cipher.c
+++ b/lib/crypto/c_src/cipher.c
@@ -72,6 +72,20 @@ static struct cipher_type_t cipher_types[] =
     {{"blowfish_ecb"},   "BF-ECB", {NULL}, 0, 0, NOT_AEAD},
 #endif
 
+#ifdef HAVE_SM4
+    {{"sm4_cbc"},   "sm4-cbc", {&EVP_sm4_cbc},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_ecb"},   "sm4-ecb", {&EVP_sm4_ecb},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_cfb"},   "sm4-cfb", {&EVP_sm4_cfb},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_ofb"},   "sm4-ofb", {&EVP_sm4_ofb},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_ctr"},   "sm4-ctr", {&EVP_sm4_ctr},   16, NO_FIPS_CIPHER, NOT_AEAD},
+#else
+    {{"sm4_cbc"},   "sm4-cbc", {NULL},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_ecb"},   "sm4-ecb", {NULL},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_cfb"},   "sm4-cfb", {NULL},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_ofb"},   "sm4-ofb", {NULL},   16, NO_FIPS_CIPHER, NOT_AEAD},
+    {{"sm4_ctr"},   "sm4-ctr", {NULL},   16, NO_FIPS_CIPHER, NOT_AEAD},
+#endif
+
     {{"aes_128_cbc"}, "aes-128-cbc", {&EVP_aes_128_cbc}, 16, 0, NOT_AEAD},
     {{"aes_192_cbc"}, "aes-192-cbc", {&EVP_aes_192_cbc}, 24, 0, NOT_AEAD},
     {{"aes_256_cbc"}, "aes-256-cbc", {&EVP_aes_256_cbc}, 32, 0, NOT_AEAD},
@@ -113,6 +127,13 @@ static struct cipher_type_t cipher_types[] =
     {{"chacha20_poly1305"}, "chacha20-poly1305", {&EVP_chacha20_poly1305}, 0, NO_FIPS_CIPHER | AEAD_CIPHER, AEAD_CTRL},
 #else
     {{"chacha20_poly1305"}, "chacha20-poly1305", {NULL}, 0, NO_FIPS_CIPHER | AEAD_CIPHER, {{0,0,0}}},
+#endif
+
+#if defined(HAVE_SM4_GCM)
+    {{"sm4_gcm"}, "sm4-gcm", {NULL}, 16, NO_FIPS_CIPHER | AEAD_CIPHER | GCM_MODE, AEAD_CTRL},
+#endif
+#if defined(HAVE_SM4_CCM)
+    {{"sm4_ccm"}, "sm4-ccm", {NULL}, 16, NO_FIPS_CIPHER | AEAD_CIPHER | CCM_MODE, AEAD_CTRL},
 #endif
 
 #if defined(HAVE_GCM) && defined(HAS_3_0_API)

--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -181,6 +181,18 @@
 # define HAVE_SHA512
 #endif
 
+// SM4
+#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,1)	\
+    && !defined(OPENSSL_NO_SM4)
+# define HAVE_SM4
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(3,1,0)	\
+    && !defined(OPENSSL_NO_SM4)
+# define HAVE_SM4_GCM
+# define HAVE_SM4_CCM
+#endif
+
 // SHA3:
 #if OPENSSL_VERSION_NUMBER >= PACKED_OPENSSL_VERSION_PLAIN(1,1,1)
 // An error in beta releases of 1.1.1 fixed in production release

--- a/lib/crypto/doc/guides/algorithm_details.md
+++ b/lib/crypto/doc/guides/algorithm_details.md
@@ -58,6 +58,7 @@ The ciphers are:
 | `blowfish_ecb`      | 16                          |  8                          |
 | `des_ecb`           |  8                          |  8                          |
 | `rc4`               | 16                          |  1                          |
+| `sm4_ecb`           | 16                          | 16                          |
 
 _Table: Ciphers without IV_
 
@@ -96,6 +97,10 @@ The ciphers are:
 | `des_cfb`           |  8                          |  8                         |  1                          |                                     |
 | `des_ede3_cfb`      | 24                          |  8                         |  1                          |                                     |
 | `rc2_cbc`           | 16                          |  8                         |  8                          |                                     |
+| `sm4_cbc`           | 16                          | 16                         | 16                          | ≥1.1.1                              |
+| `sm4_cfb`           | 16                          | 16                         | 16                          | ≥1.1.1                              |
+| `sm4_ofb`           | 16                          | 16                         | 16                          | ≥1.1.1                              |
+| `sm4_ctr`           | 16                          | 16                         | 16                          | ≥1.1.1                              |
 
 _Table: Ciphers with IV_
 
@@ -117,6 +122,8 @@ The ciphers are:
 | `aes_192_gcm`       | 24                          | ≥1                         | any                         | 1-16 default: 16            | any                         | ≥1.0.1                              |
 | `aes_256_gcm`       | 32                          | ≥1                         | any                         | 1-16 default: 16            | any                         | ≥1.0.1                              |
 | `chacha20_poly1305` | 32                          | 1-16                       | any                         | 16                          | any                         | ≥1.1.0                              |
+| `sm4_gcm`           | 16                          | 12                         | any                         | 16                          | any                         | ≥3.1.0                              |
+| `sm4_ccm`           | 16                          | 12                         | any                         | 16                          | any                         | ≥3.1.0                              |
 
 _Table: AEAD ciphers_
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -57,11 +57,11 @@ This module provides a set of cryptographic functions.
   - **Chacha20_poly1305** - [ChaCha20 and Poly1305 for IETF Protocols \[RFC
     7539\]](http://www.ietf.org/rfc/rfc7539.txt)
 
-- **Modes**
+  - **SM4** - [The SM4 Block Cipher Algorithm](https://www.iso.org/standard/81564.html)
 
-  - **ECB, CBC, CFB, OFB and CTR** - [Recommendation for Block
-    Cipher Modes of Operation: Methods and Techniques \[NIST SP
-    800-38A\]](https://csrc.nist.gov/publications/detail/sp/800-38a/final)
+- **Modes** - \* **ECB, CBC, CFB, OFB and CTR** - [Recommendation for Block
+  Cipher Modes of Operation: Methods and Techniques \[NIST SP
+  800-38A]](https://csrc.nist.gov/publications/detail/sp/800-38a/final)
 
   - **GCM** - [Recommendation for Block Cipher Modes of Operation:
     Galois/Counter Mode (GCM) and GMAC \[NIST SP
@@ -606,6 +606,7 @@ dh_params() = [P, G] | [P, G, PrivateKeyBitLength]
 
                       | blowfish_ecb
                       | des_ecb
+                      | sm4_ecb
                       | rc4 .
 
 -doc(#{title => <<"Ciphers">>}).
@@ -632,6 +633,11 @@ dh_params() = [P, G] | [P, G, PrivateKeyBitLength]
                    | aes_192_ctr
                    | aes_256_ctr
                    | aes_ctr
+
+                   | sm4_cbc
+                   | sm4_ofb
+                   | sm4_cfb
+                   | sm4_ctr
 
                    | blowfish_cbc
                    | blowfish_cfb64
@@ -661,6 +667,9 @@ support all of them.
                      | aes_192_gcm
                      | aes_256_gcm
                      | aes_gcm
+
+                     | sm4_gcm
+                     | sm4_ccm
 
                      | chacha20_poly1305 .
 
@@ -1705,6 +1714,8 @@ aead_tag_len(aes_128_gcm) -> 16;
 aead_tag_len(aes_192_gcm) -> 16;
 aead_tag_len(aes_256_gcm) -> 16;
 aead_tag_len(chacha20_poly1305) -> 16;
+aead_tag_len(sm4_gcm) -> 16;
+aead_tag_len(sm4_ccm) -> 16;
 aead_tag_len(_) ->
     error({badarg, "Not an AEAD cipher"}).
 

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -181,6 +181,13 @@
          mac_check/1,
          rc2_cbc/1,
          rc4/1,
+         sm4_ecb/1,
+         sm4_cbc/1,
+         sm4_ofb/1,
+         sm4_cfb/1,
+         sm4_ctr/1,
+         sm4_gcm/1,
+         sm4_ccm/1,
          ripemd160_incr_digest/0,
          ripemd160_incr_msgs/0,
          rsa_oaep/0,
@@ -265,6 +272,14 @@ groups() ->
                      {group, des_cfb},
                      {group, rc2_cbc},
                      {group, rc4},
+
+                     {group, sm4_ecb},
+                     {group, sm4_cbc},
+                     {group, sm4_ofb},
+                     {group, sm4_cfb},
+                     {group, sm4_ctr},
+                     {group, sm4_gcm},
+                     {group, sm4_ccm},
 
                      {group, des_ede3_cbc},
                      {group, des_ede3_cfb},
@@ -424,6 +439,13 @@ groups() ->
      {blowfish_cfb64,       [], [api_ng, api_ng_one_shot]},
      {blowfish_ofb64,       [], [api_ng, api_ng_one_shot]},
      {rc4,                  [], [api_ng, api_ng_one_shot]},
+     {sm4_ecb,              [], [api_ng, api_ng_one_shot]},
+     {sm4_cbc,              [], [api_ng, api_ng_one_shot]},
+     {sm4_ofb,              [], [api_ng, api_ng_one_shot]},
+     {sm4_cfb,              [], [api_ng, api_ng_one_shot]},
+     {sm4_ctr,              [], [api_ng, api_ng_one_shot]},
+     {sm4_gcm,              [], [aead_ng, aead_bad_tag]},
+     {sm4_ccm,              [], [aead_ng, aead_bad_tag]},
      {chacha20_poly1305,    [], [aead_ng, aead_bad_tag]},
      {chacha20,             [], [api_ng, api_ng_one_shot]},
      {poly1305,             [], [poly1305]},
@@ -3402,6 +3424,75 @@ rc4(_) ->
     [{rc4, <<"apaapa">>, <<"Yo baby yo">>},
      {rc4, <<"apaapa">>, list_to_binary(lists:seq(0, 255))},
      {rc4, <<"apaapa">>, long_msg()}
+    ].
+
+%% Test Data from https://github.com/openssl/openssl/pull/9935
+sm4_ecb(_) ->
+    [{sm4_ecb, hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), <<>>,
+	hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+    hexstr2bin("681EDF34D206965E86B3E94F536E4246")}].
+sm4_cbc(_) ->
+    [{sm4_cbc, hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210"),
+    hexstr2bin("2677F46B09C122CC975533105BD4A22AF6125F7275CE552C3A2BBCF533DE8A3B")}].
+sm4_ofb(_) ->
+    [{sm4_ofb, hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210"),
+    hexstr2bin("693D9A535BAD5BB1786F53D7253A7056F2075D28B5235F58D50027E4177D2BCE")}].
+sm4_cfb(_) ->
+    [{sm4_cfb, hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA98765432100123456789ABCDEFFEDCBA9876543210"),
+    hexstr2bin("693D9A535BAD5BB1786F53D7253A70569ED258A85A0467CC92AAB393DD978995")}].
+sm4_ctr(_) ->
+    [{sm4_ctr, hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("0123456789ABCDEFFEDCBA9876543210"), 
+	hexstr2bin("AAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBCCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDD"
+               "EEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFFEEEEEEEEEEEEEEEEAAAAAAAAAAAAAAAA"),
+    hexstr2bin("C2B4759E78AC3CF43D0852F4E8D5F9FD7256E8A5FCB65A350EE00630912E4449"
+               "2A0B17E1B85B060D0FBA612D8A95831638B361FD5FFACD942F081485A83CA35D")}
+    ].
+
+%% https://datatracker.ietf.org/doc/rfc8998 appendix A.1
+sm4_gcm(_) ->
+    [
+     {sm4_gcm,
+      hexstr2bin("0123456789ABCDEFFEDCBA9876543210"),
+      hexstr2bin("AAAAAAAAAAAAAAAABBBBBBBBBBBBBBBB"                      %% PlainText
+      "CCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDD"
+      "EEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFF"
+      "EEEEEEEEEEEEEEEEAAAAAAAAAAAAAAAA"),
+      hexstr2bin("00001234567800000000ABCD"),                            %% Nonce
+      hexstr2bin("FEEDFACEDEADBEEFFEEDFACEDEADBEEFABADDAD2"),            %% AAD
+      hexstr2bin("17F399F08C67D5EE19D0DC9969C4BB7D"                      %% CipherText
+      "5FD46FD3756489069157B282BB200735"
+      "D82710CA5C22F0CCFA7CBF93D496AC15"
+      "A56834CBCF98C397B4024A2691233B8D"),
+      hexstr2bin("83DE3541E4C2B58177E065A9BF7B62EC"),                    %% CipherTag
+      no_info
+      }
+    ].
+
+%% https://datatracker.ietf.org/doc/rfc8998 appendix A.2
+sm4_ccm(_) ->
+    [
+     {sm4_ccm,
+      hexstr2bin("0123456789ABCDEFFEDCBA9876543210"),
+      hexstr2bin("AAAAAAAAAAAAAAAABBBBBBBBBBBBBBBB"                      %% PlainText
+      "CCCCCCCCCCCCCCCCDDDDDDDDDDDDDDDD"
+      "EEEEEEEEEEEEEEEEFFFFFFFFFFFFFFFF"
+      "EEEEEEEEEEEEEEEEAAAAAAAAAAAAAAAA"),
+      hexstr2bin("00001234567800000000ABCD"),                            %% Nonce
+      hexstr2bin("FEEDFACEDEADBEEFFEEDFACEDEADBEEFABADDAD2"),            %% AAD
+      hexstr2bin("48AF93501FA62ADBCD414CCE6034D895"                      %% CipherText
+      "DDA1BF8F132F042098661572E7483094"
+      "FD12E518CE062C98ACEE28D95DF4416B"
+      "ED31A2F04476C18BB40C84A74B97DC5B"),
+      hexstr2bin("16842D4FA186F56AB33256971FA110F4"),                    %% CipherTag
+      no_info
+      }
     ].
 
 aes_128_ctr(_) ->


### PR DESCRIPTION
this PR add SM4 implementation according to GB/T 32907-2016. 
ISO accept SM4 in 2021, [Part 3: Block ciphers Amendment 1: SM4](https://www.iso.org/standard/81564.html).
openssl add SM4 support in version 1.1.1.