### PR TITLE
[kernel][dist_util] Support 4-arity #hs_data.f_handshake_complete in dist_util.erl

### DIFF
--- a/erts/doc/guides/alt_dist.md
+++ b/erts/doc/guides/alt_dist.md
@@ -551,7 +551,8 @@ The following `#hs_data{}` record fields need to be set unless otherwise stated:
   following signature:
 
   ```erlang
-  fun (DistCtrlr, Node, DHandle) -> void()
+  fun (DistCtrlr, Node, DHandle) -> void() |
+  fun (DistCtrlr, Node, DHandle, HsData) -> void()
   ```
 
   where `DistCtrlr` is the identifier of the distribution controller, `Node` is
@@ -567,6 +568,11 @@ The following `#hs_data{}` record fields need to be set unless otherwise stated:
   This function is called when the handshake has completed and the distribution
   channel is up. The distribution controller can begin dispatching traffic over
   the channel. This function is optional.
+
+  If a 4-arity function is provided, the final argument `HsData` will be passed
+  which includes information like the "chosen flags" in `#hs_data.other_flags`
+  or the remote node's `#hs_data.other_creation` once the handshake has
+  completed.
 
   Only used during handshake phase.
 

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -503,7 +503,8 @@ connection(#hs_data{other_node = Node,
 		ok ->
                     case HSData#hs_data.f_handshake_complete of
                         undefined -> ok;
-                        HsComplete -> HsComplete(Socket, Node, DHandle)
+                        HsComplete when is_function(HsComplete, 3) -> HsComplete(Socket, Node, DHandle);
+                        HsComplete when is_function(HsComplete, 4) -> HsComplete(Socket, Node, DHandle, HSData)
                     end,
 		    con_loop(#state{kernel = HSData#hs_data.kernel_pid,
                                     node = Node,


### PR DESCRIPTION
Currently, `#hs_data.f_handshake_complete` supports a 3-arity function with the following function signature:

```erlang
fun (DistCtrlr, Node, DHandle) -> void()
```

This PR extends the callback to also handle a 4-arity function:

```erlang
fun (DistCtrlr, Node, DHandle) -> void() |
fun (DistCtrlr, Node, DHandle, HsData) -> void()
```

Why?  Once the handshake compeltes, there's currently no way to find out what the final `ChosenFlags` are between `this_node` and `other_node`; or what the value of `other_creation` was.

The `HSData` variable is effectively discarded entirely when `con_loop` is called, so this information is lost for those wanting to implement an alternative dist protocol.

See here for an example of how this information is used in [WhatsApp/erldist_filter](https://github.com/WhatsApp/erldist_filter): https://github.com/WhatsApp/erldist_filter/blob/main/apps/erldist_filter/src/erldist_filter_otp_26_0_2_inet_tcp_dist.erl#L931-L937