### PR TITLE
add possibility to preserve and modify paths when using deterministic builds

### DIFF
--- a/configure
+++ b/configure
@@ -143,6 +143,10 @@ while test $# != 0; do
       config_arguments="$config_arguments --enable-deterministic-build";;
 	--disable-deterministic-build)
       config_arguments="$config_arguments --disable-deterministic-build";;
+	--enable-deterministic-keep-source)
+      config_arguments="$config_arguments --enable-deterministic-keep-source";;
+	--disable-deterministic-keep-source)
+      config_arguments="$config_arguments --disable-deterministic-keep-source";;
 	CFLAGS=* | LDFLAGS=*)
         flgs_var=`echo "$1" | sed 's/=.*$//'`
         flgs_val=`echo "$1" | sed 's/^[^=]*=//'`

--- a/configure.src
+++ b/configure.src
@@ -143,6 +143,10 @@ while test $# != 0; do
       config_arguments="$config_arguments --enable-deterministic-build";;
 	--disable-deterministic-build)
       config_arguments="$config_arguments --disable-deterministic-build";;
+	--enable-deterministic-keep-source)
+      config_arguments="$config_arguments --enable-deterministic-keep-source";;
+	--disable-deterministic-keep-source)
+      config_arguments="$config_arguments --disable-deterministic-keep-source";;
 	CFLAGS=* | LDFLAGS=*)
         flgs_var=`echo "$1" | sed 's/=.*$//'`
         flgs_val=`echo "$1" | sed 's/^[^=]*=//'`

--- a/erts/configure
+++ b/erts/configure
@@ -644,6 +644,7 @@ enable_year2038=yes
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
 DEBUG_CFLAGS
+ERL_DETERMINISTIC_KEEP_SOURCE
 ERL_DETERMINISTIC
 CFLAGS32
 CC32
@@ -863,6 +864,7 @@ enable_prefer_elapsed_monotonic_time_during_suspend
 enable_gettimeofday_as_os_system_time
 with_javac
 enable_deterministic_build
+enable_deterministic_keep_source
 enable_year2038
 '
       ac_precious_vars='build_alias
@@ -1621,6 +1623,9 @@ Optional Features:
   --enable-deterministic-build
                           enable build determinism, stripping absolute paths
                           from build output
+  --enable-deterministic-keep-source
+                          enable keeping source when using deterministic
+                          builds
   --disable-year2038      don't support timestamps after 2038
 
 Optional Packages:
@@ -26877,6 +26882,21 @@ then :
   esac
 else case e in #(
   e) ERL_DETERMINISTIC=no ;;
+esac
+fi
+
+
+
+
+# Check whether --enable-deterministic-keep-source was given.
+if test ${enable_deterministic_keep_source+y}
+then :
+  enableval=$enable_deterministic_keep_source;  case "$enableval" in
+    no)  ERL_DETERMINISTIC_KEEP_SOURCE=no ;;
+    *) ERL_DETERMINISTIC_KEEP_SOURCE=yes ;;
+  esac
+else case e in #(
+  e) ERL_DETERMINISTIC_KEEP_SOURCE=no ;;
 esac
 fi
 

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -3646,6 +3646,19 @@ AS_HELP_STRING([--enable-deterministic-build], [enable build determinism, stripp
 ERL_DETERMINISTIC=no)
 AC_SUBST(ERL_DETERMINISTIC)
 
+dnl ----------------------------------------------------------------------
+dnl Enable keep sources flag for using with determinism flag
+dnl ----------------------------------------------------------------------
+
+AC_ARG_ENABLE(deterministic-keep-source,
+AS_HELP_STRING([--enable-deterministic-keep-source], [enable keeping source when using deterministic builds]),
+[ case "$enableval" in
+    no)  ERL_DETERMINISTIC_KEEP_SOURCE=no ;;
+    *) ERL_DETERMINISTIC_KEEP_SOURCE=yes ;;
+  esac ],
+ERL_DETERMINISTIC_KEEP_SOURCE=no)
+AC_SUBST(ERL_DETERMINISTIC_KEEP_SOURCE)
+
 AC_MSG_CHECKING([CFLAGS for -O switch])
 dnl                               Remove all "-O*" options
 no_opt_CFLAGS=$(echo " $CFLAGS" | sed 's/ -O[[^ ]]*/ /g')

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -333,9 +333,12 @@ Available options:
   For details, see [beam_lib(3)](`m:beam_lib#debug_info`).
 
 - **`deterministic`** - Omit the `options` and `source` tuples in the list
-  returned by `Module:module_info(compile)`, and reduce the paths in stack
-  traces to the module name alone. This option will make it easier to achieve
-  reproducible builds.
+  returned by `Module:module_info(compile)`, reduce the paths in stack traces
+  to the module name alone, and make embedded documentation ordered. This
+  option will make it easier to achieve reproducible builds.
+
+- **`deterministic_keep_source`** - When used with `deterministic`, preserves
+  the `source` tuple in the list returned by `Module:module_info(compile)`.
 
 - **`{feature, Feature, enable | disable}`** - [](){: #feature-option } Enable
   (disable) the [feature](`e:system:features.md#features`) `Feature` during
@@ -2583,10 +2586,14 @@ beam_strip_types(Beam0, #compile{}=St) ->
 compile_info(File, CompilerOpts, Opts) ->
     IsSlim = member(slim, CompilerOpts),
     IsDeterministic = member(deterministic, CompilerOpts),
+    IsDeterministicKeepSource =
+        member(deterministic_keep_source, CompilerOpts),
     Info0 = proplists:get_value(compile_info, Opts, []),
     Info1 =
 	case paranoid_absname(File) of
 	    [_|_] = Source when not IsSlim, not IsDeterministic ->
+		[{source,Source} | Info0];
+	    [_|_] = Source when IsDeterministicKeepSource ->
 		[{source,Source} | Info0];
 	    _ ->
 		Info0

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -38,7 +38,7 @@
          beam_ssa_pp_smoke_test/1,
 	 warnings/1, pre_load_check/1, env_compiler_options/1,
          bc_options/1, deterministic_include/1, deterministic_paths/1,
-         deterministic_docs/1,
+         deterministic_docs/1, deterministic_keep_source/1,
          compile_attribute/1, message_printing/1, other_options/1,
          transforms/1, erl_compile_api/1, types_pp/1, bs_init_writable/1,
          annotations_pp/1, option_order/1
@@ -61,7 +61,7 @@ all() ->
      warnings, pre_load_check,
      env_compiler_options, custom_debug_info, bc_options,
      custom_compile_info, deterministic_include, deterministic_paths,
-     deterministic_docs,
+     deterministic_docs, deterministic_keep_source,
      compile_attribute, message_printing, other_options, transforms,
      erl_compile_api, types_pp, bs_init_writable, annotations_pp,
      option_order].
@@ -1779,6 +1779,15 @@ deterministic_include(Config) when is_list(Config) ->
     {ok,_,DetD} = compile:file(Simple, [binary, deterministic, {i,"gaffel"}]),
     true = DetC =:= DetD,
 
+    %% ... and files with +deterministic_keep_source shouldn't.
+    {ok,_,DetE} = compile:file(
+                    Simple, [binary, deterministic,
+                             deterministic_keep_source, {i,"gurka"}]),
+    {ok,_,DetF} = compile:file(
+                    Simple, [binary, deterministic,
+                             deterministic_keep_source, {i,"gaffel"}]),
+    true = DetE =:= DetF,
+
     ok.
 
 deterministic_paths(Config) when is_list(Config) ->
@@ -1790,6 +1799,10 @@ deterministic_paths(Config) when is_list(Config) ->
 
     %% ... but files with +deterministic shouldn't.
     false = deterministic_paths_1(DataDir, "simple", [deterministic]),
+
+    %% ... and files with +deterministic_keep_source shouldn't.
+    false = deterministic_paths_1(DataDir, "simple",
+                                  [deterministic, deterministic_keep_source]),
 
     ok.
 
@@ -1827,6 +1840,26 @@ deterministic_docs_1(Filepath, Opts, Checks) ->
               peer:stop(Peer),
               Testing =:= Reference
       end, lists:seq(1, Checks)).
+
+deterministic_keep_source(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    Simple = filename:join(DataDir, "simple"),
+    ModuleInfo1 = deterministic_keep_source_1(Simple, []),
+    true = lists:keymember(source, 1, ModuleInfo1),
+    ModuleInfo2 = deterministic_keep_source_1(Simple, [deterministic]),
+    false = lists:keymember(source, 1, ModuleInfo2),
+    ModuleInfo3 = deterministic_keep_source_1(
+                    Simple, [deterministic, deterministic_keep_source]),
+    true = lists:keymember(source, 1, ModuleInfo3),
+    ok.
+
+deterministic_keep_source_1(Simple, Opts) ->
+    {ok, simple} = compile:file(Simple, Opts),
+    {module, simple} = c:l(simple),
+    ModuleInfo = simple:module_info(compile),
+    true = code:delete(simple),
+    false = code:purge(simple),
+    ModuleInfo.
 
 %% ERL-1058: -compile(debug_info) had no effect
 compile_attribute(Config) when is_list(Config) ->

--- a/make/otp.mk.in
+++ b/make/otp.mk.in
@@ -92,6 +92,7 @@ BITS64 = @BITS64@
 OTP_RELEASE = @OTP_RELEASE@
 
 ERL_DETERMINISTIC = @ERL_DETERMINISTIC@
+ERL_DETERMINISTIC_KEEP_SOURCE = @ERL_DETERMINISTIC_KEEP_SOURCE@
 
 # ----------------------------------------------------
 #	Erlang language section
@@ -109,6 +110,9 @@ ifeq ($(ERL_DETERMINISTIC),yes)
   ERL_COMPILE_FLAGS += +deterministic
   YRL_FLAGS += +deterministic
   XRL_FLAGS += +deterministic
+endif
+ifeq ($(ERL_DETERMINISTIC_KEEP_SOURCE),yes)
+  ERL_COMPILE_FLAGS += +deterministic_keep_source
 endif
 
 ERLC_WFLAGS = -W


### PR DESCRIPTION
configure: add --enable/disable-deterministic-keep-source build option
compiler: add +deterministic_keep_source option
compiler: make some minor additions for +deterministic option description