### PR TITLE
STDLIB: Slightly reduce code size by using binary string literals

### DIFF
--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -295,61 +295,71 @@ warning. This function is usually called implicitly when processing an
 -spec format_error(ErrorDescriptor) -> io_lib:chars() when
       ErrorDescriptor :: term().
 
-format_error(cannot_parse) ->
-    io_lib:format("cannot parse file, giving up", []);
-format_error({bad,W}) ->
-    io_lib:format("badly formed '~s'", [W]);
-format_error({duplicated_argument, Arg}) ->
-    io_lib:format("argument '~ts' already used", [Arg]);
-format_error(missing_parenthesis) ->
-    io_lib:format("badly formed define: missing closing right parenthesis",[]);
-format_error(missing_comma) ->
-    io_lib:format("badly formed define: missing comma",[]);
-format_error(premature_end) ->
-    "premature end";
-format_error({call,What}) ->
-    io_lib:format("illegal macro call '~ts'",[What]);
-format_error({undefined,M,none}) ->
-    io_lib:format("undefined macro '~ts'", [M]);
-format_error({undefined,M,A}) ->
-    io_lib:format("undefined macro '~ts/~p'", [M,A]);
-format_error({depth,What}) ->
-    io_lib:format("~s too deep",[What]);
-format_error({mismatch,M}) ->
-    io_lib:format("argument mismatch for macro '~ts'", [M]);
-format_error({arg_error,M}) ->
-    io_lib:format("badly formed argument for macro '~ts'", [M]);
-format_error({redefine,M}) ->
-    io_lib:format("redefining macro '~ts'", [M]);
-format_error({redefine_predef,M}) ->
-    io_lib:format("redefining predefined macro '~s'", [M]);
-format_error({circular,M,none}) ->
-    io_lib:format("circular macro '~ts'", [M]);
-format_error({circular,M,A}) ->
-    io_lib:format("circular macro '~ts/~p'", [M,A]);
-format_error({include,W,F}) ->
-    io_lib:format("can't find include ~s \"~ts\"", [W,F]);
-format_error({Tag, invalid, Alternative}) when Tag =:= moduledoc; Tag =:= doc ->
-    io_lib:format("invalid ~s tag, only ~s allowed", [Tag, Alternative]);
-format_error({Tag, W, Filename}) when Tag =:= moduledoc; Tag =:= doc ->
-    io_lib:format("can't find ~s ~s \"~ts\"", [Tag, W, Filename]);
-format_error({illegal,How,What}) ->
-    io_lib:format("~s '-~s'", [How,What]);
-format_error({illegal_function,Macro}) ->
-    io_lib:format("?~s can only be used within a function", [Macro]);
-format_error({illegal_function_usage,Macro}) ->
-    io_lib:format("?~s must not begin a form", [Macro]);
-format_error(elif_after_else) ->
+format_error(Error) ->
+    case format_error_1(Error) of
+        {Format, Args} when is_list(Args) ->
+            io_lib:format(Format, Args);
+        Bin when is_binary(Bin) ->
+            unicode:characters_to_list(Bin);
+        List when is_list(List) ->
+            List
+    end.
+
+format_error_1(cannot_parse) ->
+    ~"cannot parse file, giving up";
+format_error_1({bad,W}) ->
+    {~"badly formed '~s'", [W]};
+format_error_1({duplicated_argument, Arg}) ->
+    {~"argument '~ts' already used", [Arg]};
+format_error_1(missing_parenthesis) ->
+    {~"badly formed define: missing closing right parenthesis",[]};
+format_error_1(missing_comma) ->
+    ~"badly formed define: missing comma";
+format_error_1(premature_end) ->
+    ~"premature end";
+format_error_1({call,What}) ->
+    {~"illegal macro call '~ts'",[What]};
+format_error_1({undefined,M,none}) ->
+    {~"undefined macro '~ts'", [M]};
+format_error_1({undefined,M,A}) ->
+    {~"undefined macro '~ts/~p'", [M,A]};
+format_error_1({depth,What}) ->
+    {~"~s too deep",[What]};
+format_error_1({mismatch,M}) ->
+    {~"argument mismatch for macro '~ts'", [M]};
+format_error_1({arg_error,M}) ->
+    {~"badly formed argument for macro '~ts'", [M]};
+format_error_1({redefine,M}) ->
+    {~"redefining macro '~ts'", [M]};
+format_error_1({redefine_predef,M}) ->
+    {~"redefining predefined macro '~s'", [M]};
+format_error_1({circular,M,none}) ->
+    {~"circular macro '~ts'", [M]};
+format_error_1({circular,M,A}) ->
+    {~"circular macro '~ts/~p'", [M,A]};
+format_error_1({include,W,F}) ->
+    {~"can't find include ~s \"~ts\"", [W,F]};
+format_error_1({Tag, invalid, Alternative}) when Tag =:= moduledoc; Tag =:= doc ->
+    {~"invalid ~s tag, only ~s allowed", [Tag, Alternative]};
+format_error_1({Tag, W, Filename}) when Tag =:= moduledoc; Tag =:= doc ->
+    {~"can't find ~s ~s \"~ts\"", [Tag, W, Filename]};
+format_error_1({illegal,How,What}) ->
+    {~"~s '-~s'", [How,What]};
+format_error_1({illegal_function,Macro}) ->
+    {~"?~s can only be used within a function", [Macro]};
+format_error_1({illegal_function_usage,Macro}) ->
+    {~"?~s must not begin a form", [Macro]};
+format_error_1(elif_after_else) ->
     "'elif' following 'else'";
-format_error({'NYI',What}) ->
-    io_lib:format("not yet implemented '~s'", [What]);
-format_error({error,Term}) ->
-    io_lib:format("-error(~tp).", [Term]);
-format_error({warning,Term}) ->
-    io_lib:format("-warning(~tp).", [Term]);
-format_error(ftr_after_prefix) ->
-    "feature directive not allowed after exports or record definitions";
-format_error(E) -> file:format_error(E).
+format_error_1({'NYI',What}) ->
+    {~"not yet implemented '~s'", [What]};
+format_error_1({error,Term}) ->
+    {~"-error(~tp).", [Term]};
+format_error_1({warning,Term}) ->
+    {~"-warning(~tp).", [Term]};
+format_error_1(ftr_after_prefix) ->
+    ~"feature directive not allowed after exports or record definitions";
+format_error_1(E) -> file:format_error(E).
 
 -doc """
 Preprocesses an Erlang source file returning a list of the lists of raw tokens

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -244,325 +244,345 @@ warning. This function is usually called implicitly when processing an
 -spec format_error(ErrorDescriptor) -> io_lib:chars() when
       ErrorDescriptor :: error_description().
 
-format_error(undefined_module) ->
-    "no module definition";
-format_error(redefine_module) ->
-    "redefining module";
-format_error(pmod_unsupported) ->
-    "parameterized modules are no longer supported";
-%% format_error({redefine_mod_import, M, P}) ->
-%%     io_lib:format("module '~s' already imported from package '~s'", [M, P]);
-format_error(non_latin1_module_unsupported) ->
-    "module names with non-latin1 characters are not supported";
-format_error(empty_module_name) ->
-    "the module name must not be empty";
-format_error(blank_module_name) ->
-    "the module name must contain at least one visible character";
-format_error(ctrl_chars_in_module_name) ->
-    "the module name must not contain control characters";
+format_error(Error) ->
+    case format_error_1(Error) of
+        {Format, Args} when is_list(Args) ->
+            io_lib:format(Format, Args);
+        Bin when is_binary(Bin) ->
+            unicode:characters_to_list(Bin)
+    end.
 
-format_error(invalid_call) ->
-    "invalid function call";
-format_error(invalid_record) ->
-    "invalid record expression";
+format_error_1(undefined_module) ->
+    ~"no module definition";
+format_error_1(redefine_module) ->
+    ~"redefining module";
+format_error_1(pmod_unsupported) ->
+    ~"parameterized modules are no longer supported";
+format_error_1(non_latin1_module_unsupported) ->
+    ~"module names with non-latin1 characters are not supported";
+format_error_1(empty_module_name) ->
+    ~"the module name must not be empty";
+format_error_1(blank_module_name) ->
+    ~"the module name must contain at least one visible character";
+format_error_1(ctrl_chars_in_module_name) ->
+    ~"the module name must not contain control characters";
 
-format_error({future_feature, Ftr, Atom}) ->
-    io_lib:format("atom '~p' is reserved in the experimental feature '~p'",
-                  [Atom, Ftr]);
-format_error({attribute,A}) ->
-    io_lib:format("attribute ~tw after function definitions", [A]);
-format_error({missing_qlc_hrl,A}) ->
-    io_lib:format("qlc:q/~w called, but \"qlc.hrl\" not included", [A]);
-format_error({redefine_import,{{F,A},M}}) ->
-    io_lib:format("function ~tw/~w already imported from ~w", [F,A,M]);
-format_error({bad_inline,{F,A}}) ->
-    io_lib:format("inlined function ~tw/~w undefined", [F,A]);
-format_error({undefined_nif,{F,A}}) ->
-    io_lib:format("nif ~tw/~w undefined", [F,A]);
-format_error(no_load_nif) ->
-    io_lib:format("nifs defined, but no call to erlang:load_nif/2", []);
-format_error({invalid_deprecated,D}) ->
-    io_lib:format("badly formed deprecated attribute ~tw", [D]);
-format_error({bad_deprecated,{F,A}}) ->
-    io_lib:format("deprecated function ~tw/~w undefined or not exported",
-                  [F,A]);
-format_error({invalid_removed,D}) ->
-    io_lib:format("badly formed removed attribute ~tw", [D]);
-format_error({bad_removed,{F,A}}) when F =:= '_'; A =:= '_' ->
-    io_lib:format("at least one function matching ~tw/~w is still exported",
-                  [F,A]);
-format_error({bad_removed,{F,A}}) ->
-    io_lib:format("removed function ~tw/~w is still exported",
-                  [F,A]);
-format_error({bad_nowarn_unused_function,{F,A}}) ->
-    io_lib:format("function ~tw/~w undefined", [F,A]);
-format_error({bad_nowarn_bif_clash,{F,A}}) ->
-    io_lib:format("function ~tw/~w undefined", [F,A]);
-format_error(disallowed_nowarn_bif_clash) ->
-    io_lib:format("compile directive nowarn_bif_clash is no longer allowed,~n"
-		  " - use explicit module names or -compile({no_auto_import, [F/A]})", []);
-format_error({bad_on_load,Term}) ->
-    io_lib:format("badly formed on_load attribute: ~tw", [Term]);
-format_error(multiple_on_loads) ->
-    "more than one on_load attribute";
-format_error({bad_on_load_arity,{F,A}}) ->
-    io_lib:format("function ~tw/~w has wrong arity (must be 0)", [F,A]);
-format_error({Tag, duplicate_doc_attribute, Ann}) ->
-    io_lib:format("redefining documentation attribute (~p) previously set at line ~p", [Tag, Ann]);
-format_error({undefined_on_load,{F,A}}) ->
-    io_lib:format("function ~tw/~w undefined", [F,A]);
-format_error(nif_inline) ->
-    "inlining is enabled - local calls to NIFs may call their Erlang "
-    "implementation instead";
+format_error_1(invalid_call) ->
+    ~"invalid function call";
+format_error_1(invalid_record) ->
+    ~"invalid record expression";
 
-format_error(export_all) ->
-    "export_all flag enabled - all functions will be exported";
-format_error({duplicated_export, {F,A}}) ->
-    io_lib:format("function ~tw/~w already exported", [F,A]);
-format_error({unused_import,{{F,A},M}}) ->
-    io_lib:format("import ~w:~tw/~w is unused", [M,F,A]);
-format_error({undefined_function,{F,A}}) ->
-    io_lib:format("function ~tw/~w undefined", [F,A]);
-format_error({redefine_function,{F,A}}) ->
-    io_lib:format("function ~tw/~w already defined", [F,A]);
-format_error({define_import,{F,A}}) ->
-    io_lib:format("defining imported function ~tw/~w", [F,A]);
-format_error({unused_function,{F,A}}) ->
-    io_lib:format("function ~tw/~w is unused", [F,A]);
-format_error({call_to_redefined_bif,{F,A}}) ->
-    io_lib:format("ambiguous call of overridden auto-imported BIF ~w/~w~n"
-		  " - use erlang:~w/~w or \"-compile({no_auto_import,[~w/~w]}).\" "
-		  "to resolve name clash", [F,A,F,A,F,A]);
-format_error({call_to_redefined_old_bif,{F,A}}) ->
-    io_lib:format("ambiguous call of overridden pre R14 auto-imported BIF ~w/~w~n"
-		  " - use erlang:~w/~w or \"-compile({no_auto_import,[~w/~w]}).\" "
-		  "to resolve name clash", [F,A,F,A,F,A]);
-format_error({redefine_old_bif_import,{F,A}}) ->
-    io_lib:format("import directive overrides pre R14 auto-imported BIF ~w/~w~n"
-		  " - use \"-compile({no_auto_import,[~w/~w]}).\" "
-		  "to resolve name clash", [F,A,F,A]);
-format_error({redefine_bif_import,{F,A}}) ->
-    io_lib:format("import directive overrides auto-imported BIF ~w/~w~n"
-		  " - use \"-compile({no_auto_import,[~w/~w]}).\" to resolve name clash", [F,A,F,A]);
-format_error({deprecated, MFA, String, Rel}) ->
-    io_lib:format("~s is deprecated and will be removed in ~s; ~s",
-		  [format_mfa(MFA), Rel, String]);
-format_error({deprecated, MFA, String}) when is_list(String) ->
-    io_lib:format("~s is deprecated; ~s", [format_mfa(MFA), String]);
-format_error({deprecated_type, {M1, F1, A1}, String, Rel}) ->
-    io_lib:format("the type ~p:~p~s is deprecated and will be removed in ~s; ~s",
-                  [M1, F1, gen_type_paren(A1), Rel, String]);
-format_error({deprecated_type, {M1, F1, A1}, String}) when is_list(String) ->
-    io_lib:format("the type ~p:~p~s is deprecated; ~s",
-                  [M1, F1, gen_type_paren(A1), String]);
-format_error({deprecated_callback, {M1, F1, A1}, String, Rel}) ->
-    io_lib:format("the callback ~p:~p~s is deprecated and will be removed in ~s; ~s",
-                  [M1, F1, gen_type_paren(A1), Rel, String]);
-format_error({deprecated_callback, {M1, F1, A1}, String}) when is_list(String) ->
-    io_lib:format("the callback ~p:~p~s is deprecated; ~s",
-                  [M1, F1, gen_type_paren(A1), String]);
-format_error({removed, MFA, ReplacementMFA, Rel}) ->
-    io_lib:format("call to ~s will fail, since it was removed in ~s; "
-		  "use ~s", [format_mfa(MFA), Rel, format_mfa(ReplacementMFA)]);
-format_error({removed, MFA, String}) when is_list(String) ->
-    io_lib:format("~s is removed; ~s", [format_mfa(MFA), String]);
-format_error({removed_type, MNA, String}) ->
-    io_lib:format("the type ~s is removed; ~s", [format_mna(MNA), String]);
-format_error({removed_callback, MNA, String}) ->
-    io_lib:format("the callback ~s is removed; ~s", [format_mna(MNA), String]);
-format_error({obsolete_guard, {F, A}}) ->
-    io_lib:format("~p/~p obsolete (use is_~p/~p)", [F, A, F, A]);
-format_error({obsolete_guard_overridden,Test}) ->
-    io_lib:format("obsolete ~s/1 (meaning is_~s/1) is illegal when "
-		  "there is a local/imported function named is_~p/1 ",
-		  [Test,Test,Test]);
-format_error({too_many_arguments,Arity}) ->
-    io_lib:format("too many arguments (~w) - "
-		  "maximum allowed is ~w", [Arity,?MAX_ARGUMENTS]);
-format_error(update_literal) ->
-    "expression updates a literal";
+format_error_1({future_feature, Ftr, Atom}) ->
+    {~"atom '~p' is reserved in the experimental feature '~p'",
+     [Atom, Ftr]};
+format_error_1({attribute,A}) ->
+    {~"attribute ~tw after function definitions", [A]};
+format_error_1({missing_qlc_hrl,A}) ->
+    {~"qlc:q/~w called, but \"qlc.hrl\" not included", [A]};
+format_error_1({redefine_import,{{F,A},M}}) ->
+    {~"function ~tw/~w already imported from ~w", [F,A,M]};
+format_error_1({bad_inline,{F,A}}) ->
+    {~"inlined function ~tw/~w undefined", [F,A]};
+format_error_1({undefined_nif,{F,A}}) ->
+    {~"nif ~tw/~w undefined", [F,A]};
+format_error_1(no_load_nif) ->
+    {~"nifs defined, but no call to erlang:load_nif/2", []};
+format_error_1({invalid_deprecated,D}) ->
+    {~"badly formed deprecated attribute ~tw", [D]};
+format_error_1({bad_deprecated,{F,A}}) ->
+    {~"deprecated function ~tw/~w undefined or not exported",
+     [F,A]};
+format_error_1({invalid_removed,D}) ->
+    {~"badly formed removed attribute ~tw", [D]};
+format_error_1({bad_removed,{F,A}}) when F =:= '_'; A =:= '_' ->
+    {~"at least one function matching ~tw/~w is still exported",
+     [F,A]};
+format_error_1({bad_removed,{F,A}}) ->
+    {~"removed function ~tw/~w is still exported", [F,A]};
+format_error_1({bad_nowarn_unused_function,{F,A}}) ->
+    {~"function ~tw/~w undefined", [F,A]};
+format_error_1({bad_nowarn_bif_clash,{F,A}}) ->
+    {~"function ~tw/~w undefined", [F,A]};
+format_error_1(disallowed_nowarn_bif_clash) ->
+    ~"""
+     compile directive nowarn_bif_clash is no longer allowed --
+     use explicit module names or -compile({no_auto_import, [F/A]})
+     """;
+format_error_1({bad_on_load,Term}) ->
+    {~"badly formed on_load attribute: ~tw", [Term]};
+format_error_1(multiple_on_loads) ->
+    ~"more than one on_load attribute";
+format_error_1({bad_on_load_arity,{F,A}}) ->
+    {~"function ~tw/~w has wrong arity (must be 0)", [F,A]};
+format_error_1({Tag, duplicate_doc_attribute, Ann}) ->
+    {~"redefining documentation attribute (~p) previously set at line ~p",
+     [Tag, Ann]};
+format_error_1({undefined_on_load,{F,A}}) ->
+    {~"function ~tw/~w undefined", [F,A]};
+format_error_1(nif_inline) ->
+    ~"inlining is enabled - local calls to NIFs may call their Erlang implementation instead";
+
+format_error_1(export_all) ->
+    ~"export_all flag enabled - all functions will be exported";
+format_error_1({duplicated_export, {F,A}}) ->
+    {~"function ~tw/~w already exported", [F,A]};
+format_error_1({unused_import,{{F,A},M}}) ->
+    {~"import ~w:~tw/~w is unused", [M,F,A]};
+format_error_1({undefined_function,{F,A}}) ->
+    {~"function ~tw/~w undefined", [F,A]};
+format_error_1({redefine_function,{F,A}}) ->
+    {~"function ~tw/~w already defined", [F,A]};
+format_error_1({define_import,{F,A}}) ->
+    {~"defining imported function ~tw/~w", [F,A]};
+format_error_1({unused_function,{F,A}}) ->
+    {~"function ~tw/~w is unused", [F,A]};
+format_error_1({call_to_redefined_bif,{F,A}}) ->
+    {~"""
+      ambiguous call of overridden auto-imported BIF ~w/~w --
+      use erlang:~w/~w or "-compile({no_auto_import,[~w/~w]})." to resolve name clash
+      """, [F,A,F,A,F,A]};
+format_error_1({call_to_redefined_old_bif,{F,A}}) ->
+    {~"""
+      ambiguous call of overridden pre Erlang/OTP R14 auto-imported BIF ~w/~w --
+      use erlang:~w/~w or \"-compile({no_auto_import,[~w/~w]}).\" to resolve name clash
+      """, [F,A,F,A,F,A]};
+format_error_1({redefine_old_bif_import,{F,A}}) ->
+    {~"""
+      import directive overrides pre Erlang/OTP R14 auto-imported BIF ~w/~w --
+      use "-compile({no_auto_import,[~w/~w]})." to resolve name clash
+      """, [F,A,F,A]};
+format_error_1({redefine_bif_import,{F,A}}) ->
+    {~"""
+      import directive overrides auto-imported BIF ~w/~w --
+      use "-compile({no_auto_import,[~w/~w]})." to resolve name clash
+      """, [F,A,F,A]};
+format_error_1({deprecated, MFA, String, Rel}) ->
+    {~"~s is deprecated and will be removed in ~s; ~s",
+     [format_mfa(MFA), Rel, String]};
+format_error_1({deprecated, MFA, String}) when is_list(String) ->
+    {~"~s is deprecated; ~s", [format_mfa(MFA), String]};
+format_error_1({deprecated_type, {M1, F1, A1}, String, Rel}) ->
+    {~"the type ~p:~p~s is deprecated and will be removed in ~s; ~s",
+                  [M1, F1, gen_type_paren(A1), Rel, String]};
+format_error_1({deprecated_type, {M1, F1, A1}, String}) when is_list(String) ->
+    {~"the type ~p:~p~s is deprecated; ~s",
+                  [M1, F1, gen_type_paren(A1), String]};
+format_error_1({deprecated_callback, {M1, F1, A1}, String, Rel}) ->
+    {~"the callback ~p:~p~s is deprecated and will be removed in ~s; ~s",
+                  [M1, F1, gen_type_paren(A1), Rel, String]};
+format_error_1({deprecated_callback, {M1, F1, A1}, String}) when is_list(String) ->
+    {~"the callback ~p:~p~s is deprecated; ~s",
+                  [M1, F1, gen_type_paren(A1), String]};
+format_error_1({removed, MFA, ReplacementMFA, Rel}) ->
+    {~"call to ~s will fail, since it was removed in ~s; use ~s",
+     [format_mfa(MFA), Rel, format_mfa(ReplacementMFA)]};
+format_error_1({removed, MFA, String}) when is_list(String) ->
+    {~"~s is removed; ~s", [format_mfa(MFA), String]};
+format_error_1({removed_type, MNA, String}) ->
+    {~"the type ~s is removed; ~s", [format_mna(MNA), String]};
+format_error_1({removed_callback, MNA, String}) ->
+    {~"the callback ~s is removed; ~s", [format_mna(MNA), String]};
+format_error_1({obsolete_guard, {F, A}}) ->
+    {~"~p/~p obsolete (use is_~p/~p)", [F, A, F, A]};
+format_error_1({obsolete_guard_overridden,Test}) ->
+    {~"""
+      obsolete ~s/1 (meaning is_~s/1) is illegal when there is a
+      local/imported function named is_~p/1
+      """, [Test,Test,Test]};
+format_error_1({too_many_arguments,Arity}) ->
+    {~"too many arguments (~w) -- maximum allowed is ~w", [Arity,?MAX_ARGUMENTS]};
+format_error_1(update_literal) ->
+    ~"expression updates a literal";
 %% --- patterns and guards ---
-format_error(illegal_pattern) -> "illegal pattern";
-format_error(illegal_map_key) -> "illegal map key in pattern";
-format_error(illegal_expr) -> "illegal expression";
-format_error({illegal_guard_local_call, {F,A}}) -> 
-    io_lib:format("call to local/imported function ~tw/~w is illegal in guard",
-		  [F,A]);
-format_error(illegal_guard_expr) -> "illegal guard expression";
-format_error(match_float_zero) ->
-    "matching on the float 0.0 will no longer also match -0.0 in OTP 27. If "
-    "you specifically intend to match 0.0 alone, write +0.0 instead.";
+format_error_1(illegal_pattern) -> ~"illegal pattern";
+format_error_1(illegal_map_key) -> ~"illegal map key in pattern";
+format_error_1(illegal_expr) -> ~"illegal expression";
+format_error_1({illegal_guard_local_call, {F,A}}) ->
+    {~"call to local/imported function ~tw/~w is illegal in guard",
+     [F,A]};
+format_error_1(illegal_guard_expr) -> ~"illegal guard expression";
+format_error_1(match_float_zero) ->
+    ~"""
+     matching on the float 0.0 will no longer also match -0.0 in OTP 27.
+     If you specifically intend to match 0.0 alone, write +0.0 instead.
+     """;
 %% --- maps ---
-format_error(illegal_map_construction) ->
-    "only association operators '=>' are allowed in map construction";
+format_error_1(illegal_map_construction) ->
+    ~"only association operators '=>' are allowed in map construction";
 %% --- records ---
-format_error({undefined_record,T}) ->
-    io_lib:format("record ~tw undefined", [T]);
-format_error({redefine_record,T}) ->
-    io_lib:format("record ~tw already defined", [T]);
-format_error({redefine_field,T,F}) ->
-    io_lib:format("field ~tw already defined in record ~tw", [F,T]);
-format_error(bad_multi_field_init) ->
-    io_lib:format("'_' initializes no omitted fields", []);
-format_error({undefined_field,T,F}) ->
-    io_lib:format("field ~tw undefined in record ~tw", [F,T]);
-format_error(illegal_record_info) ->
-    "illegal record info";
-format_error({field_name_is_variable,T,F}) ->
-    io_lib:format("field ~tw is not an atom or _ in record ~tw", [F,T]);
-format_error({wildcard_in_update,T}) ->
-    io_lib:format("meaningless use of _ in update of record ~tw", [T]);
-format_error({unused_record,T}) ->
-    io_lib:format("record ~tw is unused", [T]);
-format_error({untyped_record,T}) ->
-    io_lib:format("record ~tw has field(s) without type information", [T]);
+format_error_1({undefined_record,T}) ->
+    {~"record ~tw undefined", [T]};
+format_error_1({redefine_record,T}) ->
+    {~"record ~tw already defined", [T]};
+format_error_1({redefine_field,T,F}) ->
+    {~"field ~tw already defined in record ~tw", [F,T]};
+format_error_1(bad_multi_field_init) ->
+    {~"'_' initializes no omitted fields", []};
+format_error_1({undefined_field,T,F}) ->
+    {~"field ~tw undefined in record ~tw", [F,T]};
+format_error_1(illegal_record_info) ->
+    ~"illegal record info";
+format_error_1({field_name_is_variable,T,F}) ->
+    {~"field ~tw is not an atom or _ in record ~tw", [F,T]};
+format_error_1({wildcard_in_update,T}) ->
+    {~"meaningless use of _ in update of record ~tw", [T]};
+format_error_1({unused_record,T}) ->
+    {~"record ~tw is unused", [T]};
+format_error_1({untyped_record,T}) ->
+    {~"record ~tw has field(s) without type information", [T]};
 %% --- variables ----
-format_error({unbound_var,V}) ->
-    io_lib:format("variable ~w is unbound", [V]);
-format_error({unsafe_var,V,{What,Where}}) ->
-    io_lib:format("variable ~w unsafe in ~w ~s",
-                  [V,What,format_where(Where)]);
-format_error({exported_var,V,{What,Where}}) ->
-    io_lib:format("variable ~w exported from ~w ~s",
-                  [V,What,format_where(Where)]);
-format_error({match_underscore_var, V}) ->
-    io_lib:format("variable ~w is already bound. If you mean to ignore this "
-                  "value, use '_' or a different underscore-prefixed name",
-                  [V]);
-format_error({match_underscore_var_pat, V}) ->
-    io_lib:format("variable ~w is bound multiple times in this pattern. If "
-                  "you mean to ignore this value, use '_' or a different "
-                  "underscore-prefixed name",
-                  [V]);
-format_error({shadowed_var,V,In}) ->
-    io_lib:format("variable ~w shadowed in ~w", [V,In]);
-format_error({unused_var, V}) ->
-    io_lib:format("variable ~w is unused", [V]);
-format_error({variable_in_record_def,V}) ->
-    io_lib:format("variable ~w in record definition", [V]);
-format_error({stacktrace_guard,V}) ->
-    io_lib:format("stacktrace variable ~w must not be used in a guard", [V]);
-format_error({stacktrace_bound,V}) ->
-    io_lib:format("stacktrace variable ~w must not be previously bound", [V]);
+format_error_1({unbound_var,V}) ->
+    {~"variable ~w is unbound", [V]};
+format_error_1({unsafe_var,V,{What,Where}}) ->
+    {~"variable ~w unsafe in ~w ~s",
+                  [V,What,format_where(Where)]};
+format_error_1({exported_var,V,{What,Where}}) ->
+    {~"variable ~w exported from ~w ~s",
+                  [V,What,format_where(Where)]};
+format_error_1({match_underscore_var, V}) ->
+    {~"""
+      variable ~w is already bound. If you mean to ignore this
+      value, use '_' or a different underscore-prefixed name
+      """, [V]};
+format_error_1({match_underscore_var_pat, V}) ->
+    {~"""
+      variable ~w is bound multiple times in this pattern.
+      If you mean to ignore this value, use '_' or
+      a different underscore-prefixed name
+      """, [V]};
+format_error_1({shadowed_var,V,In}) ->
+    {~"variable ~w shadowed in ~w", [V,In]};
+format_error_1({unused_var, V}) ->
+    {~"variable ~w is unused", [V]};
+format_error_1({variable_in_record_def,V}) ->
+    {~"variable ~w in record definition", [V]};
+format_error_1({stacktrace_guard,V}) ->
+    {~"stacktrace variable ~w must not be used in a guard", [V]};
+format_error_1({stacktrace_bound,V}) ->
+    {~"stacktrace variable ~w must not be previously bound", [V]};
 %% --- binaries ---
-format_error({undefined_bittype,Type}) ->
-    io_lib:format("bit type ~tw undefined", [Type]);
-format_error({bittype_mismatch,Val1,Val2,What}) ->
-    io_lib:format("conflict in ~s specification for bit field: '~p' and '~p'",
-		  [What,Val1,Val2]);
-format_error(bittype_unit) ->
-    "a bit unit size must not be specified unless a size is specified too";
-format_error(illegal_bitsize) ->
-    "illegal bit size";
-format_error({illegal_bitsize_local_call, {F,A}}) ->
-    io_lib:format("call to local/imported function ~tw/~w is illegal in a size "
-                  "expression for a binary segment",
-		  [F,A]);
-format_error(non_integer_bitsize) ->
-    "a size expression in a pattern evaluates to a non-integer value; "
-        "this pattern cannot possibly match";
-format_error(unsized_binary_not_at_end) ->
-    "a binary field without size is only allowed at the end of a binary pattern";
-format_error(typed_literal_string) ->
-    "a literal string in a binary pattern must not have a type or a size";
-format_error(utf_bittype_size_or_unit) ->
-    "neither size nor unit must be given for segments of type utf8/utf16/utf32";
-format_error({bad_bitsize,Type}) ->
-    io_lib:format("bad ~s bit size", [Type]);
-format_error(unsized_binary_in_bin_gen_pattern) ->
-    "binary fields without size are not allowed in patterns of bit string generators";
+format_error_1({undefined_bittype,Type}) ->
+    {~"bit type ~tw undefined", [Type]};
+format_error_1({bittype_mismatch,Val1,Val2,What}) ->
+    {~"conflict in ~s specification for bit field: '~p' and '~p'",
+		  [What,Val1,Val2]};
+format_error_1(bittype_unit) ->
+    ~"a bit unit size must not be specified unless a size is specified too";
+format_error_1(illegal_bitsize) ->
+    ~"illegal bit size";
+format_error_1({illegal_bitsize_local_call, {F,A}}) ->
+    {~"""
+      call to local/imported function ~tw/~w is illegal
+      in a size expression for a binary segment
+      """, [F,A]};
+format_error_1(non_integer_bitsize) ->
+    ~"""
+     a size expression in a pattern evaluates to a non-integer value;
+     this pattern cannot possibly match
+     """;
+format_error_1(unsized_binary_not_at_end) ->
+    ~"a binary field without size is only allowed at the end of a binary pattern";
+format_error_1(typed_literal_string) ->
+    ~"a literal string in a binary pattern must not have a type or a size";
+format_error_1(utf_bittype_size_or_unit) ->
+    ~"neither size nor unit must be given for segments of type utf8/utf16/utf32";
+format_error_1({bad_bitsize,Type}) ->
+    {~"bad ~s bit size", [Type]};
+format_error_1(unsized_binary_in_bin_gen_pattern) ->
+    ~"binary fields without size are not allowed in patterns of bit string generators";
 %% --- behaviours ---
-format_error({conflicting_behaviours,{Name,Arity},B,FirstL,FirstB}) ->
-    io_lib:format("conflicting behaviours - callback ~tw/~w required by both '~p' "
-		  "and '~p' ~s", [Name,Arity,B,FirstB,format_where(FirstL)]);
-format_error({undefined_behaviour_func, {Func,Arity}, Behaviour}) ->
-    io_lib:format("undefined callback function ~tw/~w (behaviour '~w')",
-		  [Func,Arity,Behaviour]);
-format_error({undefined_behaviour,Behaviour}) ->
-    io_lib:format("behaviour ~tw undefined", [Behaviour]);
-format_error({undefined_behaviour_callbacks,Behaviour}) ->
-    io_lib:format("behaviour ~w callback functions are undefined",
-		  [Behaviour]);
-format_error({ill_defined_behaviour_callbacks,Behaviour}) ->
-    io_lib:format("behaviour ~w callback functions erroneously defined",
-		  [Behaviour]);
-format_error({ill_defined_optional_callbacks,Behaviour}) ->
-    io_lib:format("behaviour ~w optional callback functions erroneously defined",
-		  [Behaviour]);
-format_error({behaviour_info, {_M,F,A}}) ->
-    io_lib:format("cannot define callback attibute for ~tw/~w when "
-                  "behaviour_info is defined",[F,A]);
-format_error({redefine_optional_callback, {F, A}}) ->
-    io_lib:format("optional callback ~tw/~w duplicated", [F, A]);
-format_error({undefined_callback, {_M, F, A}}) ->
-    io_lib:format("callback ~tw/~w is undefined", [F, A]);
+format_error_1({conflicting_behaviours,{Name,Arity},B,FirstL,FirstB}) ->
+    {~"conflicting behaviours -- callback ~tw/~w required by both '~p' and '~p' ~s",
+     [Name,Arity,B,FirstB,format_where(FirstL)]};
+format_error_1({undefined_behaviour_func, {Func,Arity}, Behaviour}) ->
+    {~"undefined callback function ~tw/~w (behaviour '~w')",
+		  [Func,Arity,Behaviour]};
+format_error_1({undefined_behaviour,Behaviour}) ->
+    {~"behaviour ~tw undefined", [Behaviour]};
+format_error_1({undefined_behaviour_callbacks,Behaviour}) ->
+    {~"behaviour ~w callback functions are undefined",
+		  [Behaviour]};
+format_error_1({ill_defined_behaviour_callbacks,Behaviour}) ->
+    {~"behaviour ~w callback functions erroneously defined",
+		  [Behaviour]};
+format_error_1({ill_defined_optional_callbacks,Behaviour}) ->
+    {~"behaviour ~w optional callback functions erroneously defined",
+		  [Behaviour]};
+format_error_1({behaviour_info, {_M,F,A}}) ->
+    {~"cannot define callback attibute for ~tw/~w when behaviour_info is defined",
+     [F,A]};
+format_error_1({redefine_optional_callback, {F, A}}) ->
+    {~"optional callback ~tw/~w duplicated", [F, A]};
+format_error_1({undefined_callback, {_M, F, A}}) ->
+    {~"callback ~tw/~w is undefined", [F, A]};
 %% --- types and specs ---
-format_error({singleton_typevar, Name}) ->
-    io_lib:format("type variable ~w is only used once (is unbound)", [Name]);
-format_error({bad_export_type, _ETs}) ->
-    io_lib:format("bad export_type declaration", []);
-format_error({duplicated_export_type, {T, A}}) ->
-    io_lib:format("type ~tw/~w already exported", [T, A]);
-format_error({undefined_type, {TypeName, Arity}}) ->
-    io_lib:format("type ~tw~s undefined", [TypeName, gen_type_paren(Arity)]);
-format_error({unused_type, {TypeName, Arity}}) ->
-    io_lib:format("type ~tw~s is unused", [TypeName, gen_type_paren(Arity)]);
-format_error({redefine_builtin_type, {TypeName, Arity}}) ->
-    io_lib:format("local redefinition of built-in type: ~w~s",
-		  [TypeName, gen_type_paren(Arity)]);
-format_error({renamed_type, OldName, NewName}) ->
-    io_lib:format("type ~w() is now called ~w(); "
-		  "please use the new name instead", [OldName, NewName]);
-format_error({redefine_type, {TypeName, Arity}}) ->
-    io_lib:format("type ~tw~s already defined",
-		  [TypeName, gen_type_paren(Arity)]);
-format_error({type_syntax, Constr}) ->
-    io_lib:format("bad ~tw type", [Constr]);
-format_error(old_abstract_code) ->
-    io_lib:format("abstract code generated before Erlang/OTP 19.0 and "
-                  "having typed record fields cannot be compiled", []);
-format_error({redefine_spec, {M, F, A}}) ->
-    io_lib:format("spec for ~tw:~tw/~w already defined", [M, F, A]);
-format_error({redefine_spec, {F, A}}) ->
-    io_lib:format("spec for ~tw/~w already defined", [F, A]);
-format_error({redefine_callback, {F, A}}) ->
-    io_lib:format("callback ~tw/~w already defined", [F, A]);
-format_error({bad_callback, {M, F, A}}) ->
-    io_lib:format("explicit module not allowed for callback ~tw:~tw/~w",
-                  [M, F, A]);
-format_error({bad_module, {M, F, A}}) ->
-    io_lib:format("spec for function ~w:~tw/~w from other module", [M, F, A]);
-format_error({spec_fun_undefined, {F, A}}) ->
-    io_lib:format("spec for undefined function ~tw/~w", [F, A]);
-format_error({missing_spec, {F,A}}) ->
-    io_lib:format("missing specification for function ~tw/~w", [F, A]);
-format_error(spec_wrong_arity) ->
-    "spec has wrong arity";
-format_error(callback_wrong_arity) ->
-    "callback has wrong arity";
-format_error({deprecated_builtin_type, {Name, Arity},
+format_error_1({singleton_typevar, Name}) ->
+    {~"type variable ~w is only used once (is unbound)", [Name]};
+format_error_1({bad_export_type, _ETs}) ->
+    {~"bad export_type declaration", []};
+format_error_1({duplicated_export_type, {T, A}}) ->
+    {~"type ~tw/~w already exported", [T, A]};
+format_error_1({undefined_type, {TypeName, Arity}}) ->
+    {~"type ~tw~s undefined", [TypeName, gen_type_paren(Arity)]};
+format_error_1({unused_type, {TypeName, Arity}}) ->
+    {~"type ~tw~s is unused", [TypeName, gen_type_paren(Arity)]};
+format_error_1({redefine_builtin_type, {TypeName, Arity}}) ->
+    {~"local redefinition of built-in type: ~w~s",
+		  [TypeName, gen_type_paren(Arity)]};
+format_error_1({renamed_type, OldName, NewName}) ->
+    {~"type ~w() is now called ~w(); please use the new name instead",
+     [OldName, NewName]};
+format_error_1({redefine_type, {TypeName, Arity}}) ->
+    {~"type ~tw~s already defined",
+     [TypeName, gen_type_paren(Arity)]};
+format_error_1({type_syntax, Constr}) ->
+    {~"bad ~tw type", [Constr]};
+format_error_1(old_abstract_code) ->
+    ~"""
+     abstract code generated before Erlang/OTP 19.0 and
+     having typed record fields cannot be compiled
+     """;
+format_error_1({redefine_spec, {M, F, A}}) ->
+    {~"spec for ~tw:~tw/~w already defined", [M, F, A]};
+format_error_1({redefine_spec, {F, A}}) ->
+    {~"spec for ~tw/~w already defined", [F, A]};
+format_error_1({redefine_callback, {F, A}}) ->
+    {~"callback ~tw/~w already defined", [F, A]};
+format_error_1({bad_callback, {M, F, A}}) ->
+    {~"explicit module not allowed for callback ~tw:~tw/~w",
+                  [M, F, A]};
+format_error_1({bad_module, {M, F, A}}) ->
+    {~"spec for function ~w:~tw/~w from other module", [M, F, A]};
+format_error_1({spec_fun_undefined, {F, A}}) ->
+    {~"spec for undefined function ~tw/~w", [F, A]};
+format_error_1({missing_spec, {F,A}}) ->
+    {~"missing specification for function ~tw/~w", [F, A]};
+format_error_1(spec_wrong_arity) ->
+    ~"spec has wrong arity";
+format_error_1(callback_wrong_arity) ->
+    ~"callback has wrong arity";
+format_error_1({deprecated_builtin_type, {Name, Arity},
               Replacement, Rel}) ->
     UseS = case Replacement of
                {Mod, NewName} ->
-                   io_lib:format("use ~w:~w/~w", [Mod, NewName, Arity]);
+                   io_lib:format(~"use ~w:~w/~w", [Mod, NewName, Arity]);
                {Mod, NewName, NewArity} ->
-                   io_lib:format("use ~w:~w/~w or preferably ~w:~w/~w",
+                   io_lib:format(~"use ~w:~w/~w or preferably ~w:~w/~w",
                                  [Mod, NewName, Arity,
                                   Mod, NewName, NewArity])
            end,
-    io_lib:format("type ~w/~w is deprecated and will be "
-                  "removed in ~s; use ~s",
-                  [Name, Arity, Rel, UseS]);
-format_error({not_exported_opaque, {TypeName, Arity}}) ->
-    io_lib:format("opaque type ~tw~s is not exported",
-                  [TypeName, gen_type_paren(Arity)]);
-format_error({bad_dialyzer_attribute,Term}) ->
-    io_lib:format("badly formed dialyzer attribute: ~tw", [Term]);
-format_error({bad_dialyzer_option,Term}) ->
-    io_lib:format("unknown dialyzer warning option: ~tw", [Term]);
+    {~"type ~w/~w is deprecated and will be removed in ~s; use ~s",
+     [Name, Arity, Rel, UseS]};
+format_error_1({not_exported_opaque, {TypeName, Arity}}) ->
+    {~"opaque type ~tw~s is not exported",
+                  [TypeName, gen_type_paren(Arity)]};
+format_error_1({bad_dialyzer_attribute,Term}) ->
+    {~"badly formed dialyzer attribute: ~tw", [Term]};
+format_error_1({bad_dialyzer_option,Term}) ->
+    {~"unknown dialyzer warning option: ~tw", [Term]};
 %% --- obsolete? unused? ---
-format_error({format_error, {Fmt, Args}}) ->
-    io_lib:format(Fmt, Args).
+format_error_1({format_error, {Fmt, Args}}) ->
+    {Fmt, Args}.
 
 gen_type_paren(Arity) when is_integer(Arity), Arity >= 0 ->
     gen_type_paren_1(Arity, ")").

--- a/lib/stdlib/src/shell_default.erl
+++ b/lib/stdlib/src/shell_default.erl
@@ -75,51 +75,55 @@ code:load_abs("$PATH/user_default").
 -doc "Print the help for all shell internal commands.".
 -spec help() -> true.
 help() ->
-    format("** shell internal commands **~n"),
-    format("b()        -- display all variable bindings\n"),
-    format("e(N)       -- repeat the expression in query <N>\n"),
-    format("f()        -- forget all variable bindings\n"),
-    format("f(X)       -- forget the binding of variable X\n"),
-    format("h()        -- history\n"),
-    format("h(Mod)     -- help about module\n"),
-    format("h(Mod,Func)-- help about function in module\n"),
-    format("h(Mod,Func,Arity) -- help about function with arity in module\n"),
-    format("ht(Mod)    -- help about a module's types\n"),
-    format("ht(Mod,Type) -- help about type in module\n"),
-    format("ht(Mod,Type,Arity) -- help about type with arity in module\n"),
-    format("hcb(Mod)    -- help about a module's callbacks\n"),
-    format("hcb(Mod,CB) -- help about callback in module\n"),
-    format("hcb(Mod,CB,Arity) -- help about callback with arity in module\n"),
-    format("history(N) -- set how many previous commands to keep\n"),
-    format("results(N) -- set how many previous command results to keep\n"),
-    format("catch_exception(B) -- how exceptions are handled\n"),
-    format("v(N)       -- use the value of query <N>\n"),
-    format("rd(R,D)    -- define a record\n"),
-    format("rf()       -- remove all record information\n"),
-    format("rf(R)      -- remove record information about R\n"),
-    format("rl()       -- display all record information\n"),
-    format("rl(R)      -- display record information about R\n"),
-    format("rp(Term)   -- display Term using the shell's record information\n"),
-    format("rr(File)   -- read record information from File (wildcards allowed)\n"),
-    format("rr(F,R)    -- read selected record information from file(s)\n"),
-    format("rr(F,R,O)  -- read selected record information with options\n"),
-    format("lf()       -- list locally defined functions\n"),
-    format("lt()       -- list locally defined types\n"),
-    format("lr()       -- list locally defined records\n"),
-    format("ff()       -- forget all locally defined functions\n"),
-    format("ff({F,A})  -- forget locally defined function named as atom F and arity A\n"),
-    format("tf()       -- forget all locally defined types\n"),
-    format("tf(T)      -- forget locally defined type named as atom T\n"),
-    format("fl()       -- forget all locally defined functions, types and records\n"),
-    format("save_module(FilePath) -- save all locally defined functions, types and records to a file\n"),
+    S = ~"""
+         ** shell internal commands **
+         b()        -- display all variable bindings
+         e(N)       -- repeat the expression in query <N>
+         f()        -- forget all variable bindings
+         f(X)       -- forget the binding of variable X
+         h()        -- history
+         h(Mod)     -- help about module
+         h(Mod,Func)-- help about function in module
+         h(Mod,Func,Arity) -- help about function with arity in module
+         ht(Mod)    -- help about a module's types
+         ht(Mod,Type) -- help about type in module
+         ht(Mod,Type,Arity) -- help about type with arity in module
+         hcb(Mod)    -- help about a module's callbacks
+         hcb(Mod,CB) -- help about callback in module
+         hcb(Mod,CB,Arity) -- help about callback with arity in module
+         history(N) -- set how many previous commands to keep
+         results(N) -- set how many previous command results to keep
+         catch_exception(B) -- how exceptions are handled
+         v(N)       -- use the value of query <N>
+         rd(R,D)    -- define a record
+         rf()       -- remove all record information
+         rf(R)      -- remove record information about R
+         rl()       -- display all record information
+         rl(R)      -- display record information about R
+         rp(Term)   -- display Term using the shell's record information
+         rr(File)   -- read record information from File (wildcards allowed)
+         rr(F,R)    -- read selected record information from file(s)
+         rr(F,R,O)  -- read selected record information with options
+         lf()       -- list locally defined functions
+         lt()       -- list locally defined types
+         lr()       -- list locally defined records
+         ff()       -- forget all locally defined functions
+         ff({F,A})  -- forget locally defined function named as atom F and arity A
+         tf()       -- forget all locally defined types
+         tf(T)      -- forget locally defined type named as atom T
+         fl()       -- forget all locally defined functions, types and records
+         save_module(FilePath) -- save all locally defined functions, types and records to a file
+         """,
+    io:put_chars(S),
+    io:nl(),
     c:help(),
-    format("** commands in module i (interpreter interface) **\n"),
-    format("ih()       -- print help for the i module\n"),
+    format(~"** commands in module i (interpreter interface) **\n"),
+    format(~"ih()       -- print help for the i module\n"),
     %% format("** private commands ** \n"),
     %% format("myfunc()   -- does my operation ...\n"),
     true.
 
-%% these are in alphabetic order it would be nice if they
+%% These are in alphabetic order. It would be nice if they
 %% were to *stay* so!
 
 -doc false.


### PR DESCRIPTION
On a 64-bit computer, a character in a string occupies 8 bytes, while a character in a binary usually occupies a single byte. Save some memory by using binary literals instead of string literals in some modules that have many string literals, such as `erl_lint`.