### PR TITLE
Fix assertion in prim_tty

### DIFF
--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -544,7 +544,7 @@ reader_loop(TTY, Parent, SignalRef, ReaderRef, FromEnc, Acc) ->
                             {error, B, Error} ->
                                 %% We should only be able to get incorrect encoded data when
                                 %% using utf8
-                                FromEnc = utf8,
+                                UpdatedFromEnc = utf8,
                                 Parent ! {self(), set_unicode_state, false},
                                 receive
                                     {set_unicode_state, false} ->


### PR DESCRIPTION
The reader updates the Unicode state right before checking the input's encoding, but the assertion that encoding errors are only possible when using utf8 was done against the original state.

Sorry for not writing any test cases, but this is a trivial bugfix for a hard to reproduce race condition.