### PR TITLE
Crash dump viewer: ignore allocator type from blocks size keys

### DIFF
--- a/lib/observer/src/cdv_mem_cb.erl
+++ b/lib/observer/src/cdv_mem_cb.erl
@@ -84,5 +84,5 @@ fix_alloc([]) ->
     [].
 
 alloc_columns(Columns) ->
-    [{"",   ?wxLIST_FORMAT_LEFT,  180} |
+    [{"", ?wxLIST_FORMAT_LEFT, 240} |
      [{Column, ?wxLIST_FORMAT_RIGHT, 140} || Column <- Columns]].

--- a/lib/observer/src/crashdump_viewer.erl
+++ b/lib/observer/src/crashdump_viewer.erl
@@ -2537,7 +2537,8 @@ sort_allocator_types([],Acc,DoTotal) ->
 
 sort_type_data(Type,[?opt_e_false|Data],Acc,_) when Type=/=?sbmbc_alloc->
     sort_type_data(Type,Data,Acc,false);
-sort_type_data(Type,[{Key,Val0}|Data],Acc,DoTotal) ->
+sort_type_data(Type,[{Key0,Val0}|Data],Acc,DoTotal) ->
+    Key = re:replace(Key0, "([^[]*)(\\[[^]]*\\])(.*)", "\\1\\3", [{return, list}]),
     case lists:member(Key,?interesting_allocator_info) of
 	true ->
 	    Val = list_to_integer(hd(Val0)),

--- a/lib/observer/test/crashdump_viewer_SUITE.erl
+++ b/lib/observer/test/crashdump_viewer_SUITE.erl
@@ -364,7 +364,7 @@ browse_file(File) ->
     {ok,Mods,_ModsTW} = crashdump_viewer:loaded_modules(),
     {ok,_Mem,_MemTW} = crashdump_viewer:memory(),
     {ok,_AllocAreas,_AreaTW} = crashdump_viewer:allocated_areas(),
-    {ok,_AllocINfo,_AllocInfoTW} = crashdump_viewer:allocator_info(),
+    {ok,AllocInfo,_AllocInfoTW} = crashdump_viewer:allocator_info(),
     {ok,_HashTabs,_HashTabsTW} = crashdump_viewer:hash_tables(),
     {ok,_IndexTabs,_IndexTabsTW} = crashdump_viewer:index_tables(),
     {ok,_PTs,_PTsTW} = crashdump_viewer:persistent_terms(),
@@ -379,6 +379,9 @@ browse_file(File) ->
     io:format("  mods ok",[]),
     lookat_all_nodes(Nodes),
     io:format("  nodes ok",[]),
+
+    lookat_alloc_info(AllocInfo,is_truncated(File)),
+    io:format("  alloc info ok",[]),
 
     Procs. % used as second arg to special/2
 
@@ -732,6 +735,32 @@ lookat_all_nodes([#nod{channel=Channel0}|Nodes]) ->
     Channel = integer_to_list(Channel0),
     {ok,_Node=#nod{},_NodeTW} = crashdump_viewer:node_info(Channel),
     lookat_all_nodes(Nodes).
+
+lookat_alloc_info(_,true) ->
+    ok;
+lookat_alloc_info([AllocSummary|_],false) ->
+    {"Allocator Summary",
+     ["blocks size", "carriers size", "mseg carriers size"],
+     Data
+    } = AllocSummary,
+
+    %% All values must be integer.
+    Filter = filter_alloc_info_fun(),
+    _ = [list_to_integer(IntStr) || {_,L} <- Data,
+                                    IntStr <- Filter(L)],
+
+    ok.
+
+filter_alloc_info_fun() ->
+    case os:type() of
+        {win32,_} ->
+            fun([A,B,_]) ->
+                    %% The third column is never valid on Windows.
+                    [A,B]
+            end;
+        _ ->
+            fun([_,_,_]=L) -> L end
+    end.
 
 %%%-----------------------------------------------------------------
 %%% 


### PR DESCRIPTION
When gathering info about the allocators (particularly the summaries), crashdump viewer filters "interesting allocator info". However recent crash dumps also contain allocator type in the key so for example "mbcs blocks[sys_alloc] size" did not match the expected "mbcs blocks size". This resulted in "blocks size" always showing "N/A" on the "Allocator Summary" page. This commit removes the part in square brackets when summing blocks size values for each allocator type.

Also the first column is made wider to fit the longer keys on the per allocator instance pages.

This PR can be considered just a bug report. My solution here is just a random quick fix and there might be a better one.