### PR TITLE
Improve the coverage of the compiler application

### DIFF
--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -338,8 +338,6 @@ format_type(#t_map{super_key=none,super_value=none}) ->
     "#{}";
 format_type(#t_map{super_key=K,super_value=V}) ->
     ["#{", format_type(K), "=>", format_type(V), "}"];
-format_type(number) ->
-    "number()";
 format_type(#t_float{elements=any}) ->
     "float()";
 format_type(#t_float{elements={X,X}}) ->
@@ -377,7 +375,7 @@ format_type(other) ->
 format_type(pid) ->
     "pid()";
 format_type(port) ->
-    "pid()";
+    "port()";
 format_type(reference) ->
     "reference()";
 format_type(identifier) ->

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -1475,8 +1475,8 @@ convert_ext(?BEAM_TYPES_VERSION_25, Types0) ->
                    true ->
                        true = 0 =/= (TypeBits0 band NumberMask), %Assertion.
                        TypeBits = TypeBits0 bor
-                           ?BEAM_TYPE_HAS_LOWER_BOUND bor
-                           ?BEAM_TYPE_HAS_UPPER_BOUND,
+                           ((?BEAM_TYPE_HAS_LOWER_BOUND bor
+                                 ?BEAM_TYPE_HAS_UPPER_BOUND) bsl 1),
                        <<TypeBits:16,Min:64/signed,Max:64/signed>>;
                    false ->
                        <<TypeBits0:16>>

--- a/lib/compiler/test/beam_block_SUITE.erl
+++ b/lib/compiler/test/beam_block_SUITE.erl
@@ -317,6 +317,10 @@ coverage(Config) ->
 
     {'EXIT',{badarg,_}} = catch coverage_4(a, b),
 
+    ~"true" = coverage_5(id(latin1), id(true)),
+    ~"true" = coverage_5(id(utf8), id(false)),
+    {'EXIT',{badarg,_}} = catch coverage_5(id(42), id(42)),
+
     ok.
 
 coverage_1() ->
@@ -346,6 +350,9 @@ coverage_4(A, B) ->
 
 do_coverage_4(_, _, _, _) ->
     ok.
+
+coverage_5(B, A) ->
+    atom_to_binary((A or A) == A, B).
 
 %%%
 %%% Common functions.

--- a/lib/compiler/test/beam_validator_SUITE.erl
+++ b/lib/compiler/test/beam_validator_SUITE.erl
@@ -43,7 +43,8 @@
          container_performance/1,
          infer_relops/1,
          not_equal_inference/1,bad_bin_unit/1,singleton_inference/1,
-         inert_update_type/1,range_inference/1]).
+         inert_update_type/1,range_inference/1,
+         bif_inference/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -80,7 +81,8 @@ groups() ->
        bs_saved_position_units,parent_container,
        container_performance,infer_relops,
        not_equal_inference,bad_bin_unit,singleton_inference,
-       inert_update_type,range_inference]}].
+       inert_update_type,range_inference,
+       bif_inference]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -1145,6 +1147,27 @@ range_inference_1(<<X/utf8>>) ->
         -2147483648 ->
             ok
     end.
+
+bif_inference(_Config) ->
+    ok = bif_inference_is_bitstring(id(<<>>), id(<<>>)),
+    error = bif_inference_is_bitstring(id(a), id(a)),
+
+    ok = bif_inference_is_function(id(fun id/1), id(fun id/1)),
+    ok = bif_inference_is_function(true, true),
+    error = bif_inference_is_function(id(fun id/1), a),
+    error = bif_inference_is_function(a, a),
+
+    ok.
+
+bif_inference_is_bitstring(A, A) when A andalso ok; is_bitstring(A) ->
+    ok;
+bif_inference_is_bitstring(_, _) ->
+    error.
+
+bif_inference_is_function(A, A)  when A orelse ok; is_function(A) ->
+    ok;
+bif_inference_is_function(_, _) ->
+    error.
 
 id(I) ->
     I.

--- a/lib/compiler/test/compilation_SUITE.erl
+++ b/lib/compiler/test/compilation_SUITE.erl
@@ -58,7 +58,8 @@
 	 vsn_1/1,
 	 vsn_2/1,
          vsn_3/1,
-         infinite_loop/0,infinite_loop/1]).
+         infinite_loop/0,infinite_loop/1,
+         use_nifs/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -86,7 +87,8 @@ groups() ->
        otp_5553,otp_5632,otp_5714,otp_5872,otp_6121,
        otp_7202,on_load,on_load_inline,
        string_table,otp_8949_a,split_cases,
-       infinite_loop]}].
+       infinite_loop,
+       use_nifs]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -137,6 +139,8 @@ end_per_group(_GroupName, Config) ->
 ?comp(otp_7202).
 ?comp(on_load).
 ?comp(on_load_inline).
+
+?comp(use_nifs).
 
 infinite_loop() -> [{timetrap,{minutes,1}}].
 ?comp(infinite_loop).
@@ -441,6 +445,5 @@ do_split_cases(A) ->
 	    a=b
     end,
     Z.
-
 
 id(I) -> I.

--- a/lib/compiler/test/compilation_SUITE_data/use_nifs.erl
+++ b/lib/compiler/test/compilation_SUITE_data/use_nifs.erl
@@ -1,0 +1,19 @@
+-module(use_nifs).
+-export([?MODULE/0,calculator_nif/0,id/1]).
+-nifs([calculator_nif/0]).
+
+?MODULE() ->
+    case id(false) of
+        true ->
+            erlang:load_nif("my_nif", 42),
+            calculator_nif();
+        false ->
+            ok
+    end,
+    ok.
+
+calculator_nif() ->
+    erlang:nif_error(undef).
+
+id(I) ->
+    I.

--- a/lib/compiler/test/guard_SUITE.erl
+++ b/lib/compiler/test/guard_SUITE.erl
@@ -129,6 +129,8 @@ misc(Config) when is_list(Config) ->
     error = if abs(Zero > One) -> ok; true -> error end,
     ok = if is_integer(Zero) >= is_integer(One) -> ok end,
 
+    {'EXIT',{function_clause,_}} = catch misc_4(),
+
     ok.
 
 misc_1([{W},{X},{Y},{Z}]) ->
@@ -149,6 +151,9 @@ misc_3(LenUp, LenDw) ->
 	LenUp >= 1 orelse ((LenDw >= 2) xor true) -> true;
 	true -> false
     end.
+
+misc_4() when <<(is_atom((#{} #{ ok := ok })) orelse <<>>)/bytes>> >= ok ->
+    ok.
 
 get_data({o,Active,Raw}, BytesToRead, Buffer) 
   when Raw =:= raw; Raw =:= 0 ->
@@ -3143,6 +3148,18 @@ beam_ssa_bool_coverage() ->
     error = beam_ssa_bool_coverage_3(42),
     error = beam_ssa_bool_coverage_3(a),
 
+    error = beam_ssa_bool_coverage_4(42, 42),
+    error = beam_ssa_bool_coverage_4(ok, ok),
+    error = beam_ssa_bool_coverage_4(a, b),
+
+    ok = beam_ssa_bool_coverage_5(ok),
+    ok = beam_ssa_bool_coverage_5(2.0),
+    ok = beam_ssa_bool_coverage_5(42),
+
+    ok = beam_ssa_bool_coverage_6(<<>>),
+    error = beam_ssa_bool_coverage_6(a),
+    error = beam_ssa_bool_coverage_6(42),
+
     ok.
 
 collect_modifiers([H | T], Buffer)
@@ -3166,6 +3183,35 @@ beam_ssa_bool_coverage_3(A) when ok; ((ok =< A + 1) or false) and true orelse ok
     ok;
 beam_ssa_bool_coverage_3(_) ->
     error.
+
+beam_ssa_bool_coverage_4(A, A) when ok == A andalso ok ->
+    ok;
+beam_ssa_bool_coverage_4(_, _) ->
+    error.
+
+beam_ssa_bool_coverage_5(A) ->
+    maybe
+        case case maybe ok end of
+                 2.0 ->
+                     false;
+                 A ->
+                     true;
+                 _ ->
+                     true
+             end of
+            true ->
+                ok;
+            _ ->
+                error
+        end
+    end.
+
+beam_ssa_bool_coverage_6(A) when is_bitstring(A) orelse ok;
+                                 is_bitstring(A) andalso ok bsr ok ->
+    ok;
+beam_ssa_bool_coverage_6(_) ->
+    error.
+
 
 gh_6164() ->
     true = do_gh_6164(id([])),


### PR DESCRIPTION
This pull request extends the test suite for the compiler application to cover more lines. Most of the added tests were found with the help of [erlfuzz](https://github.com/WhatsApp/erlfuzz).

In addition, minor bugs in the pretty-printing of SSA code and the BEAM disassembler were fixed.
