### PR TITLE
Allow explicit enabling the JIT on Intel Macs

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -24558,16 +24558,25 @@ then :
         amd64)
            case "$OPSYS" in
               darwin)
-                # MacOS Sonoma introduced some very annoying popups when
+                # macOS Sonoma introduced some very annoying popups when
                 # dual-mapping memory through the documented APIs, and we did
                 # not wish to start using undocumented functionality in a patch
-                # release, so we have disabled the JIT on this platform.
+                # release, so we have disabled the JIT by default on this
+                # platform.
+                #
+                # The previous version, macOS Ventura, does not have the
+                # annoying popups, so it is still possible to explicitly
+                # enable the JIT.
                 #
                 # The ARM JIT is unaffected because it uses per-thread
                 # permissions instead of dual-mapped memory.
-                enable_jit=no
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: JIT disabled due to lack to support on x86 Macs" >&5
-printf "%s\n" "$as_me: WARNING: JIT disabled due to lack to support on x86 Macs" >&2;}
+                if test ${enable_jit} = yes; then
+                  JIT_ARCH=x86
+                else
+                  enable_jit=no
+                  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: JIT disabled due to annoying popus on x86 Macs with Sononma" >&5
+printf "%s\n" "$as_me: WARNING: JIT disabled due to annoying popus on x86 Macs with Sononma" >&2;}
+                fi
                 ;;
               *)
                 JIT_ARCH=x86

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -2867,15 +2867,24 @@ AS_IF([test ${enable_jit} != no],
         amd64)
            case "$OPSYS" in
               darwin)
-                # MacOS Sonoma introduced some very annoying popups when
+                # macOS Sonoma introduced some very annoying popups when
                 # dual-mapping memory through the documented APIs, and we did
                 # not wish to start using undocumented functionality in a patch
-                # release, so we have disabled the JIT on this platform.
+                # release, so we have disabled the JIT by default on this
+                # platform.
+                #
+                # The previous version, macOS Ventura, does not have the
+                # annoying popups, so it is still possible to explicitly
+                # enable the JIT.
                 #
                 # The ARM JIT is unaffected because it uses per-thread
                 # permissions instead of dual-mapped memory.
-                enable_jit=no
-                AC_MSG_WARN([JIT disabled due to lack to support on x86 Macs])
+                if test ${enable_jit} = yes; then
+                  JIT_ARCH=x86
+                else
+                  enable_jit=no
+                  AC_MSG_WARN([JIT disabled due to annoying popus on x86 Macs with Sononma])
+                fi
                 ;;
               *)
                 JIT_ARCH=x86


### PR DESCRIPTION
5c9581eb409f5e disabled the JIT on Intel Macs because of annoying popups on macOS Sonoma. The previous major version, macOS Ventura, does not have the popup problem. Therefore, this commit makes it possible to explicitly enable the JIT for Intel Macs. Here is how:

    ./configure --enable-jit