### PR TITLE
ssh: start monitor ConnPid before casting socket_control

### DIFF
--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -129,12 +129,13 @@ takeover(ConnPid, _, Socket, Options) ->
     {_, Callback, _} = ?GET_OPT(transport, Options),
     case Callback:controlling_process(Socket, ConnPid) of
         ok ->
+            Ref = erlang:monitor(process, ConnPid),
             gen_statem:cast(ConnPid, socket_control),
             NegTimeout = ?GET_INTERNAL_OPT(negotiation_timeout,
                                            Options,
                                            ?GET_OPT(negotiation_timeout, Options)
                                           ),
-            handshake(ConnPid, erlang:monitor(process,ConnPid), NegTimeout);
+            handshake(ConnPid, Ref, NegTimeout);
         {error, Reason}	->
             {error, Reason}
     end.


### PR DESCRIPTION
We should start monitoring ConnPid before `gen_statem:cast(ConnPid, socket_control)`. It's possible that ConnPid is closed when handling the `socket_control` cast. If we are unlucky, ConnPid is closed before we start monitoring leading to a `noproc` being returned from the monitor instead of the actual error. 

I had a planned to write a small unit test to test my changes but without meck it will be difficult..