### PR TITLE
howtos: Change wxErlang to Wx

### DIFF
--- a/HOWTO/DOCUMENTATION.md
+++ b/HOWTO/DOCUMENTATION.md
@@ -335,7 +335,7 @@ STDLIB
 Syntax_Tools
 TFTP
 Tools
-wxErlang
+Wx
 Xmerl
 ```
 

--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -82,7 +82,7 @@ also find the utilities needed for building the documentation.
     Download from <http://sourceforge.net/projects/wxwindows/files/3.0.0/>
     or get it from GitHub: <https://github.com/wxWidgets/wxWidgets>
 
-    Further instructions on wxWidgets, read [Building with wxErlang][].
+    Further instructions on wxWidgets, read [Building with Wx][].
 
 ### Building Documentation ###
 
@@ -565,9 +565,9 @@ suffix.
 If you have Xcode 4.3, or later, you will also need to download
 "Command Line Tools" via the Downloads preference pane in Xcode.
 
-[](){: #advanced-configuration-and-build-of-erlang-otp_Building_Building-with-wxErlang }
+[](){: #advanced-configuration-and-build-of-erlang-otp_Building_Building-with-Wx }
 
-#### Building with wxErlang ####
+#### Building with Wx ####
 
 wxWidgets-3.2.x is recommended for building the `wx` application
 (wxWidgets-3.0.x will also work). Download it from
@@ -810,5 +810,5 @@ Operating system
 [Required Utilities]: #Required-Utilities
 [Optional Utilities]: #Optional-Utilities
 [Building on a Mac]: #advanced-configuration-and-build-of-erlang-otp_Building_macOS-Darwin
-[Building with wxErlang]: #advanced-configuration-and-build-of-erlang-otp_Building_Building-with-wxErlang
+[Building with Wx]: #advanced-configuration-and-build-of-erlang-otp_Building_Building-with-Wx
 [libatomic_ops]: https://github.com/ivmai/libatomic_ops/

--- a/lib/wx/api_gen/README
+++ b/lib/wx/api_gen/README
@@ -1,7 +1,7 @@
 API GENERATION:
     Most of the code in wx is generated.
-    Users of wxErlang should not normally need to regenerate the generated code,
-    as it is checked in by wxErlang developers, when changes are made.
+    Users of Wx should not normally need to regenerate the generated code,
+    as it is checked in by Wx developers, when changes are made.
 
 REQUIREMENTS:
     The code generation requires doxygen (1.8.17) which is

--- a/lib/wx/doc/guides/chapter.md
+++ b/lib/wx/doc/guides/chapter.md
@@ -26,7 +26,7 @@ wxWidgets documentation instead. _wx_ tries to keep a one-to-one mapping with
 the original API so that the original documentation and examples shall be as
 easy as possible to use.
 
-wxErlang examples and test suite can be found in the erlang src release. They
+Wx examples and test suite can be found in the erlang src release. They
 can also provide some help on how to use the API.
 
 This is currently a very brief introduction to _wx_. The application is still
@@ -122,7 +122,7 @@ name and a underscore as in `ClassName_Enum`.
 Additionally some global functions, i.e. non-class functions, exist in the
 `wx_misc` module.
 
-_wxErlang_ is implemented as a (threaded) driver and a rather direct interface
+_Wx_ is implemented as a (threaded) driver and a rather direct interface
 to the C++ API, with the drawback that if the erlang programmer does an error,
 it might crash the emulator.
 

--- a/lib/wx/doc/notes.md
+++ b/lib/wx/doc/notes.md
@@ -17,9 +17,9 @@ limitations under the License.
 
 %CopyrightEnd%
 -->
-# wxErlang Release Notes
+# Wx Release Notes
 
-This document describes the changes made to the wxErlang application.
+This document describes the changes made to the Wx application.
 
 ## Wx 2.4.1
 

--- a/lib/wx/examples/demo/demo.erl
+++ b/lib/wx/examples/demo/demo.erl
@@ -17,7 +17,7 @@
 %% 
 %% %CopyrightEnd%
 
-%% This is example of the widgets and usage of wxErlang
+%% This is example of the widgets and usage of Wx.
 %% Hopefully it will contain all implemented widgets, it's event handling
 %% and some tutorials of how to use sizers and other stuff.
 
@@ -63,7 +63,7 @@ init(Options) ->
     wx:new(Options),
     process_flag(trap_exit, true),
 
-    Frame = wxFrame:new(wx:null(), ?wxID_ANY, "wxErlang widgets", [{size,{1400,800}}]),
+    Frame = wxFrame:new(wx:null(), ?wxID_ANY, "Wx widgets", [{size,{1400,800}}]),
     MB = wxMenuBar:new(),
     File    = wxMenu:new([]),
     wxMenu:append(File, ?wxID_PRINT, "&Print code"),

--- a/lib/wx/examples/demo/ex_button.erl
+++ b/lib/wx/examples/demo/ex_button.erl
@@ -17,7 +17,7 @@
 %% 
 %% %CopyrightEnd%
 
-%% This is example of the widgets and usage of wxErlang
+%% This is example of the widgets and usage of Wx.
 %% Hopefully it will contain all implemented widgets, it's event handling
 %% and some tutorials of how to use sizers and other stuff.
 

--- a/lib/wx/examples/demo/ex_notificationMessage.erl
+++ b/lib/wx/examples/demo/ex_notificationMessage.erl
@@ -17,7 +17,7 @@
 %% 
 %% %CopyrightEnd%
 
-%% This is example of the widgets and usage of wxErlang
+%% This is example of the widgets and usage of Wx.
 %% Hopefully it will contain all implemented widgets, it's event handling
 %% and some tutorials of how to use sizers and other stuff.
 

--- a/lib/wx/examples/demo/ex_webview.erl
+++ b/lib/wx/examples/demo/ex_webview.erl
@@ -17,7 +17,7 @@
 %% 
 %% %CopyrightEnd%
 
-%% This is example of the widgets and usage of wxErlang
+%% This is example of the widgets and usage of Wx.
 %% Hopefully it will contain all implemented widgets, it's event handling
 %% and some tutorials of how to use sizers and other stuff.
 

--- a/lib/wx/examples/simple/menu.erl
+++ b/lib/wx/examples/simple/menu.erl
@@ -105,7 +105,7 @@ start() ->
 %%    
 %%    
 create_frame(Wx) ->
-    Frame = wxFrame:new(Wx, -1, "wxErlang menu sample", [{size, {600,400}}]),
+    Frame = wxFrame:new(Wx, -1, "Wx menu sample", [{size, {600,400}}]),
 
     Path = code:priv_dir(wx),
     wxFrame:setIcon(Frame,  wxIcon:new(filename:join(Path,"erlang-logo128.png"), [{type, ?wxBITMAP_TYPE_PNG}])),
@@ -137,7 +137,7 @@ create_frame(Wx) ->
 				  {style, ?wxTE_MULTILINE}]),
     wxTextCtrl:setEditable(LogTextCtrl, false),
 
-    ok = wxFrame:setStatusText(Frame, "Welcome to wxErlang menu sample",[]),
+    ok = wxFrame:setStatusText(Frame, "Welcome to Wx menu sample",[]),
     
     ok = wxFrame:connect(Frame, command_menu_selected), 
     
@@ -554,14 +554,14 @@ findLogger(Frame) ->
     
    
 showDialog(?menuID_HELP_ABOUT,  Frame) ->
-    String = lists:flatten(io_lib:format("Welcome to wxErlang 0.97.5.26!~n~n"
-		       "This is the minimal wxErlang sample~n"
+    String = lists:flatten(io_lib:format("Welcome to Wx 0.97.5.26!~n~n"
+		       "This is the minimal Wx sample~n"
 		       "running under ~p.",
 		       [wx_misc:getOsDescription()])),
     MessageDialog = wxMessageDialog:new(Frame,
    			     String,
    			     [{style, ?wxOK bor ?wxICON_INFORMATION}, 
-   			      {caption, "About wxErlang minimal sample"}]),
+			      {caption, "About Wx minimal sample"}]),
 
     wxDialog:showModal(MessageDialog),
     wxDialog:destroy(MessageDialog);
@@ -571,7 +571,7 @@ showDialog(Id,  Frame) ->
     MessageDialog = wxMessageDialog:new(Frame,
    			     String,
    			     [{style, ?wxOK bor ?wxICON_INFORMATION}, 
-   			      {caption, "wxErlang minimal sample"}]),
+			      {caption, "Wx minimal sample"}]),
 
     wxDialog:showModal(MessageDialog),
     wxDialog:destroy(MessageDialog).

--- a/lib/wx/examples/simple/minimal.erl
+++ b/lib/wx/examples/simple/minimal.erl
@@ -40,7 +40,7 @@ start() ->
     ok.
 
 create_window(Wx) ->
-    Frame = wxFrame:new(Wx, -1, "Minimal wxErlang App", [{size, {600,400}}]),
+    Frame = wxFrame:new(Wx, -1, "Minimal Wx App", [{size, {600,400}}]),
 
     Path = filename:dirname(code:which(?MODULE)),
     wxFrame:setIcon(Frame,  wxIcon:new(filename:join(Path,"sample.xpm"), [{type, ?wxBITMAP_TYPE_XPM}])),
@@ -68,7 +68,7 @@ create_window(Wx) ->
     wxMenuBar:append(MenuBar, HelpM, "&Help"),
     wxFrame:setMenuBar(Frame, MenuBar),
 
-    ok = wxFrame:setStatusText(Frame, "Welcome to wxErlang!",[]),
+    ok = wxFrame:setStatusText(Frame, "Welcome to Wx!",[]),
     Frame.
 
 loop(Frame) ->
@@ -93,8 +93,8 @@ loop(Frame) ->
     end.
 
 dialog(?wxID_ABOUT,  Frame) ->
-    Str = string:join(["Welcome to wxErlang.", 
-		       "This is the minimal wxErlang sample\n",
+    Str = string:join(["Welcome to Wx.",
+		       "This is the minimal Wx sample\n",
 		       "running under ",
 		       wx_misc:getOsDescription(),
 		       "."], 
@@ -102,7 +102,7 @@ dialog(?wxID_ABOUT,  Frame) ->
     MD = wxMessageDialog:new(Frame,
    			     Str,
    			     [{style, ?wxOK bor ?wxICON_INFORMATION}, 
-   			      {caption, "About wxErlang minimal sample"}]),
+			      {caption, "About Wx minimal sample"}]),
 
     wxDialog:showModal(MD),
     wxDialog:destroy(MD).

--- a/lib/wx/src/wx.erl
+++ b/lib/wx/src/wx.erl
@@ -30,7 +30,7 @@
 %% This module contains functions for
 %% starting and stopping the wx-server, as well as  other utility functions.
 %%
-%% wxWidgets is object oriented, and not functional. Thus, in wxErlang a
+%% wxWidgets is object oriented, and not functional. Thus, in Wx a
 %% module represents a class, and the object created by this class
 %% has an own type, wxCLASS().  This module represents the base
 %% class, and all other wxMODULE's are sub-classes of this class.
@@ -70,7 +70,7 @@ This is the base api of [wxWidgets](http://www.wxwidgets.org/). This module
 contains functions for starting and stopping the wx-server, as well as other
 utility functions.
 
-wxWidgets is object oriented, and not functional. Thus, in wxErlang a module
+wxWidgets is object oriented, and not functional. Thus, in Wx a module
 represents a class, and the object created by this class has an own type,
 wxCLASS(). This module represents the base class, and all other wxMODULE's are
 sub-classes of this class.
@@ -569,11 +569,11 @@ set_debug(Level) when is_integer(Level) ->
 	    ok
     end.
 
-%% @doc Starts a wxErlang demo if examples directory exists and is compiled
+%% @doc Starts a Wx demo if examples directory exists and is compiled
 -doc """
 demo() -> ok | {error, atom()}
 
-Starts a wxErlang demo if examples directory exists and is compiled
+Starts a Wx demo if examples directory exists and is compiled
 """.
 -spec demo() -> 'ok' | {'error', atom()}.
 demo() ->


### PR DESCRIPTION
wxErlang was the old name for the `wx` application. In most places in Erlang/OTP, it is called Wx or `wx`.