### PR TITLE
Move -epmd_module and -erl_epmd_port into kernel parameters

### DIFF
--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -258,7 +258,7 @@ described in the corresponding application documentation.
 
 - **`-erl_epmd_port Port`{: #erl_epmd_port }** - This flag is deprecated and
   has been replaced by the `kernel` application parameter
-  [`erl_epmd_listen_port`](`e:kernel:kernel_app.md#erl_epmd_listen_port`).
+  [`erl_epmd_node_listen_port`](`e:kernel:kernel_app.md#erl_epmd_node_listen_port`).
 
 - **`-eval Expr` (init flag)** - Makes `init` evaluate the expression `Expr`;
   see `m:init`.

--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -252,14 +252,13 @@ described in the corresponding application documentation.
   In this example, an Erlang runtime system is started with environment variable
   `DISPLAY` set to `gin:0`.
 
-- **`-epmd_module Module` (init flag)** - Configures the module responsible to
-  communicate to [epmd](epmd_cmd.md). Defaults to `erl_epmd`.
+- **`-epmd_module Module`{: #epmd_module }** - This flag is deprecated and has
+  been replaced by the `kernel` application parameter
+  [`epmd_module`](`e:kernel:kernel_app.md#epmd_module`).
 
-- **`-erl_epmd_port Port` (init flag)** - Configures the port used by `erl_epmd`
-  to listen for connection and connect to other nodes. If this flag is set,
-  the Erlang VM will boot in distributed mode even if EPMD is not available.
-  If not set, a port is chosen automatically (equivalent to port `0`). 
-  See `m:erl_epmd` for more details.
+- **`-erl_epmd_port Port`{: #erl_epmd_port }** - This flag is deprecated and
+  has been replaced by the `kernel` application parameter
+  [`erl_epmd_listen_port`](`e:kernel:kernel_app.md#erl_epmd_listen_port`).
 
 - **`-eval Expr` (init flag)** - Makes `init` evaluate the expression `Expr`;
   see `m:init`.

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -90,6 +90,9 @@ The `init` module interprets the following command-line flags:
   It defaults to `strict` from OTP 27 and this option is scheduled for removal
   in OTP 28.
 
+- **`-epmd_module Module`** - This flag is deprecated and has been replaced by
+  the `kernel` application parameter [`epmd_module`](`e:kernel:kernel_app.md#epmd_module`).
+
 - **`-eval Expr`** - Scans, parses, and evaluates an arbitrary expression `Expr`
   during system initialization. If any of these steps fail (syntax error, parse
   error, or exception during evaluation), Erlang stops with an error message. In

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -90,9 +90,6 @@ The `init` module interprets the following command-line flags:
   It defaults to `strict` from OTP 27 and this option is scheduled for removal
   in OTP 28.
 
-- **`-epmd_module Module`** - Specifies the module to use for registration and
-  lookup of node names. Defaults to `erl_epmd`.
-
 - **`-eval Expr`** - Scans, parses, and evaluates an arbitrary expression `Expr`
   during system initialization. If any of these steps fail (syntax error, parse
   error, or exception during evaluation), Erlang stops with an error message. In

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -131,7 +131,7 @@ For more information about configuration parameters, see file
     `m:net_kernel`.
 
 - **`epmd_module = module()`{: #epmd_module }** - Configures the module
-  responsible for communication with [epmd](`e:erts:erl_cmd.md`). If this parameter
+  responsible for communication with [epmd](`e:erts:epmd_cmd.md`). If this parameter
   is undefined, it defaults to `erl_epmd`.
 
   The now deprecated command line argument

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -139,7 +139,7 @@ For more information about configuration parameters, see file
   effect as the `epmd_module` configuration parameter. If this configuration
   parameter is defined, it will override the command line argument.
 
-- **`erl_epmd_listen_port = integer()`** - Configures the port used by `m:erl_epmd`
+- **`erl_epmd_node_listen_port = integer()`** - Configures the port used by `m:erl_epmd`
   to listen for connection and connect to other nodes. If this flag is set, the
   Erlang VM will boot in distributed mode even if EPMD is not available. If not
   set, a port is chosen automatically (equivalent to port `0`). See `m:erl_epmd`
@@ -147,7 +147,7 @@ For more information about configuration parameters, see file
 
   The now deprecated command line argument
   [`erl_epmd_port <module>`](`e:erts:erl_cmd.md#erl_epmd_port`) has the same
-  effect as the `erl_epmd_listen_port` configuration parameter. If this
+  effect as the `erl_epmd_node_listen_port` configuration parameter. If this
   configuration parameter is defined, it will override the command line argument.
 
 - **`permissions = [Perm]`{: #permissions }** - Specifies the default permission

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -131,7 +131,7 @@ For more information about configuration parameters, see file
     `m:net_kernel`.
 
 - **`epmd_module = module()`{: #epmd_module }** - Configures the module
-  responsible for communication with [epmd](epmd_cmd.md). If this parameter
+  responsible for communication with [epmd](`e:erts:erl_cmd.md`). If this parameter
   is undefined, it defaults to `erl_epmd`.
 
   The now deprecated command line argument

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -139,7 +139,7 @@ For more information about configuration parameters, see file
   effect as the `epmd_module` configuration parameter. If this configuration
   parameter is defined, it will override the command line argument.
 
-- **`erl_epmd_node_listen_port = integer()`** - Configures the port used by `m:erl_epmd`
+- **`erl_epmd_node_listen_port = integer()`{: #erl_epmd_node_listen_port }** - Configures the port used by `m:erl_epmd`
   to listen for connection and connect to other nodes. If this flag is set, the
   Erlang VM will boot in distributed mode even if EPMD is not available. If not
   set, a port is chosen automatically (equivalent to port `0`). See `m:erl_epmd`

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -130,6 +130,26 @@ For more information about configuration parameters, see file
     node. If a node goes down, it must thereafter be explicitly connected. See
     `m:net_kernel`.
 
+- **`epmd_module = module()`{: #epmd_module }** - Configures the module
+  responsible for communication with [epmd](epmd_cmd.md). If this parameter
+  is undefined, it defaults to `erl_epmd`.
+
+  The now deprecated command line argument
+  [`-epmd_module <module>`](`e:erts:erl_cmd.md#epmd_module`) has the same
+  effect as the `epmd_module` configuration parameter. If this configuration
+  parameter is defined, it will override the command line argument.
+
+- **`erl_epmd_listen_port = integer()`** - Configures the port used by `m:erl_epmd`
+  to listen for connection and connect to other nodes. If this flag is set, the
+  Erlang VM will boot in distributed mode even if EPMD is not available. If not
+  set, a port is chosen automatically (equivalent to port `0`). See `m:erl_epmd`
+  for more details.
+
+  The now deprecated command line argument
+  [`erl_epmd_port <module>`](`e:erts:erl_cmd.md#erl_epmd_port`) has the same
+  effect as the `erl_epmd_listen_port` configuration parameter. If this
+  configuration parameter is defined, it will override the command line argument.
+
 - **`permissions = [Perm]`{: #permissions }** - Specifies the default permission
   for applications when they are started. In this parameter:
 

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -164,14 +164,9 @@ to when accepting new distribution requests.
       Host :: atom() | string() | inet:ip_address(),
       Port :: non_neg_integer().
 listen_port_please(_Name, _Host) ->
-    try
-        %% Should come up with a new name for this as ERL_EPMD_PORT describes what
-        %% port epmd runs on which could easily be confused with this.
-        {ok, [[StringPort]]} = init:get_argument(erl_epmd_port),
-        Port = list_to_integer(StringPort),
-        {ok, Port}
-    catch error:_ ->
-            {ok, 0}
+    case erl_epmd_listen_port() of
+        {ok, Port} -> {ok, Port};
+        undefined -> {ok, 0}
     end.
 
 -doc false.
@@ -291,26 +286,26 @@ init(_) ->
 
 handle_call({register, Name, PortNo, Family}, _From, State) ->
     case State#state.socket of
-	P when P < 0 ->
-	    case do_register_node(Name, PortNo, Family) of
-		{alive, Socket, Creation} ->
-		    S = State#state{socket = Socket,
-				    port_no = PortNo,
-				    name = Name,
-				    family = Family},
-		    {reply, {ok, Creation}, S};
+        P when P < 0 ->
+            case do_register_node(Name, PortNo, Family) of
+                {alive, Socket, Creation} ->
+                    S = State#state{socket = Socket,
+		                    port_no = PortNo,
+		                    name = Name,
+		                    family = Family},
+                    {reply, {ok, Creation}, S};
                 Error ->
-                    case init:get_argument(erl_epmd_port) of
+                    case erl_epmd_listen_port() of
                         {ok, _} ->
                             {reply, {ok, -1}, State#state{ socket = -1,
                                                            port_no = PortNo,
                                                            name = Name} };
-                        error ->
+                        undefined ->
                             {reply, Error, State}
                     end
-	    end;
-	_ ->
-	    {reply, {error, already_registered}, State}
+            end;
+        _ ->
+            {reply, {error, already_registered}, State}
     end;
 
 handle_call(client_info_req, _From, State) ->
@@ -378,7 +373,24 @@ get_epmd_port() ->
 	error ->
 	    ?erlang_daemon_port
     end.
-	    
+
+erl_epmd_listen_port() ->
+    case application:get_env(kernel, erl_epmd_listen_port) of
+        {ok, Port} when is_integer(Port), Port >= 0 ->
+            {ok, Port};
+        {ok, Invalid} ->
+            error({invalid_parameter_value, erl_epmd_listen_port, Invalid});
+        undefined ->
+            try
+                {ok, [[StringPort]]} = init:get_argument(erl_epmd_port),
+                Port = list_to_integer(StringPort),
+                ok = application:set_env(kernel, erl_epmd_listen_port, Port, [{timeout, infinity}]),
+                {ok, Port}
+            catch error:_ ->
+                undefined
+            end
+    end.
+
 %%
 %% Epmd socket
 %%

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -164,7 +164,7 @@ to when accepting new distribution requests.
       Host :: atom() | string() | inet:ip_address(),
       Port :: non_neg_integer().
 listen_port_please(_Name, _Host) ->
-    case erl_epmd_listen_port() of
+    case erl_epmd_node_listen_port() of
         {ok, Port} -> {ok, Port};
         undefined -> {ok, 0}
     end.
@@ -295,7 +295,7 @@ handle_call({register, Name, PortNo, Family}, _From, State) ->
 		                    family = Family},
                     {reply, {ok, Creation}, S};
                 Error ->
-                    case erl_epmd_listen_port() of
+                    case erl_epmd_node_listen_port() of
                         {ok, _} ->
                             {reply, {ok, -1}, State#state{ socket = -1,
                                                            port_no = PortNo,
@@ -374,17 +374,17 @@ get_epmd_port() ->
 	    ?erlang_daemon_port
     end.
 
-erl_epmd_listen_port() ->
-    case application:get_env(kernel, erl_epmd_listen_port) of
+erl_epmd_node_listen_port() ->
+    case application:get_env(kernel, erl_epmd_node_listen_port) of
         {ok, Port} when is_integer(Port), Port >= 0 ->
             {ok, Port};
         {ok, Invalid} ->
-            error({invalid_parameter_value, erl_epmd_listen_port, Invalid});
+            error({invalid_parameter_value, erl_epmd_node_listen_port, Invalid});
         undefined ->
             try
                 {ok, [[StringPort]]} = init:get_argument(erl_epmd_port),
                 Port = list_to_integer(StringPort),
-                ok = application:set_env(kernel, erl_epmd_listen_port, Port, [{timeout, infinity}]),
+                ok = application:set_env(kernel, erl_epmd_node_listen_port, Port, [{timeout, infinity}]),
                 {ok, Port}
             catch error:_ ->
                 undefined

--- a/lib/observer/src/observer_wx.erl
+++ b/lib/observer/src/observer_wx.erl
@@ -776,12 +776,13 @@ get_nodes() ->
 
 %% see erl_epmd:(listen_)port_please/2
 erl_dist_port() ->
-    try
-        erl_epmd = net_kernel:epmd_module(),
-        {ok, [[StringPort]]} = init:get_argument(erl_epmd_port),
-        list_to_integer(StringPort)
-    catch
-        _:_ ->
+    case net_kernel:epmd_module() of
+        erl_epmd ->
+            case erl_epmd:listen_port_please(nonode, nohost) of
+                {ok, 0} -> undefined;
+                {ok, Port} -> Port
+            end;
+        _ ->
             undefined
     end.
 
@@ -903,5 +904,3 @@ filter_nodedown_messages(Node) ->
 %%     io:format("[owx] " ++ F ++ "~n", A);
 %% d(_, _, _) ->
 %%     ok.
-
-

--- a/system/doc/general_info/deprecations_27.md
+++ b/system/doc/general_info/deprecations_27.md
@@ -14,3 +14,13 @@ The following features for archives are deprecated:
 Using a single archive file for holding BEAM files and other data
 files in an Escript is **not** deprecated. However, to access files in
 the archive the `escript:extract/2` function has to be used.
+
+### erl flags
+
+The following erl flags are deprecated:
+
+* `-epmd_module Module` - deprecated in favour of the `kernel` application
+  parameter `epmd_module`.
+
+* `-erl_epmd_port Port` - deprecated in favour of the `kernel` application
+  parameter `erl_epmd_node_listen_port`.


### PR DESCRIPTION
This introduces `epmd_module` and `erl_epmd_listen_port` parameters for the kernel application. I updated the docs to deprecate `-epmd_module` and `-erl_epmd_port`, similarly to `-connect_all` in https://github.com/erlang/otp/commit/1d0fe6f71c320d2d1d19d9efd6dcba7b18bedca6.

The kernel application already has a lot of parameters related to distribution, so I believe semantically this makes sense.

For context, in [Livebook](https://github.com/livebook-dev/livebook) we started using a custom `epmd_module`. In Escript and Elixir releases, there are ways to set the `-epmd_module` flag, however there is no way to do that in development, other than setting `ERL_AFLAGS` env var. We already start distribution manually using `net_kernel:start/2`, so the idea is that now we could do `application:set_env(kernel, epmd_module, Module)` right before that.