### PR TITLE
compiler: Fix crash in beam_ssa_private_append

### DIFF
--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -83,7 +83,8 @@
          bs_create_bin_on_literal/0,
 
          crash_in_value_tracking/3,
-         crash_in_value_tracking_inner/3]).
+         crash_in_value_tracking_inner/3,
+         gh8630/1]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -1025,3 +1026,13 @@ crash_in_value_tracking(_, _V0, _) ->
     ((<<((crash_in_value_tracking_inner(
             {#{#{ ok => ok || _ := _ <- ok} => ok},
              _V0, false, _V0, "Bo"}, _V0, ok)))/bytes>>) =/= ok).
+
+gh8630(<<"\\",R/binary>>, Xs) ->
+%ssa% (_, _) when post_ssa_opt ->
+%ssa% _ = bs_init_writable(_).
+    gh8630(R, [<<>> | Xs]);
+gh8630(<<A:8,R/binary>>, [X|Xs]) ->
+    gh8630(R, [<<X/binary,A:8>> | Xs]).
+
+gh8630(I) ->
+    gh8630(I, []).


### PR DESCRIPTION
With the right input, the beam_ssa_private_append pass could crash when it, during the initial value tracking phase, selected literals which were not compatible with the tracked element structure for later patching. This patch ensures that only compatible literals are scheduled for later patching.

This crash is only present in OTP versions >= 26 && < 27 and this fix should not be merged to maint or master as dce585f933d0 ("compiler: In-place update of tuples/records"), merged for OTP 27, includes essentially the same functionality.

Closes #8630