### PR TITLE
Update time_correction.md to match function reference styles

### DIFF
--- a/erts/doc/guides/time_correction.md
+++ b/erts/doc/guides/time_correction.md
@@ -615,14 +615,14 @@ use the new API.
 
 > #### Dont {: .error }
 >
-> Seed random number generation using `erlang:now()`.
+> Seed random number generation using `erlang:now/0`.
 
 > #### Do {: .tip }
 >
 > Seed random number generation using a combination of
-> [`erlang:monotonic_time()`](`erlang:monotonic_time/0`),
-> [`erlang:time_offset()`](`erlang:time_offset/0`),
-> [`erlang:unique_integer()`](`erlang:unique_integer/0`), and other
+> [`erlang:monotonic_time/0`](`erlang:monotonic_time/0`),
+> [`erlang:time_offset/0`](`erlang:time_offset/0`),
+> [`erlang:unique_integer/0`](`erlang:unique_integer/0`), and other
 > functionality.
 
 To sum up this section: _Do not use `erlang:now/0`._


### PR DESCRIPTION
Except in this particular section, the functions are being referenced as module:function/arity.