### PR TITLE
compiler: Do not emit doc chunk if no -doc features are used

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -2392,10 +2392,14 @@ save_abstract_code(Code, St) ->
 beam_docs(Code, #compile{dir = Dir, options = Options,
                          extra_chunks = ExtraChunks }=St) ->
     SourceName = deterministic_filename(St),
-    {ok, Docs, Ws} = beam_doc:main(Dir, SourceName, Code, Options),
-    MetaDocs = [{?META_DOC_CHUNK, term_to_binary(Docs)} | ExtraChunks],
-    {ok, Code, St#compile{extra_chunks = MetaDocs,
-                          warnings = St#compile.warnings ++ Ws}}.
+    case beam_doc:main(Dir, SourceName, Code, Options) of
+        {ok, Docs, Ws} ->
+            MetaDocs = [{?META_DOC_CHUNK, term_to_binary(Docs)} | ExtraChunks],
+            {ok, Code, St#compile{extra_chunks = MetaDocs,
+                                  warnings = St#compile.warnings ++ Ws}};
+        {error, no_docs} ->
+            {ok, Code, St}
+    end.
 
 %% Strips documentation attributes from the code
 remove_doc_attributes(Code, St) ->

--- a/lib/compiler/test/beam_doc_SUITE.erl
+++ b/lib/compiler/test/beam_doc_SUITE.erl
@@ -6,7 +6,8 @@
          types_and_opaques/1, callback/1, hide_moduledoc2/1,
          private_types/1, export_all/1, equiv/1, spec/1, deprecated/1, warn_missing_doc/1,
          doc_with_file/1, doc_with_file_error/1, all_string_formats/1,
-         docs_from_ast/1, spec_switch_order/1, user_defined_type/1, skip_doc/1]).
+         docs_from_ast/1, spec_switch_order/1, user_defined_type/1, skip_doc/1,
+         no_doc_attributes/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("kernel/include/eep48.hrl").
@@ -49,7 +50,8 @@ documentation_generation_tests() ->
      spec_switch_order,
      docs_from_ast,
      user_defined_type,
-     skip_doc
+     skip_doc,
+     no_doc_attributes
     ].
 
 singleton_moduledoc(Conf) ->
@@ -367,7 +369,7 @@ equiv(Conf) ->
 spec(Conf) ->
     ModuleName = ?get_name(),
     {ok, ModName} = default_compile_file(Conf, ModuleName),
-    {ok, {docs_v1, _,_, _, none, _,
+    {ok, {docs_v1, _,_, _, #{ ~"en" := ~"" }, _,
           [{{type,no,0},_,[<<"no()">>],none,#{exported := false}},
            {{type,yes,0},_,[<<"yes()">>],none,#{exported := false}},
            {{callback,me,1},_,[<<"me/1">>],none,#{}},
@@ -378,7 +380,7 @@ spec(Conf) ->
 user_defined_type(Conf) ->
     ModuleName = ?get_name(),
     {ok, ModName} = default_compile_file(Conf, ModuleName),
-    {ok, {docs_v1, _,_, _, none, _, []}} = code:get_doc(ModName),
+    {ok, {docs_v1, _,_, _, #{ ~"en" := ~"" }, _, []}} = code:get_doc(ModName),
     ok.
 
 deprecated(Conf) ->
@@ -563,10 +565,21 @@ skip_doc(Conf) ->
        [{{function,main,0},{8,1},[<<"main/0">>],none,#{}},
         {{function,foo,1},{16,1},[<<"foo/1">>],none,#{}}]}} = code:get_doc(ModName),
 
+  {error, missing} =
+      code:get_doc(ModName, #{ sources => [eep48] }),
+
   {ok, _ModName} = compile_file(Conf, ModuleName, [report, return_errors, no_docs]),
   {error, missing} = code:get_doc(ModName),
   ok.
 
+no_doc_attributes(Conf) ->
+  ModuleName =?get_name(),
+  {ok, ModName} = default_compile_file(Conf, ModuleName, []),
+
+  {error, missing} =
+      code:get_doc(ModName, #{ sources => [eep48] }),
+
+  ok.
 
 docs_from_ast(_Conf) ->
     Code = """

--- a/lib/compiler/test/beam_doc_SUITE_data/no_doc_attributes.erl
+++ b/lib/compiler/test/beam_doc_SUITE_data/no_doc_attributes.erl
@@ -1,5 +1,5 @@
--module(spec).
--moduledoc "".
+-module(no_doc_attributes).
+
 -type yes() :: integer().
 -type no() :: atom().
 
@@ -11,7 +11,7 @@
             (no()) -> yes();
             (term()) -> #name{ }.
 
--spec spec:foo(yes()) -> {yes(), yes()} | yes();
+-spec foo(yes()) -> {yes(), yes()} | yes();
               (no()) -> no().
 foo(X) ->
     _ = #name{field = none},

--- a/lib/compiler/test/beam_doc_SUITE_data/user_defined_type.erl
+++ b/lib/compiler/test/beam_doc_SUITE_data/user_defined_type.erl
@@ -1,3 +1,4 @@
 -module(user_defined_type).
+-moduledoc "".
 
 -include("user_defined_type.hrl").


### PR DESCRIPTION
If a module does not have any -doc attributes, it is not clear if we use EEP-59 or not in the system. So for edoc_*_chunks to work properly we should not emit any doc chunk as otherwise anyone using edoc will always have to pass no_docs to the compiler.

This was discovered while working on getting [rebar3_ex_doc](https://github.com/starbelly/rebar3_ex_doc/pull/83) to work with Erlang/OTP 27.