### PR TITLE
Preserve source when building with deterministic option

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -2588,6 +2588,8 @@ compile_info(File, CompilerOpts, Opts) ->
 	case paranoid_absname(File) of
 	    [_|_] = Source when not IsSlim, not IsDeterministic ->
 		[{source,Source} | Info0];
+	    [_|_] = Source when IsDeterministic ->
+		[{source,filename:basename(Source)} | Info0];
 	    _ ->
 		Info0
 	end,

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -159,7 +159,7 @@ file_1(Config) when is_list(Config) ->
     %% Test option 'deterministic'.
     {ok,simple} = compile:file(Simple, [deterministic]),
     {module,simple} = c:l(simple),
-    [{version,_}] = simple:module_info(compile),
+    [{version,_},{source,"simple.erl"}] = simple:module_info(compile),
     true = code:delete(simple),
     false = code:purge(simple),
 
@@ -172,7 +172,7 @@ file_1(Config) when is_list(Config) ->
     {DetPath, DetTarget} = get_files(Config, Det, "det_target"),
     {ok,Det,DetCode} = compile:file(DetPath, [binary]),
     {module,Det} = code:load_binary(Det, "", DetCode),
-    [{version,_}] = Det:module_info(compile),
+    [{version,_},{source,"deterministic_module.erl"}] = Det:module_info(compile),
     true = code:delete(Det),
     false = code:purge(Det),
 


### PR DESCRIPTION
This is the implementation of the fix to preserve source meta data when building with deterministic option.

Related to #8602.