### PR TITLE
use C++11 list initializers

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.cpp
@@ -74,9 +74,10 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
             stop = (ErtsCodePtr)((char *)getBaseAddress() + code.codeSize());
         }
 
-        ranges.push_back({.start = start,
-                          .stop = stop,
-                          .name = code.labelEntry(labels[val.first])->name()});
+        ranges.push_back(AsmRange{start,
+                                  stop,
+                                  code.labelEntry(labels[val.first])->name(),
+                                  {}});
     }
 
     (void)beamasm_metadata_insert("global",

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -541,10 +541,7 @@ const Label &BeamModuleAssembler::resolve_label(const Label &target,
         anchor = a.newNamedLabel(name.str().c_str());
     }
 
-    auto it = _veneers.emplace(target.id(),
-                               Veneer{.latestOffset = maxOffset,
-                                      .anchor = anchor,
-                                      .target = target});
+    auto it = _veneers.emplace(target.id(), Veneer{maxOffset, anchor, target});
 
     const Veneer &veneer = it->second;
     _pending_veneers.emplace(veneer);
@@ -590,10 +587,8 @@ arm::Mem BeamModuleAssembler::embed_constant(const ArgVal &value,
         }
     }
 
-    auto it = _constants.emplace(value,
-                                 Constant{.latestOffset = maxOffset,
-                                          .anchor = a.newLabel(),
-                                          .value = value});
+    auto it =
+            _constants.emplace(value, Constant{maxOffset, a.newLabel(), value});
     const Constant &constant = it->second;
     _pending_constants.emplace(constant);
 
@@ -608,10 +603,9 @@ arm::Mem BeamModuleAssembler::embed_label(const Label &label,
 
     ASSERT(disp >= dispMin && disp <= dispMax);
 
-    auto it = _embedded_labels.emplace(label.id(),
-                                       EmbeddedLabel{.latestOffset = maxOffset,
-                                                     .anchor = a.newLabel(),
-                                                     .label = label});
+    auto it = _embedded_labels.emplace(
+            label.id(),
+            EmbeddedLabel{maxOffset, a.newLabel(), label});
     ASSERT(it.second);
     const EmbeddedLabel &embedded_label = it.first->second;
     _pending_labels.emplace(embedded_label);


### PR DESCRIPTION
Hi, this PR changed some designated initializers back to list initializers (available from C++11) as designated initializers are available from C++20, [aggregate initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization); and we're requiring C++17 as the minimum when compiling for Windows.

https://github.com/erlang/otp/blob/40568b0d940be77a93d3a3b00cf9d7134cde0dc4/erts/etc/win32/wsl_tools/vc/cc.sh#L192

It didn't cause compile-time errors for i386/x86_64 Windows as these lines are intended for ARM64 JIT (and currently that's Linux and macOS only). Attempt to compile these lines using msvc for ARM64 targets will yield the following errors:

```
CXX    obj/win32/opt/jit/beam_asm_global.o
beam\jit\arm\beam_asm_global.cpp(77): error C7555: use of designated initializers requires at least '/std:c++20'
Failed: cl.exe -nologo -D__WIN32__ -DWIN32 -DWINDOWS -D_WIN32 -DNT -D_CRT_SECURE_NO_DEPRECATE -D__aarch64__ -MD -Ox -Z7 /std:c++17 /Zc:__cplusplus -DASMJIT_EMBED=1 -DASMJIT_NO_BUILDER=1 -DASMJIT_NO_DEPRECATED=1 -DASMJIT_STATIC=1 -DASMJIT_NO_FOREIGN=1 -Iwin32/opt/jit -Ibeam -Isys/win32 -Isys/common -Iwin32 -Izlib -Ipcre -Iryu -Iopenssl/include -I../include -I../include/win32 -I../include/internal -I../include/internal/win32 -Ibeam/jit -Ibeam/jit/arm -I"C:\src\erts\win32" -D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -DERTS_MIXED_VC -DSTATIC_ERLANG_DRIVER -DHAVE_CONFIG_H -DUSE_THREADS -DWIN32_THREADS -DBEAMASM=1 /std:c++17 /Zc:__cplusplus /EHsc /FS -c -FoC:\src\erts\emulator\obj\win32\opt\jit\beam_asm_global.o beam\jit\arm\beam_asm_global.cpp
make[4]: *** [win32/Makefile:947: obj/win32/opt/jit/beam_asm_global.o] Error 2
make[4]: Leaving directory '/mnt/c/src/erts/emulator'
make[3]: *** [/mnt/c/src/make/run_make.mk:35: opt] Error 2
make[3]: Leaving directory '/mnt/c/src/erts/emulator'
make[2]: *** [Makefile:45: opt] Error 2
make[2]: Leaving directory '/mnt/c/src/erts'
make[1]: *** [Makefile:60: jit] Error 2
make[1]: Leaving directory '/mnt/c/src/erts'
make: *** [Makefile:483: emulator] Error 2
```

This was originally discussed in https://github.com/erlang/otp/pull/8142#discussion_r1494332181