### PR TITLE
otp: Explicitly disable maybe_expr in tests targeting 24/25

### DIFF
--- a/erts/emulator/test/erts_test_utils.erl
+++ b/erts/emulator/test/erts_test_utils.erl
@@ -19,6 +19,12 @@
 %%
 
 -module(erts_test_utils).
+
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
 -compile(r24).
 
 %%

--- a/erts/test/upgrade_SUITE.erl
+++ b/erts/test/upgrade_SUITE.erl
@@ -18,9 +18,14 @@
 %% %CopyrightEnd%
 -module(upgrade_SUITE).
 
--compile(export_all).
-
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
 -compile(r24).
+
+-compile(export_all).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("kernel/include/file.hrl").

--- a/lib/common_test/src/test_server_node.erl
+++ b/lib/common_test/src/test_server_node.erl
@@ -19,6 +19,12 @@
 %%
 -module(test_server_node).
 -moduledoc false.
+
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
 -compile(r24).
 
 %% Test Controller interface

--- a/lib/kernel/test/global_SUITE.erl
+++ b/lib/kernel/test/global_SUITE.erl
@@ -19,6 +19,11 @@
 %%
 -module(global_SUITE).
 
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
 -compile(r24). % many_nodes()
 
 -export([all/0, suite/0, groups/0, 

--- a/lib/kernel/test/kernel_SUITE.erl
+++ b/lib/kernel/test/kernel_SUITE.erl
@@ -21,9 +21,15 @@
 %%% Kernel application test suite.
 %%%-----------------------------------------------------------------
 -module(kernel_SUITE).
--include_lib("common_test/include/ct.hrl").
 
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
 -compile(r24).
+
+-include_lib("common_test/include/ct.hrl").
 
 %% Test server specific exports
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 

--- a/lib/observer/test/crashdump_helper.erl
+++ b/lib/observer/test/crashdump_helper.erl
@@ -19,13 +19,21 @@
 %%
 
 -module(crashdump_helper).
+
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
+-compile(r24).
+
 -export([n1_proc/2,remote_proc/2,
          dump_maps/0,create_maps/0,
          create_binaries/0,create_sub_binaries/1,
          dump_persistent_terms/0,
          create_persistent_terms/0,
          dump_global_literals/0]).
--compile(r24).
+
 -include_lib("common_test/include/ct.hrl").
 
 n1_proc(N2,Creator) ->

--- a/lib/sasl/test/sasl_SUITE.erl
+++ b/lib/sasl/test/sasl_SUITE.erl
@@ -18,6 +18,14 @@
 %% %CopyrightEnd%
 %%
 -module(sasl_SUITE).
+
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
+-compile(r24).
+
 -include_lib("common_test/include/ct.hrl").
 
 %% Test server specific exports
@@ -31,8 +39,6 @@
 	 log_mf_h_env/1,
 	 log_file/1,
 	 utc_log/1]).
-
--compile(r24).
 
 all() -> 
     [log_mf_h_env, log_file, app_test, appup_test, utc_log].

--- a/lib/stdlib/test/stdlib_SUITE.erl
+++ b/lib/stdlib/test/stdlib_SUITE.erl
@@ -21,13 +21,19 @@
 %%% Purpose:Stdlib application test suite.
 %%%-----------------------------------------------------------------
 -module(stdlib_SUITE).
+
+%% Prior to OTP 26, maybe_expr used to require runtime support. As it's now
+%% enabled by default, all modules are tagged with the feature even when they
+%% don't use it. Therefore, we explicitly disable it until OTP 25 is out of
+%% support.
+-feature(maybe_expr, disable).
+-compile(r24).
+
 -include_lib("common_test/include/ct.hrl").
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1,
 	 init_per_group/2, end_per_group/2,
          init_per_testcase/2, end_per_testcase/2,
          app_test/1, appup_test/1, assert_test/1]).
-
--compile(r24).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 


### PR DESCRIPTION
Prior to OTP 26, `maybe_expr` used to require that the emulator was started with a certain flag for modules using `maybe` to be loaded. In OTP 26 we lifted that requirement because there was no good reason to do so.

As it's now enabled by default, all modules are tagged with the feature even when they don't use it. Therefore, we explicitly disable it in tests targeting OTP 24/25 until they're out of support.