### PR TITLE
kernel: "overwrite prompt" setting

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -818,9 +818,17 @@ more_data(What, Cont0, Drv, Shell, Ls, Encoding) ->
             get_line1(edlin:edit_line(eof, Cont0), Drv, Shell, Ls, Encoding);
         {io_request,From,ReplyAs,Req} when is_pid(From) ->
             {more_chars,Cont,_More} = edlin:edit_line([], Cont0),
-            send_drv_reqs(Drv, edlin:erase_line()),
-            io_request(Req, From, ReplyAs, Drv, Shell, []), %WRONG!!!
-            send_drv_reqs(Drv, edlin:redraw_line(Cont)),
+            Location = application:get_env(stdlib,
+                                           shell_bgmsg_location,
+                                           above),
+            case Location of
+                above ->
+                    send_drv_reqs(Drv, edlin:erase_line()),
+                    io_request(Req, From, ReplyAs, Drv, Shell, []), %WRONG!!!
+                    send_drv_reqs(Drv, edlin:redraw_line(Cont));
+                _ ->
+                    io_request(Req, From, ReplyAs, Drv, Shell, [])
+            end,
             get_line1({more_chars,Cont,[]}, Drv, Shell, Ls, Encoding);
         {reply,{From,ReplyAs},Reply} ->
             %% We take care of replies from puts here as well

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -633,18 +633,8 @@ handle_request(State, {expand_with_trim, Binary}) ->
 %% putc prints Binary and overwrites any existing characters
 handle_request(State = #state{ unicode = U }, {putc, Binary}) ->
     %% Todo should handle invalid unicode?
-    %% print above the prompt if we have a prompt.
-    %% otherwise print on the current line.
-    case {State#state.lines_before,{State#state.buffer_before, State#state.buffer_after}, State#state.lines_after} of
-        {[],{[],[]},[]} ->
-            {PutBuffer, _} = insert_buf(State, Binary),
-            {[encode(PutBuffer, U)], State};
-        _ ->
-            {Delete, DeletedState} = handle_request(State, delete_line),
-            {PutBuffer, _} = insert_buf(DeletedState, Binary),
-            {Redraw, _} = handle_request(State, redraw_prompt_pre_deleted),
-            {[Delete, encode(PutBuffer, U), Redraw], State}
-    end;
+    {PutBuffer, _} = insert_buf(State, Binary),
+    {[encode(PutBuffer, U)], State};
 handle_request(State = #state{}, delete_after_cursor) ->
     {[State#state.delete_after_cursor],
      State#state{buffer_after = [],


### PR DESCRIPTION
adds a setting -stdlib shell_bgmsg_location (above|below) where above means output bg processes io:format above the prompt and below means output bg processes io:format on the prompt, disturbing the current line, requiring a redraw to see the whole prompt

also removing code from prim_tty which was a redundant implementation of what group does when receiving "io_request" during a get_line