### PR TITLE
Remove dead macro ERTS_EMPTY_RUNQ_PORTS

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -111,9 +111,6 @@
 #define ERTS_EMPTY_RUNQ(RQ) \
     ERTS_IS_RUNQ_EMPTY_FLGS(ERTS_RUNQ_FLGS_GET_NOB((RQ)))
 
-#define ERTS_EMPTY_RUNQ_PORTS(RQ) \
-    ERTS_IS_RUNQ_EMPTY_FLGS(ERTS_RUNQ_FLGS_GET_NOB((RQ)))
-
 static ERTS_INLINE int
 runq_got_work_to_execute_flags(Uint32 flags)
 {


### PR DESCRIPTION
It was clearly wrong (copy of ERTS_EMPTY_RUNQ instead of checking ERTS_IS_RUNQ_EMPTY_***PORTS***_FLAGS), but mercifully it was unused, so let's just remove it rather than fixing it.