### PR TITLE
Make options in the `-compile` attribute take precedence

### DIFF
--- a/erts/test/erlc_SUITE.erl
+++ b/erts/test/erlc_SUITE.erl
@@ -717,20 +717,6 @@ features_atom_warnings(Config) when is_list(Config) ->
                     atom_warning(while, experimental_ftr_2),
                     skip_lines])),
 
-    %% Check for keyword warnings.  Not all warnings are checked.
-    %% This file has a -compile attribute for keyword warnings.
-    Compile("ignorant_directive.erl", "",
-            ?OK([atom_warning(ifn, experimental_ftr_1),
-                 skip_lines,
-                 atom_warning(while, experimental_ftr_2),
-                 skip_lines,
-                 atom_warning(until, experimental_ftr_2),
-                 skip_lines])),
-
-    %% Override warning attribute inside file
-    Compile("ignorant_directive.erl", "+nowarn_keywords",
-            ?OK([])),
-
     %% File has quoted atoms which are keywords in experimental_ftr_2.
     %% We should see no warnings.
     Compile("foo.erl", options([longopt(enable, experimental_ftr_2),

--- a/erts/test/erlc_SUITE_data/src/ignorant_directive.erl
+++ b/erts/test/erlc_SUITE_data/src/ignorant_directive.erl
@@ -23,7 +23,7 @@
 
 -module(ignorant_directive).
 
--compile(warn_keywords).
+
 
 -export([foo/0,
          frob/1,

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -43,6 +43,29 @@ compiler recursively from inside a parse transform.
 
 The list can be retrieved with `env_compiler_options/0`.
 
+## Order of Compiler Options
+
+Options given in the `compile()` attribute in the source code take
+precedence over options given to the compiler, which in turn take
+precedence over options given in the environment.
+
+A later compiler option takes precedence over an earlier one in the
+option list. Example:
+
+```
+compile:file(something, [nowarn_missing_spec,warn_missing_spec]).
+```
+
+Warnings will be emitted for functions without specifications, unless
+the source code for module `something` contains a `compile(nowarn_missing_spec)`
+attribute.
+
+> #### Change {: .info }
+>
+> In Erlang/OTP 26 and earlier, the option order was the opposite of what
+> is described here.
+
+
 ## Inlining
 
 The compiler can do function inlining within an Erlang
@@ -796,7 +819,7 @@ Module:format_error(ErrorDescriptor)
           CompRet :: comp_ret().
 
 file(File, Opts) when is_list(Opts) ->
-    do_compile({file,File}, Opts++env_default_opts());
+    do_compile({file,File}, env_default_opts() ++ Opts);
 file(File, Opt) ->
     file(File, [Opt|?DEFAULT_OPTIONS]).
 

--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -767,7 +767,7 @@ sets_filter([Mod|Mods], ExpTypes) ->
 
 src_compiler_opts() ->
   [no_copt, to_core, binary, return_errors,
-   no_inline, strict_record_tests, strict_record_updates,
+   no_inline, strict_record_tests,
    dialyzer, no_spawn_compiler_process].
 
 -spec format_errors([{module(), string()}]) -> [string()].

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -33,15 +33,15 @@ Section [The Abstract Format](`e:erts:absform.md`) in ERTS User's Guide.
 
 -import(lists, [map/2,foldl/3,foldr/3,sort/1,reverse/1,duplicate/2]).
 
--record(exprec, {compile=[],	% Compile flags
-		 vcount=0,	% Variable counter
-		 calltype=#{},	% Call types
-		 records=#{},	% Record definitions
-                 raw_records=[],% Raw record forms
-		 strict_ra=[],	% strict record accesses
-		 checked_ra=[], % successfully accessed records
-                 dialyzer=false % Cached value of compile flag 'dialyzer'
-		}).
+-record(exprec, {vcount=0,             % Variable counter
+                 calltype=#{},         % Call types
+                 records=#{},          % Record definitions
+                 raw_records=[],       % Raw record forms
+                 strict_ra=[],         % Strict record accesses
+                 checked_ra=[],        % Successfully accessed records
+                 dialyzer=false,       % Compiler option 'dialyzer'
+                 strict_rec_tests=true :: boolean()
+                }).
 
 -doc """
 Expands all records in a module to use explicit tuple operations and adds
@@ -57,10 +57,10 @@ module has no references to records, attributes, or code.
 %% erl_lint without errors.
 module(Fs0, Opts0) ->
     put(erl_expand_records_in_guard, false),
-    Opts = compiler_options(Fs0) ++ Opts0,
-    Dialyzer = lists:member(dialyzer, Opts),
-    Calltype = init_calltype(Fs0),
-    St0 = #exprec{compile = Opts, dialyzer = Dialyzer, calltype = Calltype},
+    Opts = Opts0 ++ compiler_options(Fs0),
+    St0 = #exprec{dialyzer = lists:member(dialyzer, Opts),
+                  calltype = init_calltype(Fs0),
+                  strict_rec_tests = strict_record_tests(Opts)},
     {Fs,_St} = forms(Fs0, St0),
     erase(erl_expand_records_in_guard),
     Fs.
@@ -635,7 +635,7 @@ index_expr(F, [_ | Fs], I) -> index_expr(F, Fs, I+1).
 %%  This expansion must be passed through expr again.
 
 get_record_field(Anno, R, Index, Name, St) ->
-    case strict_record_tests(St#exprec.compile) of
+    case St#exprec.strict_rec_tests of
         false ->
             sloppy_get_record_field(Anno, R, Index, Name, St);
         true ->
@@ -686,15 +686,17 @@ sloppy_get_record_field(Anno, R, Index, Name, St) ->
 	  {remote,Anno,{atom,Anno,erlang},{atom,Anno,element}},
 	  [I,R]}, St).
 
-strict_record_tests([strict_record_tests | _]) -> true;
-strict_record_tests([no_strict_record_tests | _]) -> false;
-strict_record_tests([_ | Os]) -> strict_record_tests(Os);
-strict_record_tests([]) -> true.		%Default.
+strict_record_tests(Opts) ->
+    strict_record_tests(Opts, true).
 
-strict_record_updates([strict_record_updates | _]) -> true;
-strict_record_updates([no_strict_record_updates | _]) -> false;
-strict_record_updates([_ | Os]) -> strict_record_updates(Os);
-strict_record_updates([]) -> false.		%Default.
+strict_record_tests([strict_record_tests | Os], _) ->
+    strict_record_tests(Os, true);
+strict_record_tests([no_strict_record_tests | Os], _) ->
+    strict_record_tests(Os, false);
+strict_record_tests([_ | Os], Bool) ->
+    strict_record_tests(Os, Bool);
+strict_record_tests([], Bool) ->
+    Bool.
 
 %% pattern_fields([RecDefField], [Match]) -> [Pattern].
 %%  Build a list of match patterns for the record tuple elements.
@@ -744,13 +746,14 @@ record_update(R, Name, Fs, Us0, St0) ->
     %% to guarantee that it is only evaluated once.
     {Var,St2} = new_var(Anno, St1),
 
-    %% Honor the `strict_record_updates` option needed by `dialyzer`, otherwise
-    %% expand everything to chains of `setelement/3` as that's far more
-    %% efficient in the JIT.
-    StrictUpdates = strict_record_updates(St2#exprec.compile),
+    %% If the `dialyzer` option is in effect, update the record by
+    %% matching out all unmodified fields and building a new tuple.
+    %% Otherwise expand everything to chains of `setelement/3` as
+    %% that is far more efficient in the JIT.
+    Dialyzer = St2#exprec.dialyzer,
     {Update,St} =
         if
-            not StrictUpdates, Us =/= [] ->
+            not Dialyzer, Us =/= [] ->
                 {record_setel(Var, Name, Fs, Us), St2};
             true ->
                 record_match(Var, Name, Anno, Fs, Us, St2)

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -698,7 +698,7 @@ module(Forms, FileName, Opts0) ->
     %% FIXME Hmm, this is not coherent with the semantics of features
     %% We want the options given on the command line to take
     %% precedence over options in the module.
-    Opts = compiler_options(Forms) ++ Opts0,
+    Opts = Opts0 ++ compiler_options(Forms),
     St = forms(Forms, start(FileName, Opts)),
     return_status(St).
 

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -2350,19 +2350,18 @@ otp_5362(Config) when is_list(Config) ->
                       {{15,24},erl_lint,{undefined_field,ok,nix}},
                       {{16,24},erl_lint,{field_name_is_variable,ok,'Var'}}]}},
 
-	  %% Nowarn_bif_clash has changed behaviour as local functions
-	  %% nowdays supersede auto-imported BIFs, why nowarn_bif_clash in itself generates an error
-	  %% (OTP-8579) /PaN
+	  %% `nowarn_bif_clash` has changed behaviour as local functions
+	  %% nowdays supersede auto-imported BIFs. Therefore,
+	  %% `nowarn_bif_clash` in itself generates an error (OTP-8579).
           {otp_5362_4,
-           <<"-compile(nowarn_deprecated_function).
-              -compile(nowarn_bif_clash).
+           <<"-compile(warn_deprecated_function).
+              -compile(warn_bif_clash).
               spawn(A) ->
                   erlang:now(),
                   spawn(A).
            ">>,
            {[nowarn_unused_function,
-             warn_deprecated_function,
-             warn_bif_clash]},
+             warn_deprecated_function]},
            {error,
             [{{5,19},erl_lint,{call_to_redefined_old_bif,{spawn,1}}}],
             [{{4,19},erl_lint,{deprecated,{erlang,now,0},


### PR DESCRIPTION
Change the compiler option processing order so that options given in the `compile()` attribute take precedence over options given to the compiler, which in turn take precedence over options given in the environment.

This order makes most sense, as each module might need customized options.

While at it, remove the undocumented `strict_record_updates` / `no_strict_record_updates` options. Their naming no longer make any sense, because record updates are always strict (that is, the source record must have the correct tag and size). Incorporate the behavior of `strict_record_updates` to update the record by matching and building a new tuple into the `dialyzer` option. When dialyzer is not used, records are updated using `setelement/3`, which is more efficient in the JIT.

(This is the second attempt to fix #6979, as #8093 did not really work.)