### PR TITLE
ct: Implement fixes for new documentation

### DIFF
--- a/lib/common_test/doc/guides/basics_chapter.md
+++ b/lib/common_test/doc/guides/basics_chapter.md
@@ -128,15 +128,15 @@ case functions that look much more like scripts than actual programs. A simple
 example:
 
 ```erlang
- session(_Config) ->
-     {started,ServerId} = my_server:start(),
-     {clients,[]} = my_server:get_clients(ServerId),
-     MyId = self(),
-     connected = my_server:connect(ServerId, MyId),
-     {clients,[MyId]} = my_server:get_clients(ServerId),
-     disconnected = my_server:disconnect(ServerId, MyId),
-     {clients,[]} = my_server:get_clients(ServerId),
-     stopped = my_server:stop(ServerId).
+session(_Config) ->
+    {started,ServerId} = my_server:start(),
+    {clients,[]} = my_server:get_clients(ServerId),
+    MyId = self(),
+    connected = my_server:connect(ServerId, MyId),
+    {clients,[MyId]} = my_server:get_clients(ServerId),
+    disconnected = my_server:disconnect(ServerId, MyId),
+    {clients,[]} = my_server:get_clients(ServerId),
+    stopped = my_server:stop(ServerId).
 ```
 
 As a test suite runs, all information (including output to `stdout`) is recorded

--- a/lib/common_test/doc/guides/config_file_chapter.md
+++ b/lib/common_test/doc/guides/config_file_chapter.md
@@ -40,15 +40,15 @@ configuration data follows:
 
 A configuration file can contain any number of elements of the type:
 
-```text
- {CfgVarName,Value}.
+```erlang
+{CfgVarName,Value}.
 ```
 
 where
 
 ```erlang
- CfgVarName = atom()
- Value = term() | [{CfgVarName,Value}]
+CfgVarName = atom()
+Value = term() | [{CfgVarName,Value}]
 ```
 
 ## Requiring and Reading Configuration Data
@@ -90,14 +90,14 @@ To read the value of a configuration variable, use function
 _Example:_
 
 ```erlang
- suite() ->
-     [{require, domain, 'CONN_SPEC_DNS_SUFFIX'}].
+suite() ->
+    [{require, domain, 'CONN_SPEC_DNS_SUFFIX'}].
 
- ...
+...
 
- testcase(Config) ->
-     Domain = ct:get_config(domain),
-     ...
+testcase(Config) ->
+    Domain = ct:get_config(domain),
+    ...
 ```
 
 ## Using Configuration Variables Defined in Multiple Files
@@ -180,27 +180,26 @@ as follows:
 
 An example of an XML configuration file follows:
 
-```c
-
- <config>
-    <ftp_host>
-        <ftp>"targethost"</ftp>
-        <username>"tester"</username>
-        <password>"letmein"</password>
-    </ftp_host>
-    <lm_directory>"/test/loadmodules"</lm_directory>
- </config>
+```xml
+<config>
+   <ftp_host>
+       <ftp>"targethost"</ftp>
+       <username>"tester"</username>
+       <password>"letmein"</password>
+   </ftp_host>
+   <lm_directory>"/test/loadmodules"</lm_directory>
+</config>
 ```
 
 Once read, this file produces the same configuration variables as the following
 text file:
 
 ```erlang
- {ftp_host, [{ftp,"targethost"},
-             {username,"tester"},
-             {password,"letmein"}]}.
+{ftp_host, [{ftp,"targethost"},
+            {username,"tester"},
+            {password,"letmein"}]}.
 
- {lm_directory, "/test/loadmodules"}.
+{lm_directory, "/test/loadmodules"}.
 ```
 
 ### Implement a User-Specific Handler
@@ -243,8 +242,8 @@ The return value is to be either of the following:
 as values, like the earlier configuration file example:
 
 ```erlang
- [{ftp_host, [{ftp, "targethost"}, {username, "tester"}, {password, "letmein"}]},
-  {lm_directory, "/test/loadmodules"}]
+[{ftp_host, [{ftp, "targethost"}, {username, "tester"}, {password, "letmein"}]},
+ {lm_directory, "/test/loadmodules"}]
 ```
 
 ## Examples of Configuration Data Handling
@@ -253,11 +252,11 @@ A configuration file for using the FTP client to access files on a remote host
 can look as follows:
 
 ```erlang
- {ftp_host, [{ftp,"targethost"},
-	     {username,"tester"},
-	     {password,"letmein"}]}.
+{ftp_host, [{ftp,"targethost"},
+            {username,"tester"},
+            {password,"letmein"}]}.
 
- {lm_directory, "/test/loadmodules"}.
+{lm_directory, "/test/loadmodules"}.
 ```
 
 The XML version shown earlier can also be used, but it is to be explicitly
@@ -268,47 +267,47 @@ The following is an example of how to assert that the configuration data is
 available and can be used for an FTP session:
 
 ```erlang
- init_per_testcase(ftptest, Config) ->
-     {ok,_} = ct_ftp:open(ftp),
-     Config.
+init_per_testcase(ftptest, Config) ->
+    {ok,_} = ct_ftp:open(ftp),
+    Config.
 
- end_per_testcase(ftptest, _Config) ->
-     ct_ftp:close(ftp).
+end_per_testcase(ftptest, _Config) ->
+    ct_ftp:close(ftp).
 
- ftptest() ->
-     [{require,ftp,ftp_host},
-      {require,lm_directory}].
+ftptest() ->
+    [{require,ftp,ftp_host},
+     {require,lm_directory}].
 
- ftptest(Config) ->
-     Remote = filename:join(ct:get_config(lm_directory), "loadmodX"),
-     Local = filename:join(proplists:get_value(priv_dir,Config), "loadmodule"),
-     ok = ct_ftp:recv(ftp, Remote, Local),
-     ...
+ftptest(Config) ->
+    Remote = filename:join(ct:get_config(lm_directory), "loadmodX"),
+    Local = filename:join(proplists:get_value(priv_dir,Config), "loadmodule"),
+    ok = ct_ftp:recv(ftp, Remote, Local),
+    ...
 ```
 
 The following is an example of how the functions in the previous example can be
 rewritten if it is necessary to open multiple connections to the FTP server:
 
 ```erlang
- init_per_testcase(ftptest, Config) ->
-     {ok,Handle1} = ct_ftp:open(ftp_host),
-     {ok,Handle2} = ct_ftp:open(ftp_host),
-     [{ftp_handles,[Handle1,Handle2]} | Config].
+init_per_testcase(ftptest, Config) ->
+    {ok,Handle1} = ct_ftp:open(ftp_host),
+    {ok,Handle2} = ct_ftp:open(ftp_host),
+    [{ftp_handles,[Handle1,Handle2]} | Config].
 
- end_per_testcase(ftptest, Config) ->
-     lists:foreach(fun(Handle) -> ct_ftp:close(Handle) end,
-                   proplists:get_value(ftp_handles,Config)).
+end_per_testcase(ftptest, Config) ->
+    lists:foreach(fun(Handle) -> ct_ftp:close(Handle) end,
+                  proplists:get_value(ftp_handles,Config)).
 
- ftptest() ->
-     [{require,ftp_host},
-      {require,lm_directory}].
+ftptest() ->
+    [{require,ftp_host},
+     {require,lm_directory}].
 
- ftptest(Config) ->
-     Remote = filename:join(ct:get_config(lm_directory), "loadmodX"),
-     Local = filename:join(proplists:get_value(priv_dir,Config), "loadmodule"),
-     [Handle | MoreHandles] = proplists:get_value(ftp_handles,Config),
-     ok = ct_ftp:recv(Handle, Remote, Local),
-     ...
+ftptest(Config) ->
+    Remote = filename:join(ct:get_config(lm_directory), "loadmodX"),
+    Local = filename:join(proplists:get_value(priv_dir,Config), "loadmodule"),
+    [Handle | MoreHandles] = proplists:get_value(ftp_handles,Config),
+    ok = ct_ftp:recv(Handle, Remote, Local),
+    ...
 ```
 
 ## Example of User-Specific Configuration Handler
@@ -317,27 +316,27 @@ A simple configuration handling driver, asking an external server for
 configuration data, can be implemented as follows:
 
 ```erlang
- -module(config_driver).
- -export([read_config/1, check_parameter/1]).
+-module(config_driver).
+-export([read_config/1, check_parameter/1]).
 
- read_config(ServerName)->
-     ServerModule = list_to_atom(ServerName),
-     ServerModule:start(),
-     ServerModule:get_config().
+read_config(ServerName)->
+    ServerModule = list_to_atom(ServerName),
+    ServerModule:start(),
+    ServerModule:get_config().
 
- check_parameter(ServerName)->
-     ServerModule = list_to_atom(ServerName),
-     case code:is_loaded(ServerModule) of
-         {file, _}->
-             {ok, {config, ServerName}};
-         false->
-             case code:load_file(ServerModule) of
-                 {module, ServerModule}->
-                     {ok, {config, ServerName}};
-                 {error, nofile}->
-                     {error, {wrong_config, "File not found: " ++ ServerName ++ ".beam"}}
-             end
-     end.
+check_parameter(ServerName)->
+    ServerModule = list_to_atom(ServerName),
+    case code:is_loaded(ServerModule) of
+        {file, _}->
+            {ok, {config, ServerName}};
+        false->
+            case code:load_file(ServerModule) of
+                {module, ServerModule}->
+                    {ok, {config, ServerName}};
+                {error, nofile}->
+                    {error, {wrong_config, "File not found: " ++ ServerName ++ ".beam"}}
+            end
+    end.
 ```
 
 The configuration string for this driver can be `config_server`, if the
@@ -345,67 +344,67 @@ The configuration string for this driver can be `config_server`, if the
 during test execution:
 
 ```erlang
- -module(config_server).
- -export([start/0, stop/0, init/1, get_config/0, loop/0]).
+-module(config_server).
+-export([start/0, stop/0, init/1, get_config/0, loop/0]).
 
- -define(REGISTERED_NAME, ct_test_config_server).
+-define(REGISTERED_NAME, ct_test_config_server).
 
- start()->
-     case whereis(?REGISTERED_NAME) of
-         undefined->
-             spawn(?MODULE, init, [?REGISTERED_NAME]),
-             wait();
-         _Pid->
-         ok
-     end,
-     ?REGISTERED_NAME.
+start()->
+    case whereis(?REGISTERED_NAME) of
+        undefined->
+            spawn(?MODULE, init, [?REGISTERED_NAME]),
+            wait();
+        _Pid->
+        ok
+    end,
+    ?REGISTERED_NAME.
 
- init(Name)->
-     register(Name, self()),
-     loop().
+init(Name)->
+    register(Name, self()),
+    loop().
 
- get_config()->
-     call(self(), get_config).
+get_config()->
+    call(self(), get_config).
 
- stop()->
-     call(self(), stop).
+stop()->
+    call(self(), stop).
 
- call(Client, Request)->
-     case whereis(?REGISTERED_NAME) of
-         undefined->
-             {error, {not_started, Request}};
-         Pid->
-             Pid ! {Client, Request},
-             receive
-                 Reply->
-                     {ok, Reply}
-             after 4000->
-                 {error, {timeout, Request}}
-             end
-     end.
+call(Client, Request)->
+    case whereis(?REGISTERED_NAME) of
+        undefined->
+            {error, {not_started, Request}};
+        Pid->
+            Pid ! {Client, Request},
+            receive
+                Reply->
+                    {ok, Reply}
+            after 4000->
+                {error, {timeout, Request}}
+            end
+    end.
 
- loop()->
-     receive
-         {Pid, stop}->
-             Pid ! ok;
-         {Pid, get_config}->
-             {D,T} = erlang:localtime(),
-             Pid !
-                 [{localtime, [{date, D}, {time, T}]},
-                  {node, erlang:node()},
-                  {now, erlang:now()},
-                  {config_server_pid, self()},
-                  {config_server_vsn, ?vsn}],
-             ?MODULE:loop()
-     end.
+loop()->
+    receive
+        {Pid, stop}->
+            Pid ! ok;
+        {Pid, get_config}->
+            {D,T} = erlang:localtime(),
+            Pid !
+                [{localtime, [{date, D}, {time, T}]},
+                 {node, erlang:node()},
+                 {now, erlang:now()},
+                 {config_server_pid, self()},
+                 {config_server_vsn, ?vsn}],
+            ?MODULE:loop()
+    end.
 
- wait()->
-     case whereis(?REGISTERED_NAME) of
-         undefined->
-             wait();
-         _Pid->
-             ok
-     end.
+wait()->
+    case whereis(?REGISTERED_NAME) of
+        undefined->
+            wait();
+        _Pid->
+            ok
+    end.
 ```
 
 Here, the handler also provides for dynamically reloading of configuration

--- a/lib/common_test/doc/guides/cover_chapter.md
+++ b/lib/common_test/doc/guides/cover_chapter.md
@@ -68,7 +68,7 @@ specification file as you start `Common Test`. Do this by using flag `-cover`
 with [`ct_run`](ct_run_cmd.md), for example:
 
 ```text
- $ ct_run -dir $TESTOBJS/db -cover $TESTOBJS/db/config/db.coverspec
+$ ct_run -dir $TESTOBJS/db -cover $TESTOBJS/db/config/db.coverspec
 ```
 
 You can also pass the cover specification file name in a call to
@@ -106,46 +106,46 @@ Here follows the general configuration terms that are allowed in a cover
 specification file:
 
 ```erlang
- %% List of Nodes on which cover will be active during test.
- %% Nodes = [atom()]
- {nodes, Nodes}.
+%% List of Nodes on which cover will be active during test.
+%% Nodes = [atom()]
+{nodes, Nodes}.
 
- %% Files with previously exported cover data to include in analysis.
- %% CoverDataFiles = [string()]
- {import, CoverDataFiles}.
+%% Files with previously exported cover data to include in analysis.
+%% CoverDataFiles = [string()]
+{import, CoverDataFiles}.
 
- %% Cover data file to export from this session.
- %% CoverDataFile = string()
- {export, CoverDataFile}.
+%% Cover data file to export from this session.
+%% CoverDataFile = string()
+{export, CoverDataFile}.
 
- %% Cover analysis level.
- %% Level = details | overview
- {level, Level}.
+%% Cover analysis level.
+%% Level = details | overview
+{level, Level}.
 
- %% Directories to include in cover.
- %% Dirs = [string()]
- {incl_dirs, Dirs}.
+%% Directories to include in cover.
+%% Dirs = [string()]
+{incl_dirs, Dirs}.
 
- %% Directories, including subdirectories, to include.
- {incl_dirs_r, Dirs}.
+%% Directories, including subdirectories, to include.
+{incl_dirs_r, Dirs}.
 
- %% Specific modules to include in cover.
- %% Mods = [atom()]
- {incl_mods, Mods}.
+%% Specific modules to include in cover.
+%% Mods = [atom()]
+{incl_mods, Mods}.
 
- %% Directories to exclude in cover.
- {excl_dirs, Dirs}.
+%% Directories to exclude in cover.
+{excl_dirs, Dirs}.
 
- %% Directories, including subdirectories, to exclude.
- {excl_dirs_r, Dirs}.
+%% Directories, including subdirectories, to exclude.
+{excl_dirs_r, Dirs}.
 
- %% Specific modules to exclude in cover.
- {excl_mods, Mods}.
+%% Specific modules to exclude in cover.
+{excl_mods, Mods}.
 
- %% Cross cover compilation
- %% Tag = atom(), an identifier for a test run
- %% Mod = [atom()], modules to compile for accumulated analysis
- {cross,[{Tag,Mods}]}.
+%% Cross cover compilation
+%% Tag = atom(), an identifier for a test run
+%% Mod = [atom()], modules to compile for accumulated analysis
+{cross,[{Tag,Mods}]}.
 ```
 
 The terms `incl_dirs_r` and `excl_dirs_r` tell `Common Test` to search the
@@ -196,8 +196,8 @@ test runs. System `s1` contains a library module `m1` tested by test run `s1`
 and is included in the cover specification of `s1` as follows:
 
 ```text
- s1.cover:
-   {incl_mods,[m1]}.
+s1.cover:
+  {incl_mods,[m1]}.
 ```
 
 When analysing code coverage, the result for `m1` can be seen in the cover log
@@ -209,8 +209,8 @@ interesting to see which parts of `m1` that are covered by the `s2` tests. To do
 this, `m1` can be included also in the cover specification of `s2` as follows:
 
 ```text
- s2.cover:
-   {incl_mods,[m1]}.
+s2.cover:
+  {incl_mods,[m1]}.
 ```
 
 This gives an entry for `m1` also in the cover log for test run `s2`. The
@@ -221,8 +221,8 @@ comes in handy.
 If instead the cover specification for `s2` is like the following:
 
 ```erlang
- s2.cover:
-   {cross,[{s1,[m1]}]}.
+s2.cover:
+  {cross,[{s1,[m1]}]}.
 ```
 
 Then `m1` is cover compiled in test run `s2`, but not shown in the coverage log.
@@ -233,7 +233,7 @@ cross cover log for test run `s1`.
 The call to the analyze function must be as follows:
 
 ```erlang
- ct_cover:cross_cover_analyse(Level, [{s1,S1LogDir},{s2,S2LogDir}]).
+ct_cover:cross_cover_analyse(Level, [{s1,S1LogDir},{s2,S2LogDir}]).
 ```
 
 Here, `S1LogDir` and `S2LogDir` are the directories named `<TestName>.logs` for

--- a/lib/common_test/doc/guides/ct_hooks_chapter.md
+++ b/lib/common_test/doc/guides/ct_hooks_chapter.md
@@ -203,13 +203,13 @@ returning a tuple with `skip` or `fail`, and a reason as the result.
 _Example:_
 
 ```erlang
- pre_init_per_suite(SuiteName, Config, CTHState) ->
-   case db:connect() of
-     {error,_Reason} ->
-       {{fail, "Could not connect to DB"}, CTHState};
-     {ok, Handle} ->
-       {[{db_handle, Handle} | Config], CTHState#state{ handle = Handle }}
-   end.
+pre_init_per_suite(SuiteName, Config, CTHState) ->
+  case db:connect() of
+    {error,_Reason} ->
+      {{fail, "Could not connect to DB"}, CTHState};
+    {ok, Handle} ->
+      {[{db_handle, Handle} | Config], CTHState#state{ handle = Handle }}
+  end.
 ```
 
 > #### Note {: .info }
@@ -251,18 +251,18 @@ pre hooks, it is also possible to fail/skip the test case in the post hook.
 _Example:_
 
 ```erlang
- post_end_per_testcase(_Suite, _TC, Config, {'EXIT',{_,_}}, CTHState) ->
-   case db:check_consistency() of
-     true ->
-       %% DB is good, pass the test.
-       {proplists:delete(tc_status, Config), CTHState};
-     false ->
-       %% DB is not good, mark as skipped instead of failing
-       {{skip, "DB is inconsistent!"}, CTHState}
-   end;
- post_end_per_testcase(_Suite, _TC, Config, Return, CTHState) ->
-   %% Do nothing if tc does not crash.
-   {Return, CTHState}.
+post_end_per_testcase(_Suite, _TC, Config, {'EXIT',{_,_}}, CTHState) ->
+  case db:check_consistency() of
+    true ->
+      %% DB is good, pass the test.
+      {proplists:delete(tc_status, Config), CTHState};
+    false ->
+      %% DB is not good, mark as skipped instead of failing
+      {{skip, "DB is inconsistent!"}, CTHState}
+  end;
+post_end_per_testcase(_Suite, _TC, Config, Return, CTHState) ->
+  %% Do nothing if tc does not crash.
+  {Return, CTHState}.
 ```
 
 > #### Note {: .info }

--- a/lib/common_test/doc/guides/ct_master_chapter.md
+++ b/lib/common_test/doc/guides/ct_master_chapter.md
@@ -58,8 +58,8 @@ merged into one combined specification before test execution.
 
 _Example:_
 
-```text
- ct_master:run(["ts1","ts2",["ts3","ts4"]])
+```erlang
+ct_master:run(["ts1","ts2",["ts3","ts4"]])
 ```
 
 Here, the tests specified by "ts1" run first, then the tests specified by "ts2",
@@ -133,32 +133,32 @@ Running Tests and Analysing Results, now extended with node information and
 intended to be executed by `Common Test` Master:
 
 ```erlang
- {define, 'Top', "/home/test"}.
- {define, 'T1', "'Top'/t1"}.
- {define, 'T2', "'Top'/t2"}.
- {define, 'T3', "'Top'/t3"}.
- {define, 'CfgFile', "config.cfg"}.
- {define, 'Node', ct_node}.
+{define, 'Top', "/home/test"}.
+{define, 'T1', "'Top'/t1"}.
+{define, 'T2', "'Top'/t2"}.
+{define, 'T3', "'Top'/t3"}.
+{define, 'CfgFile', "config.cfg"}.
+{define, 'Node', ct_node}.
 
- {node, node1, 'Node@host_x'}.
- {node, node2, 'Node@host_y'}.
+{node, node1, 'Node@host_x'}.
+{node, node2, 'Node@host_y'}.
 
- {logdir, master, "'Top'/master_logs"}.
- {logdir, "'Top'/logs"}.
+{logdir, master, "'Top'/master_logs"}.
+{logdir, "'Top'/logs"}.
 
- {config, node1, "'T1'/'CfgFile'"}.
- {config, node2, "'T2'/'CfgFile'"}.
- {config, "'T3'/'CfgFile'"}.
+{config, node1, "'T1'/'CfgFile'"}.
+{config, node2, "'T2'/'CfgFile'"}.
+{config, "'T3'/'CfgFile'"}.
 
- {suites, node1, 'T1', all}.
- {skip_suites, node1, 'T1', [t1B_SUITE,t1D_SUITE], "Not implemented"}.
- {skip_cases, node1, 'T1', t1A_SUITE, [test3,test4], "Irrelevant"}.
- {skip_cases, node1, 'T1', t1C_SUITE, [test1], "Ignore"}.
+{suites, node1, 'T1', all}.
+{skip_suites, node1, 'T1', [t1B_SUITE,t1D_SUITE], "Not implemented"}.
+{skip_cases, node1, 'T1', t1A_SUITE, [test3,test4], "Irrelevant"}.
+{skip_cases, node1, 'T1', t1C_SUITE, [test1], "Ignore"}.
 
- {suites, node2, 'T2', [t2B_SUITE,t2C_SUITE]}.
- {cases, node2, 'T2', t2A_SUITE, [test4,test1,test7]}.
+{suites, node2, 'T2', [t2B_SUITE,t2C_SUITE]}.
+{cases, node2, 'T2', t2A_SUITE, [test4,test1,test7]}.
 
- {skip_suites, 'T3', all, "Not implemented"}.
+{skip_suites, 'T3', all, "Not implemented"}.
 ```
 
 This example specifies the same tests as the original example. But now if
@@ -195,13 +195,13 @@ Two subterms are supported, `node_start` and `eval`.
 _Example:_
 
 ```erlang
- {node, node1, node1@host1}.
- {node, node2, node1@host2}.
- {node, node3, node2@host2}.
- {node, node4, node1@host3}.
- {init, node1, [{node_start, [{callback_module, my_slave_callback}]}]}.
- {init, [node2, node3], {node_start, [{username, "ct_user"}, {password, "ct_password"}]}}.
- {init, node4, {eval, {module, function, []}}}.
+{node, node1, node1@host1}.
+{node, node2, node1@host2}.
+{node, node3, node2@host2}.
+{node, node4, node1@host3}.
+{init, node1, [{node_start, [{callback_module, my_slave_callback}]}]}.
+{init, [node2, node3], {node_start, [{username, "ct_user"}, {password, "ct_password"}]}}.
+{init, node4, {eval, {module, function, []}}}.
 ```
 
 This test specification declares that `node1@host1` is to be started using the

--- a/lib/common_test/doc/guides/event_handler_chapter.md
+++ b/lib/common_test/doc/guides/event_handler_chapter.md
@@ -81,18 +81,18 @@ An event_handler tuple in argument `Opts` has the following definition (see
 `ct:run_test/1`):
 
 ```erlang
- {event_handler,EventHandlers}
+{event_handler,EventHandlers}
 
- EventHandlers = EH | [EH]
- EH = atom() | {atom(),InitArgs} | {[atom()],InitArgs}
- InitArgs = [term()]
+EventHandlers = EH | [EH]
+EH = atom() | {atom(),InitArgs} | {[atom()],InitArgs}
+InitArgs = [term()]
 ```
 
 In the following example, two event handlers for the `my_SUITE` test are
 installed:
 
 ```erlang
- 1> ct:run_test([{suite,"test/my_SUITE"},{event_handler,[my_evh1,{my_evh2,[node()]}]}]).
+1> ct:run_test([{suite,"test/my_SUITE"},{event_handler,[my_evh1,{my_evh2,[node()]}]}]).
 ```
 
 Event handler `my_evh1` is started with `[]` as argument to the init function.

--- a/lib/common_test/doc/guides/example_chapter.md
+++ b/lib/common_test/doc/guides/example_chapter.md
@@ -26,129 +26,129 @@ limitations under the License.
 The following example test suite shows some tests of a database server:
 
 ```erlang
- -module(db_data_type_SUITE).
+-module(db_data_type_SUITE).
 
- -include_lib("common_test/include/ct.hrl").
+-include_lib("common_test/include/ct.hrl").
 
- %% Test server callbacks
- -export([suite/0, all/0,
-	  init_per_suite/1, end_per_suite/1,
-	  init_per_testcase/2, end_per_testcase/2]).
+%% Test server callbacks
+-export([suite/0, all/0,
+         init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
 
- %% Test cases
- -export([string/1, integer/1]).
+%% Test cases
+-export([string/1, integer/1]).
 
- -define(CONNECT_STR, "DSN=sqlserver;UID=alladin;PWD=sesame").
+-define(CONNECT_STR, "DSN=sqlserver;UID=alladin;PWD=sesame").
 
- %%--------------------------------------------------------------------
- %% COMMON TEST CALLBACK FUNCTIONS
- %%--------------------------------------------------------------------
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
 
- %%--------------------------------------------------------------------
- %% Function: suite() -> Info
- %%
- %% Info = [tuple()]
- %%   List of key/value pairs.
- %%
- %% Description: Returns list of tuples to set default properties
- %%              for the suite.
- %%--------------------------------------------------------------------
- suite() ->
-     [{timetrap,{minutes,1}}].
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%%
+%% Info = [tuple()]
+%%   List of key/value pairs.
+%%
+%% Description: Returns list of tuples to set default properties
+%%              for the suite.
+%%--------------------------------------------------------------------
+suite() ->
+    [{timetrap,{minutes,1}}].
 
- %%--------------------------------------------------------------------
- %% Function: init_per_suite(Config0) -> Config1
- %%
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %%
- %% Description: Initialization before the suite.
- %%--------------------------------------------------------------------
- init_per_suite(Config) ->
-     {ok, Ref} = db:connect(?CONNECT_STR, []),
-     TableName = db_lib:unique_table_name(),
-     [{con_ref, Ref },{table_name, TableName}| Config].
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) -> Config1
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Initialization before the suite.
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    {ok, Ref} = db:connect(?CONNECT_STR, []),
+    TableName = db_lib:unique_table_name(),
+    [{con_ref, Ref },{table_name, TableName}| Config].
 
- %%--------------------------------------------------------------------
- %% Function: end_per_suite(Config) -> term()
- %%
- %% Config = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %%
- %% Description: Cleanup after the suite.
- %%--------------------------------------------------------------------
- end_per_suite(Config) ->
-     Ref = proplists:get_value(con_ref, Config),
-     db:disconnect(Ref),
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config) -> term()
+%%
+%% Config = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Cleanup after the suite.
+%%--------------------------------------------------------------------
+end_per_suite(Config) ->
+    Ref = proplists:get_value(con_ref, Config),
+    db:disconnect(Ref),
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: init_per_testcase(TestCase, Config0) -> Config1
- %%
- %% TestCase = atom()
- %%   Name of the test case that is about to run.
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %%
- %% Description: Initialization before each test case.
- %%--------------------------------------------------------------------
- init_per_testcase(Case, Config) ->
-     Ref = proplists:get_value(con_ref, Config),
-     TableName = proplists:get_value(table_name, Config),
-     ok = db:create_table(Ref, TableName, table_type(Case)),
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_testcase(TestCase, Config0) -> Config1
+%%
+%% TestCase = atom()
+%%   Name of the test case that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Initialization before each test case.
+%%--------------------------------------------------------------------
+init_per_testcase(Case, Config) ->
+    Ref = proplists:get_value(con_ref, Config),
+    TableName = proplists:get_value(table_name, Config),
+    ok = db:create_table(Ref, TableName, table_type(Case)),
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_testcase(TestCase, Config) -> term()
- %%
- %% TestCase = atom()
- %%   Name of the test case that is finished.
- %% Config = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %%
- %% Description: Cleanup after each test case.
- %%--------------------------------------------------------------------
- end_per_testcase(_Case, Config) ->
-     Ref = proplists:get_value(con_ref, Config),
-     TableName = proplists:get_value(table_name, Config),
-     ok = db:delete_table(Ref, TableName),
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_testcase(TestCase, Config) -> term()
+%%
+%% TestCase = atom()
+%%   Name of the test case that is finished.
+%% Config = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Cleanup after each test case.
+%%--------------------------------------------------------------------
+end_per_testcase(_Case, Config) ->
+    Ref = proplists:get_value(con_ref, Config),
+    TableName = proplists:get_value(table_name, Config),
+    ok = db:delete_table(Ref, TableName),
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: all() -> GroupsAndTestCases
- %%
- %% GroupsAndTestCases = [{group,GroupName} | TestCase]
- %% GroupName = atom()
- %%   Name of a test case group.
- %% TestCase = atom()
- %%   Name of a test case.
- %%
- %% Description: Returns the list of groups and test cases that
- %%              are to be executed.
- %%--------------------------------------------------------------------
- all() ->
-     [string, integer].
-
-
- %%--------------------------------------------------------------------
- %% TEST CASES
- %%--------------------------------------------------------------------
-
- string(Config) ->
-     insert_and_lookup(dummy_key, "Dummy string", Config).
-
- integer(Config) ->
-     insert_and_lookup(dummy_key, 42, Config).
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases
+%%
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%%   Name of a test case group.
+%% TestCase = atom()
+%%   Name of a test case.
+%%
+%% Description: Returns the list of groups and test cases that
+%%              are to be executed.
+%%--------------------------------------------------------------------
+all() ->
+    [string, integer].
 
 
- insert_and_lookup(Key, Value, Config) ->
-     Ref = proplists:get_value(con_ref, Config),
-     TableName = proplists:get_value(table_name, Config),
-     ok = db:insert(Ref, TableName, Key, Value),
-     [Value] = db:lookup(Ref, TableName, Key),
-     ok = db:delete(Ref, TableName, Key),
-     [] = db:lookup(Ref, TableName, Key),
-     ok.
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+string(Config) ->
+    insert_and_lookup(dummy_key, "Dummy string", Config).
+
+integer(Config) ->
+    insert_and_lookup(dummy_key, 42, Config).
+
+
+insert_and_lookup(Key, Value, Config) ->
+    Ref = proplists:get_value(con_ref, Config),
+    TableName = proplists:get_value(table_name, Config),
+    ok = db:insert(Ref, TableName, Key, Value),
+    [Value] = db:lookup(Ref, TableName, Key),
+    ok = db:delete(Ref, TableName, Key),
+    [] = db:lookup(Ref, TableName, Key),
+    ok.
 ```
 
 ## Test Suite Templates
@@ -161,332 +161,332 @@ callback functions. The two templates follows:
 
 _Large Common Test Suite_
 
-```text
- %%%-------------------------------------------------------------------
- %%% File    : example_SUITE.erl
- %%% Author  :
- %%% Description :
- %%%
- %%% Created :
- %%%-------------------------------------------------------------------
- -module(example_SUITE).
+```erlang
+%%%-------------------------------------------------------------------
+%%% File    : example_SUITE.erl
+%%% Author  :
+%%% Description :
+%%%
+%%% Created :
+%%%-------------------------------------------------------------------
+-module(example_SUITE).
 
- %% Note: This directive should only be used in test suites.
- -compile(export_all).
+%% Note: This directive should only be used in test suites.
+-compile(export_all).
 
- -include_lib("common_test/include/ct.hrl").
+-include_lib("common_test/include/ct.hrl").
 
- %%--------------------------------------------------------------------
- %% COMMON TEST CALLBACK FUNCTIONS
- %%--------------------------------------------------------------------
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
 
- %%--------------------------------------------------------------------
- %% Function: suite() -> Info
- %%
- %% Info = [tuple()]
- %%   List of key/value pairs.
- %%
- %% Description: Returns list of tuples to set default properties
- %%              for the suite.
- %%
- %% Note: The suite/0 function is only meant to be used to return
- %% default data values, not perform any other operations.
- %%--------------------------------------------------------------------
- suite() ->
-     [{timetrap,{minutes,10}}].
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%%
+%% Info = [tuple()]
+%%   List of key/value pairs.
+%%
+%% Description: Returns list of tuples to set default properties
+%%              for the suite.
+%%
+%% Note: The suite/0 function is only meant to be used to return
+%% default data values, not perform any other operations.
+%%--------------------------------------------------------------------
+suite() ->
+    [{timetrap,{minutes,10}}].
 
- %%--------------------------------------------------------------------
- %% Function: init_per_suite(Config0) ->
- %%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
- %%
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %% Reason = term()
- %%   The reason for skipping the suite.
- %%
- %% Description: Initialization before the suite.
- %%
- %% Note: This function is free to add any key/value pairs to the Config
- %% variable, but should NOT alter/remove any existing entries.
- %%--------------------------------------------------------------------
- init_per_suite(Config) ->
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the suite.
+%%
+%% Description: Initialization before the suite.
+%%
+%% Note: This function is free to add any key/value pairs to the Config
+%% variable, but should NOT alter/remove any existing entries.
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_suite(Config0) -> term() | {save_config,Config1}
- %%
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %%
- %% Description: Cleanup after the suite.
- %%--------------------------------------------------------------------
- end_per_suite(_Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> term() | {save_config,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%%
+%% Description: Cleanup after the suite.
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: init_per_group(GroupName, Config0) ->
- %%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
- %%
- %% GroupName = atom()
- %%   Name of the test case group that is about to run.
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding configuration data for the group.
- %% Reason = term()
- %%   The reason for skipping all test cases and subgroups in the group.
- %%
- %% Description: Initialization before each test case group.
- %%--------------------------------------------------------------------
- init_per_group(_GroupName, Config) ->
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% GroupName = atom()
+%%   Name of the test case group that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding configuration data for the group.
+%% Reason = term()
+%%   The reason for skipping all test cases and subgroups in the group.
+%%
+%% Description: Initialization before each test case group.
+%%--------------------------------------------------------------------
+init_per_group(_GroupName, Config) ->
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_group(GroupName, Config0) ->
- %%               term() | {save_config,Config1}
- %%
- %% GroupName = atom()
- %%   Name of the test case group that is finished.
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding configuration data for the group.
- %%
- %% Description: Cleanup after each test case group.
- %%--------------------------------------------------------------------
- end_per_group(_GroupName, _Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_group(GroupName, Config0) ->
+%%               term() | {save_config,Config1}
+%%
+%% GroupName = atom()
+%%   Name of the test case group that is finished.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding configuration data for the group.
+%%
+%% Description: Cleanup after each test case group.
+%%--------------------------------------------------------------------
+end_per_group(_GroupName, _Config) ->
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: init_per_testcase(TestCase, Config0) ->
- %%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
- %%
- %% TestCase = atom()
- %%   Name of the test case that is about to run.
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %% Reason = term()
- %%   The reason for skipping the test case.
- %%
- %% Description: Initialization before each test case.
- %%
- %% Note: This function is free to add any key/value pairs to the Config
- %% variable, but should NOT alter/remove any existing entries.
- %%--------------------------------------------------------------------
- init_per_testcase(_TestCase, Config) ->
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%
+%% TestCase = atom()
+%%   Name of the test case that is about to run.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the test case.
+%%
+%% Description: Initialization before each test case.
+%%
+%% Note: This function is free to add any key/value pairs to the Config
+%% variable, but should NOT alter/remove any existing entries.
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_testcase(TestCase, Config0) ->
- %%               term() | {save_config,Config1} | {fail,Reason}
- %%
- %% TestCase = atom()
- %%   Name of the test case that is finished.
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %% Reason = term()
- %%   The reason for failing the test case.
- %%
- %% Description: Cleanup after each test case.
- %%--------------------------------------------------------------------
- end_per_testcase(_TestCase, _Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_testcase(TestCase, Config0) ->
+%%               term() | {save_config,Config1} | {fail,Reason}
+%%
+%% TestCase = atom()
+%%   Name of the test case that is finished.
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for failing the test case.
+%%
+%% Description: Cleanup after each test case.
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, _Config) ->
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: groups() -> [Group]
- %%
- %% Group = {GroupName,Properties,GroupsAndTestCases}
- %% GroupName = atom()
- %%   The name of the group.
- %% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
- %%   Group properties that may be combined.
- %% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
- %% TestCase = atom()
- %%   The name of a test case.
- %% Shuffle = shuffle | {shuffle,Seed}
- %%   To get cases executed in random order.
- %% Seed = {integer(),integer(),integer()}
- %% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
- %%              repeat_until_any_ok | repeat_until_any_fail
- %%   To get execution of cases repeated.
- %% N = integer() | forever
- %%
- %% Description: Returns a list of test case group definitions.
- %%--------------------------------------------------------------------
- groups() ->
-     [].
+%%--------------------------------------------------------------------
+%% Function: groups() -> [Group]
+%%
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%%   The name of the group.
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%%   Group properties that may be combined.
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%%   The name of a test case.
+%% Shuffle = shuffle | {shuffle,Seed}
+%%   To get cases executed in random order.
+%% Seed = {integer(),integer(),integer()}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%%   To get execution of cases repeated.
+%% N = integer() | forever
+%%
+%% Description: Returns a list of test case group definitions.
+%%--------------------------------------------------------------------
+groups() ->
+    [].
 
- %%--------------------------------------------------------------------
- %% Function: all() -> GroupsAndTestCases | {skip,Reason}
- %%
- %% GroupsAndTestCases = [{group,GroupName} | TestCase]
- %% GroupName = atom()
- %%   Name of a test case group.
- %% TestCase = atom()
- %%   Name of a test case.
- %% Reason = term()
- %%   The reason for skipping all groups and test cases.
- %%
- %% Description: Returns the list of groups and test cases that
- %%              are to be executed.
- %%--------------------------------------------------------------------
- all() ->
-     [my_test_case].
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases | {skip,Reason}
+%%
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%%   Name of a test case group.
+%% TestCase = atom()
+%%   Name of a test case.
+%% Reason = term()
+%%   The reason for skipping all groups and test cases.
+%%
+%% Description: Returns the list of groups and test cases that
+%%              are to be executed.
+%%--------------------------------------------------------------------
+all() ->
+    [my_test_case].
 
 
- %%--------------------------------------------------------------------
- %% TEST CASES
- %%--------------------------------------------------------------------
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
 
- %%--------------------------------------------------------------------
- %% Function: TestCase() -> Info
- %%
- %% Info = [tuple()]
- %%   List of key/value pairs.
- %%
- %% Description: Test case info function - returns list of tuples to set
- %%              properties for the test case.
- %%
- %% Note: This function is only meant to be used to return a list of
- %% values, not perform any other operations.
- %%--------------------------------------------------------------------
- my_test_case() ->
-     [].
+%%--------------------------------------------------------------------
+%% Function: TestCase() -> Info
+%%
+%% Info = [tuple()]
+%%   List of key/value pairs.
+%%
+%% Description: Test case info function - returns list of tuples to set
+%%              properties for the test case.
+%%
+%% Note: This function is only meant to be used to return a list of
+%% values, not perform any other operations.
+%%--------------------------------------------------------------------
+my_test_case() ->
+    [].
 
- %%--------------------------------------------------------------------
- %% Function: TestCase(Config0) ->
- %%               ok | exit() | {skip,Reason} | {comment,Comment} |
- %%               {save_config,Config1} | {skip_and_save,Reason,Config1}
- %%
- %% Config0 = Config1 = [tuple()]
- %%   A list of key/value pairs, holding the test case configuration.
- %% Reason = term()
- %%   The reason for skipping the test case.
- %% Comment = term()
- %%   A comment about the test case that will be printed in the html log.
- %%
- %% Description: Test case function. (The name of it must be specified in
- %%              the all/0 list or in a test case group for the test case
- %%              to be executed).
- %%--------------------------------------------------------------------
- my_test_case(_Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: TestCase(Config0) ->
+%%               ok | exit() | {skip,Reason} | {comment,Comment} |
+%%               {save_config,Config1} | {skip_and_save,Reason,Config1}
+%%
+%% Config0 = Config1 = [tuple()]
+%%   A list of key/value pairs, holding the test case configuration.
+%% Reason = term()
+%%   The reason for skipping the test case.
+%% Comment = term()
+%%   A comment about the test case that will be printed in the html log.
+%%
+%% Description: Test case function. (The name of it must be specified in
+%%              the all/0 list or in a test case group for the test case
+%%              to be executed).
+%%--------------------------------------------------------------------
+my_test_case(_Config) ->
+    ok.
 ```
 
 _Small Common Test Suite_
 
 ```erlang
- %%%-------------------------------------------------------------------
- %%% File    : example_SUITE.erl
- %%% Author  :
- %%% Description :
- %%%
- %%% Created :
- %%%-------------------------------------------------------------------
- -module(example_SUITE).
+%%%-------------------------------------------------------------------
+%%% File    : example_SUITE.erl
+%%% Author  :
+%%% Description :
+%%%
+%%% Created :
+%%%-------------------------------------------------------------------
+-module(example_SUITE).
 
- -compile(export_all).
+-compile(export_all).
 
- -include_lib("common_test/include/ct.hrl").
+-include_lib("common_test/include/ct.hrl").
 
- %%--------------------------------------------------------------------
- %% Function: suite() -> Info
- %% Info = [tuple()]
- %%--------------------------------------------------------------------
- suite() ->
-     [{timetrap,{seconds,30}}].
+%%--------------------------------------------------------------------
+%% Function: suite() -> Info
+%% Info = [tuple()]
+%%--------------------------------------------------------------------
+suite() ->
+    [{timetrap,{seconds,30}}].
 
- %%--------------------------------------------------------------------
- %% Function: init_per_suite(Config0) ->
- %%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
- %% Config0 = Config1 = [tuple()]
- %% Reason = term()
- %%--------------------------------------------------------------------
- init_per_suite(Config) ->
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_suite(Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_suite(Config0) -> term() | {save_config,Config1}
- %% Config0 = Config1 = [tuple()]
- %%--------------------------------------------------------------------
- end_per_suite(_Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_suite(Config0) -> term() | {save_config,Config1}
+%% Config0 = Config1 = [tuple()]
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: init_per_group(GroupName, Config0) ->
- %%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
- %% GroupName = atom()
- %% Config0 = Config1 = [tuple()]
- %% Reason = term()
- %%--------------------------------------------------------------------
- init_per_group(_GroupName, Config) ->
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_group(GroupName, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+init_per_group(_GroupName, Config) ->
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_group(GroupName, Config0) ->
- %%               term() | {save_config,Config1}
- %% GroupName = atom()
- %% Config0 = Config1 = [tuple()]
- %%--------------------------------------------------------------------
- end_per_group(_GroupName, _Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_group(GroupName, Config0) ->
+%%               term() | {save_config,Config1}
+%% GroupName = atom()
+%% Config0 = Config1 = [tuple()]
+%%--------------------------------------------------------------------
+end_per_group(_GroupName, _Config) ->
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: init_per_testcase(TestCase, Config0) ->
- %%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
- %% TestCase = atom()
- %% Config0 = Config1 = [tuple()]
- %% Reason = term()
- %%--------------------------------------------------------------------
- init_per_testcase(_TestCase, Config) ->
-     Config.
+%%--------------------------------------------------------------------
+%% Function: init_per_testcase(TestCase, Config0) ->
+%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+    Config.
 
- %%--------------------------------------------------------------------
- %% Function: end_per_testcase(TestCase, Config0) ->
- %%               term() | {save_config,Config1} | {fail,Reason}
- %% TestCase = atom()
- %% Config0 = Config1 = [tuple()]
- %% Reason = term()
- %%--------------------------------------------------------------------
- end_per_testcase(_TestCase, _Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: end_per_testcase(TestCase, Config0) ->
+%%               term() | {save_config,Config1} | {fail,Reason}
+%% TestCase = atom()
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, _Config) ->
+    ok.
 
- %%--------------------------------------------------------------------
- %% Function: groups() -> [Group]
- %% Group = {GroupName,Properties,GroupsAndTestCases}
- %% GroupName = atom()
- %% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
- %% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
- %% TestCase = atom()
- %% Shuffle = shuffle | {shuffle,{integer(),integer(),integer()}}
- %% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
- %%              repeat_until_any_ok | repeat_until_any_fail
- %% N = integer() | forever
- %%--------------------------------------------------------------------
- groups() ->
-     [].
+%%--------------------------------------------------------------------
+%% Function: groups() -> [Group]
+%% Group = {GroupName,Properties,GroupsAndTestCases}
+%% GroupName = atom()
+%% Properties = [parallel | sequence | Shuffle | {RepeatType,N}]
+%% GroupsAndTestCases = [Group | {group,GroupName} | TestCase]
+%% TestCase = atom()
+%% Shuffle = shuffle | {shuffle,{integer(),integer(),integer()}}
+%% RepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+%%              repeat_until_any_ok | repeat_until_any_fail
+%% N = integer() | forever
+%%--------------------------------------------------------------------
+groups() ->
+    [].
 
- %%--------------------------------------------------------------------
- %% Function: all() -> GroupsAndTestCases | {skip,Reason}
- %% GroupsAndTestCases = [{group,GroupName} | TestCase]
- %% GroupName = atom()
- %% TestCase = atom()
- %% Reason = term()
- %%--------------------------------------------------------------------
- all() ->
-     [my_test_case].
+%%--------------------------------------------------------------------
+%% Function: all() -> GroupsAndTestCases | {skip,Reason}
+%% GroupsAndTestCases = [{group,GroupName} | TestCase]
+%% GroupName = atom()
+%% TestCase = atom()
+%% Reason = term()
+%%--------------------------------------------------------------------
+all() ->
+    [my_test_case].
 
- %%--------------------------------------------------------------------
- %% Function: TestCase() -> Info
- %% Info = [tuple()]
- %%--------------------------------------------------------------------
- my_test_case() ->
-     [].
+%%--------------------------------------------------------------------
+%% Function: TestCase() -> Info
+%% Info = [tuple()]
+%%--------------------------------------------------------------------
+my_test_case() ->
+    [].
 
- %%--------------------------------------------------------------------
- %% Function: TestCase(Config0) ->
- %%               ok | exit() | {skip,Reason} | {comment,Comment} |
- %%               {save_config,Config1} | {skip_and_save,Reason,Config1}
- %% Config0 = Config1 = [tuple()]
- %% Reason = term()
- %% Comment = term()
- %%--------------------------------------------------------------------
- my_test_case(_Config) ->
-     ok.
+%%--------------------------------------------------------------------
+%% Function: TestCase(Config0) ->
+%%               ok | exit() | {skip,Reason} | {comment,Comment} |
+%%               {save_config,Config1} | {skip_and_save,Reason,Config1}
+%% Config0 = Config1 = [tuple()]
+%% Reason = term()
+%% Comment = term()
+%%--------------------------------------------------------------------
+my_test_case(_Config) ->
+    ok.
 ```

--- a/lib/common_test/doc/guides/getting_started_chapter.md
+++ b/lib/common_test/doc/guides/getting_started_chapter.md
@@ -81,14 +81,14 @@ without configuration functions, including one simple test case, to check that
 module `mymod` exists (that is, can be successfully loaded by the code server):
 
 ```erlang
- -module(my1st_SUITE).
- -compile(export_all).
+-module(my1st_SUITE).
+-compile(export_all).
 
- all() ->
-     [mod_exists].
+all() ->
+    [mod_exists].
 
- mod_exists(_) ->
-     {module,mymod} = code:load_file(mymod).
+mod_exists(_) ->
+    {module,mymod} = code:load_file(mymod).
 ```
 
 If the operation fails, a bad match error occurs that terminates the test case.
@@ -109,30 +109,30 @@ open and close a log file for the test cases (an operation that is unnecessary
 and irrelevant to perform by each test case):
 
 ```erlang
- -module(check_log_SUITE).
- -export([all/0, init_per_suite/1, end_per_suite/1]).
- -export([check_restart_result/1, check_no_errors/1]).
+-module(check_log_SUITE).
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([check_restart_result/1, check_no_errors/1]).
 
- -define(value(Key,Config), proplists:get_value(Key,Config)).
+-define(value(Key,Config), proplists:get_value(Key,Config)).
 
- all() -> [check_restart_result, check_no_errors].
+all() -> [check_restart_result, check_no_errors].
 
- init_per_suite(InitConfigData) ->
-     [{logref,open_log()} | InitConfigData].
+init_per_suite(InitConfigData) ->
+    [{logref,open_log()} | InitConfigData].
 
- end_per_suite(ConfigData) ->
-     close_log(?value(logref, ConfigData)).
+end_per_suite(ConfigData) ->
+    close_log(?value(logref, ConfigData)).
 
- check_restart_result(ConfigData) ->
-     TestData = read_log(restart, ?value(logref, ConfigData)),
-     {match,_Line} = search_for("restart successful", TestData).
+check_restart_result(ConfigData) ->
+    TestData = read_log(restart, ?value(logref, ConfigData)),
+    {match,_Line} = search_for("restart successful", TestData).
 
- check_no_errors(ConfigData) ->
-     TestData = read_log(all, ?value(logref, ConfigData)),
-     case search_for("error", TestData) of
-	 {match,Line} -> ct:fail({error_found_in_log,Line});
-	 nomatch -> ok
-     end.
+check_no_errors(ConfigData) ->
+    TestData = read_log(all, ?value(logref, ConfigData)),
+    case search_for("error", TestData) of
+        {match,Line} -> ct:fail({error_found_in_log,Line});
+        nomatch -> ok
+    end.
 ```
 
 The test cases verify, by parsing a log file, that our SUT has performed a
@@ -143,25 +143,25 @@ UNIX/Linux command line (assuming that the suite module is in the current
 working directory):
 
 ```text
- $ ct_run -dir .
+$ ct_run -dir .
 ```
 
 or:
 
 ```text
- $ ct_run -suite check_log_SUITE
+$ ct_run -suite check_log_SUITE
 ```
 
 To use the Erlang shell to run our test, you can evaluate the following call:
 
 ```erlang
- 1> ct:run_test([{dir, "."}]).
+1> ct:run_test([{dir, "."}]).
 ```
 
 or:
 
 ```erlang
- 1> ct:run_test([{suite, "check_log_SUITE"}]).
+1> ct:run_test([{suite, "check_log_SUITE"}]).
 ```
 
 The result from running the test is printed in log files in HTML format (stored

--- a/lib/common_test/doc/guides/run_test_chapter.md
+++ b/lib/common_test/doc/guides/run_test_chapter.md
@@ -106,24 +106,24 @@ command line, for example, as follows:
 _Examples:_
 
 ```text
- $ ct_run -config $CFGS/sys1.cfg $CFGS/sys2.cfg -dir $SYS1_TEST $SYS2_TEST
- $ ct_run -userconfig ct_config_xml $CFGS/sys1.xml $CFGS/sys2.xml -dir $SYS1_TEST $SYS2_TEST
- $ ct_run -suite $SYS1_TEST/setup_SUITE $SYS2_TEST/config_SUITE
- $ ct_run -suite $SYS1_TEST/setup_SUITE -case start stop
- $ ct_run -suite $SYS1_TEST/setup_SUITE -group installation -case start stop
+$ ct_run -config $CFGS/sys1.cfg $CFGS/sys2.cfg -dir $SYS1_TEST $SYS2_TEST
+$ ct_run -userconfig ct_config_xml $CFGS/sys1.xml $CFGS/sys2.xml -dir $SYS1_TEST $SYS2_TEST
+$ ct_run -suite $SYS1_TEST/setup_SUITE $SYS2_TEST/config_SUITE
+$ ct_run -suite $SYS1_TEST/setup_SUITE -case start stop
+$ ct_run -suite $SYS1_TEST/setup_SUITE -group installation -case start stop
 ```
 
 The flags `dir`, `suite`, and `group/case` can be combined. For example, to run
 `x_SUITE` and `y_SUITE` in directory `testdir`, as follows:
 
 ```text
- $ ct_run -dir ./testdir -suite x_SUITE y_SUITE
+$ ct_run -dir ./testdir -suite x_SUITE y_SUITE
 ```
 
 This has the same effect as the following:
 
 ```text
- $ ct_run -suite ./testdir/x_SUITE ./testdir/y_SUITE
+$ ct_run -suite ./testdir/x_SUITE ./testdir/y_SUITE
 ```
 
 For details, see
@@ -264,7 +264,7 @@ If auto-skipped test cases do not affect the exit status. The default behavior
 can be changed using start flag:
 
 ```text
- -exit_status ignore_config
+-exit_status ignore_config
 ```
 
 > #### Note {: .info }
@@ -331,13 +331,13 @@ groups can be specified, optionally in combination with specific test cases. The
 syntax for specifying groups on the command line is as follows:
 
 ```text
- $ ct_run -group <group_names_or_paths> [-case <cases>]
+$ ct_run -group <group_names_or_paths> [-case <cases>]
 ```
 
 The syntax in the Erlang shell is as follows:
 
 ```erlang
- 1> ct:run_test([{group,GroupsNamesOrPaths}, {case,Cases}]).
+1> ct:run_test([{group,GroupsNamesOrPaths}, {case,Cases}]).
 ```
 
 Parameter `group_names_or_paths` specifies one or more group names and/or one or
@@ -405,60 +405,60 @@ configuration functions in order `g4..g3..g1`.
 _Examples:_
 
 ```erlang
- -module(x_SUITE).
- ...
- %% The group definitions:
- groups() ->
-   [{top1,[],[tc11,tc12,
-	      {sub11,[],[tc12,tc13]},
-	      {sub12,[],[tc14,tc15,
-			 {sub121,[],[tc12,tc16]}]}]},
+-module(x_SUITE).
+...
+%% The group definitions:
+groups() ->
+  [{top1,[],[tc11,tc12,
+             {sub11,[],[tc12,tc13]},
+             {sub12,[],[tc14,tc15,
+       		 {sub121,[],[tc12,tc16]}]}]},
 
-    {top2,[],[{group,sub21},{group,sub22}]},
-    {sub21,[],[tc21,{group,sub2X2}]},
-    {sub22,[],[{group,sub221},tc21,tc22,{group,sub2X2}]},
-    {sub221,[],[tc21,tc23]},
-    {sub2X2,[],[tc21,tc24]}].
+   {top2,[],[{group,sub21},{group,sub22}]},
+   {sub21,[],[tc21,{group,sub2X2}]},
+   {sub22,[],[{group,sub221},tc21,tc22,{group,sub2X2}]},
+   {sub221,[],[tc21,tc23]},
+   {sub2X2,[],[tc21,tc24]}].
 ```
 
 The following executes two tests, one for all cases and all subgroups under
 `top1`, and one for all under `top2`:
 
-```text
- $ ct_run -suite "x_SUITE" -group all
- 1> ct:run_test([{suite,"x_SUITE"}, {group,all}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group all
+1> ct:run_test([{suite,"x_SUITE"}, {group,all}]).
 ```
 
 Using `-group top1 top2`, or `{group,[top1,top2]}` gives the same result.
 
 The following executes one test for all cases and subgroups under `top1`:
 
-```text
- $ ct_run -suite "x_SUITE" -group top1
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[top1]}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group top1
+1> ct:run_test([{suite,"x_SUITE"}, {group,[top1]}]).
 ```
 
 The following runs a test executing `tc12` in `top1` and any subgroup under
 `top1` where it can be found (`sub11` and `sub121`):
 
-```text
- $ ct_run -suite "x_SUITE" -group top1 -case tc12
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[top1]}, {testcase,[tc12]}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group top1 -case tc12
+1> ct:run_test([{suite,"x_SUITE"}, {group,[top1]}, {testcase,[tc12]}]).
 ```
 
 The following executes `tc12` _only_ in group `top1`:
 
-```text
- $ ct_run -suite "x_SUITE" -group [top1] -case tc12
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[[top1]]}, {testcase,[tc12]}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group [top1] -case tc12
+1> ct:run_test([{suite,"x_SUITE"}, {group,[[top1]]}, {testcase,[tc12]}]).
 ```
 
 The following searches `top1` and all its subgroups for `tc16` resulting in that
 this test case executes in group `sub121`:
 
-```text
- $ ct_run -suite "x_SUITE" -group top1 -case tc16
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[top1]}, {testcase,[tc16]}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group top1 -case tc16
+1> ct:run_test([{suite,"x_SUITE"}, {group,[top1]}, {testcase,[tc16]}]).
 ```
 
 Using the specific path `-group [sub121]` or `{group,[[sub121]]}` gives the same
@@ -467,18 +467,18 @@ result in this example.
 The following executes two tests, one including all cases and subgroups under
 `sub12`, and one with _only_ the test cases in `sub12`:
 
-```text
- $ ct_run -suite "x_SUITE" -group sub12 [sub12]
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[sub12,[sub12]]}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group sub12 [sub12]
+1> ct:run_test([{suite,"x_SUITE"}, {group,[sub12,[sub12]]}]).
 ```
 
 In the following example, `Common Test` finds and executes two tests, one for
 the path from `top2` to `sub2X2` through `sub21`, and one from `top2` to
 `sub2X2` through `sub22`:
 
-```text
- $ ct_run -suite "x_SUITE" -group sub2X2
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[sub2X2]}]).
+```erlang
+$ ct_run -suite "x_SUITE" -group sub2X2
+1> ct:run_test([{suite,"x_SUITE"}, {group,[sub2X2]}]).
 ```
 
 In the following example, by specifying the unique path
@@ -486,16 +486,16 @@ In the following example, by specifying the unique path
 from `top2` to `sub2X2` (from the former example) is discarded:
 
 ```erlang
- $ ct_run -suite "x_SUITE" -group [sub21,sub2X2]
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[[sub21,sub2X2]]}]).
+$ ct_run -suite "x_SUITE" -group [sub21,sub2X2]
+1> ct:run_test([{suite,"x_SUITE"}, {group,[[sub21,sub2X2]]}]).
 ```
 
 The following executes only the test cases for `sub22` and in reverse order
 compared to the group definition:
 
 ```erlang
- $ ct_run -suite "x_SUITE" -group [sub22] -case tc22 tc21
- 1> ct:run_test([{suite,"x_SUITE"}, {group,[[sub22]]}, {testcase,[tc22,tc21]}]).
+$ ct_run -suite "x_SUITE" -group [sub22] -case tc22 tc21
+1> ct:run_test([{suite,"x_SUITE"}, {group,[[sub22]]}, {testcase,[tc22,tc21]}]).
 ```
 
 If a test case belonging to a group (according to the group definition) is
@@ -555,13 +555,12 @@ to a `require` statement in the
 _Example:_
 
 ```erlang
-
- 1> ct:require(unix_telnet, unix).
- ok
- 2> ct_telnet:open(unix_telnet).
- {ok,<0.105.0>}
- 4> ct_telnet:cmd(unix_telnet, "ls .").
- {ok,["ls .","file1  ...",...]}
+1> ct:require(unix_telnet, unix).
+ok
+2> ct_telnet:open(unix_telnet).
+{ok,<0.105.0>}
+4> ct_telnet:cmd(unix_telnet, "ls .").
+{ok,["ls .","file1  ...",...]}
 ```
 
 Everything that `Common Test` normally prints in the test case logs, are in the
@@ -680,11 +679,11 @@ above).
 _Example:_
 
 ```erlang
- %% In specification file "a.spec"
- {specs, join, ["b.spec", "c.spec"]}.
- {specs, separate, ["d.spec", "e.spec"]}.
- %% Config and test terms follow
- ...
+%% In specification file "a.spec"
+{specs, join, ["b.spec", "c.spec"]}.
+{specs, separate, ["d.spec", "e.spec"]}.
+%% Config and test terms follow
+...
 ```
 
 In this example, the test terms defined in files "b.spec" and "c.spec" are
@@ -768,160 +767,160 @@ sections in the User's Guide, for example, the following:
 _Configuration terms:_
 
 ```erlang
- {merge_tests, Bool}.
+{merge_tests, Bool}.
 
- {define, Constant, Value}.
+{define, Constant, Value}.
 
- {specs, InclSpecsOption, TestSpecs}.
+{specs, InclSpecsOption, TestSpecs}.
 
- {node, NodeAlias, Node}.
+{node, NodeAlias, Node}.
 
- {init, InitOptions}.
- {init, [NodeAlias], InitOptions}.
+{init, InitOptions}.
+{init, [NodeAlias], InitOptions}.
 
- {label, Label}.
- {label, NodeRefs, Label}.
+{label, Label}.
+{label, NodeRefs, Label}.
 
- {verbosity, VerbosityLevels}.
- {verbosity, NodeRefs, VerbosityLevels}.
+{verbosity, VerbosityLevels}.
+{verbosity, NodeRefs, VerbosityLevels}.
 
- {stylesheet, CSSFile}.
- {stylesheet, NodeRefs, CSSFile}.
+{stylesheet, CSSFile}.
+{stylesheet, NodeRefs, CSSFile}.
 
- {silent_connections, ConnTypes}.
- {silent_connections, NodeRefs, ConnTypes}.
+{silent_connections, ConnTypes}.
+{silent_connections, NodeRefs, ConnTypes}.
 
- {multiply_timetraps, N}.
- {multiply_timetraps, NodeRefs, N}.
+{multiply_timetraps, N}.
+{multiply_timetraps, NodeRefs, N}.
 
- {scale_timetraps, Bool}.
- {scale_timetraps, NodeRefs, Bool}.
+{scale_timetraps, Bool}.
+{scale_timetraps, NodeRefs, Bool}.
 
- {cover, CoverSpecFile}.
- {cover, NodeRefs, CoverSpecFile}.
+{cover, CoverSpecFile}.
+{cover, NodeRefs, CoverSpecFile}.
 
- {cover_stop, Bool}.
- {cover_stop, NodeRefs, Bool}.
+{cover_stop, Bool}.
+{cover_stop, NodeRefs, Bool}.
 
- {include, IncludeDirs}.
- {include, NodeRefs, IncludeDirs}.
+{include, IncludeDirs}.
+{include, NodeRefs, IncludeDirs}.
 
- {auto_compile, Bool},
- {auto_compile, NodeRefs, Bool},
+{auto_compile, Bool},
+{auto_compile, NodeRefs, Bool},
 
- {abort_if_missing_suites, Bool},
- {abort_if_missing_suites, NodeRefs, Bool},
+{abort_if_missing_suites, Bool},
+{abort_if_missing_suites, NodeRefs, Bool},
 
- {config, ConfigFiles}.
- {config, ConfigDir, ConfigBaseNames}.
- {config, NodeRefs, ConfigFiles}.
- {config, NodeRefs, ConfigDir, ConfigBaseNames}.
+{config, ConfigFiles}.
+{config, ConfigDir, ConfigBaseNames}.
+{config, NodeRefs, ConfigFiles}.
+{config, NodeRefs, ConfigDir, ConfigBaseNames}.
 
- {userconfig, {CallbackModule, ConfigStrings}}.
- {userconfig, NodeRefs, {CallbackModule, ConfigStrings}}.
+{userconfig, {CallbackModule, ConfigStrings}}.
+{userconfig, NodeRefs, {CallbackModule, ConfigStrings}}.
 
- {logdir, LogDir}.
- {logdir, NodeRefs, LogDir}.
+{logdir, LogDir}.
+{logdir, NodeRefs, LogDir}.
 
- {logopts, LogOpts}.
- {logopts, NodeRefs, LogOpts}.
+{logopts, LogOpts}.
+{logopts, NodeRefs, LogOpts}.
 
- {create_priv_dir, PrivDirOption}.
- {create_priv_dir, NodeRefs, PrivDirOption}.
+{create_priv_dir, PrivDirOption}.
+{create_priv_dir, NodeRefs, PrivDirOption}.
 
- {event_handler, EventHandlers}.
- {event_handler, NodeRefs, EventHandlers}.
- {event_handler, EventHandlers, InitArgs}.
- {event_handler, NodeRefs, EventHandlers, InitArgs}.
+{event_handler, EventHandlers}.
+{event_handler, NodeRefs, EventHandlers}.
+{event_handler, EventHandlers, InitArgs}.
+{event_handler, NodeRefs, EventHandlers, InitArgs}.
 
- {ct_hooks, CTHModules}.
- {ct_hooks, NodeRefs, CTHModules}.
+{ct_hooks, CTHModules}.
+{ct_hooks, NodeRefs, CTHModules}.
 
- {ct_hooks_order, CTHOrder}.
+{ct_hooks_order, CTHOrder}.
 
- {enable_builtin_hooks, Bool}.
+{enable_builtin_hooks, Bool}.
 
- {basic_html, Bool}.
- {basic_html, NodeRefs, Bool}.
+{basic_html, Bool}.
+{basic_html, NodeRefs, Bool}.
 
- {esc_chars, Bool}.
- {esc_chars, NodeRefs, Bool}.
+{esc_chars, Bool}.
+{esc_chars, NodeRefs, Bool}.
 
- {release_shell, Bool}.
+{release_shell, Bool}.
 ```
 
 _Test terms:_
 
 ```erlang
- {suites, Dir, Suites}.
- {suites, NodeRefs, Dir, Suites}.
+{suites, Dir, Suites}.
+{suites, NodeRefs, Dir, Suites}.
 
- {groups, Dir, Suite, Groups}.
- {groups, NodeRefs, Dir, Suite, Groups}.
+{groups, Dir, Suite, Groups}.
+{groups, NodeRefs, Dir, Suite, Groups}.
 
- {groups, Dir, Suite, Groups, {cases,Cases}}.
- {groups, NodeRefs, Dir, Suite, Groups, {cases,Cases}}.
+{groups, Dir, Suite, Groups, {cases,Cases}}.
+{groups, NodeRefs, Dir, Suite, Groups, {cases,Cases}}.
 
- {cases, Dir, Suite, Cases}.
- {cases, NodeRefs, Dir, Suite, Cases}.
+{cases, Dir, Suite, Cases}.
+{cases, NodeRefs, Dir, Suite, Cases}.
 
- {skip_suites, Dir, Suites, Comment}.
- {skip_suites, NodeRefs, Dir, Suites, Comment}.
+{skip_suites, Dir, Suites, Comment}.
+{skip_suites, NodeRefs, Dir, Suites, Comment}.
 
- {skip_groups, Dir, Suite, GroupNames, Comment}.
- {skip_groups, NodeRefs, Dir, Suite, GroupNames, Comment}.
+{skip_groups, Dir, Suite, GroupNames, Comment}.
+{skip_groups, NodeRefs, Dir, Suite, GroupNames, Comment}.
 
- {skip_cases, Dir, Suite, Cases, Comment}.
- {skip_cases, NodeRefs, Dir, Suite, Cases, Comment}.
+{skip_cases, Dir, Suite, Cases, Comment}.
+{skip_cases, NodeRefs, Dir, Suite, Cases, Comment}.
 ```
 
 [](){: #types } _Types:_
 
-```text
- Bool            = true | false
- Constant        = atom()
- Value           = term()
- InclSpecsOption = join | separate
- TestSpecs       = string() | [string()]
- NodeAlias       = atom()
- Node            = node()
- NodeRef         = NodeAlias | Node | master
- NodeRefs        = all_nodes | [NodeRef] | NodeRef
- InitOptions     = term()
- Label           = atom() | string()
- VerbosityLevels = integer() | [{Category,integer()}]
- Category        = atom()
- CSSFile         = string()
- ConnTypes       = all | [atom()]
- N               = integer()
- CoverSpecFile   = string()
- IncludeDirs     = string() | [string()]
- ConfigFiles     = string() | [string()]
- ConfigDir       = string()
- ConfigBaseNames = string() | [string()]
- CallbackModule  = atom()
- ConfigStrings   = string() | [string()]
- LogDir          = string()
- LogOpts         = [term()]
- PrivDirOption   = auto_per_run | auto_per_tc | manual_per_tc
- EventHandlers   = atom() | [atom()]
- InitArgs        = [term()]
- CTHModules      = [CTHModule |
-		    {CTHModule, CTHInitArgs} |
-		    {CTHModule, CTHInitArgs, CTHPriority}]
- CTHModule       = atom()
- CTHInitArgs     = term()
- CTHOrder        = test | config
- Dir             = string()
- Suites          = atom() | [atom()] | all
- Suite           = atom()
- Groups          = GroupPath | GroupSpec | [GroupSpec] | all
- GroupPath       = [[GroupSpec]]
- GroupSpec       = GroupName | {GroupName,Properties} | {GroupName,Properties,[GroupSpec]}
- GroupName       = atom()
- GroupNames      = GroupName | [GroupName]
- Cases           = atom() | [atom()] | all
- Comment         = string() | ""
+```erlang
+Bool            = true | false
+Constant        = atom()
+Value           = term()
+InclSpecsOption = join | separate
+TestSpecs       = string() | [string()]
+NodeAlias       = atom()
+Node            = node()
+NodeRef         = NodeAlias | Node | master
+NodeRefs        = all_nodes | [NodeRef] | NodeRef
+InitOptions     = term()
+Label           = atom() | string()
+VerbosityLevels = integer() | [{Category,integer()}]
+Category        = atom()
+CSSFile         = string()
+ConnTypes       = all | [atom()]
+N               = integer()
+CoverSpecFile   = string()
+IncludeDirs     = string() | [string()]
+ConfigFiles     = string() | [string()]
+ConfigDir       = string()
+ConfigBaseNames = string() | [string()]
+CallbackModule  = atom()
+ConfigStrings   = string() | [string()]
+LogDir          = string()
+LogOpts         = [term()]
+PrivDirOption   = auto_per_run | auto_per_tc | manual_per_tc
+EventHandlers   = atom() | [atom()]
+InitArgs        = [term()]
+CTHModules      = [CTHModule |
+       	    {CTHModule, CTHInitArgs} |
+       	    {CTHModule, CTHInitArgs, CTHPriority}]
+CTHModule       = atom()
+CTHInitArgs     = term()
+CTHOrder        = test | config
+Dir             = string()
+Suites          = atom() | [atom()] | all
+Suite           = atom()
+Groups          = GroupPath | GroupSpec | [GroupSpec] | all
+GroupPath       = [[GroupSpec]]
+GroupSpec       = GroupName | {GroupName,Properties} | {GroupName,Properties,[GroupSpec]}
+GroupName       = atom()
+GroupNames      = GroupName | [GroupName]
+Cases           = atom() | [atom()] | all
+Comment         = string() | ""
 ```
 
 The difference between the `config` terms above is that with `ConfigDir`,
@@ -930,10 +929,10 @@ The difference between the `config` terms above is that with `ConfigDir`,
 two terms have the same meaning:
 
 ```erlang
- {config, ["/home/testuser/tests/config/nodeA.cfg",
-           "/home/testuser/tests/config/nodeB.cfg"]}.
+{config, ["/home/testuser/tests/config/nodeA.cfg",
+          "/home/testuser/tests/config/nodeB.cfg"]}.
 
- {config, "/home/testuser/tests/config", ["nodeA.cfg","nodeB.cfg"]}.
+{config, "/home/testuser/tests/config", ["nodeA.cfg","nodeB.cfg"]}.
 ```
 
 > #### Note {: .info }
@@ -968,24 +967,24 @@ avoid repetition) of long strings, such as file paths.
 _Examples:_
 
 ```erlang
- %% 1a. no constant
- {config, "/home/testuser/tests/config", ["nodeA.cfg","nodeB.cfg"]}.
- {suites, "/home/testuser/tests/suites", all}.
+%% 1a. no constant
+{config, "/home/testuser/tests/config", ["nodeA.cfg","nodeB.cfg"]}.
+{suites, "/home/testuser/tests/suites", all}.
 
- %% 1b. with constant
- {define, 'TESTDIR', "/home/testuser/tests"}.
- {config, "'TESTDIR'/config", ["nodeA.cfg","nodeB.cfg"]}.
- {suites, "'TESTDIR'/suites", all}.
+%% 1b. with constant
+{define, 'TESTDIR', "/home/testuser/tests"}.
+{config, "'TESTDIR'/config", ["nodeA.cfg","nodeB.cfg"]}.
+{suites, "'TESTDIR'/suites", all}.
 
- %% 2a. no constants
- {config, [testnode@host1, testnode@host2], "../config", ["nodeA.cfg","nodeB.cfg"]}.
- {suites, [testnode@host1, testnode@host2], "../suites", [x_SUITE, y_SUITE]}.
+%% 2a. no constants
+{config, [testnode@host1, testnode@host2], "../config", ["nodeA.cfg","nodeB.cfg"]}.
+{suites, [testnode@host1, testnode@host2], "../suites", [x_SUITE, y_SUITE]}.
 
- %% 2b. with constants
- {define, 'NODE', testnode}.
- {define, 'NODES', ['NODE'@host1, 'NODE'@host2]}.
- {config, 'NODES', "../config", ["nodeA.cfg","nodeB.cfg"]}.
- {suites, 'NODES', "../suites", [x_SUITE, y_SUITE]}.
+%% 2b. with constants
+{define, 'NODE', testnode}.
+{define, 'NODES', ['NODE'@host1, 'NODE'@host2]}.
+{config, 'NODES', "../config", ["nodeA.cfg","nodeB.cfg"]}.
+{suites, 'NODES', "../suites", [x_SUITE, y_SUITE]}.
 ```
 
 Constants make the test specification term `alias`, in previous versions of
@@ -994,17 +993,17 @@ upcoming `Common Test` releases. Replacing `alias` terms with `define` is
 strongly recommended though. An example of such replacement follows:
 
 ```erlang
- %% using the old alias term
- {config, "/home/testuser/tests/config/nodeA.cfg"}.
- {alias, suite_dir, "/home/testuser/tests/suites"}.
- {groups, suite_dir, x_SUITE, group1}.
+%% using the old alias term
+{config, "/home/testuser/tests/config/nodeA.cfg"}.
+{alias, suite_dir, "/home/testuser/tests/suites"}.
+{groups, suite_dir, x_SUITE, group1}.
 
- %% replacing with constants
- {define, 'TestDir', "/home/testuser/tests"}.
- {define, 'CfgDir', "'TestDir'/config"}.
- {define, 'SuiteDir', "'TestDir'/suites"}.
- {config, 'CfgDir', "nodeA.cfg"}.
- {groups, 'SuiteDir', x_SUITE, group1}.
+%% replacing with constants
+{define, 'TestDir', "/home/testuser/tests"}.
+{define, 'CfgDir', "'TestDir'/config"}.
+{define, 'SuiteDir', "'TestDir'/suites"}.
+{config, 'CfgDir', "nodeA.cfg"}.
+{groups, 'SuiteDir', x_SUITE, group1}.
 ```
 
 Constants can well replace term `node` also, but this still has a declarative
@@ -1016,25 +1015,25 @@ value, mainly when used in combination with `NodeRefs == all_nodes` (see
 Here follows a simple test specification example:
 
 ```erlang
- {define, 'Top', "/home/test"}.
- {define, 'T1', "'Top'/t1"}.
- {define, 'T2', "'Top'/t2"}.
- {define, 'T3', "'Top'/t3"}.
- {define, 'CfgFile', "config.cfg"}.
+{define, 'Top', "/home/test"}.
+{define, 'T1', "'Top'/t1"}.
+{define, 'T2', "'Top'/t2"}.
+{define, 'T3', "'Top'/t3"}.
+{define, 'CfgFile', "config.cfg"}.
 
- {logdir, "'Top'/logs"}.
+{logdir, "'Top'/logs"}.
 
- {config, ["'T1'/'CfgFile'", "'T2'/'CfgFile'", "'T3'/'CfgFile'"]}.
+{config, ["'T1'/'CfgFile'", "'T2'/'CfgFile'", "'T3'/'CfgFile'"]}.
 
- {suites, 'T1', all}.
- {skip_suites, 'T1', [t1B_SUITE,t1D_SUITE], "Not implemented"}.
- {skip_cases, 'T1', t1A_SUITE, [test3,test4], "Irrelevant"}.
- {skip_cases, 'T1', t1C_SUITE, [test1], "Ignore"}.
+{suites, 'T1', all}.
+{skip_suites, 'T1', [t1B_SUITE,t1D_SUITE], "Not implemented"}.
+{skip_cases, 'T1', t1A_SUITE, [test3,test4], "Irrelevant"}.
+{skip_cases, 'T1', t1C_SUITE, [test1], "Ignore"}.
 
- {suites, 'T2', [t2B_SUITE,t2C_SUITE]}.
- {cases, 'T2', t2A_SUITE, [test4,test1,test7]}.
+{suites, 'T2', [t2B_SUITE,t2C_SUITE]}.
+{cases, 'T2', t2A_SUITE, [test4,test1,test7]}.
 
- {skip_suites, 'T3', all, "Not implemented"}.
+{skip_suites, 'T3', all, "Not implemented"}.
 ```
 
 The example specifies the following:
@@ -1082,23 +1081,23 @@ tag (or tags) in `Tags`.
 For example, in the test specification:
 
 ```text
- ...
- {label, my_server_smoke_test}.
- {config, "../../my_server_setup.cfg"}.
- {config, "../../my_server_interface.cfg"}.
- ...
+...
+{label, my_server_smoke_test}.
+{config, "../../my_server_setup.cfg"}.
+{config, "../../my_server_interface.cfg"}.
+...
 ```
 
 And in, for example, a test suite or a `Common Test Hook` function:
 
 ```erlang
- ...
- [{label,[{_Node,TestType}]}, {config,CfgFiles}] =
-     ct:get_testspec_terms([label,config]),
+...
+[{label,[{_Node,TestType}]}, {config,CfgFiles}] =
+    ct:get_testspec_terms([label,config]),
 
- [verify_my_server_cfg(TestType, CfgFile) || {Node,CfgFile} <- CfgFiles,
-					     Node == node()];
- ...
+[verify_my_server_cfg(TestType, CfgFile) || {Node,CfgFile} <- CfgFiles,
+                                            Node == node()];
+...
 ```
 
 [](){: #log_files }
@@ -1276,7 +1275,7 @@ correctly in the browser of your choice, or you prefer a more primitive ("pre
 `Common Test` v1.6") look of the logs, use the start flag/option:
 
 ```text
- basic_html
+basic_html
 ```
 
 This disables the use of style sheets and JavaScripts (see
@@ -1293,10 +1292,10 @@ different one for test system state information, and finally one for errors
 detected by the test case functions. The corresponding style sheet can look as
 follows:
 
-```text
- div.sys_config  { background:blue }
- div.sys_state   { background:yellow }
- div.error       { background:red }
+```css
+div.sys_config  { background:blue }
+div.sys_state   { background:yellow }
+div.error       { background:red }
 ```
 
 Common Test prints the text from `ct:log/3,4,5` or `ct:pal/3,4,5` inside a `pre`
@@ -1319,7 +1318,7 @@ the file name can be provided when executing `ct_run`.
 _Example:_
 
 ```text
- $ ct_run -dir $TEST/prog -stylesheet $TEST/styles/test_categories.css
+$ ct_run -dir $TEST/prog -stylesheet $TEST/styles/test_categories.css
 ```
 
 Categories in a CSS file installed with flag `-stylesheet` are on a global test
@@ -1331,18 +1330,18 @@ Style sheets can also be installed on a per suite and per test case basis.
 _Example:_
 
 ```erlang
- -module(my_SUITE).
- ...
- suite() -> [..., {stylesheet,"suite_categories.css"}, ...].
- ...
- my_testcase(_) ->
-     ...
-     ct:log(sys_config, "Test node version: ~p", [VersionInfo]),
-     ...
-     ct:log(sys_state, "Connections: ~p", [ConnectionInfo]),
-     ...
-     ct:pal(error, "Error ~p detected! Info: ~p", [SomeFault,ErrorInfo]),
-     ct:fail(SomeFault).
+-module(my_SUITE).
+...
+suite() -> [..., {stylesheet,"suite_categories.css"}, ...].
+...
+my_testcase(_) ->
+    ...
+    ct:log(sys_config, "Test node version: ~p", [VersionInfo]),
+    ...
+    ct:log(sys_state, "Connections: ~p", [ConnectionInfo]),
+    ...
+    ct:pal(error, "Error ~p detected! Info: ~p", [SomeFault,ErrorInfo]),
+    ct:fail(SomeFault).
 ```
 
 If the style sheet is installed as in this example, the categories are private
@@ -1423,7 +1422,7 @@ information includes the repetition number, remaining time, and so on.
 _Example 1:_
 
 ```text
- $ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -duration 001000 -force_stop
+$ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -duration 001000 -force_stop
 ```
 
 Here, the suites in test directory `to1`, followed by the suites in `to2`, are
@@ -1436,7 +1435,7 @@ be aborted after test `to1` and before test `to2`.
 _Example 2:_
 
 ```text
- $ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -duration 001000 -forces_stop skip_rest
+$ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -duration 001000 -forces_stop skip_rest
 ```
 
 Here, the same tests as in Example 1 are run, but with flag `force_stop` set to
@@ -1449,10 +1448,10 @@ test is aborted.
 _Example 3:_
 
 ```text
- $ date
- Fri Sep 28 15:00:00 MEST 2007
+$ date
+Fri Sep 28 15:00:00 MEST 2007
 
- $ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -until 160000
+$ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -until 160000
 ```
 
 Here, the same test run as in the previous examples are executed (and possibly
@@ -1463,7 +1462,7 @@ always executed in the same test run).
 _Example 4:_
 
 ```text
- $ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -repeat 5
+$ ct_run -dir $TEST_ROOT/to1 $TEST_ROOT/to2 -repeat 5
 ```
 
 Here, the test run, including both the `to1` and the `to2` test, is repeated
@@ -1488,7 +1487,7 @@ The protocol handling processes in `Common Test`, implemented by `ct_telnet`,
 can be switched off with flag `-silent_connections`:
 
 ```text
- ct_run -silent_connections [conn_types]
+ct_run -silent_connections [conn_types]
 ```
 
 Here, `conn_types` specifies SSH, Telnet, FTP, RPC, and/or SNMP.
@@ -1496,7 +1495,7 @@ Here, `conn_types` specifies SSH, Telnet, FTP, RPC, and/or SNMP.
 _Example 1:_
 
 ```text
- ct_run ... -silent_connections ssh telnet
+ct_run ... -silent_connections ssh telnet
 ```
 
 This switches off logging for SSH and Telnet connections.
@@ -1504,7 +1503,7 @@ This switches off logging for SSH and Telnet connections.
 _Example 2:_
 
 ```text
- ct_run ... -silent_connections
+ct_run ... -silent_connections
 ```
 
 This switches off logging for all connection types.
@@ -1524,20 +1523,20 @@ connections.
 _Example 3:_
 
 ```erlang
- -module(my_SUITE).
+-module(my_SUITE).
 
- suite() -> [..., {silent_connections,[telnet,ssh]}, ...].
+suite() -> [..., {silent_connections,[telnet,ssh]}, ...].
 
- ...
+...
 
- my_testcase1() ->
-     [{silent_connections,[ssh]}].
+my_testcase1() ->
+    [{silent_connections,[ssh]}].
 
- my_testcase1(_) ->
-     ...
+my_testcase1(_) ->
+    ...
 
- my_testcase2(_) ->
-     ...
+my_testcase2(_) ->
+    ...
 ```
 
 In this example, `suite/0` tells `Common Test` to suppress printouts from Telnet

--- a/lib/common_test/doc/guides/write_test_chapter.md
+++ b/lib/common_test/doc/guides/write_test_chapter.md
@@ -260,20 +260,20 @@ The following tags have special meaning:
   _Examples:_
 
   ```erlang
-   testcase1() ->
-       [{require, ftp},
-        {default_config, ftp, [{ftp, "my_ftp_host"},
-                               {username, "aladdin"},
-                               {password, "sesame"}]}}].
+  testcase1() ->
+      [{require, ftp},
+       {default_config, ftp, [{ftp, "my_ftp_host"},
+                              {username, "aladdin"},
+                              {password, "sesame"}]}}].
   ```
 
   ```erlang
-   testcase2() ->
-       [{require, unix_telnet, unix},
-        {require, {unix, [telnet, username, password]}},
-        {default_config, unix, [{telnet, "my_telnet_host"},
-                                {username, "aladdin"},
-                                {password, "sesame"}]}}].
+  testcase2() ->
+      [{require, unix_telnet, unix},
+       {require, {unix, [telnet, username, password]}},
+       {default_config, unix, [{telnet, "my_telnet_host"},
+                               {username, "aladdin"},
+                               {password, "sesame"}]}}].
   ```
 
 For more information about `require`, see section
@@ -295,14 +295,14 @@ Tags other than the earlier mentioned are ignored by the test server.
 An example of a test case information function follows:
 
 ```erlang
- reboot_node() ->
-     [
-      {timetrap,{seconds,60}},
-      {require,interfaces},
-      {userdata,
-          [{description,"System Upgrade: RpuAddition Normal RebootNode"},
-           {fts,"http://someserver.ericsson.se/test_doc4711.pdf"}]}
-     ].
+reboot_node() ->
+    [
+     {timetrap,{seconds,60}},
+     {require,interfaces},
+     {userdata,
+         [{description,"System Upgrade: RpuAddition Normal RebootNode"},
+          {fts,"http://someserver.ericsson.se/test_doc4711.pdf"}]}
+    ].
 ```
 
 [](){: #suite }
@@ -328,14 +328,14 @@ The following options can also be specified with the suite information list:
 An example of the suite information function follows:
 
 ```erlang
- suite() ->
-     [
-      {timetrap,{minutes,10}},
-      {require,global_names},
-      {userdata,[{info,"This suite tests database transactions."}]},
-      {silent_connections,[telnet]},
-      {stylesheet,"db_testing.css"}
-     ].
+suite() ->
+    [
+     {timetrap,{minutes,10}},
+     {require,global_names},
+     {userdata,[{info,"This suite tests database transactions."}]},
+     {silent_connections,[telnet]},
+     {stylesheet,"db_testing.css"}
+    ].
 ```
 
 [](){: #test_case_groups }
@@ -348,17 +348,17 @@ execution properties. Test case groups are defined by function
 following syntax:
 
 ```text
- groups() -> GroupDefs
+groups() -> GroupDefs
 
- Types:
+Types:
 
- GroupDefs = [GroupDef]
- GroupDef = {GroupName,Properties,GroupsAndTestCases}
- GroupName = atom()
- GroupsAndTestCases = [GroupDef | {group,GroupName} | TestCase |
-                      {testcase,TestCase,TCRepeatProps}]
- TestCase = atom()
- TCRepeatProps = [{repeat,N} | {repeat_until_ok,N} | {repeat_until_fail,N}]
+GroupDefs = [GroupDef]
+GroupDef = {GroupName,Properties,GroupsAndTestCases}
+GroupName = atom()
+GroupsAndTestCases = [GroupDef | {group,GroupName} | TestCase |
+                     {testcase,TestCase,TCRepeatProps}]
+TestCase = atom()
+TCRepeatProps = [{repeat,N} | {repeat_until_ok,N} | {repeat_until_fail,N}]
 ```
 
 `GroupName` is the name of the group and must be unique within the test suite
@@ -367,12 +367,12 @@ module. Groups can be nested, by including a group definition within the
 execution properties for the group. The possible values are as follows:
 
 ```erlang
- Properties = [parallel | sequence | Shuffle | {GroupRepeatType,N}]
- Shuffle = shuffle | {shuffle,Seed}
- Seed = {integer(),integer(),integer()}
- GroupRepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
-                   repeat_until_any_ok | repeat_until_any_fail
- N = integer() | forever
+Properties = [parallel | sequence | Shuffle | {GroupRepeatType,N}]
+Shuffle = shuffle | {shuffle,Seed}
+Seed = {integer(),integer(),integer()}
+GroupRepeatType = repeat | repeat_until_all_ok | repeat_until_all_fail |
+                  repeat_until_any_ok | repeat_until_any_fail
+N = integer() | forever
 ```
 
 _Explanations:_
@@ -393,8 +393,8 @@ _Explanations:_
 _Example:_
 
 ```erlang
- groups() -> [{group1, [parallel], [test1a,test1b]},
-              {group2, [shuffle,sequence], [test2a,test2b,test2c]}].
+groups() -> [{group1, [parallel], [test1a,test1b]},
+             {group2, [shuffle,sequence], [test2a,test2b,test2c]}].
 ```
 
 To specify in which order groups are to be executed (also with respect to test
@@ -403,8 +403,8 @@ cases that are not part of any group), add tuples on the form
 
 _Example:_
 
-```text
- all() -> [testcase1, {group,group1}, {testcase,testcase2,[{repeat,10}]}, {group,group2}].
+```erlang
+all() -> [testcase1, {group,group1}, {testcase,testcase2,[{repeat,10}]}, {group,group2}].
 ```
 
 Execution properties with a group tuple in `all/0`:
@@ -423,27 +423,27 @@ list, executes with their predefined properties.
 _Example:_
 
 ```erlang
- groups() -> [{tests1, [], [{tests2, [], [t2a,t2b]},
-                           {tests3, [], [t31,t3b]}]}].
+groups() -> [{tests1, [], [{tests2, [], [t2a,t2b]},
+                          {tests3, [], [t31,t3b]}]}].
 ```
 
 To execute group `tests1` twice with different properties for `tests2` each
 time:
 
 ```erlang
- all() ->
-    [{group, tests1, default, [{tests2, [parallel]}]},
-     {group, tests1, default, [{tests2, [shuffle,{repeat,10}]}]}].
+all() ->
+   [{group, tests1, default, [{tests2, [parallel]}]},
+    {group, tests1, default, [{tests2, [shuffle,{repeat,10}]}]}].
 ```
 
 This is equivalent to the following specification:
 
 ```erlang
- all() ->
-    [{group, tests1, default, [{tests2, [parallel]},
-                               {tests3, default}]},
-     {group, tests1, default, [{tests2, [shuffle,{repeat,10}]},
-                               {tests3, default}]}].
+all() ->
+   [{group, tests1, default, [{tests2, [parallel]},
+                              {tests3, default}]},
+    {group, tests1, default, [{tests2, [shuffle,{repeat,10}]},
+                              {tests3, default}]}].
 ```
 
 Value `default` states that the predefined properties are to be used.
@@ -452,15 +452,15 @@ The following example shows how to override properties in a scenario with deeply
 nested groups:
 
 ```erlang
- groups() ->
-    [{tests1, [], [{group, tests2}]},
-     {tests2, [], [{group, tests3}]},
-     {tests3, [{repeat,2}], [t3a,t3b,t3c]}].
+groups() ->
+   [{tests1, [], [{group, tests2}]},
+    {tests2, [], [{group, tests3}]},
+    {tests3, [{repeat,2}], [t3a,t3b,t3c]}].
 
- all() ->
-    [{group, tests1, default,
-      [{tests2, default,
-        [{tests3, [parallel,{repeat,100}]}]}]}].
+all() ->
+   [{group, tests1, default,
+     [{tests2, default,
+       [{tests3, [parallel,{repeat,100}]}]}]}].
 ```
 
 For ease of readability, all syntax definitions can be replaced by a function
@@ -469,15 +469,15 @@ call whose return value should match the expected syntax case.
 _Example:_
 
 ```erlang
- all() ->
-    [{group, tests1, default, test_cases()},
-     {group, tests1, default, [shuffle_test(),
-                               {tests3, default}]}].
- test_cases() ->
-    [{tests2, [parallel]}, {tests3, default}].
+all() ->
+   [{group, tests1, default, test_cases()},
+    {group, tests1, default, [shuffle_test(),
+                              {tests3, default}]}].
+test_cases() ->
+   [{tests2, [parallel]}, {tests3, default}].
 
- shuffle_test() ->
-    {tests2, [shuffle,{repeat,10}]}.
+shuffle_test() ->
+   {tests2, [shuffle,{repeat,10}]}.
 ```
 
 The described syntax can also be used in test specifications to change group
@@ -525,13 +525,13 @@ list of another group.
 _Example:_
 
 ```erlang
- groups() -> [{group1, [shuffle], [test1a,
-                                   {group2, [], [test2a,test2b]},
-                                   test1b]},
-              {group3, [], [{group,group4},
-                            {group,group5}]},
-              {group4, [parallel], [test4a,test4b]},
-              {group5, [sequence], [test5a,test5b,test5c]}].
+groups() -> [{group1, [shuffle], [test1a,
+                                  {group2, [], [test2a,test2b]},
+                                  test1b]},
+             {group3, [], [{group,group4},
+                           {group,group5}]},
+             {group4, [parallel], [test4a,test4b]},
+             {group5, [sequence], [test5a,test5b,test5c]}].
 ```
 
 In the previous example, if `all/0` returns group name references in the order
@@ -541,21 +541,21 @@ test cases becomes the following (notice that `init_per_testcase/2` and
 for simplification):
 
 ```text
- init_per_group(group1, Config) -> Config1  (*)
-      test1a(Config1)
-      init_per_group(group2, Config1) -> Config2
-           test2a(Config2), test2b(Config2)
-      end_per_group(group2, Config2)
-      test1b(Config1)
- end_per_group(group1, Config1)
- init_per_group(group3, Config) -> Config3
-      init_per_group(group4, Config3) -> Config4
-           test4a(Config4), test4b(Config4)  (**)
-      end_per_group(group4, Config4)
-      init_per_group(group5, Config3) -> Config5
-           test5a(Config5), test5b(Config5), test5c(Config5)
-      end_per_group(group5, Config5)
- end_per_group(group3, Config3)
+init_per_group(group1, Config) -> Config1  (*)
+     test1a(Config1)
+     init_per_group(group2, Config1) -> Config2
+          test2a(Config2), test2b(Config2)
+     end_per_group(group2, Config2)
+     test1b(Config1)
+end_per_group(group1, Config1)
+init_per_group(group3, Config) -> Config3
+     init_per_group(group4, Config3) -> Config4
+          test4a(Config4), test4b(Config4)  (**)
+     end_per_group(group4, Config4)
+     init_per_group(group5, Config3) -> Config5
+          test5a(Config5), test5b(Config5), test5c(Config5)
+     end_per_group(group5, Config5)
+end_per_group(group3, Config3)
 ```
 
 (\*) The order of test case `test1a`, `test1b`, and `group2` is undefined, as
@@ -626,14 +626,14 @@ of test cases that have been executed with the corresponding status as result.
 The following is an example of how to return the status from a group:
 
 ```erlang
- end_per_group(_Group, Config) ->
-     Status = proplists:get_value(tc_group_result, Config),
-     case proplists:get_value(failed, Status) of
-         [] ->                                   % no failed cases
-             {return_group_result,ok};
-         _Failed ->                              % one or more failed
-             {return_group_result,failed}
-     end.
+end_per_group(_Group, Config) ->
+    Status = proplists:get_value(tc_group_result, Config),
+    case proplists:get_value(failed, Status) of
+        [] ->                                   % no failed cases
+            {return_group_result,ok};
+        _Failed ->                              % one or more failed
+            {return_group_result,failed}
+    end.
 ```
 
 It is also possible, in `end_per_group/2`, to check the status of a subgroup
@@ -645,16 +645,16 @@ lists.
 _Example:_
 
 ```erlang
- end_per_group(group1, Config) ->
-     Status = proplists:get_value(tc_group_result, Config),
-     Failed = proplists:get_value(failed, Status),
-     case lists:member({group_result,group2}, Failed) of
-           true ->
-               {return_group_result,failed};
-           false ->
-               {return_group_result,ok}
-     end;
- ...
+end_per_group(group1, Config) ->
+    Status = proplists:get_value(tc_group_result, Config),
+    Failed = proplists:get_value(failed, Status),
+    case lists:member({group_result,group2}, Failed) of
+          true ->
+              {return_group_result,failed};
+          false ->
+              {return_group_result,ok}
+    end;
+...
 ```
 
 > #### Note {: .info }
@@ -700,9 +700,9 @@ subgroups in the group in question (`GroupName`).
 _Example:_
 
 ```erlang
- group(connection_tests) ->
-    [{require,login_data},
-     {timetrap,1000}].
+group(connection_tests) ->
+   [{require,login_data},
+    {timetrap,1000}].
 ```
 
 The group information properties override those set with the suite information
@@ -902,8 +902,8 @@ _Examples:_
 Some printouts during test case execution:
 
 ```erlang
- io:format("1. Standard IO, importance = ~w~n", [?STD_IMPORTANCE]),
- ct:log("2. Uncategorized, importance = ~w", [?STD_IMPORTANCE]),
+io:format("1. Standard IO, importance = ~w~n", [?STD_IMPORTANCE]),
+ct:log("2. Uncategorized, importance = ~w", [?STD_IMPORTANCE]),
  ct:log(info, "3. Categorized info, importance = ~w", [?STD_IMPORTANCE]),
  ct:log(info, ?LOW_IMPORTANCE, "4. Categorized info, importance = ~w", [?LOW_IMPORTANCE]),
  ct:log(error, ?HI_IMPORTANCE, "5. Categorized error, importance = ~w", [?HI_IMPORTANCE]),
@@ -913,31 +913,31 @@ Some printouts during test case execution:
 If starting the test with a general verbosity level of 50 (`?STD_VERBOSITY`):
 
 ```text
- $ ct_run -verbosity 50
+$ ct_run -verbosity 50
 ```
 
 the following is printed:
 
 ```text
- 1. Standard IO, importance = 50
- 2. Uncategorized, importance = 50
- 3. Categorized info, importance = 50
- 5. Categorized error, importance = 75
- 6. Categorized error, importance = 99
+1. Standard IO, importance = 50
+2. Uncategorized, importance = 50
+3. Categorized info, importance = 50
+5. Categorized error, importance = 75
+6. Categorized error, importance = 99
 ```
 
 If starting the test with:
 
 ```text
- $ ct_run -verbosity 1 and info 75
+$ ct_run -verbosity 1 and info 75
 ```
 
 the following is printed:
 
 ```erlang
- 3. Categorized info, importance = 50
- 4. Categorized info, importance = 25
- 6. Categorized error, importance = 99
+3. Categorized info, importance = 50
+4. Categorized info, importance = 25
+6. Categorized error, importance = 99
 ```
 
 Note that the category argument is not required in order to only specify the

--- a/lib/common_test/src/ct_cover.erl
+++ b/lib/common_test/src/ct_cover.erl
@@ -34,8 +34,6 @@ This module exports help functions for performing code coverage analysis.
 -include_lib("kernel/include/file.hrl").
 
 -doc """
-add_nodes(Nodes) -> {ok, StartedNodes} | {error, Reason}
-
 Adds nodes to current cover test. Notice that this only works if cover support
 is active.
 
@@ -73,8 +71,6 @@ add_nodes(Nodes) ->
     end.
 
 -doc """
-remove_nodes(Nodes) -> ok | {error, Reason}
-
 Removes nodes from the current cover test.
 
 Call this function to stop cover test on nodes previously added with
@@ -110,10 +106,8 @@ remove_nodes(Nodes) ->
     end.
     
 -doc """
-cross_cover_analyse(Level, Tests) -> ok
-
 Accumulates cover results over multiple tests. See section
-[Cross Cover Analysis](cover_chapter.md#cross_cover) in the Users's Guide.
+[Cross Cover Analysis](cover_chapter.md#cross_cover) in the User's Guide.
 """.
 -doc(#{since => <<"OTP R16B">>}).
 -spec cross_cover_analyse(Level, Tests) -> 'ok'

--- a/lib/common_test/src/ct_ftp.erl
+++ b/lib/common_test/src/ct_ftp.erl
@@ -48,8 +48,6 @@ FTP client module (based on the `ftp` application).
 %%% API
 
 -doc """
-put(KeyOrName, LocalFile, RemoteFile) -> ok | {error, Reason}
-
 Opens an FTP connection and sends a file to the remote host.
 
 `LocalFile` and `RemoteFile` must be absolute paths.
@@ -60,16 +58,16 @@ If the target host is a "special" node, the FTP address must be specified in the
 configuration file as follows:
 
 ```erlang
- {node,[{ftp,IpAddr}]}.
+{node,[{ftp,IpAddr}]}.
 ```
 
 If the target host is something else, for example, a UNIX host, the
 configuration file must also include the username and password (both strings):
 
 ```erlang
- {unix,[{ftp,IpAddr},
-        {username,Username},
-        {password,Password}]}.
+{unix,[{ftp,IpAddr},
+       {username,Username},
+       {password,Password}]}.
 ```
 
 See also `ct:require/2`.
@@ -84,8 +82,6 @@ put(KeyOrName,LocalFile,RemoteFile) ->
     open_and_do(KeyOrName,Fun).
 
 -doc """
-get(KeyOrName, RemoteFile, LocalFile) -> ok | {error, Reason}
-
 Opens an FTP connection and fetches a file from the remote host.
 
 `RemoteFile` and `LocalFile` must be absolute paths.
@@ -106,8 +102,6 @@ get(KeyOrName,RemoteFile,LocalFile) ->
     open_and_do(KeyOrName,Fun).
 
 -doc """
-open(KeyOrName) -> {ok, Handle} | {error, Reason}
-
 Opens an FTP connection to the specified node.
 
 You can open a connection for a particular `Name` and use the same name as
@@ -166,8 +160,6 @@ open(KeyOrName,Username,Password) ->
     end.
 
 -doc """
-send(Connection, LocalFile) -> ok | {error, Reason}
-
 Sends a file over FTP.
 
 The file gets the same name on the remote host.
@@ -182,8 +174,6 @@ send(Connection,LocalFile) ->
     send(Connection,LocalFile,filename:basename(LocalFile)).
 
 -doc """
-send(Connection, LocalFile, RemoteFile) -> ok | {error, Reason}
-
 Sends a file over FTP.
 
 The file is named `RemoteFile` on the remote host.
@@ -202,8 +192,6 @@ send(Connection,LocalFile,RemoteFile) ->
     end.
 
 -doc """
-recv(Connection, RemoteFile) -> ok | {error, Reason}
-
 Fetches a file over FTP.
 
 The file gets the same name on the local host.
@@ -218,8 +206,6 @@ recv(Connection,RemoteFile) ->
     recv(Connection,RemoteFile,filename:basename(RemoteFile)).
 
 -doc """
-recv(Connection, RemoteFile, LocalFile) -> ok | {error, Reason}
-
 Fetches a file over FTP.
 
 The file is named `LocalFile` on the local host.
@@ -238,8 +224,6 @@ recv(Connection,RemoteFile,LocalFile) ->
     end.
 
 -doc """
-cd(Connection, Dir) -> ok | {error, Reason}
-
 Changes directory on remote host.
 """.
 -spec cd(Connection, Dir) -> 'ok' | {'error', Reason}
@@ -255,8 +239,6 @@ cd(Connection,Dir) ->
     end.
 
 -doc """
-ls(Connection, Dir) -> {ok, Listing} | {error, Reason}
-
 Lists directory `Dir`.
 """.
 -spec ls(Connection, Dir) -> {'ok', Listing} | {'error', Reason}
@@ -273,8 +255,6 @@ ls(Connection,Dir) ->
     end.
 
 -doc """
-type(Connection, Type) -> ok | {error, Reason}
-
 Changes the file transfer type.
 """.
 -spec type(Connection, Type) -> 'ok' | {'error', Reason}
@@ -290,8 +270,6 @@ type(Connection,Type) ->
     end.
     
 -doc """
-delete(Connection, File) -> ok | {error, Reason}
-
 Deletes a file on remote host.
 """.
 -spec delete(Connection, File) -> 'ok' | {'error', Reason}
@@ -307,8 +285,6 @@ delete(Connection,File) ->
     end.
 
 -doc """
-close(Connection) -> ok | {error, Reason}
-
 Closes the FTP connection.
 """.
 -spec close(Connection) -> 'ok' | {'error', Reason}

--- a/lib/common_test/src/ct_master.erl
+++ b/lib/common_test/src/ct_master.erl
@@ -55,8 +55,6 @@ in parallel.
 -export_type([test_spec/0]).
 
 -doc """
-run_test(Node, Opts) -> ok
-
 Tests are spawned on `Node` using `ct:run_test/1`
 """.
 -spec run_test(Node, Opts) -> 'ok'
@@ -152,8 +150,6 @@ run_test(NodeOptsList) when is_list(NodeOptsList) ->
     start_master(NodeOptsList).
 
 -doc """
-run(TestSpecs, AllowUserTerms, InclNodes, ExclNodes) -> [{Specs, ok} | {error, Reason}]
-
 Tests are spawned on the nodes as specified in `TestSpecs`. Each specification
 in `TestSpec` is handled separately. However, it is also possible to specify a
 list of specifications to be merged into one specification before the tests are
@@ -209,8 +205,6 @@ run(TS,AllowUserTerms,InclNodes,ExclNodes) when is_list(InclNodes),
     run([TS],AllowUserTerms,InclNodes,ExclNodes).
 
 -doc """
-run(TestSpecs, InclNodes, ExclNodes) -> [{Specs, ok} | {error, Reason}]
-
 Equivalent to
 [`ct_master:run(TestSpecs, false, InclNodes, ExclNodes)`](`run/4`).
 """.
@@ -225,8 +219,6 @@ run(TestSpecs,InclNodes,ExclNodes) ->
     run(TestSpecs,false,InclNodes,ExclNodes).
 
 -doc """
-run(TestSpecs) -> [{Specs, ok} | {error, Reason}]
-
 Equivalent to [`ct_master:run(TestSpecs, false, [], [])`](`run/4`).
 """.
 -spec run(TestSpecs) -> [{Specs, 'ok'} | {'error', Reason}]
@@ -247,8 +239,6 @@ exclude_nodes([],RunSkipPerNode) ->
 
 
 -doc """
-run_on_node(TestSpecs, AllowUserTerms, Node) -> [{Specs, ok} | {error, Reason}]
-
 Tests are spawned on `Node` according to `TestSpecs`.
 """.
 -spec run_on_node(TestSpecs, AllowUserTerms, Node) -> [{Specs, 'ok'} | {'error', Reason}]
@@ -288,8 +278,6 @@ run_on_node(TS,AllowUserTerms,Node) when is_atom(Node) ->
     run_on_node([TS],AllowUserTerms,Node).
 
 -doc """
-run_on_node(TestSpecs, Node) -> [{Specs, ok} | {error, Reason}]
-
 Equivalent to
 [`ct_master:run_on_node(TestSpecs, false, Node)`](`run_on_node/3`).
 """.
@@ -363,8 +351,6 @@ run_all([],AllLogDirs,_,AllEvHs,_AllIncludes,
     
 
 -doc """
-abort() -> ok
-
 Stops all running tests.
 """.
 -spec abort() -> 'ok'.
@@ -372,8 +358,6 @@ abort() ->
     call(abort).
 
 -doc """
-abort(Nodes) -> ok
-
 Stops tests on specified nodes.
 """.
 -spec abort(Nodes) -> 'ok'
@@ -386,8 +370,6 @@ abort(Node) when is_atom(Node) ->
     abort([Node]).
     
 -doc """
-progress() -> [{Node, Status}]
-
 Returns test progress. If `Status` is `ongoing`, tests are running on the node
 and are not yet finished.
 """.
@@ -398,8 +380,6 @@ progress() ->
     call(progress).
 
 -doc """
-get_event_mgr_ref() -> MasterEvMgrRef
-
 Gets a reference to the `Common Test` master event manager. The reference can be
 used to, for example, add a user-specific event handler while tests are running.
 
@@ -415,8 +395,6 @@ get_event_mgr_ref() ->
     ?CT_MEVMGR_REF.
 
 -doc """
-basic_html(Bool) -> ok
-
 If set to `true`, the `ct_master logs` are written on a primitive HTML format,
 not using the `Common Test` CSS style sheet.
 """.

--- a/lib/common_test/src/ct_property_test.erl
+++ b/lib/common_test/src/ct_property_test.erl
@@ -47,17 +47,17 @@ follows:
 
 -include_lib("common_test/include/ct.hrl").
 
- all() -> [prop_ftp_case].
+all() -> [prop_ftp_case].
 
- init_per_suite(Config) ->
-     ct_property_test:init_per_suite(Config).
+init_per_suite(Config) ->
+    ct_property_test:init_per_suite(Config).
 
- %%%---- test case
- prop_ftp_case(Config) ->
-     ct_property_test:quickcheck(
-       ftp_simple_client_server:prop_ftp(),
-       Config
-      ).
+%%%---- test case
+prop_ftp_case(Config) ->
+    ct_property_test:quickcheck(
+      ftp_simple_client_server:prop_ftp(),
+      Config
+     ).
 ```
 
 and the the property test module (in this example
@@ -110,8 +110,6 @@ prop_ftp() ->
 %%% the property tests
 %%%
 -doc """
-init_per_suite(Config) -> Config | {skip, Reason} | {fail, Reason}
-
 Initializes and extends `Config` for property based testing.
 
 This function investigates if support is available for either
@@ -209,8 +207,6 @@ init_tool_extensions(_) ->
 %%% Call the found property tester (if any)
 %%%
 -doc """
-quickcheck(Property, Config) -> true | {fail, Reason}
-
 Calls the selected tool's function for running the `Property`. It is usually and
 by historical reasons called quickcheck, and that is why that name is used in
 this module (`ct_property_test`).
@@ -235,8 +231,6 @@ quickcheck(Property, Config) ->
 %%% Present a nice table of the statem result
 %%%
 -doc """
-present_result(Module, Cmds, Triple, Config) -> Result
-
 Same as [`present_result(Module, Cmds, Triple, Config, [])`](`present_result/5`)
 """.
 -doc(#{since => <<"OTP 22.3">>}).
@@ -252,8 +246,6 @@ present_result(Module, Cmds, Triple, Config) ->
     present_result(Module, Cmds, Triple, Config, []).
 
 -doc """
-present_result(Module, Cmds, Triple, Config, Options) -> Result
-
 Presents the result of _stateful (statem) property testing_ using the aggregate
 function in PropEr, QuickCheck or other similar property testing tool.
 
@@ -291,8 +283,8 @@ Each tuple will produce one table in the order of their places in the list.
   the number of each item is counted and the percentage is printed for each. The
   list \[a,b,a,a,c] could for example return
 
-  ```text
-   ["a 60%\n","b 20%\n","c 20%\n"]
+  ```erlang
+  ["a 60%\n","b 20%\n","c 20%\n"]
   ```
 
   which will be printed by the `print_fun`. The default `print_fun` will print
@@ -308,7 +300,7 @@ The default `StatisticsSpec` is:
 
 - For sequential commands:
 
-  ```text
+  ```erlang
   [{"Function calls", fun cmnd_names/1},
    {"Length of command sequences", fun print_frequency_ranges/0,
                                                     fun num_calls/1}]

--- a/lib/common_test/src/ct_rpc.erl
+++ b/lib/common_test/src/ct_rpc.erl
@@ -33,8 +33,6 @@ Common Test specific layer on Erlang/OTP rpc.
 %%%  API
 %%%=========================================================================
 -doc """
-app_node(App, Candidates) -> NodeName
-
 From a set of candidate nodes determines which of them is running the
 application `App`. If none of the candidate nodes is running `App`, the function
 makes the test case calling this function to fail. This function is the same as
@@ -48,8 +46,6 @@ app_node(App, Candidates) ->
     app_node(App, Candidates, true, []).
 
 -doc """
-app_node(App, Candidates, FailOnBadRPC) -> NodeName
-
 Same as [`ct_rpc:app_node/2`](`app_node/2`), except that argument `FailOnBadRPC`
 determines if the search for a candidate node is to stop if `badrpc` is received
 at some point.
@@ -63,8 +59,6 @@ app_node(App, Candidates, FailOnBadRPC) ->
     app_node(App, Candidates, FailOnBadRPC, []).
 
 -doc """
-app_node(App, Candidates, FailOnBadRPC, Cookie) -> NodeName
-
 Same as [`ct_rpc:app_node/2`](`app_node/2`), except that argument `FailOnBadRPC`
 determines if the search for a candidate node is to stop if `badrpc` is received
 at some point.
@@ -103,8 +97,6 @@ app_node(App, _Candidates = [CandidateNode | Nodes], FailOnBadRPC, Cookie) ->
     end.
 
 -doc """
-call(Node, Module, Function, Args) -> term() | {badrpc, Reason}
-
 Same as [`call(Node, Module, Function, Args, infinity)`](`call/5`).
 """.
 -spec call(Node, Module, Function, Args) -> term() | {badrpc, Reason}
@@ -117,8 +109,6 @@ call(Node, Module, Function, Args) ->
     call(Node, Module, Function, Args, infinity, []). 
 
 -doc """
-call(Node, Module, Function, Args, TimeOut) -> term() | {badrpc, Reason}
-
 Evaluates [`apply(Module, Function, Args)`](`apply/3`) on the node `Node`.
 Returns either whatever `Function` returns, or `{badrpc, Reason}` if the remote
 procedure call fails. If `Node` is `{Fun, FunArgs}`, applying `Fun` to `FunArgs`
@@ -135,8 +125,6 @@ call(Node, Module, Function, Args, TimeOut) ->
     call(Node, Module, Function, Args, TimeOut, []).
 
 -doc """
-call(Node, Module, Function, Args, TimeOut, Cookie) -> term() | {badrpc, Reason}
-
 Evaluates [`apply(Module, Function, Args)`](`apply/3`) on the node `Node`.
 Returns either whatever `Function` returns, or `{badrpc, Reason}` if the remote
 procedure call fails. If `Node` is `{Fun, FunArgs}`, applying `Fun` to `FunArgs`
@@ -163,8 +151,6 @@ call(Node, Module, Function, Args, TimeOut, Cookie) when is_atom(Node) ->
     Result.    
 
 -doc """
-cast(Node, Module, Function, Args) -> ok
-
 Evaluates [`apply(Module, Function, Args)`](`apply/3`) on the node `Node`. No
 response is delivered and the process that makes the call is not suspended until
 the evaluation is completed as in the case of `call/3,4`. If `Node` is
@@ -179,8 +165,6 @@ cast(Node, Module, Function, Args) ->
     cast(Node, Module, Function, Args, []).
 
 -doc """
-cast(Node, Module, Function, Args, Cookie) -> ok
-
 Evaluates [`apply(Module, Function, Args)`](`apply/3`) on the node `Node`. No
 response is delivered and the process that makes the call is not suspended until
 the evaluation is completed as in the case of `call/3,4`. If `Node` is

--- a/lib/common_test/src/ct_snmp.erl
+++ b/lib/common_test/src/ct_snmp.erl
@@ -220,8 +220,6 @@ These data types are described in the documentation for the
 %%%=========================================================================
 
 -doc """
-start(Config, MgrAgentConfName) -> ok | {error, Reason}
-
 Equivalent to [`ct_snmp:start(Config, MgrAgentConfName, undefined)`](`start/3`).
 """.
 -spec start(Config, MgrAgentConfName) -> 'ok' | {'error', Reason}
@@ -232,8 +230,6 @@ start(Config, MgrAgentConfName) ->
     start(Config, MgrAgentConfName, undefined).
 
 -doc """
-start(Config, MgrAgentConfName, SnmpAppConfName) -> ok | {error, Reason}
-
 Starts an SNMP manager and/or agent. In the manager case, registrations of users
 and agents, as specified by the configuration `MgrAgentConfName`, are performed.
 When using SNMPv3, called USM users are also registered. Users, `usm_users`, and
@@ -282,8 +278,6 @@ start_application(App) ->
     end.
  
 -doc """
-stop(Config) -> ok
-
 Stops the SNMP manager and/or agent, and removes all files created.
 """.
 -spec stop(Config) -> 'ok'
@@ -302,8 +296,6 @@ stop(Config) ->
     
     
 -doc """
-get_values(Agent, Oids, MgrAgentConfName) -> SnmpReply
-
 Issues a synchronous SNMP `get` request.
 """.
 -spec get_values(Agent, Oids, MgrAgentConfName) -> SnmpReply
@@ -317,8 +309,6 @@ get_values(Agent, Oids, MgrAgentConfName) ->
     SnmpReply.
 
 -doc """
-get_next_values(Agent, Oids, MgrAgentConfName) -> SnmpReply
-
 Issues a synchronous SNMP `get next` request.
 """.
 -spec get_next_values(Agent, Oids, MgrAgentConfName) -> SnmpReply
@@ -332,8 +322,6 @@ get_next_values(Agent, Oids, MgrAgentConfName) ->
     SnmpReply.
 
 -doc """
-set_values(Agent, VarsAndVals, MgrAgentConfName, Config) -> SnmpReply
-
 Issues a synchronous SNMP `set` request.
 """.
 -spec set_values(Agent, VarsAndVals, MgrAgentConfName, Config) -> SnmpReply
@@ -358,8 +346,6 @@ set_values(Agent, VarsAndVals, MgrAgentConfName, Config) ->
     SnmpSetReply.
 
 -doc """
-set_info(Config) -> [{Agent, OldVarsAndVals, NewVarsAndVals}]
-
 Returns a list of all successful `set` requests performed in the test case in
 reverse order. The list contains the involved user and agent, the value before
 `set`, and the new value. This is intended to simplify the cleanup in function
@@ -383,8 +369,6 @@ set_info(Config) ->
     end.
 
 -doc """
-register_users(MgrAgentConfName, Users) -> ok | {error, Reason}
-
 Registers the manager entity (=user) responsible for specific agent(s).
 Corresponds to making an entry in `users.conf`.
 
@@ -412,8 +396,6 @@ register_users(MgrAgentConfName, Users) ->
     end.
 
 -doc """
-register_agents(MgrAgentConfName, ManagedAgents) -> ok | {error, Reason}
-
 Explicitly instructs the manager to handle this agent. Corresponds to making an
 entry in `agents.conf`.
 
@@ -445,8 +427,6 @@ register_agents(MgrAgentConfName, ManagedAgents) ->
     end.
 
 -doc """
-register_usm_users(MgrAgentConfName, UsmUsers) -> ok | {error, Reason}
-
 Explicitly instructs the manager to handle this USM user. Corresponds to making
 an entry in `usm.conf`.
 
@@ -474,8 +454,6 @@ register_usm_users(MgrAgentConfName, UsmUsers) ->
     end.
 
 -doc """
-unregister_users(MgrAgentConfName) -> ok
-
 Unregisters all users.
 """.
 -spec unregister_users(MgrAgentConfName) -> 'ok'
@@ -485,8 +463,6 @@ unregister_users(MgrAgentConfName) ->
     unregister_users(MgrAgentConfName,Users).
 
 -doc """
-unregister_users(MgrAgentConfName, Users) -> ok
-
 Unregisters the specified users.
 """.
 -doc(#{since => <<"OTP R16B">>}).
@@ -506,8 +482,6 @@ unregister_users(MgrAgentConfName,Users) ->
     ok.
 
 -doc """
-unregister_agents(MgrAgentConfName) -> ok
-
 Unregisters all managed agents.
 """.
 -spec unregister_agents(MgrAgentConfName) -> 'ok'
@@ -519,8 +493,6 @@ unregister_agents(MgrAgentConfName) ->
     unregister_agents(MgrAgentConfName,ManagedAgents).
 
 -doc """
-unregister_agents(MgrAgentConfName, ManagedAgents) -> ok
-
 Unregisters the specified managed agents.
 """.
 -doc(#{since => <<"OTP R16B">>}).
@@ -541,8 +513,6 @@ unregister_agents(MgrAgentConfName,ManagedAgents) ->
     ok.
 
 -doc """
-unregister_usm_users(MgrAgentConfName) -> ok
-
 Unregisters all USM users.
 """.
 -doc(#{since => <<"OTP R16B">>}).
@@ -553,8 +523,6 @@ unregister_usm_users(MgrAgentConfName) ->
     unregister_usm_users(MgrAgentConfName,UsmUsers).
 
 -doc """
-unregister_usm_users(MgrAgentConfName, UsmUsers) -> ok
-
 Unregisters the specified USM users.
 """.
 -doc(#{since => <<"OTP R16B">>}).
@@ -576,8 +544,6 @@ unregister_usm_users(MgrAgentConfName,UsmUsers) ->
     ok.
 
 -doc """
-load_mibs(Mibs) -> ok | {error, Reason}
-
 Loads the MIBs into agent `snmp_master_agent`.
 """.
 -spec load_mibs(Mibs) -> 'ok' | {'error', Reason}
@@ -589,8 +555,6 @@ load_mibs(Mibs) ->
     snmpa:load_mibs(snmp_master_agent, Mibs).
  
 -doc """
-unload_mibs(Mibs) -> ok | {error, Reason}
-
 Unloads the MIBs from agent `snmp_master_agent`.
 """.
 -doc(#{since => <<"OTP R16B">>}).

--- a/lib/common_test/src/ct_ssh.erl
+++ b/lib/common_test/src/ct_ssh.erl
@@ -22,8 +22,6 @@
 -moduledoc """
 SSH/SFTP client module.
 
-SSH/SFTP client module.
-
 This module uses application `SSH`, which provides detailed information about,
 for example, functions, types, and options.
 
@@ -36,14 +34,14 @@ The following options are valid for specifying an SSH/SFTP connection (that is,
 can be used as configuration elements):
 
 ```erlang
- [{ConnType, Addr},
-  {port, Port},
-  {user, UserName}
-  {password, Pwd}
-  {user_dir, String}
-  {public_key_alg, PubKeyAlg}
-  {connect_timeout, Timeout}
-  {key_cb, KeyCallbackMod}]
+[{ConnType, Addr},
+ {port, Port},
+ {user, UserName}
+ {password, Pwd}
+ {user_dir, String}
+ {public_key_alg, PubKeyAlg}
+ {connect_timeout, Timeout}
+ {key_cb, KeyCallbackMod}]
 ```
 
 `ConnType = ssh | sftp`.
@@ -108,8 +106,6 @@ The valid values are `0` ("normal") and `1` ("stderr"), see
 %%%------------------------ SSH COMMANDS ---------------------------
 
 -doc """
-connect(KeyOrName) -> {ok, Handle} | {error, Reason}
-
 Equivalent to [`ct_ssh:connect(KeyOrName, host, [])`](`connect/3`).
 """.
 -spec connect(KeyOrName) -> {'ok', Handle} | {'error', Reason}
@@ -120,8 +116,6 @@ connect(KeyOrName) ->
     connect(KeyOrName, host).
 
 -doc """
-connect(KeyOrName, ConnType) -> {ok, Handle} | {error, Reason}
-
 Equivalent to [`ct_ssh:connect(KeyOrName, ConnType, [])`](`connect/3`).
 """.
 -spec connect(KeyOrName, ConnType) -> {'ok', Handle} | {'error', Reason}
@@ -144,8 +138,6 @@ connect(KeyOrName, ExtraOpts) when is_list(ExtraOpts) ->
     connect(KeyOrName, host, ExtraOpts).
 
 -doc """
-connect(KeyOrName, ConnType, ExtraOpts) -> {ok, Handle} | {error, Reason}
-
 Opens an SSH or SFTP connection using the information associated with
 `KeyOrName`.
 
@@ -254,8 +246,6 @@ connect(KeyOrName, ConnType, ExtraOpts) ->
     end.
 
 -doc """
-disconnect(SSH) -> ok | {error, Reason}
-
 Closes an SSH/SFTP connection.
 """.
 -spec disconnect(SSH) -> 'ok' | {'error', Reason}
@@ -276,8 +266,6 @@ disconnect(SSH) ->
     end.
 
 -doc """
-session_open(SSH) -> {ok, ChannelId} | {error, Reason}
-
 Equivalent to [`ct_ssh:session_open(SSH, DefaultTimeout)`](`session_open/2`).
 """.
 -spec session_open(SSH) -> {'ok', ChannelId} | {'error', Reason}
@@ -288,8 +276,6 @@ session_open(SSH) ->
     call(SSH, {session_open,?DEFAULT_TIMEOUT}).
 
 -doc """
-session_open(SSH, Timeout) -> {ok, ChannelId} | {error, Reason}
-
 Opens a channel for an SSH session.
 """.
 -spec session_open(SSH, Timeout) -> {'ok', ChannelId} | {'error', Reason}
@@ -301,8 +287,6 @@ session_open(SSH, Timeout) ->
     call(SSH, {session_open,Timeout}).
 
 -doc """
-session_close(SSH, ChannelId) -> ok | {error, Reason}
-
 Closes an SSH session channel.
 """.
 -spec session_close(SSH, ChannelId) -> 'ok' | {'error', Reason}
@@ -313,8 +297,6 @@ session_close(SSH, ChannelId) ->
     call(SSH, {session_close,ChannelId}).
 
 -doc """
-exec(SSH, Command) -> {ok, Data} | {error, Reason}
-
 Equivalent to [`ct_ssh:exec(SSH, Command, DefaultTimeout)`](`exec/3`).
 """.
 -spec exec(SSH, Command) -> {'ok', Data} | {'timeout', Data} | {'error', Reason}
@@ -326,8 +308,6 @@ exec(SSH, Command) ->
     exec(SSH, undefined, Command, ?DEFAULT_TIMEOUT).
 
 -doc """
-exec(SSH, Command, Timeout) -> {ok, Data} | {timeout, Data} | {error, Reason}
-
 Requests server to perform `Command`. A session channel is opened automatically
 for the request. `Data` is received from the server as a result of the command.
 """.
@@ -350,8 +330,6 @@ exec(SSH, ChannelId, Command) when is_integer(ChannelId) ->
     exec(SSH, ChannelId, Command, ?DEFAULT_TIMEOUT).
 
 -doc """
-exec(SSH, ChannelId, Command, Timeout) -> {ok, Data} | {timeout, Data} | {error, Reason}
-
 Requests server to perform `Command`. A previously opened session channel is
 used for the request. `Data` is received from the server as a result of the
 command.
@@ -367,8 +345,6 @@ exec(SSH, ChannelId, Command, Timeout) ->
     call(SSH, {exec,ChannelId,Command,Timeout}).
 
 -doc """
-receive_response(SSH, ChannelId) -> {ok, Data} | {timeout, Data} | {error, Reason}
-
 Equivalent to
 [`ct_ssh:receive_response(SSH, ChannelId, close)`](`receive_response/3`).
 """.
@@ -381,8 +357,6 @@ receive_response(SSH, ChannelId) ->
     receive_response(SSH, ChannelId, close, ?DEFAULT_TIMEOUT).
 
 -doc """
-receive_response(SSH, ChannelId, End) -> {ok, Data} | {timeout, Data} | {error, Reason}
-
 Equivalent to
 [`ct_ssh:receive_response(SSH, ChannelId, End, DefaultTimeout)`](`receive_response/4`).
 """.
@@ -406,9 +380,6 @@ receive_response(SSH, ChannelId, Timeout) when is_integer(Timeout) ->
     receive_response(SSH, ChannelId, close, Timeout).
 
 -doc """
-receive_response(SSH, ChannelId, End, Timeout) -> {ok, Data} | {timeout, Data} |
-{error, Reason}
-
 Receives expected data from server on the specified session channel.
 
 If `End == close`, data is returned to the caller when the channel is closed by
@@ -436,8 +407,6 @@ receive_response(SSH, ChannelId, End, Timeout) ->
     call(SSH, {receive_response,ChannelId,End,Timeout}).
 
 -doc """
-send(SSH, ChannelId, Data) -> ok | {error, Reason}
-
 Equivalent to
 [`ct_ssh:send(SSH, ChannelId, 0, Data, DefaultTimeout)`](`send/5`).
 """.
@@ -450,8 +419,6 @@ send(SSH, ChannelId, Data) ->
     send(SSH, ChannelId, 0, Data, ?DEFAULT_TIMEOUT).
 
 -doc """
-send(SSH, ChannelId, Data, Timeout) -> ok | {error, Reason}
-
 Equivalent to [`ct_ssh:send(SSH, ChannelId, 0, Data, Timeout)`](`send/5`).
 """.
 -spec send(SSH, ChannelId, Data, Timeout) -> 'ok' | {'error', Reason}
@@ -473,8 +440,6 @@ send(SSH, ChannelId, Type, Data) when is_integer(Type) ->
     send(SSH, ChannelId, Type, Data, ?DEFAULT_TIMEOUT).
 
 -doc """
-send(SSH, ChannelId, Type, Data, Timeout) -> ok | {error, Reason}
-
 Sends data to server on specified session channel.
 """.
 -spec send(SSH, ChannelId, Type, Data, Timeout) -> 'ok' | {'error', Reason}
@@ -488,8 +453,6 @@ send(SSH, ChannelId, Type, Data, Timeout) ->
     call(SSH, {send,ChannelId,Type,Data,Timeout}).
 
 -doc """
-send_and_receive(SSH, ChannelId, Data) -> {ok, Data} | {timeout, Data} | {error, Reason}
-
 Equivalent to
 [`ct_ssh:send_and_receive(SSH, ChannelId, Data, close)`](`send_and_receive/4`).
 """.
@@ -504,11 +467,8 @@ send_and_receive(SSH, ChannelId, Data) ->
     send_and_receive(SSH, ChannelId, 0, Data, close, ?DEFAULT_TIMEOUT).
 
 -doc """
-send_and_receive(SSH, ChannelId, Data, End) -> {ok, ReceivedData} | {timeout, ReceivedData} |
-{error, Reason}
-
 Equivalent to
-[`ct_ssh;send_and_receive(SSH, ChannelId, 0, Data, End, DefaultTimeout)`](`send_and_receive/6`).
+[`ct_ssh:send_and_receive(SSH, ChannelId, 0, Data, End, DefaultTimeout)`](`send_and_receive/6`).
 """.
 -spec send_and_receive(SSH, ChannelId, Data, End) -> {'ok', ReceivedData}
               | {'timeout', ReceivedData} | {'error', Reason}
@@ -544,9 +504,6 @@ send_and_receive(SSH, ChannelId, Type, Data) when is_integer(Type) ->
     send_and_receive(SSH, ChannelId, Type, Data, close, ?DEFAULT_TIMEOUT).
 
 -doc """
-send_and_receive(SSH, ChannelId, Data, End, Timeout) -> {ok, ReceivedData} | {timeout, ReceivedData}
-| {error, Reason}
-
 Equivalent to
 [`ct_ssh:send_and_receive(SSH, ChannelId, 0, Data, End, Timeout)`](`send_and_receive/6`).
 """.
@@ -587,9 +544,6 @@ send_and_receive(SSH, ChannelId, Type, Data, End) when is_function(End) ->
     send_and_receive(SSH, ChannelId, Type, Data, End, ?DEFAULT_TIMEOUT).
 
 -doc """
-send_and_receive(SSH, ChannelId, Type, Data, End, Timeout) -> {ok, ReceivedData}
-| {timeout, ReceivedData} | {error, Reason}
-
 Sends data to server on specified session channel and waits to receive the
 server response.
 
@@ -610,8 +564,6 @@ send_and_receive(SSH, ChannelId, Type, Data, End, Timeout) ->
     call(SSH, {send_and_receive,ChannelId,Type,Data,End,Timeout}).
 
 -doc """
-subsystem(SSH, ChannelId, Subsystem) -> Status | {error, Reason}
-
 Equivalent to
 [`ct_ssh:subsystem(SSH, ChannelId, Subsystem, DefaultTimeout)`](`subsystem/4`).
 """.
@@ -625,8 +577,6 @@ subsystem(SSH, ChannelId, Subsystem) ->
     subsystem(SSH, ChannelId, Subsystem, ?DEFAULT_TIMEOUT).
 
 -doc """
-subsystem(SSH, ChannelId, Subsystem, Timeout) -> Status | {error, Reason}
-
 Sends a request to execute a predefined subsystem.
 """.
 -spec subsystem(SSH, ChannelId, Subsystem, Timeout) -> Status | {'error', Reason} when
@@ -641,8 +591,6 @@ subsystem(SSH, ChannelId, Subsystem, Timeout) ->
 
 
 -doc """
-shell(SSH, ChannelId) -> ok | {error, Reason}
-
 Equivalent to [`ct_ssh:shell(SSH, ChannelId, DefaultTimeout)`](`shell/3`).
 """.
 -doc(#{since => <<"OTP 20.0">>}).
@@ -654,8 +602,6 @@ shell(SSH, ChannelId) ->
     shell(SSH, ChannelId, ?DEFAULT_TIMEOUT).
 
 -doc """
-shell(SSH, ChannelId, Timeout) -> ok | {error, Reason}
-
 Requests that the user default shell (typically defined in `/etc/passwd` in Unix
 systems) is executed at the server end.
 """.
@@ -673,8 +619,6 @@ shell(SSH, ChannelId, Timeout) ->
 %%%------------------------ SFTP COMMANDS --------------------------
 
 -doc """
-sftp_connect(SSH) -> {ok, Server} | {error, Reason}
-
 Starts an SFTP session on an already existing SSH connection. `Server`
 identifies the new session and must be specified whenever SFTP requests are to
 be sent.
@@ -687,8 +631,6 @@ sftp_connect(SSH) ->
     call(SSH, sftp_connect).
 
 -doc """
-read_file(SSH, File) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_file(SSH, File) -> Result when
@@ -701,8 +643,6 @@ read_file(SSH, File) ->
     call(SSH, {read_file,sftp,File}).
 
 -doc """
-read_file(SSH, Server, File) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_file(SSH, Server, File) -> Result when
@@ -716,8 +656,6 @@ read_file(SSH, Server, File) ->
     call(SSH, {read_file,Server,File}).
 
 -doc """
-write_file(SSH, File, Iolist) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec write_file(SSH, File, Iolist) -> Result when
@@ -730,8 +668,6 @@ write_file(SSH, File, Iolist) ->
     call(SSH, {write_file,sftp,File,Iolist}).
 
 -doc """
-write_file(SSH, Server, File, Iolist) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec write_file(SSH, Server, File, Iolist) -> Result when
@@ -745,8 +681,6 @@ write_file(SSH, Server, File, Iolist) ->
     call(SSH, {write_file,Server,File,Iolist}).
 
 -doc """
-list_dir(SSH, Path) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec list_dir(SSH, Path) -> Result when
@@ -760,8 +694,6 @@ list_dir(SSH, Path) ->
     call(SSH, {list_dir,sftp,Path}).
 
 -doc """
-list_dir(SSH, Server, Path) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec list_dir(SSH, Server, Path) -> Result when
@@ -776,8 +708,6 @@ list_dir(SSH, Server, Path) ->
     call(SSH, {list_dir,Server,Path}).
 
 -doc """
-open(SSH, File, Mode) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec open(SSH, File, Mode) -> Result when
@@ -791,8 +721,6 @@ open(SSH, File, Mode) ->
     call(SSH, {open,sftp,File,Mode}).
 
 -doc """
-open(SSH, Server, File, Mode) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec open(SSH, Server, File, Mode) -> Result when
@@ -807,8 +735,6 @@ open(SSH, Server, File, Mode) ->
     call(SSH, {open,Server,File,Mode}).
 
 -doc """
-opendir(SSH, Path) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec opendir(SSH, Path) -> Result when
@@ -821,8 +747,6 @@ opendir(SSH, Path) ->
     call(SSH, {opendir,sftp,Path}).
 
 -doc """
-opendir(SSH, Server, Path) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec opendir(SSH, Server, Path) -> Result when
@@ -836,8 +760,6 @@ opendir(SSH, Server, Path) ->
     call(SSH, {opendir,Server,Path}).
 
 -doc """
-close(SSH, Handle) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec close(SSH, Handle) -> Result when
@@ -849,8 +771,6 @@ close(SSH, Handle) ->
     call(SSH, {close,sftp,Handle}).
 
 -doc """
-close(SSH, Server, Handle) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec close(SSH, Server, Handle) -> Result when
@@ -863,8 +783,6 @@ close(SSH, Server, Handle) ->
     call(SSH, {close,Server,Handle}).
 
 -doc """
-read(SSH, Handle, Len) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read(SSH, Handle, Len) -> Result when
@@ -878,8 +796,6 @@ read(SSH, Handle, Len) ->
     call(SSH, {read,sftp,Handle,Len}).
 
 -doc """
-read(SSH, Server, Handle, Len) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read(SSH, Server, Handle, Len) -> Result when
@@ -894,8 +810,6 @@ read(SSH, Server, Handle, Len) ->
     call(SSH, {read,Server,Handle,Len}).
 
 -doc """
-pread(SSH, Handle, Position, Length) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec pread(SSH, Handle, Position, Length) -> Result when
@@ -910,8 +824,6 @@ pread(SSH, Handle, Position, Length) ->
     call(SSH, {pread,sftp,Handle,Position,Length}).
 
 -doc """
-pread(SSH, Server, Handle, Position, Length) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec pread(SSH, Server, Handle, Position, Length) -> Result when
@@ -927,8 +839,6 @@ pread(SSH, Server, Handle, Position, Length) ->
     call(SSH, {pread,Server,Handle,Position,Length}).
 
 -doc """
-aread(SSH, Handle, Len) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec aread(SSH, Handle, Len) -> Result when
@@ -942,8 +852,6 @@ aread(SSH, Handle, Len) ->
     call(SSH, {aread,sftp,Handle,Len}).
 
 -doc """
-aread(SSH, Server, Handle, Len) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec aread(SSH, Server, Handle, Len) -> Result when
@@ -958,8 +866,6 @@ aread(SSH, Server, Handle, Len) ->
     call(SSH, {aread,Server,Handle,Len}).
 
 -doc """
-apread(SSH, Handle, Position, Length) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec apread(SSH, Handle, Position, Length) -> Result when
@@ -974,8 +880,6 @@ apread(SSH, Handle, Position, Length) ->
     call(SSH, {apread,sftp,Handle,Position,Length}).
 
 -doc """
-apread(SSH, Server, Handle, Position, Length) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec apread(SSH, Server, Handle, Position, Length) -> Result when
@@ -991,8 +895,6 @@ apread(SSH, Server, Handle, Position, Length) ->
     call(SSH, {apread,Server,Handle,Position,Length}).
 
 -doc """
-write(SSH, Handle, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec write(SSH, Handle, Data) -> Result when
@@ -1005,8 +907,6 @@ write(SSH, Handle, Data) ->
     call(SSH, {write,sftp,Handle,Data}).
 
 -doc """
-write(SSH, Server, Handle, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec write(SSH, Server, Handle, Data) -> Result when
@@ -1020,8 +920,6 @@ write(SSH, Server, Handle, Data) ->
     call(SSH, {write,Server,Handle,Data}).
 
 -doc """
-pwrite(SSH, Handle, Position, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec pwrite(SSH, Handle, Position, Data) -> Result when
@@ -1035,8 +933,6 @@ pwrite(SSH, Handle, Position, Data) ->
     call(SSH, {pwrite,sftp,Handle,Position,Data}).
 
 -doc """
-pwrite(SSH, Server, Handle, Position, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec pwrite(SSH, Server, Handle, Position, Data) -> Result when
@@ -1051,8 +947,6 @@ pwrite(SSH, Server, Handle, Position, Data) ->
     call(SSH, {pwrite,Server,Handle,Position,Data}).
 
 -doc """
-awrite(SSH, Handle, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec awrite(SSH, Handle, Data) -> Result when
@@ -1066,8 +960,6 @@ awrite(SSH, Handle, Data) ->
     call(SSH, {awrite,sftp,Handle, Data}).
 
 -doc """
-awrite(SSH, Server, Handle, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec awrite(SSH, Server, Handle, Data) -> Result when
@@ -1082,8 +974,6 @@ awrite(SSH, Server, Handle, Data) ->
     call(SSH, {awrite,Server,Handle, Data}).
 
 -doc """
-apwrite(SSH, Handle, Position, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec apwrite(SSH, Handle, Position, Data) -> Result when
@@ -1098,8 +988,6 @@ apwrite(SSH, Handle, Position, Data) ->
     call(SSH, {apwrite,sftp,Handle,Position,Data}).
 
 -doc """
-apwrite(SSH, Server, Handle, Position, Data) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec apwrite(SSH, Server, Handle, Position, Data) -> Result when
@@ -1115,8 +1003,6 @@ apwrite(SSH, Server, Handle, Position, Data) ->
     call(SSH, {apwrite,Server,Handle,Position,Data}).
 
 -doc """
-position(SSH, Handle, Location) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec position(SSH, Handle, Location) -> Result when
@@ -1132,8 +1018,6 @@ position(SSH, Handle, Location) ->
     call(SSH, {position,sftp,Handle,Location}).
 
 -doc """
-position(SSH, Server, Handle, Location) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec position(SSH, Server, Handle, Location) -> Result when
@@ -1150,8 +1034,6 @@ position(SSH, Server, Handle, Location) ->
     call(SSH, {position,Server,Handle,Location}).
 
 -doc """
-read_file_info(SSH, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_file_info(SSH, Name) -> Result when
@@ -1164,8 +1046,6 @@ read_file_info(SSH, Name) ->
     call(SSH, {read_file_info,sftp,Name}).
 
 -doc """
-read_file_info(SSH, Server, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_file_info(SSH, Server, Name) -> Result when
@@ -1179,8 +1059,6 @@ read_file_info(SSH, Server, Name) ->
     call(SSH, {read_file_info,Server,Name}).
 
 -doc """
-get_file_info(SSH, Handle) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec get_file_info(SSH, Handle) -> Result when
@@ -1193,8 +1071,6 @@ get_file_info(SSH, Handle) ->
     call(SSH, {get_file_info,sftp,Handle}).
 
 -doc """
-get_file_info(SSH, Server, Handle) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec get_file_info(SSH, Server, Handle) -> Result when
@@ -1208,8 +1084,6 @@ get_file_info(SSH, Server, Handle) ->
     call(SSH, {get_file_info,Server,Handle}).
 
 -doc """
-read_link_info(SSH, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_link_info(SSH, Name) -> Result when
@@ -1222,8 +1096,6 @@ read_link_info(SSH, Name) ->
     call(SSH, {read_link_info,sftp,Name}).
 
 -doc """
-read_link_info(SSH, Server, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_link_info(SSH, Server, Name) -> Result when
@@ -1237,8 +1109,6 @@ read_link_info(SSH, Server, Name) ->
     call(SSH, {read_link_info,Server,Name}).
 
 -doc """
-write_file_info(SSH, Name, Info) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec write_file_info(SSH, Name, Info) -> Result when
@@ -1251,8 +1121,6 @@ write_file_info(SSH, Name, Info) ->
     call(SSH, {write_file_info,sftp,Name,Info}).
 
 -doc """
-write_file_info(SSH, Server, Name, Info) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec write_file_info(SSH, Server, Name, Info) -> Result when
@@ -1266,8 +1134,6 @@ write_file_info(SSH, Server, Name, Info) ->
     call(SSH, {write_file_info,Server,Name,Info}).
 
 -doc """
-read_link(SSH, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_link(SSH, Name) -> Result when
@@ -1280,8 +1146,6 @@ read_link(SSH, Name) ->
     call(SSH, {read_link,sftp,Name}).
 
 -doc """
-read_link(SSH, Server, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec read_link(SSH, Server, Name) -> Result when
@@ -1295,8 +1159,6 @@ read_link(SSH, Server, Name) ->
     call(SSH, {read_link,Server,Name}).
 
 -doc """
-make_symlink(SSH, Name, Target) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec make_symlink(SSH, Name, Target) -> Result when
@@ -1309,8 +1171,6 @@ make_symlink(SSH, Name, Target) ->
     call(SSH, {make_symlink,sftp,Name,Target}).
 
 -doc """
-make_symlink(SSH, Server, Name, Target) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec make_symlink(SSH, Server, Name, Target) -> Result when
@@ -1324,8 +1184,6 @@ make_symlink(SSH, Server, Name, Target) ->
     call(SSH, {make_symlink,Server,Name,Target}).
 
 -doc """
-rename(SSH, OldName, NewName) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec rename(SSH, OldName, NewName) -> Result when
@@ -1338,8 +1196,6 @@ rename(SSH, OldName, NewName) ->
     call(SSH, {rename,sftp,OldName,NewName}).
 
 -doc """
-rename(SSH, Server, OldName, NewName) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec rename(SSH, Server, OldName, NewName) -> Result when
@@ -1354,8 +1210,6 @@ rename(SSH, Server, OldName, NewName) ->
 
 
 -doc """
-delete(SSH, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec delete(SSH, Name) -> Result when
@@ -1367,8 +1221,6 @@ delete(SSH, Name) ->
     call(SSH, {delete,sftp,Name}).
 
 -doc """
-delete(SSH, Server, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec delete(SSH, Server, Name) -> Result when
@@ -1381,8 +1233,6 @@ delete(SSH, Server, Name) ->
     call(SSH, {delete,Server,Name}).
 
 -doc """
-make_dir(SSH, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec make_dir(SSH, Name) -> Result when
@@ -1394,8 +1244,6 @@ make_dir(SSH, Name) ->
     call(SSH, {make_dir,sftp,Name}).
 
 -doc """
-make_dir(SSH, Server, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec make_dir(SSH, Server, Name) -> Result when
@@ -1408,8 +1256,6 @@ make_dir(SSH, Server, Name) ->
     call(SSH, {make_dir,Server,Name}).
 
 -doc """
-del_dir(SSH, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec del_dir(SSH, Name) -> Result when
@@ -1421,8 +1267,6 @@ del_dir(SSH, Name) ->
     call(SSH, {del_dir,sftp,Name}).
 
 -doc """
-del_dir(SSH, Server, Name) -> Result
-
 For information and other types, see `m:ssh_sftp`.
 """.
 -spec del_dir(SSH, Server, Name) -> Result when

--- a/lib/common_test/src/ct_telnet.erl
+++ b/lib/common_test/src/ct_telnet.erl
@@ -50,14 +50,14 @@ These parameters can be modified by the user with the following configuration
 term:
 
 ```erlang
- {telnet_settings, [{connect_timeout,Millisec},
-                    {command_timeout,Millisec},
-                    {reconnection_attempts,N},
-                    {reconnection_interval,Millisec},
-                    {keep_alive,Bool},
-                    {poll_limit,N},
-                    {poll_interval,Millisec},
-                    {tcp_nodelay,Bool}]}.
+{telnet_settings, [{connect_timeout,Millisec},
+                   {command_timeout,Millisec},
+                   {reconnection_attempts,N},
+                   {reconnection_interval,Millisec},
+                   {keep_alive,Bool},
+                   {poll_limit,N},
+                   {poll_interval,Millisec},
+                   {tcp_nodelay,Bool}]}.
 ```
 
 `Millisec = integer(), N = integer()`
@@ -82,8 +82,8 @@ _all_ Telnet traffic. To use this handler, install a `Common Test` hook named
 `cth_conn_log`. Example (using the test suite information function):
 
 ```erlang
- suite() ->
-     [{ct_hooks, [{cth_conn_log, [{conn_mod(),hook_options()}]}]}].
+suite() ->
+    [{ct_hooks, [{cth_conn_log, [{conn_mod(),hook_options()}]}]}].
 ```
 
 `conn_mod()` is the name of the `Common Test` module implementing the connection
@@ -112,8 +112,8 @@ configuration file with configuration variable `ct_conn_log`.
 _Example:_
 
 ```erlang
- {ct_conn_log, [{ct_telnet,[{log_type,raw},
-                            {hosts,[key_or_name()]}]}]}
+{ct_conn_log, [{ct_telnet,[{log_type,raw},
+                           {hosts,[key_or_name()]}]}]}
 ```
 
 > #### Note {: .info }
@@ -130,23 +130,23 @@ logs for the connections `server1` and `server2`. Traffic for any other
 connections is logged in the default Telnet log.
 
 ```erlang
- suite() ->
-     [{ct_hooks,
-       [{cth_conn_log, [{ct_telnet,[{hosts,[server1,server2]}]}]}]}].
+suite() ->
+    [{ct_hooks,
+      [{cth_conn_log, [{ct_telnet,[{hosts,[server1,server2]}]}]}]}].
 ```
 
 As previously explained, this specification can also be provided by an entry
 like the following in a configuration file:
 
 ```erlang
- {ct_conn_log, [{ct_telnet,[{hosts,[server1,server2]}]}]}.
+{ct_conn_log, [{ct_telnet,[{hosts,[server1,server2]}]}]}.
 ```
 
 In this case the `ct_hooks` statement in the test suite can look as follows:
 
 ```erlang
- suite() ->
-     [{ct_hooks, [{cth_conn_log, []}]}].
+suite() ->
+    [{ct_hooks, [{cth_conn_log, []}]}].
 ```
 
 ## See Also
@@ -210,8 +210,6 @@ STDLIB) must return a list with one single element.
 	       tcp_nodelay=false}).
 
 -doc """
-open(Name) -> {ok, Handle} | {error, Reason}
-
 Equivalent to [`ct_telnet:open(Name, telnet)`](`open/2`).
 """.
 -spec open(Name) -> {'ok', Handle} | {'error', Reason}
@@ -222,8 +220,6 @@ open(Name) ->
     open(Name,telnet).
 
 -doc """
-open(Name, ConnType) -> {ok, Handle} | {error, Reason}
-
 Opens a Telnet connection to the specified target host.
 """.
 -spec open(Name, ConnType) -> {'ok', Handle} | {'error', Reason}
@@ -242,8 +238,6 @@ open(Name,ConnType) ->
     end.
 
 -doc """
-open(KeyOrName, ConnType, TargetMod) -> {ok, Handle} | {error, Reason}
-
 Equivalent to
 [`ct_telnet:ct_telnet:open(KeyOrName, ConnType, TargetMod, [])`](`open/4`).
 """.
@@ -257,8 +251,6 @@ open(KeyOrName,ConnType,TargetMod) ->
     open(KeyOrName,ConnType,TargetMod,KeyOrName).
 
 -doc """
-open(KeyOrName, ConnType, TargetMod, Extra) -> {ok, Handle} | {error, Reason}
-
 Opens a Telnet connection to the specified target host.
 
 The target data must exist in a configuration file. The connection can be
@@ -329,8 +321,6 @@ open(KeyOrName,ConnType,TargetMod,Extra) ->
     end.
 
 -doc """
-close(Connection) -> ok | {error, Reason}
-
 Closes the Telnet connection and stops the process managing it.
 
 A connection can be associated with a target name and/or a handle. If
@@ -359,8 +349,6 @@ close(Connection) ->
 %%%-----------------------------------------------------------------
 
 -doc """
-cmd(Connection, Cmd) -> {ok, Data} | {error, Reason}
-
 Equivalent to [`ct_telnet:cmd(Connection, Cmd, [])`](`cmd/3`).
 """.
 -spec cmd(Connection, Cmd) -> {'ok', Data} | {'error', Reason}
@@ -372,8 +360,6 @@ cmd(Connection,Cmd) ->
     cmd(Connection,Cmd,[]).
 
 -doc """
-cmd(Connection, Cmd, Opts) -> {ok, Data} | {error, Reason}
-
 Sends a command through Telnet and waits for prompt.
 
 By default, this function adds "\\n" to the end of the specified command. If
@@ -421,8 +407,6 @@ check_cmd_opts(Opts) ->
     check_send_opts(Opts).
 
 -doc """
-cmdf(Connection, CmdFormat, Args) -> {ok, Data} | {error, Reason}
-
 Equivalent to [`ct_telnet:cmdf(Connection, CmdFormat, Args, [])`](`cmdf/4`).
 """.
 -spec cmdf(Connection, CmdFormat, Args) -> {'ok', Data} | {'error', Reason}
@@ -435,8 +419,6 @@ cmdf(Connection,CmdFormat,Args) ->
     cmdf(Connection,CmdFormat,Args,[]).
 
 -doc """
-cmdf(Connection, CmdFormat, Args, Opts) -> {ok, Data} | {error, Reason}
-
 Sends a Telnet command and waits for prompt (uses a format string and a list of
 arguments to build the command).
 
@@ -455,8 +437,6 @@ cmdf(Connection,CmdFormat,Args,Opts) when is_list(Args) ->
     cmd(Connection,Cmd,Opts).
 
 -doc """
-get_data(Connection) -> {ok, Data} | {error, Reason}
-
 Gets all data received by the Telnet client since the last command was sent.
 Only newline-terminated strings are returned. If the last received string has
 not yet been terminated, the connection can be polled automatically until the
@@ -480,8 +460,6 @@ get_data(Connection) ->
     end.
 
 -doc """
-send(Connection, Cmd) -> ok | {error, Reason}
-
 Equivalent to [`ct_telnet:send(Connection, Cmd, [])`](`send/3`).
 """.
 -spec send(Connection, Cmd) -> 'ok' | {'error', Reason}
@@ -492,8 +470,6 @@ send(Connection,Cmd) ->
     send(Connection,Cmd,[]).
 
 -doc """
-send(Connection, Cmd, Opts) -> ok | {error, Reason}
-
 Sends a Telnet command and returns immediately.
 
 By default, this function adds "\\n" to the end of the specified command. If
@@ -542,8 +518,6 @@ check_send_opts([]) ->
     ok.
 
 -doc """
-sendf(Connection, CmdFormat, Args) -> ok | {error, Reason}
-
 Equivalent to [`ct_telnet:sendf(Connection, CmdFormat, Args, [])`](`sendf/4`).
 """.
 -spec sendf(Connection, CmdFormat, Args) -> 'ok' | {'error', Reason}
@@ -555,8 +529,6 @@ sendf(Connection,CmdFormat,Args) when is_list(Args) ->
     sendf(Connection,CmdFormat,Args,[]).
 
 -doc """
-sendf(Connection, CmdFormat, Args, Opts) -> ok | {error, Reason}
-
 Sends a Telnet command and returns immediately (uses a format string and a list
 of arguments to build the command).
 
@@ -574,8 +546,6 @@ sendf(Connection,CmdFormat,Args,Opts) when is_list(Args) ->
     send(Connection,Cmd,Opts).
 
 -doc """
-expect(Connection, Patterns) -> term()
-
 Equivalent to [`ct_telnet:expect(Connections, Patterns, [])`](`expect/3`).
 """.
 -spec expect(Connection, Patterns) -> {'ok', Match} | {'ok', Match, HaltReason}
@@ -597,9 +567,6 @@ expect(Connection,Patterns) ->
     expect(Connection,Patterns,[]).
 
 -doc """
-expect(Connection, Patterns, Opts) -> {ok, Match} | {ok, MatchList, HaltReason}
-| {error, Reason}
-
 Gets data from Telnet and waits for the expected pattern.
 
 `Pattern` can be a POSIX regular expression. The function returns when a pattern
@@ -659,7 +626,7 @@ _Options:_
 _Example 1:_
 
 ```erlang
- expect(Connection,[{abc,"ABC"},{xyz,"XYZ"}],[sequence,{halt,[{nnn,"NNN"}]}])
+expect(Connection,[{abc,"ABC"},{xyz,"XYZ"}],[sequence,{halt,[{nnn,"NNN"}]}])
 ```
 
 First this tries to match `"ABC"`, and then `"XYZ"`, but if `"NNN"` appears, the
@@ -669,7 +636,7 @@ matched, the function returns `{ok,[AbcMatch,XyzMatch]}`.
 _Example 2:_
 
 ```erlang
- expect(Connection,[{abc,"ABC"},{xyz,"XYZ"}],[{repeat,2},{halt,[{nnn,"NNN"}]}])
+expect(Connection,[{abc,"ABC"},{xyz,"XYZ"}],[{repeat,2},{halt,[{nnn,"NNN"}]}])
 ```
 
 This tries to match `"ABC"` or `"XYZ"` twice. If `"NNN"` appears, the function

--- a/lib/common_test/src/ct_testspec.erl
+++ b/lib/common_test/src/ct_testspec.erl
@@ -820,11 +820,9 @@ list_nodes(#testspec{nodes=NodeRefs}) ->
 %%% [Spec1,Spec2,...] means create separate tests per spec
 %%% [[Spec1,Spec2,...]] means merge all specs into one
 -doc """
-get_tests(SpecsIn) -> {ok, [{Specs,Tests}]} | {error, Reason}
+Parse the given test specification files and return the tests to run and skip.
 
 [](){: #add_nodes-1 }
-
-Parse the given test specification files and return the tests to run and skip.
 
 If `SpecsIn=[Spec1,Spec2,...]`, separate tests will be created per
 specification. If `SpecsIn=[[Spec1,Spec2,...]]`, all specifications will be

--- a/lib/common_test/src/unix_telnet.erl
+++ b/lib/common_test/src/unix_telnet.erl
@@ -28,11 +28,11 @@ host.
 It requires the following entry in the configuration file:
 
 ```erlang
- {unix,[{telnet,HostNameOrIpAddress},
-        {port,PortNum},                 % optional
-        {username,UserName},
-        {password,Password},
-        {keep_alive,Bool}]}.            % optional
+{unix,[{telnet,HostNameOrIpAddress},
+       {port,PortNum},                 % optional
+       {username,UserName},
+       {password,Password},
+       {keep_alive,Bool}]}.            % optional
 ```
 
 To communicate through Telnet to the host specified by `HostNameOrIpAddress`,
@@ -43,13 +43,13 @@ use the interface functions in `m:ct_telnet`, for example, `open(Name)` and
 for example:
 
 ```erlang
- suite() -> [{require,Name,{unix,[telnet]}}].
+suite() -> [{require,Name,{unix,[telnet]}}].
 ```
 
 or
 
 ```erlang
- ct:require(Name,{unix,[telnet]}).
+ct:require(Name,{unix,[telnet]}).
 ```
 
 The "keep alive" activity (that is, that `Common Test` sends NOP to the server
@@ -75,8 +75,6 @@ used. Also the `keep_alive` tuple is optional, and the value default to `true`
 -define(prx,"login: |Password: |\\\$ |> ").
 
 -doc """
-get_prompt_regexp() -> PromptRegexp
-
 Callback for `ct_telnet.erl`.
 
 Returns a suitable `regexp` string matching common prompts for users on Unix
@@ -90,12 +88,9 @@ get_prompt_regexp() ->
     ?prx.
 
 -doc """
-connect(ConnName, Ip, Port, Timeout, KeepAlive, TCPNoDelay, Extra) -> {ok,
-Handle} | {error, Reason}
+Callback for `ct_telnet.erl`.
 
 [](){: #connect-6 }
-
-Callback for `ct_telnet.erl`.
 
 Setup Telnet connection to a Unix host.
 


### PR DESCRIPTION
This PR removes whitespace from codeblocks in the User's Guide (as with 70789d1 & 495b045) and removes redundant function signatures from docstrings.