### PR TITLE
compiler tests: Correct bad timetrap limit

### DIFF
--- a/lib/compiler/test/random_code_SUITE.erl
+++ b/lib/compiler/test/random_code_SUITE.erl
@@ -58,8 +58,9 @@ compile(_Config) ->
                        list_to_integer(NumTests0)
                end,
 
-    %% Conservatively assume that we can run 10 tests each second.
-    TimeTrap = {seconds,60_000 + (NumTests+99) div 100},
+    %% Conservatively assume that we can run 10 tests each
+    %% second.
+    TimeTrap = {seconds, (60 + (NumTests+9) div 10)},
     ct:timetrap(TimeTrap),
     io:format("~p tests\n", [NumTests]),
     true = proper:quickcheck(compile_prop:compile(),


### PR DESCRIPTION
The compiler's random_code test suite always fails when running with a debug emulator due to a `timeout_value` exit. A `timeout_value` exit appears to be triggered when a timer is given a timeout that is either miss-formed or out of range. Checking the relevant part of `random_code_SUITE`, it appears that the timeout is calculated in milliseconds, but it is given to `ct:timetrap/1` as a timeout in seconds.

Although not sure about the exact failure mechanism, changing the calculation to produce a timeout in seconds, allows the test-suite to successfully complete both with an `opt` and `debug` build of the emulator.