### PR TITLE
Use spawn_link instead of spawn for export/1 related calls

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -1259,7 +1259,7 @@ main_process_loop(State) ->
 	    ?MODULE:main_process_loop(S);
 
 	{From, {export,OutFile,Module}} ->
-	    spawn(fun() ->
+	    spawn_link(fun() ->
 			  ?SPAWN_DBG(export,{OutFile, Module}),
 			  do_export(Module, OutFile, From, State)
 		  end),
@@ -1671,7 +1671,7 @@ remote_start(MainNode) ->
     case whereis(?SERVER) of
 	undefined ->
 	    Starter = self(),
-	    Pid = spawn(fun() -> 
+	    Pid = spawn_link(fun() -> 
 				?SPAWN_DBG(remote_start,{MainNode}),
 				init_remote(Starter,MainNode) 
 			end),


### PR DESCRIPTION
This PR tries to fix https://github.com/erlang/otp/issues/8661. @arcusfelis suggested this solution on OTP's end. 

Now a `cover_server` process on remote node will crash when a process spawned by it crashes. This is better than the `cover_server` process never knowing about the crash.