### PR TITLE
ssl: Remove documentation of internal value

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -3444,14 +3444,12 @@ format_error(Reason) ->
 -doc(#{title => <<"Utility Functions">>,
        since => <<"OTP 21.0">>}).
 -spec suite_to_str(CipherSuite) -> string() when
-      CipherSuite :: erl_cipher_suite();
-                  (CipherSuite) -> string() when
-      %% For internal use!
-      CipherSuite :: #{key_exchange := null,
-                       cipher := null,
-                       mac := null,
-                       prf := null}.
--doc "Converts `t:erl_cipher_suite/0` to RFC name string.".
+      CipherSuite :: erl_cipher_suite().
+-doc """
+Converts an [`erl_cipher_suite()`](`t:erl_cipher_suite/0`) value to an RFC
+name string.
+""".
+
 %%--------------------------------------------------------------------
 suite_to_str(Cipher) ->
     ssl_cipher_format:suite_map_to_str(Cipher).

--- a/lib/ssl/src/ssl_cipher_format.erl
+++ b/lib/ssl/src/ssl_cipher_format.erl
@@ -67,6 +67,7 @@ suite_map_to_str(#{key_exchange := null,
                cipher := null,
                mac := null,
                prf := null}) ->
+    %% Internal value for signaling renegotiation abilities.
     "TLS_EMPTY_RENEGOTIATION_INFO_SCSV";
 suite_map_to_str(#{key_exchange := any,
                cipher := Cipher,
@@ -89,6 +90,7 @@ suite_map_to_str(#{key_exchange := Kex,
         "_" ++ string:to_upper(atom_to_list(Mac)).
 
 suite_str_to_map("TLS_EMPTY_RENEGOTIATION_INFO_SCSV") ->
+    %% Internal value for signaling renegotiation abilities.
     #{key_exchange => null,
       cipher => null,
       mac => null,


### PR DESCRIPTION
Doc conversion for OTP-27 caused an internal value to become documented.