### PR TITLE
Mention blocking supervisor operations in Supervision Principles chapter

### DIFF
--- a/system/doc/design_principles/sup_princ.md
+++ b/system/doc/design_principles/sup_princ.md
@@ -615,6 +615,13 @@ Because a `simple_one_for_one` supervisor can have many children, it shuts them
 all down asynchronously. This means that the children will do their cleanup in
 parallel and therefore the order in which they are stopped is not defined.
 
+Starting, restarting and manually terminating children are synchronous operations
+however, which are executed in the context of the supervisor process. This means
+that the supervisor process will be blocked while it is performing any of those
+operations.
+Child processes are responsible for keeping their start and shutdown phases as
+short as possible.
+
 ## Stopping
 
 Since the supervisor is part of a supervision tree, it is automatically

--- a/system/doc/design_principles/sup_princ.md
+++ b/system/doc/design_principles/sup_princ.md
@@ -615,8 +615,8 @@ Because a `simple_one_for_one` supervisor can have many children, it shuts them
 all down asynchronously. This means that the children will do their cleanup in
 parallel and therefore the order in which they are stopped is not defined.
 
-Starting, restarting and manually terminating children are synchronous operations
-however, which are executed in the context of the supervisor process. This means
+Starting, restarting, and manually terminating children are synchronous operations
+which are executed in the context of the supervisor process. This means
 that the supervisor process will be blocked while it is performing any of those
 operations.
 Child processes are responsible for keeping their start and shutdown phases as


### PR DESCRIPTION
The operations of starting, restarting and manually terminating children block a supervisor process, which is something to consider when designing children to be used under a `simple_one_for_one` supervisor.