### PR TITLE
httpc: Fix percent-encoding of userinfo in URLs

### DIFF
--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -285,10 +285,12 @@ handle_user_info([], Headers) ->
 handle_user_info(UserInfo, Headers) ->
     case string:tokens(UserInfo, ":") of
 	[User, Passwd] ->
-	    UserPasswd = base64:encode_to_string(User ++ ":" ++ Passwd),
+	    UserPasswd = base64:encode_to_string(
+	        uri_string:percent_decode(User) ++ ":" ++ uri_string:percent_decode(Passwd)
+	    ),
 	    Headers#http_request_h{authorization = "Basic " ++ UserPasswd};
 	[User] ->
-	    UserPasswd = base64:encode_to_string(User ++ ":"),
+	    UserPasswd = base64:encode_to_string(uri_string:percent_decode(User) ++ ":"),
 	    Headers#http_request_h{authorization = "Basic " ++ UserPasswd}; 
 	_ ->
 	    Headers

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -973,14 +973,14 @@ userinfo() ->
     [{doc, "Test user info e.i. http://user:passwd@host:port/"}].
 userinfo(Config) when is_list(Config) ->
     
-    URLAuth = url(group_name(Config), "alladin:sesame", "/userinfo.html", Config),
+    URLAuth = url(group_name(Config), "alladin%40example.com:sesame", "/userinfo.html", Config),
     RequestOpts = proplists:get_value(request_opts, Config, []),
     Profile = ?profile(Config),
 
     {ok, {{_,200,_}, [_ | _], _}}
 	= httpc:request(get, {URLAuth, []}, [?SSL_NO_VERIFY], RequestOpts, Profile),
 
-    URLUnAuth = url(group_name(Config), "alladin:foobar", "/userinfo.html", Config),
+    URLUnAuth = url(group_name(Config), "alladin%40example.com:foobar", "/userinfo.html", Config),
 
     {ok, {{_,401, _}, [_ | _], _}} =
 	httpc:request(get, {URLUnAuth, []}, [?SSL_NO_VERIFY], RequestOpts, Profile).
@@ -2521,7 +2521,7 @@ content_type_header([_|T]) ->
 
 handle_auth("Basic " ++ UserInfo, Challenge, DefaultResponse) ->
     case string:tokens(base64:decode_to_string(UserInfo), ":") of
-	["alladin", "sesame"] = Auth ->
+	["alladin@example.com", "sesame"] = Auth ->
 	    ct:log("Auth: ~p~n", [Auth]),
 	    DefaultResponse;
 	Other ->


### PR DESCRIPTION
According to RFC3986 section-3.2.1, the valid characters for the userinfo component are as follows:

  userinfo    = *( unreserved / pct-encoded / sub-delims / ":" )

This does not include the "@" character, which must be percent-encoded when it appears in the userinfo component of a URL.

The Basic authentication scheme, as defined in RFC7617, does not restrict the use of any characters except for the colon (":") character in the user id. The colon should not be percent-encoded, it is just not a valid part of the user id.

When the userinfo component from the URL is converted into a Basic Authorization header, then the string is correctly validated, but is not decoded. This means that the percent-encoded characters end up in the Authorization header, which the servers are expected to interpet literally and not as percent-encoded. This results in user ids and passwords containing reserved characters to be misinterpreted by servers and rejected.

This commit ensures that the userinfo component is properly decoded before being used in the Basic Authorization header.