### PR TITLE
Fix type `calendar:secs_per_day/0`

### DIFF
--- a/lib/stdlib/src/calendar.erl
+++ b/lib/stdlib/src/calendar.erl
@@ -572,7 +572,7 @@ seconds_to_daystime(Secs) ->
 %%
 %% Wraps.
 %%
--type secs_per_day() :: 0..?SECONDS_PER_DAY.
+-type secs_per_day() :: 0..86399.
 -doc """
 Computes the time from the specified number of seconds. `Seconds` must be less
 than the number of seconds per day (86400).


### PR DESCRIPTION
Closes #8137.

It is spec'ed as `0..86400`, for which `86400` is a constant used in other places (which is the reason we don't change the constant's value).

This affects functions:

- `calendar:seconds_to_time/1`
- `calendar:time_to_seconds/1`

## After the fix

```erlang
> calendar:seconds_to_time(86399).
{23,59,59}

> calendar:seconds_to_time(0).
{0,0,0}

> calendar:time_to_seconds({23, 59, 59}).
86399

> calendar:time_to_seconds({0, 0, 0}).
86399
```