### PR TITLE
stdlib: turn singleton type var warning into error

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -799,9 +799,6 @@ start(File, Opts) ->
          {redefined_builtin_type,
           bool_option(warn_redefined_builtin_type, nowarn_redefined_builtin_type,
                       true, Opts)},
-         {singleton_typevar,
-          bool_option(warn_singleton_typevar, nowarn_singleton_typevar,
-                      true, Opts)},
          {match_float_zero,
           bool_option(warn_match_float_zero, nowarn_match_float_zero,
                       true, Opts)},
@@ -3191,24 +3188,16 @@ warn_redefined_builtin_type(Anno, TypePair, #lint{compile=Opts}=St) ->
 
 check_type(Types, St) ->
     {SeenVars, St1} = check_type_1(Types, maps:new(), St),
-    maps:fold(fun(Var, {seen_once, Anno}, AccSt) ->
-		      case atom_to_list(Var) of
-			  "_"++_ -> AccSt;
-			  _ -> add_error(Anno, {singleton_typevar, Var}, AccSt)
-		      end;
-                 (Var, {seen_once_union, Anno}, AccSt) ->
-                      case is_warn_enabled(singleton_typevar, AccSt) of
-                          true ->
-                              case atom_to_list(Var) of
-                                  "_"++_ -> AccSt;
-                                  _ -> add_warning(Anno, {singleton_typevar, Var}, AccSt)
-                              end;
-                          false ->
-                              AccSt
+    maps:fold(fun(Var, {SeenOnce, Anno}, AccSt)
+                    when SeenOnce =:= seen_once;
+                         SeenOnce =:= seen_once_union ->
+                      case atom_to_list(Var) of
+                          "_"++_ -> AccSt;
+                          _ -> add_error(Anno, {singleton_typevar, Var}, AccSt)
                       end;
-		 (_Var, seen_multiple, AccSt) ->
-		      AccSt
-	      end, St1, SeenVars).
+                 (_Var, seen_multiple, AccSt) ->
+                      AccSt
+              end, St1, SeenVars).
 
 check_type_1({type, Anno, TypeName, Args}=Type, SeenVars, #lint{types=Types}=St) ->
     TypePair = {TypeName,

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -1034,7 +1034,7 @@ singleton_type_var_errors(Config) when is_list(Config) ->
                   error.
              ">>,
            [],
-           {warnings,[{{2,36},erl_lint,{singleton_typevar,'Unknown'}}]}},
+           {errors,[{{2,36},erl_lint,{singleton_typevar,'Unknown'}}], []}},
 
           {singleton_error2,
            <<"-spec test_singleton_list_typevars_in_union([Opts]) -> term() when
@@ -1042,7 +1042,7 @@ singleton_type_var_errors(Config) when is_list(Config) ->
                 test_singleton_list_typevars_in_union(_) ->
                     error.">>,
            [],
-           {warnings,[{{2,36},erl_lint,{singleton_typevar,'Unknown'}}]}},
+           {errors,[{{2,36},erl_lint,{singleton_typevar,'Unknown'}}], []}},
 
           {singleton_error3,
            <<"-spec test_singleton_list_typevars_in_list([Opts]) -> term() when
@@ -1067,7 +1067,7 @@ singleton_type_var_errors(Config) when is_list(Config) ->
                 test_singleton_buried_typevars_in_union(_) ->
                     error.">>,
            [],
-           {warnings,[{{3,38},erl_lint,{singleton_typevar,'X'}}]}},
+           {errors,[{{3,38},erl_lint,{singleton_typevar,'X'}}], []}},
 
           {singleton_error6,
            <<"-spec test_multiple_subtypes_to_same_typevar(Opts) -> term() when
@@ -1098,15 +1098,6 @@ singleton_type_var_errors(Config) when is_list(Config) ->
                   error.">>,
            [],
            {errors,[{{2,21},erl_lint,{singleton_typevar,'Unused'}}],[]}},
-
-          {singleton_disabled_warning,
-           <<"-spec test_singleton_typevars_in_union(Opts) -> term() when
-                      Opts :: {ok, Unknown} | {error, Unknown}.
-                test_singleton_typevars_in_union(_) ->
-                  error.
-             ">>,
-           [nowarn_singleton_typevar],
-           []},
 
           {singleton_ok1,
            <<"-spec test_multiple_occurrences_singleton(Opts) -> term() when


### PR DESCRIPTION
Singleton type variables in an union type do not make sense from Dialyzer's point of view. The following example is ill-typed:

```erlang
-spec run_test(Opts) -> term()
      when Opts :: {join_specs, Bool} | {test, Bool}.
```

But this cannot be ever checked by Dialyzer as the type variable `Bool` is in a union and used a single time. Dialyzer cannot check that the `Bool` set of values passed to `join_specs` will be the same set of values as the ones passed in the `Bool` type variable in the `test` branch. Thus, an error follows.