### PR TITLE
compiler alias analysis: Fix bug in status of map extracts

### DIFF
--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -918,6 +918,8 @@ aa_derive_from(Dst, [Parent|Parents], State0) ->
     aa_derive_from(Dst, Parents, aa_derive_from(Dst, Parent, State0));
 aa_derive_from(_Dst, [], State0) ->
     State0;
+aa_derive_from(#b_var{}=Dst, #b_literal{val=Val}, State) when is_map(Val) ->
+    aa_set_aliased(Dst, State);
 aa_derive_from(#b_var{}, #b_literal{}, State) ->
     State;
 aa_derive_from(#b_var{}=Dst, #b_var{}=Parent, State) ->

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -60,6 +60,7 @@
 	 not_transformable3/1,
 	 not_transformable4/1,
 	 not_transformable5/1,
+	 not_transformable6/0,
 
          bad_get_status_by_type/0,
          stacktrace0/0,
@@ -606,6 +607,17 @@ not_transformable5b([H|T], Acc) ->
     not_transformable5a(T, <<Acc/binary, 1:8, H:8>>);
 not_transformable5b([], Acc) ->
     Acc.
+
+%% Check that anything extracted from a map is aliased. This is
+%% required as otherwise the destructive update pass could try to
+%% update a literal.
+not_transformable6() ->
+%ssa% () when post_ssa_opt ->
+%ssa% E = get_map_element(...),
+%ssa% _ = bs_create_bin(append, _, E, ...) { aliased => [E], first_fragment_dies => true }.
+    M = #{a=> <<>>},
+    #{a:=X} = M,
+    <<X/binary, 17:8>>.
 
 %% Reproducer for a bug in beam_ssa_alias:aa_get_status_by_type/2
 %% where it would return the wrong alias/uniqe status for certain


### PR DESCRIPTION
As the destructive update pass does not have any support for patching literal maps, as it can do for tuples to ensure that the term that will be destructively updated is on the heap, we must conservatively consider anything extracted from a literal map as aliased.

This is not a significant limitation as tracking the alias status of individual associations of non-literal maps is currently considered non feasible.

This bug is present in 26, 27 as well as in master. I'm not at all sure on the interrelationship between the various maint branches and the patch cannot be just merged forward. To help merging [here is what applies to maint-27](https://github.com/frej/otp/tree/frej/fix-alias-analysis-error-for-maint-27) and [this](https://github.com/frej/otp/tree/frej/fix-alias-analysis-error) is what should go into master.