### PR TITLE
dialyzer: Fix type inference for UTF-8 segments

### DIFF
--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -1608,13 +1608,14 @@ bind_bin_segs([Seg|Segs], BinType, Acc, Map, State) ->
       {Map1, [Type]} = do_bind_pat_vars([Val], [T], Map,
                                         State, false, []),
       Type1 = remove_local_opaque_types(Type, State#state.opaques),
-      bind_bin_segs(Segs, t_bitstr(0, 0), [Type1|Acc], Map1, State);
+      bind_bin_segs(Segs, t_none(), [Type1|Acc], Map1, State);
     SizeType when SegType =:= utf8; SegType =:= utf16; SegType =:= utf32 ->
       {literal, undefined} = SizeType,          %Assertion.
       {Map1, [_]} = do_bind_pat_vars([Val], [t_integer()],
                                      Map, State, false, []),
       Type = t_binary(),
-      bind_bin_segs(Segs, BinType, [Type|Acc], Map1, State);
+      bind_bin_segs(Segs, t_bitstr_match(Type, BinType),
+                    [Type | Acc], Map1, State);
     {literal, N} when not is_integer(N); N < 0 ->
       %% Bogus literal size, fails in runtime.
       bind_error([Seg], BinType, t_none(), bind);

--- a/lib/dialyzer/test/small_SUITE_data/src/bs_utf8.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/bs_utf8.erl
@@ -6,7 +6,7 @@
 
 -module(bs_utf8).
 
--export([doit/2]).
+-export([doit/2, gh_8383/1]).
 
 doit(N, Bin) when is_integer(N), N > 0 ->
     count_and_find(Bin, N).
@@ -25,3 +25,13 @@ cafu(<<_/utf8, Rest/binary>> = Whole, N, Count, ByteCount, SavePos) ->
     cafu(Rest, N-1, Count+1, ByteCount+Delta, SavePos);
 cafu(_Other, _N, Count, ByteCount, _SavePos) -> % Non Unicode character at end
     {Count, ByteCount}.
+
+%% GH-8383: UTF-8 segments did not update the type for the next segment.
+%%
+%% In the case below, this left the type at the start of the `Rest` segment as
+%% the incoming <<_:32>>, causing `X` to be inferred to <<_:32>> and the
+%% subsequent match on the empty binary to fail.
+gh_8383(_) -> <<>> == gh_8383_1(<<"exit">>).
+
+gh_8383_1(<<_/utf8, Rest/binary>>) -> gh_8383_1(Rest);
+gh_8383_1(X) -> X.


### PR DESCRIPTION
Fixes #8383