### PR TITLE
Fix failing test

### DIFF
--- a/lib/ssl/src/dtls_gen_connection.erl
+++ b/lib/ssl/src/dtls_gen_connection.erl
@@ -417,7 +417,9 @@ handle_protocol_record(#ssl_tls{type = ?APPLICATION_DATA, fragment = Data}, Stat
                 {next_state, StateName, State} ->
                     ssl_gen_statem:hibernate_after(StateName, State, []);
                 {next_state, StateName, State, Actions} ->
-                    ssl_gen_statem:hibernate_after(StateName, State, Actions)
+                    ssl_gen_statem:hibernate_after(StateName, State, Actions);
+                {stop, _, _} = Stop ->
+                    Stop
             end
     end;
 %%% DTLS record protocol level handshake messages 
@@ -531,7 +533,9 @@ handle_state_timeout(flight_retransmission_timeout, StateName,
             {repeat_state, State#state{protocol_specific = PS}, Actions};
         {next_state, StateName, #state{protocol_specific = PS0} = State} ->
             PS = PS0#{flight_state => {retransmit, new_timeout(CurrentTimeout)}},
-            {repeat_state, State#state{protocol_specific = PS}}
+            {repeat_state, State#state{protocol_specific = PS}};
+        {stop, _, _} = Stop ->
+            Stop
     end.
 
 send_handshake(Handshake, #state{connection_states = ConnectionStates} = State) ->

--- a/lib/ssl/src/dtls_packet_demux.erl
+++ b/lib/ssl/src/dtls_packet_demux.erl
@@ -149,9 +149,9 @@ handle_call(sockname, _, #state{listener = Socket} = State) ->
 handle_call(close, _, State0) ->
     case do_close(State0) of
         {stop, State} ->
-            {stop, normal, ok, State};
+            {stop, normal, stop, State};
         {wait, State} ->
-            {reply, ok, State}
+            {reply, waiting, State}
     end;
 handle_call({new_owner, Owner}, _, State) ->
     {reply, ok,  State#state{close = false, first = true, owner = Owner}};

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2240,7 +2240,7 @@ handshake_cancel(Socket) ->
 close(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
     ssl_gen_statem:close(Pid, {close, ?DEFAULT_TIMEOUT});
 close(#sslsocket{pid = {dtls, #config{dtls_handler = {_, _}}}} = DTLSListen) ->
-    dtls_socket:close(DTLSListen);
+    dtls_socket:close_listen(DTLSListen, ?DEFAULT_TIMEOUT);
 close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}) ->
     Transport:close(ListenSocket).
 
@@ -2276,8 +2276,9 @@ close(#sslsocket{pid = [TLSPid|_]}, {Pid, Timeout} = DownGrade)
 close(#sslsocket{pid = [TLSPid|_]}, Timeout)
   when is_pid(TLSPid), ?IS_TIMEOUT(Timeout) ->
     ssl_gen_statem:close(TLSPid, {close, Timeout});
-close(#sslsocket{pid = {dtls, #config{dtls_handler = {_, _}}}} = DTLSListen, _) ->
-    dtls_socket:close(DTLSListen);
+close(#sslsocket{pid = {dtls, #config{dtls_handler = {_, _}}}} = DTLSListen, Timeout)
+  when ?IS_TIMEOUT(Timeout) ->
+    dtls_socket:close_listen(DTLSListen, Timeout);
 close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
     tls_socket:close(Transport, ListenSocket).
 

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -195,7 +195,7 @@ init_per_suite(Config0) ->
 	    ssl_test_lib:clean_start(),
 	    Config1 = ssl_test_lib:make_rsa_cert_with_protected_keyfile(Config0,
                                                                         ?CORRECT_PASSWORD),
-            ssl_test_lib:make_dsa_cert(Config1)
+            ssl_test_lib:make_ecdsa_cert(Config1)
     catch _:_ ->
 	    {skip, "Crypto did not start"}
     end.
@@ -300,16 +300,16 @@ tls_upgrade_new_opts_with_sni_fun() ->
 tls_upgrade_new_opts_with_sni_fun(Config) when is_list(Config) ->
     ClientOpts = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
     ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
-    ServerDsaOpts = ssl_test_lib:ssl_options(server_dsa_opts, Config),
+    ServerEcdsaOpts = ssl_test_lib:ssl_options(server_ecdsa_opts, Config),
     {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
     TcpOpts = [binary, {reuseaddr, true}],
     Version = ssl_test_lib:protocol_version(Config),
     NewVersions = new_versions(Version),
-    Ciphers =  ssl:filter_cipher_suites(ssl:cipher_suites(all, Version),
-                                        [{key_exchange, fun(srp_rsa) -> false;
-                                                           (srp_dss) -> false;
-                                                           (_) -> true
-                                                        end}]),
+    Ciphers = ssl:filter_cipher_suites(ssl:cipher_suites(all, Version),
+                                       [{key_exchange, fun(srp_rsa) -> false;
+                                                          (srp_dss) -> false;
+                                                          (_) -> true
+                                                       end}]),
 
     NewOpts = [{versions, NewVersions},
                {ciphers, Ciphers},
@@ -323,7 +323,7 @@ tls_upgrade_new_opts_with_sni_fun(Config) when is_list(Config) ->
                  [{active, false} | TcpOpts]},
                 {ssl_options, [{versions, [Version |NewVersions]},
                                {sni_fun, fun(_SNI) -> ServerOpts ++ NewOpts end}
-                              | ServerDsaOpts]}]),
+                              | ServerEcdsaOpts]}]),
     Port = ssl_test_lib:inet_port(Server),
     Client = ssl_test_lib:start_upgrade_client(
                [{node, ClientNode},


### PR DESCRIPTION
DSA is not available on OpenBSD, which causes the testcase to fail, so use ECDSA certs instead.