### PR TITLE
Remove locking in erts_schedulers_state() during crash dump

### DIFF
--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -805,9 +805,6 @@ erl_crash_dump_v(char *file, int line, const char* fmt, va_list args)
     LimitedWriterInfo lwi;
     static char* write_buffer;  /* 'static' to avoid a leak warning in valgrind */
 
-    if (ERTS_SOMEONE_IS_CRASH_DUMPING)
-	return;
-
     /* Order all managed threads to block, this has to be done
        first to guarantee that this is the only thread to generate
        crash dump. */

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -8007,7 +8007,10 @@ erts_schedulers_state(Uint *total,
 {
     if (active || online || dirty_cpu_online
 	|| dirty_cpu_active || dirty_io_active) {
-	erts_mtx_lock(&schdlr_sspnd.mtx);
+        const int lock = !ERTS_IS_CRASH_DUMPING;
+        if (lock) {
+            erts_mtx_lock(&schdlr_sspnd.mtx);
+        }
 	if (active)
 	    *active = schdlr_sspnd_get_nscheds(&schdlr_sspnd.active,
 					       ERTS_SCHED_NORMAL);
@@ -8023,7 +8026,9 @@ erts_schedulers_state(Uint *total,
 	if (dirty_io_active)
 	    *dirty_io_active = schdlr_sspnd_get_nscheds(&schdlr_sspnd.active,
 							ERTS_SCHED_DIRTY_IO);
-	erts_mtx_unlock(&schdlr_sspnd.mtx);
+        if (lock) {
+            erts_mtx_unlock(&schdlr_sspnd.mtx);
+        }
     }
 
     if (total)


### PR DESCRIPTION
Fix #8498
