### PR TITLE
public_key: adjustments for OCSP interoperability

### DIFF
--- a/lib/common_test/src/cte_track.erl
+++ b/lib/common_test/src/cte_track.erl
@@ -116,7 +116,7 @@ handle_event(#event{name = tc_done,
 handle_event(#event{name = tc_done,
                     data = Data},
              State = #{device := D}) ->
-    print(D, "~n~nUnhandled interesting event:~nName = tc_done~nData = ~p~n~n",
+    print(D, "~n~n[cte_track] Unhandled interesting event:~nName = tc_done~nData = ~p~n~n",
           [Data]),
     {ok, State};
 handle_event(#event{name = Name, data = {Suite, {Case, Group}, Comment}},

--- a/lib/public_key/src/pubkey_ocsp.erl
+++ b/lib/public_key/src/pubkey_ocsp.erl
@@ -251,14 +251,20 @@ do_verify_signature(ResponseDataDer, Signature, AlgorithmID,
 
 get_public_key_rec(#'OTPCertificate'{tbsCertificate = TbsCert}) ->
     PKInfo = TbsCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
-    PKInfo#'OTPSubjectPublicKeyInfo'.subjectPublicKey.
+    Params = PKInfo#'OTPSubjectPublicKeyInfo'.algorithm#'PublicKeyAlgorithm'.parameters,
+    SubjectPublicKey = PKInfo#'OTPSubjectPublicKeyInfo'.subjectPublicKey,
+    case Params of
+        {namedCurve, _} ->
+            {SubjectPublicKey, Params};
+        _ ->
+            SubjectPublicKey
+    end.
 
 get_subject_name(#'OTPCertificate'{tbsCertificate = TbsCert}) ->
     public_key:pkix_encode('Name', TbsCert#'OTPTBSCertificate'.subject, otp).
 
-get_public_key(#'OTPCertificate'{tbsCertificate = TbsCert}) ->
-    PKInfo = TbsCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
-    enc_pub_key(PKInfo#'OTPSubjectPublicKeyInfo'.subjectPublicKey).
+get_public_key(OtpCert) ->
+    enc_pub_key(get_public_key_rec(OtpCert)).
 
 enc_pub_key(Key = #'RSAPublicKey'{}) ->
     public_key:der_encode('RSAPublicKey', Key);

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -2003,8 +2003,7 @@ pkix_ocsp_validate(Cert, IssuerCert, OcspRespDer, NonceExt, Options)
 %% Description: Get OCSP stapling extensions for request
 %%--------------------------------------------------------------------
 ocsp_extensions(Nonce) ->
-    [Extn || Extn <- [pubkey_ocsp:get_nonce_extn(Nonce),
-                      pubkey_ocsp:get_acceptable_response_types_extn()],
+    [Extn || Extn <- [pubkey_ocsp:get_nonce_extn(Nonce)],
              erlang:is_record(Extn, 'Extension')].
 
 %%--------------------------------------------------------------------

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -1490,11 +1490,7 @@ ocsp_extensions(_Config) ->
         [{'Extension',
           ?'id-pkix-ocsp-nonce',
           asn1_DEFAULT,
-          <<4,8,66,243,220,236,16,118,51,215>>},
-         {'Extension',
-          ?'id-pkix-ocsp-response',
-          asn1_DEFAULT,
-          <<48,11,6,9,43,6,1,5,5,7,48,1,1>>}],
+          <<4,8,66,243,220,236,16,118,51,215>>}],
     ExpectedExtentions = public_key:ocsp_extensions(Nonce).
 
 pkix_ocsp_validate() ->

--- a/lib/ssl/src/ssl_trace.erl
+++ b/lib/ssl/src/ssl_trace.erl
@@ -466,7 +466,7 @@ trace_profiles() ->
       fun(M, F, A) -> dbg:tpl(M, F, A, x) end,
       fun(M, F, A) -> dbg:ctpl(M, F, A) end,
       [{public_key, [{pkix_path_validation, 3}, {path_validation, 2},
-                     {pkix_decode_cert, 2}]},
+                     {pkix_decode_cert, 2}, {pkix_verify_hostname, 3}]},
        {ssl_certificate, [{validate, 3}, {trusted_cert_and_paths, 4},
                           {certificate_chain, 3}, {certificate_chain, 5},
                           {issuer, 1}]},

--- a/lib/ssl/src/tls_client_connection.erl
+++ b/lib/ssl/src/tls_client_connection.erl
@@ -496,6 +496,11 @@ next_statem_state(_) ->
 %%====================================================================
 %% Tracing
 %%====================================================================
+handle_trace(crt,
+             {call, {?MODULE, init,
+                     [[_Role, _Sender, _Host, _Port, _Socket, _Options, _User, _CbInfo]]}},
+             Stack) ->
+    {io_lib:format("Host = ~s Port = ~p User = ~p", [_Host, _Port, _User]), Stack};
 handle_trace(hbn,
              {call, {?MODULE, connection,
                      [_Type = info, Event, _State]}},


### PR DESCRIPTION
- don't include get_acceptable_response_types_extn
- ClientHello StatusRequest will have empty extensions unless OCSP nonce is requested
- see GH-8242