### PR TITLE
erts: Read child cgroup instead of root when using cgroup v2

### DIFF
--- a/erts/lib_src/common/erl_misc_utils.c
+++ b/erts/lib_src/common/erl_misc_utils.c
@@ -1289,6 +1289,8 @@ read_cpu_quota(int limit)
             free((void*)cgroup_path);
             return calculate_cpu_quota(limit, cfs_quota_us, cfs_period_us);
         }
+
+        free((void*)cgroup_path);
         break;
     default:
         break;

--- a/erts/lib_src/common/erl_misc_utils.c
+++ b/erts/lib_src/common/erl_misc_utils.c
@@ -1126,7 +1126,7 @@ get_cgroup_path(const char *controller, const char **path) {
          * This fails if any of the fs options contain a hyphen, but this is
          * not likely to happen on a cgroup, so we just skip such lines. */
         if (sscanf(line_buf,
-                   "%*d %*d %*d:%*d %4095s %4095s %*s %*[^-]- "
+                   "%*d %*d %*d:%*d %4095s %4095s %*s%*[^-]- "
                    "%63s %*s %511[^\n]\n",
                    root_path, mount_path,
                    fs_type, fs_flags) != 4) {


### PR DESCRIPTION
Fixes #7928