### PR TITLE
log/2 callback return type fix

### DIFF
--- a/lib/kernel/doc/guides/logger_chapter.md
+++ b/lib/kernel/doc/guides/logger_chapter.md
@@ -302,7 +302,7 @@ A handler is defined as a module exporting at least the following callback
 function:
 
 ```text
-log(LogEvent, Config) -> void()
+log(LogEvent, Config) -> term()
 ```
 
 This function is called when a log event has passed through all primary filters,


### PR DESCRIPTION
Nitpick, `void()` refers to nothing. I understand that `void()` have different semantic meaning, but it's not a valid type.