### PR TITLE
erts: Change arity type back to Uint

### DIFF
--- a/erts/emulator/beam/code_ix.h
+++ b/erts/emulator/beam/code_ix.h
@@ -87,7 +87,11 @@ typedef unsigned ErtsCodeIndex;
 typedef struct ErtsCodeMFA_ {
     Eterm module;
     Eterm function;
-    byte arity;
+
+    /* This is technically a byte, but the interpreter needs this to be a word
+     * for argument packing to work properly, and declaring it as a byte won't
+     * save any space due to tail padding. */
+    Uint arity;
 } ErtsCodeMFA;
 
 /*


### PR DESCRIPTION
`op_i_func_info_IaaI`, and perhaps a few others, indirectly rely on the arity being stored as a word. Since declaring the field as a byte doesn't actually save anything because of tail padding, we'll change it back to `Uint`.

Fixes #8410