### PR TITLE
crypto: Remove incorrect configure check for FIPS_mode_set

### DIFF
--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -7486,38 +7486,8 @@ then :
 then :
   as_fn_error $? "FIPS support requested, but no crypto library found" "$LINENO" 5
 fi
-          saveCFLAGS="$CFLAGS"
-          saveLDFLAGS="$LDFLAGS"
-          saveLIBS="$LIBS"
-          CFLAGS="$DED_BASIC_CFLAGS $SSL_INCLUDE"
-          if test $SSL_DYNAMIC_ONLY = yes
-then :
-
-                    LDFLAGS="$DED_LDFLAGS_CONFTEST $ded_ld_rpath -L$SSL_LIBDIR"
-                    LIBS="$LIBS -l$SSL_CRYPTO_LIBNAME $SSL_EXTRA_LIBS"
-
-else $as_nop
-
-                    LDFLAGS="$DED_LDFLAGS_CONFTEST"
-                    if test "$host_os" = "win32"
-then :
-  LIBS="$LIBS $SSL_LIBDIR/$SSL_CRYPTO_LIBNAME.lib $SSL_EXTRA_LIBS"
-else $as_nop
-  LIBS="$LIBS $SSL_LIBDIR/lib$SSL_CRYPTO_LIBNAME.a $SSL_EXTRA_LIBS"
-fi
-
-fi
-          ac_fn_c_check_func "$LINENO" "FIPS_mode_set" "ac_cv_func_FIPS_mode_set"
-if test "x$ac_cv_func_FIPS_mode_set" = xyes
-then :
-  SSL_FLAGS="-DFIPS_SUPPORT"
-else $as_nop
-  as_fn_error $? "FIPS support requested, but cannot be enabled" "$LINENO" 5
-fi
-
-          CFLAGS="$saveCFLAGS"
-          LDFLAGS="$saveLDFLAGS"
-          LIBS="$saveLIBS"
+          # Insert check for FIPS support here
+          SSL_FLAGS="-DFIPS_SUPPORT"
 
 fi
 

--- a/lib/crypto/configure.ac
+++ b/lib/crypto/configure.ac
@@ -861,27 +861,8 @@ AS_IF([test "$enable_fips_support" = "yes"],
       [
           AS_IF([test "$CRYPTO_APP" = ""],
                 [AC_MSG_ERROR([FIPS support requested, but no crypto library found])])
-          saveCFLAGS="$CFLAGS"
-          saveLDFLAGS="$LDFLAGS"
-          saveLIBS="$LIBS"
-          CFLAGS="$DED_BASIC_CFLAGS $SSL_INCLUDE"
-          AS_IF([test $SSL_DYNAMIC_ONLY = yes],
-                [
-                    LDFLAGS="$DED_LDFLAGS_CONFTEST $ded_ld_rpath -L$SSL_LIBDIR"
-                    LIBS="$LIBS -l$SSL_CRYPTO_LIBNAME $SSL_EXTRA_LIBS"
-                ],
-                [
-                    LDFLAGS="$DED_LDFLAGS_CONFTEST"
-                    AS_IF([test "$host_os" = "win32"],
-                          [LIBS="$LIBS $SSL_LIBDIR/$SSL_CRYPTO_LIBNAME.lib $SSL_EXTRA_LIBS"],
-                          [LIBS="$LIBS $SSL_LIBDIR/lib$SSL_CRYPTO_LIBNAME.a $SSL_EXTRA_LIBS"])
-                ])
-          AC_CHECK_FUNC([FIPS_mode_set],
-                        [SSL_FLAGS="-DFIPS_SUPPORT"],
-                        [AC_MSG_ERROR([FIPS support requested, but cannot be enabled])])
-          CFLAGS="$saveCFLAGS"
-          LDFLAGS="$saveLDFLAGS"
-          LIBS="$saveLIBS"
+          # Insert check for FIPS support here
+          SSL_FLAGS="-DFIPS_SUPPORT"
       ])
 
 AS_IF([test "x$v3_include" = "xyes"],


### PR DESCRIPTION
Fix #8271

* `FIPS_mode_set` does not exists since OpenSSL 3.x

* The configure check with `AC_CHECK_FUNC` for `FIPS_mode_set` succeeds anyway on Linux as compiler accepts implicit declaration (with only a warning) and linker accepts undefined symbols as we build a shared lib.

* Checking for `FIPS_mode_set` was pointless as it was available even for non-fips builds of OpenSSL 1.x


On MacOS however, the check "works" and thereby hinders building Erlang/OTP with `--enabled-fips` for OpenSSL 3.x.