### PR TITLE
`ssl`: Fix creation of process labels

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -198,9 +198,14 @@ init_label(?SERVER_ROLE = Role, _, Port, Options) ->
 
 host_str(Host) when is_list(Host) ->
     Host;
-host_str(Host) when is_tuple(Host) ->
-    IPStrs = [erlang:integer_to_list(I) || I <- tuple_to_list(Host)],
+host_str({local, File}) when is_list(File); is_binary(File) ->
+    File;
+host_str(IPv4) when tuple_size(IPv4) =:= 4 ->
+    IPStrs = [erlang:integer_to_list(I) || I <- tuple_to_list(IPv4)],
     lists:join(".", IPStrs);
+host_str(IPv6) when tuple_size(IPv6) =:= 8 ->
+    IPStrs = [erlang:integer_to_list(I, 16) || I <- tuple_to_list(IPv6)],
+    lists:join(":", IPStrs);
 host_str(Host) when is_atom(Host) ->
     atom_to_list(Host).
 


### PR DESCRIPTION
The current generation of process labels from the given `Host` breaks the ability to use local sockets (as can be easily seen from how I fixed it), specifically in `ssl:connect`. While the ability to use local sockets is not officially supported and poses a rare edge case, I see no reason not to keep supporting it ATM, certainly not for the reason of generating a label.

This PR also improves the label generated for IPv6 addresses. In the current implementation, it would be generated as a string of dot-separated decimals ("IPv4-style"), instead of as a string of colon-separated hexadecimals (the usual representation of IPv6 addresses).