### PR TITLE
Handle process_labels set as list of terms

### DIFF
--- a/lib/runtime_tools/src/appmon_info.erl
+++ b/lib/runtime_tools/src/appmon_info.erl
@@ -731,11 +731,13 @@ format(X) ->
     "???".
 
 format_label(Id, Pid) when is_list(Id); is_binary(Id) ->
-    case unicode:characters_to_binary(Id) of
+    try unicode:characters_to_binary(Id) of
         {error, _, _} ->
             io_lib:format("~0.tp ~w", [Id, Pid]);
         BinString ->
             io_lib:format("~ts ~w", [BinString, Pid])
+    catch _:_ ->
+            io_lib:format("~0.tp ~w", [Id, Pid])
     end;
 format_label(Id, Pid) ->
     io_lib:format("~0.tp ~w", [Id, Pid]).

--- a/lib/runtime_tools/src/observer_backend.erl
+++ b/lib/runtime_tools/src/observer_backend.erl
@@ -609,11 +609,13 @@ etop_collect([P|Ps], Acc) ->
 etop_collect([], Acc) -> Acc.
 
 id_to_binary(Id) when is_list(Id); is_binary(Id) ->
-    case unicode:characters_to_binary(Id) of
+    try unicode:characters_to_binary(Id) of
         {error, _, _} ->
             unicode:characters_to_binary(io_lib:format("~0.tp", [Id]));
         BinString ->
             BinString
+    catch _:_ ->
+            unicode:characters_to_binary(io_lib:format("~0.tp", [Id]))
     end;
 id_to_binary(TermId) ->
     unicode:characters_to_binary(io_lib:format("~0.tp", [TermId])).

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -872,11 +872,13 @@ fetch_label(Reg, _) ->
     Reg.
 
 format_label(Id) when is_list(Id); is_binary(Id) ->
-    case unicode:characters_to_binary(Id) of
+    try unicode:characters_to_binary(Id) of
         {error, _, _} ->
             io_lib:format("~0.tp", [Id]);
         BinString ->
             BinString
+    catch _:_ ->
+            io_lib:format("~0.tp", [Id])
     end;
 format_label(TermId) ->
     io_lib:format("~0.tp", [TermId]).


### PR DESCRIPTION
Don't crash when a list is not a string, but a list of terms.