### PR TITLE
ssl: Map ECSDA scheme name to hash/signature pair for TLS-1.2

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -629,6 +629,11 @@ signature_schemes_1_2(SigAlgs) ->
                                 [{Hash, Sign} | Acc];
                             {Hash, Sign = rsa_pss_rsae,_} ->
                                 [{Hash, Sign} | Acc];
+                            %% TLS-1.2 do not constrian the
+                            %% curve, however must be one
+                            %% present in "supported groups" (eccs)
+                            {Hash, ecdsa = Sign, _} ->
+                                [{Hash, Sign} | Acc];
                             {Hash, Sign, undefined} ->
                                 [{Hash, format_sign(Sign)} | Acc];
                             {_, _, _} ->


### PR DESCRIPTION
closes #8376