### PR TITLE
Fix small inconsistencies in mnesia documentation after documentation move

### DIFF
--- a/lib/mnesia/doc/guides/mnesia_app_a.md
+++ b/lib/mnesia/doc/guides/mnesia_app_a.md
@@ -22,8 +22,6 @@ limitations under the License.
 ## mnesia_backup Callback Behavior
 
 ```erlang
-
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
 %% This module contains one implementation of callback functions

--- a/lib/mnesia/doc/guides/mnesia_app_b.md
+++ b/lib/mnesia/doc/guides/mnesia_app_b.md
@@ -22,8 +22,6 @@ limitations under the License.
 ## mnesia_access Callback Behavior
 
 ```erlang
-
-
 -module(mnesia_frag).
 
 %% Callback functions when accessed within an activity
@@ -40,8 +38,6 @@ limitations under the License.
 ```
 
 ```erlang
-
-
 %% Callback functions which provides transparent
 %% access of fragmented tables from any activity
 %% access context.

--- a/lib/mnesia/doc/guides/mnesia_app_c.md
+++ b/lib/mnesia/doc/guides/mnesia_app_c.md
@@ -22,7 +22,6 @@ limitations under the License.
 ## mnesia_frag_hash Callback Behavior
 
 ```erlang
-
 -module(mnesia_frag_hash).
 -compile([{nowarn_deprecated_function, [{erlang,phash,2}]}]).
 
@@ -37,7 +36,6 @@ limitations under the License.
 ```
 
 ```erlang
-
 -record(hash_state,
 	{n_fragments,
 	 next_n_to_split,

--- a/lib/mnesia/doc/guides/mnesia_chap2.md
+++ b/lib/mnesia/doc/guides/mnesia_chap2.md
@@ -39,41 +39,41 @@ This section provides a simplified demonstration of a `Mnesia` system startup.
 The dialogue from the Erlang shell is as follows:
 
 ```erlang
-        unix>  erl -mnesia dir '"/tmp/funky"'
-        Erlang (BEAM) emulator version 4.9
+unix> erl -mnesia dir '"/tmp/funky"'
+Erlang (BEAM) emulator version 4.9
 
-        Eshell V4.9  (abort with ^G)
-        1>
-        1> mnesia:create_schema([node()]).
-        ok
-        2> mnesia:start().
-        ok
-        3> mnesia:create_table(funky, []).
-        {atomic,ok}
-        4> mnesia:info().
-        ---> Processes holding locks <---
-        ---> Processes waiting for locks <---
-        ---> Pending (remote) transactions <---
-        ---> Active (local) transactions <---
-        ---> Uncertain transactions <---
-        ---> Active tables <---
-        funky          : with 0 records occupying 269 words of mem
-        schema         : with 2 records occupying 353 words of mem
-        ===> System info in version "1.0", debug level = none <===
-        opt_disc. Directory "/tmp/funky" is used.
-        use fall-back at restart = false
-        running db nodes = [nonode@nohost]
-        stopped db nodes = []
-        remote           = []
-        ram_copies       = [funky]
-        disc_copies      = [schema]
-        disc_only_copies = []
-        [{nonode@nohost,disc_copies}] = [schema]
-        [{nonode@nohost,ram_copies}] = [funky]
-        1 transactions committed, 0 aborted, 0 restarted, 1 logged to disc
-        0 held locks, 0 in queue; 0 local transactions, 0 remote
-        0 transactions waits for other nodes: []
-        ok
+Eshell V4.9  (abort with ^G)
+1>
+1> mnesia:create_schema([node()]).
+ok
+2> mnesia:start().
+ok
+3> mnesia:create_table(funky, []).
+{atomic,ok}
+4> mnesia:info().
+---> Processes holding locks <---
+---> Processes waiting for locks <---
+---> Pending (remote) transactions <---
+---> Active (local) transactions <---
+---> Uncertain transactions <---
+---> Active tables <---
+funky          : with 0 records occupying 269 words of mem
+schema         : with 2 records occupying 353 words of mem
+===> System info in version "1.0", debug level = none <===
+opt_disc. Directory "/tmp/funky" is used.
+use fall-back at restart = false
+running db nodes = [nonode@nohost]
+stopped db nodes = []
+remote           = []
+ram_copies       = [funky]
+disc_copies      = [schema]
+disc_only_copies = []
+[{nonode@nohost,disc_copies}] = [schema]
+[{nonode@nohost,ram_copies}] = [funky]
+1 transactions committed, 0 aborted, 0 restarted, 1 logged to disc
+0 held locks, 0 in queue; 0 local transactions, 0 remote
+0 transactions waits for other nodes: []
+ok
 ```
 
 In this example, the following actions are performed:
@@ -122,7 +122,6 @@ First the record definitions are entered into a text file named `company.hrl`.
 This file defines the following structure for the example database:
 
 ```erlang
-
 -record(employee, {emp_no,
                    name,
                    salary,
@@ -170,21 +169,19 @@ The following shell interaction starts `Mnesia` and initializes the schema for
 the `Company` database:
 
 ```erlang
-        % erl -mnesia dir '"/ldisc/scratch/Mnesia.Company"'
-         Erlang (BEAM) emulator version 4.9
+% erl -mnesia dir '"/ldisc/scratch/Mnesia.Company"'
+Erlang (BEAM) emulator version 4.9
 
-          Eshell V4.9  (abort with ^G)
-          1> mnesia:create_schema([node()]).
-          ok
-          2> mnesia:start().
-          ok
+Eshell V4.9  (abort with ^G)
+1> mnesia:create_schema([node()]).
+ok
+2> mnesia:start().
+ok
 ```
 
 The following program module creates and populates previously defined tables:
 
 ```erlang
-
-
 -include_lib("stdlib/include/qlc.hrl").
 -include("company.hrl").
 
@@ -222,39 +219,39 @@ database:
 Continuing the dialogue with the Erlang shell produces the following:
 
 ```erlang
-        3> company:init().
-        {atomic,ok}
-        4> mnesia:info().
-        ---> Processes holding locks <---
-        ---> Processes waiting for locks <---
-        ---> Pending (remote) transactions <---
-        ---> Active (local) transactions <---
-        ---> Uncertain transactions <---
-        ---> Active tables <---
-        in_proj        : with 0 records occuping 269 words of mem
-        at_dep         : with 0 records occuping 269 words of mem
-        manager        : with 0 records occuping 269 words of mem
-        project        : with 0 records occuping 269 words of mem
-        dept           : with 0 records occuping 269 words of mem
-        employee       : with 0 records occuping 269 words of mem
-        schema         : with 7 records occuping 571 words of mem
-        ===> System info in version "1.0", debug level = none <===
-        opt_disc. Directory "/ldisc/scratch/Mnesia.Company" is used.
-        use fall-back at restart = false
-        running db nodes = [nonode@nohost]
-        stopped db nodes = []
-        remote           = []
-        ram_copies       =
-            [at_dep,dept,employee,in_proj,manager,project]
-        disc_copies      = [schema]
-        disc_only_copies = []
-        [{nonode@nohost,disc_copies}] = [schema]
-        [{nonode@nohost,ram_copies}] =
-            [employee,dept,project,manager,at_dep,in_proj]
-        6 transactions committed, 0 aborted, 0 restarted, 6 logged to disc
-        0 held locks, 0 in queue; 0 local transactions, 0 remote
-        0 transactions waits for other nodes: []
-        ok
+3> company:init().
+{atomic,ok}
+4> mnesia:info().
+---> Processes holding locks <---
+---> Processes waiting for locks <---
+---> Pending (remote) transactions <---
+---> Active (local) transactions <---
+---> Uncertain transactions <---
+---> Active tables <---
+in_proj        : with 0 records occuping 269 words of mem
+at_dep         : with 0 records occuping 269 words of mem
+manager        : with 0 records occuping 269 words of mem
+project        : with 0 records occuping 269 words of mem
+dept           : with 0 records occuping 269 words of mem
+employee       : with 0 records occuping 269 words of mem
+schema         : with 7 records occuping 571 words of mem
+===> System info in version "1.0", debug level = none <===
+opt_disc. Directory "/ldisc/scratch/Mnesia.Company" is used.
+use fall-back at restart = false
+running db nodes = [nonode@nohost]
+stopped db nodes = []
+remote           = []
+ram_copies       =
+    [at_dep,dept,employee,in_proj,manager,project]
+disc_copies      = [schema]
+disc_only_copies = []
+[{nonode@nohost,disc_copies}] = [schema]
+[{nonode@nohost,ram_copies}] =
+    [employee,dept,project,manager,at_dep,in_proj]
+6 transactions committed, 0 aborted, 0 restarted, 6 logged to disc
+0 held locks, 0 in queue; 0 local transactions, 0 remote
+0 transactions waits for other nodes: []
+ok
 ```
 
 A set of tables is created. The function
@@ -279,8 +276,6 @@ must be an `at_dep` record and a set of `in_proj` records inserted. Examine the
 following code used to complete this action:
 
 ```erlang
-
-
 insert_emp(Emp, DeptId, ProjNames) ->
     Ename = Emp#employee.name,
     Fun = fun() ->
@@ -317,13 +312,13 @@ as a transaction with the following properties:
 The function can be used as follows:
 
 ```erlang
-          Emp  = #employee{emp_no= 104732,
-                           name = klacke,
-                           salary = 7,
-                           sex = male,
-                           phone = 98108,
-                           room_no = {221, 015}},
-        insert_emp(Emp, 'B/SFR', [Erlang, mnesia, otp]).
+Emp = #employee{emp_no = 104732,
+                name = klacke,
+                salary = 7,
+                sex = male,
+                phone = 98108,
+                room_no = {221, 015}},
+insert_emp(Emp, 'B/SFR', [Erlang, mnesia, otp]).
 ```
 
 > #### Note {: .info }
@@ -395,35 +390,35 @@ following records:
 `employees`:
 
 ```erlang
-        {employee, 104465, "Johnson Torbjorn",   1, male,  99184, {242,038}}.
-        {employee, 107912, "Carlsson Tuula",     2, female,94556, {242,056}}.
-        {employee, 114872, "Dacker Bjarne",      3, male,  99415, {221,035}}.
-        {employee, 104531, "Nilsson Hans",       3, male,  99495, {222,026}}.
-        {employee, 104659, "Tornkvist Torbjorn", 2, male,  99514, {222,022}}.
-        {employee, 104732, "Wikstrom Claes",     2, male,  99586, {221,015}}.
-        {employee, 117716, "Fedoriw Anna",       1, female,99143, {221,031}}.
-        {employee, 115018, "Mattsson Hakan",     3, male,  99251, {203,348}}.
+{employee, 104465, "Johnson Torbjorn",   1, male,  99184, {242,038}}.
+{employee, 107912, "Carlsson Tuula",     2, female,94556, {242,056}}.
+{employee, 114872, "Dacker Bjarne",      3, male,  99415, {221,035}}.
+{employee, 104531, "Nilsson Hans",       3, male,  99495, {222,026}}.
+{employee, 104659, "Tornkvist Torbjorn", 2, male,  99514, {222,022}}.
+{employee, 104732, "Wikstrom Claes",     2, male,  99586, {221,015}}.
+{employee, 117716, "Fedoriw Anna",       1, female,99143, {221,031}}.
+{employee, 115018, "Mattsson Hakan",     3, male,  99251, {203,348}}.
 ```
 
 `dept`:
 
 ```erlang
-        {dept, 'B/SF',  "Open Telecom Platform"}.
-        {dept, 'B/SFP', "OTP - Product Development"}.
-        {dept, 'B/SFR', "Computer Science Laboratory"}.
+{dept, 'B/SF',  "Open Telecom Platform"}.
+{dept, 'B/SFP', "OTP - Product Development"}.
+{dept, 'B/SFR', "Computer Science Laboratory"}.
 ```
 
 `projects`:
 
 ```erlang
-        %% projects
-        {project, erlang, 1}.
-        {project, otp, 2}.
-        {project, beam, 3}.
-        {project, mnesia, 5}.
-        {project, wolf, 6}.
-        {project, documentation, 7}.
-        {project, www, 8}.
+%% projects
+{project, erlang, 1}.
+{project, otp, 2}.
+{project, beam, 3}.
+{project, mnesia, 5}.
+{project, wolf, 6}.
+{project, documentation, 7}.
+{project, www, 8}.
 ```
 
 These three tables, `employees`, `dept`, and `projects`, are made up of real
@@ -433,42 +428,42 @@ relationships. These tables are `manager`, `at_dep`, and `in_proj`.
 `manager`:
 
 ```erlang
-        {manager, 104465, 'B/SF'}.
-        {manager, 104465, 'B/SFP'}.
-        {manager, 114872, 'B/SFR'}.
+{manager, 104465, 'B/SF'}.
+{manager, 104465, 'B/SFP'}.
+{manager, 114872, 'B/SFR'}.
 ```
 
 `at_dep`:
 
 ```erlang
-        {at_dep, 104465, 'B/SF'}.
-        {at_dep, 107912, 'B/SF'}.
-        {at_dep, 114872, 'B/SFR'}.
-        {at_dep, 104531, 'B/SFR'}.
-        {at_dep, 104659, 'B/SFR'}.
-        {at_dep, 104732, 'B/SFR'}.
-        {at_dep, 117716, 'B/SFP'}.
-        {at_dep, 115018, 'B/SFP'}.
+{at_dep, 104465, 'B/SF'}.
+{at_dep, 107912, 'B/SF'}.
+{at_dep, 114872, 'B/SFR'}.
+{at_dep, 104531, 'B/SFR'}.
+{at_dep, 104659, 'B/SFR'}.
+{at_dep, 104732, 'B/SFR'}.
+{at_dep, 117716, 'B/SFP'}.
+{at_dep, 115018, 'B/SFP'}.
 ```
 
 `in_proj`:
 
 ```erlang
-        {in_proj, 104465, otp}.
-        {in_proj, 107912, otp}.
-        {in_proj, 114872, otp}.
-        {in_proj, 104531, otp}.
-        {in_proj, 104531, mnesia}.
-        {in_proj, 104545, wolf}.
-        {in_proj, 104659, otp}.
-        {in_proj, 104659, wolf}.
-        {in_proj, 104732, otp}.
-        {in_proj, 104732, mnesia}.
-        {in_proj, 104732, erlang}.
-        {in_proj, 117716, otp}.
-        {in_proj, 117716, documentation}.
-        {in_proj, 115018, otp}.
-        {in_proj, 115018, mnesia}.
+{in_proj, 104465, otp}.
+{in_proj, 107912, otp}.
+{in_proj, 114872, otp}.
+{in_proj, 104531, otp}.
+{in_proj, 104531, mnesia}.
+{in_proj, 104545, wolf}.
+{in_proj, 104659, otp}.
+{in_proj, 104659, wolf}.
+{in_proj, 104732, otp}.
+{in_proj, 104732, mnesia}.
+{in_proj, 104732, erlang}.
+{in_proj, 117716, otp}.
+{in_proj, 117716, documentation}.
+{in_proj, 115018, otp}.
+{in_proj, 115018, mnesia}.
 ```
 
 The room number is an attribute of the employee record. This is a structured
@@ -486,7 +481,6 @@ Retrieving data from DBMS is usually to be done with the functions
 raises the salary:
 
 ```erlang
-
 raise(Eno, Raise) ->
     F = fun() ->
                 [E] = mnesia:read(employee, Eno, write),
@@ -525,7 +519,6 @@ mnesia:select(employee, [{#employee{sex = female, name = '$1', _ = '_'},[], ['$1
 following function can be constructed to call from the shell:
 
 ```erlang
-
 all_females() ->
     F = fun() ->
 		Female = #employee{sex = female, name = '$1', _ = '_'},
@@ -540,8 +533,8 @@ The `select` expression matches all entries in table employee with the field
 This function can be called from the shell as follows:
 
 ```erlang
-          (klacke@gin)1> company:all_females().
-          {atomic,  ["Carlsson Tuula", "Fedoriw Anna"]}
+(klacke@gin)1> company:all_females().
+{atomic, ["Carlsson Tuula", "Fedoriw Anna"]}
 ```
 
 For a description of `select` and its syntax, see
@@ -558,16 +551,15 @@ offers a nice syntax.
 The following function extracts a list of female employees from the database:
 
 ```erlang
-          Q = qlc:q([E#employee.name || E <- mnesia:table(employee),
-                                E#employee.sex == female]),
-          qlc:e(Q),
+Q = qlc:q([E#employee.name || E <- mnesia:table(employee),
+                              E#employee.sex == female]),
+qlc:e(Q),
 ```
 
 Accessing `Mnesia` tables from a QLC list comprehension must always be done
 within a transaction. Consider the following function:
 
 ```erlang
-
 females() ->
     F = fun() ->
 		Q = qlc:q([E#employee.name || E <- mnesia:table(employee),
@@ -580,8 +572,8 @@ females() ->
 This function can be called from the shell as follows:
 
 ```erlang
-          (klacke@gin)1> company:females().
-          {atomic, ["Carlsson Tuula", "Fedoriw Anna"]}
+(klacke@gin)1> company:females().
+{atomic, ["Carlsson Tuula", "Fedoriw Anna"]}
 ```
 
 In traditional relational database terminology, this operation is called a
@@ -604,7 +596,6 @@ same transaction. To raise the salary of all female employees, execute the
 following:
 
 ```erlang
-
 raise_females(Amount) ->
     F = fun() ->
                 Q = qlc:q([E || E <- mnesia:table(employee),
@@ -630,7 +621,7 @@ that the salary is not raised for any employee.
 
 _Example:_
 
-```text
-          33>company:raise_females(33).
-          {atomic,2}
+```erlang
+33> company:raise_females(33).
+{atomic,2}
 ```

--- a/lib/mnesia/doc/guides/mnesia_chap2.md
+++ b/lib/mnesia/doc/guides/mnesia_chap2.md
@@ -82,15 +82,15 @@ In this example, the following actions are performed:
   `-mnesia dir '"/tmp/funky"'`, which indicates in which directory to store the
   data.
 - _Step 2:_ A new empty schema is initialized on the local node by evaluating
-  [mnesia:create_schema(\[node()])](`mnesia:create_schema/1`). The schema
+  [`mnesia:create_schema([node()])`](`mnesia:create_schema/1`). The schema
   contains information about the database in general. This is explained in
   detail later.
 - _Step 3:_ The DBMS is started by evaluating
-  [mnesia:start()](`mnesia:start/0`).
+  [`mnesia:start()`](`mnesia:start/0`).
 - _Step 4:_ A first table is created, called `funky`, by evaluating the
-  expression `mnesia:create_table(funky, [])`. The table is given default
-  properties.
-- _Step 5:_ [mnesia:info()](`mnesia:info/0`) is evaluated to display information
+  expression [`mnesia:create_table(funky, [])`](`mnesia:create_table/2`). The
+  table is given default properties.
+- _Step 5:_ [`mnesia:info()`](`mnesia:info/0`) is evaluated to display information
   on the terminal about the status of the database.
 
 ## Example
@@ -147,7 +147,7 @@ This file defines the following structure for the example database:
 ```
 
 The structure defines six tables in the database. In `Mnesia`, the function
-[mnesia:create_table(Name, ArgList)](`mnesia:create_table/2`) creates tables.
+[`mnesia:create_table(Name, ArgList)`](`mnesia:create_table/2`) creates tables.
 `Name` is the table name.
 
 > #### Note {: .info }
@@ -209,11 +209,11 @@ database:
   command-line entry that starts the Erlang system. The flag `-mnesia dir Dir`
   specifies the location of the database directory. The system responds and
   waits for further input with the prompt `1>`.
-- [mnesia:create_schema(\[node()])](`mnesia:create_schema/1`). This function has
+- [`mnesia:create_schema([node()])`](`mnesia:create_schema/1`). This function has
   the format `mnesia:create_schema(DiscNodeList)` and initiates a new schema. In
   this example, a non-distributed system using only one node is created. Schemas
   are fully explained in [Define a Schema](mnesia_chap3.md#def_schema).
-- [mnesia:start()](`mnesia:start/0`). This function starts `Mnesia` and is fully
+- [`mnesia:start()`](`mnesia:start/0`). This function starts `Mnesia` and is fully
   explained in [Start Mnesia](mnesia_chap3.md#start_mnesia).
 
 Continuing the dialogue with the Erlang shell produces the following:
@@ -255,7 +255,7 @@ ok
 ```
 
 A set of tables is created. The function
-[mnesia:create_table(Name, ArgList)](`mnesia:create_table/2`) creates the
+[`mnesia:create_table(Name, ArgList)`](`mnesia:create_table/2`) creates the
 required database tables. The options available with `ArgList` are explained in
 [Create New Tables](mnesia_chap3.md#create_tables).
 
@@ -266,7 +266,7 @@ employee can participate in several projects. However, the `at_dep` relation is
 `set`, as an employee can only work in one department. In this data model, there
 are examples of relations that are 1-to-1 (`set`) and 1-to-many (`bag`).
 
-[mnesia:info()](`mnesia:info/0`) now indicates that a database has seven local
+[`mnesia:info()`](`mnesia:info/0`) now indicates that a database has seven local
 tables, where six are the user-defined tables and one is the schema. Six
 transactions have been committed, as six successful transactions were run when
 creating the tables.
@@ -302,7 +302,7 @@ mk_projs(_, []) -> ok.
 
 The function `insert_emp/3` creates a Functional Object (Fun). `Fun` is passed
 as a single argument to the function
-[mnesia:transaction(Fun)](`mnesia:transaction/1`). This means that `Fun` is run
+[`mnesia:transaction(Fun)`](`mnesia:transaction/1`). This means that `Fun` is run
 as a transaction with the following properties:
 
 - A `Fun` either succeeds or fails.
@@ -373,7 +373,7 @@ A `Mnesia` table is populated by `Mnesia` records. For example, the tuple
 `{boss, klacke, bjarne}` is a record. The second element in this tuple is the
 key. To identify a table uniquely, both the key and the table name is needed.
 The term Object Identifier (OID) is sometimes used for the arity two tuple
-\{Tab, Key\}. The OID for the record `{boss, klacke, bjarne}` is the arity two
+`{Tab, Key}`. The OID for the record `{boss, klacke, bjarne}` is the arity two
 tuple `{boss, klacke}`. The first element of the tuple is the type of the record
 and the second element is the key. An OID can lead to zero, one, or more records
 depending on whether the table type is `set` or `bag`.
@@ -477,7 +477,7 @@ The `Company` database is now initialized and contains data.
 ### Writing Queries
 
 Retrieving data from DBMS is usually to be done with the functions
-`mnesia:read/3` or [mnesia:read/1](`mnesia:read/2`). The following function
+`mnesia:read/3` or [`mnesia:read/1`](`mnesia:read/2`). The following function
 raises the salary:
 
 ```erlang
@@ -498,7 +498,7 @@ acquired when the record from the table is read.
 To read the values from the table directly is not always possible. It can be
 needed to search one or more tables to get the wanted data, and this is done by
 writing database queries. Queries are always more expensive operations than
-direct lookups done with `mnesia:read`. Therefore, avoid queries in
+direct lookups done with `mnesia:read/1`. Therefore, avoid queries in
 performance-critical code.
 
 Two methods are available for writing database queries:

--- a/lib/mnesia/doc/guides/mnesia_chap3.md
+++ b/lib/mnesia/doc/guides/mnesia_chap3.md
@@ -58,7 +58,7 @@ return either of the following tuples:
 
 The schema functions are as follows:
 
-- [mnesia:create_schema(NodeList)](`mnesia:create_schema/1`) initializes a new,
+- [`mnesia:create_schema(NodeList)`](`mnesia:create_schema/1`) initializes a new,
   empty schema. This is a mandatory requirement before `Mnesia` can be started.
   `Mnesia` is a truly distributed DBMS and the schema is a system table that is
   replicated on all nodes in a `Mnesia` system. This function fails if a schema
@@ -66,29 +66,29 @@ The schema functions are as follows:
   `Mnesia` to be stopped on the all `db_nodes` contained in parameter
   `NodeList`. Applications call this function only once, as it is usually a
   one-time activity to initialize a new database.
-- [mnesia:delete_schema(DiscNodeList)](`mnesia:delete_schema/1`) erases any old
+- [`mnesia:delete_schema(DiscNodeList)`](`mnesia:delete_schema/1`) erases any old
   schemas on the nodes in `DiscNodeList`. It also removes all old tables
   together with all data. This function requires `Mnesia` to be stopped on all
   `db_nodes`.
-- [mnesia:delete_table(Tab)](`mnesia:delete_table/1`) permanently deletes all
+- [`mnesia:delete_table(Tab)`](`mnesia:delete_table/1`) permanently deletes all
   replicas of table `Tab`.
-- [mnesia:clear_table(Tab)](`mnesia:clear_table/1`) permanently deletes all
+- [`mnesia:clear_table(Tab)`](`mnesia:clear_table/1`) permanently deletes all
   entries in table `Tab`.
-- [mnesia:move_table_copy(Tab, From, To)](`mnesia:move_table_copy/3`) moves the
+- [`mnesia:move_table_copy(Tab, From, To)`](`mnesia:move_table_copy/3`) moves the
   copy of table `Tab` from node `From` to node `To`. The table storage type
   `{type}` is preserved, so if a RAM table is moved from one node to another, it
   remains a RAM table on the new node. Other transactions can still perform read
   and write operation to the table while it is being moved.
-- [mnesia:add_table_copy(Tab, Node, Type)](`mnesia:add_table_copy/3`) creates a
+- [`mnesia:add_table_copy(Tab, Node, Type)`](`mnesia:add_table_copy/3`) creates a
   replica of table `Tab` at node `Node`. Argument `Type` must be either of the
   atoms `ram_copies`, `disc_copies`, or `disc_only_copies`. If you add a copy of
   the system table `schema` to a node, you want the `Mnesia` schema to reside
   there as well. This action extends the set of nodes that comprise this
   particular `Mnesia` system.
-- [mnesia:del_table_copy(Tab, Node)](`mnesia:del_table_copy/2`) deletes the
+- [`mnesia:del_table_copy(Tab, Node)`](`mnesia:del_table_copy/2`) deletes the
   replica of table `Tab` at node `Node`. When the last replica of a table is
   removed, the table is deleted.
-- [mnesia:transform_table(Tab, Fun, NewAttributeList, NewRecordName)](`mnesia:transform_table/4`)
+- [`mnesia:transform_table(Tab, Fun, NewAttributeList, NewRecordName)`](`mnesia:transform_table/4`)
   changes the format on all records in table `Tab`. It applies argument `Fun` to
   all records in the table. `Fun` must be a function that takes a record of the
   old type, and returns the record of the new type. The table key must not be
@@ -116,9 +116,9 @@ The schema functions are as follows:
   creates inconsistencies between the metadata and the actual data) but it is
   included as a possibility for the user do to an own (offline) transform.
 
-- `change_table_copy_type(Tab, Node, ToType)` changes the storage type of a
-  table. For example, a RAM table is changed to a `disc_table` at the node
-  specified as `Node`.
+- [`mnesia:change_table_copy_type(Tab, Node, ToType)`](`mnesia:change_table_copy_type/3`)
+  changes the storage type of a table. For example, a RAM table is changed to a
+  `disc_table` at the node specified as `Node`.
 
 ## Data Model
 
@@ -154,10 +154,10 @@ Before starting `Mnesia`, the following must be done:
 - An empty schema must be initialized on all the participating nodes.
 - The Erlang system must be started.
 - Nodes with disc database schema must be defined and implemented with the
-  function [mnesia:create_schema(NodeList)](`mnesia:create_schema/1`).
+  function [`mnesia:create_schema(NodeList)`](`mnesia:create_schema/1`).
 
 When running a distributed system with two or more participating nodes, the
-function [mnesia:start()](`mnesia:start/0`) must be executed on each
+function [`mnesia:start()`](`mnesia:start/0`) must be executed on each
 participating node. This would typically be part of the boot script in an
 embedded environment. In a test environment or an interactive environment,
 `mnesia:start()` can also be used either from the Erlang shell or another
@@ -203,7 +203,7 @@ skeppet % erl -sname b -mnesia dir '"/ldisc/scratch/Mnesia.company"'
 (a@gin)1> mnesia:create_schema([a@gin, b@skeppet]).
 ```
 
-1. The function [mnesia:start()](`mnesia:start/0`) is called on both nodes.
+1. The function [`mnesia:start()`](`mnesia:start/0`) is called on both nodes.
 1. To initialize the database, execute the following code on one of the two
    nodes:
 
@@ -238,7 +238,7 @@ As illustrated, the two directories reside on different nodes, because
 By executing these commands, two Erlang nodes are configured to run the
 `Company` database, and therefore, initialize the database. This is required
 only once when setting up. The next time the system is started,
-[mnesia:start()](`mnesia:start/0`) is called on both nodes, to initialize the
+[`mnesia:start()`](`mnesia:start/0`) is called on both nodes, to initialize the
 system from disc.
 
 In a system of `Mnesia` nodes, every node is aware of the current location of
@@ -247,7 +247,7 @@ manipulate the data in the tables can be executed on either of the two nodes.
 Code that manipulate `Mnesia` data behaves identically regardless of where the
 data resides.
 
-The function [mnesia:stop()](`mnesia:stop/0`) stops `Mnesia` on the node where
+The function [`mnesia:stop()`](`mnesia:stop/0`) stops `Mnesia` on the node where
 the function is executed. The functions `mnesia:start/0` and `mnesia:stop/0`
 work on the "local" `Mnesia` system. No functions start or stop a set of nodes.
 
@@ -274,11 +274,11 @@ The alternatives are as follows:
    they are loaded.
 
 Table initialization is asynchronous. The function call
-[mnesia:start()](`mnesia:start/0`) returns the atom `ok` and then starts to
+[`mnesia:start()`](`mnesia:start/0`) returns the atom `ok` and then starts to
 initialize the different tables. Depending on the size of the database, this can
 take some time, and the application programmer must wait for the tables that the
 application needs before they can be used. This is achieved by using the
-function [mnesia:wait_for_tables(TabList, Timeout)](`mnesia:wait_for_tables/2`),
+function [`mnesia:wait_for_tables(TabList, Timeout)`](`mnesia:wait_for_tables/2`),
 which suspends the caller until all tables specified in `TabList` are properly
 initiated.
 
@@ -290,7 +290,7 @@ remote node has initialized the table from its local disc and the node has
 copied the table over the network to the local node.
 
 However, this procedure can be time-consuming, the shortcut function
-[mnesia:force_load_table(Tab)](`mnesia:force_load_table/1`) loads all the tables
+[`mnesia:force_load_table(Tab)`](`mnesia:force_load_table/1`) loads all the tables
 from disc at a faster rate. The function forces tables to be loaded from disc
 regardless of the network situation.
 
@@ -314,7 +314,7 @@ end.
 > remote replica was alive, are lost. This can cause the database to become
 > inconsistent.
 
-If the startup procedure fails, the function [mnesia:start()](`mnesia:start/0`)
+If the startup procedure fails, the function [`mnesia:start()`](`mnesia:start/0`)
 returns the cryptic tuple
 `{error,{shutdown, {mnesia_sup,start_link,[normal,[]]}}}`. To get more
 information about the start failure, use command-line arguments
@@ -324,7 +324,7 @@ information about the start failure, use command-line arguments
 
 ## Create Tables
 
-The function [mnesia:create_table(Name, ArgList)](`mnesia:create_table/2`)
+The function [`mnesia:create_table(Name, ArgList)`](`mnesia:create_table/2`)
 creates tables. When executing this function, it returns one of the following
 responses:
 
@@ -392,7 +392,7 @@ The function arguments are as follows:
     to create a table, it is located on the local node only.
 
     Table replicas of type `ram_copies` can be dumped to disc with the function
-    [mnesia:dump_tables(TabList)](`mnesia:dump_tables/1`).
+    [`mnesia:dump_tables(TabList)`](`mnesia:dump_tables/1`).
 
   - `{disc_only_copies, NodeList}`. These table replicas are stored on disc only
     and are therefore slower to access. However, a disc-only replica consumes

--- a/lib/mnesia/doc/guides/mnesia_chap3.md
+++ b/lib/mnesia/doc/guides/mnesia_chap3.md
@@ -176,7 +176,7 @@ can be started. There are two ways to specify the `Mnesia` directory to be used:
   following example was used to create the directory for the `Company` database:
 
   ```text
-  %erl -mnesia dir '"/ldisc/scratch/Mnesia.Company"'
+  % erl -mnesia dir '"/ldisc/scratch/Mnesia.Company"'
   ```
 
 - If no command-line flag is entered, the `Mnesia` directory becomes the current
@@ -188,19 +188,19 @@ enter the following commands:
 1. On the node `a@gin`:
 
 ```text
- gin %erl -sname a  -mnesia dir '"/ldisc/scratch/Mnesia.company"'
+ gin % erl -sname a  -mnesia dir '"/ldisc/scratch/Mnesia.company"'
 ```
 
 1. On the node `b@skeppet`:
 
 ```text
-skeppet %erl -sname b -mnesia dir '"/ldisc/scratch/Mnesia.company"'
+skeppet % erl -sname b -mnesia dir '"/ldisc/scratch/Mnesia.company"'
 ```
 
 1. On one of the two nodes:
 
-```text
-(a@gin)1>mnesia:create_schema([a@gin, b@skeppet]).
+```erlang
+(a@gin)1> mnesia:create_schema([a@gin, b@skeppet]).
 ```
 
 1. The function [mnesia:start()](`mnesia:start/0`) is called on both nodes.
@@ -208,8 +208,6 @@ skeppet %erl -sname b -mnesia dir '"/ldisc/scratch/Mnesia.company"'
    nodes:
 
 ```erlang
-
-
 dist_init() ->
     mnesia:create_table(employee,
                          [{ram_copies, [a@gin, b@skeppet]},
@@ -257,8 +255,8 @@ work on the "local" `Mnesia` system. No functions start or stop a set of nodes.
 
 Start `Mnesia` by calling the following function:
 
-```text
-          mnesia:start().
+```erlang
+mnesia:start().
 ```
 
 This function initiates the DBMS locally.
@@ -301,12 +299,12 @@ the application must perform some action similar to following before it can use
 the tables:
 
 ```erlang
-          case mnesia:wait_for_tables([a, b], 20000) of
-            {timeout,   RemainingTabs} ->
-              panic(RemainingTabs);
-            ok ->
-              synced
-          end.
+case mnesia:wait_for_tables([a, b], 20000) of
+  {timeout, RemainingTabs} ->
+    panic(RemainingTabs);
+  ok ->
+    synced
+end.
 ```
 
 > #### Warning {: .warning }
@@ -448,21 +446,21 @@ The function arguments are as follows:
 As an example, consider the following record definition:
 
 ```erlang
-      -record(funky, {x, y}).
+-record(funky, {x, y}).
 ```
 
 The following call would create a table that is replicated on two nodes, has an
 extra index on attribute `y`, and is of type `bag`.
 
 ```erlang
-      mnesia:create_table(funky, [{disc_copies, [N1, N2]}, {index,
-      [y]}, {type, bag}, {attributes, record_info(fields, funky)}]).
+mnesia:create_table(funky, [{disc_copies, [N1, N2]}, {index, [y]},
+                            {type, bag}, {attributes, record_info(fields, funky)}]).
 ```
 
 Whereas a call to the following default code values would return a table with a
 RAM copy on the local node, no extra indexes, and the attributes defaulted to
 the list `[key,val]`.
 
-```text
+```erlang
 mnesia:create_table(stuff, [])
 ```

--- a/lib/mnesia/doc/guides/mnesia_chap4.md
+++ b/lib/mnesia/doc/guides/mnesia_chap4.md
@@ -55,7 +55,6 @@ The following example shows a transaction that raises the salary of certain
 employee numbers:
 
 ```erlang
-
 raise(Eno, Raise) ->
     F = fun() ->
                 [E] = mnesia:read(employee, Eno, write),
@@ -188,7 +187,6 @@ messages are sent by the transaction Fun. The following example illustrates this
 situation:
 
 ```erlang
-
 bad_raise(Eno, Raise) ->
     F = fun() ->
                 [E] = mnesia:read({employee, Eno}),
@@ -265,10 +263,10 @@ that first acquired the lock has terminated. To illustrate this, assume that the
 following transaction is executed:
 
 ```erlang
-        F = fun() ->
-              mnesia:write(#foo{a = kalle})
-            end,
-        mnesia:transaction(F).
+F = fun() ->
+      mnesia:write(#foo{a = kalle})
+    end,
+mnesia:transaction(F).
 ```
 
 The `foo` table is replicated on the two nodes `N1` and `N2`.
@@ -281,10 +279,10 @@ Normal locking requires the following:
 If sticky locks are used, the code must first be changed as follows:
 
 ```erlang
-        F = fun() ->
-              mnesia:s_write(#foo{a = kalle})
-            end,
-        mnesia:transaction(F).
+F = fun() ->
+      mnesia:s_write(#foo{a = kalle})
+    end,
+mnesia:transaction(F).
 ```
 
 This code uses the function [s_write/1](`mnesia:s_write/1`) instead of the
@@ -323,8 +321,8 @@ operations:
 Alternative syntax for acquisition of table locks is as follows:
 
 ```erlang
-        mnesia:lock({table, Tab}, read)
-        mnesia:lock({table, Tab}, write)
+mnesia:lock({table, Tab}, read)
+mnesia:lock({table, Tab}, write)
 ```
 
 The matching operations in `Mnesia` can either lock the entire table or only a
@@ -341,9 +339,9 @@ previously) but also for situations when locks need to be acquired regardless of
 how tables have been replicated:
 
 ```text
-        mnesia:lock({global, GlobalKey, Nodes}, LockKind)
+mnesia:lock({global, GlobalKey, Nodes}, LockKind)
 
-        LockKind ::= read | write | ...
+LockKind ::= read | write | ...
 ```
 
 The lock is acquired on `LockItem` on all nodes in the node list.
@@ -472,7 +470,7 @@ property `record_name`, the following code ensures that all records in the
 tables have the same name as the table:
 
 ```erlang
-      mnesia:create_table(subscriber, [])
+mnesia:create_table(subscriber, [])
 ```
 
 However, if the table is created with an explicit record name as argument, as
@@ -480,9 +478,9 @@ shown in the following example, subscriber records can be stored in both of the
 tables regardless of the table names:
 
 ```erlang
-      TabDef = [{record_name, subscriber}],
-      mnesia:create_table(my_subscriber, TabDef),
-      mnesia:create_table(your_subscriber, TabDef).
+TabDef = [{record_name, subscriber}],
+mnesia:create_table(my_subscriber, TabDef),
+mnesia:create_table(your_subscriber, TabDef).
 ```
 
 To access such tables, simplified access functions (as described earlier) cannot
@@ -491,9 +489,9 @@ function `mnesia:write/3` instead of the simplified functions `mnesia:write/1`
 and `mnesia:s_write/1`:
 
 ```erlang
-      mnesia:write(subscriber, #subscriber{}, write)
-      mnesia:write(my_subscriber, #subscriber{}, sticky_write)
-      mnesia:write(your_subscriber, #subscriber{}, write)
+mnesia:write(subscriber, #subscriber{}, write)
+mnesia:write(my_subscriber, #subscriber{}, sticky_write)
+mnesia:write(your_subscriber, #subscriber{}, write)
 ```
 
 The following simple code illustrates the relationship between the simplified
@@ -501,67 +499,67 @@ access functions used in most of the examples and their more flexible
 counterparts:
 
 ```erlang
-      mnesia:dirty_write(Record) ->
-        Tab = element(1, Record),
-        mnesia:dirty_write(Tab, Record).
+mnesia:dirty_write(Record) ->
+  Tab = element(1, Record),
+  mnesia:dirty_write(Tab, Record).
 
-      mnesia:dirty_delete({Tab, Key}) ->
-        mnesia:dirty_delete(Tab, Key).
+mnesia:dirty_delete({Tab, Key}) ->
+  mnesia:dirty_delete(Tab, Key).
 
-      mnesia:dirty_delete_object(Record) ->
-        Tab = element(1, Record),
-        mnesia:dirty_delete_object(Tab, Record)
+mnesia:dirty_delete_object(Record) ->
+  Tab = element(1, Record),
+  mnesia:dirty_delete_object(Tab, Record)
 
-      mnesia:dirty_update_counter({Tab, Key}, Incr) ->
-        mnesia:dirty_update_counter(Tab, Key, Incr).
+mnesia:dirty_update_counter({Tab, Key}, Incr) ->
+  mnesia:dirty_update_counter(Tab, Key, Incr).
 
-      mnesia:dirty_read({Tab, Key}) ->
-        Tab = element(1, Record),
-        mnesia:dirty_read(Tab, Key).
+mnesia:dirty_read({Tab, Key}) ->
+  Tab = element(1, Record),
+  mnesia:dirty_read(Tab, Key).
 
-      mnesia:dirty_match_object(Pattern) ->
-        Tab = element(1, Pattern),
-        mnesia:dirty_match_object(Tab, Pattern).
+mnesia:dirty_match_object(Pattern) ->
+  Tab = element(1, Pattern),
+  mnesia:dirty_match_object(Tab, Pattern).
 
-      mnesia:dirty_index_match_object(Pattern, Attr)
-        Tab = element(1, Pattern),
-        mnesia:dirty_index_match_object(Tab, Pattern, Attr).
+mnesia:dirty_index_match_object(Pattern, Attr)
+  Tab = element(1, Pattern),
+  mnesia:dirty_index_match_object(Tab, Pattern, Attr).
 
-      mnesia:write(Record) ->
-        Tab = element(1, Record),
-        mnesia:write(Tab, Record, write).
+mnesia:write(Record) ->
+  Tab = element(1, Record),
+  mnesia:write(Tab, Record, write).
 
-      mnesia:s_write(Record) ->
-        Tab = element(1, Record),
-        mnesia:write(Tab, Record, sticky_write).
+mnesia:s_write(Record) ->
+  Tab = element(1, Record),
+  mnesia:write(Tab, Record, sticky_write).
 
-      mnesia:delete({Tab, Key}) ->
-        mnesia:delete(Tab, Key, write).
+mnesia:delete({Tab, Key}) ->
+  mnesia:delete(Tab, Key, write).
 
-      mnesia:s_delete({Tab, Key}) ->
-        mnesia:delete(Tab, Key, sticky_write).
+mnesia:s_delete({Tab, Key}) ->
+  mnesia:delete(Tab, Key, sticky_write).
 
-      mnesia:delete_object(Record) ->
-        Tab = element(1, Record),
-        mnesia:delete_object(Tab, Record, write).
+mnesia:delete_object(Record) ->
+  Tab = element(1, Record),
+  mnesia:delete_object(Tab, Record, write).
 
-      mnesia:s_delete_object(Record) ->
-        Tab = element(1, Record),
-        mnesia:delete_object(Tab, Record, sticky_write).
+mnesia:s_delete_object(Record) ->
+  Tab = element(1, Record),
+  mnesia:delete_object(Tab, Record, sticky_write).
 
-      mnesia:read({Tab, Key}) ->
-        mnesia:read(Tab, Key, read).
+mnesia:read({Tab, Key}) ->
+  mnesia:read(Tab, Key, read).
 
-      mnesia:wread({Tab, Key}) ->
-        mnesia:read(Tab, Key, write).
+mnesia:wread({Tab, Key}) ->
+  mnesia:read(Tab, Key, write).
 
-      mnesia:match_object(Pattern) ->
-        Tab = element(1, Pattern),
-        mnesia:match_object(Tab, Pattern, read).
+mnesia:match_object(Pattern) ->
+  Tab = element(1, Pattern),
+  mnesia:match_object(Tab, Pattern, read).
 
-      mnesia:index_match_object(Pattern, Attr) ->
-        Tab = element(1, Pattern),
-        mnesia:index_match_object(Tab, Pattern, Attr, read).
+mnesia:index_match_object(Pattern, Attr) ->
+  Tab = element(1, Pattern),
+  mnesia:index_match_object(Tab, Pattern, Attr, read).
 ```
 
 ## Activity Concept and Various Access Contexts
@@ -704,9 +702,9 @@ tables.
 Consider a function that adds a subscriber to a telephony system:
 
 ```erlang
-      add_subscriber(S) ->
-          mnesia:transaction(fun() ->
-              case mnesia:read( ..........
+add_subscriber(S) ->
+    mnesia:transaction(fun() ->
+        case mnesia:read( ..........
 ```
 
 This function needs to be called as a transaction. Assume that you wish to write
@@ -722,20 +720,20 @@ two or three phase commit.
 _Example:_
 
 ```erlang
-      add_subscriber(S) ->
-          mnesia:transaction(fun() ->
-             %% Transaction context
-             mnesia:read({some_tab, some_data}),
-             mnesia:sync_dirty(fun() ->
-                 %% Still in a transaction context.
-                 case mnesia:read( ..) ..end), end).
-      add_subscriber2(S) ->
-          mnesia:sync_dirty(fun() ->
-             %% In dirty context
-             mnesia:read({some_tab, some_data}),
-             mnesia:transaction(fun() ->
-                 %% In a transaction context.
-                 case mnesia:read( ..) ..end), end).
+add_subscriber(S) ->
+    mnesia:transaction(fun() ->
+       %% Transaction context
+       mnesia:read({some_tab, some_data}),
+       mnesia:sync_dirty(fun() ->
+           %% Still in a transaction context.
+           case mnesia:read( ..) ..end), end).
+add_subscriber2(S) ->
+    mnesia:sync_dirty(fun() ->
+       %% In dirty context
+       mnesia:read({some_tab, some_data}),
+       mnesia:transaction(fun() ->
+           %% In a transaction context.
+           case mnesia:read( ..) ..end), end).
 ```
 
 ## Pattern Matching
@@ -747,14 +745,14 @@ programmer with several functions for matching records against a pattern. The
 most useful ones are the following:
 
 ```erlang
-      mnesia:select(Tab, MatchSpecification, LockKind) ->
-          transaction abort | [ObjectList]
-      mnesia:select(Tab, MatchSpecification, NObjects, Lock) ->
-          transaction abort | {[Object],Continuation} | '$end_of_table'
-      mnesia:select(Cont) ->
-          transaction abort | {[Object],Continuation} | '$end_of_table'
-      mnesia:match_object(Tab, Pattern, LockKind) ->
-          transaction abort | RecordList
+mnesia:select(Tab, MatchSpecification, LockKind) ->
+    transaction abort | [ObjectList]
+mnesia:select(Tab, MatchSpecification, NObjects, Lock) ->
+    transaction abort | {[Object],Continuation} | '$end_of_table'
+mnesia:select(Cont) ->
+    transaction abort | {[Object],Continuation} | '$end_of_table'
+mnesia:match_object(Tab, Pattern, LockKind) ->
+    transaction abort | RecordList
 ```
 
 These functions match a `Pattern` against all records in table `Tab`. In a
@@ -780,24 +778,24 @@ code more vulnerable to future changes of the record definition.
 _Example:_
 
 ```erlang
-      Wildpattern = mnesia:table_info(employee, wild_pattern),
-      %% Or use
-      Wildpattern = #employee{_ = '_'},
+Wildpattern = mnesia:table_info(employee, wild_pattern),
+%% Or use
+Wildpattern = #employee{_ = '_'},
 ```
 
 For the employee table, the wild pattern looks as follows:
 
-```text
-      {employee, '_', '_', '_', '_', '_',' _'}.
+```erlang
+{employee, '_', '_', '_', '_', '_',' _'}.
 ```
 
 To constrain the match, it is needed to replace some of the `'_'` elements. The
 code for matching out all female employees looks as follows:
 
 ```erlang
-      Pat = #employee{sex = female, _ = '_'},
-      F = fun() -> mnesia:match_object(Pat) end,
-      Females = mnesia:transaction(F).
+Pat = #employee{sex = female, _ = '_'},
+F = fun() -> mnesia:match_object(Pat) end,
+Females = mnesia:transaction(F).
 ```
 
 The match function can also be used to check the equality of different
@@ -805,9 +803,9 @@ attributes. For example, to find all employees with an employee number equal to
 their room number:
 
 ```erlang
-      Pat = #employee{emp_no = '$1', room_no = '$1', _ = '_'},
-      F = fun() -> mnesia:match_object(Pat) end,
-      Odd = mnesia:transaction(F).
+Pat = #employee{emp_no = '$1', room_no = '$1', _ = '_'},
+F = fun() -> mnesia:match_object(Pat) end,
+Odd = mnesia:transaction(F).
 ```
 
 The function `mnesia:match_object/3` lacks some important features that
@@ -816,11 +814,10 @@ can only return the matching records, and it cannot express constraints other
 than equality. To find the names of the male employees on the second floor:
 
 ```erlang
-
-      MatchHead = #employee{name='$1', sex=male, room_no={'$2', '_'}, _='_'},
-      Guard = [{'>=', '$2', 220},{'<', '$2', 230}],
-      Result = '$1',
-      mnesia:select(employee,[{MatchHead, Guard, [Result]}])
+MatchHead = #employee{name='$1', sex=male, room_no={'$2', '_'}, _='_'},
+Guard = [{'>=', '$2', 220},{'<', '$2', 230}],
+Result = '$1',
+mnesia:select(employee,[{MatchHead, Guard, [Result]}])
 ```
 
 The function `select` can be used to add more constraints and create output that
@@ -863,7 +860,7 @@ remedied with indexes (see [Indexing](mnesia_chap5.md#indexing)) if the function
 QLC queries can also be used to search `Mnesia` tables. By using the function
 [mnesia:table/1,2](`mnesia:table/1`) as the generator inside a QLC query, you
 let the query operate on a `Mnesia` table. `Mnesia`\-specific options to
-`mnesia:table/2` are `{lock, Lock}`, `{n_objects,Integer}`, and
+`mnesia:table/2` are `{lock, Lock}`, `{n_objects, Integer}`, and
 `{traverse, SelMethod}`:
 
 - `lock` specifies whether `Mnesia` is to acquire a read or write lock on the
@@ -880,8 +877,8 @@ If no options are specified, a read lock is acquired, 100 results are returned
 in each chunk, and `select` is used to traverse the table, that is:
 
 ```erlang
-      mnesia:table(Tab) ->
-          mnesia:table(Tab, [{n_objects,100},{lock, read}, {traverse, select}]).
+mnesia:table(Tab) ->
+    mnesia:table(Tab, [{n_objects, 100},{lock, read}, {traverse, select}]).
 ```
 
 The function [mnesia:all_keys(Tab)](`mnesia:all_keys/1`) returns all keys in a
@@ -893,10 +890,10 @@ table.
 table:
 
 ```erlang
-      mnesia:foldl(Fun, Acc0, Tab) -> NewAcc | transaction abort
-      mnesia:foldr(Fun, Acc0, Tab) -> NewAcc | transaction abort
-      mnesia:foldl(Fun, Acc0, Tab, LockType) -> NewAcc | transaction abort
-      mnesia:foldr(Fun, Acc0, Tab, LockType) -> NewAcc | transaction abort
+mnesia:foldl(Fun, Acc0, Tab) -> NewAcc | transaction abort
+mnesia:foldr(Fun, Acc0, Tab) -> NewAcc | transaction abort
+mnesia:foldl(Fun, Acc0, Tab, LockType) -> NewAcc | transaction abort
+mnesia:foldr(Fun, Acc0, Tab, LockType) -> NewAcc | transaction abort
 ```
 
 These functions iterate over the `Mnesia` table `Tab` and apply the function
@@ -923,32 +920,32 @@ For example, finding all the employees who have a salary less than 10 can look
 as follows:
 
 ```erlang
-      find_low_salaries() ->
-        Constraint =
-             fun(Emp, Acc) when Emp#employee.salary < 10 ->
-                    [Emp | Acc];
-                (_, Acc) ->
-                    Acc
-             end,
-        Find = fun() -> mnesia:foldl(Constraint, [], employee) end,
-        mnesia:transaction(Find).
+find_low_salaries() ->
+  Constraint =
+       fun(Emp, Acc) when Emp#employee.salary < 10 ->
+              [Emp | Acc];
+          (_, Acc) ->
+              Acc
+       end,
+  Find = fun() -> mnesia:foldl(Constraint, [], employee) end,
+  mnesia:transaction(Find).
 ```
 
 To raise the salary to 10 for everyone with a salary less than 10 and return the
 sum of all raises:
 
 ```erlang
-      increase_low_salaries() ->
-         Increase =
-             fun(Emp, Acc) when Emp#employee.salary < 10 ->
-                    OldS = Emp#employee.salary,
-                    ok = mnesia:write(Emp#employee{salary = 10}),
-                    Acc + 10 - OldS;
-                (_, Acc) ->
-                    Acc
-             end,
-        IncLow = fun() -> mnesia:foldl(Increase, 0, employee, write) end,
-        mnesia:transaction(IncLow).
+increase_low_salaries() ->
+   Increase =
+       fun(Emp, Acc) when Emp#employee.salary < 10 ->
+              OldS = Emp#employee.salary,
+              ok = mnesia:write(Emp#employee{salary = 10}),
+              Acc + 10 - OldS;
+          (_, Acc) ->
+              Acc
+       end,
+  IncLow = fun() -> mnesia:foldl(Increase, 0, employee, write) end,
+  mnesia:transaction(IncLow).
 ```
 
 Many nice things can be done with the iterator functions but take some caution
@@ -963,11 +960,11 @@ iterate over the table. The order of the iteration is unspecified if the table
 is not of type `ordered_set`:
 
 ```erlang
-      mnesia:first(Tab) ->  Key | transaction abort
-      mnesia:last(Tab)  ->  Key | transaction abort
-      mnesia:next(Tab,Key)  ->  Key | transaction abort
-      mnesia:prev(Tab,Key)  ->  Key | transaction abort
-      mnesia:snmp_get_next_index(Tab,Index) -> {ok, NextIndex} | endOfTable
+mnesia:first(Tab) ->  Key | transaction abort
+mnesia:last(Tab)  ->  Key | transaction abort
+mnesia:next(Tab,Key)  ->  Key | transaction abort
+mnesia:prev(Tab,Key)  ->  Key | transaction abort
+mnesia:snmp_get_next_index(Tab,Index) -> {ok, NextIndex} | endOfTable
 ```
 
 The order of `first`/`last` and `next`/`prev` is only valid for `ordered_set`

--- a/lib/mnesia/doc/guides/mnesia_chap4.md
+++ b/lib/mnesia/doc/guides/mnesia_chap4.md
@@ -224,27 +224,27 @@ functions that work with transactions. Notice that these functions must be
 embedded in a transaction. If no enclosing transaction (or other enclosing
 `Mnesia` activity) exists, they all fail.
 
-- [mnesia:transaction(Fun) -> \{aborted, Reason\} |\{atomic, Value\}](`mnesia:transaction/1`)
+- [`mnesia:transaction(Fun) -> {aborted, Reason} | {atomic, Value}`](`mnesia:transaction/1`)
   executes one transaction with the functional object `Fun` as the single
   parameter.
-- [mnesia:read(\{Tab, Key\}) -> transaction abort | RecordList](`mnesia:read/1`)
+- [`mnesia:read({Tab, Key}) -> transaction abort | RecordList`](`mnesia:read/1`)
   reads all records with `Key` as key from table `Tab`. This function has the
   same semantics regardless of the location of `Table`. If the table is of type
   `bag`, `read({Tab, Key})` can return an arbitrarily long list. If the table is
   of type `set`, the list is either of length one or `[]`.
-- [mnesia:wread(\{Tab, Key\}) -> transaction abort | RecordList](`mnesia:wread/1`)
+- [`mnesia:wread({Tab, Key}) -> transaction abort | RecordList`](`mnesia:wread/1`)
   behaves the same way as the previously listed function `read/1`, except that
   it acquires a write lock instead of a read lock. To execute a transaction that
   reads a record, modifies the record, and then writes the record, it is
   slightly more efficient to set the write lock immediately. When a
   `mnesia:read/1` is issued, followed by a `mnesia:write/1` the first read lock
   must be upgraded to a write lock when the write operation is executed.
-- [mnesia:write(Record) -> transaction abort | ok](`mnesia:write/1`) writes a
+- [`mnesia:write(Record) -> transaction abort | ok`](`mnesia:write/1`) writes a
   record into the database. Argument `Record` is an instance of a record. The
   function returns `ok`, or terminates the transaction if an error occurs.
-- [mnesia:delete(\{Tab, Key\}) -> transaction abort | ok](`mnesia:delete/1`)
+- [`mnesia:delete({Tab, Key}) -> transaction abort | ok`](`mnesia:delete/1`)
   deletes all records with the given key.
-- [mnesia:delete_object(Record) -> transaction abort | ok](`mnesia:delete_object/1`)
+- [`mnesia:delete_object(Record) -> transaction abort | ok`](`mnesia:delete_object/1`)
   deletes records with the OID `Record`. Use this function to delete only some
   records in a table of type `bag`.
 
@@ -285,8 +285,8 @@ F = fun() ->
 mnesia:transaction(F).
 ```
 
-This code uses the function [s_write/1](`mnesia:s_write/1`) instead of the
-function [write/1](`mnesia:write/1`) The function `s_write/1` sets a sticky lock
+This code uses the function [`s_write/1`](`mnesia:s_write/1`) instead of the
+function [`write/1`](`mnesia:write/1`) The function `s_write/1` sets a sticky lock
 instead of a normal lock. If the table is not replicated, sticky locks have no
 special effect. If the table is replicated, and a sticky lock is set on node
 `N1`, this lock then sticks to node `N1`. The next time you try to set a sticky
@@ -313,9 +313,9 @@ on this table. This blocks other concurrent transactions from the table. The
 following two functions are used to set explicit table locks for read and write
 operations:
 
-- [mnesia:read_lock_table(Tab)](`mnesia:read_lock_table/1`) sets a read lock on
+- [`mnesia:read_lock_table(Tab)`](`mnesia:read_lock_table/1`) sets a read lock on
   table `Tab`.
-- [mnesia:write_lock_table(Tab)](`mnesia:write_lock_table/1`) sets a write lock
+- [`mnesia:write_lock_table(Tab)`](`mnesia:write_lock_table/1`) sets a write lock
   on table `Tab`.
 
 Alternative syntax for acquisition of table locks is as follows:
@@ -382,16 +382,16 @@ All dirty functions execute a call to [`exit({aborted, Reason})`](`exit/1`) on
 failure. Even if the following functions are executed inside a transaction no
 locks are acquired. The following functions are available:
 
-- [mnesia:dirty_read(\{Tab, Key\})](`mnesia:dirty_read/1`) reads one or more
+- [`mnesia:dirty_read({Tab, Key})`](`mnesia:dirty_read/1`) reads one or more
   records from `Mnesia`.
-- [mnesia:dirty_write(Record)](`mnesia:dirty_write/1`) writes the record
+- [`mnesia:dirty_write(Record)`](`mnesia:dirty_write/1`) writes the record
   `Record`.
-- [mnesia:dirty_delete(\{Tab, Key\})](`mnesia:dirty_delete/1`) deletes one or
+- [`mnesia:dirty_delete({Tab, Key})`](`mnesia:dirty_delete/1`) deletes one or
   more records with key `Key`.
-- [mnesia:dirty_delete_object(Record)](`mnesia:dirty_delete_object/1`) is the
+- [`mnesia:dirty_delete_object(Record)`](`mnesia:dirty_delete_object/1`) is the
   dirty operation alternative to the function
-  [delete_object/1](`mnesia:delete_object/1`).
-- [mnesia:dirty_first(Tab)](`mnesia:dirty_first/1`) returns the "first" key in
+  [`delete_object/1`](`mnesia:delete_object/1`).
+- [`mnesia:dirty_first(Tab)`](`mnesia:dirty_first/1`) returns the "first" key in
   table `Tab`.
 
   Records in `set` or `bag` tables are not sorted. However, there is a record
@@ -402,7 +402,7 @@ locks are acquired. The following functions are available:
   `'$end_of_table'`. It is not recommended to use this atom as the key for any
   user records.
 
-- [mnesia:dirty_next(Tab, Key)](`mnesia:dirty_next/2`) returns the "next" key in
+- [`mnesia:dirty_next(Tab, Key)`](`mnesia:dirty_next/2`) returns the "next" key in
   table `Tab`. This function makes it possible to traverse a table and perform
   some operation on all records in the table. When the end of the table is
   reached, the special key `'$end_of_table'` is returned. Otherwise, the
@@ -410,25 +410,25 @@ locks are acquired. The following functions are available:
 
   The behavior is undefined if any process performs a write operation on the
   table while traversing the table with the function
-  [dirty_next/2](`mnesia:dirty_next/2`) This is because `write` operations on a
+  [`dirty_next/2`](`mnesia:dirty_next/2`) This is because `write` operations on a
   `Mnesia` table can lead to internal reorganizations of the table itself. This
   is an implementation detail, but remember that the dirty functions are
   low-level functions.
 
-- [mnesia:dirty_last(Tab)](`mnesia:dirty_last/1`) works exactly like
+- [`mnesia:dirty_last(Tab)`](`mnesia:dirty_last/1`) works exactly like
   `mnesia:dirty_first/1` but returns the last object in Erlang term order for
   the table type `ordered_set`. For all other table types,
   `mnesia:dirty_first/1` and `mnesia:dirty_last/1` are synonyms.
-- [mnesia:dirty_prev(Tab, Key)](`mnesia:dirty_prev/2`) works exactly like
+- [`mnesia:dirty_prev(Tab, Key)`](`mnesia:dirty_prev/2`) works exactly like
   `mnesia:dirty_next/2` but returns the previous object in Erlang term order for
   the table type `ordered_set`. For all other table types, `mnesia:dirty_next/2`
   and `mnesia:dirty_prev/2` are synonyms.
 - The behavior of this function is undefined if the table is written on while
   being traversed. The function
-  [mnesia:read_lock_table(Tab)](`mnesia:read_lock_table/1`) can be used to
+  [`mnesia:read_lock_table(Tab)`](`mnesia:read_lock_table/1`) can be used to
   ensure that no transaction-protected writes are performed during the
   iteration.
-- [mnesia:dirty_update_counter(\{Tab,Key\}, Val)](`mnesia:dirty_update_counter/2`).
+- [`mnesia:dirty_update_counter({Tab, Key}, Val)`](`mnesia:dirty_update_counter/2`).
   Counters are positive integers with a value greater than or equal to zero.
   Updating a counter adds `Val` and the counter where `Val` is a positive or
   negative integer.
@@ -442,20 +442,20 @@ locks are acquired. The following functions are available:
   reading the record, performing the arithmetic, and writing the record:
 
   1. It is much more efficient.
-  1. The function [dirty_update_counter/2](`mnesia:dirty_update_counter/2`) is
+  1. The function [`dirty_update_counter/2`](`mnesia:dirty_update_counter/2`) is
      performed as an atomic operation although it is not protected by a
      transaction. Therefore no table update is lost if two processes
      simultaneously execute the function `dirty_update_counter/2`.
 
-- [mnesia:dirty_match_object(Pat)](`mnesia:dirty_match_object/2`) is the dirty
+- [`mnesia:dirty_match_object(Pat)`](`mnesia:dirty_match_object/2`) is the dirty
   equivalent of `mnesia:match_object/1`.
-- [mnesia:dirty_select(Tab, Pat)](`mnesia:dirty_select/2`) is the dirty
+- [`mnesia:dirty_select(Tab, Pat)`](`mnesia:dirty_select/2`) is the dirty
   equivalent of `mnesia:select/2`.
-- [mnesia:dirty_index_match_object(Pat, Pos)](`mnesia:dirty_index_match_object/2`)
+- [`mnesia:dirty_index_match_object(Pat, Pos)`](`mnesia:dirty_index_match_object/2`)
   is the dirty equivalent of `mnesia:index_match_object/2`.
-- [mnesia:dirty_index_read(Tab, SecondaryKey, Pos)](`mnesia:dirty_index_read/3`)
+- [`mnesia:dirty_index_read(Tab, SecondaryKey, Pos)`](`mnesia:dirty_index_read/3`)
   is the dirty equivalent of `mnesia:index_read/3`.
-- [mnesia:dirty_all_keys(Tab)](`mnesia:dirty_all_keys/1`) is the dirty
+- [`mnesia:dirty_all_keys(Tab)`](`mnesia:dirty_all_keys/1`) is the dirty
   equivalent of `mnesia:all_keys/1`.
 
 [](){: #recordnames_tablenames }
@@ -566,15 +566,15 @@ mnesia:index_match_object(Pattern, Attr) ->
 
 As previously described, a Functional Object (Fun) performing table access
 operations, as listed here, can be passed on as arguments to the function
-[mnesia:transaction/1,2,3](`mnesia:transaction/1`):
+[`mnesia:transaction/1,2,3`](`mnesia:transaction/1`):
 
-- [mnesia:write/3 (write/1, s_write/1)](`mnesia:write/3`)
+- [`mnesia:write/3` (`write/1`, `s_write/1`)](`mnesia:write/3`)
 - `mnesia:delete/3` (`mnesia:delete/1`, `mnesia:s_delete/1`)
 - `mnesia:delete_object/3` (`mnesia:delete_object/1`,
   `mnesia:s_delete_object/1`)
 - `mnesia:read/3` (`mnesia:read/1`, `mnesia:wread/1`)
-- [mnesia:match_object/2](`mnesia:match_object/3`) (`mnesia:match_object/1`)
-- [mnesia:select/3](`mnesia:select/2`) (`mnesia:select/2`)
+- [`mnesia:match_object/2`](`mnesia:match_object/3`) (`mnesia:match_object/1`)
+- [`mnesia:select/3`](`mnesia:select/2`) (`mnesia:select/2`)
 - `mnesia:foldl/3` (`mnesia:foldl/4`, `mnesia:foldr/3`, `mnesia:foldr/4`)
 - `mnesia:all_keys/1`
 - `mnesia:index_match_object/4` (`mnesia:index_match_object/2`)
@@ -596,7 +596,7 @@ The following activity access contexts are currently supported:
 - `ets`
 
 By passing the same "fun" as argument to the function
-[mnesia:sync_transaction(Fun \[, Args])](`mnesia:sync_transaction/1`) it is
+[`mnesia:sync_transaction(Fun [, Args])`](`mnesia:sync_transaction/1`) it is
 performed in synced transaction context. Synced transactions wait until all
 active replicas has committed the transaction (to disc) before returning from
 the `mnesia:sync_transaction` call. Using `sync_transaction` is useful in the
@@ -605,14 +605,14 @@ following cases:
 - When an application executes on several nodes and wants to be sure that the
   update is performed on the remote nodes before a remote process is spawned or
   a message is sent to a remote process.
-- When a combining transaction writes with "dirty_reads", that is, the functions
+- When a combining transaction writes with "dirty reads", that is, the functions
   `dirty_match_object`, `dirty_read`, `dirty_index_read`, `dirty_select`, and so
   on.
 - When an application performs frequent or voluminous updates that can overload
   `Mnesia` on other nodes.
 
-By passing the same "fun" as argument to the function [mnesia:async_dirty(Fun
-\[, Args])](`mnesia:async_dirty/1`), it is performed in dirty context. The
+By passing the same "fun" as argument to the function [`mnesia:async_dirty(Fun
+[, Args])`](`mnesia:async_dirty/1`), it is performed in dirty context. The
 function calls are mapped to the corresponding dirty functions. This still
 involves logging, replication, and subscriptions but no locking, local
 transaction storage, or commit protocols are involved. Checkpoint retainers are
@@ -620,9 +620,9 @@ updated but updated "dirty". Thus, they are updated asynchronously. The
 functions wait for the operation to be performed on one node but not the others.
 If the table resides locally, no waiting occurs.
 
-By passing the same "fun" as an argument to the function [mnesia:sync_dirty(Fun
-\[, Args])](`mnesia:sync_dirty/1`), it is performed in almost the same context
-as the function [mnesia:async_dirty/1,2](`mnesia:async_dirty/1`). The difference
+By passing the same "fun" as an argument to the function [`mnesia:sync_dirty(Fun
+[, Args])`](`mnesia:sync_dirty/1`), it is performed in almost the same context
+as the function [`mnesia:async_dirty/1,2`](`mnesia:async_dirty/1`). The difference
 is that the operations are performed synchronously. The caller waits for the
 updates to be performed on all active replicas. Using `mnesia:sync_dirty/1,2` is
 useful in the following cases:
@@ -641,7 +641,7 @@ context, otherwise `false`.
 internally as `ets` tables. Applications can access the these tables directly.
 This is only recommended if all options have been weighed and the possible
 outcomes are understood. By passing the earlier mentioned "fun" to the function
-[mnesia:ets(Fun \[, Args])](`mnesia:ets/1`), it is performed but in a raw
+[`mnesia:ets(Fun [, Args])`](`mnesia:ets/1`), it is performed but in a raw
 context. The operations are performed directly on the local `ets` tables,
 assuming that the local storage type is `RAM_copies` and that the table is not
 replicated on other nodes.
@@ -651,7 +651,7 @@ operation is blindingly fast. Disc resident tables are not to be updated with
 the `ets` function, as the disc is not updated.
 
 The Fun can also be passed as an argument to the function
-[mnesia:activity/2,3,4](`mnesia:activity/2`), which enables use of customized
+[`mnesia:activity/2,3,4`](`mnesia:activity/2`), which enables use of customized
 activity access callback modules. It can either be obtained directly by stating
 the module name as argument, or implicitly by use of configuration parameter
 `access_module`. A customized callback module can be used for several purposes,
@@ -756,7 +756,7 @@ mnesia:match_object(Tab, Pattern, LockKind) ->
 ```
 
 These functions match a `Pattern` against all records in table `Tab`. In a
-[mnesia:select](`mnesia:select/2`) call, `Pattern` is a part of
+[`mnesia:select`](`mnesia:select/2`) call, `Pattern` is a part of
 `MatchSpecification` described in the following. It is not necessarily performed
 as an exhaustive search of the entire table. By using indexes and bound values
 in the key of the pattern, the actual work done by the function can be condensed
@@ -770,7 +770,7 @@ Erlang term). The special elements `'$<number>'` behave as Erlang variables,
 that is, they match anything, bind the first occurrence, and match the coming
 occurrences of that variable against the bound value.
 
-Use function [mnesia:table_info(Tab, wild_pattern)](`mnesia:table_info/2`) to
+Use function [`mnesia:table_info(Tab, wild_pattern)`](`mnesia:table_info/2`) to
 obtain a basic pattern, which matches all records in a table, or use the default
 value in record creation. Do not make the pattern hard-coded, as this makes the
 code more vulnerable to future changes of the record definition.
@@ -809,7 +809,7 @@ Odd = mnesia:transaction(F).
 ```
 
 The function `mnesia:match_object/3` lacks some important features that
-[mnesia:select/3](`mnesia:select/2`) have. For example, `mnesia:match_object/3`
+[`mnesia:select/3`](`mnesia:select/2`) have. For example, `mnesia:match_object/3`
 can only return the matching records, and it cannot express constraints other
 than equality. To find the names of the male employees on the second floor:
 
@@ -836,7 +836,7 @@ For details about the match specifications, see "Match Specifications in Erlang"
 in [ERTS](`e:erts:index.html`) User's Guide. For more information, see the
 `m:ets` and `m:dets` manual pages in `STDLIB`.
 
-The functions [select/4](`mnesia:select/4`) and [select/1](`mnesia:select/2`)
+The functions [`select/4`](`mnesia:select/4`) and [`select/1`](`mnesia:select/2`)
 are used to get a limited number of results, where `Continuation` gets the next
 chunk of results. `Mnesia` uses `NObjects` as a recommendation only. Thus, more
 or less results than specified with `NObjects` can be returned in the result
@@ -855,11 +855,11 @@ However, if the key attribute in a pattern is given as `'_'` or `'$1'`, the
 whole `employee` table must be searched for records that match. Hence if the
 table is large, this can become a time-consuming operation, but it can be
 remedied with indexes (see [Indexing](mnesia_chap5.md#indexing)) if the function
-[mnesia:match_object](`mnesia:match_object/1`) is used.
+[`mnesia:match_object`](`mnesia:match_object/1`) is used.
 
 QLC queries can also be used to search `Mnesia` tables. By using the function
-[mnesia:table/1,2](`mnesia:table/1`) as the generator inside a QLC query, you
-let the query operate on a `Mnesia` table. `Mnesia`\-specific options to
+[`mnesia:table/1,2`](`mnesia:table/1`) as the generator inside a QLC query, you
+let the query operate on a `Mnesia` table. `Mnesia`-specific options to
 `mnesia:table/2` are `{lock, Lock}`, `{n_objects, Integer}`, and
 `{traverse, SelMethod}`:
 
@@ -870,7 +870,7 @@ let the query operate on a `Mnesia` table. `Mnesia`\-specific options to
 - `traverse` specifies which function `Mnesia` is to use to traverse the table.
   Default `select` is used, but by using
   `{traverse, {select, MatchSpecification}}` as an option to
-  [mnesia:table/2](`mnesia:table/1`) the user can specify its own view of the
+  [`mnesia:table/2`](`mnesia:table/1`) the user can specify its own view of the
   table.
 
 If no options are specified, a read lock is acquired, 100 results are returned
@@ -881,7 +881,7 @@ mnesia:table(Tab) ->
     mnesia:table(Tab, [{n_objects, 100},{lock, read}, {traverse, select}]).
 ```
 
-The function [mnesia:all_keys(Tab)](`mnesia:all_keys/1`) returns all keys in a
+The function [`mnesia:all_keys(Tab)`](`mnesia:all_keys/1`) returns all keys in a
 table.
 
 ## Iteration

--- a/lib/mnesia/doc/guides/mnesia_chap5.md
+++ b/lib/mnesia/doc/guides/mnesia_chap5.md
@@ -46,8 +46,8 @@ and matching of records.
 
 The following two functions manipulate indexes on existing tables:
 
-- [mnesia:add_table_index(Tab, AttributeName) -> \{aborted, R\} |\{atomic, ok\}](`mnesia:add_table_index/2`)
-- [mnesia:del_table_index(Tab, AttributeName) -> \{aborted, R\} |\{atomic, ok\}](`mnesia:del_table_index/2`)
+- [`mnesia:add_table_index(Tab, AttributeName) -> {aborted, R} | {atomic, ok}`](`mnesia:add_table_index/2`)
+- [`mnesia:del_table_index(Tab, AttributeName) -> {aborted, R} | {atomic, ok}`](`mnesia:del_table_index/2`)
 
 These functions create or delete a table index on a field defined by
 `AttributeName`. To illustrate this, add an index to the table definition
@@ -59,14 +59,14 @@ The indexing capabilities of `Mnesia` are used with the following three
 functions, which retrieve and match records based on index entries in the
 database:
 
-- [mnesia:index_read(Tab, SecondaryKey, AttributeName) -> transaction abort | RecordList](`mnesia:index_read/3`)
+- [`mnesia:index_read(Tab, SecondaryKey, AttributeName) -> transaction abort | RecordList`](`mnesia:index_read/3`)
   avoids an exhaustive search of the entire table, by looking up `SecondaryKey`
   in the index to find the primary keys.
-- [mnesia:index_match_object(Pattern, AttributeName) -> transaction abort | RecordList](`mnesia:index_match_object/2`)
+- [`mnesia:index_match_object(Pattern, AttributeName) -> transaction abort | RecordList`](`mnesia:index_match_object/2`)
   avoids an exhaustive search of the entire table, by looking up the secondary
   key in the index to find the primary keys. The secondary key is found in field
   `AttributeName` of `Pattern`. The secondary key must be bound.
-- [mnesia:match_object(Pattern) -> transaction abort | RecordList](`mnesia:match_object/1`)
+- [`mnesia:match_object(Pattern) -> transaction abort | RecordList`](`mnesia:match_object/1`)
   uses indexes to avoid exhaustive search of the entire table. Unlike the
   previous functions, this function can use any index as long as the secondary
   key is bound.
@@ -229,7 +229,7 @@ ok
 ### Fragmentation Properties
 
 The table property `frag_properties` can be read with the function
-[mnesia:table_info(Tab, frag_properties)](`mnesia:table_info/2`). The
+[`mnesia:table_info(Tab, frag_properties)`](`mnesia:table_info/2`). The
 fragmentation properties are a list of tagged tuples with arity 2. By default
 the list is empty, but when it is non-empty it triggers `Mnesia` to regard the
 table as fragmented. The fragmentation properties are as follows:
@@ -245,7 +245,7 @@ table as fragmented. The fragmentation properties are as follows:
   distribute the replicas of each fragment evenly over all the nodes in the node
   pool. Hopefully all nodes end up with the same number of replicas. `node_pool`
   defaults to the return value from the function
-  [mnesia:system_info(db_nodes)](`mnesia:system_info/1`).
+  [`mnesia:system_info(db_nodes)`](`mnesia:system_info/1`).
 
 - **`{n_ram_copies, Int}`** - Regulates how many `ram_copies` replicas that each
   fragment is to have. This property can explicitly be set at table creation.
@@ -366,7 +366,7 @@ following values:
   records are dynamically rehashed in the same manner as for the main table.
 
   Argument `NodesOrDist` can either be a list of nodes or the result from the
-  function [mnesia:table_info(Tab, frag_dist)](`mnesia:table_info/2`). Argument
+  function [`mnesia:table_info(Tab, frag_dist)`](`mnesia:table_info/2`). Argument
   `NodesOrDist` is assumed to be a sorted list with the best nodes to host new
   replicas first in the list. The new fragment gets the same number of replicas
   as the first fragment (see `n_ram_copies`, `n_disc_copies`, and
@@ -381,11 +381,11 @@ following values:
 
 - **`{add_node, Node}`** - Adds a node to `node_pool`. The new node pool affects
   the list returned from the function
-  [mnesia:table_info(Tab, frag_dist)](`mnesia:table_info/2`).
+  [`mnesia:table_info(Tab, frag_dist)`](`mnesia:table_info/2`).
 
 - **`{del_node, Node}`** - Deletes a node from `node_pool`. The new node pool
   affects the list returned from the function
-  [mnesia:table_info(Tab, frag_dist)](`mnesia:table_info/2`).
+  [`mnesia:table_info(Tab, frag_dist)`](`mnesia:table_info/2`).
 
 ### Extensions of Existing Functions
 
@@ -418,7 +418,7 @@ module `mnesia_frag`, information of several new items can be obtained:
   when adding new fragments) they are determined by counting the number of each
   replica for each storage type. This means that when the functions
   `mnesia:add_table_copy/3`, `mnesia:del_table_copy/2`, and
-  [mnesia:change_table_copy_type/2](`mnesia:change_table_copy_type/3`) are
+  [`mnesia:change_table_copy_type/2`](`mnesia:change_table_copy_type/3`) are
   applied on the first fragment, it affects the settings on `n_ram_copies`,
   `n_disc_copies`, and `n_disc_only_copies`.
 
@@ -473,7 +473,7 @@ needs. The following examples of situations need some attention:
 Use the function `mnesia:change_table_frag/2` to add new fragments and apply the
 usual schema manipulation functions (such as `mnesia:add_table_copy/3`,
 `mnesia:del_table_copy/2`, and
-[mnesia:change_table_copy_type/2](`mnesia:change_table_copy_type/3`)) on each
+[`mnesia:change_table_copy_type/2`](`mnesia:change_table_copy_type/3`)) on each
 fragment to perform the actual redistribution.
 
 ## Local Content Tables
@@ -599,11 +599,11 @@ each time a RAM node connects to another node.
 
 Further, the following applies:
 
-- [mnesia:system_info(schema_location)](`mnesia:system_info/1`) and
-  [mnesia:system_info(extra_db_nodes)](`mnesia:system_info/1`) can be used to
+- [`mnesia:system_info(schema_location)`](`mnesia:system_info/1`) and
+  [`mnesia:system_info(extra_db_nodes)`](`mnesia:system_info/1`) can be used to
   determine the actual values of `schema_location` and `extra_db_nodes`,
   respectively.
-- [mnesia:system_info(use_dir)](`mnesia:system_info/1`) can be used to determine
+- [`mnesia:system_info(use_dir)`](`mnesia:system_info/1`) can be used to determine
   whether `Mnesia` is actually using the `Mnesia` directory.
 - `use_dir` can be determined even before `Mnesia` is started.
 
@@ -631,10 +631,10 @@ generates in various situations.
 A user process can subscribe on the events generated by `Mnesia`. The following
 two functions are provided:
 
-- **[mnesia:subscribe(Event-Category)](`mnesia:subscribe/1`)** - Ensures that a
+- [`mnesia:subscribe(Event-Category)`](`mnesia:subscribe/1`) - Ensures that a
   copy of all events of type `Event-Category` are sent to the calling process
 
-- **[mnesia:unsubscribe(Event-Category)](`mnesia:unsubscribe/1`)** - Removes the
+- [`mnesia:unsubscribe(Event-Category)`](`mnesia:unsubscribe/1`) - Removes the
   subscription on events of type `Event-Category`
 
 `Event-Category` can be either of the following:
@@ -663,8 +663,8 @@ application parameter `event_module`. The value of this parameter must be the
 name of a module implementing a complete handler, as specified by the
 `m:gen_event` module in `STDLIB`.
 
-[mnesia:system_info(subscribers)](`mnesia:system_info/1`) and
-[mnesia:table_info(Tab, subscribers)](`mnesia:table_info/2`) can be used to
+[`mnesia:system_info(subscribers)`](`mnesia:system_info/1`) and
+[`mnesia:table_info(Tab, subscribers)`](`mnesia:table_info/2`) can be used to
 determine which processes are subscribed to various events.
 
 ### System Events
@@ -687,7 +687,7 @@ The system events are as follows:
 - **`{mnesia_checkpoint_deactivated, Checkpoint}`** - A checkpoint with the name
   `Checkpoint` is deactivated and the current node is involved in the
   checkpoint. Checkpoints can be deactivated explicitly with the function
-  [mnesia:deactivate/1](`mnesia:deactivate_checkpoint/1`) or implicitly when the
+  [`mnesia:deactivate/1`](`mnesia:deactivate_checkpoint/1`) or implicitly when the
   last replica of a table (involved in the checkpoint) becomes unavailable, for
   example, at node-down. By default this event is ignored.
 
@@ -719,8 +719,8 @@ The system events are as follows:
   as potential inconsistent and gives its applications a chance to recover from
   the inconsistency. For example, by installing a consistent backup as fallback
   and then restart the system. An alternative is to pick a `MasterNode` from
-  [mnesia:system_info(db_nodes)](`mnesia:system_info/1`) and invoke
-  [mnesia:set_master_node(\[MasterNode])](`mnesia:set_master_nodes/1`). By
+  [`mnesia:system_info(db_nodes)`](`mnesia:system_info/1`) and invoke
+  [`mnesia:set_master_nodes([MasterNode])`](`mnesia:set_master_nodes/1`). By
   default an error is reported to `error_logger`.
 
 - **`{mnesia_fatal, Format, Args, BinaryCore}`** - `Mnesia` detected a fatal
@@ -744,7 +744,7 @@ The system events are as follows:
   `error_logger`.
 
 - **`{mnesia_user, Event}`** - An application started the function
-  [mnesia:report_event(Event)](`mnesia:report_event/1`). `Event` can be any
+  [`mnesia:report_event(Event)`](`mnesia:report_event/1`). `Event` can be any
   Erlang data structure. When tracing a system of `Mnesia` applications, it is
   useful to be able to interleave own events of `Mnesia` with
   application-related events that give information about the application
@@ -825,8 +825,8 @@ mechanisms work. Another source of confusion can be the semantics of nested
 transactions.
 
 The debug level of `Mnesia` is set by calling the function
-[mnesia:set_debug_level(Level)](`mnesia:set_debug_level/1`), where `Level`is one
-of the following:
+[`mnesia:set_debug_level(Level)`](`mnesia:set_debug_level/1`), where `Level` is
+one of the following:
 
 - **`none`** - No trace outputs. This is the default.
 
@@ -894,11 +894,11 @@ and have the data in the file inserted into the database. `Mnesia` can be
 initialized with data read from a text file. The following two functions can be
 used to work with text files.
 
-- [mnesia:load_textfile(Filename)](`mnesia:load_textfile/1`) loads a series of
+- [`mnesia:load_textfile(Filename)`](`mnesia:load_textfile/1`) loads a series of
   local table definitions and data found in the file into `Mnesia`. This
   function also starts `Mnesia` and possibly creates a new schema. The function
   operates on the local node only.
-- [mnesia:dump_to_textfile(Filename)](`mnesia:dump_to_textfile/1`) dumps all
+- [`mnesia:dump_to_textfile(Filename)`](`mnesia:dump_to_textfile/1`) dumps all
   local tables of a `Mnesia` system into a text file, which can be edited (with
   a normal text editor) and later reloaded.
 

--- a/lib/mnesia/doc/guides/mnesia_chap5.md
+++ b/lib/mnesia/doc/guides/mnesia_chap5.md
@@ -97,9 +97,9 @@ Table attributes are specified when the table is created. For example, the
 following function creates a table with two RAM replicas:
 
 ```erlang
-      mnesia:create_table(foo,
-                          [{ram_copies, [N1, N2]},
-                           {attributes, record_info(fields, foo)}]).
+mnesia:create_table(foo,
+                    [{ram_copies, [N1, N2]},
+                     {attributes, record_info(fields, foo)}]).
 ```
 
 Tables can also have the following properties, where each attribute has a list
@@ -539,10 +539,10 @@ When `schema_location` is set to `opt_disc`, the function
 schema. This is illustrated as follows:
 
 ```erlang
-        1> mnesia:start().
-        ok
-        2> mnesia:change_table_copy_type(schema, node(), disc_copies).
-        {atomic, ok}
+1> mnesia:start().
+ok
+2> mnesia:change_table_copy_type(schema, node(), disc_copies).
+{atomic, ok}
 ```
 
 Assuming that the call to `mnesia:start/0` does not find any schema to read on
@@ -855,7 +855,7 @@ possible to start an Erlang system to turn on `Mnesia` debug in the initial
 startup phase by using the following code:
 
 ```text
-      % erl -mnesia debug verbose
+% erl -mnesia debug verbose
 ```
 
 ## Concurrent Processes in Mnesia
@@ -910,11 +910,11 @@ use.
 The format of the text file is as follows:
 
 ```erlang
-      {tables, [{Typename, [Options]},
-      {Typename2 ......}]}.
+{tables, [{Typename, [Options]},
+{Typename2 ......}]}.
 
-      {Typename, Attribute1, Attribute2 ....}.
-      {Typename, Attribute1, Attribute2 ....}.
+{Typename, Attribute1, Attribute2 ....}.
+{Typename, Attribute1, Attribute2 ....}.
 ```
 
 `Options` is a list of `{Key,Value}` tuples conforming to the options that you
@@ -924,7 +924,6 @@ For example, to start playing with a small database for healthy foods, enter the
 following data into file `FRUITS`:
 
 ```erlang
-
 {tables,
  [{fruit, [{attributes, [name, color, taste]}]},
   {vegetable, [{attributes, [name, color, taste, price]}]}]}.
@@ -940,40 +939,40 @@ The following session with the Erlang shell shows how to load the `FRUITS`
 database:
 
 ```erlang
-      % erl
-      Erlang (BEAM) emulator version 4.9
+% erl
+Erlang (BEAM) emulator version 4.9
 
-      Eshell V4.9  (abort with ^G)
-      1> mnesia:load_textfile("FRUITS").
-      New table fruit
-      New table vegetable
-      {atomic,ok}
-      2> mnesia:info().
-      ---> Processes holding locks <---
-      ---> Processes waiting for locks <---
-      ---> Pending (remote) transactions <---
-      ---> Active (local) transactions <---
-      ---> Uncertain transactions <---
-      ---> Active tables <---
-      vegetable      : with 2 records occuping 299 words of mem
-      fruit          : with 2 records occuping 291 words of mem
-      schema         : with 3 records occuping 401 words of mem
-      ===> System info in version "1.1", debug level = none <===
-      opt_disc. Directory "/var/tmp/Mnesia.nonode@nohost" is used.
-      use fallback at restart = false
-      running db nodes = [nonode@nohost]
-      stopped db nodes = []
-      remote           = []
-      ram_copies       = [fruit,vegetable]
-      disc_copies      = [schema]
-      disc_only_copies = []
-      [{nonode@nohost,disc_copies}] = [schema]
-      [{nonode@nohost,ram_copies}] = [fruit,vegetable]
-      3 transactions committed, 0 aborted, 0 restarted, 2 logged to disc
-      0 held locks, 0 in queue; 0 local transactions, 0 remote
-      0 transactions waits for other nodes: []
-      ok
-      3>
+Eshell V4.9  (abort with ^G)
+1> mnesia:load_textfile("FRUITS").
+New table fruit
+New table vegetable
+{atomic,ok}
+2> mnesia:info().
+---> Processes holding locks <---
+---> Processes waiting for locks <---
+---> Pending (remote) transactions <---
+---> Active (local) transactions <---
+---> Uncertain transactions <---
+---> Active tables <---
+vegetable      : with 2 records occuping 299 words of mem
+fruit          : with 2 records occuping 291 words of mem
+schema         : with 3 records occuping 401 words of mem
+===> System info in version "1.1", debug level = none <===
+opt_disc. Directory "/var/tmp/Mnesia.nonode@nohost" is used.
+use fallback at restart = false
+running db nodes = [nonode@nohost]
+stopped db nodes = []
+remote           = []
+ram_copies       = [fruit,vegetable]
+disc_copies      = [schema]
+disc_only_copies = []
+[{nonode@nohost,disc_copies}] = [schema]
+[{nonode@nohost,ram_copies}] = [fruit,vegetable]
+3 transactions committed, 0 aborted, 0 restarted, 2 logged to disc
+0 held locks, 0 in queue; 0 local transactions, 0 remote
+0 transactions waits for other nodes: []
+ok
+3>
 ```
 
 It can be seen that the DBMS was initiated from a regular text file.
@@ -991,7 +990,6 @@ operations are also easier to perform on a normalized data model. For example,
 one project can easily be removed, as the following example illustrates:
 
 ```erlang
-
 remove_proj(ProjName) ->
     F = fun() ->
                 Ip = qlc:e(qlc:q([X || X <- mnesia:table(in_proj),
@@ -1030,7 +1028,6 @@ or contain other records that are not part of the `Mnesia` schema.
 The following record definitions can be created:
 
 ```erlang
-
 -record(employee, {emp_no,
 		   name,
 		   salary,
@@ -1053,15 +1050,15 @@ The following record definitions can be created:
 A record that describes an employee can look as follows:
 
 ```erlang
-        Me = #employee{emp_no= 104732,
-        name = klacke,
-        salary = 7,
-        sex = male,
-        phone = 99586,
-        room_no = {221, 015},
-        dept = 'B/SFR',
-        projects = [erlang, mnesia, otp],
-        manager = 114872},
+Me = #employee{emp_no = 104732,
+               name = klacke,
+               salary = 7,
+               sex = male,
+               phone = 99586,
+               room_no = {221, 015},
+               dept = 'B/SFR',
+               projects = [erlang, mnesia, otp],
+               manager = 114872},
 ```
 
 This model has only three different tables, and the employee records contain
@@ -1087,7 +1084,6 @@ find all employees at department `Dep` with a salary higher than `Salary`, use
 the following code:
 
 ```erlang
-
 get_emps(Salary, Dep) ->
     Q = qlc:q(
           [E || E <- mnesia:table(employee),

--- a/lib/mnesia/doc/guides/mnesia_chap7.md
+++ b/lib/mnesia/doc/guides/mnesia_chap7.md
@@ -36,10 +36,10 @@ The following topics are included:
 The following two functions can be used to retrieve system information. For
 details, see the Reference Manual.
 
-- [mnesia:table_info(Tab, Key) -> Info | exit(\{aborted,Reason\})](`mnesia:table_info/2`)
+- [`mnesia:table_info(Tab, Key) -> Info | exit({aborted, Reason})`](`mnesia:table_info/2`)
   returns information about one table, for example, the current size of the
   table and on which nodes it resides.
-- [mnesia:system_info(Key) -> Info | exit(\{aborted, Reason\})](`mnesia:system_info/1`)
+- [`mnesia:system_info(Key) -> Info | exit({aborted, Reason})`](`mnesia:system_info/1`)
   returns information about the `Mnesia` system, for example, transaction
   statistics, `db_nodes`, and configuration parameters.
 
@@ -56,7 +56,7 @@ included in the bug report.
 Tables of type `ram_copies` are by definition stored in memory only. However,
 these tables can be dumped to disc, either at regular intervals or before the
 system is shut down. The function
-[mnesia:dump_tables(TabList)](`mnesia:dump_tables/1`) dumps all replicas of a
+[`mnesia:dump_tables(TabList)`](`mnesia:dump_tables/1`) dumps all replicas of a
 set of RAM tables to disc. The tables can be accessed while being dumped to
 disc. To dump the tables to disc, all replicas must have the storage type
 `ram_copies`.
@@ -90,7 +90,7 @@ survives as long as there is at least one active checkpoint retainer attached to
 each table.
 
 Checkpoints can be explicitly deactivated with the function
-[mnesia:deactivate_checkpoint(Name)](`mnesia:deactivate_checkpoint/1`), where
+[`mnesia:deactivate_checkpoint(Name)`](`mnesia:deactivate_checkpoint/1`), where
 `Name` is the name of an active checkpoint. This function returns `ok` if
 successful or `{error, Reason}` if there is an error. All tables in a checkpoint
 must be attached to at least one checkpoint retainer. The checkpoint is
@@ -102,28 +102,28 @@ degree of checkpoint retainer redundancy.
 [](){: #mnesia%3Achkpt%28Args%29 }
 
 Checkpoints are activated with the function
-[mnesia:activate_checkpoint(Args)](`mnesia:activate_checkpoint/1`), where `Args`
+[`mnesia:activate_checkpoint(Args)`](`mnesia:activate_checkpoint/1`), where `Args`
 is a list of the following tuples:
 
-- `{name,Name}`, where `Name` specifies a temporary name of the checkpoint. The
+- `{name, Name}`, where `Name` specifies a temporary name of the checkpoint. The
   name can be reused when the checkpoint has been deactivated. If no name is
   specified, a name is generated automatically.
-- `{max,MaxTabs}`, where `MaxTabs` is a list of tables that are to be included
+- `{max, MaxTabs}`, where `MaxTabs` is a list of tables that are to be included
   in the checkpoint. Default is `[]` (empty list). For these tables, the
   redundancy is maximized. The old content of the table is retained in the
   checkpoint retainer when the main table is updated by the applications. The
   checkpoint is more fault tolerant if the tables have several replicas. When
   new replicas are added by the schema manipulation function
   `mnesia:add_table_copy/3` it also attaches a local checkpoint retainer.
-- `{min,MinTabs}`, where `MinTabs` is a list of tables that are to be included
+- `{min, MinTabs}`, where `MinTabs` is a list of tables that are to be included
   in the checkpoint. Default is `[]`. For these tables, the redundancy is
   minimized, and there is to be single checkpoint retainer per table, preferably
   at the local node.
-- `{allow_remote,Bool}`, where `false` means that all checkpoint retainers must
+- `{allow_remote, Bool}`, where `false` means that all checkpoint retainers must
   be local. If a table does not reside locally, the checkpoint cannot be
   activated. `true` allows checkpoint retainers to be allocated on any node.
   Default is `true`.
-- `{ram_overrides_dump,Bool}`. This argument only applies to tables of type
+- `{ram_overrides_dump, Bool}`. This argument only applies to tables of type
   `ram_copies`. `Bool` specifies if the table state in RAM is to override the
   table state on disc. `true` means that the latest committed records in RAM are
   included in the checkpoint retainer. These are the records that the
@@ -131,7 +131,7 @@ is a list of the following tuples:
   are included in the checkpoint retainer. These records are loaded on startup.
   Default is `false`.
 
-The function [mnesia:activate_checkpoint(Args)](`mnesia:activate_checkpoint/1`)
+The function [`mnesia:activate_checkpoint(Args)`](`mnesia:activate_checkpoint/1`)
 returns one of the following values:
 
 - `{ok, Name, Nodes}`
@@ -142,9 +142,9 @@ known.
 
 A list of active checkpoints can be obtained with the following functions:
 
-- [mnesia:system_info(checkpoints)](`mnesia:system_info/1`) returns all active
+- [`mnesia:system_info(checkpoints)`](`mnesia:system_info/1`) returns all active
   checkpoints on the current node.
-- [mnesia:table_info(Tab, checkpoints)](`mnesia:table_info/2`) returns active
+- [`mnesia:table_info(Tab, checkpoints)`](`mnesia:table_info/2`) returns active
   checkpoints on a specific table.
 
 ## Startup Files, Log File, and Data Files
@@ -330,10 +330,10 @@ you are unlucky, other nodes can be down and you must wait for the table to be
 loaded on one of these nodes before receiving a fresh copy of the table.
 
 Before an application makes its first access to a table,
-[mnesia:wait_for_tables(TabList, Timeout)](`mnesia:wait_for_tables/2`) is to be
+[`mnesia:wait_for_tables(TabList, Timeout)`](`mnesia:wait_for_tables/2`) is to be
 executed to ensure that the table is accessible from the local node. If the
 function times out, the application can choose to force a load of the local
-replica with [mnesia:force_load_table(Tab)](`mnesia:force_load_table/1`) and
+replica with [`mnesia:force_load_table(Tab)`](`mnesia:force_load_table/1`) and
 deliberately lose all updates that can have been performed on the other nodes
 while the local node was down. If `Mnesia` has loaded the table on another node
 already, or intends to do so, copy the table from that node to avoid unnecessary
@@ -342,13 +342,13 @@ inconsistency.
 > #### Warning {: .warning }
 >
 > Only one table is loaded by
-> [mnesia:force_load_table(Tab)](`mnesia:force_load_table/1`). Since committed
+> [`mnesia:force_load_table(Tab)`](`mnesia:force_load_table/1`). Since committed
 > transactions can have caused updates in several tables, the tables can become
 > inconsistent because of the forced load.
 
 The allowed `AccessMode` of a table can be defined to be `read_only` or
 `read_write`. It can be toggled with the function
-[mnesia:change_table_access_mode(Tab, AccessMode)](`mnesia:change_table_access_mode/2`)
+[`mnesia:change_table_access_mode(Tab, AccessMode)`](`mnesia:change_table_access_mode/2`)
 in runtime. `read_only` tables and `local_content` tables are always loaded
 locally, as there is no need for copying the table from other nodes. Other
 tables are primarily loaded remotely from active replicas on other nodes if the
@@ -369,7 +369,7 @@ table load mechanism does not cope with communication failures.
 When `Mnesia` loads many tables, the default load order is used. However, the
 load order can be affected, by explicitly changing property `load_order` for the
 tables, with the function
-[mnesia:change_table_load_order(Tab, LoadOrder)](`mnesia:change_table_load_order/2`).
+[`mnesia:change_table_load_order(Tab, LoadOrder)`](`mnesia:change_table_load_order/2`).
 `LoadOrder` is by default `0` for all tables, but it can be set to any integer.
 The table with the highest `load_order` is loaded first. Changing the load order
 is especially useful for applications that need to ensure early availability of
@@ -395,7 +395,7 @@ partitioned because of a communication failure, for example:
 
 If the application detects that there has been a communication failure that can
 have caused an inconsistent database, it can use the function
-[mnesia:set_master_nodes(Tab, Nodes)](`mnesia:set_master_nodes/2`) to pinpoint
+[`mnesia:set_master_nodes(Tab, Nodes)`](`mnesia:set_master_nodes/2`) to pinpoint
 from which nodes each table can be loaded.
 
 At startup, the `Mnesia` normal table load algorithm is bypassed and the table
@@ -405,17 +405,17 @@ the table has a replica. If `Nodes` is empty, the master node recovery mechanism
 for the particular table is reset and the normal load mechanism is used at the
 next restart.
 
-The function [mnesia:set_master_nodes(Nodes)](`mnesia:set_master_nodes/1`) sets
+The function [`mnesia:set_master_nodes(Nodes)`](`mnesia:set_master_nodes/1`) sets
 master nodes for all tables. For each table it determines its replica nodes and
-starts [mnesia:set_master_nodes(Tab, TabNodes)](`mnesia:set_master_nodes/2`)
+starts [`mnesia:set_master_nodes(Tab, TabNodes)`](`mnesia:set_master_nodes/2`)
 with those replica nodes that are included in the `Nodes` list (that is,
 `TabNodes` is the intersection of `Nodes` and the replica nodes of the table).
 If the intersection is empty, the master node recovery mechanism for the
 particular table is reset and the normal load mechanism is used at the next
 restart.
 
-The functions [mnesia:system_info(master_node_tables)](`mnesia:system_info/1`)
-and [mnesia:table_info(Tab, master_nodes)](`mnesia:table_info/2`) can be used to
+The functions [`mnesia:system_info(master_node_tables)`](`mnesia:system_info/1`)
+and [`mnesia:table_info(Tab, master_nodes)`](`mnesia:table_info/2`) can be used to
 obtain information about the potential master nodes.
 
 Determining what data to keep after a communication failure is outside the scope
@@ -425,7 +425,7 @@ that nodes that are not part of a "majority island" cannot update those tables.
 Notice that this constitutes a reduction in service on the minority nodes. This
 would be a tradeoff in favor of higher consistency guarantees.
 
-The function [mnesia:force_load_table(Tab)](`mnesia:force_load_table/1`) can be
+The function [`mnesia:force_load_table(Tab)`](`mnesia:force_load_table/1`) can be
 used to force load the table regardless of which table load mechanism that is
 activated.
 
@@ -524,22 +524,22 @@ network (as described earlier).
 The following functions are used to back up data, to install a backup as
 fallback, and for disaster recovery:
 
-- [mnesia:backup_checkpoint(Name, Opaque, \[Mod])](`mnesia:backup_checkpoint/2`)
+- [`mnesia:backup_checkpoint(Name, Opaque, [Mod])`](`mnesia:backup_checkpoint/2`)
   performs a backup of the tables included in the checkpoint.
-- [mnesia:backup(Opaque, \[Mod])](`mnesia:backup/1`) activates a new checkpoint
+- [`mnesia:backup(Opaque, [Mod])`](`mnesia:backup/1`) activates a new checkpoint
   that covers all `Mnesia` tables and performs a backup. It is performed with
   maximum degree of redundancy (see also the function
-  [mnesia:activate_checkpoint(Args)](mnesia_chap7.md#checkpoints),
+  [`mnesia:activate_checkpoint(Args)`](mnesia_chap7.md#checkpoints),
   `{max, MaxTabs} and {min, MinTabs})`.
-- [mnesia:traverse_backup(Source, \[SourceMod,] Target, \[TargetMod,] Fun,
-  Acc)](`mnesia:traverse_backup/4`) can be used to read an existing backup,
+- [`mnesia:traverse_backup(Source, [SourceMod,] Target, [TargetMod,] Fun,
+  Acc)`](`mnesia:traverse_backup/4`) can be used to read an existing backup,
   create a backup from an existing one, or to copy a backup from one type media
   to another.
-- [mnesia:uninstall_fallback()](`mnesia:uninstall_fallback/0`) removes
+- [`mnesia:uninstall_fallback()`](`mnesia:uninstall_fallback/0`) removes
   previously installed fallback files.
-- [mnesia:restore(Opaque, Args)](`mnesia:restore/2`) restores a set of tables
+- [`mnesia:restore(Opaque, Args)`](`mnesia:restore/2`) restores a set of tables
   from a previous backup.
-- [mnesia:install_fallback(Opaque, \[Mod])](`mnesia:install_fallback/1`) can be
+- [`mnesia:install_fallback(Opaque, [Mod])`](`mnesia:install_fallback/1`) can be
   configured to restart `Mnesia` and the reload data tables, and possibly the
   schema tables, from an existing backup. This function is typically used for
   disaster recovery purposes, when data or schema tables are corrupted.
@@ -552,14 +552,14 @@ used to activate and deactivate checkpoints.
 
 Backup operation are performed with the following functions:
 
-- [mnesia:backup_checkpoint(Name, Opaque, \[Mod])](`mnesia:backup_checkpoint/2`)
-- [mnesia:backup(Opaque, \[Mod])](`mnesia:backup/1`)
-- [mnesia:traverse_backup(Source, \[SourceMod,] Target, \[TargetMod,] Fun,
-  Acc)](`mnesia:traverse_backup/4`)
+- [`mnesia:backup_checkpoint(Name, Opaque, [Mod])`](`mnesia:backup_checkpoint/2`)
+- [`mnesia:backup(Opaque, [Mod])`](`mnesia:backup/1`)
+- [`mnesia:traverse_backup(Source, [SourceMod,] Target, [TargetMod,] Fun,
+  Acc)`](`mnesia:traverse_backup/4`)
 
 By default, the actual access to the backup media is performed through module
 `mnesia_backup` for both read and write. Currently `mnesia_backup` is
-implemented with the standard library module `disc_log`. However, you can write
+implemented with the standard library module `disk_log`. However, you can write
 your own module with the same interface as `mnesia_backup` and configure
 `Mnesia` so that the alternative module performs the actual accesses to the
 backup media. The user can therefore put the backup on a media that `Mnesia`
@@ -567,7 +567,7 @@ does not know about, possibly on hosts where Erlang is not running. Use
 configuration parameter `-mnesia backup_module <module>` for this purpose.
 
 The source for a backup is an activated checkpoint. The backup function
-[mnesia:backup_checkpoint(Name, Opaque,\[Mod])](`mnesia:backup_checkpoint/2`) is
+[`mnesia:backup_checkpoint(Name, Opaque,[Mod])`](`mnesia:backup_checkpoint/2`) is
 most commonly used and returns `ok` or `{error,Reason}`. It has the following
 arguments:
 
@@ -580,15 +580,15 @@ arguments:
   interprets this argument as a local filename.
 - `Mod` is the name of an alternative backup module.
 
-The function [mnesia:backup(Opaque \[,Mod])](`mnesia:backup/1`) activates a new
+The function [`mnesia:backup(Opaque [,Mod])`](`mnesia:backup/1`) activates a new
 checkpoint that covers all `Mnesia` tables with maximum degree of redundancy and
 performs a backup. Maximum redundancy means that each table replica has a
 checkpoint retainer. Tables with property `local_contents` are backed up as they
 look on the current node.
 
 You can iterate over a backup, either to transform it into a new backup, or only
-read it. The function [mnesia:traverse_backup(Source, \[SourceMod,] Target,
-\[TargetMod,] Fun, Acc)](`mnesia:traverse_backup/4`), which normally returns
+read it. The function [`mnesia:traverse_backup(Source, [SourceMod,] Target,
+[TargetMod,] Fun, Acc)`](`mnesia:traverse_backup/4`), which normally returns
 `{ok, LastAcc}`, is used for both of these purposes.
 
 Before the traversal starts, the source backup media is opened with
@@ -634,7 +634,7 @@ The schema itself is a table and is possibly included in the backup. Each node
 where the schema table resides is regarded as a `db_node`.
 
 The following example shows how
-[mnesia:traverse_backup](`mnesia:traverse_backup/4`) can be used to rename a
+[`mnesia:traverse_backup`](`mnesia:traverse_backup/4`) can be used to rename a
 `db_node` in a backup file:
 
 ```erlang
@@ -678,7 +678,7 @@ view(Source, Mod) ->
 
 Tables can be restored online from a backup without restarting `Mnesia`. A
 restore is performed with the function
-[mnesia:restore(Opaque, Args)](`mnesia:restore/2`), where `Args` can contain the
+[`mnesia:restore(Opaque, Args)`](`mnesia:restore/2`), where `Args` can contain the
 following tuples:
 
 - `{module,Mod}`. The backup module `Mod` is used to access the backup media. If
@@ -716,8 +716,8 @@ installing a fallback, followed by a restart.
 
 ### Fallback
 
-The function [mnesia:install_fallback(Opaque,
-\[Mod])](`mnesia:install_fallback/2`) installs a backup as fallback. It uses the
+The function [`mnesia:install_fallback(Opaque,
+[Mod])`](`mnesia:install_fallback/2`) installs a backup as fallback. It uses the
 backup module `Mod`, or the default backup module, to access the backup media.
 The function returns `ok` if successful, or `{error, Reason}` if there is an
 error.
@@ -738,7 +738,7 @@ upgrade begins.
 If the system upgrade fails, `Mnesia` must be restarted on all `db_nodes` to
 restore the old database. The fallback is automatically deinstalled after a
 successful startup. The function
-[mnesia:uninstall_fallback()](`mnesia:uninstall_fallback/0`) can also be used to
+[`mnesia:uninstall_fallback()`](`mnesia:uninstall_fallback/0`) can also be used to
 deinstall the fallback after a successful system upgrade. Again, this is a
 distributed operation that is either performed on all `db_nodes` or none. Both
 the installation and deinstallation of fallbacks require Erlang to be
@@ -762,7 +762,7 @@ parameter affects the repair behavior of log files, `DAT` files, and the default
 backup media.
 
 Configuration parameter `-mnesia dump_log_update_in_place <bool>` controls the
-safety level of the function [mnesia:dump_log()](`mnesia:dump_log/0`) By
+safety level of the function [`mnesia:dump_log()`](`mnesia:dump_log/0`) By
 default, `Mnesia` dumps the transaction log directly into the `DAT` files. If a
 power failure occurs during the dump, this can cause the randomly accessed `DAT`
 files to become corrupt. If the parameter is set to `false`, `Mnesia` copies the

--- a/lib/mnesia/doc/guides/mnesia_chap7.md
+++ b/lib/mnesia/doc/guides/mnesia_chap7.md
@@ -638,7 +638,6 @@ The following example shows how
 `db_node` in a backup file:
 
 ```erlang
-
 change_node_name(Mod, From, To, Source, Target) ->
     Switch =
         fun(Node) when Node == From -> To;

--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -262,7 +262,7 @@ are checked, and finally, the default value is chosen.
 
 ## See Also
 
-`m:application`, `m:dets`, `m:disk_log`, `m:ets`, `m:mnesia_registry`, `m:qlc`
+`m:application`, `m:dets`, `m:disk_log`, `m:ets`, `m:qlc`
 """.
 %-behaviour(mnesia_access).
 


### PR DESCRIPTION
This PR updates the mnesia documentation (specifically the user's guide) to:
- Remove any leading whitespace in code blocks (both on top and on the left) that was not present in the previous documentation. I believe this was added accidentally during conversion from XML due to the indent.
- Do not link to the deprecated `mnesia_registry` module in "see also"
- Ensure any references to functions are wrapped in code blocks
- Be more consistent with whitespace in code examples
