### PR TITLE
Fix race bugs in emulator Makefile

### DIFF
--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -646,15 +646,12 @@ GENERATE += $(TTF_DIR)/driver_tab.c
 
 ifeq ($(TYPE)@EXTERNAL_WORD_SIZE@,debug64)
 YCF_DEBUG_FLAG = -debug
-MAPS_YCF_OUTPUT=$(TARGET)/erl_map.debug.ycf.h
-UTILS_YCF_OUTPUT=$(TARGET)/utils.debug.ycf.h
-DB_INSERT_LIST_OUTPUT=$(TARGET)/erl_db_insert_list.debug.ycf.h
 else
 YCF_DEBUG_FLAG =
-MAPS_YCF_OUTPUT=$(TARGET)/erl_map.ycf.h
-UTILS_YCF_OUTPUT=$(TARGET)/utils.ycf.h
-DB_INSERT_LIST_OUTPUT=$(TARGET)/erl_db_insert_list.ycf.h
 endif
+MAPS_YCF_OUTPUT=$(TTF_DIR)/erl_map.ycf.h
+UTILS_YCF_OUTPUT=$(TTF_DIR)/utils.ycf.h
+DB_INSERT_LIST_OUTPUT=$(TTF_DIR)/erl_db_insert_list.ycf.h
 
 DB_INSERT_LIST_YCF_FLAGS=-yield \
 		$(YCF_DEBUG_FLAG) \
@@ -765,12 +762,12 @@ PRELOAD_BEAM =	$(ERL_TOP)/erts/preloaded/ebin/erts_code_purger.beam \
 ifeq ($(TARGET),win32)
 # On windows the preloaded objects are in a resource object.
 PRELOAD_OBJ = $(OBJDIR)/beams.$(RES_EXT)
-PRELOAD_SRC = $(TARGET)/beams.rc
+PRELOAD_SRC = $(TTF_DIR)/beams.rc
 $(PRELOAD_SRC): $(PRELOAD_BEAM)
 	$(gen_verbose)LANG=C $(PERL) utils/make_preload $(MAKE_PRELOAD_EXTRA) -rc $^ > $@
 else
 PRELOAD_OBJ = $(OBJDIR)/preload.o
-PRELOAD_SRC = $(TARGET)/preload.c
+PRELOAD_SRC = $(TTF_DIR)/preload.c
 $(PRELOAD_SRC): $(PRELOAD_BEAM)
 	$(gen_verbose)LANG=C $(PERL) utils/make_preload -old $^ > $@
 endif
@@ -818,8 +815,8 @@ ifeq ($(TARGET),win32)
 $(OBJDIR)/dll_sys.o: sys/$(ERLANG_OSTYPE)/sys.c
 	$(V_CC) $(CFLAGS) -DERL_RUN_SHARED_LIB=1 $(INCLUDES) -c $< -o $@
 
-$(OBJDIR)/beams.$(RES_EXT): $(TARGET)/beams.rc
-	$(V_RC) -o $@  -I$(ERL_TOP)/erts/etc/win32 $(TARGET)/beams.rc
+$(PRELOAD_OBJ): $(PRELOAD_SRC)
+	$(V_RC) -o $@  -I$(ERL_TOP)/erts/etc/win32 $(PRELOAD_SRC)
 
 endif
 

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -2046,11 +2046,7 @@ static BIF_RETTYPE ets_insert_2_list(Process* p,
  * < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
  * < < < < < < < < < < < < < < < < < < < < < < < < < < < < < <
  */
-#if defined(DEBUG) && defined(ARCH_64)
-#include "erl_db_insert_list.debug.ycf.h"
-#else
 #include "erl_db_insert_list.ycf.h"
-#endif
 
 static void* ets_insert_2_yield_alloc(size_t size, void* ctx)
 {

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -124,11 +124,7 @@ static int hxnodecmpkey(const void* a, const void* b);
  * code that it transforms.
  *
  */
-#if defined(DEBUG) && defined(ARCH_64)
-#include "erl_map.debug.ycf.h"
-#else
 #include "erl_map.ycf.h"
-#endif
 #define NOT_YCF_YIELDING_VERSION 1
 #define YCF_CONSUME_REDS(X) while(0){}
 

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -102,10 +102,8 @@ void ycf_debug_reset_stack_start(void) {
 void *ycf_debug_get_stack_start(void) {
     return erts_tsd_get(erts_ycf_debug_stack_start_tsd_key);
 }
-#include "utils.debug.ycf.h"
-#else
-#include "utils.ycf.h"
 #endif
+#include "utils.ycf.h"
 
 #if defined(DEBUG)
 # define IF_DEBUG(X) X


### PR DESCRIPTION
### Problem:
When building emulator with several targets, like
`$> make opt debug`
it could sometimes fail with corrupted generated files under `erts/emulator/$TARGET/`
as the result of interleaved output from parallel running make instances.

### Solution:
Store all generated files under the `erts/emulator/$TARGET/$TYPE/$FLAVOR/` specific directories.
