### PR TITLE
Make a printout when env is misconfigured

### DIFF
--- a/system/doc/top/src/otp_man_index.erl
+++ b/system/doc/top/src/otp_man_index.erl
@@ -75,7 +75,9 @@ module_path_to_app_vsn(Path) ->
               ["/", "lib", AppStr | _] ->
                   list_to_atom(AppStr);
               ["lib", AppStr | _] ->
-                  list_to_atom(AppStr)
+                  list_to_atom(AppStr);
+              ["nomatch"] ->
+                  error("ERL_TOP environment variable doesn't match the PATH " ++ Path)
           end,
     case application:load(App) of
         ok -> ok;


### PR DESCRIPTION
Make the error clearer for when I make the same mistake next time.