### PR TITLE
Emacs: Add electric-pair-mode support for triple-quoted strings

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -1606,7 +1606,9 @@ Other commands:
   (put 'bitsyntax-close-outer 'syntax-table '(5 . ?<))
   (put 'bitsyntax-close-outer 'rear-nonsticky '(category))
   (make-local-variable 'parse-sexp-lookup-properties)
-  (setq parse-sexp-lookup-properties 't))
+  (setq parse-sexp-lookup-properties 't)
+  (add-hook 'post-self-insert-hook
+    #'erlang-electric-pair-string-delimiter 'append t))
 
 
 (defun erlang-mode-variables ()
@@ -4388,6 +4390,17 @@ non-whitespace characters following the point on the current line."
           (remove-text-properties (point) (1+ (point))
                                   '(category nil))
           (forward-char 1))))))
+
+(defun erlang-electric-pair-string-delimiter ()
+  "Check if a third double-quote was just inserted, and if so, insert three more."
+  (when (and electric-pair-mode
+             (eq last-command-event ?\")
+             (let ((count 0))
+               (while (eq (char-before (- (point) count)) last-command-event)
+                 (cl-incf count))
+               (= count 3))
+             (eq (char-after) last-command-event))
+    (save-excursion (insert (make-string 2 last-command-event)))))
 
 (defun erlang-after-bitsyntax-close ()
   "Return t if point is immediately after a bit-syntax close parenthesis (`>>')."

--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -4400,7 +4400,8 @@ non-whitespace characters following the point on the current line."
                  (cl-incf count))
                (= count 3))
              (eq (char-after) last-command-event))
-    (save-excursion (insert (make-string 2 last-command-event)))))
+    (insert ?\n)
+    (save-excursion (insert "\n\"\""))))
 
 (defun erlang-after-bitsyntax-close ()
   "Return t if point is immediately after a bit-syntax close parenthesis (`>>')."


### PR DESCRIPTION
This adds support for automatically inserting the closing delimiter for triple-quoted string literals in the Emacs mode.

If `erlang-mode` and `electric-pair-mode` are enabled, it works as follows, if `|` is the cursor position and a double quote is inserted.
```
""|  ->  """|"""
```

This is accomplished by adding a function to `post-self-insert-hook` checking whenever `electric-pair-mode` is enabled and a third double quote is inserted, and then inserting three more.  The approach is taken from `python.el`, which has the same feature for Python's triple-quote strings.