### PR TITLE
Fix faulty 'since' versions on master branch

### DIFF
--- a/lib/common_test/src/ct_netconfc.erl
+++ b/lib/common_test/src/ct_netconfc.erl
@@ -783,7 +783,7 @@ only_open(KeyOrName, ExtraOpts) ->
 %% hello/1
 
 -doc(#{equiv => hello/3}).
--doc(#{since => <<"OTP 17.5.3,OTP R15B02">>}).
+-doc(#{since => <<"OTP R15B02">>}).
 -spec hello(Client) -> Result when
       Client :: handle(),
       Result :: ok | {error, error_reason()}.
@@ -794,7 +794,7 @@ hello(Client) ->
 %% hello/2
 
 -doc(#{equiv => hello/3}).
--doc(#{since => <<"OTP 17.5.3,OTP R15B02">>}).
+-doc(#{since => <<"OTP R15B02">>}).
 -spec hello(Client, Timeout) -> Result when
       Client :: handle(),
       Timeout :: timeout(),
@@ -811,7 +811,7 @@ been received or after the specified timeout.
 
 Note that capabilities for an outgoing hello can be passed directly to `open/2`.
 """.
--doc(#{since => <<"OTP 17.5.3,OTP R15B02">>}).
+-doc(#{since => <<"OTP 17.5.3">>}).
 -spec hello(Client, Options, Timeout) -> Result when
       Client :: handle(),
       Options :: [{capability, [string()]}],
@@ -1037,7 +1037,7 @@ get_config(Client, Source, Filter, Timeout) ->
 %%----------------------------------------------------------------------
 %% Send a 'edit-config' request.
 -doc(#{equiv => edit_config/5}).
--doc(#{since => <<"OTP 18.0,OTP R15B02">>}).
+-doc(#{since => <<"OTP R15B02">>}).
 -spec edit_config(Client, Target, Config) -> Result when
       Client :: client(),
       Target :: netconf_db(),
@@ -1047,7 +1047,7 @@ edit_config(Client, Target, Config) ->
     edit_config(Client, Target, Config, ?DEFAULT_TIMEOUT).
 
 -doc(#{equiv => edit_config/5}).
--doc(#{since => <<"OTP 18.0,OTP R15B02">>}).
+-doc(#{since => <<"OTP R15B02">>}).
 -spec edit_config(Client, Target, Config, OptParams) -> Result when
       Client :: client(),
       Target :: netconf_db(),
@@ -1082,7 +1082,7 @@ value must be a list containing valid simple XML, for example:
 
 If `OptParams` is not given, the default value `[]` is used.
 """.
--doc(#{since => <<"OTP 18.0,OTP R15B02">>}).
+-doc(#{since => <<"OTP 18.0">>}).
 -spec edit_config(Client, Target, Config, OptParams, Timeout) -> Result when
       Client :: client(),
       Target :: netconf_db(),
@@ -1355,7 +1355,7 @@ create_subscription(Client, Stream, Filter, StartTime, StopTime, Timeout) ->
 %% Send a request to get the given event streams
 %% See RFC5277, NETCONF Event Notifications
 -doc(#{equiv => get_event_streams/3}).
--doc(#{since => <<"OTP 20.0,OTP R15B02">>}).
+-doc(#{since => <<"OTP 20.0">>}).
 -spec get_event_streams(Client)
 		       -> Result when
       Client :: client(),
@@ -1364,7 +1364,7 @@ get_event_streams(Client) ->
     get_event_streams(Client,[],?DEFAULT_TIMEOUT).
 
 -doc(#{equiv => get_event_streams/3}).
--doc(#{since => <<"OTP 20.0,OTP R15B02">>}).
+-doc(#{since => <<"OTP R15B02">>}).
 -spec get_event_streams(Client, Timeout)
 		       -> Result when
       Client :: client(),
@@ -1412,7 +1412,7 @@ If more complex filtering is needed, use [`ct_netconfc:get/2,3`](`get/2`) and
 specify the exact filter according to "XML Schema for Event Notifications" in
 RFC 5277.
 """.
--doc(#{since => <<"OTP 20.0,OTP R15B02">>}).
+-doc(#{since => <<"OTP R15B02">>}).
 -spec get_event_streams(Client, Streams, Timeout)
 		       -> Result when
       Client :: client(),

--- a/lib/compiler/src/cerl_trees.erl
+++ b/lib/compiler/src/cerl_trees.erl
@@ -349,7 +349,7 @@ much like [`fold/3`](`fold/3`).
 This is equivalent to `mapfold/4` with an identity function as the
 pre-operation.
 
-_See also: _`fold/3`, `map/2`, `mapfold/4`.
+_See also:_ `fold/3`, `map/2`, `mapfold/4`.
 """.
 -spec mapfold(Function :: fun((cerl(), term()) -> {cerl(), term()}),
 	      Initial :: term(),

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -1011,7 +1011,6 @@ server.
 > `inets:services/0` and `inets:services_info/0`, see `m:inets`.
 """.
 -doc(#{equiv => info/4}).
--doc(#{since => <<"OTP 18.0">>}).
 -spec info(Pid, Properties) -> HttpInformation  when
       Pid     :: pid(),
       Properties :: [atom()],
@@ -1103,7 +1102,6 @@ info(Address, Port) when is_integer(Port) ->
     info(Address, Port, default).
 
 -doc(#{equiv => info/4}).
--doc(#{since => <<"OTP 18.0">>}).
 -spec info(Address, Port, Profile) -> HttpInformation when
       Address :: inet:ip_address() | any,
       Port    :: integer(),

--- a/lib/inets/src/http_server/mod_auth.erl
+++ b/lib/inets/src/http_server/mod_auth.erl
@@ -279,7 +279,6 @@ delete_group_member(GroupName, UserName, Addr, Port, Dir) ->
 					GroupName, UserName, ?NOPASSWORD).
 
 -doc(#{equiv => list_users/3}).
--doc(#{since => <<"OTP R14B01">>}).
 list_users(Opt) ->
     case get_options(Opt, mandatory) of
 	{Addr, Port, Dir, AuthPwd} ->
@@ -300,7 +299,6 @@ a list of users in the user database for a specific `Port/Dir`. When
 [`list_users/1`](`list_users/1`) is called, options `Port` and `Dir` are
 mandatory.
 """.
--doc(#{since => <<"OTP R14B01">>}).
 list_users(Addr, Port, Dir) ->
     mod_auth_server:list_users(Addr, Port, Dir, ?NOPASSWORD).
 

--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -298,8 +298,9 @@ unload(Application) ->
     application_controller:unload_application(Application).
 
 
+%% ensure_all_started/1
 -doc(#{equiv => ensure_all_started(Applications, temporary, serial)}).
--doc(#{since => <<"OTP 26.0,OTP R16B02">>}).
+-doc(#{since => <<"OTP R16B02">>}).
 -spec ensure_all_started(Applications) -> {'ok', Started} | {'error', Reason} when
       Applications :: atom() | [atom()],
       Started :: [atom()],
@@ -307,8 +308,9 @@ unload(Application) ->
 ensure_all_started(Application) ->
     ensure_all_started(Application, temporary, serial).
 
+%% ensure_all_started/2
 -doc(#{equiv => ensure_all_started(Applications, Type, serial)}).
--doc(#{since => <<"OTP 26.0,OTP R16B02">>}).
+-doc(#{since => <<"OTP R16B02">>}).
 -spec ensure_all_started(Applications, Type) -> {'ok', Started} | {'error', AppReason} when
       Applications :: atom() | [atom()],
       Type :: restart_type(),
@@ -317,6 +319,7 @@ ensure_all_started(Application) ->
 ensure_all_started(Application, Type) ->
     ensure_all_started(Application, Type, serial).
 
+%% ensure_all_started/3
 -doc """
 `Applications` is either an an `t:atom/0` or a list of `t:atom/0` representing
 multiple applications.
@@ -341,7 +344,7 @@ specific dependency.
 If an error occurs, the applications started by the function are stopped to
 bring the set of running applications back to its initial state.
 """.
--doc(#{since => <<"OTP 26.0,OTP R16B02">>}).
+-doc(#{since => <<"OTP 26.0">>}).
 -spec ensure_all_started(Applications, Type, Mode) -> {'ok', Started} | {'error', AppReason} when
       Applications :: atom() | [atom()],
       Type :: restart_type(),

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -986,7 +986,6 @@ is_sticky(Mod) when is_atom(Mod) ->
 
 -type set_path_ret() :: 'true' | {'error', 'bad_directory'}.
 -doc #{equiv => set_path(PathList, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec set_path(Path) -> set_path_ret() when
       Path :: [Dir :: file:filename()].
 set_path(PathList) -> set_path(PathList, nocache).
@@ -1036,7 +1035,6 @@ get_path() -> call(get_path).
 
 -type add_path_ret() :: 'true' | {'error', 'bad_directory'}.
 -doc #{equiv => add_pathz(Dir, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec add_path(Dir) -> add_path_ret() when
       Dir :: file:filename().
 add_path(Dir) -> add_path(Dir, nocache).
@@ -1048,7 +1046,6 @@ add_path(Dir) -> add_path(Dir, nocache).
 add_path(Dir, Cache) when is_list(Dir), ?is_cache(Cache) -> add_pathz(Dir, Cache).
 
 -doc #{equiv => add_pathz(Dir, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec add_pathz(Dir) -> add_path_ret() when
       Dir :: file:filename().
 add_pathz(Dir) -> add_pathz(Dir, nocache).
@@ -1073,7 +1070,6 @@ add_pathz(Dir, Cache) when is_list(Dir), ?is_cache(Cache) ->
     call({add_path,last,Normalized,Cache}).
 
 -doc #{equiv => add_patha(Dir, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec add_patha(Dir) -> add_path_ret() when
       Dir :: file:filename().
 add_patha(Dir) -> add_patha(Dir, nocache).
@@ -1098,7 +1094,6 @@ add_patha(Dir, Cache) when is_list(Dir), ?is_cache(Cache) ->
     call({add_path,first,Normalized,Cache}).
 
 -doc #{equiv => add_pathsz(Dirs, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec add_paths(Dirs) -> 'ok' when
       Dirs :: [Dir :: file:filename()].
 add_paths(Dirs) -> add_paths(Dirs, nocache).
@@ -1111,7 +1106,6 @@ add_paths(Dirs, Cache) when is_list(Dirs), ?is_cache(Cache) ->
     add_pathsz(Dirs, Cache).
 
 -doc #{equiv => add_pathsz(Dirs, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec add_pathsz(Dirs) -> 'ok' when
       Dirs :: [Dir :: file:filename()].
 add_pathsz(Dirs) -> add_pathsz(Dirs, nocache).
@@ -1135,7 +1129,6 @@ add_pathsz(Dirs, Cache) when is_list(Dirs), ?is_cache(Cache) ->
     call({add_paths,last,Normalized,Cache}).
 
 -doc #{equiv => add_pathsa(Dirs, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec add_pathsa(Dirs) -> 'ok' when
       Dirs :: [Dir :: file:filename()].
 add_pathsa(Dirs) -> add_pathsa(Dirs, nocache).
@@ -1204,7 +1197,6 @@ del_paths(Dirs) when is_list(Dirs) -> call({del_paths,Dirs}).
 -type replace_path_ret() :: 'true' |
                             {'error', 'bad_directory' | 'bad_name' | {'badarg',_}}.
 -doc #{equiv => replace_path(Name, Dir, nocache)}.
--doc(#{since => <<"OTP 26.0">>}).
 -spec replace_path(Name, Dir) -> replace_path_ret() when
       Name:: atom(),
       Dir :: file:filename().

--- a/lib/kernel/src/erpc.erl
+++ b/lib/kernel/src/erpc.erl
@@ -383,7 +383,7 @@ Fails with an `{erpc, badarg}` `error` exception if:
 > You cannot make _any_ assumptions about the process that will perform the
 > `apply()`. It may be a server, or a freshly spawned process.
 """.
--doc(#{since => <<"OTP 23.0, OTP 25.0">>}).
+-doc(#{since => <<"OTP 23.0">>}).
 -spec send_request(Node, Module, Function, Args) -> RequestId when
       Node :: node(),
       Module :: atom(),

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -468,7 +468,6 @@ set_cwd(Dirname) ->
     check_and_call(set_cwd, [file_name(Dirname)]).
 
 -doc(#{equiv => delete(Filename, [])}).
--doc(#{since => <<"OTP 24.0">>}).
 -spec delete(Filename) -> ok | {error, Reason} when
       Filename :: name_all(),
       Reason :: posix() | badarg.
@@ -644,7 +643,6 @@ del_dir_r(File) -> % rm -rf File
     end.
 
 -doc(#{equiv => read_file_info(File, [])}).
--doc(#{since => <<"OTP R15B">>}).
 -spec read_file_info(File) -> {ok, FileInfo} | {error, Reason} when
       File :: name_all() | io_device(),
       FileInfo :: file_info(),
@@ -805,7 +803,6 @@ altname(Name) ->
     check_and_call(altname, [file_name(Name)]).
 
 -doc(#{equiv => read_link_info(Name, [])}).
--doc(#{since => <<"OTP R15B">>}).
 -spec read_link_info(Name) -> {ok, FileInfo} | {error, Reason} when
       Name :: name_all(),
       FileInfo :: file_info(),
@@ -899,7 +896,6 @@ read_link_all(Name) ->
     check_and_call(read_link_all, [file_name(Name)]).
 
 -doc(#{equiv => write_file_info(Filename, FileInfo, [])}).
--doc(#{since => <<"OTP R15B">>}).
 -spec write_file_info(Filename, FileInfo) -> ok | {error, Reason} when
       Filename :: name_all(),
       FileInfo :: file_info(),

--- a/lib/kernel/src/gen_sctp.erl
+++ b/lib/kernel/src/gen_sctp.erl
@@ -914,7 +914,6 @@ an SCTP server socket.
 For type `stream`, sockets Backlog define the backlog queue length just like in
 TCP.
 """.
--doc(#{since => <<"OTP R15B">>}).
 -spec listen(Socket, IsServer) -> ok | {error, Reason} when
       Socket :: sctp_socket(),
       IsServer :: boolean(),

--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -435,7 +435,6 @@ The [`options`](`m:gen_tcp#connect-options`) available are the same as for
 > Kernel configuration parameter `inet_default_connect_options`. For details,
 > see `m:inet`.
 """.
--doc(#{since => <<"OTP 24.3">>}).
 -doc(#{equiv => connect/4}).
 -spec connect(Address, Port, Opts) -> {ok, Socket} | {error, Reason} when
       Address  :: inet:socket_address() | inet:hostname(),

--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -392,7 +392,6 @@ This is a legacy clause mostly for `Destination = {local, Binary}` where
 [`send(Socket, Destination, [], Packet)`](`m:gen_udp#send-4-AncData`), the
 clause right above here.
 """.
--doc(#{since => <<"OTP 22.1">>}).
 -spec send(Socket, Host, Port, Packet) -> ok | {error, Reason} when
       Socket :: socket(),
       Host :: inet:hostname() | inet:ip_address(),

--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -844,9 +844,11 @@ remove_handler(HandlerId) ->
 Add or update primary configuration data for Logger. If the given `Key` already
 exists, its associated value will be changed to the given value. If it does not
 exist, it will be added.
+
+The `metadata` key was added in OTP 24.0.
 """.
 -doc(#{title => <<"Configuration API functions">>,
-       since => <<"OTP 21.0,OTP 24.0">>}).
+       since => <<"OTP 21.0">>}).
 -spec set_primary_config(level,Level) -> ok | {error,term()} when
       Level :: level() | all | none;
                         (filter_default,FilterDefault) -> ok | {error,term()} when

--- a/lib/observer/src/ttb.erl
+++ b/lib/observer/src/ttb.erl
@@ -780,7 +780,6 @@ proc_port({global,Name}) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Trace pattern
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec tp(tp_module(), match_spec()) ->
           {ok, match_desc()} | {error, term()}.
 tp(A,B) ->
@@ -789,7 +788,6 @@ tp(A,B) ->
     dbg:tp(A,ms(B)).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec tp(tp_module(), tp_function(), match_spec()) ->
           {ok, match_desc()} | {error, term()}.
 tp(A,B,C) ->
@@ -798,7 +796,6 @@ tp(A,B,C) ->
     dbg:tp(A,B,ms(C)).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec tp(tp_module(), tp_function(), tp_arity(), match_spec()) ->
           {ok, match_desc()} | {error, term()}.
 tp(A,B,C,D) ->
@@ -807,7 +804,6 @@ tp(A,B,C,D) ->
     dbg:tp(A,B,C,ms(D)).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec tpl(tp_module(), match_spec()) ->
           {ok, match_desc()} | {error, term()}.
 tpl(A,B) ->
@@ -816,7 +812,6 @@ tpl(A,B) ->
     dbg:tpl(A,ms(B)).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec tpl(tp_module(), tp_function(), match_spec()) ->
           {ok, match_desc()} | {error, term()}.
 tpl(A,B,C) ->
@@ -873,7 +868,6 @@ The shortcuts are as follows:
 - `{codestr, Str}` \- for `dbg:fun2ms/1` arguments passed as strings (example:
   `"fun(_) -> return_trace() end"`)
 """.
--doc(#{since => <<"OTP 19.0">>}).
 -spec tpl(tp_module(), tp_function(), tp_arity(), match_spec()) ->
           {ok, match_desc()} | {error, term()}.
 tpl(A,B,C,D) ->
@@ -892,14 +886,12 @@ tpe(A,B) ->
     dbg:tpe(A,ms(B)).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctp() -> {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctp() ->
     store(ctp,[]),
     dbg:ctp().
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctp(Module | {Module, Function, Arity}) ->
           {ok, MatchDesc :: match_desc()} | {error, term()} when
       Module :: tp_module(),
@@ -910,7 +902,6 @@ ctp(A) ->
     dbg:ctp(A).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctp(Module :: tp_module(), Function :: tp_function()) ->
           {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctp(A,B) ->
@@ -918,7 +909,6 @@ ctp(A,B) ->
     dbg:ctp(A,B).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctp(Module :: tp_module(), Function :: tp_function(), Arity :: tp_arity()) ->
           {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctp(A,B,C) ->
@@ -927,14 +917,12 @@ ctp(A,B,C) ->
 
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpl() -> {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctpl() ->
     store(ctpl,[]),
     dbg:ctpl().
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpl(Module | {Module, Function :: tp_function(), Arity :: tp_arity()}) ->
               {ok, MatchDesc :: term()} | {error, term()} when
       Module :: tp_module().
@@ -943,7 +931,6 @@ ctpl(A) ->
     dbg:ctpl(A).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpl(Module :: tp_module(), Function :: tp_function()) ->
           {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctpl(A,B) ->
@@ -951,7 +938,6 @@ ctpl(A,B) ->
     dbg:ctpl(A,B).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpl(Module :: tp_module(), Function :: tp_function(), Arity :: tp_arity()) ->
           {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctpl(A,B,C) ->
@@ -959,14 +945,12 @@ ctpl(A,B,C) ->
     dbg:ctpl(A,B,C).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpg() -> {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctpg() ->
     store(ctpg,[]),
     dbg:ctpg().
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpg(Module | {Module, Function :: tp_function(), Arity :: tp_arity()}) ->
           {ok, MatchDesc :: term()} | {error, term()} when
       Module :: tp_module().
@@ -975,7 +959,6 @@ ctpg(A) ->
     dbg:ctpg(A).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpg(Module :: tp_module(), Function :: tp_function()) ->
           {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctpg(A,B) ->
@@ -983,7 +966,6 @@ ctpg(A,B) ->
     dbg:ctpg(A,B).
 
 -doc(#{equiv => tpl/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec ctpg(Module :: tp_module(), Function :: tp_function(), Arity :: tp_arity()) ->
           {ok, MatchDesc :: match_desc()} | {error, term()}.
 ctpg(A,B,C) ->

--- a/lib/parsetools/src/leex.erl
+++ b/lib/parsetools/src/leex.erl
@@ -461,7 +461,6 @@ The standard `t:error_info/0` structure that is returned from all I/O modules.
 -type leex_ret() :: ok_ret() | error_ret().
 
 -doc #{equiv => file(File, [])}.
--doc(#{since => <<"OTP R16B02">>}).
 -spec file(FileName) -> leex_ret() when
       FileName :: file:filename().
 

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -728,7 +728,7 @@ decrypt_public(CipherText, #'RSAPublicKey'{modulus = N, publicExponent = E},
 %% Description: Public key encryption using the public key.
 %%--------------------------------------------------------------------
 -doc(#{equiv => encrypt_public/3}).
--doc(#{since => <<"OTP 21.1,OTP R14B">>}).
+-doc(#{since => <<"OTP R14B">>}).
 -spec encrypt_public(PlainText, Key) ->
 			     CipherText
                                  when  PlainText :: binary(),
@@ -739,7 +739,7 @@ encrypt_public(PlainText, Key) ->
 
 
 -doc "Public-key encryption using the public key. See also `crypto:public_encrypt/4`.".
--doc(#{since => <<"OTP 21.1,OTP R14B">>}).
+-doc(#{since => <<"OTP 21.1">>}).
 -spec encrypt_public(PlainText, Key, Options) ->
 			     CipherText
                                  when  PlainText :: binary(),
@@ -755,7 +755,7 @@ encrypt_public(PlainText, #'RSAPublicKey'{modulus=N,publicExponent=E},
 %% Description: Public key encryption using the private key.
 %%--------------------------------------------------------------------
 -doc(#{equiv => encrypt_private/3}).
--doc(#{since => <<"OTP 21.1,OTP R14B">>}).
+-doc(#{since => <<"OTP R14B">>}).
 -spec encrypt_private(PlainText, Key) ->
 			     CipherText
                                  when  PlainText :: binary(),
@@ -772,7 +772,7 @@ specifing the key algorithm `rsa` and a fun to handle the encryption operation.
 This may be used for customized the encryption operation with for instance
 hardware security modules (HSM) or trusted platform modules (TPM).
 """.
--doc(#{since => <<"OTP 21.1,OTP R14B">>}).
+-doc(#{since => <<"OTP 21.1">>}).
 -spec encrypt_private(PlainText, Key, Options) ->
 			     CipherText
                                  when  PlainText :: binary(),
@@ -1004,7 +1004,6 @@ pkix_hash_type('id-md5') ->
 %% Description: Create digital signature.
 %%--------------------------------------------------------------------
 -doc(#{equiv => sign/4}).
--doc(#{since => <<"OTP 20.1">>}).
 -spec sign(Msg, DigestType, Key) ->
                   Signature when Msg ::  binary() | {digest,binary()},
                                  DigestType :: digest_type(),
@@ -1051,7 +1050,7 @@ sign(DigestOrPlainText, DigestType, Key, Options) ->
 %% Description: Verifies a digital signature.
 %%--------------------------------------------------------------------
 -doc(#{equiv => verify/5}).
--doc(#{since => <<"OTP 20.1,OTP R14B">>}).
+-doc(#{since => <<"OTP R14B">>}).
 -spec verify(Msg, DigestType, Signature, Key) ->
                     boolean() when Msg :: binary() | {digest, binary()},
                                    DigestType :: digest_type(),
@@ -1067,7 +1066,7 @@ Verifies a digital signature.
 The `Msg` is either the binary "plain text" data or it is the hashed value of
 "plain text", that is, the digest.
 """.
--doc(#{since => <<"OTP 20.1,OTP R14B">>}).
+-doc(#{since => <<"OTP 20.1">>}).
 -spec verify(Msg, DigestType, Signature, Key, Options) ->
                     boolean() when Msg :: binary() | {digest, binary()},
                                    DigestType :: digest_type(),

--- a/lib/sasl/src/release_handler.erl
+++ b/lib/sasl/src/release_handler.erl
@@ -368,7 +368,6 @@ unpack_release(ReleaseName) ->
 %%                   exit_reason()
 %%-----------------------------------------------------------------
 -doc(#{equiv => check_install_release(Vsn, [])}).
--doc(#{since => <<"OTP R14B04">>}).
 -spec check_install_release(Vsn) -> {ok, OtherVsn, Descr} | {error, Reason} when Vsn :: string(),
    OtherVsn :: string(),
    Descr :: term(),
@@ -862,7 +861,6 @@ corresponding modules are to be located under `Dir/App-Vsn/ebin`. The
 directories for applications not specified in `AppDirs` are assumed to be
 located in `$ROOT/lib`.
 """.
--doc(#{since => <<"OTP 25.0">>}).
 -spec create_RELEASES(Root, RelDir, RelFile, AppDirs) -> ok | {error, Reason} when Root :: string(),
    RelDir :: string(),
    RelFile :: string(),

--- a/lib/snmp/src/agent/snmp_community_mib.erl
+++ b/lib/snmp/src/agent/snmp_community_mib.erl
@@ -272,7 +272,6 @@ table_del_row(Tab, Key) ->
 
 
 -doc(#{equiv => add_community/6}).
--doc(#{since => <<"OTP R14B03">>}).
 -spec add_community(Idx, CommName, SecName, CtxName, TransportTag) ->
           {ok, Key} | {error, Reason} when
       Idx          :: index(),

--- a/lib/snmp/src/agent/snmpa.erl
+++ b/lib/snmp/src/agent/snmpa.erl
@@ -719,7 +719,6 @@ load_mib(Agent, Mib) ->
 
 
 -doc(#{equiv => load_mibs/3}).
--doc(#{since => <<"OTP R16B02">>}).
 -spec load_mibs(Mibs) -> 
           ok | {error, Reason} when
       Mibs           :: [MibName],
@@ -731,7 +730,6 @@ load_mibs(Mibs) ->
     load_mibs(snmp_master_agent, Mibs, false).
 
 -doc(#{equiv => load_mibs/3}).
--doc(#{since => <<"OTP R16B02">>}).
 -spec load_mibs(Agent, Mibs) -> ok | {error, Reason} when
       Agent          :: pid() | AgentName,
       AgentName      :: atom(),
@@ -812,7 +810,6 @@ unload_mib(Agent, Mib) ->
 
 
 -doc(#{equiv => unload_mibs/3}).
--doc(#{since => <<"OTP R16B02">>}).
 -spec unload_mibs(Mibs) ->
           ok | {error, Reason} when
       Mibs           :: [MibName], 
@@ -824,7 +821,6 @@ unload_mibs(Mibs) ->
     unload_mibs(snmp_master_agent, Mibs).
 
 -doc(#{equiv => unload_mibs/3}).
--doc(#{since => <<"OTP R16B02">>}).
 -spec unload_mibs(Agent, Mibs) ->
           ok | {error, Reason} when
       Agent          :: pid() | AgentName, 
@@ -1656,7 +1652,6 @@ send_notification2(Agent, Notification, SendOpts) ->
 
 
 -doc(#{equiv => send_notification/7}).
--doc(#{since => <<"OTP R14B">>}).
 -spec send_notification(Agent, Notification, Receiver) -> snmp:void() when
       Agent        :: pid() | AgentName,
       AgentName    :: atom(),
@@ -1683,7 +1678,6 @@ send_notification(Agent, Notification, Receiver) ->
     send_notification2(Agent, Notification, SendOpts).
 
 -doc(#{equiv => send_notification/7}).
--doc(#{since => <<"OTP R14B">>}).
 -spec send_notification(Agent, Notification, Receiver,
                         Varbinds) -> snmp:void() when
       Agent        :: pid() | AgentName,
@@ -1720,7 +1714,6 @@ send_notification(Agent, Notification, Receiver, Varbinds) ->
     send_notification2(Agent, Notification, SendOpts).
 
 -doc(#{equiv => send_notification/7}).
--doc(#{since => <<"OTP R14B">>}).
 -spec send_notification(Agent, Notification, Receiver, NotifyName, Varbinds) ->
           snmp:void() when
       Agent        :: pid() | AgentName,
@@ -1758,7 +1751,6 @@ send_notification(Agent, Notification, Receiver, NotifyName, Varbinds) ->
     send_notification2(Agent, Notification, SendOpts).
 
 -doc(#{equiv => send_notification/7}).
--doc(#{since => <<"OTP R14B">>}).
 -spec send_notification(Agent, Notification, Receiver,
                         NotifyName, ContextName, Varbinds) ->
           snmp:void() when
@@ -2349,7 +2341,7 @@ get_agent_caps() ->
 %%%-----------------------------------------------------------------
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
+-doc(#{since => <<"OTP R15B01">>}).
 -spec log_to_txt(LogDir) -> snmp:void() when
       LogDir :: snmp:dir().
 
@@ -2358,7 +2350,6 @@ log_to_txt(LogDir) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
 -spec log_to_txt(LogDir, Block) -> snmp:void() when
       LogDir :: snmp:dir(),
       Block  :: boolean();
@@ -2382,7 +2373,6 @@ log_to_txt(LogDir, Mibs) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, Block) -> snmp:void() when
       LogDir :: snmp:dir(),
       Mibs   :: [snmp:mib_name()],
@@ -2406,7 +2396,6 @@ log_to_txt(LogDir, Mibs, OutFile) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, OutFile, Block) -> snmp:void() when
       LogDir  :: snmp:dir(),
       Mibs    :: [snmp:mib_name()],
@@ -2430,7 +2419,6 @@ log_to_txt(LogDir, Mibs, OutFile, LogName) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, OutFile, LogName, Block) -> snmp:void() when
       LogDir  :: snmp:dir(),
       Mibs    :: [snmp:mib_name()],
@@ -2454,7 +2442,6 @@ log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile, Block) ->
           snmp:void() when
       LogDir  :: snmp:dir(),
@@ -2481,7 +2468,6 @@ log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile, Start) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs,
                  OutFile, LogName, LogFile,
 		 Block,
@@ -2528,7 +2514,7 @@ wrap during conversion). Defaults to `true`.
 
 See [snmp:log_to_txt](`m:snmp#log_to_txt`) for more info.
 """.
--doc(#{since => <<"OTP R15B01, OTP R16B03">>}).
+-doc(#{since => <<"OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs,
 		 OutFile, LogName, LogFile,
 		 Block,
@@ -2726,7 +2712,7 @@ wrap during conversion). Defaults to `true`.
 
 See [snmp:log_to_io](`m:snmp#log_to_io`) for more info.
 """.
--doc(#{since => <<"OTP R15B01">>}).
+-doc(#{since => <<"OTP R16B03">>}).
 -spec log_to_io(LogDir, Mibs, LogName, LogFile, Block, Start, Stop) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),

--- a/lib/snmp/src/agent/snmpa_conf.erl
+++ b/lib/snmp/src/agent/snmpa_conf.erl
@@ -1040,7 +1040,6 @@ Create an entry for the agent target_addr config file, `target_addr.conf`.
 See [Target Address Definitions](snmp_agent_config_files.md#target_addr) for
 more info.
 """.
--doc(#{since => <<"OTP 17.3">>}).
 -spec target_addr_entry(Name, Domain, Addr, TagList,
                         ParamsName, EngineId) -> TargetAddrEntry when
       Name            :: snmp_target_mib:name(),
@@ -1140,7 +1139,6 @@ Create an entry for the agent target_addr config file, `target_addr.conf`.
 See [Target Address Definitions](snmp_agent_config_files.md#target_addr) for
 more info.
 """.
--doc(#{since => <<"OTP 17.3">>}).
 -spec target_addr_entry(Name, Domain, Addr, TagList,
                         ParamsName, EngineId, TMask, MaxMessageSize) ->
           TargetAddrEntry when
@@ -1189,7 +1187,6 @@ Create an entry for the agent target_addr config file, `target_addr.conf`.
 See [Target Address Definitions](snmp_agent_config_files.md#target_addr) for
 more info.
 """.
--doc(#{since => <<"OTP 17.3">>}).
 -spec target_addr_entry(Name,
                         Domain, Addr,
                         Timeout, RetryCount, TagList,

--- a/lib/snmp/src/app/snmp.erl
+++ b/lib/snmp/src/app/snmp.erl
@@ -1386,7 +1386,6 @@ read_mib(FileName) ->
 %%%-----------------------------------------------------------------
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),
@@ -1407,7 +1406,6 @@ log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile, Block) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),
@@ -1445,7 +1443,6 @@ log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile, Start) ->
 
 
 -doc(#{equiv => log_to_txt/8}).
--doc(#{since => <<"OTP R16B03">>}).
 -spec log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile, Block, Start) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),
@@ -1544,7 +1541,7 @@ log_to_txt(LogDir, Mibs, OutFile, LogName, LogFile, Block, Start, Stop) ->
 
 
 -doc(#{equiv => log_to_io/7}).
--doc(#{since => <<"OTP R15B01,OTP R16B03">>}).
+-doc(#{since => <<"OTP R15B01">>}).
 -spec log_to_io(LogDir, Mibs, LogName, LogFile) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),
@@ -1564,7 +1561,7 @@ log_to_io(LogDir, Mibs, LogName, LogFile) ->
 
 
 -doc(#{equiv => log_to_io/7}).
--doc(#{since => <<"OTP R15B01,OTP R16B03">>}).
+-doc(#{since => <<"OTP R15B01">>}).
 -spec log_to_io(LogDir, Mibs, LogName, LogFile, Block) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),
@@ -1599,7 +1596,7 @@ log_to_io(LogDir, Mibs, LogName, LogFile, Start) ->
     log_to_io(LogDir, Mibs, LogName, LogFile, Block, Start, Stop).
 
 -doc(#{equiv => log_to_io/7}).
--doc(#{since => <<"OTP R15B01,OTP R16B03">>}).
+-doc(#{since => <<"OTP R15B01">>}).
 -spec log_to_io(LogDir, Mibs, LogName, LogFile, Block, Start) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),
@@ -1639,7 +1636,7 @@ Converts an Audit Trail Log to a readable format and prints it on stdio. See
 
 [](){: #change_log_size }
 """.
--doc(#{since => <<"OTP R15B01,OTP R16B03">>}).
+-doc(#{since => <<"OTP R16B03">>}).
 -spec log_to_io(LogDir, Mibs, LogName, LogFile, Block, Start, Stop) ->
           ok | {ok, Cnt} | {error, Reason} when
       LogDir  :: string(),

--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -295,7 +295,6 @@ connect(_OpenTcpSocket, Options) ->
     bad_arg([{options, Options}]).
 
 -doc(#{equiv => connect/4}).
--doc(#{since => <<"OTP 19.0">>}).
 -spec connect(open_socket(), client_options(), timeout()) ->
                      {ok, connection_ref()} | {error, term()}
            ; (host(), inet:port_number(), client_options()) ->
@@ -340,7 +339,6 @@ the value of the [`connect_timeout`](`t:connect_timeout_client_option/0`)
 option, if present. For connection timeout, use the option
 [`connect_timeout`](`t:connect_timeout_client_option/0`).
 """.
--doc(#{since => <<"OTP 19.0">>}).
 -spec connect(Host, Port, Options, NegotiationTimeout)
              -> {ok, connection_ref()}
               | {error, term()} when
@@ -485,7 +483,6 @@ Returns information about a connection intended for e.g debugging or logging.
 
 When the `Key` is a single `Item`, the result is a single `InfoTuple`
 """.
--doc(#{since => <<"OTP 22.1">>}).
 -spec connection_info(ConnectionRef, ItemList|Item) ->  InfoTupleList|InfoTuple when
       ConnectionRef :: connection_ref(),
       ItemList :: [Item],
@@ -706,7 +703,7 @@ default values.
       | {options, daemon_options()}.
 
 -doc(#{equiv => daemon_info/2}).
--doc(#{since => <<"OTP 19.0,OTP 22.1">>}).
+-doc(#{since => <<"OTP 19.0">>}).
 -spec daemon_info(DaemonRef) -> {ok,InfoTupleList} | {error,bad_daemon_ref} when
       DaemonRef :: daemon_ref(),
       InfoTupleList :: [InfoTuple],
@@ -752,7 +749,7 @@ Note that [`daemon_info/1`](`daemon_info/1`) and
 [`daemon_info/2`](`daemon_info/2`) returns different types due to compatibility
 reasons.
 """.
--doc(#{since => <<"OTP 19.0,OTP 22.1">>}).
+-doc(#{since => <<"OTP 22.1">>}).
 -spec daemon_info(DaemonRef, ItemList|Item) ->  InfoTupleList|InfoTuple | {error,bad_daemon_ref} when
       DaemonRef :: daemon_ref(),
       ItemList :: [Item],
@@ -779,7 +776,6 @@ daemon_info(DaemonRef, Keys) ->
 %% existing connections started by the listener up and running.
 %%--------------------------------------------------------------------
 -doc(#{equiv => stop_listener/3}).
--doc(#{since => <<"OTP 21.0">>}).
 -spec stop_listener(daemon_ref()) -> ok.
 
 stop_listener(SysSup) ->
@@ -787,7 +783,6 @@ stop_listener(SysSup) ->
 
 
 -doc(#{equiv => stop_listener/3}).
--doc(#{since => <<"OTP 21.0">>}).
 -spec stop_listener(inet:ip_address(), inet:port_number()) -> ok.
 
 stop_listener(Address, Port) ->
@@ -811,7 +806,6 @@ stop_listener(Address, Port, Profile) ->
                                                     profile=Profile})).
 
 -doc(#{equiv => stop_daemon/3}).
--doc(#{since => <<"OTP 21.0">>}).
 -spec stop_daemon(DaemonRef::daemon_ref()) -> ok.
 
 stop_daemon(SysSup) ->
@@ -819,7 +813,6 @@ stop_daemon(SysSup) ->
 
 
 -doc(#{equiv => stop_daemon/3}).
--doc(#{since => <<"OTP 21.0">>}).
 -spec stop_daemon(inet:ip_address(), inet:port_number()) -> ok.
 
 stop_daemon(Address, Port) ->

--- a/lib/ssh/src/ssh_client_channel.erl
+++ b/lib/ssh/src/ssh_client_channel.erl
@@ -261,6 +261,7 @@ calls [Module:handle_cast/2](`c:handle_cast/2`) to handle the message.
 cast(ChannelRef, Msg) ->
     gen_server:cast(ChannelRef, Msg).
 
+-opaque client() :: term().
 -doc """
 reply(Client, Reply) -> \_
 
@@ -273,7 +274,6 @@ This function can be used by a channel to send a reply to a client that called
 given back to the client as the return value of [call/\[2,3].](`call/2`)
 """.
 -doc(#{since => <<"OTP 21.0">>}).
--opaque client() :: term().
 -spec reply(Client, Reply) -> _ when
       Client :: client(),
       Reply :: term().

--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -609,7 +609,7 @@ reply_request(_,false, _, _) ->
 %% Description: Sends a ssh connection protocol pty_req.
 %%--------------------------------------------------------------------
 -doc(#{equiv => ptty_alloc/4}).
--doc(#{since => <<"OTP 17.4,OTP 17.5">>}).
+-doc(#{since => <<"OTP 17.5">>}).
 -spec ptty_alloc(ConnectionRef, ChannelId, Options) -> result() when
       ConnectionRef :: ssh:connection_ref(),
       ChannelId :: ssh:channel_id(),
@@ -640,7 +640,7 @@ Options:
   list. Otherwise, see possible _POSIX_ names in Section 8 in
   [RFC 4254](http://www.ietf.org/rfc/rfc4254.txt).
 """.
--doc(#{since => <<"OTP 17.4,OTP 17.5">>}).
+-doc(#{since => <<"OTP 17.4">>}).
 -spec ptty_alloc(ConnectionRef, ChannelId, Options, Timeout) -> result() when
       ConnectionRef :: ssh:connection_ref(),
       ChannelId :: ssh:channel_id(),

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2023,8 +2023,7 @@ connect(Host, Port, TLSOptions, infinity).
 ```
 """.
 
--doc(#{title => <<"Client Functions">>,
-       since => <<"OTP R14B">>}).
+-doc(#{title => <<"Client Functions">>}).
 -doc(#{equiv => connect/4}).
 -spec connect(TCPSocketOrHost, TLSOptionsOrPort, TimeoutOrTLSOptions) ->
           {ok, sslsocket()} |
@@ -3306,7 +3305,7 @@ Equivalent to
 `export_key_materials(TLSSocket, Labels, Contexts, WantedLengths, true).`
 """.
 -doc(#{title => <<"Utility Functions">>,
-       since => <<"OTP 27">>}).
+       since => <<"OTP 27.0">>}).
 -spec export_key_materials(SslSocket, Labels, Contexts, WantedLengths) ->
                  {ok, ExportKeyMaterials} | {error, reason()} when
       SslSocket :: sslsocket(),
@@ -3322,7 +3321,7 @@ export_key_materials(#sslsocket{pid = {_Listen, #config{}}}, _,_,_) ->
 
 %%--------------------------------------------------------------------
 -doc(#{title => <<"Utility Functions">>,
-       since => <<"OTP 27">>}).
+       since => <<"OTP 27.0">>}).
 -spec export_key_materials(SslSocket, Labels, Contexts, WantedLengths, ConsumeSecret) ->
                  {ok, ExportKeyMaterials} | {error, exporter_master_secret_already_consumed | bad_input} when
       SslSocket :: sslsocket(),

--- a/lib/ssl/src/ssl_crl_cache_api.erl
+++ b/lib/ssl/src/ssl_crl_cache_api.erl
@@ -50,7 +50,7 @@ For description see
 -type logger_info()     :: {logger:level(), Report::#{description => string(), reason => term()}, logger:metadata()}.
 
 
--doc(#{equiv => lookup/3,since => <<"OTP 18">>}).
+-doc(#{equiv => lookup/3,since => <<"OTP 18.0">>}).
 -doc """
 Backwards compatibility, replaced by lookup/3
 """.
@@ -83,7 +83,7 @@ produce log events.
     {{logger, logger_info()}, [public_key:der_encoded()]}.
 
 
--doc(#{since => <<"OTP 18">>}).
+-doc(#{since => <<"OTP 18.0">>}).
 -doc """
 Select the CRLs in the cache that are issued by `Issuer` unless the value is a
 list of so called general names, see
@@ -102,7 +102,7 @@ produce log events.
       IssuerOrDPLocations::public_key:issuer_name() | list(),
       CacheRef :: crl_cache_ref().
 
--doc(#{since => <<"OTP 18">>}).
+-doc(#{since => <<"OTP 18.0">>}).
 -doc """
 `fun fresh_crl/2` will be used as input option `update_crl` to
 `public_key:pkix_crls_validate/3`.

--- a/lib/stdlib/examples/erl_id_trans.erl
+++ b/lib/stdlib/examples/erl_id_trans.erl
@@ -70,6 +70,7 @@ parse_transform(Forms, _Options) ->
     forms(Forms).
 
 -doc "Returns information about the parse transform itself.".
+-doc(#{since => <<"OTP 24.0">>}).
 -spec parse_transform_info() -> #{ 'error_location' => 'column' | 'line' }.
 parse_transform_info() ->
     #{error_location => column}.

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -572,7 +572,6 @@ Used to set a time limit on how long to wait for a response using either
 %% -----------------------------------------------------------------
 
 -doc(#{equiv => start([])}).
--doc(#{since => <<"OTP 20.0">>}).
 -spec start() -> start_ret().
 start() ->
     gen:start(?MODULE, nolink, ?NO_CALLBACK, [], []).
@@ -584,7 +583,6 @@ not part of a supervision tree and thus has no supervisor.
 For a description of the arguments and return values, see
 [`start_link/1`](`start_link/1`).
 """.
--doc(#{since => <<"OTP 20.0">>}).
 -spec start(EventMgrNameOrOptions :: emgr_name() | options()) -> start_ret().
 start(Name) when is_tuple(Name) ->
     gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], []);
@@ -608,7 +606,6 @@ start(Name, Options) ->
     error(badarg, [Name, Options]).
 
 -doc(#{equiv => start_link([])}).
--doc(#{since => <<"OTP 20.0">>}).
 -spec start_link() -> start_ret().
 start_link() ->
     gen:start(?MODULE, link, ?NO_CALLBACK, [], []).
@@ -623,7 +620,6 @@ If called with `t:options/0`, then a nameless event manager is created using `Op
 For a description of the arguments and return values, see
 [`start_link/2`](`start_link/2`).
 """.
--doc(#{since => <<"OTP 20.0">>}).
 -spec start_link(EventMgrNameOrOptions :: emgr_name() | options()) -> start_ret().
 start_link(Name) when is_tuple(Name) ->
     gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], []);
@@ -1371,7 +1367,6 @@ For a description of `Handler`, see `add_handler/3`.
 which_handlers(M) -> rpc(M, which_handlers).
 
 -doc(#{equiv => stop(EventMgrRef, normal, infinity)}).
--doc(#{since => <<"OTP 18.0">>}).
 -spec stop(EventMgrRef :: emgr_ref()) -> 'ok'.
 stop(M) ->
     gen:stop(M).

--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -642,7 +642,6 @@ read(Io, Prompt) ->
     end.
 
 -doc(#{equiv => read(IoDevice, Prompt, StartLocation, [])}).
--doc(#{since => <<"OTP R16B">>}).
 -spec read(IoDevice, Prompt, StartLocation) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),
@@ -1277,7 +1276,6 @@ format(Io, Format, Args) ->
 %% Scanning Erlang code.
 
 -doc(#{equiv => scan_erl_exprs(standard_io, Prompt)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec scan_erl_exprs(Prompt) -> Result when
       Prompt :: prompt(),
       Result :: erl_scan:tokens_result() | server_no_data().
@@ -1286,7 +1284,6 @@ scan_erl_exprs(Prompt) ->
     scan_erl_exprs(default_input(), Prompt, 1).
 
 -doc(#{equiv => scan_erl_exprs(Device, Prompt, 1)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec scan_erl_exprs(Device, Prompt) -> Result when
       Device :: device(),
       Prompt :: prompt(),
@@ -1296,7 +1293,6 @@ scan_erl_exprs(Io, Prompt) ->
     scan_erl_exprs(Io, Prompt, 1).
 
 -doc(#{equiv => scan_erl_exprs(Device, Prompt, StartLocation, [])}).
--doc(#{since => <<"OTP R16B">>}).
 -spec scan_erl_exprs(Device, Prompt, StartLocation) -> Result when
       Device :: device(),
       Prompt :: prompt(),
@@ -1350,7 +1346,6 @@ scan_erl_exprs(Io, Prompt, Pos0, Options) ->
     request(Io, {get_until,unicode,Prompt,erl_scan,tokens,[Pos0,Options]}).
 
 -doc(#{equiv => scan_erl_form(standard_io, Prompt)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec scan_erl_form(Prompt) -> Result when
       Prompt :: prompt(),
       Result :: erl_scan:tokens_result() | server_no_data().
@@ -1359,7 +1354,6 @@ scan_erl_form(Prompt) ->
     scan_erl_form(default_input(), Prompt, 1).
 
 -doc(#{equiv => scan_erl_form(IoDevice, Prompt, 1)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec scan_erl_form(IoDevice, Prompt) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),
@@ -1369,7 +1363,6 @@ scan_erl_form(Io, Prompt) ->
     scan_erl_form(Io, Prompt, 1).
 
 -doc(#{equiv => scan_erl_form(IoDevice, Prompt, StartLocation, [])}).
--doc(#{since => <<"OTP R16B">>}).
 -spec scan_erl_form(IoDevice, Prompt, StartLocation) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),
@@ -1414,7 +1407,6 @@ scan_erl_form(Io, Prompt, Pos0, Options) ->
                    | server_no_data().
 
 -doc(#{equiv => parse_erl_exprs(standard_io, Prompt)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec parse_erl_exprs(Prompt) -> Result when
       Prompt :: prompt(),
       Result :: parse_ret().
@@ -1423,7 +1415,6 @@ parse_erl_exprs(Prompt) ->
     parse_erl_exprs(default_input(), Prompt, 1).
 
 -doc(#{equiv => parse_erl_exprs(IoDevice, Prompt, 1)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec parse_erl_exprs(IoDevice, Prompt) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),
@@ -1433,7 +1424,6 @@ parse_erl_exprs(Io, Prompt) ->
     parse_erl_exprs(Io, Prompt, 1).
 
 -doc(#{equiv => parse_erl_exprs(IoDevice, Prompt, StartLocation, [])}).
--doc(#{since => <<"OTP R16B">>}).
 -spec parse_erl_exprs(IoDevice, Prompt, StartLocation) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),
@@ -1506,7 +1496,6 @@ parse_erl_exprs(Io, Prompt, Pos0, Options) ->
                         | server_no_data().
 
 -doc(#{equiv => parse_erl_form(standard_io, Prompt)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec parse_erl_form(Prompt) -> Result when
       Prompt :: prompt(),
       Result :: parse_form_ret().
@@ -1515,7 +1504,6 @@ parse_erl_form(Prompt) ->
     parse_erl_form(default_input(), Prompt, 1).
 
 -doc(#{equiv => parse_erl_form(IoDevice, Prompt, 1)}).
--doc(#{since => <<"OTP R16B">>}).
 -spec parse_erl_form(IoDevice, Prompt) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),
@@ -1525,7 +1513,6 @@ parse_erl_form(Io, Prompt) ->
     parse_erl_form(Io, Prompt, 1).
 
 -doc(#{equiv => parse_erl_form(IoDevice, Prompt, StartLocation, [])}).
--doc(#{since => <<"OTP R16B">>}).
 -spec parse_erl_form(IoDevice, Prompt, StartLocation) -> Result when
       IoDevice :: device(),
       Prompt :: prompt(),

--- a/lib/stdlib/src/io_lib.erl
+++ b/lib/stdlib/src/io_lib.erl
@@ -464,7 +464,6 @@ add_modifier(_, C) ->
 %%  representation of the term. write/3 is for backward compatibility.
 
 -doc(#{equiv => write(Term, -1)}).
--doc(#{since => <<"OTP 20.0">>}).
 -spec write(Term) -> chars() when
       Term :: term().
 
@@ -504,7 +503,6 @@ _Example:_
 "{[1,2|...],[4|...],...}"
 ```
 """.
--doc(#{since => <<"OTP 20.0">>}).
 -spec write(Term, Depth) -> chars() when
       Term :: term(),
       Depth :: depth();

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -621,7 +621,6 @@ delete(_, []) -> [].
 %% Xn] and [Y0, Y1, ..., Yn].
 
 -doc(#{equiv => zip(List1, List2, fail)}).
--doc(#{since => <<"OTP 26.0">>}).
 -spec zip(List1, List2) -> List3 when
       List1 :: [A],
       List2 :: [B],
@@ -718,7 +717,6 @@ unzip([], Xs, Ys) -> {reverse(Xs), reverse(Ys)}.
 %% X1, ..., Xn], [Y0, Y1, ..., Yn] and [Z0, Z1, ..., Zn].
 
 -doc(#{equiv => zip3(List1, List2, List3, fail)}).
--doc(#{since => <<"OTP 26.0">>}).
 -spec zip3(List1, List2, List3) -> List4 when
       List1 :: [A],
       List2 :: [B],
@@ -803,7 +801,6 @@ unzip3([], Xs, Ys, Zs) ->
 %% Xn] and [Y0, Y1, ..., Yn].
 
 -doc(#{equiv => zipwith(Combine, List1, List2, fail)}).
--doc(#{since => <<"OTP 26.0">>}).
 -spec zipwith(Combine, List1, List2) -> List3 when
       Combine :: fun((X, Y) -> T),
       List1 :: [X],
@@ -865,7 +862,6 @@ zipwith(F, [_ | _]=Xs, [], {pad, {_, Y}}) ->
 %% [X0, X1, ..., Xn], [Y0, Y1, ..., Yn] and [Z0, Z1, ..., Zn].
 
 -doc(#{equiv => zipwith3(Combine, List1, List2, List3, fail)}).
--doc(#{since => <<"OTP 26.0">>}).
 -spec zipwith3(Combine, List1, List2, List3) -> List4 when
       Combine :: fun((X, Y, Z) -> T),
       List1 :: [X],
@@ -1568,7 +1564,7 @@ keymap(Fun, Index, []) when is_integer(Index), Index >= 1,
                             is_function(Fun, 1) -> [].
 
 -doc(#{equiv => enumerate(1, 1, List1)}).
--doc(#{since => <<"OTP 25.0,OTP 26.0">>}).
+-doc(#{since => <<"OTP 25.0">>}).
 -spec enumerate(List1) -> List2 when
       List1 :: [T],
       List2 :: [{Index, T}],
@@ -1578,7 +1574,7 @@ enumerate(List1) ->
     enumerate(1, 1, List1).
 
 -doc(#{equiv => enumerate(Index, 1, List1)}).
--doc(#{since => <<"OTP 25.0,OTP 26.0">>}).
+-doc(#{since => <<"OTP 25.0">>}).
 -spec enumerate(Index, List1) -> List2 when
       List1 :: [T],
       List2 :: [{Index, T}],
@@ -1620,7 +1616,7 @@ _Examples:_
 [{0,a},{-2,b},{-4,c}]
 ```
 """.
--doc(#{since => <<"OTP 25.0,OTP 26.0">>}).
+-doc(#{since => <<"OTP 26.0">>}).
 -spec enumerate(Index, Step, List1) -> List2 when
       List1 :: [T],
       List2 :: [{Index, T}],

--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -735,7 +735,7 @@ from the specified `t:seed/0` integers.
 `Alg = default` is an alias for the [_default algorithm_](#default-algorithm)
 that has been implemented *since OTP 24.0*.
 """.
--doc(#{title => <<"Plug-in framework API">>,since => <<"OTP 18.0,OTP 24.0">>}).
+-doc(#{title => <<"Plug-in framework API">>,since => <<"OTP 18.0">>}).
 -spec seed_s(Alg, Seed) -> state() when
       Alg  :: builtin_alg() | 'default',
       Seed :: seed().

--- a/lib/stdlib/src/shell_docs.erl
+++ b/lib/stdlib/src/shell_docs.erl
@@ -531,7 +531,7 @@ render(_Module, Function, Arity, #docs_v1{ } = D) ->
     render(_Module, Function, Arity, D, #{}).
 
 -doc "Render the documentation for a function.".
--doc(#{since => <<"OTP 23.0">>}).
+-doc(#{since => <<"OTP 23.2">>}).
 -spec render(Module, Function, Arity, Docs, Config) -> Res when
       Module :: module(),
       Function :: atom(),
@@ -632,7 +632,7 @@ render_type(_Module, Type, Arity, #docs_v1{ } = D) ->
     render_type(_Module, Type, Arity, D, #{}).
 
 -doc "Render the documentation of a type in a module.".
--doc(#{since => <<"OTP 23.0">>}).
+-doc(#{since => <<"OTP 23.2">>}).
 -spec render_type(Module, Type, Arity, Docs, Config) -> Res when
       Module :: module(), Type :: atom(), Arity :: arity(),
       Docs :: docs_v1(),
@@ -730,7 +730,7 @@ render_callback(_Module, Callback, #docs_v1{ docs = Docs } = D, Config) ->
                    end, Docs), D, Config).
 
 -doc "Render the documentation of a callback in a module.".
--doc(#{since => <<"OTP 23.0">>}).
+-doc(#{since => <<"OTP 23.2">>}).
 -spec render_callback(Module, Callback, Arity, Docs, Config) -> Res when
       Module :: module(), Callback :: atom(), Arity :: arity(),
       Docs :: docs_v1(),

--- a/lib/stdlib/src/string.erl
+++ b/lib/stdlib/src/string.erl
@@ -283,7 +283,7 @@ to_graphemes(CD0) ->
 %% Compare two strings return boolean, assumes that the input are
 %% normalized to same form, see unicode:characters_to_nfX_xxx(..)
 -doc(#{equiv => equal(A, B, true)}).
--doc(#{title => <<"Functions">>,since => <<"OTP 20.0">>}).
+-doc(#{title => <<"Functions">>}).
 -spec equal(A, B) -> boolean() when
       A::unicode:chardata(),
       B::unicode:chardata().

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -790,7 +790,6 @@ call(Supervisor, Req) ->
     gen_server:call(Supervisor, Req, infinity).
 
 -doc(#{equiv => check_childspecs(ChildSpecs, undefined)}).
--doc(#{since => <<"OTP 24.0">>}).
 -spec check_childspecs(ChildSpecs) -> Result when
       ChildSpecs :: [child_spec()],
       Result :: 'ok' | {'error', Error :: term()}.

--- a/lib/stdlib/src/timer.erl
+++ b/lib/stdlib/src/timer.erl
@@ -605,7 +605,6 @@ Equivalent to [`tc(Module, Function, Arguments, microsecond)`](`tc/4`) if called
 
 Equivalent to [`tc(erlang, apply, [Fun, Arguments], TimeUnit)`](`tc/4`) if called as `tc(Fun, Arguments, TimeUnit)`. Added in OTP 26.0
 """.
--doc(#{since => <<"OTP R14B">>}).
 -spec tc(Module, Function, Arguments) -> {Time, Value}
               when Module :: module(),
                    Function :: atom(),


### PR DESCRIPTION
touched the following files:
```
lib/common_test/src/ct_netconfc.erl
lib/inets/src/http_server/httpd.erl
lib/inets/src/http_server/mod_auth.erl
lib/kernel/src/application.erl
lib/kernel/src/code.erl
lib/kernel/src/erpc.erl
lib/kernel/src/file.erl
lib/kernel/src/gen_sctp.erl
lib/kernel/src/gen_tcp.erl
lib/kernel/src/gen_udp.erl
lib/kernel/src/logger.erl
lib/observer/src/ttb.erl
lib/parsetools/src/leex.erl
lib/public_key/src/public_key.erl
lib/sasl/src/release_handler.erl
lib/snmp/src/agent/snmp_community_mib.erl
lib/snmp/src/agent/snmpa.erl
lib/snmp/src/agent/snmpa_conf.erl
lib/snmp/src/app/snmp.erl
lib/ssh/src/ssh.erl
lib/ssh/src/ssh_client_channel.erl
lib/ssh/src/ssh_connection.erl
lib/ssl/src/ssl.erl
lib/ssl/src/ssl_crl_cache_api.erl
lib/stdlib/examples/erl_id_trans.erl
lib/stdlib/src/gen_event.erl
lib/stdlib/src/io.erl
lib/stdlib/src/io_lib.erl
lib/stdlib/src/lists.erl
lib/stdlib/src/rand.erl
lib/stdlib/src/shell_docs.erl
lib/stdlib/src/string.erl
lib/stdlib/src/supervisor.erl
lib/stdlib/src/timer.erl
```