### PR TITLE
erts: Fix a few vestigial issues from bitstring refactor

### DIFF
--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1448,7 +1448,7 @@ build_writable_bitstring(Process *p,
     p->wrt_bins = (struct erl_off_heap_header*)br;
     br->val = bin;
 
-    MSO(p).overhead += apparent_size / (sizeof(Eterm) * 8);
+    OH_OVERHEAD(&MSO(p), NBYTES(apparent_size) / sizeof(Eterm));
 
     erl_sub_bits_init(sb,
                       ERL_SUB_BITS_FLAGS_WRITABLE,

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -2722,6 +2722,7 @@ static Eterm erts_term_to_binary_int(Process* p, Sint bif_ix, Eterm Term, Eterm 
                     if (referenced_cbin) {
                         result_ref->next = MSO(p).first;
                         MSO(p).first = (struct erl_off_heap_header*)result_ref;
+                        OH_OVERHEAD(&MSO(p), result_bin->orig_size);
 
                         /* Ownership has been transferred to the result_ref, so
                          * we do not need to bump refc. */
@@ -4883,8 +4884,9 @@ dec_term_atom_common:
                                                      &data);
                     hp = factory->hp;
 
-                    if (ctx && size_in_bits > ERL_ONHEAP_BITS_LIMIT) {
+                    if (ctx) {
                         unsigned int n_limit = reds * B2T_MEMCPY_FACTOR;
+
                         if (nu > n_limit) {
                             ctx->state = B2TDecodeBinary;
                             ctx->u.dc.remaining_n = nu - n_limit;


### PR DESCRIPTION
This PR improves #8322 and #8329. It doesn't fully restore the same performance characteristics -- some things are still a bit slower -- but we're back in the same ballpark across the board, and some things are faster than before.