### PR TITLE
docs: update book links

### DIFF
--- a/system/doc/top/templates/index.html.src
+++ b/system/doc/top/templates/index.html.src
@@ -146,10 +146,10 @@ In addition to the documentation here Erlang is described in several books like:
 <a href="https://www.nostarch.com/erlang">"Learn You Some Erlang for Great Good!"</a> from No Starch Press.
 </li>
 <li>
-<a href="https://oreilly.com/catalog/9780596518189">"Erlang Programming"</a> from O'Reilly.
+<a href="https://www.oreilly.com/library/view/erlang-programming/9780596803940">"Erlang Programming"</a> from O'Reilly.
 </li>
 <li>
-<a href="https://www.pragprog.com/book/jaerlang2/programming-erlang">"Programming Erlang"</a> from Pragmatic.
+<a href="https://www.pragprog.com/titles/jaerlang2/programming-erlang-2nd-edition/">"Programming Erlang"</a> from Pragmatic.
 </li>
 <li>
 <a href="https://www.manning.com/logan">"Erlang and OTP in Action"</a> from Manning.


### PR DESCRIPTION
- fixes links to "Erlang Programming" and "Programming Erlang" books