### PR TITLE
Make sets default to maps-based implementation

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -73,7 +73,7 @@ assemble({Mod,Exp0,Attr0,Asm0,NumLabels}, ExtraChunks, CompileInfo, CompilerOpts
     Dict3 = reject_unsupported_versions(Dict2),
     NumFuncs = length(Asm0),
     {Asm,Attr} = on_load(Asm0, Attr0),
-    Exp = sets:from_list(Exp0, [{version, 2}]),
+    Exp = sets:from_list(Exp0),
     {Code,Dict} = assemble_1(Asm, Exp, Dict3, []),
     build_file(Code, Attr, Dict, NumLabels, NumFuncs,
                ExtraChunks, CompileInfo, CompilerOpts).

--- a/lib/compiler/src/beam_clean.erl
+++ b/lib/compiler/src/beam_clean.erl
@@ -34,7 +34,7 @@ module({Mod,Exp,Attr,Fs0,_}, Opts) ->
     Order = [Lbl || {function,_,_,Lbl,_} <- Fs1],
     All = #{Lbl => Func || {function,_,_,Lbl,_}=Func <- Fs1},
     WorkList = rootset(Fs1, Exp, Attr),
-    Used = find_all_used(WorkList, All, sets:from_list(WorkList, [{version, 2}])),
+    Used = find_all_used(WorkList, All, sets:from_list(WorkList)),
     Fs2 = remove_unused(Order, Used, All),
     {Fs3,Lc} = clean_labels(Fs2),
     Fs4 = fix_bs_create_bin(Fs3, Opts),

--- a/lib/compiler/src/beam_core_to_ssa.erl
+++ b/lib/compiler/src/beam_core_to_ssa.erl
@@ -145,7 +145,7 @@ get_anno(#cg_select{anno=Anno}) -> Anno.
                fargs=[] :: [#b_var{}], %Arguments for current function
                vcount=0,               %Variable counter
                fcount=0,               %Fun counter
-               ds=sets:new([{version, 2}]) :: sets:set(), %Defined variables
+               ds=sets:new() :: sets:set(), %Defined variables
                funs=[],                         %Fun functions
                free=#{},                        %Free variables
                ws=[]   :: [warning()],          %Warnings.
@@ -1555,7 +1555,7 @@ partition_keys(#ialias{pat=Map}=Alias, Ks) ->
     {Map1,Alias#ialias{pat=Map2}}.
 
 find_key_intersection(Ps) ->
-    Sets = [sets:from_list(Ks, [{version, 2}]) || Ks <- Ps],
+    Sets = [sets:from_list(Ks) || Ks <- Ps],
     Intersection = sets:intersection(Sets),
     case sets:is_empty(Intersection) of
         true ->

--- a/lib/compiler/src/beam_digraph.erl
+++ b/lib/compiler/src/beam_digraph.erl
@@ -132,7 +132,7 @@ in_neighbours(#dg{in_es=InEsMap}, V) ->
 
 -spec is_path(graph(), vertex(), vertex()) -> boolean().
 is_path(G, From, To) ->
-    Seen = sets:new([{version, 2}]),
+    Seen = sets:new(),
     try
         _ = is_path_1([From], To, G, Seen),
         false
@@ -182,7 +182,7 @@ vertices(#dg{vs=Vs}) ->
 
 -spec reverse_postorder(graph(), [vertex()]) -> [vertex()].
 reverse_postorder(G, Vs) ->
-    Seen = sets:new([{version, 2}]),
+    Seen = sets:new(),
     {RPO, _} = reverse_postorder_1(Vs, G, Seen, []),
     RPO.
 

--- a/lib/compiler/src/beam_jump.erl
+++ b/lib/compiler/src/beam_jump.erl
@@ -847,7 +847,7 @@ initial_labels([{line,_}|Is], Acc) ->
 initial_labels([{label,Lbl}|Is], Acc) ->
     initial_labels(Is, [Lbl|Acc]);
 initial_labels([{func_info,_,_,_},{label,Lbl}|_], Acc) ->
-    sets:from_list([Lbl|Acc], [{version, 2}]).
+    sets:from_list([Lbl|Acc]).
 
 drop_upto_label([{label,_}|_]=Is) -> Is;
 drop_upto_label([_|Is]) -> drop_upto_label(Is);

--- a/lib/compiler/src/beam_ssa_bool.erl
+++ b/lib/compiler/src/beam_ssa_bool.erl
@@ -213,7 +213,7 @@ pre_opt(Blocks, Count) ->
     Sub = maps:remove(uses, Sub1),
 
     %% Now do the actual optimizations.
-    Reached = sets:from_list([hd(Top)], [{version, 2}]),
+    Reached = sets:from_list([hd(Top)]),
     pre_opt(Top, Sub, Reached, Count, Blocks).
 
 -spec get_phi_info(Ls, Blocks, Sub0) -> Sub when
@@ -319,13 +319,13 @@ pre_opt([L|Ls], Sub0, Reached0, Count0, Blocks) ->
                     Blk = Blk0#b_blk{is=Is++[Test],last=Br},
                     Successors = beam_ssa:successors(Blk),
                     Reached = sets:union(Reached0,
-                                              sets:from_list(Successors, [{version, 2}])),
+                                              sets:from_list(Successors)),
                     pre_opt(Ls, Sub, Reached, Count, Blocks#{L:=Blk});
                 Last ->
                     Blk = Blk0#b_blk{is=Is,last=Last},
                     Successors = beam_ssa:successors(Blk),
                     Reached = sets:union(Reached0,
-                                              sets:from_list(Successors, [{version, 2}])),
+                                              sets:from_list(Successors)),
                     pre_opt(Ls, Sub, Reached, Count0, Blocks#{L:=Blk})
             end
     end;
@@ -788,7 +788,7 @@ split_dom_block_is([], PreAcc) ->
 
 collect_digraph_blocks(FirstL, LastL, #b_br{succ=Succ,fail=Fail}, Blocks) ->
     Ws = gb_sets:singleton(FirstL),
-    Seen = sets:from_list([Succ,Fail], [{version, 2}]),
+    Seen = sets:from_list([Succ,Fail]),
     collect_digraph_blocks(Ws, LastL, Blocks, Seen, []).
 
 collect_digraph_blocks(Ws0, LastL, Blocks, Seen0, Acc0) ->
@@ -1582,7 +1582,7 @@ join_inits_1([], VarMap) ->
 %%%
 
 digraph_to_ssa(Ls, G, Blocks0) ->
-    Seen = sets:new([{version, 2}]),
+    Seen = sets:new(),
     {Blocks,_} = digraph_to_ssa(Ls, G, Blocks0, Seen),
     Blocks.
 

--- a/lib/compiler/src/beam_ssa_dead.erl
+++ b/lib/compiler/src/beam_ssa_dead.erl
@@ -184,7 +184,7 @@ shortcut(L, _From, Bs, #st{test=none,target=one_way}) when map_size(Bs) =:= 0 ->
     %% block has a two-way `br` terminator.
     #b_br{bool=#b_literal{val=true},succ=L,fail=L};
 shortcut(L, From, Bs, St) ->
-    shortcut_1(L, From, Bs, sets:new([{version, 2}]), St).
+    shortcut_1(L, From, Bs, sets:new(), St).
 
 shortcut_1(L, From, Bs0, UnsetVars0, St) ->
     case shortcut_2(L, From, Bs0, UnsetVars0, St) of
@@ -1415,7 +1415,7 @@ used_vars([{L,#b_blk{is=Is}=Blk}|Bs], UsedVars0, Skip0) ->
     %% shortcut_opt/1.
 
     Successors = beam_ssa:successors(Blk),
-    Used0 = used_vars_succ(Successors, L, UsedVars0, sets:new([{version, 2}])),
+    Used0 = used_vars_succ(Successors, L, UsedVars0, sets:new()),
     Used = used_vars_blk(Blk, Used0),
     UsedVars = used_vars_phis(Is, L, Used, UsedVars0),
 
@@ -1426,7 +1426,7 @@ used_vars([{L,#b_blk{is=Is}=Blk}|Bs], UsedVars0, Skip0) ->
     %% shortcut_opt/1.
 
     Defined0 = [Def || #b_set{dst=Def} <- Is],
-    Defined = sets:from_list(Defined0, [{version, 2}]),
+    Defined = sets:from_list(Defined0),
     MaySkip = sets:is_disjoint(Defined, Used0),
     case MaySkip of
         true ->
@@ -1497,7 +1497,7 @@ list_set_union([], Set) ->
 list_set_union([E], Set) ->
     sets:add_element(E, Set);
 list_set_union(List, Set) ->
-    sets:union(sets:from_list(List, [{version, 2}]), Set).
+    sets:union(sets:from_list(List), Set).
 
 sub(#b_set{args=Args}=I, Sub) when map_size(Sub) =/= 0 ->
     I#b_set{args=[sub_arg(A, Sub) || A <- Args]};

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -409,7 +409,7 @@ get_call_order_po(StMap, FuncDb) when is_map(FuncDb) ->
 
 gco_po(FuncDb) ->
     All = sort(maps:keys(FuncDb)),
-    {RPO,_} = gco_rpo(All, FuncDb, sets:new([{version, 2}]), []),
+    {RPO,_} = gco_rpo(All, FuncDb, sets:new(), []),
     reverse(RPO).
 
 gco_rpo([Id|Ids], FuncDb, Seen0, Acc0) ->
@@ -1588,7 +1588,7 @@ ssa_opt_live({#opt_st{ssa=Linear0}=St, FuncDb}) ->
 live_opt([{L,Blk0}|Bs], LiveMap0, Blocks) ->
     Blk1 = beam_ssa_share:block(Blk0, Blocks),
     Successors = beam_ssa:successors(Blk1),
-    Live0 = live_opt_succ(Successors, L, LiveMap0, sets:new([{version, 2}])),
+    Live0 = live_opt_succ(Successors, L, LiveMap0, sets:new()),
     {Blk,Live} = live_opt_blk(Blk1, Live0),
     LiveMap = live_opt_phis(Blk#b_blk.is, L, Live, LiveMap0),
     live_opt(Bs, LiveMap, Blocks#{L:=Blk});
@@ -1718,7 +1718,7 @@ opt_try(Linear, Count0) when is_list(Linear) ->
 
     Reduced = reduce_try(Shrunk, []),
 
-    EmptySet = sets:new([{version, 2}]),
+    EmptySet = sets:new(),
     Trimmed = trim_try(Reduced, EmptySet, EmptySet, []),
 
     {Count, Trimmed}.
@@ -1824,7 +1824,7 @@ is_safe_sink_try(#b_set{op=Op}=I) ->
 reduce_try([{L,#b_blk{is=[#b_set{op=new_try_tag}],
                       last=Last}=Blk0} | Bs0], Acc) ->
     #b_br{succ=Succ,fail=Fail} = Last,
-    Ws = sets:from_list([Succ,Fail], [{version, 2}]),
+    Ws = sets:from_list([Succ,Fail]),
     try do_reduce_try(Bs0, Ws) of
         Bs ->
             Blk = Blk0#b_blk{is=[],
@@ -1989,7 +1989,7 @@ trim_try_is([], _Killed) ->
 
 ssa_opt_bsm({#opt_st{ssa=Linear0}=St, FuncDb}) ->
     Extracted0 = bsm_extracted(Linear0),
-    Extracted = sets:from_list(Extracted0, [{version, 2}]),
+    Extracted = sets:from_list(Extracted0),
     Linear1 = bsm_skip(Linear0, Extracted),
     Linear = bsm_coalesce_skips(Linear1, #{}),
     {St#opt_st{ssa=Linear}, FuncDb}.
@@ -3707,7 +3707,7 @@ list_set_union([], Set) ->
 list_set_union([E], Set) ->
     sets:add_element(E, Set);
 list_set_union(List, Set) ->
-    sets:union(sets:from_list(List, [{version, 2}]), Set).
+    sets:union(sets:from_list(List), Set).
 
 non_guards(Linear) ->
     gb_sets:from_list(non_guards_1(Linear)).

--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -454,7 +454,7 @@ propagate_references(Candidates, G) ->
     propagate_references_1(Roots, G, #{}).
 
 propagate_references_1([{Vertex, Ref} | VRefs], G, Acc0) ->
-    Refs = maps:get(Vertex, Acc0, sets:new([{version, 2}])),
+    Refs = maps:get(Vertex, Acc0, sets:new()),
     Acc = case sets:is_element(Ref, Refs) of
               true ->
                   %% Already visited
@@ -672,8 +672,8 @@ intersect_uses(UsageMap, RefMap, Graph) ->
     intersect_uses_1(Roots, RefMap, Graph, #{}).
 
 intersect_uses_1([{Vertex, Ref} | Vs], RefMap, Graph, Acc0) ->
-    PossibleRefs = maps:get(Vertex, RefMap, sets:new([{version, 2}])),
-    ActiveRefs0 = maps:get(Vertex, Acc0, sets:new([{version, 2}])),
+    PossibleRefs = maps:get(Vertex, RefMap, sets:new()),
+    ActiveRefs0 = maps:get(Vertex, Acc0, sets:new()),
     Acc = case {sets:is_element(Ref, PossibleRefs),
                 sets:is_element(Ref, ActiveRefs0)} of
               {true, false} ->
@@ -745,7 +745,7 @@ plan_clears(UsageMap, Graph) ->
 
 plan_clears_1([{From, To, branch} | Edges], ActiveRefs, UsageMap) ->
     %% Clear all references that are no longer active on the `To` block.
-    ToRefs = maps:get(To, UsageMap, sets:new([{version, 2}])),
+    ToRefs = maps:get(To, UsageMap, sets:new()),
     Refs = sets:subtract(ActiveRefs, ToRefs),
 
     {FuncId, FromLbl} = From,

--- a/lib/compiler/src/beam_ssa_throw.erl
+++ b/lib/compiler/src/beam_ssa_throw.erl
@@ -57,7 +57,7 @@
 %% Per-module scan state
 -record(gst, {tlh_roots :: gb_trees:tree(#b_local{}, gb_sets:set(handler())),
               tlh_edges=#{} :: #{ #b_local{} => gb_sets:set(#b_local{}) },
-              throws=sets:new([{version, 2}]) :: sets:set(#b_local{})}).
+              throws=sets:new() :: sets:set(#b_local{})}).
 
 %% Per-function scan state
 -record(lst, {suitability=#{} :: #{ #b_var{} => suitability() },

--- a/lib/compiler/src/beam_trim.erl
+++ b/lib/compiler/src/beam_trim.erl
@@ -351,7 +351,7 @@ safe_labels([{label,L}|Is], Acc) ->
     end;
 safe_labels([_|Is], Acc) ->
     safe_labels(Is, Acc);
-safe_labels([], Acc) -> sets:from_list(Acc, [{version, 2}]).
+safe_labels([], Acc) -> sets:from_list(Acc).
 
 is_safe_label([{'%',_}|Is]) ->
     is_safe_label(Is);

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -182,7 +182,7 @@ validate_0([{function, Name, Arity, Entry, Code} | Fs], Module, Level, Ft) ->
          %% A set of all registers containing "fragile" terms. That is, terms
          %% that don't exist on our process heap and would be destroyed by a
          %% GC.
-         fragile=sets:new([{version, 2}]) :: sets:set(),
+         fragile=sets:new() :: sets:set(),
          %% Number of Y registers.
          %%
          %% Note that this may be 0 if there's a frame without saved values,
@@ -229,7 +229,7 @@ validate_0([{function, Name, Arity, Entry, Code} | Fs], Module, Level, Ft) ->
          %% States at labels
          branched=#{}              :: #{ label() => state() },
          %% All defined labels
-         labels=sets:new([{version, 2}])    :: sets:set(),
+         labels=sets:new()    :: sets:set(),
          %% Information of other functions in the module
          ft=#{}                    :: #{ label() => map() },
          %% Counter for #value_ref{} creation
@@ -302,7 +302,7 @@ init_vst({_, _, Arity}, Level, Ft) ->
     Vst = #vst{branched=#{},
                current=#st{},
                ft=Ft,
-               labels=sets:new([{version, 2}]),
+               labels=sets:new(),
                level=Level},
     init_function_args(Arity - 1, Vst).
 
@@ -1439,7 +1439,7 @@ extract_map_keys([], _Vst) ->
 
 
 extract_map_vals(List, Src, SuccVst) ->
-    Seen = sets:new([{version, 2}]),
+    Seen = sets:new(),
     extract_map_vals(List, Src, Seen, SuccVst, SuccVst).
 
 extract_map_vals([Key0, Dst | Vs], Map, Seen0, Vst0, Vsti0) ->
@@ -2206,7 +2206,7 @@ assert_unique_map_keys([_,_|_]=Ls) ->
               assert_literal(L),
               L
           end || L <- Ls],
-    case length(Vs) =:= sets:size(sets:from_list(Vs, [{version, 2}])) of
+    case length(Vs) =:= sets:size(sets:from_list(Vs)) of
         true -> ok;
         false -> error(keys_not_unique)
     end.
@@ -3372,7 +3372,7 @@ mark_fragile(Reg, Vst) ->
 propagate_fragility(Reg, Args, #vst{current=St0}=Vst) ->
     #st{fragile=Fragile0} = St0,
 
-    Sources = sets:from_list(Args, [{version, 2}]),
+    Sources = sets:from_list(Args),
     Fragile = case sets:is_disjoint(Sources, Fragile0) of
                   true -> sets:del_element(Reg, Fragile0);
                   false -> sets:add_element(Reg, Fragile0)
@@ -3396,7 +3396,7 @@ remove_fragility(Reg, Vst) ->
 
 %% Marks all registers as durable.
 remove_fragility(#vst{current=St0}=Vst) ->
-    St = St0#st{fragile=sets:new([{version, 2}])},
+    St = St0#st{fragile=sets:new()},
     Vst#vst{current=St}.
 
 assert_durable_term(Src, Vst) ->

--- a/lib/compiler/src/sys_core_alias.erl
+++ b/lib/compiler/src/sys_core_alias.erl
@@ -47,7 +47,7 @@
 -define(HAS_SUBS(Sub), Sub#sub.t =/= none).
 
 -record(sub, {p=#{} :: #{term() => ?NOTSET | atom()},              %% Found pattern substitutions
-              v=sets:new([{version, 2}]) :: sets:set(cerl:var_name()), %% Variables used by patterns
+              v=sets:new() :: sets:set(cerl:var_name()), %% Variables used by patterns
               t=none :: temp()}).                                  %% Temporary information from pre to post
 
 -type sub() :: #sub{}.
@@ -238,7 +238,7 @@ new_var_name(Key, #sub{p=Pat}=Sub) ->
 %% merge_variables/2
 
 get_variables(NodesList) ->
-    sets:from_list([Var || Node <- NodesList, Var <- cerl_trees:variables(Node)], [{version, 2}]).
+    sets:from_list([Var || Node <- NodesList, Var <- cerl_trees:variables(Node)]).
 
 is_disjoint_variables(Vars1, Vars2) ->
     sets:is_disjoint(Vars1, Vars2).

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -99,7 +99,7 @@
 
 %% Variable value info.
 -record(sub, {v=[],                                 %Variable substitutions
-              s=sets:new([{version, 2}]) :: sets:set(), %Variables in scope
+              s=sets:new() :: sets:set(), %Variables in scope
               t=#{} :: map(),                       %Types
               in_guard=false,                       %In guard or not.
               top=true}).                           %Not inside a term.
@@ -1332,7 +1332,7 @@ is_subst(_) -> false.
 %%  to force renaming if variables in the scope occurs as pattern
 %%  variables.
 
-sub_new() -> #sub{v=orddict:new(),s=sets:new([{version, 2}]),t=#{}}.
+sub_new() -> #sub{v=orddict:new(),s=sets:new(),t=#{}}.
 
 sub_new(#sub{}=Sub) ->
     Sub#sub{v=orddict:new(),t=#{}}.
@@ -2124,7 +2124,7 @@ is_bool_expr_list([]) -> true.
 %%  (i.e. it cannot fail).
 %%
 is_safe_bool_expr(Core) ->
-    is_safe_bool_expr_1(Core, sets:new([{version, 2}])).
+    is_safe_bool_expr_1(Core, sets:new()).
 
 is_safe_bool_expr_1(#c_call{module=#c_literal{val=erlang},
                             name=#c_literal{val=is_function},
@@ -2427,7 +2427,7 @@ opt_let_1(#c_let{vars=Vs0,body=B0}=Let, Arg0, Ctxt, Sub0) ->
     %% Optimise let and add new substitutions.
     {Vs,Args,Sub1} = let_substs(Vs0, Arg0, Sub0),
     BodySub = update_let_types(Vs, Args, Sub1),
-    Sub = Sub1#sub{v=[],s=sets:new([{version, 2}])},
+    Sub = Sub1#sub{v=[],s=sets:new()},
     B = body(B0, Ctxt, BodySub),
     Arg = core_lib:make_values(Args),
     opt_let_2(Let, Vs, Arg, B, B0, Sub).

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -229,7 +229,7 @@ form({attribute,_,export,Es}, #imodule{exports=Exp0}=Module, _Opts) ->
 form({attribute,_,nifs,Ns}, #imodule{nifs=Nifs0}=Module, _Opts) ->
     Nifs1 = case Nifs0 of
                 none ->
-                    sets:new([{version, 2}]);
+                    sets:new();
                 _ ->
                     Nifs0
             end,
@@ -1135,7 +1135,7 @@ badmap_term(Map, #core{in_guard=false}) ->
     c_tuple([#c_literal{val=badmap},Map]).
 
 map_build_pairs(Map, Es0, Ann, St0) ->
-    {Es,Pre,_,St1} = map_build_pairs_1(Es0, sets:new([{version, 2}]), St0),
+    {Es,Pre,_,St1} = map_build_pairs_1(Es0, sets:new(), St0),
     {ann_c_map(Ann, Map, Es),Pre,St1}.
 
 map_build_pairs_1([{Op0,L,K0,V0}|Es], Used0, St0) ->

--- a/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_analysis_callgraph.erl
@@ -134,7 +134,7 @@ analysis_start(Parent, Analysis, LegalWarnings) ->
   Plt1 = dialyzer_plt:insert_callbacks(Plt1_a, NewCServer),
   State1 = State#analysis_state{codeserver = NewCServer, plt = Plt1},
   Exports = dialyzer_codeserver:get_exports(NewCServer),
-  NonExports = sets:subtract(sets:from_list(AllNodes, [{version, 2}]), Exports),
+  NonExports = sets:subtract(sets:from_list(AllNodes), Exports),
   NonExportsList = sets:to_list(NonExports),
   State2 = analyze_callgraph(Callgraph, State1),
   ModTypeDeps = dict:from_list(maps:to_list(dialyzer_typegraph:module_type_deps(Analysis#analysis.use_contracts, CServer, Modules))),
@@ -385,7 +385,7 @@ cleanup_callgraph(#analysis_state{plt = InitPlt, parent = Parent,
   {BadCalls1, RealExtCalls} =
     if ExtCalls1 =:= [] -> {[], []};
        true ->
-	ModuleSet = sets:from_list(Modules, [{version, 2}]),
+	ModuleSet = sets:from_list(Modules),
 	PltModuleSet = dialyzer_plt:all_modules(InitPlt),
 	AllModules = sets:union(ModuleSet, PltModuleSet),
 	Pred = fun({_From2, {M, _F, _A}}) -> sets:is_element(M, AllModules) end,
@@ -478,7 +478,7 @@ get_exported_types_from_core(Core) ->
                                     cerl:concrete(L1) =:= 'export_type'],
   ExpTypes2 = lists:flatten(ExpTypes1),
   M = cerl:atom_val(cerl:module_name(Core)),
-  sets:from_list([{M, F, A} || {F, A} <- ExpTypes2], [{version, 2}]).
+  sets:from_list([{M, F, A} || {F, A} <- ExpTypes2]).
 
 get_exports_from_core(Core) ->
   Tree = cerl:from_records(Core),

--- a/lib/dialyzer/src/dialyzer_callgraph.erl
+++ b/lib/dialyzer/src/dialyzer_callgraph.erl
@@ -206,7 +206,7 @@ remove_external(#callgraph{digraph = DG} = CG) ->
 
 non_local_calls(#callgraph{digraph = DG}) ->
   Edges = digraph_edges(DG),
-  find_non_local_calls(Edges, sets:new([{version, 2}])).
+  find_non_local_calls(Edges, sets:new()).
 
 -type call_tab() :: sets:set(mfa_call()).
 
@@ -258,7 +258,7 @@ modules(#callgraph{digraph = DG}) ->
 -spec module_postorder(callgraph()) -> {[module()], {'d', digraph:graph()}}.
 
 module_postorder(#callgraph{digraph = DG}) ->
-  Edges = lists:foldl(fun edge_fold/2, sets:new([{version, 2}]), digraph_edges(DG)),
+  Edges = lists:foldl(fun edge_fold/2, sets:new(), digraph_edges(DG)),
   Modules = ordsets:from_list([M || {M,_F,_A} <- digraph_vertices(DG)]),
   MDG = digraph:new([acyclic]),
   digraph_confirm_vertices(Modules, MDG),
@@ -281,7 +281,7 @@ edge_fold(_, Set) -> Set.
 -spec module_call_deps(callgraph()) -> mod_deps().
 
 module_call_deps(#callgraph{digraph = DG}) ->
-  Edges = lists:foldl(fun edge_fold/2, sets:new([{version, 2}]), digraph_edges(DG)),
+  Edges = lists:foldl(fun edge_fold/2, sets:new(), digraph_edges(DG)),
   Modules = ordsets:from_list([M || {M,_F,_A} <- digraph_vertices(DG)]),
   MDG = digraph:new(),
   digraph_confirm_vertices(Modules, MDG),

--- a/lib/dialyzer/src/dialyzer_cl.erl
+++ b/lib/dialyzer/src/dialyzer_cl.erl
@@ -486,8 +486,8 @@ clean_plt(PltFile, RemovedMods) ->
 	    Plt, RemovedMods).
 
 expand_dependent_modules(Md5, DiffMd5, ModDeps) ->
-  ChangedMods = sets:from_list([M || {differ, M} <- DiffMd5], [{version, 2}]),
-  RemovedMods = sets:from_list([M || {removed, M} <- DiffMd5], [{version, 2}]),
+  ChangedMods = sets:from_list([M || {differ, M} <- DiffMd5]),
+  RemovedMods = sets:from_list([M || {removed, M} <- DiffMd5]),
   BigSet = sets:union(ChangedMods, RemovedMods),
   BigList = sets:to_list(BigSet),
   ExpandedSet = expand_dependent_modules_1(BigList, BigSet, ModDeps),

--- a/lib/dialyzer/src/dialyzer_codeserver.erl
+++ b/lib/dialyzer/src/dialyzer_codeserver.erl
@@ -124,7 +124,7 @@ ets_set_insert_list(List, Table) ->
 
 ets_set_to_set(Table) ->
   Fold = fun({E}, Set) -> sets:add_element(E, Set) end,
-  ets:foldl(Fold, sets:new([{version, 2}]), Table).
+  ets:foldl(Fold, sets:new(), Table).
 
 %%--------------------------------------------------------------------
 

--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -2902,7 +2902,7 @@ state__new(Callgraph, Codeserver, Tree, Plt, Module, Records) ->
          envs = Env, fun_tab = FunTab, fun_homes = FunHomes, opaques = Opaques,
 	 plt = Plt, records = Records,
 	 warning_mode = false, warnings = [], work = Work, tree_map = TreeMap,
-	 module = Module, reachable_funs = sets:new([{version, 2}])}.
+	 module = Module, reachable_funs = sets:new()}.
 
 state__warning_mode(#state{warning_mode = WM}) ->
   WM.
@@ -3313,7 +3313,7 @@ state__translate_file(FakeFile, State) ->
 %%% ===========================================================================
 
 init_work(List) ->
-  {List, [], sets:from_list(List, [{version, 2}])}.
+  {List, [], sets:from_list(List)}.
 
 get_work({[], [], _Set}) ->
   none;

--- a/lib/dialyzer/src/dialyzer_dep.erl
+++ b/lib/dialyzer/src/dialyzer_dep.erl
@@ -384,10 +384,10 @@ is_literal_op(M, F, A) when is_atom(M), is_atom(F), is_integer(A) -> false.
 -record(set, {set :: sets:set()}).
 
 set__singleton(Val) ->
-  #set{set = sets:add_element(Val, sets:new([{version, 2}]))}.
+  #set{set = sets:add_element(Val, sets:new())}.
 
 set__from_list(List) ->
-  #set{set = sets:from_list(List, [{version, 2}])}.
+  #set{set = sets:from_list(List)}.
 
 set__is_element(_El, none) ->
   false;

--- a/lib/dialyzer/src/dialyzer_iplt.erl
+++ b/lib/dialyzer/src/dialyzer_iplt.erl
@@ -262,7 +262,7 @@ to_file_custom_vsn(
   Info = maps:from_list(dialyzer_utils:ets_tab2list(ETSInfo)),
   Types = dialyzer_utils:ets_tab2list(ETSTypes),
   Contracts = maps:from_list(dialyzer_utils:ets_tab2list(ETSContracts)),
-  ExpTypes = sets:from_list([E || {E} <- dialyzer_utils:ets_tab2list(ETSExpTypes)], [{version, 2}]),
+  ExpTypes = sets:from_list([E || {E} <- dialyzer_utils:ets_tab2list(ETSExpTypes)]),
   Record = #ifile_plt{version = Vsn,
                       module_md5_list = MD5,
                       info = term_to_binary(Info, [{compressed,9}]),

--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -182,7 +182,7 @@ analyze_scc(SCC, NextLabel, CallGraph, CServer, Plt, PropTypes, Solvers0) ->
   Solvers = solvers(Solvers0),
   State1 = new_state(SCC, NextLabel, CallGraph, CServer, Plt, PropTypes,
                      Solvers),
-  DefSet = add_def_list(maps:values(State1#state.name_map), sets:new([{version, 2}])),
+  DefSet = add_def_list(maps:values(State1#state.name_map), sets:new()),
   State2 = traverse_scc(SCC, CServer, DefSet, State1),
   State3 = state__finalize(State2),
   Funs = state__scc(State3),

--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -562,7 +562,7 @@ core_to_attr_tuples(Core) ->
       %% Starting from Erlang/OTP 26, locally defining a type having
       %% the same name as a built-in type is allowed. Change the tag
       %% from `type` to `user_type` for all such redefinitions.
-      massage_forms(As, sets:new([{version, 2}]))
+      massage_forms(As, sets:new())
   end.
 
 get_core_location([L | _As]) when is_integer(L) -> L;

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -4684,10 +4684,10 @@ validate_certs_or_anon_ciphers(CertsKeys, Ciphers, Versions) ->
 
 validate_anon_ciphers(Ciphers, Versions) ->
     MakeSet = fun(Version, Acc) ->
-                      Set = sets:from_list(ssl_cipher:anonymous_suites(Version), [{version, 2}]),
+                      Set = sets:from_list(ssl_cipher:anonymous_suites(Version)),
                       sets:union(Set, Acc)
               end,
-    Anonymous = lists:foldl(MakeSet, sets:new([{version, 2}]), Versions),
+    Anonymous = lists:foldl(MakeSet, sets:new(), Versions),
     CiphersSet = sets:from_list(Ciphers, [{version,2}]),
     case sets:is_disjoint(Anonymous, CiphersSet) of
         false -> ok;

--- a/lib/stdlib/src/filelib.erl
+++ b/lib/stdlib/src/filelib.erl
@@ -997,7 +997,7 @@ safe_relative_path(Path, "") ->
 safe_relative_path(Path, Cwd) ->
     srp_path(filename:split(Path),
              Cwd,
-             sets:new([{version, 2}]),
+             sets:new(),
              []).
 
 srp_path([], _Cwd, _Seen, []) ->
@@ -1017,7 +1017,7 @@ srp_path([<<"..">>|_Segs], _Cwd, _Seen, []) ->
 srp_path([<<"..">>|Segs], Cwd, Seen, [_|_]=Acc) ->
     srp_path(Segs, Cwd, Seen, lists:droplast(Acc));
 srp_path([clear|Segs], Cwd, _Seen, Acc) ->
-    srp_path(Segs, Cwd, sets:new([{version, 2}]), Acc);
+    srp_path(Segs, Cwd, sets:new(), Acc);
 srp_path([Seg|_]=Segs, Cwd, Seen, Acc) ->
     case filename:pathtype(Seg) of
         relative ->

--- a/lib/stdlib/test/property_test/lists_prop.erl
+++ b/lib/stdlib/test/property_test/lists_prop.erl
@@ -2056,7 +2056,7 @@ check_uniqed(L, UL) ->
     check_uniqed(fun(X) -> X end, L, UL).
 
 check_uniqed(Fn, L, UL) ->
-    check_uniqed1(Fn, L, UL, sets:new([{version, 2}])).
+    check_uniqed1(Fn, L, UL, sets:new()).
 
 check_uniqed1(Fn, [E|L], [], Seen) ->
     sets:is_element(Fn(E), Seen) andalso

--- a/lib/stdlib/test/sets_SUITE.erl
+++ b/lib/stdlib/test/sets_SUITE.erl
@@ -1,8 +1,8 @@
 %%
 %% %CopyrightBegin%
-%% 
+%%
 %% Copyright Ericsson AB 2004-2024. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -14,7 +14,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 
@@ -23,7 +23,7 @@
 
 -module(sets_SUITE).
 
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 	 init_per_testcase/2,end_per_testcase/2,
 	 create/1,add_element/1,del_element/1,
@@ -45,13 +45,13 @@ suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{minutes,5}}].
 
-all() -> 
+all() ->
     [create, add_element, del_element, subtract,
      intersection, union, is_subset, is_set, fold, filter, map,
      filtermap, take_smallest, take_largest, iterate, is_empty,
      is_disjoint, is_equal].
 
-groups() -> 
+groups() ->
     [].
 
 init_per_suite(Config) ->
@@ -121,7 +121,7 @@ add_element_del([], M, S, Del, _) ->
 del_element(Config) when is_list(Config) ->
     test_all([{0,132},{253,258},{510,514},{1022,1026}], fun del_element_1/2).
 
-del_element_1(List, M) ->    
+del_element_1(List, M) ->
     S0 = M(from_list, List),
     Empty = foldl(fun(El, Set) -> M(del_element, {El,Set}) end, S0, List),
     true = M(is_equal, {Empty,M(empty, [])}),
@@ -564,13 +564,13 @@ sets_mods() ->
 mixed_new() ->
     case erlang:erase(sets_type) of
         undefined -> erlang:put(sets_type, deprecated), sets:new([{version,2}]);
-        deprecated -> sets:new()
+        deprecated -> sets:new([{version, 1}])
     end.
 
 mixed_from_list(L) ->
     case erlang:erase(sets_type) of
         undefined -> erlang:put(sets_type, deprecated), sets:from_list(L, [{version,2}]);
-        deprecated -> sets:from_list(L)
+        deprecated -> sets:from_list(L, [{version, 1}])
     end.
 
 test_all(Tester) ->
@@ -604,7 +604,7 @@ all_same_1([], _) -> ok.
 
 rnd_list(Sz) ->
     rnd_list_1(Sz, []).
-    
+
 atomic_rnd_term() ->
     case rand:uniform(3) of
 	1 -> list_to_atom(integer_to_list($\s+rand:uniform(94))++"rnd");
@@ -617,7 +617,7 @@ rnd_list_1(N, Acc) -> rnd_list_1(N-1, [atomic_rnd_term()|Acc]).
 
 mutate_some(List) ->
     mutate_some(List, []).
-    
+
 mutate_some([X,Y,Z|T], Acc) ->
     %% Intentionally change order. (Order should not matter.)
     mutate_some(T, [{X},Z,Y|Acc]);


### PR DESCRIPTION
I have tagged it as a Erlang/OTP 28 change.

This should be safe to do as the new data type was introduced on Erlang/OTP 24. Feel free to close it if you believe it is too early.