### PR TITLE
Fix disk_log bug/typo

### DIFF
--- a/lib/kernel/src/disk_log.erl
+++ b/lib/kernel/src/disk_log.erl
@@ -582,7 +582,12 @@ check_arg([], Res) ->
 		disk_log_1:read_size_file_version(Res#arg.file),
 	    check_wrap_arg(Ret, OldSize, Version);
         Res#arg.type =:= rotate ->
-            {ok, Res#arg{format = external}};
+            case Ret of
+                {ok, Patched} ->
+                    {ok, Patched#arg{format = external}};
+                _ ->
+                    Ret
+            end;
 	true ->
 	    Ret
     end;


### PR DESCRIPTION
It returned the wrong record when checking arguments, which caused the element `head` to be set wrongly.