### PR TITLE
Fix xmerl_sax_parser:file/2 spec

### DIFF
--- a/lib/xmerl/src/xmerl_sax_parser.erl
+++ b/lib/xmerl/src/xmerl_sax_parser.erl
@@ -294,7 +294,8 @@ This functions uses a default continuation function to read the file in blocks.
       Options :: options(),
       EventState :: event_state(),
       Rest :: unicode_binary() | latin1_binary(),
-      ErrorOrUserReturn :: {Tag, Location, Reason, EndTags, EventState},
+      ErrorOrUserReturn :: {Tag, Location, Reason, EndTags, EventState}
+                         | {error, {Name, Reason}},
       Tag :: fatal_error | atom(),
       Location :: event_location(),
       Reason :: term(),

--- a/lib/xmerl/test/xmerl_sax_SUITE.erl
+++ b/lib/xmerl/test/xmerl_sax_SUITE.erl
@@ -195,6 +195,7 @@ external_entities_test(Config) ->
     {ok, undefined, <<>>} = xmerl_sax_parser:file(File2, [{external_entities, file}]),
     %% Allow none (default)
     {fatal_error, _, _, _, _} = xmerl_sax_parser:file(File1, []),
+    {error, _} = xmerl_sax_parser:file("NonExistingFileError.xml", []),
     {ok, undefined, <<>>} = xmerl_sax_parser:file(File2, []), %% Not included but parsed, See if it can be fixed
     ok.
 


### PR DESCRIPTION
Add missing error return type resulted from file:open.