### PR TITLE
Fixed typo in `erlc` documentation

### DIFF
--- a/erts/doc/references/erlc_cmd.md
+++ b/erts/doc/references/erlc_cmd.md
@@ -63,7 +63,7 @@ The following flags are supported:
   containing tuples and lists must be quoted. Terms containing spaces must be
   quoted on all platforms.
 
-- **`-WError`** - Makes all warnings into errors.
+- **`-Werror`** - Makes all warnings into errors.
 
 - **`-W<Number>`** - Sets warning level to `Number`. Defaults to `1`. To turn
   off warnings, use `-W0`.


### PR DESCRIPTION
* Documentation is [inconsistent with `erlc` arguments](https://www.erlang.org/doc/apps/erts/erlc_cmd.html#generally-useful-flags)
* Made the change `s/WError/Werror/`

```shell
# erlc --help 2>&1 | grep 'W[eE]'
-Werror        make all warnings into errors
```