### PR TITLE
Fix monotonicity of Erlang monotonic time

### DIFF
--- a/erts/emulator/beam/erl_time_sup.c
+++ b/erts/emulator/beam/erl_time_sup.c
@@ -276,7 +276,8 @@ calc_corrected_erl_mtime(ErtsMonotonicTime os_mtime,
 	diff += (cip->correction.drift*diff)/ERTS_MONOTONIC_TIME_UNIT;
     erl_mtime = cip->erl_mtime;
     erl_mtime += diff;
-    erl_mtime += cip->correction.error*(diff/ERTS_TCORR_ERR_UNIT);
+    erl_mtime += (cip->correction.error*diff)/ERTS_TCORR_ERR_UNIT;
+
     if (os_mdiff_p)
 	*os_mdiff_p = diff;
     return erl_mtime;


### PR DESCRIPTION
When *no time warp mode* was enabled, a smaller Erlang monotonic time could be read than a previously read time, i.e., breaking the monotonic property. The runtime system will abort when detecting an issue like this since OTP 24.3.4.17 and OTP 25.0.
