### PR TITLE
Use type information to improve destructive update pass

### DIFF
--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -514,7 +514,12 @@ set_alias([], State) ->
     State.
 
 get_alias_edges(V, State) ->
-    OutEdges = [To || {#b_var{},To,_} <- beam_digraph:out_edges(State, V)],
+    OutEdges = [To
+                || {#b_var{},To,Kind} <- beam_digraph:out_edges(State, V),
+                   case Kind of
+                       {embed,_} -> false;
+                       _ -> true
+                   end],
     EmbedEdges = [Src
                   || {#b_var{}=Src,_,Lbl} <- beam_digraph:in_edges(State, V),
                      case Lbl of

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -105,7 +105,9 @@ private_append_checks(Config) when is_list(Config) ->
 tuple_inplace_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(tuple_inplace_checks, Config),
     run_post_ssa_opt(tuple_inplace_abort0, Config),
-    run_post_ssa_opt(tuple_inplace_abort1, Config).
+    run_post_ssa_opt(tuple_inplace_abort1, Config),
+    run_post_ssa_opt(tuple_inplace_abort2, Config),
+    run_post_ssa_opt(tuple_inplace_abort3, Config).
 
 ret_annotation_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(ret_annotation, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -819,8 +819,8 @@ aliasing_after_tuple_extract(N, Acc) ->
     aliasing_after_tuple_extract(N - 1, {<<X/bitstring, 1>>, Acc}).
 
 
-%% Check that both the pair (Acc) and the extracted element (X) are
-%% aliased.
+%% Check that the pair (Acc) is unique on entry but that its contents
+%% are alised.
 alias_after_pair_hd(N) ->
     alias_after_pair_hd(N, [<<>>|dummy]).
 
@@ -834,8 +834,8 @@ alias_after_pair_hd(N, Acc) ->
     [X|_] = Acc,
     alias_after_pair_hd(N - 1, [<<X/bitstring, 1>>|Acc]).
 
-%% Check that both the pair (Acc) and the extracted element (X) are
-%% aliased.
+%% Check that the pair (Acc) is unique on entry but that its contents
+%% are alised.
 alias_after_pair_tl(N) ->
     alias_after_pair_tl(N, [dummy|<<>>]).
 

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -806,12 +806,13 @@ aliased_pair_tl_instr(Ls) ->
 aliasing_after_tuple_extract(N) ->
     aliasing_after_tuple_extract(N, {<<>>, dummy}).
 
-%% Check that both the tuple (Acc) and the extracted element (X) are
-%% aliased.
+%% Check that the Acc tuple is unique on entry, but that the elements
+%% are aliased.
 aliasing_after_tuple_extract(0, Acc) ->
 %ssa% (_,Acc) when post_ssa_opt ->
-%ssa% X = get_tuple_element(Acc, 0) {aliased => [Acc]},
-%ssa% _ = bs_create_bin(_,_,X,...) {aliased => [X]}.
+%ssa% X = get_tuple_element(Acc, 0) {unique => [Acc]},
+%ssa% Bin = bs_create_bin(_,_,X,...) {aliased => [X]},
+%ssa% Tuple = put_tuple(Bin, Acc) {aliased => [Bin], unique => [Acc]}.
     Acc;
 aliasing_after_tuple_extract(N, Acc) ->
     {X,_} = Acc,
@@ -827,8 +828,9 @@ alias_after_pair_hd(0, Acc) ->
     Acc;
 alias_after_pair_hd(N, Acc) ->
 %ssa% (_,Acc) when post_ssa_opt ->
-%ssa% X = get_hd(Acc) {aliased => [Acc]},
-%ssa% _ = bs_create_bin(_,_,X,...) {aliased => [X]}.
+%ssa% X = get_hd(Acc) {unique => [Acc]},
+%ssa% Bin = bs_create_bin(_,_,X,...) {aliased => [X]},
+%ssa% Tuple = put_list(Bin, Acc) {aliased => [Bin], unique => [Acc]}.
     [X|_] = Acc,
     alias_after_pair_hd(N - 1, [<<X/bitstring, 1>>|Acc]).
 
@@ -841,8 +843,9 @@ alias_after_pair_tl(0, Acc) ->
     Acc;
 alias_after_pair_tl(N, Acc) ->
 %ssa% (_,Acc) when post_ssa_opt ->
-%ssa% X = get_tl(Acc) {aliased => [Acc]},
-%ssa% _ = bs_create_bin(_,_,X,...) {aliased => [X]}.
+%ssa% X = get_tl(Acc) {unique => [Acc]},
+%ssa% Bin = bs_create_bin(_,_,X,...) {aliased => [X]},
+%ssa% Tuple = put_list(Acc, Bin) {aliased => [Bin], unique => [Acc]}.
     [_|X] = Acc,
     alias_after_pair_tl(N - 1, [Acc|<<X/bitstring, 1>>]).
 

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_abort1.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_abort1.erl
@@ -29,7 +29,7 @@ f() ->
     g({#rec{}}).
 
 g({A}) ->
-%ssa% xfail (_) when post_ssa_opt ->
+%ssa% (_) when post_ssa_opt ->
 %ssa% _ = update_record(inplace, 3, ...).
     g(A);
 g(#rec{} = A) ->

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_abort2.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_abort2.erl
@@ -16,21 +16,29 @@
 %%
 %% %CopyrightEnd%
 %%
-%% Check that the compiler doesn't enter an infinte loop while trying
+%% Check that the compiler doesn't enter an infinite loop while trying
 %% to run the destructive update pass.
 %%
--module(tuple_inplace_abort0).
+-module(tuple_inplace_abort2).
 
--export([f/0]).
+-export([f0/0,f1/0,f2/0]).
 
 -record(rec, {a, b = ext:ernal()}).
 
-f() ->
+f0() ->
     g([#rec{}]).
+
+f1() ->
+    g({#rec{}}).
+
+f2() ->
+    g([[{#rec{}}]]).
 
 g([A]) ->
     g(A);
+g({A}) ->
+    g(A);
 g(#rec{} = A) ->
 %ssa% (_) when post_ssa_opt ->
-%ssa% _ = update_record(inplace, 3, ...).
+%ssa% _ = update_record(reuse, 3, ...).
     A#rec{ a = a }.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_abort3.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_abort3.erl
@@ -16,21 +16,34 @@
 %%
 %% %CopyrightEnd%
 %%
-%% Check that the compiler doesn't enter an infinte loop while trying
+%% Check that the compiler doesn't enter an infinite loop while trying
 %% to run the destructive update pass.
 %%
--module(tuple_inplace_abort0).
+-module(tuple_inplace_abort3).
 
--export([f/0]).
+-export([f0/0,f1/0,f2/0,f3/0]).
 
 -record(rec, {a, b = ext:ernal()}).
 
-f() ->
+f0() ->
     g([#rec{}]).
 
+f1() ->
+    g({#rec{}}).
+
+f2() ->
+    g([[{#rec{}}]]).
+
+f3() ->
+    g([[[#rec{}]]]).
+
+g({A}) ->
+    g(A);
+g([[A]]) ->
+    g(A);
 g([A]) ->
     g(A);
 g(#rec{} = A) ->
 %ssa% (_) when post_ssa_opt ->
-%ssa% _ = update_record(inplace, 3, ...).
+%ssa% _ = update_record(reuse, 3, ...).
     A#rec{ a = a }.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_checks.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_checks.erl
@@ -22,7 +22,7 @@
 
 -export([do0a/0, do0b/2, different_sizes/2, ambiguous_inits/1,
          update_record0/0, fc/0, track_update_record/1,
-         gh8124_a/0, gh8124_b/0]).
+         gh8124_a/0, gh8124_b/0, tuple_set_a/1, tuple_set_b/0]).
 
 -record(r, {a=0,b=0,c=0,tot=0}).
 -record(r1, {a}).
@@ -236,3 +236,30 @@ gh8124_b() ->
     [R] = gh8124_b_inner(),
     R#r{a = <<"value 2">>}.
 
+
+%% Example which provides a get_tuple_element instruction with a tuple
+%% typed as a tuple set.
+tuple_set_a(Something) ->
+    case ex:f() of
+	a ->
+	    {ok,
+	     {key_a, Something}};
+	b ->
+	    {error, {override_include}}
+    end.
+
+tuple_set_b() ->
+%ssa% () when post_ssa_opt ->
+%ssa% _ = update_record(inplace, 2, _, ...).
+    case tuple_set_a(ex:f()) of
+	{ok, A} ->
+	    case e:f() of
+		{} ->
+		    case A of
+			{key_a, _} ->
+			    setelement(1, A, aa)
+		    end
+	    end;
+	{error,_} ->
+	    bad
+    end.


### PR DESCRIPTION
Fix a bug in the alias analysis pass which led to missed optimization opportunities and improve the destructive update pass to use types in order to avoid unnecessary aborts. More details in the individual commit messages.