### PR TITLE
fix typo: crypto_aead should be crypto_one_time_aead

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -1658,7 +1658,7 @@ Do a complete encrypt or decrypt with an AEAD cipher of the full text.
 
 For encryption, set the `EncryptFlag` to `true` and set the `TagOrTagLength` to
 the wanted size (in bytes) of the tag, that is, the tag length. If the default
-length is wanted, the `crypto_aead/6` form may be used.
+length is wanted, the `crypto_one_time_aead/6` form may be used.
 
 For decryption, set the `EncryptFlag` to `false` and put the tag to be checked
 in the argument `TagOrTagLength`.


### PR DESCRIPTION
`crypto_aead/6 ` might be `crypto_one_time_aead/6` in `crypto_one_time_aead/7` doc string.
there is no `crypto_aead/6` func in crypto app.