### PR TITLE
Optimize process and port creation without tracing

### DIFF
--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -249,10 +249,15 @@ Eterm erts_make_trace_session_weak_ref(ErtsTraceSession *s, Eterm **hpp)
 void
 erts_bif_trace_init(void)
 {
+    erts_rwmtx_opt_t rwmtx_opts = ERTS_RWMTX_OPT_DEFAULT_INITER;
+    rwmtx_opts.type = ERTS_RWMTX_TYPE_EXTREMELY_FREQUENT_READ;
+    rwmtx_opts.lived = ERTS_RWMTX_LONG_LIVED;
+
     erts_trace_session_init(&erts_trace_session_0, erts_tracer_nil, am_legacy);
-    erts_rwmtx_init(&erts_trace_session_list_lock, "trace_session_list", NIL,
-		    ERTS_LOCK_FLAGS_PROPERTY_STATIC |
-		    ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
+    erts_rwmtx_init_opt(&erts_trace_session_list_lock, &rwmtx_opts,
+                        "trace_session_list", NIL,
+                        ERTS_LOCK_FLAGS_PROPERTY_STATIC |
+                        ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
     erts_mtx_init(&erts_trace_cleaner_lock, "trace_cleaner", NIL,
                     ERTS_LOCK_FLAGS_PROPERTY_STATIC |
                     ERTS_LOCK_FLAGS_CATEGORY_GENERIC);

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -132,10 +132,10 @@ int erts_trace_session_init(ErtsTraceSession* s, ErtsTracer tracer,
     s->on_load_trace_pattern_flags = erts_trace_pattern_flags_off;
     s->on_load_meta_tracer = erts_tracer_nil;
 
-    s->on_spawn_proc_trace_flags = F_INITIAL_TRACE_FLAGS;
-    s->on_spawn_proc_tracer = erts_tracer_nil;
-    s->on_open_port_trace_flags = F_INITIAL_TRACE_FLAGS;
-    s->on_open_port_tracer = erts_tracer_nil;
+    s->new_procs_trace_flags = F_INITIAL_TRACE_FLAGS;
+    s->new_procs_tracer = erts_tracer_nil;
+    s->new_ports_trace_flags = F_INITIAL_TRACE_FLAGS;
+    s->new_ports_tracer = erts_tracer_nil;
 
 
     erts_atomic32_init_nob(&s->trace_control_word, 0);
@@ -1120,11 +1120,11 @@ Eterm trace(Process* p, ErtsTraceSession *session,
 	    ok = 1;
             if (mask & ERTS_PROC_TRACEE_FLAGS &&
                 pid_spec != am_ports && pid_spec != am_new_ports)
-                erts_change_default_proc_tracing(session,
+                erts_change_new_procs_tracing(session,
                     on, mask & ERTS_PROC_TRACEE_FLAGS, tracer);
             if (mask & ERTS_PORT_TRACEE_FLAGS &&
                 pid_spec != am_processes && pid_spec != am_new_processes)
-                erts_change_default_port_tracing(
+                erts_change_new_ports_tracing(
                     session, on, mask & ERTS_PORT_TRACEE_FLAGS, tracer);
 
 #ifdef HAVE_ERTS_NOW_CPU
@@ -1205,8 +1205,8 @@ static void free_session(ErtsTraceSession *session)
     ASSERT(erts_refc_read(&session->dbg_p_refc, 0) == 0);
     ASSERT(erts_atomic_read_nob(&session->state) == ERTS_TRACE_SESSION_DEAD);
     ASSERT(ERTS_TRACER_IS_NIL(session->tracer));
-    ASSERT(ERTS_TRACER_IS_NIL(session->on_spawn_proc_tracer));
-    ASSERT(ERTS_TRACER_IS_NIL(session->on_open_port_tracer));
+    ASSERT(ERTS_TRACER_IS_NIL(session->new_procs_tracer));
+    ASSERT(ERTS_TRACER_IS_NIL(session->new_ports_tracer));
     ASSERT(ERTS_TRACER_IS_NIL(session->on_load_meta_tracer));
     erts_magic_binary_free(bin);
 }
@@ -1352,8 +1352,8 @@ trace_session_destroy(ErtsTraceSession* session)
     erts_rwmtx_rwunlock(&erts_trace_session_list_lock);
 
     ERTS_TRACER_CLEAR(&session->tracer);
-    ERTS_TRACER_CLEAR(&session->on_spawn_proc_tracer);
-    ERTS_TRACER_CLEAR(&session->on_open_port_tracer);
+    ERTS_TRACER_CLEAR(&session->new_procs_tracer);
+    ERTS_TRACER_CLEAR(&session->new_ports_tracer);
     clear_on_load_trace_pattern(session);
 
     prepare_clear_all_trace_pattern(session);
@@ -1656,12 +1656,12 @@ trace_info_pid(Process* p, ErtsTraceSession* session, Eterm pid_spec, Eterm key)
 
     if (pid_spec == am_new || pid_spec == am_new_processes) {
         ErtsTracer def_tracer;
-	erts_get_on_spawn_tracing(session, &trace_flags, &def_tracer);
+	erts_get_new_proc_tracing(session, &trace_flags, &def_tracer);
         tracer = erts_tracer_to_term(p, def_tracer);
         ERTS_TRACER_CLEAR(&def_tracer);
     } else if (pid_spec == am_new_ports) {
         ErtsTracer def_tracer;
-	erts_get_on_open_port_tracing(session, &trace_flags, &def_tracer);
+	erts_get_new_port_tracing(session, &trace_flags, &def_tracer);
         tracer = erts_tracer_to_term(p, def_tracer);
         ERTS_TRACER_CLEAR(&def_tracer);
     } else if (is_internal_port(pid_spec)) {
@@ -2214,8 +2214,8 @@ trace_info_sessions(Process* p, Eterm What, Eterm key)
         case am_send:      on = s->send_tracing[bp_ix].on; break;
         case am_receive:   on = s->receive_tracing[bp_ix].on; break;
         case am_new_processes:
-        case am_new:       on = s->on_spawn_proc_trace_flags; break;
-        case am_new_ports: on = s->on_open_port_trace_flags; break;
+        case am_new:       on = s->new_procs_trace_flags; break;
+        case am_new_ports: on = s->new_ports_trace_flags; break;
         default:
             erts_rwmtx_runlock(&erts_trace_session_list_lock);
             erts_factory_undo(&factory);

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -103,6 +103,8 @@ static void clean_export_entries(BpFunctions* f);
 
 ErtsTraceSession erts_trace_session_0;
 erts_rwmtx_t erts_trace_session_list_lock;
+erts_refc_t erts_new_procs_trace_cnt;
+erts_refc_t erts_new_ports_trace_cnt;
 
 ErtsTraceSession* erts_trace_cleaner_wait_list;
 erts_mtx_t erts_trace_cleaner_lock;
@@ -254,6 +256,8 @@ erts_bif_trace_init(void)
     erts_mtx_init(&erts_trace_cleaner_lock, "trace_cleaner", NIL,
                     ERTS_LOCK_FLAGS_PROPERTY_STATIC |
                     ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
+    erts_refc_init(&erts_new_procs_trace_cnt, 0);
+    erts_refc_init(&erts_new_ports_trace_cnt, 0);
 }
 
 /*

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12551,7 +12551,7 @@ erl_create_process(Process* parent, /* Parent of process (default group leader).
         for(ErtsTraceSession *s = &erts_trace_session_0; s; s = s->next) {
             Uint32 trace_flags;
             ErtsTracer tracer;
-            erts_get_on_spawn_tracing(s, &trace_flags, &tracer);
+            erts_get_new_proc_tracing(s, &trace_flags, &tracer);
             if (trace_flags) {
                 ErtsTracerRef *ref = new_tracer_ref(&p->common, s);
                 ref->flags = trace_flags;

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -12545,19 +12545,21 @@ erl_create_process(Process* parent, /* Parent of process (default group leader).
 
     ERTS_P_ALL_TRACE_FLAGS(p) = 0;
     p->common.tracee.first_ref = NULL;
-    erts_rwmtx_rlock(&erts_trace_session_list_lock);
-    for(ErtsTraceSession *s = &erts_trace_session_0; s; s = s->next) {
-        Uint32 trace_flags;
-        ErtsTracer tracer;
-        // ToDo: Optimize
-        erts_get_on_spawn_tracing(s, &trace_flags, &tracer);
-        if (trace_flags) {
-            ErtsTracerRef *ref = new_tracer_ref(&p->common, s);
-            ref->flags = trace_flags;
-            ref->tracer = tracer;
+
+    if (erts_refc_read(&erts_new_procs_trace_cnt, 0)) {
+        erts_rwmtx_rlock(&erts_trace_session_list_lock);
+        for(ErtsTraceSession *s = &erts_trace_session_0; s; s = s->next) {
+            Uint32 trace_flags;
+            ErtsTracer tracer;
+            erts_get_on_spawn_tracing(s, &trace_flags, &tracer);
+            if (trace_flags) {
+                ErtsTracerRef *ref = new_tracer_ref(&p->common, s);
+                ref->flags = trace_flags;
+                ref->tracer = tracer;
+            }
         }
+        erts_rwmtx_runlock(&erts_trace_session_list_lock);
     }
-    erts_rwmtx_runlock(&erts_trace_session_list_lock);
 
     if (parent && ERTS_IS_P_TRACED(parent)) {
         if (ERTS_IS_P_TRACED_FL(parent, F_TRACE_SOS|F_TRACE_SOS1)

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -542,11 +542,24 @@ erts_change_default_proc_tracing(ErtsTraceSession* session,
                                  int setflags, Uint32 flags,
                                  const ErtsTracer tracer)
 {
+    Uint32 was_tracer;
+
     erts_rwmtx_rwlock(&sys_trace_rwmtx);
+    was_tracer = session->on_spawn_proc_tracer;
+
     erts_change_on_spawn_tracing(
         setflags, flags, tracer,
         &session->on_spawn_proc_trace_flags,
         &session->on_spawn_proc_tracer);
+
+    if (session->on_spawn_proc_tracer != was_tracer) {
+        if (ERTS_TRACER_IS_NIL(was_tracer)) {
+            erts_refc_inc(&erts_num_on_spawn_tracers, 1);
+        }
+        else if (ERTS_TRACER_IS_NIL(session->on_spawn_proc_tracer)) {
+            erts_refc_dec(&erts_num_on_spawn_tracers, 0);
+        }
+    }
     erts_rwmtx_rwunlock(&sys_trace_rwmtx);
 }
 
@@ -555,11 +568,24 @@ erts_change_default_port_tracing(ErtsTraceSession* session,
                                  int setflags, Uint32 flags,
                                  const ErtsTracer tracer)
 {
+    Uint32 was_tracer;
+
     erts_rwmtx_rwlock(&sys_trace_rwmtx);
+    was_tracer = session->on_open_port_tracer;
+
     erts_change_on_spawn_tracing(
         setflags, flags, tracer,
         &session->on_open_port_trace_flags,
         &session->on_open_port_tracer);
+
+    if (session->on_open_port_tracer != was_tracer) {
+        if (ERTS_TRACER_IS_NIL(was_tracer)) {
+            erts_refc_inc(&erts_num_on_open_port_tracers, 1);
+        }
+        else if (ERTS_TRACER_IS_NIL(session->on_open_port_tracer)) {
+            erts_refc_dec(&erts_num_on_open_port_tracers, 0);
+        }
+    }
     erts_rwmtx_rwunlock(&sys_trace_rwmtx);
 }
 

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -476,9 +476,9 @@ erts_get_system_seq_tracer(void)
 }
 
 static ERTS_INLINE void
-get_on_spawn_tracing(Uint32 *flagsp, ErtsTracer *tracerp,
-                    Uint32 *default_trace_flags,
-                    ErtsTracer *default_tracer)
+get_new_p_tracing(Uint32 *flagsp, ErtsTracer *tracerp,
+                  Uint32 *default_trace_flags,
+                  ErtsTracer *default_tracer)
 {
     if (!(*default_trace_flags & TRACEE_FLAGS))
 	ERTS_TRACER_CLEAR(default_tracer);
@@ -522,10 +522,10 @@ get_on_spawn_tracing(Uint32 *flagsp, ErtsTracer *tracerp,
 }
 
 static void
-erts_change_on_spawn_tracing(int setflags, Uint32 flags,
-                            const ErtsTracer tracer,
-                            Uint32 *default_trace_flags,
-                            ErtsTracer *default_tracer)
+erts_change_new_p_tracing(int setflags, Uint32 flags,
+                          const ErtsTracer tracer,
+                          Uint32 *default_trace_flags,
+                          ErtsTracer *default_tracer)
 {
     if (setflags)
         *default_trace_flags |= flags;
@@ -534,84 +534,84 @@ erts_change_on_spawn_tracing(int setflags, Uint32 flags,
 
     erts_tracer_update(default_tracer, tracer);
 
-    get_on_spawn_tracing(NULL, NULL, default_trace_flags, default_tracer);
+    get_new_p_tracing(NULL, NULL, default_trace_flags, default_tracer);
 }
 
 void
-erts_change_default_proc_tracing(ErtsTraceSession* session,
-                                 int setflags, Uint32 flags,
-                                 const ErtsTracer tracer)
+erts_change_new_procs_tracing(ErtsTraceSession* session,
+                              int setflags, Uint32 flags,
+                              const ErtsTracer tracer)
 {
     Uint32 was_tracer;
 
     erts_rwmtx_rwlock(&sys_trace_rwmtx);
-    was_tracer = session->on_spawn_proc_tracer;
+    was_tracer = session->new_procs_tracer;
 
-    erts_change_on_spawn_tracing(
+    erts_change_new_p_tracing(
         setflags, flags, tracer,
-        &session->on_spawn_proc_trace_flags,
-        &session->on_spawn_proc_tracer);
+        &session->new_procs_trace_flags,
+        &session->new_procs_tracer);
 
-    if (session->on_spawn_proc_tracer != was_tracer) {
+    if (session->new_procs_tracer != was_tracer) {
         if (ERTS_TRACER_IS_NIL(was_tracer)) {
-            erts_refc_inc(&erts_num_on_spawn_tracers, 1);
+            erts_refc_inc(&erts_new_procs_trace_cnt, 1);
         }
-        else if (ERTS_TRACER_IS_NIL(session->on_spawn_proc_tracer)) {
-            erts_refc_dec(&erts_num_on_spawn_tracers, 0);
+        else if (ERTS_TRACER_IS_NIL(session->new_procs_tracer)) {
+            erts_refc_dec(&erts_new_procs_trace_cnt, 0);
         }
     }
     erts_rwmtx_rwunlock(&sys_trace_rwmtx);
 }
 
 void
-erts_change_default_port_tracing(ErtsTraceSession* session,
-                                 int setflags, Uint32 flags,
-                                 const ErtsTracer tracer)
+erts_change_new_ports_tracing(ErtsTraceSession* session,
+                              int setflags, Uint32 flags,
+                              const ErtsTracer tracer)
 {
     Uint32 was_tracer;
 
     erts_rwmtx_rwlock(&sys_trace_rwmtx);
-    was_tracer = session->on_open_port_tracer;
+    was_tracer = session->new_ports_tracer;
 
-    erts_change_on_spawn_tracing(
+    erts_change_new_p_tracing(
         setflags, flags, tracer,
-        &session->on_open_port_trace_flags,
-        &session->on_open_port_tracer);
+        &session->new_ports_trace_flags,
+        &session->new_ports_tracer);
 
-    if (session->on_open_port_tracer != was_tracer) {
+    if (session->new_ports_tracer != was_tracer) {
         if (ERTS_TRACER_IS_NIL(was_tracer)) {
-            erts_refc_inc(&erts_num_on_open_port_tracers, 1);
+            erts_refc_inc(&erts_new_ports_trace_cnt, 1);
         }
-        else if (ERTS_TRACER_IS_NIL(session->on_open_port_tracer)) {
-            erts_refc_dec(&erts_num_on_open_port_tracers, 0);
+        else if (ERTS_TRACER_IS_NIL(session->new_ports_tracer)) {
+            erts_refc_dec(&erts_new_ports_trace_cnt, 0);
         }
     }
     erts_rwmtx_rwunlock(&sys_trace_rwmtx);
 }
 
 void
-erts_get_on_spawn_tracing(ErtsTraceSession* session,
+erts_get_new_proc_tracing(ErtsTraceSession* session,
                           Uint32 *flagsp, ErtsTracer *tracerp)
 {
     erts_rwmtx_rlock(&sys_trace_rwmtx);
     *tracerp = erts_tracer_nil; /* initialize */
-    get_on_spawn_tracing(
+    get_new_p_tracing(
         flagsp, tracerp,
-        &session->on_spawn_proc_trace_flags,
-        &session->on_spawn_proc_tracer);
+        &session->new_procs_trace_flags,
+        &session->new_procs_tracer);
     erts_rwmtx_runlock(&sys_trace_rwmtx);
 }
 
 void
-erts_get_on_open_port_tracing(ErtsTraceSession* session,
+erts_get_new_port_tracing(ErtsTraceSession* session,
                               Uint32 *flagsp, ErtsTracer *tracerp)
 {
     erts_rwmtx_rlock(&sys_trace_rwmtx);
     *tracerp = erts_tracer_nil; /* initialize */
-    get_on_spawn_tracing(
+    get_new_p_tracing(
         flagsp, tracerp,
-        &session->on_open_port_trace_flags,
-        &session->on_open_port_tracer);
+        &session->new_ports_trace_flags,
+        &session->new_ports_tracer);
     erts_rwmtx_runlock(&sys_trace_rwmtx);
 }
 

--- a/erts/emulator/beam/erl_trace.h
+++ b/erts/emulator/beam/erl_trace.h
@@ -116,6 +116,8 @@ Eterm erts_make_trace_session_weak_ref(ErtsTraceSession*, Eterm **hpp);
 
 extern ErtsTraceSession erts_trace_session_0;
 extern erts_rwmtx_t erts_trace_session_list_lock;
+extern erts_refc_t erts_new_procs_trace_cnt;
+extern erts_refc_t erts_new_ports_trace_cnt;
 
 void erts_ref_trace_session(ErtsTraceSession*);
 void erts_deref_trace_session(ErtsTraceSession*);

--- a/erts/emulator/beam/erl_trace.h
+++ b/erts/emulator/beam/erl_trace.h
@@ -100,10 +100,10 @@ typedef struct ErtsTraceSession {
     struct trace_pattern_flags  on_load_trace_pattern_flags;
     ErtsTracer                  on_load_meta_tracer;
 
-    Uint32 on_spawn_proc_trace_flags;
-    ErtsTracer on_spawn_proc_tracer;
-    Uint32 on_open_port_trace_flags;
-    ErtsTracer on_open_port_tracer;
+    Uint32 new_procs_trace_flags;
+    ErtsTracer new_procs_tracer;
+    Uint32 new_ports_trace_flags;
+    ErtsTracer new_ports_tracer;
 
 #ifdef DEBUG
     erts_refc_t dbg_bp_refc;  /* Number of breakpoints */
@@ -152,15 +152,15 @@ ErtsTracer erts_set_system_seq_tracer(Process *c_p,
                                       ErtsProcLocks c_p_locks,
                                       ErtsTracer new_);
 ErtsTracer erts_get_system_seq_tracer(void);
-void erts_change_default_proc_tracing(ErtsTraceSession* session,
+void erts_change_new_procs_tracing(ErtsTraceSession* session,
                                       int setflags, Uint32 flags,
                                       const ErtsTracer tracerp);
-void erts_get_on_spawn_tracing(ErtsTraceSession*,
+void erts_get_new_proc_tracing(ErtsTraceSession*,
                                Uint32 *flagsp, ErtsTracer *tracerp);
-void erts_change_default_port_tracing(ErtsTraceSession* session,
+void erts_change_new_ports_tracing(ErtsTraceSession* session,
                                       int setflags, Uint32 flags,
                                       const ErtsTracer tracerp);
-void erts_get_on_open_port_tracing(ErtsTraceSession*,
+void erts_get_new_port_tracing(ErtsTraceSession*,
                                    Uint32 *flagsp, ErtsTracer *tracerp);
 void erts_set_system_monitor(Eterm monitor);
 Eterm erts_get_system_monitor(void);

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -423,7 +423,7 @@ static Port *create_port(char *name,
         for (ErtsTraceSession *s = &erts_trace_session_0; s; s = s->next) {
             Uint32 trace_flags;
             ErtsTracer tracer;
-            erts_get_on_open_port_tracing(s, &trace_flags, &tracer);
+            erts_get_new_port_tracing(s, &trace_flags, &tracer);
             if (trace_flags) {
                 ErtsTracerRef *ref = new_tracer_ref(&prt->common, s);
                 ref->flags = trace_flags;

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -414,23 +414,25 @@ static Port *create_port(char *name,
 				&erts_port,
 				internal_port_index(prt->common.id))));
 
-    /* Set default tracing */
     ERTS_P_ALL_TRACE_FLAGS(prt) = 0;
     prt->common.tracee.first_ref = NULL;
-    erts_rwmtx_rlock(&erts_trace_session_list_lock);
-    for (ErtsTraceSession *s = &erts_trace_session_0; s; s = s->next) {
-        Uint32 trace_flags;
-        ErtsTracer tracer;
-        // ToDo: Optimize
-        erts_get_on_open_port_tracing(s, &trace_flags, &tracer);
-        if (trace_flags) {
-            ErtsTracerRef *ref = new_tracer_ref(&prt->common, s);
-            ref->flags = trace_flags;
-            ref->tracer = tracer;
+
+    if (erts_refc_read(&erts_new_ports_trace_cnt, 0)) {
+        /* Set new port tracing */
+        erts_rwmtx_rlock(&erts_trace_session_list_lock);
+        for (ErtsTraceSession *s = &erts_trace_session_0; s; s = s->next) {
+            Uint32 trace_flags;
+            ErtsTracer tracer;
+            erts_get_on_open_port_tracing(s, &trace_flags, &tracer);
+            if (trace_flags) {
+                ErtsTracerRef *ref = new_tracer_ref(&prt->common, s);
+                ref->flags = trace_flags;
+                ref->tracer = tracer;
+            }
         }
+        erts_rwmtx_runlock(&erts_trace_session_list_lock);
+        ERTS_P_ALL_TRACE_FLAGS(prt) = erts_sum_all_trace_flags(&prt->common);
     }
-    erts_rwmtx_runlock(&erts_trace_session_list_lock);
-    ERTS_P_ALL_TRACE_FLAGS(prt) = erts_sum_all_trace_flags(&prt->common);
 
     initq(prt);
 


### PR DESCRIPTION
Fast skip in spawn/open_port if no session is tracing new processes/ports.