### PR TITLE
Add EX_DOC to m4 influential environment variables

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -711,7 +711,6 @@ INSTALL_DATA
 INSTALL_SCRIPT
 INSTALL_PROGRAM
 ELIXIR
-EX_DOC
 LN_S
 PERL
 YFLAGS
@@ -759,6 +758,7 @@ erl_xcomp_double_middle_endian
 erl_xcomp_bigendian
 erl_xcomp_isysroot
 erl_xcomp_sysroot
+EX_DOC
 GETCONF
 AR
 RANLIB
@@ -885,6 +885,7 @@ DED_LD_FLAG_RUNTIME_LIBRARY_PATH
 RANLIB
 AR
 GETCONF
+EX_DOC
 erl_xcomp_sysroot
 erl_xcomp_isysroot
 erl_xcomp_bigendian
@@ -1701,6 +1702,7 @@ Some influential environment variables:
   RANLIB      ranlib
   AR          ar
   GETCONF     getconf
+  EX_DOC      Path to ex_doc executable
   erl_xcomp_sysroot
               Absolute cross system root path (only used when cross compiling)
   erl_xcomp_isysroot
@@ -3526,6 +3528,7 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 
 

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -690,6 +690,7 @@ erl_xcomp_double_middle_endian
 erl_xcomp_bigendian
 erl_xcomp_isysroot
 erl_xcomp_sysroot
+EX_DOC
 GETCONF
 AR
 RANLIB
@@ -795,6 +796,7 @@ DED_LD_FLAG_RUNTIME_LIBRARY_PATH
 RANLIB
 AR
 GETCONF
+EX_DOC
 erl_xcomp_sysroot
 erl_xcomp_isysroot
 erl_xcomp_bigendian
@@ -1497,6 +1499,7 @@ Some influential environment variables:
   RANLIB      ranlib
   AR          ar
   GETCONF     getconf
+  EX_DOC      Path to ex_doc executable
   erl_xcomp_sysroot
               Absolute cross system root path (only used when cross compiling)
   erl_xcomp_isysroot
@@ -3220,6 +3223,7 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 
 

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -106,6 +106,7 @@ AC_ARG_VAR(DED_LD_FLAG_RUNTIME_LIBRARY_PATH, [runtime library path linker flag f
 AC_ARG_VAR(RANLIB, [ranlib])
 AC_ARG_VAR(AR, [ar])
 AC_ARG_VAR(GETCONF, [getconf])
+AC_ARG_VAR(EX_DOC, [Path to ex_doc executable])
 
 dnl Cross system root
 AC_ARG_VAR(erl_xcomp_sysroot, [Absolute cross system root path (only used when cross compiling)])

--- a/make/configure
+++ b/make/configure
@@ -702,6 +702,7 @@ erl_xcomp_double_middle_endian
 erl_xcomp_bigendian
 erl_xcomp_isysroot
 erl_xcomp_sysroot
+EX_DOC
 GETCONF
 AR
 RANLIB
@@ -812,6 +813,7 @@ DED_LD_FLAG_RUNTIME_LIBRARY_PATH
 RANLIB
 AR
 GETCONF
+EX_DOC
 erl_xcomp_sysroot
 erl_xcomp_isysroot
 erl_xcomp_bigendian
@@ -1565,6 +1567,7 @@ Some influential environment variables:
   RANLIB      ranlib
   AR          ar
   GETCONF     getconf
+  EX_DOC      Path to ex_doc executable
   erl_xcomp_sysroot
               Absolute cross system root path (only used when cross compiling)
   erl_xcomp_isysroot
@@ -3167,6 +3170,7 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 
 


### PR DESCRIPTION
Closes #8377 

In #8377, Lukas was kind enough to explain to me how to contribute this documentation myself. I added `EX_DOC` to https://github.com/erlang/otp/blob/master/make/autoconf/otp.m4#L85-L130 and ran `./otp_build update_configure --no-commit`. 

I am not very familiar with configuring autoconf, happy to make any changes necessary.

The new documentation,

```
$ ./configure --help
...
Some influential environment variables:
...
  EX_DOC      Path to ex_doc executable
...
```
