### PR TITLE
erts: send port exit status when process eofs without exiting on Windows

### DIFF
--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -5443,8 +5443,6 @@ receive_replies(ReqId, N, Acc) ->
               do (that is, 128+signal).</p>
             <p>If option <c>eof</c> is specified also, the messages <c>eof</c>
               and <c>exit_status</c> appear in an unspecified order.</p>
-            <p>If the port program closes its <c>stdout</c> without exiting,
-              option <c>exit_status</c> does not work.</p>
           </item>
           <tag><c>use_stdio</c></tag>
           <item>

--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -883,6 +883,14 @@ set_driver_data(DriverData* dp, HANDLE ifd, HANDLE ofd, int read_write, int repo
 			       ERL_DRV_WRITE|ERL_DRV_USE, 1);
 	ASSERT(result != -1);
     }
+
+    /* Get "input" from process handle when it exits. */
+    if (dp->report_exit && dp->port_pid != INVALID_HANDLE_VALUE) {
+	result = driver_select(dp->port_num, (ErlDrvEvent)dp->port_pid,
+			       ERL_DRV_READ|ERL_DRV_USE, 1);
+	ASSERT(result != -1);
+    }
+
     return (ErlDrvData) dp;
 }
 
@@ -2290,6 +2298,11 @@ stop(ErlDrvData data)
 			     (ErlDrvEvent)dp->out.ov.hEvent,
 			     ERL_DRV_WRITE|ERL_DRV_USE_NO_CALLBACK, 0);
     }    
+    if (dp->report_exit) {
+	(void) driver_select(dp->port_num,
+			     (ErlDrvEvent)dp->port_pid,
+			     ERL_DRV_READ|ERL_DRV_USE_NO_CALLBACK, 0);
+    }
 
     if (dp->out.thread == (HANDLE) -1 && dp->in.thread == (HANDLE) -1) {
 	release_driver_data(dp);
@@ -2542,11 +2555,45 @@ ready_input(ErlDrvData drv_data, ErlDrvEvent ready_event)
     DriverData* dp = (DriverData *) drv_data;
     int pb;
 
+    DEBUGF(("ready_input: dp %p, event 0x%x\n", dp, ready_event));
+
+    /*
+     * Port process exit.
+     */
+
+    if (ready_event == (ErlDrvEvent) dp->port_pid) {
+	DWORD exitcode;
+
+	if (GetExitCodeProcess(dp->port_pid, &exitcode)) {
+	    ASSERT(exitcode != STILL_ACTIVE);
+	    driver_report_exit(dp->port_num, exitcode);
+	}
+
+	{
+	    erts_aint32_t state;
+	    Port *prt = erts_drvport2port_state(dp->port_num, &state);
+
+	    /*
+	     * Stop polling process handle, otherwise we'll still
+	     * get "input" from it.
+	     */
+
+	    if (prt != ERTS_INVALID_ERL_DRV_PORT &&
+		(state & ERTS_PORT_SFLG_SOFT_EOF)) {
+		(void) driver_select(dp->port_num,
+				     (ErlDrvEvent)dp->port_pid,
+				     ERL_DRV_READ|ERL_DRV_USE_NO_CALLBACK, 0);
+	    }
+	}
+
+	driver_failure_eof(dp->port_num);
+	return;
+    }
+
     pb = dp->packet_bytes;
     if(dp->in.thread == (HANDLE) -1) {
 	dp->in.async_io_active = 0;
     }
-    DEBUGF(("ready_input: dp %p, event 0x%x\n", dp, ready_event));
 
     /*
      * Evaluate the result of the overlapped read.
@@ -2682,15 +2729,9 @@ ready_input(ErlDrvData drv_data, ErlDrvEvent ready_event)
     } else {
 	DEBUGF(("ready_input(): error: %s\n", win32_errorstr(error)));
 	if (error == ERROR_BROKEN_PIPE || error == ERROR_HANDLE_EOF) {
-	    /* Maybe check exit status */
-	    if (dp->report_exit) {
-		DWORD exitcode;
-		if (GetExitCodeProcess(dp->port_pid, &exitcode) &&
-		    exitcode != STILL_ACTIVE) {
-		    driver_report_exit(dp->port_num, exitcode);
-		}
-	    }
-	    driver_failure_eof(dp->port_num);
+	    /* Don't repeat this call when reporting exit. */
+	    if (!dp->report_exit || dp->port_pid == INVALID_HANDLE_VALUE)
+		driver_failure_eof(dp->port_num);
 	} else {			/* Report real errors. */
 	    int error = GetLastError();
 


### PR DESCRIPTION
Fixes #8317, working on Windows 11, I will try to test it on older Windows versions.

Successfully compiles the latest Elixir version on Cygwin, and also normally compiles, tests and starts an Elixir application on Cygwin, since it fixes https://github.com/elixir-lang/elixir/issues/13449.