### PR TITLE
`ssh`: Fix stealing of `'EXIT'` messages if a client is trapping exits

### DIFF
--- a/lib/ssh/src/Makefile
+++ b/lib/ssh/src/Makefile
@@ -57,6 +57,7 @@ BEHAVIOUR_MODULES_2= \
 MODULES= \
 	ssh \
 	ssh_acceptor \
+	ssh_acceptor_subsup \
 	ssh_acceptor_sup \
 	ssh_agent \
 	ssh_app \

--- a/lib/ssh/src/ssh.app.src
+++ b/lib/ssh/src/ssh.app.src
@@ -6,6 +6,7 @@
   {modules, [ssh,
 	     ssh_app,
 	     ssh_acceptor,
+	     ssh_acceptor_subsup,
 	     ssh_acceptor_sup,
              ssh_options,
 	     ssh_agent,
@@ -48,6 +49,7 @@
   {applications, [kernel, stdlib, crypto, public_key]},
   {env, [{filter_modules, [
                            ssh_acceptor_sup,
+                           ssh_acceptor_subsup,
                            ssh_acceptor,
                            ssh_channel_sup,
                            ssh_connection_handler,

--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -624,9 +624,9 @@ daemon(Host0, Port0, UserOptions0) when 0 =< Port0, Port0 =< 65535,
                     {ok,DaemonRef};
                 {ok,DaemonRef} ->
                     receive
-                        {request_control, ListenSocket, ReqPid} ->
+                        {request_control, ListenSocket, ReqPid, ReplyToPid} ->
                             ok = controlling_process(ListenSocket, ReqPid, Options1),
-                            ReqPid ! {its_yours,ListenSocket}
+                            ReplyToPid ! {its_yours,ListenSocket}
                     end,
                     {ok,DaemonRef};
                 {error, {already_started, _}} ->
@@ -1293,10 +1293,10 @@ maybe_open_listen_socket(Host, Port, Options) ->
     Opened =
         case ?GET_SOCKET_OPT(fd, Options) of
             undefined when Port == 0 ->
-                ssh_acceptor:listen(0, Options);
+                ssh_acceptor_subsup:listen(0, Options);
             Fd when is_integer(Fd) ->
                 %% Do gen_tcp:listen with the option {fd,Fd}:
-                ssh_acceptor:listen(0, Options);
+                ssh_acceptor_subsup:listen(0, Options);
             undefined ->
                 open_later
         end,

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1141,17 +1141,19 @@ in the User's Guide chapter.
   By default, this option is not set. This means that the number is not limited.
 
 - **`parallel_login`{: #hardening_daemon_options-parallel_login }** - If set to
-  false (the default value), only one login is handled at a time. If set to
-  true, an unlimited number of login attempts are allowed simultaneously.
+  `false` (the default value), only one login is handled at a time. If set to
+  `true`, an unlimited number of login attempts are allowed simultaneously. If
+  set to a number `N`, the given number of login attempts are allowed
+  simultaneously.
 
   If the `max_sessions` option is set to `N` and `parallel_login` is set to
-  `true`, the maximum number of simultaneous login attempts at any time is
-  limited to `N-K`, where `K` is the number of authenticated connections present
-  at this daemon.
+  `true` or a number `M>=N`, the maximum number of simultaneous login attempts
+  at any time is limited to `N-K`, where `K` is the number of authenticated
+  connections present at this daemon.
 
   > #### Warning {: .warning }
   >
-  > Do not enable `parallel_logins` without protecting the server by other
+  > Do not set `parallel_login` to `true` without protecting the server by other
   > means, for example, by the `max_sessions` option or a firewall
   > configuration. If set to `true`, there is no protection against DOS attacks.
 
@@ -1164,7 +1166,7 @@ in the User's Guide chapter.
 -type hardening_daemon_options() ::
         {max_sessions, pos_integer()}
       | {max_channels, pos_integer()}
-      | {parallel_login, boolean()}
+      | {parallel_login, boolean() | pos_integer()}
       | {minimal_remote_max_packet_size, pos_integer()}.
 
 -doc """

--- a/lib/ssh/src/ssh_acceptor.erl
+++ b/lib/ssh/src/ssh_acceptor.erl
@@ -42,7 +42,7 @@
 %%====================================================================
 %% Supposed to be called in a child-spec of the ssh_acceptor_sup
 start_link(SystemSup, LSock, Address, Options) ->
-    proc_lib:start_link(?MODULE, acceptor_init, [self(), SystemSup, LSock, Address, Options]).
+	{ok, proc_lib:spawn_link(?MODULE, acceptor_init, [self(), SystemSup, LSock, Address, Options])}.
 
 %%%----------------------------------------------------------------
 accept(ListenSocket, AcceptTimeout, Options) ->
@@ -62,7 +62,6 @@ acceptor_init(Parent, SystemSup, LSock,
     ssh_lib:set_label(server,
                       {acceptor,
                        list_to_binary(ssh_lib:format_address_port(Address, Port))}),
-    proc_lib:init_ack(Parent, {ok, self()}),
     AcceptTimeout = ?GET_INTERNAL_OPT(timeout, Opts, ?DEFAULT_TIMEOUT),
     MaxSessions = ?GET_OPT(max_sessions, Opts),
     ParallelLogin = ?GET_OPT(parallel_login, Opts),

--- a/lib/ssh/src/ssh_acceptor_subsup.erl
+++ b/lib/ssh/src/ssh_acceptor_subsup.erl
@@ -1,0 +1,142 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2008-2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%%
+%%----------------------------------------------------------------------
+%% Purpose: The acceptor supervisor for ssh servers hangs under 
+%%          ssh_system_sup.
+%%----------------------------------------------------------------------
+
+-module(ssh_acceptor_subsup).
+-moduledoc false.
+-behaviour(supervisor).
+
+-include("ssh.hrl").
+
+-export([start_link/3,
+         listen/2
+        ]).
+
+%% Supervisor callback
+-export([init/1]).
+
+%%%=========================================================================
+%%%  API
+%%%=========================================================================
+start_link(SystemSup, Address, Options) ->
+    case supervisor:start_link(?MODULE, [SystemSup, Address, Options]) of
+        {error, {shutdown, {failed_to_start_child, _, Error}}} ->
+            {error,Error};
+        Other ->
+            Other
+    end.
+
+%%%=========================================================================
+%%%  Supervisor callback
+%%%=========================================================================
+init([SystemSup, Address=#address{port=Port}, Options]) ->
+    ssh_lib:set_label(server, acceptor_subsup),
+    %% Initial start of ssh_acceptor_sup for this port
+    Self = self(),
+    NumAcceptors = case ?GET_OPT(parallel_login, Options) of
+                       true -> 1;
+                       false -> 1;
+                       N -> N
+                   end,
+    {Sock, Opts} = case ?GET_INTERNAL_OPT(lsocket, Options, undefined) of
+        {LSock, SockOwner} ->
+            %% A listening socket (or fd option) was provided in the ssh:daemon call
+            case inet:sockname(LSock) of
+                {ok, {_, Port}} ->
+                    %% A usable, open LSock
+                    spawn_link(fun() ->
+                              SockOwner ! {request_control, LSock, Self, self()},
+                              receive {its_yours, LSock} -> ok end,
+                              [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)],
+                              unlink(Self)
+                          end),
+                    {LSock, Options};
+
+                {error, _Error} ->
+                    %% Not open, a restart
+                    %% Allow gen_tcp:listen to fail 4 times if eaddrinuse (It is a bug fix):
+                    case try_listen(Port, Options, 4) of
+                        {ok, NewLSock} ->
+                            spawn_link(fun() ->
+                                           [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)],
+                                           unlink(Self)
+                                       end),
+                            {NewLSock, ?DELETE_INTERNAL_OPT(lsocket, Options)};
+                        {error, Error} ->
+                            exit({error, Error})
+                    end
+            end;
+
+        undefined ->
+            %% No listening socket (nor fd option) was provided; open a listening socket:
+            case listen(Port, Options) of
+                {ok, LSock} ->
+                    spawn_link(fun() ->
+                                   [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)],
+                                   unlink(Self)
+                               end),
+                    {LSock, Options};
+                {error, Error} ->
+                    exit({error, Error})
+            end
+    end,
+    SupFlags = #{strategy  => simple_one_for_one, 
+                 intensity => 1000000,
+                 period    => 1
+                },
+    ChildSpecs = [#{id => ssh_acceptor,
+                    start => {ssh_acceptor, start_link, [SystemSup, Sock, Address, Opts]},
+                    restart => transient}],
+    {ok, {SupFlags,ChildSpecs}}.
+
+%%%=========================================================================
+%%%  Internal functions
+%%%=========================================================================
+
+listen(Port, Options) ->
+    {_, Callback, _} = ?GET_OPT(transport, Options),
+    SockOpts = ?GET_OPT(socket_options, Options) ++ [{active, false}, {reuseaddr, true}],
+    case Callback:listen(Port, SockOpts) of
+        {error, nxdomain} ->
+            Callback:listen(Port, lists:delete(inet6, SockOpts));
+        {error, enetunreach} ->
+            Callback:listen(Port, lists:delete(inet6, SockOpts));
+        {error, eafnosupport} ->
+            Callback:listen(Port, lists:delete(inet6, SockOpts));
+        Other ->
+            Other
+    end.
+
+try_listen(Port, Opts, NtriesLeft) ->
+    try_listen(Port, Opts, 1, NtriesLeft).
+
+try_listen(Port, Opts, N, Nmax) ->
+    case listen(Port, Opts) of
+        {error,eaddrinuse} when N<Nmax ->
+            timer:sleep(10*N), % Sleep 10, 20, 30,... ms
+            try_listen(Port, Opts, N+1, Nmax);
+        Other ->
+            Other
+    end.

--- a/lib/ssh/src/ssh_acceptor_subsup.erl
+++ b/lib/ssh/src/ssh_acceptor_subsup.erl
@@ -79,10 +79,9 @@ init([SystemSup, Address=#address{port=Port}, Options]) ->
                     %% Allow gen_tcp:listen to fail 4 times if eaddrinuse (It is a bug fix):
                     case try_listen(Port, Options, 4) of
                         {ok, NewLSock} ->
-                            spawn_link(fun() ->
-                                           [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)],
-                                           unlink(Self)
-                                       end),
+                            spawn(fun() ->
+                                      [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)]
+                                  end),
                             {NewLSock, ?DELETE_INTERNAL_OPT(lsocket, Options)};
                         {error, Error} ->
                             exit({error, Error})
@@ -93,10 +92,9 @@ init([SystemSup, Address=#address{port=Port}, Options]) ->
             %% No listening socket (nor fd option) was provided; open a listening socket:
             case listen(Port, Options) of
                 {ok, LSock} ->
-                    spawn_link(fun() ->
-                                   [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)],
-                                   unlink(Self)
-                               end),
+                    spawn(fun() ->
+                              [supervisor:start_child(Self, []) || _ <- lists:seq(1, NumAcceptors)]
+                          end),
                     {LSock, Options};
                 {error, Error} ->
                     exit({error, Error})

--- a/lib/ssh/src/ssh_acceptor_sup.erl
+++ b/lib/ssh/src/ssh_acceptor_sup.erl
@@ -62,8 +62,9 @@ init([SystemSup, Address, Options]) ->
                  period    => 3600
                 },
     ChildSpecs = [#{id       => {?MODULE,Address},
-                    start    => {ssh_acceptor, start_link, [SystemSup, Address, Options]},
-                    restart  => transient % because a crashed listener could be replaced by a new one
+                    start    => {ssh_acceptor_subsup, start_link, [SystemSup, Address, Options]},
+                    restart  => transient, % because a crashed listener could be replaced by a new one
+                    type     => supervisor
                    }
                  ],
     {ok, {SupFlags,ChildSpecs}}.

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -501,10 +501,7 @@ handshake(Pid, Ref, Timeout) ->
 	{'DOWN', Ref, process, Pid, {shutdown, Reason}} ->
 	    {error, Reason};
 	{'DOWN', Ref, process, Pid, Reason} ->
-	    {error, Reason};
-        {'EXIT',_,Reason} ->
-            stop(Pid),
-            {error, {exit,Reason}}
+	    {error, Reason}
     after Timeout ->
 	    erlang:demonitor(Ref, [flush]),
 	    ssh_connection_handler:stop(Pid),

--- a/lib/ssh/src/ssh_info.erl
+++ b/lib/ssh/src/ssh_info.erl
@@ -112,7 +112,7 @@ walk_tree(_Role, [], _) ->
 format_sup(server,
            {{{ssh_system_sup,LocalAddress},Pid,supervisor,[ssh_system_sup]}, _Spec,
             [{{{ssh_acceptor_sup,Address},AccSupPid,supervisor,[ssh_acceptor_sup]}, _AccSupSpec,
-              [{{{ssh_acceptor_sup,Address},AccPid,worker,[ssh_acceptor]}, _AccSpec}]}
+              [{{{ssh_acceptor_sup,Address},AccPid,supervisor,[ssh_acceptor_subsup]}, _AccSpec}]}
              | Children]
            }, Indent) ->
    [indent(Indent),
@@ -191,10 +191,6 @@ format_sup(Role, {H, Spec, Children}, Indent) ->
     ].
 
 
-format_wrk(_Role, {{{ssh_acceptor_sup,Address},Pid,worker,[ssh_acceptor]}, _Spec}, Indent) ->
-    [indent(Indent),
-     io_lib:format("acceptor: ~s ~s~n", [format_address(Address),print_pid(Pid)])
-    ];
 format_wrk(_Role, {{{From,To},Pid,worker,[ssh_tcpip_forward_acceptor]}, _Spec}, Indent) ->
     io_lib:format("~sssh_tcpip_forward_acceptor ~s From: ~s, To: ~s~n", [indent(Indent),print_pid(Pid),
                                                                          format_address(From), format_address(To)]);

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -565,7 +565,7 @@ default(server) ->
 
       parallel_login =>
           #{default => false,
-            chk => fun(V) -> erlang:is_boolean(V) end,
+            chk => fun(V) -> erlang:is_boolean(V) orelse check_pos_integer(V) end,
             class => user_option
            },
 

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -1247,15 +1247,17 @@ find_handshake_parent([{{ssh_system_sup,{address,_,Port,_}},
 
 find_handshake_parent([{{ssh_acceptor_sup,{address,_,Port,_}},
                         PidS,supervisor,[ssh_acceptor_sup]}|T],
+                       Port, Acc) ->
+    find_handshake_parent(supervisor:which_children(PidS), Port, Acc);
+
+find_handshake_parent([{{ssh_acceptor_sup,{address,_,Port,_}},
+                        PidS,supervisor,[ssh_acceptor_subsup]}|T],
                        Port, {AccP,AccC,AccH}) ->
     ParentHandshakers =
-        [{PidW,PidH} ||
-            {{ssh_acceptor_sup,{address,_,Port1,_}}, PidW, worker, [ssh_acceptor]} <-
+        [{PidW,PidW} ||
+            {undefined, PidW, worker, [ssh_acceptor]} <-
                 supervisor:which_children(PidS),
-            Port1 == Port,
-            PidH <- element(2, process_info(PidW,links)),
-            is_pid(PidH),
-            process_info(PidH,current_function) == {current_function,{ssh_connection_handler,handshake,3}}],
+                process_info(PidW,current_function) == {current_function,{ssh_connection_handler,handshake,3}}],
     {Parents,Handshakers} = lists:unzip(ParentHandshakers),
     find_handshake_parent(T, Port, {AccP++Parents, AccC, AccH++Handshakers});
 


### PR DESCRIPTION
Fixes #8223.

I haven't written any tests for that yet. TBH, I don't know in which of the 20 suites I should put them :sweat_smile: