### PR TITLE
Fix unsafe code generation for binary matching

### DIFF
--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -671,11 +671,22 @@ grab_bag(_Config) ->
     %% Cover a line v3_kernel:get_line/1.
     _ = catch << ok || <<>> <= ok, ok >>,
 
+    [] = grab_bag_gh_8617(<<>>),
+    [0] = grab_bag_gh_8617(<<1:1>>),
+    [0,0,0] = grab_bag_gh_8617(<<0:3>>),
+
     ok.
 
 grab_bag_gh_6553(<<X>>) ->
     %% Would crash in beam_ssa_pre_codegen.
     <<X, ((<<_:0>> = <<_>>) = <<>>)>>.
+
+grab_bag_gh_8617(Bin) ->
+    %% GH-8617: CSE would cause a call self/0 to be inserted in
+    %% the middle of a sequence of `bs_match` instructions, causing
+    %% unsafe matching code to be emitted.
+    [0 || <<_:0, _:(tuple_size({self()}))>> <= Bin,
+          is_pid(id(self()))].
 
 cs_init() ->
     erts_debug:set_internal_state(available_internal_state, true),


### PR DESCRIPTION
The common sub expression (CSE) optimization could cause a call to a guard BIF to be inserted into the middle of a sequence of binary syntax matching instructions, which in turn could cause unsafe `bs_match` (BEAM) instructions to be emitted.

Resolves #8617