### PR TITLE
Migrate dbg and etop to use trace sessions

### DIFF
--- a/erts/emulator/test/trace_session_SUITE.erl
+++ b/erts/emulator/test/trace_session_SUITE.erl
@@ -1335,11 +1335,13 @@ error_info(_Config) ->
          {session_destroy, [make_ref()]},
          {session_destroy, [atomics:new(1,[])]},
 
-         {session_info, [ExternalPid]}
+         {session_info, [ExternalPid]},
+
+         {delivered, 2} %% Cannot fail
         ],
 
     try
-        error_info_lib:test_error_info(trace, L)
+        error_info_lib:test_error_info(trace, L, [allow_nyi])
     after
         peer:stop(Peer)
     end.

--- a/lib/kernel/src/trace.erl
+++ b/lib/kernel/src/trace.erl
@@ -128,6 +128,7 @@ on the same local node as the call is made. To trace remote nodes use `m:dbg` or
          process/4,
          port/4,
          info/3,
+         delivered/2,
          session_create/3,
          session_destroy/1,
          session_info/1]).
@@ -1198,7 +1199,13 @@ info(Session, PidPortFuncEvent, Item) ->
             error_with_inherited_info(R, [Session, PidPortFuncEvent, Item], Stk)
     end.
 
-
+-doc """
+Equivalent to [`erlang:trace_delivered(Tracee)`](`erlang:trace_delivered/1`)
+except that it is run within the given `t:session/0`.
+""".
+-spec delivered(Session :: session(), Tracee :: pid() | all) -> reference().
+delivered(_Session , Tracee) ->
+    erlang:trace_delivered(Tracee).
 
 
 %% session_create/3

--- a/lib/observer/src/etop.erl
+++ b/lib/observer/src/etop.erl
@@ -220,7 +220,7 @@ start(Opts) ->
 
     %% Maybe set up the tracing
     Config3 = 
-	if Config2#opts.tracing == on, Node /= node() ->
+	if Node /= node() ->
 		%% Cannot trace on current node since the tracer will
 		%% trace itself
 		etop_tr:setup_tracer(Config2);

--- a/lib/observer/src/etop_defs.hrl
+++ b/lib/observer/src/etop_defs.hrl
@@ -26,5 +26,5 @@
 -record(opts, {node=node(), port = 8415, accum = false, intv = 5000, lines = 10,
 	       width = 700, height = 340, sort = runtime, tracing = on,
 	       %% Other state information
-	       out_mod=etop_txt, out_proc, server, host, tracer, store,
+	       out_mod=etop_txt, out_proc, server, host, tracer, session, store,
 	       accum_tab, remote}).

--- a/lib/observer/src/observer.app.src
+++ b/lib/observer/src/observer.app.src
@@ -68,5 +68,5 @@
     {applications, [kernel, stdlib, runtime_tools, et]},
     {optional_applications, [wx, runtime_tools, et]},
     {env, []},
-    {runtime_dependencies, ["wx-2.3","stdlib-5.0","runtime_tools-1.19",
-			    "kernel-9.0","et-1.5","erts-14.0"]}]}.
+    {runtime_dependencies, ["wx-2.3","stdlib-5.0","runtime_tools-@OTP-19081@",
+			    "kernel-@OTP-18980@","et-1.5","erts-@OTP-18980@"]}]}.

--- a/lib/runtime_tools/src/runtime_tools.app.src
+++ b/lib/runtime_tools/src/runtime_tools.app.src
@@ -29,5 +29,5 @@
     {applications, [kernel, stdlib]},
     {env,          []},
     {mod,          {runtime_tools, []}},
-    {runtime_dependencies, ["stdlib-@OTP-18789@","mnesia-4.12","kernel-8.1",
-			    "erts-14.2"]}]}.
+    {runtime_dependencies, ["stdlib-@OTP-18789@","mnesia-4.12","kernel-@OTP-18980@",
+			    "erts-@OTP-18980@"]}]}.

--- a/lib/runtime_tools/test/dbg_SUITE.erl
+++ b/lib/runtime_tools/test/dbg_SUITE.erl
@@ -21,7 +21,8 @@
 
 %% Test functions
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1,
-         big/1, tiny/1, simple/1, message/1, distributed/1, port/1,
+         groups/0, init_per_group/2, end_per_group/2]).
+-export([big/1, tiny/1, simple/1, message/1, distributed/1, port/1,
 	 send/1, recv/1,
          ip_port/1, file_port/1, file_port2/1, file_tracer/1,
          ip_port_busy/1, wrap_port/1, wrap_port_time/1,
@@ -39,18 +40,29 @@ suite() ->
      {timetrap, {minutes, 1}}].
 
 all() -> 
-    [big, tiny, simple, message, distributed, port, ip_port,
-     send, recv,
-     file_port, file_port2, file_tracer, ip_port_busy,
-     wrap_port, wrap_port_time, with_seq_trace, dead_suspend,
-     local_trace, saved_patterns, tracer_exit_on_stop,
-     erl_tracer, distributed_erl_tracer].
+    [{group, global}].
+
+groups() ->
+    [{global,[],[{group, tests}]},
+     {tests,[],[
+                big, tiny, simple, message, distributed, port, ip_port,
+                send, recv,
+                file_port, file_port2, file_tracer, ip_port_busy,
+                wrap_port, wrap_port_time, with_seq_trace, dead_suspend,
+                local_trace, saved_patterns, tracer_exit_on_stop,
+                erl_tracer, distributed_erl_tracer]}].
 
 init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
     dbg:stop(),
+    ok.
+
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, _Config) ->
     ok.
 
 %% Rudimentary interface test
@@ -478,7 +490,7 @@ port(Config) when is_list(Config) ->
         %% Do a run to get rid of all extra port operations
         port_close(Fun()),
 
-        dbg:p(new,ports),
+        dbg:p(new_ports,ports),
         Port = Fun(),
         port_close(Port),
         stop(),


### PR DESCRIPTION
This PR moves all `dbg` functionality to use a trace session instead of relying on the global session.

In addition it also adds a a new `dbg:session/1,2` API that can be used to create new `dbg` session that are isolated from eachother.

As a proof of concept the `etop` application has been converted to use the new sessions so that it now is possible to run multiple `etop` and `dbg` at the same time in a system without them interfeering with eachother.