### PR TITLE
Fix incorrect carrier count statistics after using instrument module

### DIFF
--- a/erts/emulator/beam/erl_alloc_util.h
+++ b/erts/emulator/beam/erl_alloc_util.h
@@ -262,6 +262,8 @@ int erts_alcu_gather_carrier_info(struct process *p, int allocator_num,
 struct alcu_blockscan;
 
 typedef struct {
+    ErtsThrPrgrLaterOp later_op;
+
     struct alcu_blockscan *current;
     struct alcu_blockscan *last;
 } ErtsAlcuBlockscanYieldData;


### PR DESCRIPTION
The number of carriers in a shared pool (`allctr->cpool.stat.no_carriers`) was decremented every time a call to `instrument:allocations` or `instrument:carriers` yielded while traversing the pool.

Also make sure to not free or re-insert a yield cursor (dummy carrier) into shared carrier pool until thread progress has passed.