### PR TITLE
Correct coverage for functions on the same line

### DIFF
--- a/erts/emulator/beam/beam_code.h
+++ b/erts/emulator/beam/beam_code.h
@@ -96,6 +96,7 @@ typedef struct beam_code_header {
     Uint coverage_mode;
     void *coverage;
     byte *line_coverage_valid;
+    Uint32 *loc_index_to_cover_id;
     Uint line_coverage_len;
 
 #endif

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -95,7 +95,7 @@ move S X0=x==0 | line Loc => line Loc | move S X0
 line n => _
 line I
 
-executable_line Line => _
+executable_line Id Line => _
 
 # For the JIT, the init_yregs/1 instruction allows generation of better code.
 # For the BEAM interpreter, though, it will probably be more efficient to

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -451,7 +451,8 @@ void BeamModuleAssembler::emit_func_line(const ArgWord &Loc) {
 void BeamModuleAssembler::emit_empty_func_line() {
 }
 
-void BeamModuleAssembler::emit_executable_line(const ArgWord &Loc) {
+void BeamModuleAssembler::emit_executable_line(const ArgWord &Loc,
+                                               const ArgWord &Index) {
 }
 
 /*

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -86,7 +86,7 @@ func_line I
 line n => _
 line I
 
-executable_line I
+executable_line I I
 
 allocate t t
 allocate_heap t I t

--- a/erts/emulator/beam/jit/load.h
+++ b/erts/emulator/beam/jit/load.h
@@ -87,6 +87,8 @@ struct LoaderState_ {
      */
     void *coverage;
     byte *line_coverage_valid;
+    unsigned int current_index;
+    unsigned int *loc_index_to_cover_id;
 
     /* Translates lambda indexes to the literal holding their FunRef.
      *

--- a/erts/emulator/beam/jit/x86/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_module.cpp
@@ -383,7 +383,8 @@ void BeamModuleAssembler::emit_func_line(const ArgWord &Loc) {
 void BeamModuleAssembler::emit_empty_func_line() {
 }
 
-void BeamModuleAssembler::emit_executable_line(const ArgWord &Loc) {
+void BeamModuleAssembler::emit_executable_line(const ArgWord &Loc,
+                                               const ArgWord &Index) {
 }
 
 /*

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -86,7 +86,7 @@ func_line I
 line n => _
 line I
 
-executable_line I
+executable_line I I
 
 allocate t t
 allocate_heap t I t

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -365,9 +365,9 @@ make_op({'%',_}, Dict) ->
 make_op({line=Op,Location}, Dict0) ->
     {Index,Dict} = beam_dict:line(Location, Dict0, Op),
     encode_op(line, [Index], Dict);
-make_op({executable_line=Op,Location}, Dict0) ->
-    {Index,Dict} = beam_dict:line(Location, Dict0, Op),
-    encode_op(executable_line, [Index], Dict);
+make_op({executable_line=Op,Location,Index}, Dict0) ->
+    {LocationIndex,Dict} = beam_dict:line(Location, Dict0, Op),
+    encode_op(executable_line, [LocationIndex,Index], Dict);
 make_op({bif, Bif, {f,_}, [], Dest}, Dict) ->
     %% BIFs without arguments cannot fail.
     encode_op(bif0, [{extfunc, erlang, Bif, 0}, Dest], Dict);

--- a/lib/compiler/src/beam_block.erl
+++ b/lib/compiler/src/beam_block.erl
@@ -171,7 +171,7 @@ collect({put_map,{f,0},Op,S,D,R,{list,Puts}}) ->
     {set,[D],[S|Puts],{alloc,R,{put_map,Op,{f,0}}}};
 collect({fmove,S,D})         -> {set,[D],[S],fmove};
 collect({fconv,S,D})         -> {set,[D],[S],fconv};
-collect({executable_line,Line}) -> {set,[],[],{executable_line,Line}};
+collect({executable_line,_,_}=Line) -> {set,[],[],Line};
 collect({swap,D1,D2})        ->
     Regs = [D1,D2],
     {set,Regs,Regs,swap};

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1308,8 +1308,8 @@ resolve_inst({bs_match,[{Fail,Ctx,{z,1},{u,_},Args}]},_,_,_) ->
 %% OTP 27.
 %%
 
-resolve_inst({executable_line,[Index]},_,_,_) ->
-    {line,resolve_arg(Index)};
+resolve_inst({executable_line,[Location,Index]},_,_,_) ->
+    {executable_line,resolve_arg(Location),resolve_arg(Index)};
 
 %%
 %% Catches instructions that are not yet handled.

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -64,7 +64,7 @@ norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
     {put_map,F,Op,S,D,R,{list,Puts}};
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],{line,_}=Line}) -> Line;
-norm({set,[],[],{executable_line,_}=Line}) -> Line;
+norm({set,[],[],{executable_line,_,_}=Line}) -> Line;
 norm({set,[D1,D2],[D1,D2],swap})   -> {swap,D1,D2}.
 
 norm_allocate({_Zero,nostack,Nh,[]}, Regs) ->

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -1819,9 +1819,9 @@ cg_instr(bs_get_tail, [Src], Dst, Set) ->
 cg_instr(bs_get_position, [Ctx], Dst, Set) ->
     Live = get_live(Set),
     [{bs_get_position,Ctx,Dst,Live}];
-cg_instr(executable_line, [], _Dst, #cg_set{anno=Anno}) ->
+cg_instr(executable_line, [{integer,Index}], _Dst, #cg_set{anno=Anno}) ->
     {line,Location} = line(Anno),
-    [{executable_line,Location}];
+    [{executable_line,Location,Index}];
 cg_instr(put_map, [{atom,assoc},SrcMap|Ss], Dst, Set) ->
     Live = get_live(Set),
     [{put_map_assoc,{f,0},SrcMap,Dst,Live,{list,Ss}}];

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -373,7 +373,7 @@ vi({'%',_}, Vst) ->
     Vst;
 vi({line,_}, Vst) ->
     Vst;
-vi({executable_line,_}, Vst) ->
+vi({executable_line,_,_}, Vst) ->
     Vst;
 vi(nif_start, Vst) ->
     Vst;

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -692,6 +692,6 @@ BEAM_FORMAT_NUMBER=0
 
 # OTP 27
 
-## @spec executable_line Location
+## @spec executable_line Location Index
 ## @doc  Provide location for an executable line.
-183: executable_line/1
+183: executable_line/2

--- a/lib/compiler/src/sys_coverage.erl
+++ b/lib/compiler/src/sys_coverage.erl
@@ -35,8 +35,15 @@
         {'ok',[form()]}.
 
 module(Forms0, _Opts) when is_list(Forms0) ->
-    IndexFun = fun(_, _, _, _, _) -> 0 end,
-    transform(Forms0, IndexFun).
+    put(executable_line_index, 1),
+    GetIndex = fun(_, _, _, _, _) ->
+                       Index = get(executable_line_index),
+                       put(executable_line_index, Index + 1),
+                       Index
+               end,
+    Forms = transform(Forms0, GetIndex),
+    erase(executable_line_index),
+    Forms.
 
 %% Undocumented helper function for the `cover` module.
 -spec cover_transform([form()], index_fun()) ->

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -977,10 +977,10 @@ expr({op,L,Op,L0,R0}, St0) ->
     {#icall{anno=#a{anno=LineAnno},		%Must have an #a{}
 	    module=#c_literal{anno=LineAnno,val=erlang},
 	    name=#c_literal{anno=LineAnno,val=Op},args=As},Aps,St1};
-expr({executable_line,L,_}, St0) ->
-    {#iprimop{anno=#a{anno=lineno_anno(L, St0)},
+expr({executable_line,Loc,Index}, St0) ->
+    {#iprimop{anno=#a{anno=lineno_anno(Loc, St0)},
               name=#c_literal{val=executable_line},
-              args=[]},[],St0};
+              args=[#c_literal{val=Index}]},[],St0};
 expr({ssa_check_when,L,WantedResult,Args,Tag,Clauses}, St) ->
     {#c_opaque{anno=full_anno(L, St),val={ssa_check_when,WantedResult,Tag,Args,Clauses}}, [], St}.
 

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -2010,6 +2010,8 @@ coverage mode:
 - **`line_counters`** - For each executable line in the module, an integer
   giving the number of times that line was executed is returned.
 
+Level `cover_id_line` is used by the `m:cover` tool.
+
 Failures:
 
 - **`badarg`** - If `Level` is not `function` or `line`.
@@ -2028,13 +2030,14 @@ Failures:
 """.
 -doc(#{since => <<"OTP @OTP-18856@">>}).
 -spec get_coverage(Level, module()) -> Result when
-      Level :: 'function' | 'line',
+      Level :: 'function' | 'line' | 'cover_id_line',
       Result :: [{Entity, CoverageInfo}],
-      Entity :: {Function, Arity} | Line,
+      Entity :: {Function, Arity} | Line | CoverId,
       CoverageInfo :: Covered | Counter,
       Function :: atom(),
       Arity :: arity(),
       Line :: non_neg_integer(),
+      CoverId :: pos_integer(),
       Covered :: boolean(),
       Counter :: non_neg_integer().
 get_coverage(_Level, _Module) ->

--- a/lib/kernel/test/code_coverage_SUITE.erl
+++ b/lib/kernel/test/code_coverage_SUITE.erl
@@ -113,6 +113,15 @@ do_get_coverage(PrivDir) ->
                [{5,0},{8,0},{10,0},{13,1},{16,1},{18,5}]},
     do_get_coverage(M, Beam, Run2, Result2),
 
+    %% Test cover_id_line used by cover.
+    _ = code:set_coverage_mode(line_counters),
+    {module,M} = code:load_binary(M, "", Beam),
+    line_counters = code:set_coverage_mode(none),
+    _ = M:fib(5),
+    [{1,0},{2,0},{3,0},{4,1},{5,1},{6,5}] =
+        code:get_coverage(cover_id_line, M),
+    unload(M),
+
     %% Compile without line_coverage.
     {ok,M,BeamFun} = compile:file(ErlFile, [report,binary]),
     do_get_function_coverage(M, BeamFun, Run1, Result1),


### PR DESCRIPTION
This pull request fixes the bug reported in #8159.

It also eliminates a weird behavior when there are multiple functions on the same line. Consider this module:

    -module(foo).
    -export([bar/0, baz/0]).

    bar() -> ok. baz() -> not_ok.

In Erlang/OTP 26, analysing on the line level would return two entries for line 4:

    1> cover:compile_module(foo).
    {ok,foo}
    2> foo:bar().
    ok
    3> cover:analyse(foo, coverage, line).
    {ok,[{{foo,4},{1,0}},{{foo,4},{0,1}}]}
    4> cover:analyse(foo, calls, line).
    {ok,[{{foo,4},1},{{foo,4},0}]}

This has been changed to coalesce all information about each line to a single entry in the resulting list:

    1> cover:compile_module(foo).
    {ok,foo}
    2> foo:bar().
    ok
    3> cover:analyse(foo, coverage, line).
    {ok,[{{foo,4},{1,0}}]}
    4> cover:analyse(foo, calls, line).
    {ok,[{{foo,4},1}]}

Closes #8159