### PR TITLE
Add `{heir, immortal}` option to ets

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -360,6 +360,7 @@ atom http httph https http_response http_request http_header http_eoh http_error
 atom id
 atom if_clause
 atom ignore
+atom immortal
 atom in
 atom in_exiting
 atom inactive

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -318,8 +318,8 @@ typedef struct db_table_common {
     erts_mtx_t fixlock;   /* Protects fixing_procs and time */
     int is_thread_safe;       /* No fine locking inside table needed */
     Uint32 type;              /* table type, *read only* after creation */
-    Eterm owner;              /* Pid of the creator */
-    Eterm heir;               /* Pid of the heir */
+    Eterm owner;              /* Pid of the current owner, or none */
+    Eterm heir;               /* Pid of the heir, or none, or immortal */
     UWord heir_data;          /* To send in ETS-TRANSFER (is_immed or (DbTerm*) */
     Uint64 heir_started_interval;  /* To further identify the heir */
     Eterm the_name;           /* an atom */

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -1017,11 +1017,13 @@ same as specifying
 
   [](){: #heir }
 
-- **`{heir,Pid,HeirData} | {heir,none}`** - Set a process as heir. The heir
-  inherits the table if the owner terminates. Message
+- **`{heir,Pid,HeirData} | {heir,none} | {heir, immortal}`** - Set a process
+  as heir. The heir inherits the table if the owner terminates. Message
   `{'ETS-TRANSFER',tid(),FromPid,HeirData}` is sent to the heir when that
   occurs. The heir must be a local process. Default heir is `none`, which
-  destroys the table when the owner terminates.
+  destroys the table when the owner terminates. If heir is `immortal`, the
+  table isn't removed and becomes unassociated with any process when the
+  owner terminates.
 
   [](){: #new_2_write_concurrency }
 


### PR DESCRIPTION
Some times I wanted to have an ets decoupled from any process lifecycle. This PR introduces the `{heir, immortal}` option,
which allows exactly that.

Tables that have the atom `immortal` as a heir don't get deleted upon process termination, nor transferred to another process. Instead, they continue to exist with `owner` = `none`.

If this were to be merged, there are a few necessary tweaks:
- disallowing the ability of setting `heir` for an `ets` with owner `none`
- disallowing `{heir, immortal}` for private tables
- typespec changes 
- extending documentation

My implementation is also probably missing some considerations (it feels __too simple__), but in my tests it work.