### PR TITLE
`inet_res`: relax RD flag query/response check

### DIFF
--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -1124,7 +1124,7 @@ decode_answer_noerror(
             {error,badid};
         H#dns_header.qr     =/= true;
         H#dns_header.opcode =/= Q_H#dns_header.opcode;
-        H#dns_header.rd     =/= Q_H#dns_header.rd ->
+        H#dns_header.rd andalso not Q_H#dns_header.rd ->
             {error,{unknown,Msg}};
         true ->
             case QDList of


### PR DESCRIPTION
Fixes #8303, as suggested by @Maria-12648430.

[Section 3.1.3](https://datatracker.ietf.org/doc/html/rfc8906#section-3.1.3) of [RFC 8906](https://datatracker.ietf.org/doc/html/rfc8906) suggests that DNS servers that do not understand a flag should not copy it to the response. Further, section [3.1.3.1](https://datatracker.ietf.org/doc/html/rfc8906#section-3.1.3.1) suggests that non-recursive servers should respond as if the RD flag was not set.