### PR TITLE
Fix errors for gcc 14

### DIFF
--- a/erts/emulator/test/float_SUITE_data/fp_drv.c
+++ b/erts/emulator/test/float_SUITE_data/fp_drv.c
@@ -123,7 +123,7 @@ static ErlDrvSSizeT control(ErlDrvData drv_data,
 	    res_str = "skip: no thread support";
 	else if (0 != erl_drv_thread_create("test", &tid, do_test, NULL, NULL))
 	    res_str = "failed to create thread";
-	else if (0 != erl_drv_thread_join(tid, &res_str))
+	else if (0 != erl_drv_thread_join(tid, (void**)&res_str))
 	    res_str = "failed to join thread";
 	break;
     }

--- a/erts/emulator/test/port_SUITE_data/dead_port.c
+++ b/erts/emulator/test/port_SUITE_data/dead_port.c
@@ -40,7 +40,7 @@
 #include "winbase.h"
 #endif
 
-#define MAIN(argc, argv) main(argc, argv)
+#define MAIN(argc, argv) int main(argc, argv)
 
 extern int errno;
 

--- a/erts/emulator/test/signal_SUITE_data/unlink_signal_drv.c
+++ b/erts/emulator/test/signal_SUITE_data/unlink_signal_drv.c
@@ -61,7 +61,7 @@ DRIVER_INIT(unlink_signal_entry)
 }
 
 typedef struct {
-    ErlDrvData port;
+    ErlDrvPort port;
     int timeout_count;
 } us_drv_state;
 


### PR DESCRIPTION
Hi,

When building Erlang/OTP 27 with GCC 14.1.0, I got some compilations errors.


Thanks.