### PR TITLE
Add ability to prioritize termination to `gen_*` behaviors

### DIFF
--- a/lib/stdlib/src/gen.erl
+++ b/lib/stdlib/src/gen.erl
@@ -28,6 +28,7 @@
 %%% The standard behaviour should export init_it/6.
 %%%-----------------------------------------------------------------
 -export([start/5, start/6, debug_options/2, hibernate_after/1,
+	 prioritize_termination/1,
 	 name/1, unregister_name/1, get_proc_name/1, get_parent/0,
 	 call/3, call/4, reply/2,
          send_request/3, send_request/5,
@@ -736,6 +737,14 @@ hibernate_after(Options) ->
 		false ->
 			infinity
 	end.
+
+prioritize_termination(Options) ->
+    case lists:keyfind(prioritize_termination, 1, Options) of
+        {_, PrioritizeTermination} ->
+            PrioritizeTermination;
+        false ->
+            false
+    end.
 
 debug_options(Name, Opts) ->
     case lists:keyfind(debug, 1, Opts) of


### PR DESCRIPTION
This PR adds the ability to `gen_server`, `gen_statem`, `gen_event` and `supervisor` implementations to handle terminating events (`'EXIT'` from the parent when trapping exits, or manual shutdown via `gen_*:stop/1,3`) _before_ any other messages in the message queue at that time. This can be enabled by a new start option `{prioritize_termination`, boolean()}` (default `false`).

_(There are currently no tests or any documentation for this feature. I first wanted to see if there is any interest in it before investing more time.)_

When enabled, the respective behavior will perform a selective receive for `{'EXIT', Parent, _Reason}` or `{system, _From, {terminate, _Reason}}` messages before the general receive for other messages. If a parent exit or system terminate message is thus received, it will handled accordingly by calling the implementations' `terminate` function and ignoring any other messages remaining in the message queue.

When disabled, all messages are handled strictly in order as in the current implementation, which means that parent exit or manual termination messages will only be handled after _all other_ messages before them have been handled.


Use cases (at least mine) are services that perform long-running tasks on varying demand. The (message) queue of tasks given to such a service may become rather long at busy times. In the current implementation (or when `prioritize_termination` is disabled for that matter), shutting down such a service means that it will only do so when it has performed all the queued-up tasks. It is not unlikely that it reaches the shutdown timeout and will be killed by the parent supervisor, thereby preventing any possibly necessary cleanup. Picking a sensible shutdown timeout for such children is notoriously difficult, with `infinity` being the only safe option.

Another use case is the use of dynamic children which are slow to (re-)start in a `simple_one_for_one` supervisor. Here again, a long queue of `start_child` requests, and/or restarts if the children are `transient`, may build up. If the supervisor is to be shut down, it can only do so when it has performed all the starts and restarts that were enqueued before.

As a side note, adding this feature to supervisors unfortunately means that we have to add an additional different semantic to `supervisor:start_link/3`: Currently, there is `start_link/2` (with arguments `Module` and `Args`) and `start_link/3` (with arguments `SupName`, `Module` and `Args`). In order to be able to specify options, `start_link/3` must additionally serve as "`start_link/2` plus options".