### PR TITLE
Remove usage of xmerl as test data for edoc

### DIFF
--- a/lib/edoc/test/edoc_SUITE.erl
+++ b/lib/edoc/test/edoc_SUITE.erl
@@ -76,8 +76,6 @@ build_std(Config) when is_list(Config) ->
     ok = edoc:application(syntax_tools, [{overview, Overview2},
 	    {def, {vsn,MF}},
 	    {dir, PrivDir}]),
-
-    ok = edoc:application(xmerl, [{preprocess,true},{dir, PrivDir}]),
     ok.
 
 build_map_module(Config) when is_list(Config) ->


### PR DESCRIPTION
xmerl is no longer using edoc for documentation and is therefore removed as test data for edoc.