### PR TITLE
compiler alias analysis: Enable forgotten test case

### DIFF
--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -59,6 +59,7 @@
          transformable32/0,
          transformable32/1,
          transformable33/0,
+         transformable34/0,
 
 	 not_transformable1/2,
 	 not_transformable2/1,


### PR DESCRIPTION
Add `transformable34/0` to the exports. Back when (79ca4ba31bc5 "Make alias analysis less conservative with calls") was merged, no one noticed (including me) that the added test was not added to the list of exports, and therefore never actually run.