### PR TITLE
`net_kernel:allowed/0`, specs and docs

### DIFF
--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -1193,8 +1193,8 @@ handle_call({spawn_opt,M,F,A,O,L,Gleader},{From,Tag},State) when is_pid(From) ->
 handle_call({allow, Nodes}, From, State) ->
     case all_atoms(Nodes) of
 	true ->
-	    Allowed = State#state.allowed,
-            async_reply({reply,ok,State#state{allowed = Allowed ++ Nodes}},
+	    Allowed = lists:uniq(State#state.allowed ++ Nodes),
+            async_reply({reply,ok,State#state{allowed = Allowed}},
                         From);
 	false ->
 	    async_reply({reply,error,State}, From)

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -205,13 +205,13 @@ in the Erlang Reference Manual.
 -record(tick,
         {ticker     :: pid(),                 %% ticker
          time       :: pos_integer(),         %% net tick time (ms)
-         intensity  :: 4..1000                %% ticks until timout
+         intensity  :: 4..1000                %% ticks until timeout
         }).
 
 -record(tick_change,
         {ticker     :: pid(),                 %% ticker
          time       :: pos_integer(),         %% net tick time (ms)
-         intensity  :: 4..1000,               %% ticks until timout
+         intensity  :: 4..1000,               %% ticks until timeout
          how        :: 'longer' | 'shorter'   %% What type of change
         }).
 
@@ -248,13 +248,25 @@ that list will be rejected.
 Subsequent calls to [`allow/1`](`allow/1`) will add the specified nodes to the
 list of allowed nodes. It is not possible to remove nodes from the list.
 
-Returns `error` if any element in `Nodes` is not an atom.
+Disallowing an already connected node will not cause it to be disconnected. It
+will, however, prevent any future reconnection attempts.
+
+Passing `Nodes` as an empty list has never any affect at all.
+
+Returns `error` if any element in `Nodes` is not an atom, and `ignored` if the
+local node is not alive.
 """.
--spec allow(Nodes) -> ok | error when
+-spec allow(Nodes) -> ok | error | ignored when
       Nodes :: [node()].
 allow(Nodes) ->                request({allow, Nodes}).
 
--doc false.
+-doc """
+Returns a list of nodes that are explicitly allowed to connect to the node by calling
+[`allow/1`](`allow/1`). If empty list is returned, it means that any node using the
+same cookie will be able to connect.
+""".
+-spec allowed() -> {ok, Nodes} | ignored when
+      Nodes :: [node()].
 allowed() ->                   request(allowed).
 
 -doc false.


### PR DESCRIPTION
Few changes:
1. `net_kernel:allowed/0` is speced and documented. Notice that it is already listed in "documented API exports", but for some reason docs were missing. I think it's a must to have it documented, because if you don't then the user can't figure out if `net_kernel:allow/1` was called in the past, therefore blocking nodes with the same cookie to connect (which I believe can be very frustrating and and to debug!). This is just a pure getter function, I see no threat exposing it.
2. `net_kernel:allow/1` was missing `ignored` value it can return. You'll get it if e.g. your node is started without (s)name. 
3. 2 small typos in comments