### PR TITLE
Add clang-format to build tools

### DIFF
--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -13,7 +13,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 ## Install build tools
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y build-essential m4 autoconf \
+    apt-get install -y build-essential m4 autoconf clang-format \
     default-jdk flex pkg-config locales tzdata sudo ${INSTALL_LIBS} && \
     sed -i 's@# en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && locale-gen && \
     update-alternatives --set wx-config /usr/lib/x86_64-linux-gnu/wx/config/gtk3-unicode-3.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -449,12 +449,6 @@ jobs:
       - uses: ./.github/actions/build-base-image
         with:
             BASE_BRANCH: ${{ env.BASE_BRANCH }}
-      - name: Install clang-format
-        run: |
-          docker build -t otp - <<EOF
-          FROM otp
-          RUN sudo apt-get install -y clang-format
-          EOF
         ## Check formatting of cpp code
       - name: Check format
         run: docker run otp "make format-check"


### PR DESCRIPTION
This change allows running full `otp_build_check` in docker dev environment, without this you need to do `otp_build_check --no-format-check` (or install clang-format yourself).

I think this is fine to do, it depends on following packages (showing only clang related):
- clang-format-10
- libclang-cpp10

So full clang binaries are not installed, @garazdawi can I do that?