### PR TITLE
inets: Implement fixes and small improvements for new documentation

### DIFF
--- a/lib/inets/doc/docs.exs
+++ b/lib/inets/doc/docs.exs
@@ -6,5 +6,11 @@
     "guides/inets_services.md",
     "guides/http_client.md",
     "guides/http_server.md"
+  ],
+  groups_for_modules: [
+    "Service API": [:inets],
+    "HTTP client modules": [:httpc],
+    "HTTP server modules": [~r/httpd/, ~r/mod_/],
+    "Deprecated functionality": [:http_uri]
   ]
 ]

--- a/lib/inets/doc/guides/http_client.md
+++ b/lib/inets/doc/guides/http_client.md
@@ -35,7 +35,7 @@ The following is to be put in the Erlang node application configuration file to
 start a profile at application startup:
 
 ```erlang
-      [{inets, [{services, [{httpc, PropertyList}]}]}]
+[{inets, [{services, [{httpc, PropertyList}]}]}]
 ```
 
 For valid properties, see `m:httpc`.
@@ -45,8 +45,8 @@ For valid properties, see `m:httpc`.
 Start `Inets`:
 
 ```erlang
- 1 > inets:start().
-      ok
+1> inets:start().
+ok
 ```
 
 The following calls use the default client profile. Use the proxy
@@ -56,38 +56,38 @@ applies to all the following requests.
 Example:
 
 ```erlang
-      2 > httpc:set_options([{proxy, {{"www-proxy.mycompany.com", 8000},
-      ["localhost"]}}]).
-      ok
+2> httpc:set_options([{proxy, {{"www-proxy.mycompany.com", 8000},
+["localhost"]}}]).
+ok
 ```
 
 The following is an ordinary synchronous request:
 
 ```erlang
-      3 > {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
-      httpc:request(get, {"http://www.erlang.org", []}, [], []).
+3> {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
+.. httpc:request(get, {"http://www.erlang.org", []}, [], []).
 ```
 
 With all the default values presented, a get request can also be written as
 follows:
 
 ```erlang
-      4 > {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
-      httpc:request("http://www.erlang.org").
+4> {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
+.. httpc:request("http://www.erlang.org").
 ```
 
 The following is a https request and with verification of the host:
 
 ```erlang
-      5 > {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
-      httpc:request(get, {"https://www.erlang.org", []}, [{ssl, httpc:ssl_verify_host_options(true)}], []).
+5> {ok, {{Version, 200, ReasonPhrase}, Headers, Body}} =
+.. httpc:request(get, {"https://www.erlang.org", []}, [{ssl, httpc:ssl_verify_host_options(true)}], []).
 ```
 
 The following is an ordinary asynchronous request:
 
 ```erlang
-      6 > {ok, RequestId} =
-      httpc:request(get, {"http://www.erlang.org", []}, [], [{sync, false}]).
+6> {ok, RequestId} =
+.. httpc:request(get, {"http://www.erlang.org", []}, [], [{sync, false}]).
 ```
 
 The result is sent to the calling process as `{http, {ReqestId, Result}}`.
@@ -96,51 +96,50 @@ In this case, the calling process is the shell, so the following result is
 received:
 
 ```erlang
-      7 > receive {http, {RequestId, Result}} -> ok after 500 -> error end.
-      ok
+7> receive {http, {RequestId, Result}} -> ok after 500 -> error end.
+ok
 ```
 
 This sends a request with a specified connection header:
 
 ```erlang
-      8 > {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
-      httpc:request(get, {"http://www.erlang.org", [{"connection", "close"}]},
-      [], []).
+8> {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
+.. httpc:request(get, {"http://www.erlang.org", [{"connection", "close"}]},
+.. [], []).
 ```
 
 This sends an HTTP request over a unix domain socket (experimental):
 
 ```erlang
-      9 > httpc:set_options([{ipfamily, local},
-      {unix_socket,"/tmp/unix_socket/consul_http.sock"}]).
-      10 > {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
-      httpc:request(put, {"http:///v1/kv/foo", [], [], "hello"}, [], []).
+9> httpc:set_options([{ipfamily, local}, {unix_socket,"/tmp/unix_socket/consul_http.sock"}]).
+10> {ok, {{NewVersion, 200, NewReasonPhrase}, NewHeaders, NewBody}} =
+ .. httpc:request(put, {"http:///v1/kv/foo", [], [], "hello"}, [], []).
 ```
 
 Start an HTTP client profile:
 
 ```erlang
-      10 > {ok, Pid} = inets:start(httpc, [{profile, foo}]).
-      {ok, <0.45.0>}
+10> {ok, Pid} = inets:start(httpc, [{profile, foo}]).
+{ok, <0.45.0>}
 ```
 
 The new profile has no proxy settings, so the connection is refused:
 
 ```erlang
-      11 > httpc:request("http://www.erlang.org", foo).
-      {error, econnrefused}
+11> httpc:request("http://www.erlang.org", foo).
+{error, econnrefused}
 ```
 
 Stop the HTTP client profile:
 
 ```erlang
-      12 > inets:stop(httpc, foo).
-      ok
+12> inets:stop(httpc, foo).
+ok
 ```
 
 Alternative way to stop the HTTP client profile:
 
 ```erlang
-      13 > inets:stop(httpc, Pid).
-      ok
+13> inets:stop(httpc, Pid).
+ok
 ```

--- a/lib/inets/doc/guides/http_server.md
+++ b/lib/inets/doc/guides/http_server.md
@@ -55,10 +55,10 @@ The following is to be put in the Erlang node application configuration file to
 start an HTTP server at application startup:
 
 ```erlang
-      [{inets, [{services, [{httpd, [{proplist_file,
-                 "/var/tmp/server_root/conf/8888_props.conf"}]},
-                {httpd, [{proplist_file,
-                 "/var/tmp/server_root/conf/8080_props.conf"}]}]}]}].
+[{inets, [{services, [{httpd, [{proplist_file,
+           "/var/tmp/server_root/conf/8888_props.conf"}]},
+          {httpd, [{proplist_file,
+           "/var/tmp/server_root/conf/8080_props.conf"}]}]}]}].
 ```
 
 The server is configured using an Erlang property list. For the available
@@ -67,16 +67,16 @@ properties, see `m:httpd`.
 The available configuration properties are as follows:
 
 ```erlang
-     httpd_service() -> {httpd, httpd()}
-     httpd()         -> [httpd_config()]
-     httpd_config()  -> {proplist_file, file()}
-                        {debug, debug()} |
-                        {accept_timeout, integer()}
-     debug()         -> disable | [debug_options()]
-     debug_options() -> {all_functions, modules()} |
-                        {exported_functions, modules()} |
-                        {disable, modules()}
-     modules()       -> [atom()]
+httpd_service() -> {httpd, httpd()}
+httpd()         -> [httpd_config()]
+httpd_config()  -> {proplist_file, file()}
+                   {debug, debug()} |
+                   {accept_timeout, integer()}
+debug()         -> disable | [debug_options()]
+debug_options() -> {all_functions, modules()} |
+                   {exported_functions, modules()} |
+                   {disable, modules()}
+modules()       -> [atom()]
 ```
 
 Here:
@@ -97,8 +97,8 @@ Here:
 Start `Inets`:
 
 ```erlang
-      1 > inets:start().
-      ok
+1> inets:start().
+ok
 ```
 
 Start an HTTP server with minimal required configuration. If you specify port
@@ -106,30 +106,31 @@ Start an HTTP server with minimal required configuration. If you specify port
 find which port number that was picked:
 
 ```erlang
-      2 > {ok, Pid} = inets:start(httpd, [{port, 0}, {server_root,"/tmp"},
-      {document_root,"/tmp/htdocs"}, {bind_address, "localhost"}]).
-      {ok, 0.79.0}
+2> {ok, Pid} = inets:start(httpd, [{port, 0}, {server_root,"/tmp"},
+.. {document_root,"/tmp/htdocs"}, {bind_address, "localhost"}]).
+{ok, 0.79.0}
 ```
 
 Call `info`:
 
 ```erlang
-      3 >  httpd:info(Pid).
-      [{mime_types,[{"html","text/html"},{"htm","text/html"}]},
-      {server_name,"machine.local"},
-      {bind_address, {127,0,0,1}},
-      {server_root,"/tmp"},
-      {port,59408},
-      {document_root,"/tmp/htdocs"}]
+3> httpd:info(Pid).
+[{mime_types,[{"html","text/html"},{"htm","text/html"}]},
+ {server_name,"machine.local"},
+ {bind_address, {127,0,0,1}},
+ {server_root,"/tmp"},
+ {port,59408},
+ {document_root,"/tmp/htdocs"},
+ {ipfamily,inet}]
 ```
 
 Reload the configuration without restarting the server:
 
 ```erlang
-    4 > httpd:reload_config([{port, 59408},
-      {server_root,"/tmp/www_test"}, {document_root,"/tmp/www_test/htdocs"},
-      {bind_address, "localhost"}], non_disturbing).
-    ok.
+4> httpd:reload_config([{port, 59408},
+.. {server_root,"/tmp/www_test"}, {document_root,"/tmp/www_test/htdocs"},
+.. {bind_address, "localhost"}], non_disturbing).
+ok.
 ```
 
 > #### Note {: .info }
@@ -138,18 +139,18 @@ Reload the configuration without restarting the server:
 > server during the reload get a service temporary unavailable answer.
 
 ```erlang
-      5 >  httpd:info(Pid, [server_root, document_root]).
-      [{server_root,"/tmp/www_test"},{document_root,"/tmp/www_test/htdocs"}]
+5> httpd:info(Pid, [server_root, document_root]).
+[{server_root,"/tmp/www_test"},{document_root,"/tmp/www_test/htdocs"}]
 ```
 
 ```erlang
-      6 > ok = inets:stop(httpd, Pid).
+6> ok = inets:stop(httpd, Pid).
 ```
 
 Alternative:
 
 ```erlang
-      6 > ok = inets:stop(httpd, {{127,0,0,1}, 59408}).
+6> ok = inets:stop(httpd, {{127,0,0,1}, 59408}).
 ```
 
 Notice that `bind_address` must be the IP address reported by function `info`
@@ -545,7 +546,7 @@ localhost.
 For example, to serve files from directory `test_results` on port `4000`:
 
 ```text
-      erl -S httpd serve --port 4000 test_results
+erl -S httpd serve --port 4000 test_results
 ```
 
 For a full reference of all options, run `erl -S httpd serve --help`.

--- a/lib/inets/doc/guides/inets_services.md
+++ b/lib/inets/doc/guides/inets_services.md
@@ -36,7 +36,7 @@ Services to be configured for startup at application startup are to be put into
 the Erlang node configuration file on the following form:
 
 ```erlang
-      [{inets, [{services, ListofConfiguredServices}]}].
+[{inets, [{services, ListofConfiguredServices}]}].
 ```
 
 For details of what to put in the list of configured services, see the

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -42,7 +42,7 @@ This module provides the API to an HTTP/1.1 compatible client according to
 > `https` links need to go through a proxy, the CONNECT method extension to
 > HTTP-1.1 is used to establish a tunnel and then the connection is upgraded to
 > TLS. However, "TLS upgrade" according to
-> [RFC 2817](http://www.ietf.org/rfc/rfc2817.txt)is not supported.
+> [RFC 2817](http://www.ietf.org/rfc/rfc2817.txt) is not supported.
 >
 > Pipelining is only used if the pipeline time-out is set, otherwise persistent
 > connections without pipelining are used. That is, the client always waits for
@@ -50,7 +50,7 @@ This module provides the API to an HTTP/1.1 compatible client according to
 
 Some examples are provided in the [Inets User's Guide](http_client.md).
 
-## HTTP CLIENT SERVICE START/STOP
+## HTTP client service start & stop
 
 An HTTP client can be configured to start when starting the `Inets` application
 or started dynamically in runtime by calling the `Inets` application API
@@ -78,7 +78,7 @@ The client can be stopped using [`inets:stop(httpc, Pid)`](`inets:stop/2`) or
 > `http://localhost/foo%25bar`, the percent character must be percent-encoded
 > when creating the request: `httpc:request("http://localhost/foo%2525bar").`
 
-## SEE ALSO
+## See also
 
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), `m:inets`, `m:gen_tcp`, `m:ssl`
 """.

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -619,11 +619,11 @@ Sets options to be used for subsequent requests.
   made.
 
 - **`IpAddress`** - If the host has several network interfaces, this option
-  specifies which one to use. See [gen_tcp:connect/3,4](`gen_tcp#connect/3`) for
+  specifies which one to use. See [`gen_tcp:connect/3,4`](`gen_tcp:connect/3`) for
   details.
 
 - **`Port`** - Example: `8080`. Local port number to use. See
-  [gen_tcp:connect/3,4](`gen_tcp#connect/3`) for details.
+  [`gen_tcp:connect/3,4`](`gen_tcp:connect/3`) for details.
 
 - **`SocketOpts`** - The options are appended to the socket options used by the
   client. These are the default values when a new request handler is started

--- a/lib/inets/src/http_lib/http_uri.erl
+++ b/lib/inets/src/http_lib/http_uri.erl
@@ -24,7 +24,7 @@ Old URI utility module, use uri_string instead
 This module is deprecated since OTP 23. Use the module `m:uri_string` to
 properly handle URIs, this is the recommended module since OTP 21.
 
-## DATA TYPES
+### Data types
 
 Type definitions that are related to URI:
 

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -27,7 +27,7 @@ An implementation of an HTTP 1.1 compliant web server, as defined in
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt). Provides web server start
 options, administrative functions, and an Erlang callback API.
 
-## DATA TYPES
+## Data types
 
 Type definitions that are used more than once in this module:
 
@@ -43,7 +43,7 @@ Type definitions that are used more than once in this module:
 
 `property() = atom()`
 
-## ERLANG HTTP SERVER SERVICE START/STOP
+## HTTP server service start & stop
 
 A web server can be configured to start when starting the `Inets` application,
 or dynamically in runtime by calling the `Inets` application API
@@ -717,7 +717,7 @@ The properties for the security directories are as follows:
   remembered. After this time has passed, the authentication is no longer
   reported. Default is `30`.
 
-## ERLANG WEB SERVER API DATA TYPES
+## Web server API data types
 
 The Erlang web server API data types are as follows:
 
@@ -796,13 +796,13 @@ The fields of record `mod` have the following meaning:
   client is a persistent connection and is not closed when the request is
   served.
 
-## SEE ALSO
+### See also
 
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), `m:inets`, `m:ssl`
 """.
 -moduledoc(#{titles =>
-                 [{callback,<<"ERLANG WEB SERVER API CALLBACK FUNCTIONS">>},
-                  {function,<<"ERLANG WEB SERVER API HELP FUNCTIONS">>}]}).
+                 [{callback,<<"Web server API callback functions">>},
+                  {function,<<"Web server API help functions">>}]}).
 
 -behaviour(inets_service).
 
@@ -922,7 +922,7 @@ this particular callback module.
 scripts (see `m:mod_esi`) as defined in the standard URL format, that is, '+'
 becomes 'space' and decoding of hexadecimal characters (`%xx`).
 """.
--doc(#{title => <<"ERLANG WEB SERVER API HELP FUNCTIONS">>}).
+-doc(#{title => <<"Web server API help functions">>}).
 -spec parse_query(QueryString) -> QueryList | uri_string:error() when
       QueryString :: string(),
       QueryList :: [{unicode:chardata(), unicode:chardata() | true}].

--- a/lib/inets/src/http_server/httpd_socket.erl
+++ b/lib/inets/src/http_server/httpd_socket.erl
@@ -41,11 +41,9 @@ mechanism is transparently used, that is, `ip_comm` or `ssl`.
 -include_lib("kernel/include/inet.hrl").
 
 -doc """
-deliver(SocketType, Socket, Data) -> Result
-
-[`deliver/3`](`deliver/3`) sends `Data` over `Socket` using the specified
-`SocketType`. `Socket` and `SocketType` is to be the socket and the
-`socket_type` form the `mod` record as defined in `httpd.hrl`
+`deliver/3` sends `Data` over `Socket` using the specified `SocketType`.
+`Socket` and `SocketType` is to be the socket and the `socket_type` form the
+`mod` record as defined in `httpd.hrl`
 
 [](){: #peername }
 """.
@@ -64,11 +62,7 @@ deliver(SocketType, Socket, IOListOrBinary)  ->
     end.
 
 -doc """
-peername(SocketType,Socket) -> {Port,IPAddress}
-
-[`peername/2`](`peername/2`) returns the `Port` and `IPAddress` of the remote
-`Socket`.
-
+`peername/2` returns the `Port` and `IPAddress` of the remote `Socket`.
 """.
 -spec peername(SocketType, Socket) -> {Port, IpAdress} when
       SocketType :: httpd:socket_type(),
@@ -79,8 +73,6 @@ peername(SocketType, Socket) ->
     http_transport:peername(SocketType, Socket).
 
 -doc """
-resolve() -> HostName
-
 `resolve/0` returns the official `HostName` of the current host.
 """.
 -spec resolve() -> HostName when

--- a/lib/inets/src/http_server/httpd_socket.erl
+++ b/lib/inets/src/http_server/httpd_socket.erl
@@ -27,7 +27,7 @@ This module provides the Erlang web server API module programmer with utility
 functions for generic sockets communication. The appropriate communication
 mechanism is transparently used, that is, `ip_comm` or `ssl`.
 
-## SEE ALSO
+### See also
 
 `m:httpd`
 """.

--- a/lib/inets/src/http_server/httpd_util.erl
+++ b/lib/inets/src/http_server/httpd_util.erl
@@ -33,7 +33,7 @@ miscellaneous utility functions.
 
 [](){: #convert_request_date }
 
-## SEE ALSO
+### See also
 
 `m:httpd`
 """.

--- a/lib/inets/src/http_server/httpd_util.erl
+++ b/lib/inets/src/http_server/httpd_util.erl
@@ -105,12 +105,10 @@ lookup(Table,Key) ->
     lookup(Table,Key,undefined).
 
 -doc """
-lookup(ETSTable,Key,Undefined) -> Result
-
-`lookup` extracts `{Key,Value}` tuples from `ETSTable` and returns the `Value`
+`lookup` extracts `{Key, Value}` tuples from `ETSTable` and returns the `Value`
 associated with `Key`. If `ETSTable` is of type `bag`, only the first `Value`
-associated with `Key` is returned. [`lookup/2`](`lookup/2`) returns `undefined`
-and [`lookup/3`](`lookup/3`) returns `Undefined` if no `Value` is found.
+associated with `Key` is returned. `lookup/2` returns `undefined`
+and `lookup/3` returns `Undefined` if no `Value` is found.
 """.
 -spec lookup(EtsTable,Key,Undefined) -> Result when
       EtsTable :: ets:table(),
@@ -128,9 +126,7 @@ lookup(Table,Key,Undefined) ->
 %% multi_lookup
 
 -doc """
-multi_lookup(ETSTable,Key) -> Result
-
-`multi_lookup` extracts all `{Key,Value}` tuples from an `ETSTable` and returns
+`multi_lookup` extracts all `{Key, Value}` tuples from an `ETSTable` and returns
 _all_ `Values` associated with `Key` in a list.
 """.
 -spec multi_lookup(EtsTable,Key) -> Result when
@@ -156,8 +152,6 @@ lookup_mime(ConfigDB,Suffix) ->
     lookup_mime(ConfigDB,Suffix,undefined).
 
 -doc """
-lookup_mime(ConfigDB,Suffix,Undefined) -> MimeType
-
 `lookup_mime` returns the MIME type associated with a specific file suffix as
 specified in the file `mime.types` (located in the config directory).
 """.
@@ -186,8 +180,6 @@ lookup_mime_default(ConfigDB,Suffix) ->
     lookup_mime_default(ConfigDB,Suffix,undefined).
 
 -doc """
-lookup_mime_default(ConfigDB,Suffix,Undefined) -> MimeType
-
 `lookup_mime_default` returns the MIME type associated with a specific file
 suffix as specified in the `mime.types` file (located in the config directory).
 If no appropriate association is found, the value of `DefaultType` is returned.
@@ -220,8 +212,6 @@ lookup_mime_default(ConfigDB,Suffix,Undefined) ->
 
 %%% RFC 2616, HTTP 1.1 Status codes
 -doc """
-reason_phrase(StatusCode) -> Description
-
 `reason_phrase` returns `Description` of an HTTP 1.1 `StatusCode`, for example,
 200 is "OK" and 201 is "Created". For more information, see
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt).
@@ -300,9 +290,7 @@ reason_phrase(_) -> "Internal Server Error".
 %% message
 
 -doc """
-message(StatusCode,PhraseArgs,ConfigDB) -> Message
-
-[`message/3`](`message/3`) returns an informative HTTP 1.1 status string in
+`message/3` returns an informative HTTP 1.1 status string in
 HTML. Each `StatusCode` requires a specific `PhraseArgs`:
 
 - **`301`** - `t:string/0`: A URL pointing at the new document position.
@@ -312,7 +300,7 @@ HTML. Each `StatusCode` requires a specific `PhraseArgs`:
 - **`403 | 404`** - `t:string/0`: A `Request-URI` as described in
   [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt).
 
-- **`501`** - `{Method,RequestURI,HTTPVersion}`: The HTTP `Method`,
+- **`501`** - `{Method, RequestURI, HTTPVersion}`: The HTTP `Method`,
   `Request-URI`, and `HTTP-Version` as defined in RFC 2616.
 
 - **`504`** - `t:string/0`: A string describing why the service was unavailable.
@@ -389,9 +377,7 @@ html_encode(String) ->
 %%convert_rfc_date(Date)->{{YYYY,MM,DD},{HH,MIN,SEC}}
 
 -doc """
-convert_request_date(DateString) -> ErlDate|bad_date
-
-[`convert_request_date/1`](`convert_request_date/1`) converts `DateString` to
+`convert_request_date/1` converts `DateString` to
 the Erlang date format. `DateString` must be in one of the three date formats
 defined in [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt).
 """.
@@ -486,8 +472,6 @@ rfc1123_date() ->
 		    [day(DayNumber),DD,month(MM),YYYY,Hour,Min,Sec])).
 
 -doc """
-rfc1123_date(Date) -> RFC1123Date
-
 `rfc1123_date/0` returns the current date in RFC 1123 format. `rfc_date/1`
 converts the date in the Erlang format to the RFC 1123 date format.
 """.
@@ -545,9 +529,7 @@ uniq([First|Rest]) ->
 %% day
 
 -doc """
-day(NthDayOfWeek) -> DayOfWeek
-
-[`day/1`](`day/1`) converts the day of the week (`NthDayOfWeek`) from an integer
+`day/1` converts the day of the week (`NthDayOfWeek`) from an integer
 (1-7) to an abbreviated string, that is:
 
 1 = "Mon", 2 = "Tue", ..., 7 = "Sat".
@@ -566,9 +548,7 @@ day(7) -> "Sun".
 %% month
 
 -doc """
-month(NthMonth) -> Month
-
-[`month/1`](`month/1`) converts the month `NthMonth` as an integer (1-12) to an
+`month/1` converts the month `NthMonth` as an integer (1-12) to an
 abbreviated string, that is:
 
 1 = "Jan", 2 = "Feb", ..., 12 = "Dec".
@@ -593,9 +573,7 @@ month(12) -> "Dec".
 %% and should only be decoded once(RFC3986, 2.4).
 
 -doc """
-split_path(RequestLine) -> {Path,QueryStringOrPathInfo}
-
-[`split_path/1`](`split_path/1`) splits `RequestLine` in a file reference
+`split_path/1` splits `RequestLine` in a file reference
 (`Path`), and a `QueryString` or a `PathInfo` string as specified in
 [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt). A `QueryString` is isolated
 from `Path` with a question mark (`?`) and `PathInfo` with a slash (/). In the
@@ -630,12 +608,9 @@ add_hashmark(Query, Fragment) ->
 
 
 -doc """
-split_script_path(RequestLine) -> Split
-
-[`split_script_path/1`](`split_script_path/1`) is equivalent to
-[`split_path/1`](`split_path/1`) with one exception. If the longest possible
-path is not a regular, accessible, and executable file, then `not_a_script` is
-returned.
+`split_script_path/1` is equivalent to `split_path/1` with one exception. If
+the longest possible path is not a regular, accessible, and executable file,
+then `not_a_script` is returned.
 """.
 -spec split_script_path(URIString) -> Split when
       URIString :: string(),
@@ -669,11 +644,9 @@ strip_extension_dot(Path) ->
 %% split
 
 -doc """
-split(String,RegExp,N) -> SplitRes
-
-[`split/3`](`split/3`) splits `String` in `N` chunks using `RegExp`.
-[`split/3`](`split/3`) is equivalent to `re:split/3` with the exception that `N`
-defines the maximum number of fields in `FieldList`.
+`split/3` splits `String` in `N` chunks using `RegExp`. `split/3` is equivalent
+to `re:split/3` with the exception that `N` defines the maximum number of
+fields in `FieldList`.
 """.
 -spec split(String,RegExp,N) -> SplitRes when
       String :: string(),
@@ -748,11 +721,8 @@ search_and_replace(S,A,B) ->
     lists:map(Fun,S).
 
 -doc """
-create_etag(FileInfo) -> Etag
-
-[`create_etag/1`](`create_etag/1`) calculates the Etag for a file from its size
-and time for last modification. `FileInfo` is a record defined in
-`kernel/include/file.hrl`.
+`create_etag/1` calculates the Etag for a file from its size and time for last
+modification. `FileInfo` is a record defined in `kernel/include/file.hrl`.
 """.
 -spec create_etag(FileInfo) -> Etag when
       FileInfo :: file:file_info(),

--- a/lib/inets/src/http_server/mod_alias.erl
+++ b/lib/inets/src/http_server/mod_alias.erl
@@ -91,9 +91,7 @@ do_alias(#mod{config_db   = ConfigDB,
 %% real_name
 
 -doc """
-real_name(ConfigDB, RequestURI, Aliases) -> Ret
-
-[`real_name/3`](`real_name/3`) traverses `Aliases`, typically extracted from
+`real_name/3` traverses `Aliases`, typically extracted from
 `ConfigDB`, and matches each `FakeName` with `RequestURI`. If a match is found,
 `FakeName` is replaced with `RealName` in the match. The resulting path is split
 into two parts, `ShortPath` and `AfterPath`, as defined in
@@ -167,9 +165,7 @@ longest_match([], _RequestURI, _LongestNo, LongestAlias) ->
 %% real_script_name
 
 -doc """
-real_script_name(ConfigDB, RequestURI, ScriptAliases) -> Ret
-
-[`real_script_name/3`](`real_script_name/3`) traverses `ScriptAliases`,
+`real_script_name/3` traverses `ScriptAliases`,
 typically extracted from `ConfigDB`, and matches each `FakeName` with
 `RequestURI`. If a match is found, `FakeName` is replaced with `RealName` in the
 match. If the resulting match is not an executable script, `not_a_script` is
@@ -210,9 +206,7 @@ abs_script_path(_, RelPath) ->
 %% default_index
 
 -doc """
-default_index(ConfigDB, Path) -> NewPath
-
-If `Path` is a directory, [`default_index/2`](`default_index/2`), it starts
+If `Path` is a directory, `default_index/2`, it starts
 searching for resources or files that are specified in the config directive
 `DirectoryIndex`. If an appropriate resource or file is found, it is appended to
 the end of `Path` and then returned. `Path` is returned unaltered if no
@@ -247,11 +241,9 @@ append_index(RealName, [Index | Rest]) ->
 %% path
 
 -doc """
-path(PathData, ConfigDB, RequestURI) -> Path
-
-[`path/3`](`path/3`) returns the file `Path` in the `RequestURI` (see
+`path/3` returns the file `Path` in the `RequestURI` (see
 [RFC 1945](https://www.ietf.org/rfc/rfc1945.txt)). If the interaction data
-`{real_name,{Path,AfterPath}}` has been exported by `mod_alias`, `Path` is
+`{real_name, {Path, AfterPath}}` has been exported by `mod_alias`, `Path` is
 returned. If no interaction data has been exported, `ServerRoot` is used to
 generate a file `Path`. `config_db()` and `interaction_data()` are as defined in
 [Inets User's Guide](http_server.md).

--- a/lib/inets/src/http_server/mod_auth.erl
+++ b/lib/inets/src/http_server/mod_auth.erl
@@ -25,7 +25,7 @@ User authentication using text files, Dets, or Mnesia database.
 This module provides for basic user authentication using textual files, Dets
 databases, or Mnesia databases.
 
-## SEE ALSO
+### See also
 
 `m:httpd`, `m:mod_alias`
 """.

--- a/lib/inets/src/http_server/mod_auth.erl
+++ b/lib/inets/src/http_server/mod_auth.erl
@@ -210,7 +210,7 @@ Reason}
 
 `add_user/2, add_user/5`, and [`add_user/6`](`add_user/6`) each adds a user to
 the user database. If the operation is successful, this function returns `true`.
-If an error occurs, `{error,Reason}` is returned. When
+If an error occurs, `{error, Reason}` is returned. When
 [`add_user/2`](`add_user/2`) is called, options `Password`, `UserData`, `Port`,
 and `Dir` are mandatory.
 """.
@@ -256,12 +256,10 @@ get_user(UserName, Opt) ->
 get_user(UserName, Port, Dir) ->
     get_user(UserName, undefined, Port, Dir).
 -doc """
-get_user(UserName, Address, Port, Dir) -> {ok, #httpd_user} | {error, Reason}
-
-`get_user/2, get_user/3`, and [`get_user/4`](`get_user/4`) each returns an
-`httpd_user` record containing the userdata for a specific user. If the user
-cannot be found, `{error, Reason}` is returned. When
-[`get_user/2`](`get_user/2`) is called, options `Port` and `Dir` are mandatory.
+`get_user/2`, `get_user/3`, and `get_user/4` each returns an `t:httpd_user/0`
+record containing the userdata for a specific user. If the user cannot be
+found, `{error, Reason}` is returned. When `get_user/2` is called, options
+`Port` and `Dir` are mandatory.
 """.
 -spec get_user(UserName, Address, Port, Directory) -> {ok, User} | {error, Reason} when
       UserName :: string(),
@@ -304,14 +302,10 @@ add_group_member(GroupName, UserName, Port, Dir) ->
     add_group_member(GroupName, UserName, undefined, Port, Dir).
 
 -doc """
-add_group_member(GroupName, UserName, Address, Port, Dir) -> true | {error,
-Reason}
-
-`add_group_member/3, add_group_member/4`, and
-[`add_group_member/5`](`add_group_member/5`) each adds a user to a group. If the
-group does not exist, it is created and the user is added to the group. Upon
-successful operation, this function returns `true`. When `add_group_members/3`
-is called, options `Port` and `Dir` are mandatory.
+`add_group_member/3`, `add_group_member/4`, and `add_group_member/5` each adds
+a user to a group. If the group does not exist, it is created and the user is
+added to the group. Upon successful operation, this function returns `true`.
+When `add_group_members/3` is called, options `Port` and `Dir` are mandatory.
 """.
 -spec add_group_member(GroupName, UserName, Address, Port, Directory) -> true | {error, Reason} when
       GroupName :: string(),
@@ -354,13 +348,9 @@ delete_group_member(GroupName, UserName, Opt) ->
 delete_group_member(GroupName, UserName, Port, Dir) ->
     delete_group_member(GroupName, UserName, undefined, Port, Dir).
 -doc """
-delete_group_member(GroupName, UserName, Address, Port, Dir) -> true | {error,
-Reason}
-
-`delete_group_member/3, delete_group_member/4`, and
-[`delete_group_member/5`](`delete_group_member/5`) each deletes a user from a
-group. If the group or the user does not exist, this function returns an error,
-otherwise `true`. When [`delete_group_member/3`](`delete_group_member/3`) is
+`delete_group_member/3`, `delete_group_member/4`, and `delete_group_member/5`
+each deletes a user from a group. If the group or the user does not exist, this
+function returns an error, otherwise `true`. When `delete_group_member/3` is
 called, the options `Port` and `Dir` are mandatory.
 """.
 -spec delete_group_member(GroupName, UserName, Address, Port, Directory) -> true | {error, Reason} when
@@ -403,12 +393,9 @@ list_users(Opt) ->
 list_users(Port, Dir) ->
     list_users(undefined, Port, Dir).
 -doc """
-list_users(Address, Port, Dir) -> {ok, Users} | {error, Reason}
-
-`list_users/1, list_users/2`, and [`list_users/3`](`list_users/3`) each returns
-a list of users in the user database for a specific `Port/Dir`. When
-[`list_users/1`](`list_users/1`) is called, options `Port` and `Dir` are
-mandatory.
+`list_users/1`, `list_users/2`, and `list_users/3` each returns a list of users
+in the user database for a specific `Port/Dir`. When `list_users/1` is called,
+options `Port` and `Dir` are mandatory.
 """.
 -spec list_users(Address, Port, Directory) -> {ok, Users} | {error, Reason} when
       Port :: inet:port_number(),
@@ -446,12 +433,10 @@ delete_user(UserName, Opt) ->
 delete_user(UserName, Port, Dir) ->
     delete_user(UserName, undefined, Port, Dir).
 -doc """
-delete_user(UserName, Address, Port, Dir) -> true | {error, Reason}
-
-`delete_user/2, delete_user/3`, and [`delete_user/4`](`delete_user/4`) each
+`delete_user/2`, `delete_user/3`, and `delete_user/4` each
 deletes a user from the user database. If the operation is successful, this
-function returns `true`. If an error occurs, `{error,Reason}` is returned. When
-[`delete_user/2`](`delete_user/2`) is called, options `Port` and `Dir` are
+function returns `true`. If an error occurs, `{error, Reason}` is returned. When
+`delete_user/2` is called, options `Port` and `Dir` are
 mandatory.
 """.
 -spec delete_user(UserName, Address, Port, Directory) -> true | {error, Reason} when
@@ -480,7 +465,7 @@ delete_group(GroupName, Opt) ->
 	    {error, Reason}
     end.
 
--doc false.
+-doc (#{equiv => delete_group(GroupName, undefined, Port, Dir)}).
 -spec delete_group(GroupName, Port, Directory) -> true | {error, Reason} when
       GroupName :: string(),
       Port :: inet:port_number(),
@@ -489,12 +474,10 @@ delete_group(GroupName, Opt) ->
 delete_group(GroupName, Port, Dir) ->
     delete_group(GroupName, undefined, Port, Dir).
 -doc """
-delete_group(GroupName, Address, Port, Dir) -> true | {error, Reason}
-
-`delete_group/2, delete_group/3`, and [`delete_group/4`](`delete_group/4`) each
-deletes the group specified and returns `true`. If there is an error,
-`{error, Reason}` is returned. When [`delete_group/2`](`delete_group/2`) is
-called, option `Port` and `Dir` are mandatory.
+`delete_group/2`, `delete_group/3`, and `delete_group/4` each deletes the group
+specified and returns `true`. If there is an error, `{error, Reason}` is
+returned. When `delete_group/2` is called, option `Port` and `Dir` are
+mandatory.
 """.
 -spec delete_group(GroupName, Address, Port, Directory) -> true | {error, Reason} when
       GroupName :: string(),
@@ -531,12 +514,9 @@ list_groups(Opt) ->
 list_groups(Port, Dir) ->
     list_groups(undefined, Port, Dir).
 -doc """
-list_groups(Address, Port, Dir) -> {ok, Groups} | {error, Reason}
-
-`list_groups/1, list_groups/2`, and [`list_groups/3`](`list_groups/3`) each
-lists all the groups available. If there is an error, `{error, Reason}` is
-returned. When [`list_groups/1`](`list_groups/1`) is called, options `Port` and
-`Dir` are mandatory.
+`list_groups/1`, `list_groups/2`, and `list_groups/3` each lists all the groups
+available. If there is an error, `{error, Reason}` is returned. When
+`list_groups/1` is called, options `Port` and `Dir` are mandatory.
 """.
 -spec list_groups(Address, Port, Directory) -> {ok, Groups} | {error, Reason} when
       Port :: inet:port_number(),
@@ -577,15 +557,10 @@ list_group_members(GroupName, Opt) ->
 list_group_members(GroupName, Port, Dir) ->
     list_group_members(GroupName, undefined, Port, Dir).
 -doc """
-list_group_members(GroupName, Address, Port, Dir) -> {ok, Users} | {error,
-Reason}
-
-`list_group_members/2, list_group_members/3`, and
-[`list_group_members/4`](`list_group_members/4`) each lists the members of a
-specified group. If the group does not exist or there is an error,
-`{error, Reason}` is returned. When
-[`list_group_members/2`](`list_group_members/2`) is called, options `Port` and
-`Dir` are mandatory.
+`list_group_members/2`, `list_group_members/3`, and `list_group_members/4` each
+lists the members of a specified group. If the group does not exist or there is
+an error, `{error, Reason}` is returned. When `list_group_members/2` is called,
+options `Port` and `Dir` are mandatory.
 """.
 -spec list_group_members(GroupName, Address, Port, Directory) -> {ok, Users} | {error, Reason} when
       GroupName :: string(),
@@ -609,13 +584,9 @@ update_password(Port, Dir, Old, New, New)->
     update_password(undefined, Port, Dir, Old, New, New).
 
 -doc """
-update_password(Address,Port, Dir, OldPassword, NewPassword, NewPassword) -> ok
-| {error, Reason}
-
-[`update_password/5`](`update_password/5`) and
-[`update_password/6`](`update_password/6`) each updates `AuthAccessPassword` for
-the specified directory. If `NewPassword` is equal to "NoPassword", no password
-is required to change authorisation data. If `NewPassword` is equal to
+`update_password/5` and `update_password/6` each updates `AuthAccessPassword`
+for the specified directory. If `NewPassword` is equal to "NoPassword", no
+password is required to change authorisation data. If `NewPassword` is equal to
 "DummyPassword", no changes can be done without changing the password first.
 """.
 -spec update_password(Address, Port, Dir, OldPassword, NewPassword, NewPassword) -> ok | {error, Reason} when

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -176,8 +176,6 @@ any data that it needs to keep track of when handling the chunks.
 %% request handling process so it can forward it to the client.
 %%-------------------------------------------------------------------------
 -doc """
-deliver(SessionID, Data) -> ok | {error, Reason}
-
 This function is _only_ intended to be used from functions called by the Erl
 Scheme interface to deliver parts of the content to the user.
 

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -26,7 +26,7 @@ This module defines the Erlang Server Interface (ESI) API. It is a more
 efficient way of writing Erlang scripts for your `Inets` web server than writing
 them as common CGI scripts.
 
-## DATA TYPES
+### Data types
 
 The following data types are used in the functions for mod_esi:
 

--- a/lib/inets/src/http_server/mod_security.erl
+++ b/lib/inets/src/http_server/mod_security.erl
@@ -215,8 +215,6 @@ list_blocked_users(Addr, Port) when is_integer(Port) ->
 	      mod_security_server:list_blocked_users(Addr, Port)).
 
 -doc """
-list_blocked_users(Address, Port, Dir) -> Users | []
-
 [`list_blocked_users/1`](`list_blocked_users/1`),
 [`list_blocked_users/2`](`list_blocked_users/2`), and
 [`list_blocked_users/3`](`list_blocked_users/3`) each returns a list of users
@@ -243,8 +241,6 @@ list_blocked_users(Addr, Port, Dir) ->
 block_user(User, Port, Dir, Time) ->
     block_user(User, undefined, Port, Dir, Time).
 -doc """
-block_user(User, Address, Port, Dir, Seconds) -> true | {error, Reason}
-
 [`block_user/4`](`block_user/4`) and [`block_user/5`](`block_user/5`) each
 blocks the user `User` from directory `Dir` for a specified amount of time.
 """.
@@ -283,8 +279,6 @@ unblock_user(User, Addr, Port) when is_integer(Port) ->
     mod_security_server:unblock_user(User, Addr, Port).
 
 -doc """
-unblock_user(User, Address, Port, Dir) -> true | {error, Reason}
-
 [`unblock_user/2`](`unblock_user/2`), [`unblock_user/3`](`unblock_user/3`), and
 [`unblock_user/4`](`unblock_user/4`) each removes the user `User` from the list
 of blocked users for `Port` (and `Dir`).
@@ -320,8 +314,6 @@ list_auth_users(Addr, Port) when is_integer(Port) ->
     mod_security_server:list_auth_users(Addr, Port).
 
 -doc """
-list_auth_users(Address, Port, Dir) -> Users | []
-
 [`list_auth_users/1`](`list_auth_users/1`),
 [`list_auth_users/2`](`list_auth_users/2`), and
 [`list_auth_users/3`](`list_auth_users/3`) each returns a list of users that are

--- a/lib/inets/src/inets_app/inets.erl
+++ b/lib/inets/src/inets_app/inets.erl
@@ -31,7 +31,7 @@ of the `Inets` application, such as start and stop.
 
 [](){: #common_data_types }
 
-## DATA TYPES
+### Data types
 
 Type definitions that are used more than once in this module:
 
@@ -39,7 +39,7 @@ Type definitions that are used more than once in this module:
 
 `property() = atom()`
 
-## SEE ALSO
+### See also
 
 `m:httpc`, `m:httpd`
 """.

--- a/lib/inets/src/inets_app/inets.erl
+++ b/lib/inets/src/inets_app/inets.erl
@@ -75,8 +75,6 @@ start() ->
     application:start(inets, temporary).
 
 -doc """
-start(Type) -> ok | {error, Reason}
-
 Starts the `Inets` application. Default type is `temporary`. See also
 `m:application`.
 
@@ -128,8 +126,6 @@ start(Service, ServiceConfig) ->
     start_service(Service, ServiceConfig, inets).
 
 -doc """
-start(Service, ServiceConfig, How) -> {ok, Pid} | {error, Reason}
-
 Dynamically starts an `Inets` service after the `Inets` application has been
 started.
 
@@ -172,8 +168,6 @@ start(Service, ServiceConfig, How) ->
 %% Description: Stops the inets application.
 %%--------------------------------------------------------------------
 -doc """
-stop() -> ok
-
 Stops the `Inets` application. See also `m:application`.
 
 [](){: #start2 }
@@ -192,8 +186,6 @@ stop() ->
 %% down a stand alone "service" gracefully.
 %%--------------------------------------------------------------------
 -doc """
-stop(Service, Reference) -> ok | {error, Reason}
-
 Stops a started service of the `Inets` application or takes down a
 `stand_alone`\-service gracefully. When option `stand_alone` is used in start,
 only the pid is a valid argument to stop.
@@ -219,8 +211,6 @@ stop(Service, Pid) ->
 %% Note: Services started with the stand alone option will not be listed
 %%--------------------------------------------------------------------
 -doc """
-services() -> [{Service, Pid}]
-
 Returns a list of currently running services.
 
 > #### Note {: .info }
@@ -249,12 +239,10 @@ services() ->
 %% each service is described by a [{Property, Value}] list. 
 %%--------------------------------------------------------------------
 -doc """
-services_info() -> [{Service, Pid, Info}]
-
 Returns a list of currently running services where each service is described by
 an `[{Option, Value}]` list. The information in the list is specific for each
 service and each service has probably its own info function that gives more
-details about the service. If specific service info returns \{error, Reason\},
+details about the service. If specific service info returns `{error, Reason}`,
 Info will contain Reason term.
 
 [](){: #service_names }
@@ -488,8 +476,6 @@ key1search(Key, Vals, Def) ->
 %% Description: Returns a list of supported services
 %%-------------------------------------------------------------------
 -doc """
-service_names() -> [Service]
-
 Returns a list of available service names.
 
 [](){: #start }


### PR DESCRIPTION
This PR:
- removes whitespace from codeblocks in the User's Guide, similar to 70789d145fe9
- adjust whitespace in codeblocks to be more consistent
- use line continuation character from newer Erlang shells in interactive examples
- removes function specifications from the first line of function docstrings
- fixes documentation build warnings due to broken links to `gen_tcp`
- use more readable section headers (shorten them, match their casing to the rest of the sidebar, remove "See also" from the table of contents on the sidebar)
- group modules on the sidebar based on their functionality
and adds the `ipfamily` to the result of `httpd:info`, which is returned when testing this locally.

---

I saw that the deadline for OTP 27 is tomorrow, so if you want to have this in the release but spot something that should be changed quickly, you should have edit access. Feel free to throw out commits / changes