### PR TITLE
diameter: modify diameter_traffic:pick_peer/4 to be able to handle requests of type: #diameter_packet{}

### DIFF
--- a/lib/diameter/src/base/diameter_traffic.erl
+++ b/lib/diameter/src/base/diameter_traffic.erl
@@ -1785,6 +1785,12 @@ pick_peer(SvcName,
           CallOpts) ->
     pick_peer(SvcName, App, Msg, CallOpts#options{extra = []});
 
+pick_peer(SvcName,
+          App,
+          #diameter_packet{msg = Msg},
+          CallOpts) ->
+    pick_peer(SvcName, App, Msg, CallOpts#options{extra = []});
+
 pick_peer(_, _, undefined, _) ->
     {error, no_connection};
 

--- a/lib/diameter/test/diameter_traffic_SUITE.erl
+++ b/lib/diameter/test/diameter_traffic_SUITE.erl
@@ -80,6 +80,7 @@
          send_destination_4/1,
          send_destination_5/1,
          send_destination_6/1,
+         send_destination_7/1,
          send_bad_option_1/1,
          send_bad_option_2/1,
          send_bad_filter_1/1,
@@ -952,6 +953,25 @@ send_destination_6(Config) ->
     ?answer_message(?UNABLE_TO_DELIVER)
         = call(Config, Req).
 
+%% Send unknown host in diameter_packet with filtering and expect error.
+send_destination_7(Config) ->
+    #group{client_service = CN,
+           client_dict = Dict0}
+        = group(Config),
+    Name = proplists:get_value(testcase, Config),
+    Svc = ?util:unique_string(),
+    SN = [$S | Svc],
+    Req =
+        #diameter_packet{msg = ['STR' |
+                                #{'Termination-Cause' => ?LOGOUT,
+                                  'Destination-Host' => [?HOST(SN, ?REALM)]}]},
+    {error, no_connection} =
+        diameter:call(CN,
+                      Dict0,
+                      Req,
+                      [{extra, [Name, diameter_lib:now()]},
+                       {filter, {all, [host, realm]}}]).
+
 %% Specify an invalid option and expect failure.
 send_bad_option_1(Config) ->
     send_bad_option(Config, x).
@@ -1236,7 +1256,6 @@ id(Id, {Pid, _Caps}, SvcName) ->
     lists:member({id, Id}, Opts).
 
 %% prepare_request/6-7
-
 prepare_request(_Pkt, [$C|_], {_Ref, _Caps}, _, send_discard, _) ->
     {discard, unprepared};
 


### PR DESCRIPTION
In case of requests in the format of #diameter_packet{}, pick_peer functionality is working incorrectly as the current implementation cannot find Destination-Host in the request. Added a clause to handle #diameter_packet.