### PR TITLE
debugger: Run tracing in a separate session

### DIFF
--- a/lib/debugger/doc/guides/introduction.md
+++ b/lib/debugger/doc/guides/introduction.md
@@ -29,12 +29,6 @@ changed.
 The Erlang interpreter can also be accessed through the interface module
 `m:int`.
 
-> #### Warning {: .warning }
->
-> Debugger might at some point start tracing on the processes that execute the
-> interpreted code. This means that a conflict occurs if tracing by other means
-> is started on any of these processes.
-
 ## Prerequisites
 
 It is assumed that the reader is familiar with the Erlang programming language.

--- a/lib/debugger/src/debugger.app.src
+++ b/lib/debugger/src/debugger.app.src
@@ -49,5 +49,5 @@
   {registered, [dbg_iserver, dbg_wx_mon, dbg_wx_winman]},
   {applications, [kernel, stdlib, compiler]},
   {optional_applications, [compiler, wx]},
-  {runtime_dependencies, ["wx-2.0","stdlib-3.15","kernel-8.0","erts-@OTP-18941@",
+  {runtime_dependencies, ["wx-2.0","stdlib-3.15","kernel-@OTP-18980@","erts-@OTP-18941@",
 			  "compiler-8.0"]}]}.


### PR DESCRIPTION
The debugger uses tracing in the implementation of `receive`. Run `receive` trace in its own session to avoid disturbing the user's use of tracing.