### PR TITLE
beam_types: Add base case for convert_ext_26/2 recursion

### DIFF
--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -1503,7 +1503,9 @@ convert_ext_26(<<TypeBits0:16/big,More/binary>>, Types) ->
         end,
 
     Encoded = encode_ext(decode_fix(Res, R, Unit)),
-    convert_ext_26(Rest, <<Types/bits, Encoded/bits>>).
+    convert_ext_26(Rest, <<Types/bits, Encoded/bits>>);
+convert_ext_26(<<>>, Types) ->
+    Types.
 
 ext_type_mapping() ->
     [{?BEAM_TYPE_ATOM,          #t_atom{}},


### PR DESCRIPTION
This fixes a function clause error when using `beam_disasm:file/1` on a beam file with a type table version 2 from OTP 27:
    
```erl
> beam_disasm:file("./erts/ebin/erlang.beam").
{error,beam_disasm,
       {internal,{function_clause,[{beam_types,convert_ext_26,
                                               [<<>>,<<15,255,0,1,0,32,16,32,0,0,0,0,0,0,0,2,...>>],
                                               [{file,"beam_types.erl"},{line,1488}]},
                                   {beam_disasm,beam_disasm_types,1,
                                                [{file,"beam_disasm.erl"},{line,271}]},
                                   {beam_disasm,process_chunks,1,
                                                [{file,"beam_disasm.erl"},{line,197}]},
                                   {beam_disasm,file,1,[{file,"beam_disasm.erl"},{line,176}]},
                                   {erl_eval,do_apply,7,[{file,"erl_eval.erl"},{line,907}]},
                                   {shell,exprs,7,[{file,"shell.erl"},{line,1656}]},
                                   {shell,eval_exprs,7,[{file,"shell.erl"},{line,1612}]},
                                   {shell,eval_loop,4,[{file,"shell.erl"},{line,1597}]}]}}}
```