### PR TITLE
Improve the concurrency of erts_fun_table insertions

### DIFF
--- a/erts/emulator/beam/erl_fun.c
+++ b/erts/emulator/beam/erl_fun.c
@@ -105,6 +105,7 @@ erts_put_fun_entry2(Eterm mod, int old_uniq, int old_index,
     ErlFunEntryContainer *fc;
     ErlFunEntry *tp;
     erts_aint_t refc;
+    int is_read_lock;
 
     tp = &template.entry;
 
@@ -118,14 +119,34 @@ erts_put_fun_entry2(Eterm mod, int old_uniq, int old_index,
 
     sys_memcpy(tp->uniq, uniq, sizeof(tp->uniq));
 
-    erts_fun_write_lock();
-    fc = (ErlFunEntryContainer*)hash_put(&erts_fun_table, (void*)&template);
+    /*
+     * Start with a shared, reader-lock which avoids contention when an insert
+     * is not required.
+     */
+    is_read_lock = 1;
+    erts_fun_read_lock();
+    fc = (ErlFunEntryContainer*)hash_get(&erts_fun_table, (void*)&template);
+    if (fc == NULL) {
+        /*
+         * Key is not present.  Acquire an exclusive, writer-lock and retry with
+         * a lookup that will insert if the key is still not present.
+         */
+        erts_fun_read_unlock();
+        is_read_lock = 0;
+        erts_fun_write_lock();
+        fc = (ErlFunEntryContainer*)hash_put(&erts_fun_table, (void*)&template);
+    }
+
     refc = erts_refc_inctest(&fc->entry.refc, 0);
     if (refc < 2) {
         /* New or pending delete */
         erts_refc_inc(&fc->entry.refc, 1);
     }
-    erts_fun_write_unlock();
+
+    if (is_read_lock)
+        erts_fun_read_unlock();
+    else
+        erts_fun_write_unlock();
 
     return &fc->entry;
 }


### PR DESCRIPTION
While the erts_fun_table is protected by a read-write lock but, when inserting a fun, the runtime always acquires a writer lock allowing it to insert if the lookup fails.  This has the undesirable effect of serializing the insertions even in the degenerate case where the fun is already present and the table does not need to be modified.

This change uses a reader lock initially to offer more concurrency in the case where the fun is present, which can be a common case for applications that repeatedly transmit essentially the same fun objects between nodes.  If the lookup fails, the code behaves as it did before and falls back to acquiring a writer lock and doing a lookup and insert as needed.