### PR TITLE
[erts|inet-drv] Fixed add-membership

### DIFF
--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -153,6 +153,7 @@ open(Port) ->
       Reason :: system_limit | inet:posix().
 
 open(Port, Opts0) ->
+    %% ?DBG(['entry', {port, Port}, {opts0, Opts0}]),
     case inet:gen_udp_module(Opts0) of
 	{?MODULE, Opts} ->
 	    open1(Port, Opts);
@@ -161,8 +162,11 @@ open(Port, Opts0) ->
     end.
 
 open1(Port, Opts0) ->
+    %% ?DBG(['entry', {port, Port}, {opts0, Opts0}]),
     {Mod, Opts} = inet:udp_module(Opts0),
+    %% ?DBG([{mod, Mod}, {opts, Opts}]),
     {ok, UP} = Mod:getserv(Port),
+    %% ?DBG([{up, UP}]),
     Mod:open(UP, Opts).
     
 

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -1901,6 +1901,7 @@ open_opts(Fd_or_OpenOpts, BAddr, BPort, Opts, Protocol, Family, Type, Module) ->
 	end,
     case prim_inet:open(Protocol, Family, Type, OpenOpts) of
 	{ok,S} ->
+            %% ?DBG(['prim_inet:open', {s, S}]),
             open_setopts(S, BAddr, BPort, Opts, Module);
         Error ->
             Error
@@ -1910,13 +1911,14 @@ open_opts(Fd_or_OpenOpts, BAddr, BPort, Opts, Protocol, Family, Type, Module) ->
 %%
 open_setopts(S, BAddr, BPort, Opts, Module) ->
     %% ?DBG([{s, S}, {baddr, BAddr}, {bport, BPort}, {opts, Opts}, {mod, Module}]),
+    %% ok = prim_inet:setopts(S, [{debug, true}]),
     case prim_inet:setopts(S, Opts) of
         ok when BAddr =:= undefined ->
-            %% ?DBG("register socket"),
+            %% ?DBG("ok -> register socket"),
             inet_db:register_socket(S, Module),
             {ok,S};
         ok ->
-            %% ?DBG("try bind"),
+            %% ?DBG("ok -> try bind"),
             try bind(S, BAddr, BPort) of
                 {ok, _} ->
                     %% ?DBG("bound"),
@@ -1933,7 +1935,7 @@ open_setopts(S, BAddr, BPort, Opts, Module) ->
                     erlang:raise(BC, BE, BS)
             end;
         Error  ->
-            %% ?DBG(["setopts error", {error, Error}]),
+            %% ?DBG(["error", {error, Error}]),
             prim_inet:close(S),
             Error
     end.

--- a/lib/kernel/src/inet6_udp.erl
+++ b/lib/kernel/src/inet6_udp.erl
@@ -33,6 +33,8 @@
 -define(TYPE,   dgram).
 
 
+%% -define(DBG(T), erlang:display({{self(), ?MODULE, ?LINE, ?FUNCTION_NAME}, T})).
+
 %% inet_udp port lookup
 getserv(Port) when is_integer(Port) -> {ok, Port};
 getserv(Name) when is_atom(Name) -> inet:getservbyname(Name, ?PROTO).
@@ -49,6 +51,7 @@ open(Port) -> open(Port, []).
 
 -spec open(_, _) -> {ok, port()} | {error, atom()}.
 open(Port, Opts) ->
+    %% ?DBG(['entry', {port, Port}, {opts, Opts}]),
     case inet:udp_options(
 	   [{port,Port} | Opts],
 	   ?MODULE) of
@@ -62,6 +65,10 @@ open(Port, Opts) ->
           when is_map(BAddr); % sockaddr_in()
                ?port(BPort), ?ip6(BAddr);
                ?port(BPort), BAddr =:= undefined ->
+            %% ?DBG(['udp-options',
+            %%       {fd, Fd},
+            %%       {baddr, BAddr}, {bport, BPort},
+            %%       {sock_opts, SockOpts}]),
 	    inet:open_bind(
 	      Fd, BAddr, BPort, SockOpts, ?PROTO, ?FAMILY, ?TYPE, ?MODULE);
 	{ok, _} -> exit(badarg)


### PR DESCRIPTION
Fixed a (probable) copy-and-paste bug for the option add_membership. When domain = inet6 it used drop_membership type instead.