### PR TITLE
Improve illegal pattern error for accidental map associations

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -394,6 +394,7 @@ format_error_1({too_many_arguments,Arity}) ->
 format_error_1(update_literal) ->
     ~"expression updates a literal";
 %% --- patterns and guards ---
+format_error_1(illegal_map_assoc_in_pattern) -> ~"illegal pattern, did you mean to use `:=`?";
 format_error_1(illegal_pattern) -> ~"illegal pattern";
 format_error_1(illegal_map_key) -> ~"illegal map key in pattern";
 format_error_1(illegal_expr) -> ~"illegal expression";
@@ -2047,7 +2048,7 @@ is_pattern_expr_1(_Other) -> false.
 
 pattern_map(Ps, Vt0, Old, St0) ->
     foldl(fun({map_field_assoc,A,_,_}, {Psvt,Psnew,St1}) ->
-                  {Psvt,Psnew,add_error(A, illegal_pattern, St1)};
+                  {Psvt,Psnew,add_error(A, illegal_map_assoc_in_pattern, St1)};
              ({map_field_exact,_A,K,V}, {Psvt,Psnew,St1}) ->
                   St2 = St1#lint{gexpr_context=map_key},
                   {Kvt, St3} = gexpr(K, Vt0, St2),

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -4070,7 +4070,7 @@ maps(Config) ->
              {{4,24},erl_lint,illegal_map_construction},
              {{8,36},erl_lint,illegal_map_construction}],
             [{{5,20},erl_lint,update_literal}]}},
-          {illegal_pattern,
+          {illegal_map_assoc_in_pattern,
            <<"t(#{ a := A,
                    c => d,
                    e := F,
@@ -4082,7 +4082,7 @@ maps(Config) ->
                   {A,F}.
             ">>,
            [],
-           {errors,[{{2,22},erl_lint,illegal_pattern},
+           {errors,[{{2,22},erl_lint,illegal_map_assoc_in_pattern},
                     {{7,28},erl_lint,illegal_pattern}],
             []}},
           {error_in_illegal_map_construction,


### PR DESCRIPTION
Given a module such as this:

    -module(test).
    -export([pattern/1]).

    pattern(#{foo => bar}) -> ok.

We presently report an error as:

    test.erl:4:15: illegal pattern
    %    4| pattern(#{foo => bar}) -> ok.
    %     |               ^

Since we have information in `erl_lint` on the bad pattern being a map field update, we can be a bit more helpful by extending the error with a hint instructing the user that `:=` is most likely wanted instead:

    test.erl:4:15: illegal pattern, did you mean to use `:=`?
    %    4| pattern(#{foo => bar}) -> ok.
    %     |               ^