### PR TITLE
Prepare NSIS scripts for ARM64 Windows

### DIFF
--- a/erts/etc/win32/nsis/Makefile
+++ b/erts/etc/win32/nsis/Makefile
@@ -54,6 +54,9 @@ WTARGET_DIR=$(shell (w32_path.sh -d "$(TARGET_DIR)"))
 ifeq ($(CONFIG_SUBTYPE),win64)
   WINTYPE=win64
   REDIST_TARGET=vcredist_x64.exe
+else ifeq ($(CONFIG_SUBTYPE),arm64)
+  WINTYPE=arm64
+  REDIST_TARGET=vcredist_arm64.exe
 else
   WINTYPE=win32
   REDIST_TARGET=vcredist_x86.exe

--- a/erts/etc/win32/nsis/erlang20.nsi
+++ b/erts/etc/win32/nsis/erlang20.nsi
@@ -68,7 +68,11 @@ Var STARTMENU_FOLDER
 !if ${WINTYPE} == "win64"
 	!define MUI_STARTMENUPAGE_DEFAULTFOLDER "${OTP_PRODUCT} ${OTP_RELEASE} (x64)"
 !else
-	!define MUI_STARTMENUPAGE_DEFAULTFOLDER "${OTP_PRODUCT} ${OTP_RELEASE} (i386)"
+	!if ${WINTYPE} == "arm64"
+		!define MUI_STARTMENUPAGE_DEFAULTFOLDER "${OTP_PRODUCT} ${OTP_RELEASE} (arm64)"
+	!else
+		!define MUI_STARTMENUPAGE_DEFAULTFOLDER "${OTP_PRODUCT} ${OTP_RELEASE} (i386)"
+	!endif
 !endif  
 
 ;--------------------------------
@@ -384,6 +388,10 @@ Function .onInit
    SectionGetFlags 0 $MYTEMP
    StrCmpS ${WINTYPE} "win64" +1 +4
 	StrCpy $archprefix "amd64"
+	StrCpy $sysnativedir "$WINDIR\sysnative"
+   Goto +4
+    StrCmpS ${WINTYPE} "arm64" +1 +6
+	StrCpy $archprefix "arm64"
 	StrCpy $sysnativedir "$WINDIR\sysnative"
    Goto +3
 	StrCpy $archprefix "x86"

--- a/erts/etc/win32/nsis/find_redist.sh
+++ b/erts/etc/win32/nsis/find_redist.sh
@@ -85,13 +85,19 @@ add_path_element()
 if [ "$1" = "win64" ]; then
     AMD64DIR=true
     VCREDIST=vcredist_x64
+    VCREDIST2=vcredist.x64
     COMPONENTS="cl amd64 bin vc"
 elif [ "$1" = "win32" ]; then
     AMD64DIR=false
     VCREDIST=vcredist_x86
+    VCREDIST2=vcredist.x86
     COMPONENTS="cl bin vc"
+elif [ "$1" = "arm64" ]; then
+    AMD64DIR=false
+    VCREDIST=vcredist_arm64
+    VCREDIST2=vcredist.arm64
 else
-    echo "TARGET argument should win32 or win64"
+    echo "TARGET argument should win32, win64 or arm64"
     exit 2
 fi
 
@@ -101,11 +107,16 @@ if [ x"$VCToolsRedistDir" != x"" ]; then
 	echo "$File"
 	exit 0
     fi
+    File="$VCToolsRedistDir/$VCREDIST2.exe"
+    if [ -r "$File" ]; then
+	echo "$File"
+	exit 0
+    fi
 fi
 
 CLPATH=`lookup_prog_in_path cl`
 if [ -z "$CLPATH" ]; then 
-    echo "Can not locate cl.exe and vcredist_x86/x64.exe - OK if using mingw" >&2
+    echo "Can not locate cl.exe and vcredist_x86/x64/arm64.exe - OK if using mingw" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Hi, this PR prepares NSIS scripts for ARM64 windows and adds checks for the new vcredist filename format, [`vcredist.ARCH.exe`](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version).