### PR TITLE
Corrected the syntax of `'=='/2`, & `'=:='/2` in comments & documentation

### DIFF
--- a/lib/edoc/src/edoc_html_to_markdown.erl
+++ b/lib/edoc/src/edoc_html_to_markdown.erl
@@ -332,7 +332,7 @@ render_element({code, Attr, Content}, State, Pos, Ind, D) ->
                     {["[",NameStr,"](",NameStr,"_cmd.md)"], Pos + string:length(NameStr)};
                 false ->
                     try
-                        %% This is an op type (such as <c>=:=/2</c>)
+                        %% This is an op type (such as <c>'=:='/2</c>)
                         erl_internal:op_type(Name, length(Args)),
                         {lists:concat(["[`",Docs,"`](`erlang:",io_lib:write_atom(Name),"/",length(Args),"`)"]), NewPos}
                     catch error:function_clause ->

--- a/lib/stdlib/doc/notes.md
+++ b/lib/stdlib/doc/notes.md
@@ -6673,7 +6673,7 @@ This document describes the changes made to the STDLIB application.
 ### Improvements and New Features
 
 - A new option, `key_equality`, has been added to `qlc:table/2`. This option
-  makes it possible for `qlc` to better handle tables that use `==/2` when
+  makes it possible for `qlc` to better handle tables that use `'=='/2` when
   comparing keys for equality (examples of such tables are ordered ETS tables
   and gb_table in qlc(3)).
 

--- a/lib/stdlib/doc/src/qlc.md
+++ b/lib/stdlib/doc/src/qlc.md
@@ -100,7 +100,7 @@ user to order the joins by introducing query handles.
 The join is to be expressed as a guard filter. The filter must be placed
 immediately after the two joined generators, possibly after guard filters that
 use variables from no other generators but the two joined generators. The `qlc`
-module inspects the operands of `=:=/2`, `==/2`, [`is_record/2`](`is_record/2`),
+module inspects the operands of `'=:='/2`, `'=='/2`, [`is_record/2`](`is_record/2`),
 [`element/2`](`element/2`), and logical operators (`and/2`, `or/2`, `andalso/2`,
 `orelse/2`, `xor/2`) when determining which joins to consider.
 
@@ -406,17 +406,17 @@ before secondary keys regardless of the number of constants to look up.
 
 ## Key Equality
 
-Erlang/OTP has two operators for testing term equality: `==/2` and `=:=/2`. The
+Erlang/OTP has two operators for testing term equality: `'=='/2` and `'=:='/2`. The
 difference is all about the integers that can be represented by floats. For
 example, `2 == 2.0` evaluates to `true` while `2 =:= 2.0` evaluates to `false`.
 Normally this is a minor issue, but the `qlc` module cannot ignore the
 difference, which affects the user's choice of operators in QLCs.
 
 If the `qlc` module at compile time can determine that some constant is free of
-integers, it does not matter which one of `==/2` or `=:=/2` is used:
+integers, it does not matter which one of `'=='/2` or `'=:='/2` is used:
 
 ```erlang
-1> E1 = ets:new(t, [set]), % uses =:=/2 for key equality
+1> E1 = ets:new(t, [set]), % uses '=:='/2 for key equality
 Q1 = qlc:q([K ||
 {K} <- ets:table(E1),
 K == 2.71 orelse K == a]),
@@ -430,9 +430,9 @@ ets:match_spec_run(
        ets:match_spec_compile([{{'$1'}, [], ['$1']}]))
 ```
 
-In the example, operator `==/2` has been handled exactly as `=:=/2` would have
+In the example, operator `'=='/2` has been handled exactly as `'=:='/2` would have
 been handled. However, if it cannot be determined at compile time that some
-constant is free of integers, and the table uses `=:=/2` when comparing keys for
+constant is free of integers, and the table uses `'=:='/2` when comparing keys for
 equality (see option [key_equality](`m:qlc#key_equality`)), then the `qlc`
 module does not try to look up the constant. The reason is that there is in the
 general case no upper limit on the number of key values that can compare equal
@@ -456,12 +456,12 @@ ets:table(#Ref<0.3098908599.2283929601.256125>,
 
 Looking up only `{2,2}` would not return `b` and `c`.
 
-If the table uses `==/2` when comparing keys for equality, the `qlc` module
+If the table uses `'=='/2` when comparing keys for equality, the `qlc` module
 looks up the constant regardless of which operator is used in the QLC. However,
-`==/2` is to be preferred:
+`'=='/2` is to be preferred:
 
 ```erlang
-4> E3 = ets:new(t, [ordered_set]), % uses ==/2 for key equality
+4> E3 = ets:new(t, [ordered_set]), % uses '=='/2 for key equality
 true = ets:insert(E3, [{{2,2.0},b}]),
 F3 = fun(I) ->
 qlc:q([V || {K,V} <- ets:table(E3), K == I])
@@ -476,8 +476,8 @@ ets:match_spec_run(ets:lookup(#Ref<0.3098908599.2283929601.256211>,
 ```
 
 Lookup join is handled analogously to lookup of constants in a table: if the
-join operator is `==/2`, and the table where constants are to be looked up uses
-`=:=/2` when testing keys for equality, then the `qlc` module does not consider
+join operator is `'=='/2`, and the table where constants are to be looked up uses
+`'=:='/2` when testing keys for equality, then the `qlc` module does not consider
 lookup join for that table.
 
 ## See Also

--- a/lib/stdlib/doc/src/sofs.md
+++ b/lib/stdlib/doc/src/sofs.md
@@ -292,7 +292,7 @@ The functions of this module exit the process with a `badarg`, `bad_function`,
 or `type_mismatch` message when given badly formed arguments or sets the types
 of which are not compatible.
 
-When comparing external sets, operator `==/2` is used.
+When comparing external sets, operator `'=='/2` is used.
 
 ## See Also
 

--- a/lib/stdlib/src/sofs.erl
+++ b/lib/stdlib/src/sofs.erl
@@ -679,7 +679,7 @@ constant_function(S, _) when ?IS_ORDSET(S) ->
 
 -doc """
 Returns `true` if `AnySet1` and `AnySet2` are [equal](`m:sofs#equal`), otherwise
-`false`. The following example shows that `==/2` is used when comparing sets for
+`false`. The following example shows that `'=='/2` is used when comparing sets for
 equality:
 
 ```erlang

--- a/lib/stdlib/test/dets_SUITE.erl
+++ b/lib/stdlib/test/dets_SUITE.erl
@@ -3070,7 +3070,7 @@ otp_6359(Config) ->
     file:delete(File),
     ok.
 
-%% OTP-4738. ==/2 and =:=/2.
+%% OTP-4738. '=='/2 and '=:='/2.
 otp_4738(Config) ->
     otp_4738_set(Config),
     otp_4738_bag(Config),

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -7196,7 +7196,7 @@ manpage(Config) when is_list(Config) ->
        \"end\",
           L = qlc:info(Q)">>,
 
-       <<"E1 = ets:new(t, [set]), % uses =:=/2
+       <<"E1 = ets:new(t, [set]), % uses '=:='/2
           Q1 = qlc:q([K ||
           {K} <- ets:table(E1),
           K == 2.71 orelse K == a]),
@@ -7216,7 +7216,7 @@ manpage(Config) when is_list(Config) ->
           [a,b,c] = lists:sort(qlc:e(Q2)),
           true = ets:delete(E2),
 
-          E3 = ets:new(t, [ordered_set]), % uses ==/2
+          E3 = ets:new(t, [ordered_set]), % uses '=='/2
           true = ets:insert(E3, [{{2,2.0},b}]),
           Q3 = F(E3,{2,2}),
           {list,{table,_},[{{'$1','$2'},[],['$2']}]} = i(Q3),

--- a/lib/stdlib/test/shell_docs_SUITE_data/stdlib_sofs.txt
+++ b/lib/stdlib/test/shell_docs_SUITE_data/stdlib_sofs.txt
@@ -344,7 +344,7 @@
   [;;4mbad_function[0m, or [;;4mtype_mismatch[0m message when given badly formed
   arguments or sets the types of which are not compatible.
 
-  When comparing external sets, operator [;;4m==/2[0m is used.
+  When comparing external sets, operator [;;4m'=='/2[0m is used.
 
 [;1mSee Also[0m
 

--- a/lib/stdlib/test/shell_docs_SUITE_data/stdlib_sofs_is_equal_2_func.txt
+++ b/lib/stdlib/test/shell_docs_SUITE_data/stdlib_sofs_is_equal_2_func.txt
@@ -6,7 +6,7 @@
   [;1m                      Bool :: boolean().[0m
 
   Returns [;;4mtrue[0m if [;;4mAnySet1[0m and [;;4mAnySet2[0m are equal, otherwise [;;4m[0m
-  [;;4mfalse[0m. The following example shows that [;;4m==/2[0m is used when
+  [;;4mfalse[0m. The following example shows that [;;4m'=='/2[0m is used when
   comparing sets for equality:
 
     1> S1 = sofs:set([1.0]),

--- a/lib/tools/src/xref_base.erl
+++ b/lib/tools/src/xref_base.erl
@@ -1782,7 +1782,7 @@ warnings(Flag, Message, [F | Fs]) ->
 %% pack(term()) -> term()
 %%
 %% The identify function. The returned term does not use more heap
-%% than the given term. Tuples that are equal (=:=/2) are made
+%% than the given term. Tuples that are equal ('=:='/2) are made
 %% "the same".
 %%
 %% The process dictionary is used because it seems to be faster than


### PR DESCRIPTION
* the two infix equality operators were defined as enclosed in single quotes
```shell
# git grep -n "ubif erlang:'" | grep -P "'=:?='"
erts/emulator/beam/bif.tab:301:ubif erlang:'=:='/2                      seq_2
erts/emulator/beam/bif.tab:302:ubif erlang:'=='/2                       seqeq_2
```
* made the change: `s/==/'=='/` & `s/=:=/'=:='/`
* I would also check if all the infix operators are consistently quoted:
```shell
# git grep "ubif erlang:'" | perl -nE 'say $& if m!(?<=erlang:).*/\d!' 
'and'/2
'or'/2
'xor'/2
'not'/1
'>'/2
'>='/2
'<'/2
'=<'/2
'=:='/2
'=='/2
'=/='/2
'/='/2
'+'/2
'-'/2
'*'/2
'/'/2
'div'/2
'rem'/2
'bor'/2
'band'/2
'bxor'/2
'bsl'/2
'bsr'/2
'bnot'/1
'-'/1
'+'/1
'+'/2
```