### PR TITLE
Fix type and thus docs for ttb

### DIFF
--- a/lib/observer/src/ttb.erl
+++ b/lib/observer/src/ttb.erl
@@ -59,7 +59,7 @@ parallel.
 -define(get_status,).
 -endif.
 
--type nodes() :: node() | [node()] | all | existing | new.
+-type nodes() :: node() | [node()] | all.
 -type item() :: pid() | port() | atom() | {global, term()} | all | processes |
                 ports | existing | existing_processes | existing_ports |
                 new | new_processes | new_ports.


### PR DESCRIPTION
The node options `existing` and `new` is not handled in the code as the type and docs suggests.