### PR TITLE
Fix pr-comment email links

### DIFF
--- a/.github/scripts/pr-comment.js
+++ b/.github/scripts/pr-comment.js
@@ -74,13 +74,14 @@ module.exports = async({ github, context, state, pr_number }) => {
 
     console.log(`ct_body: ${ct_body}`);
 
+    const repoURL = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`
     const body = `${ct_body}
 
 <!-- marker -->
 
-To speed up review, make sure that you have read [Contributing to Erlang/OTP](/${context.repo.owner}/${context.repo.repo}/blob/master/CONTRIBUTING.md) and that all [checks](/${context.repo.owner}/${context.repo.repo}/pull/${pr_number}/checks) pass.
+To speed up review, make sure that you have read [Contributing to Erlang/OTP](${repoURL}/blob/master/CONTRIBUTING.md) and that all [checks](${repoURL}/pull/${pr_number}/checks) pass.
 
-See the [TESTING](/${context.repo.owner}/${context.repo.repo}/blob/master/HOWTO/TESTING.md) and [DEVELOPMENT](/${context.repo.owner}/${context.repo.repo}/blob/master/HOWTO/DEVELOPMENT.md) HowTo guides for details about how to run test locally.
+See the [TESTING](${repoURL}/blob/master/HOWTO/TESTING.md) and [DEVELOPMENT](${repoURL}/blob/master/HOWTO/DEVELOPMENT.md) HowTo guides for details about how to run test locally.
 
 ## Artifacts
 * ` + (ct_logs ? `[Complete CT logs](https://erlang.github.io/prs/${pr_number}/ct_logs/index.html) ([Download Logs](${nightlyURL(ct_logs)}))` : "No CT logs found") + `


### PR DESCRIPTION
The PR comment posted by the github action contains some relative links such as [/erlang/otp/blob/master/CONTRIBUTING.md](/erlang/otp/blob/master/CONTRIBUTING.md) that work as expected when viewed from the GitHub interface, but they don't work at all when followed from the triggered email notification.

Making the URLs absolute fixes the issue.