### PR TITLE
archives: Formally deprecate and schedule for removal

### DIFF
--- a/system/doc/general_info/deprecations_27.md
+++ b/system/doc/general_info/deprecations_27.md
@@ -1,0 +1,16 @@
+### Archives
+
+The following features for archives are deprecated:
+
+* Using archives for packaging a single application or parts of a
+  single application into an archive file that is included in the code
+  path.
+
+* All functionality to handle archives in module
+  [`erl_prim_loader`](https://www.erlang.org/doc/man/erl_prim_loader).
+
+* The `-code_path_choice` flag for `erl`.
+
+Using a single archive file for holding BEAM files and other data
+files in an Escript is **not** deprecated. However, to access files in
+the archive the `escript:extract/2` function has to be used.

--- a/system/doc/general_info/scheduled_for_removal_28.md
+++ b/system/doc/general_info/scheduled_for_removal_28.md
@@ -1,0 +1,14 @@
+### Archives
+
+The following features of archives will be removed:
+
+* Using archives for packaging a single application or parts of a single application
+  into an archive file that is included in the code path.
+
+* All functionality to handle archives in module `m:erl_prim_loader`.
+
+* The `-code_path_choice` flag for `erl`.
+
+The functionality to use a single archive file in Escripts is **not**
+deprecated and will continue to work.  However, to access files in the
+archive, the `escript:extract/2` function has to be used.


### PR DESCRIPTION
Archives is an experimental feature. Its mere presence makes its hard or impossible to improve the time for starting `erl`.

Warn for the removal of archives for the purpose of holding a single application and including those archives in the code path.

Using a single archive in an Escript is **not** deprecated.