### PR TITLE
Fix BEAM crash from from port/NIF thread

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -437,6 +437,8 @@ Eterm erts_system_profile;
 struct erts_system_profile_flags_t erts_system_profile_flags;
 int erts_system_profile_ts_type = ERTS_TRACE_FLG_NOW_TIMESTAMP;
 
+erts_atomic_t erts_sched_local_random_nosched_state;
+
 #if ERTS_MAX_PROCESSES > 0x7fffffff
 #error "Need to store process_count in another type"
 #endif
@@ -6201,7 +6203,8 @@ erts_init_scheduling(int no_schedulers, int no_schedulers_online, int no_poll_th
     erts_atomic32_init_relb(&erts_halt_progress, -1);
     erts_halt_code = 0;
 
-
+    erts_atomic_init_nob(&erts_sched_local_random_nosched_state,
+                         (erts_aint_t)&erts_sched_local_random_nosched_state >> 3);
 }
 
 ErtsRunQueue *

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -2804,9 +2804,16 @@ Uint32 erts_sched_local_random_hash_64_to_32_shift(Uint64 key)
 ERTS_GLB_INLINE
 Uint32 erts_sched_local_random(Uint additional_seed)
 {
+    extern erts_atomic_t erts_sched_local_random_nosched_state;
     ErtsSchedulerData *esdp = erts_get_scheduler_data();
-    esdp->rand_state++;
-    return erts_sched_local_random_hash_64_to_32_shift(esdp->rand_state
+    Uint64 rand_state;
+
+    if(ERTS_UNLIKELY(esdp == NULL)) {
+        rand_state = erts_atomic_inc_read_nob(&erts_sched_local_random_nosched_state);
+    } else {
+        rand_state = esdp->rand_state++;
+    }
+    return erts_sched_local_random_hash_64_to_32_shift(rand_state
                                                        + additional_seed);
 }
 


### PR DESCRIPTION
This patch prevents non-scheduler threads from crashing the emulator.
Fixes #8208