### PR TITLE
crypto: Warning if FIPS supported but application 'crypto' not loaded

### DIFF
--- a/lib/crypto/src/crypto.app.src
+++ b/lib/crypto/src/crypto.app.src
@@ -25,6 +25,6 @@
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, [{fips_mode, false}, {rand_cache_size, 896}]},
-    {runtime_dependencies, ["erts-9.0","stdlib-3.9","kernel-5.3"]}]}.
+    {runtime_dependencies, ["erts-9.0","stdlib-3.9","kernel-6.0"]}]}.
 
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -2139,7 +2139,15 @@ on_load() ->
 	      end,
     Lib = filename:join([PrivDir, "lib", LibName]),
     LibBin   = path2bin(Lib),
-    FipsMode = application:get_env(crypto, fips_mode, false) == true,
+    {FipsMode,AppLoaded} =
+        case application:get_env(crypto, fips_mode) of
+            {ok, true} -> {true, loaded};
+            {ok, _} -> {false, loaded};
+            undefined ->
+                %% We assume application crypto has a default value for fips_mode.
+                %% If undefined the application has not been loaded.
+                {false, unloaded}
+        end,
     Status = case erlang:load_nif(Lib, {?CRYPTO_NIF_VSN,LibBin,FipsMode}) of
 		 ok -> ok;
 		 {error, {load_failed, _}}=Error1 ->
@@ -2161,7 +2169,9 @@ on_load() ->
 		 Error1 -> Error1
 	     end,
     case Status of
-	ok -> ok;
+	ok ->
+            warn_app_not_loaded_maybe(AppLoaded),
+            ok;
 	{error, {E, Str}} ->
             Fmt = "Unable to load crypto library. Failed with error:~n\"~p, ~s\"~n~s",
             Extra = case E of
@@ -2171,6 +2181,19 @@ on_load() ->
                     end,
 	    error_logger:error_msg(Fmt, [E,Str,Extra]),
 	    Status
+    end.
+
+warn_app_not_loaded_maybe(loaded) ->
+    ok;
+warn_app_not_loaded_maybe(unloaded) ->
+    %% For backward compatible reasons we allow application crypto
+    %% not being loaded.
+    case info_fips() of
+        not_enabled ->
+            logger:warning("Module 'crypto' loaded without application 'crypto' being loaded.\n"
+                           "Without application config 'fips_mode' loaded, FIPS mode is disabled by default.");
+        _ ->
+            ok
     end.
 
 path2bin(Path) when is_list(Path) ->


### PR DESCRIPTION
Fix #8582.

To enable FIPS mode, crypto application config parameter `fips_mode` must be `true`.
However, the application must first be loaded for the config to be accessible when module crypto is invoked.

If application crypto is not loaded, module crypto will use default `fips_mode` as `false` which may come as a surprise if erl was started with command line `-crypto fips_mode true`.

Issue this warning if the underlying OpenSSL lib supports FIPS but the crypto application has not been loaded:

```
=WARNING REPORT==== 17-Jun-2024::17:34:17.238651 ===
Module 'crypto' loaded without application 'crypto' being loaded.
Without application config 'fips_mode' loaded, FIPS mode is disabled by default.
```
