### PR TITLE
Improve supervisor restart calculation

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -456,11 +456,14 @@ see more details [above](`m:supervisor#sup_flags`).
 		intensity = 1          :: non_neg_integer(),
 		period    = 5          :: pos_integer(),
 		restarts = [],
+                nrestarts = 0,
 		dynamic_restarts = 0   :: non_neg_integer(),
 		auto_shutdown = never  :: auto_shutdown(),
 	        module,
 	        args}).
 -type state() :: #state{}.
+
+-define(DIRTY_RESTART_LIMIT, 1000).
 
 -define(is_simple(State), State#state.strategy =:= simple_one_for_one).
 -define(is_temporary(_Child_), _Child_#child.restart_type=:=temporary).
@@ -2064,27 +2067,39 @@ child_to_spec(#child{id = Id,
 %%% Returns: {ok, State'} | {terminate, State'}
 %%% ------------------------------------------------------
 
-add_restart(State) ->  
-    I = State#state.intensity,
-    P = State#state.period,
-    R = State#state.restarts,
-    Now = erlang:monotonic_time(1),
-    R1 = add_restart(R, Now, P),
-    State1 = State#state{restarts = R1},
-    case length(R1) of
-	CurI when CurI  =< I ->
-	    {ok, State1};
-	_ ->
-	    {terminate, State1}
+%% shortcut: if the intensity limit is 0, no restarts are allowed;
+%% it is safe to disallow the restart flat out
+add_restart(State=#state{intensity=0}) -> 
+    {terminate, State};
+%% shortcut: if the number of restarts is below the intensity
+%% limit, it is safe to allow the restart, add the restart to
+%% the list and not care about expired restarts; to prevent
+%% accumulating a large list of expired restarts over time,
+%% this shortcut is limited to ?DIRTY_RESTART_LIMIT restarts
+add_restart(State=#state{intensity=I, restarts=R, nrestarts=NR})
+  when NR < min(I, ?DIRTY_RESTART_LIMIT) ->
+    {ok, State#state{restarts=[erlang:monotonic_time(second)|R], nrestarts=NR + 1}};
+%% calculate the real number of restarts within the period
+%% and remove expired restarts; based on the calculated number
+%% of restarts, allow or disallow the restart
+add_restart(State=#state{intensity=I, period=P, restarts=R}) ->  
+    Now = erlang:monotonic_time(second),
+    Treshold = Now - P,
+    case can_restart(I - 1, Treshold, R, [], 0) of
+        {true, NR1, R1} ->
+            {ok, State#state{restarts = [Now|R1], nrestarts = NR1 + 1}};
+        {false, NR1, R1} ->
+            {terminate, State#state{restarts = R1, nrestarts = NR1}}
     end.
 
-add_restart(Restarts0, Now, Period) ->
-    Threshold = Now - Period,
-    Restarts1 = lists:takewhile(
-                  fun (R) -> R >= Threshold end,
-                  Restarts0
-                 ),
-    [Now | Restarts1].
+can_restart(_, _, [], Acc, NR) ->
+    {true, NR, lists:reverse(Acc)};
+can_restart(_, Treshold, [Restart|_], Acc, NR) when Restart < Treshold ->
+    {true, NR, lists:reverse(Acc)};
+can_restart(0, _, [_|_], Acc, NR) ->
+    {false, NR, lists:reverse(Acc)};
+can_restart(N, Treshold, [Restart|Restarts], Acc, NR) ->
+    can_restart(N - 1, Treshold, Restarts, [Restart|Acc], NR + 1).
 
 %%% ------------------------------------------------------
 %%% Error and progress reporting.


### PR DESCRIPTION
Before restarting a child, a supervisor must check if the restart limit is reached. This adds a penalty to the overall restart time, which should be kept low.

The current implementation does this check by traversing the list of restarts in order to filter out those that have expired. Then it essentially traverses the result list via `length` in order to check if it is over the intensity limit. This behavior is `2*O(n)` (?), with `n` being the number of past restarts within the period.

This PR introduces two optimizations:
* it checks whether the restart limit is reached _while_ it is traversing the restart list in order to remove expired restarts, thereby eliminating the need for an additional traversal via the call to `length`. Depending on the outcome, a restart is either allowed or disallowed. This behavior is `O(n)`.
* it sidesteps the need to perform the step above by keeping a separate counter for restarts; as long as that counter is below the intensity value, it is safe to allow the restart, add the restart to the list, and increment the counter. This behavior is `O(1)`.

  Only when the counter reaches the intensity limit, the actual number of restarts within the given period must be calculated via the step above; if the restart is allowed, the restart list is updated and the counter set to the according value.

  _(Over time, this may lead to a large list of accumulated expired restarts being carried around. For this reason, the counter is limited not by the intensity value alone but rather by the minimum of the intensity value and a hardcoded limit. By gut feeling, I picked 1000)_