### PR TITLE
fprof: Fix crash when using pause/restart/continue when profiling all

### DIFF
--- a/lib/tools/src/tprof.erl
+++ b/lib/tools/src/tprof.erl
@@ -1368,6 +1368,10 @@ collect_ad_hoc(Session, Pattern, Type) ->
                   not (Mod =:= erts_internal andalso Fun =:= trace andalso Arity =:= 4)
            ]}.
 
+foreach(S, all, Action, Type) ->
+    _ = trace:function(S, on_load, Action, [Type]),
+    _ = trace:function(S, {'_', '_', '_'}, Action, [Type]),
+    ok;
 foreach(S, Map, Action, Type) ->
     maps:foreach(
         fun (Mod, Funs) ->


### PR DESCRIPTION
When running in server mode and profiling all, the function pause/restart/continue would crash as they received the atom 'all' as an interator.

closes #8472