### PR TITLE
Speed up alias analysis

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -112,6 +112,7 @@ BEAM_H = $(wildcard ../priv/beam_h/*.h)
 HRL_FILES= \
 	beam_asm.hrl \
 	beam_disasm.hrl \
+	beam_ssa_alias_debug.hrl \
 	beam_ssa_opt.hrl \
 	beam_ssa.hrl \
 	beam_types.hrl \
@@ -216,7 +217,8 @@ $(EBIN)/beam_jump.beam: beam_asm.hrl
 $(EBIN)/beam_listing.beam: core_parse.hrl beam_ssa.hrl \
      beam_asm.hrl beam_types.hrl
 $(EBIN)/beam_ssa.beam: beam_ssa.hrl
-$(EBIN)/beam_ssa_alias.beam: beam_ssa_opt.hrl beam_types.hrl
+$(EBIN)/beam_ssa_alias.beam: beam_ssa_opt.hrl beam_ssa_alias_debug.hrl \
+     beam_types.hrl
 $(EBIN)/beam_ssa_bsm.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_bool.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_check.beam: beam_ssa.hrl beam_types.hrl
@@ -229,7 +231,7 @@ $(EBIN)/beam_ssa_pp.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_ssa_pre_codegen.beam: beam_ssa.hrl beam_asm.hrl
 $(EBIN)/beam_ssa_recv.beam: beam_ssa.hrl
 $(EBIN)/beam_ssa_share.beam: beam_ssa.hrl
-$(EBIN)/beam_ssa_ss.beam: beam_ssa.hrl beam_types.hrl
+$(EBIN)/beam_ssa_ss.beam: beam_ssa.hrl beam_ssa_alias_debug.hrl beam_types.hrl
 $(EBIN)/beam_ssa_throw.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_ssa_type.beam: beam_ssa.hrl beam_types.hrl
 $(EBIN)/beam_trim.beam: beam_asm.hrl

--- a/lib/compiler/src/beam_digraph.erl
+++ b/lib/compiler/src/beam_digraph.erl
@@ -37,7 +37,7 @@
          in_degree/2, in_edges/2, in_neighbours/2,
          no_vertices/1,
          out_degree/2, out_edges/2, out_neighbours/2,
-         vertex/2, vertices/1,
+         vertex/2, vertex/3, vertices/1,
          reverse_postorder/2,
          roots/1,
          topsort/1,
@@ -188,6 +188,12 @@ no_vertices(#dg{vs=Vs}) ->
 -spec vertex(graph(), vertex()) -> label().
 vertex(#dg{vs=Vs}, V) ->
     map_get(V, Vs).
+
+%% As vertex/2 but if the vertex does not exist a default value is
+%% returned.
+-spec vertex(graph(), vertex(), label()) -> label().
+vertex(#dg{vs=Vs}, V, Default) ->
+    maps:get(V, Vs, Default).
 
 -spec vertices(graph()) -> [{vertex(), label()}].
 vertices(#dg{vs=Vs}) ->

--- a/lib/compiler/src/beam_digraph.erl
+++ b/lib/compiler/src/beam_digraph.erl
@@ -30,6 +30,7 @@
 -export([new/0,
          add_vertex/2, add_vertex/3, add_edge/3, add_edge/4,
          del_edge/2, del_edges/2,
+         del_vertex/2,
          foldv/3,
          has_vertex/2,
          is_path/3,
@@ -75,6 +76,18 @@ add_vertex(Dg, V, Label) ->
     #dg{vs=Vs0} = Dg,
     Vs = Vs0#{V=>Label},
     Dg#dg{vs=Vs}.
+
+-spec del_vertex(graph(), vertex()) -> graph().
+del_vertex(Dg, V) ->
+    #dg{vs=Vs0,in_es=InEsMap0,out_es=OutEsMap0} = Dg,
+    InEs = maps:get(V, InEsMap0, []),
+    OutEsMap = foldl(fun({From,_,_}=E, A) -> edge_map_del(From, E, A) end,
+                     maps:remove(V, OutEsMap0), InEs),
+    OutEs = maps:get(V, OutEsMap0, []),
+    InEsMap = foldl(fun({_,To,_}=E, A) -> edge_map_del(To, E, A) end,
+                    maps:remove(V, InEsMap0), OutEs),
+    Vs = maps:remove(V, Vs0),
+    Dg#dg{vs=Vs,in_es=InEsMap,out_es=OutEsMap}.
 
 -spec add_edge(graph(), vertex(), vertex()) -> graph().
 add_edge(Dg, From, To) ->

--- a/lib/compiler/src/beam_digraph.erl
+++ b/lib/compiler/src/beam_digraph.erl
@@ -31,6 +31,7 @@
          add_vertex/2, add_vertex/3, add_edge/3, add_edge/4,
          del_edge/2, del_edges/2,
          del_vertex/2,
+         edges/1,
          foldv/3,
          has_vertex/2,
          is_path/3,
@@ -235,6 +236,12 @@ roots_1([], _G) -> [].
 topsort(G) ->
     Seen = roots(G),
     reverse_postorder(G, Seen).
+
+-spec edges(graph()) -> [edge()].
+edges(#dg{out_es=OutEsMap}) ->
+    maps:fold(fun(_, Es, Acc) ->
+                      Es ++ Acc
+              end, [], OutEsMap).
 
 %%
 %% Kosaraju's algorithm

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -32,12 +32,9 @@
 
 -include("beam_ssa_opt.hrl").
 -include("beam_types.hrl").
+-include("beam_ssa_alias_debug.hrl").
 
-%% Uncomment the following to get trace printouts.
-
-%% -define(DEBUG, true).
-
--ifdef(DEBUG).
+-ifdef(DEBUG_ALIAS).
 -define(DP(FMT, ARGS), io:format(FMT, ARGS)).
 -define(DP(FMT), io:format(FMT)).
 -define(DBG(STMT), STMT).

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -825,7 +825,10 @@ aa_update_annotation_for_var(Var, Status, Anno0) ->
                                  ordsets:del_element(Var, Unique0)};
                             unique ->
                                 {ordsets:del_element(Var, Aliased0),
-                                 ordsets:add_element(Var, Unique0)}
+                                 ordsets:add_element(Var, Unique0)};
+                            no_info ->
+                                {ordsets:del_element(Var, Aliased0),
+                                 ordsets:del_element(Var, Unique0)}
                         end,
     Anno1 = case Aliased of
                 [] ->

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -354,7 +354,7 @@ aa_fixpoint(Funs, AAS=#aas{func_db=FuncDb}) ->
     Order = aa_order(Funs, FuncDb),
     ?DP("Traversal order:~n  ~s~n",
         [string:join([fn(F) || F <- Order], ",\n  ")]),
-    aa_fixpoint(Order, Order, AAS, 1).
+    aa_fixpoint(Order, reverse(Order), AAS, 1).
 
 aa_fixpoint([F|Fs], Order,
             AAS0=#aas{func_db=FuncDb,st_map=StMap,
@@ -388,7 +388,7 @@ aa_fixpoint([], Order, #aas{func_db=FuncDb,repeats=Repeats}=AAS, NoofIters) ->
             {StMap, FuncDb};
         NewOrder ->
             ?DP("**** Starting traversal ~p ****~n", [NoofIters + 1]),
-            aa_fixpoint(NewOrder, Order,
+            aa_fixpoint(NewOrder, reverse(Order),
                         AAS#aas{repeats=sets:new()}, NoofIters + 1)
     end.
 

--- a/lib/compiler/src/beam_ssa_alias_debug.hrl
+++ b/lib/compiler/src/beam_ssa_alias_debug.hrl
@@ -1,0 +1,43 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% The beam_ssa_alias and beam_ssa_ss modules are both used by the
+%% alias analysis pass of the compiler, where beam_ssa_ss provides the
+%% underlying database manipulated by the beam_ssa_alias
+%% module. Debugging beam_ssa_alias is simplified when the module can
+%% print out the internal state of beam_ssa_ss, but as that code is
+%% redundant otherwise it is ifdefed-out, this header exist in order
+%% to avoid having to modify multiple modules when toggling debugging
+%% traces for beam_ssa_alias and beam_ssa_ss.
+
+%% Uncomment the following to get trace printouts.
+
+%% -define(DEBUG_ALIAS, true). % For beam_ssa_alias
+
+%% -define(DEBUG_SS, true). % For beam_ssa_ss
+
+%% Uncomment the following to check that all invariants for the state
+%% hold. These checks are expensive and not enabled by default.
+
+%% -define(SS_EXTRA_ASSERTS, true).
+
+-if(defined(DEBUG_ALIAS) orelse defined(DEBUG_SS)
+    orelse defined(SS_EXTRA_ASSERTS)).
+-define(PROVIDE_DUMP, true).
+-endif.

--- a/lib/compiler/src/beam_ssa_check.erl
+++ b/lib/compiler/src/beam_ssa_check.erl
@@ -159,6 +159,12 @@ op_check([set,Result,{{atom,_,bif},{atom,_,Op}}|PArgs], PAnno,
         [Op, Result, Dst, PArgs, AArgs, _I]),
     Env = op_check_call(Op, Result, Dst, PArgs, AArgs, Env0),
     check_annos(PAnno, AAnno, Env);
+op_check([set,Result,{{atom,_,succeeded},{atom,_,Kind}}|PArgs], PAnno,
+         #b_set{dst=Dst,args=AArgs,op={succeeded,Kind},anno=AAnno}=_I, Env0) ->
+    ?DP("trying succeed ~p:~n  res: ~p <-> ~p~n  args: ~p <-> ~p~n  i: ~p~n",
+        [Kind, Result, Dst, PArgs, AArgs, _I]),
+    Env = op_check_call(dont_care, Result, Dst, PArgs, AArgs, Env0),
+    check_annos(PAnno, AAnno, Env);
 op_check([none,{atom,_,ret}|PArgs], PAnno,
          #b_ret{arg=AArg,anno=AAnno}=_I, Env) ->
     ?DP("trying return:, arg: ~p <-> ~p~n  i: ~p~n",

--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -43,6 +43,7 @@
          merge_in_args/3,
          new/0,
          new/3,
+         phi/4,
          prune/3,
          set_call_result/4,
          set_status/3,
@@ -449,6 +450,20 @@ accumulate_edges(V, State, Edges0) ->
 -spec new() -> sharing_state().
 new() ->
     beam_digraph:new().
+
+-spec phi(beam_ssa:b_var(), [beam_ssa:b_var()],
+          sharing_state(), non_neg_integer())
+         -> sharing_state().
+phi(Dst, Args, State0, Cnt) ->
+    ?assert_state(State0),
+    ?DP("** phi **~n~s~n", [dump(State0)]),
+    ?DP("  dst: ~p~n", [Dst]),
+    ?DP("  args: ~p~n", [Args]),
+    Structure = foldl(fun(Arg, Acc) ->
+                              merge_in_arg(Arg, Acc, ?ARGS_DEPTH_LIMIT, State0)
+                      end, no_info, Args),
+    ?DP("  structure: ~p~n", [Structure]),
+    new([Dst], [Structure], Cnt, State0).
 
 %%%
 %%% Throws `too_deep` if the depth of sharing state value chains

--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -50,15 +50,18 @@
 
 -include("beam_ssa.hrl").
 -include("beam_types.hrl").
+-include("beam_ssa_alias_debug.hrl").
+
+-ifdef(PROVIDE_DUMP).
+-export([dump/1]).
+-endif.
 
 -import(lists, [foldl/3]).
 
 -define(ARGS_DEPTH_LIMIT, 4).
 -define(SS_DEPTH_LIMIT, 30).
 
-%% -define(DEBUG, true).
-
--ifdef(DEBUG).
+-ifdef(DEBUG_SS).
 -define(DP(FMT, ARGS), io:format(FMT, ARGS)).
 -define(DP(FMT), io:format(FMT)).
 -else.
@@ -66,13 +69,7 @@
 -define(DP(FMT), skip).
 -endif.
 
-
-%% Uncomment the following to check that all invariants for the state
-%% hold. These checks are expensive and not enabled by default.
-
-%% -define(EXTRA_ASSERTS, true).
-
--ifdef(EXTRA_ASSERTS).
+-ifdef(SS_EXTRA_ASSERTS).
 -define(assert_state(State), assert_state(State)).
 -define(ASSERT(Assert), Assert).
 -else.
@@ -786,7 +783,7 @@ has_out_edges(V, State) ->
 
 %% Debug support below
 
--ifdef(EXTRA_ASSERTS).
+-ifdef(SS_EXTRA_ASSERTS).
 
 -spec assert_state(sharing_state()) -> sharing_state().
 
@@ -910,8 +907,9 @@ assert_variable_exists(#b_var{}=V, State) ->
     end.
 
 -endif.
--ifdef(DEBUG).
 
+-ifdef(PROVIDE_DUMP).
+-spec dump(sharing_state()) -> iolist().
 dump(State) ->
     Ls = lists:enumerate(0, beam_digraph:vertices(State)),
     V2Id = #{ V=>Id || {Id,{V,_}} <- Ls },

--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -557,7 +557,6 @@ get_alias_edges(V, State) ->
 
 -spec variables(sharing_state()) -> [beam_ssa:b_var()].
 variables(State) ->
-    %% TODO: Sink this beam_digraph to avoid splitting the list?
     [V || {V,_Lbl} <- beam_digraph:vertices(State)].
 
 -type call_in_arg_status() :: no_info

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -33,6 +33,7 @@
          appendable_checks/1,
          bs_size_unit_checks/1,
          no_reuse_hint_checks/1,
+         no_type_info_checks/1,
          private_append_checks/1,
          ret_annotation_checks/1,
          sanity_checks/1,
@@ -49,6 +50,7 @@ groups() ->
        annotation_checks,
        appendable_checks,
        no_reuse_hint_checks,
+       no_type_info_checks,
        private_append_checks,
        ret_annotation_checks,
        sanity_checks,
@@ -103,6 +105,9 @@ bs_size_unit_checks(Config) when is_list(Config) ->
 
 no_reuse_hint_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(no_reuse_hint, Config).
+
+no_type_info_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(no_type_info, Config).
 
 private_append_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(private_append, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -519,7 +519,7 @@ transformable24(L) ->
     transformable24(L, {<<>>, ex:foo(),ex:foo()}).
 
 transformable24([H|T], {Acc,X,Y}) ->
-%ssa% (_, Arg1) when post_ssa_opt ->
+%ssa% xfail (_, Arg1) when post_ssa_opt ->
 %ssa% X = get_tuple_element(Arg1, 1),
 %ssa% Acc = get_tuple_element(Arg1, 0),
 %ssa% A = bs_create_bin(append, _, Acc, _, _, _, Sum, _) { unique => [Sum,Acc], first_fragment_dies => true },

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -1207,7 +1207,7 @@ see_through() ->
     see_through1(R).
 
 see_through1({_,R}) ->
-%ssa% xfail (_) when post_ssa_opt ->
+%ssa% (_) when post_ssa_opt ->
 %ssa% _ = update_record(reuse, 3, Rec, _, _) {unique => [Rec], source_dies => true}.
     R#see_through{a=e:f()}.
 

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -519,7 +519,7 @@ transformable24(L) ->
     transformable24(L, {<<>>, ex:foo(),ex:foo()}).
 
 transformable24([H|T], {Acc,X,Y}) ->
-%ssa% xfail (_, Arg1) when post_ssa_opt ->
+%ssa% (_, Arg1) when post_ssa_opt ->
 %ssa% X = get_tuple_element(Arg1, 1),
 %ssa% Acc = get_tuple_element(Arg1, 0),
 %ssa% A = bs_create_bin(append, _, Acc, _, _, _, Sum, _) { unique => [Sum,Acc], first_fragment_dies => true },
@@ -1207,7 +1207,7 @@ see_through() ->
     see_through1(R).
 
 see_through1({_,R}) ->
-%ssa% (_) when post_ssa_opt ->
+%ssa% xfail (_) when post_ssa_opt ->
 %ssa% _ = update_record(reuse, 3, Rec, _, _) {unique => [Rec], source_dies => true}.
     R#see_through{a=e:f()}.
 

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -110,7 +110,9 @@
 
          nested_tuple/0,
          nested_cons/0,
-         nested_mixed/0]).
+         nested_mixed/0,
+
+         see_through/0]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -1194,3 +1196,20 @@ nested_mixed() ->
 %ssa% ret(R).
     [{[{Z,X}]}] = nested_mixed_inner(),
     {<<Z/binary, 1:8>>,X}.
+
+%%
+%% Check that the analysis can see through embed-extract chains.
+%%
+-record(see_through, {a,b}).
+
+see_through() ->
+    [R] = see_through0(),
+    see_through1(R).
+
+see_through1({_,R}) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% _ = update_record(reuse, 3, Rec, _, _) {unique => [Rec], source_dies => true}.
+    R#see_through{a=e:f()}.
+
+see_through0() ->
+    [{foo, #see_through{a={bar, [foo]}}}].

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/no_info0.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/no_info0.erl
@@ -1,0 +1,60 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% Extracts from beam_clean.erl to test cases when special handling of
+%% the no_info sharing state is required for correct functioning.
+%%
+-module(no_info0).
+-moduledoc false.
+
+-export([clean_labels/1]).
+
+-import(lists, [reverse/1]).
+
+-type label() :: beam_asm:label().
+
+-record(st, {lmap :: [{label(),label()}], %Translation tables for labels.
+	     entry :: beam_asm:label(),   %Number of entry label.
+	     lc :: non_neg_integer()      %Label counter
+	     }).
+
+clean_labels(Fs0) ->
+    St0 = #st{lmap=[],entry=1,lc=1},
+    function_renumber(Fs0, St0, []).
+
+function_renumber([{function,Name,Arity,_Entry,Asm0}|Fs], St0, Acc) ->
+    {Asm,St} = renumber_labels(Asm0, [], St0),
+    function_renumber(Fs, St, [{function,Name,Arity,St#st.entry,Asm}|Acc]);
+function_renumber([], St, Acc) -> {Acc,St}.
+
+renumber_labels([{label,Old}|Is], [{label,New}|_]=Acc, #st{lmap=D0}=St) ->
+%ssa% (_, _, Rec) when post_ssa_opt ->
+%ssa% _ = update_record(inplace, 4, Rec, ...),
+%ssa% _ = update_record(inplace, 4, Rec, ...),
+%ssa% _ = update_record(inplace, 4, Rec, ...).
+    D = [{Old,New}|D0],
+    renumber_labels(Is, Acc, St#st{lmap=D});
+renumber_labels([{label,Old}|Is], Acc, St0) ->
+    New = St0#st.lc,
+    D = [{Old,New}|St0#st.lmap],
+    renumber_labels(Is, [{label,New}|Acc], St0#st{lmap=D,lc=New+1});
+renumber_labels([{func_info,_,_,_}=Fi|Is], Acc, St0) ->
+    renumber_labels(Is, [Fi|Acc], St0#st{entry=St0#st.lc});
+renumber_labels([I|Is], Acc, St0) ->
+    renumber_labels(Is, [I|Acc], St0);
+renumber_labels([], Acc, St) -> {Acc,St}.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/no_type_info.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/no_type_info.erl
@@ -1,0 +1,51 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% This module tests functions which have previously crashed the
+%% compiler when the `no_type_opt` option was used.
+%%
+
+-module(no_type_info).
+-export([bug/0]).
+
+-compile(no_type_opt).
+
+bug() ->
+%ssa% () when post_ssa_opt ->
+%ssa% X = bif:hd(L) { unique => [L] },
+%ssa% _ = succeeded:body(X) { aliased => [X] }.
+    begin
+        + <<42 ||
+              $s <-
+                  try
+                      something
+                  catch
+                      error:false ->
+                          []
+                  end
+          >>
+    end:(hd(not girl))(
+      try home of
+          _ when 34 ->
+              8
+      catch
+          _:_ ->
+              whatever
+      after
+          ok
+      end).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/phis.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/phis.erl
@@ -1,0 +1,57 @@
+%% Extracted from lib/syntax_tools/src/erl_recomment.erl to test
+%% omissions in handling of Phi instructions.
+
+%% =====================================================================
+%% Licensed under the Apache License, Version 2.0 (the "License"); you may
+%% not use this file except in compliance with the License. You may obtain
+%% a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0>
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% Alternatively, you may use this file under the terms of the GNU Lesser
+%% General Public License (the "LGPL") as published by the Free Software
+%% Foundation; either version 2.1, or (at your option) any later version.
+%% If you wish to allow use of your version of this file only under the
+%% terms of the LGPL, you should delete the provisions above and replace
+%% them with the notice and other provisions required by the LGPL; see
+%% <http://www.gnu.org/licenses/>. If you do not delete the provisions
+%% above, a recipient may use your version of this file under the terms of
+%% either the Apache License or the LGPL.
+%%
+%% @copyright 1997-2006 Richard Carlsson
+%% @author Richard Carlsson <carlsson.richard@gmail.com>
+%% @end
+%% =====================================================================
+
+-module(phis).
+
+-export([filter_forms/1]).
+
+-record(filter, {file = undefined :: file:filename() | 'undefined',
+		 line = 0         :: integer()}).
+
+filter_forms(Fs) ->
+    filter_forms(Fs, #filter{}).
+
+filter_forms([{A1, A2} | Fs], S) ->
+%ssa% (_, Rec0) when post_ssa_opt ->
+%ssa% Rec = update_record(inplace, 3, Rec0, ...),
+%ssa% Phi = phi({Rec0, _}, {Rec, _}),
+%ssa% _ = update_record(inplace, 3, Phi, ...).
+    S1 = case ex:f() of
+	     undefined ->
+		 S#filter{file = A1, line = A2};
+	     _ ->
+		 S
+	 end,
+    if S1#filter.file =:= A1 ->
+	    filter_forms(Fs, S1#filter{line = A2});
+       true ->
+	    filter_forms(Fs, S1)
+    end;
+filter_forms([], _) ->
+    [].

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/sanity_checks.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/sanity_checks.erl
@@ -37,7 +37,8 @@
          t35/1, t36/0, t37/0, t38/0, t39/1,
          t40/0, t41/0, t42/0, t43/0, t44/0,
 
-         check_env/0]).
+         check_env/0,
+         check_succeeded/1]).
 
 %% Check that we do not trigger on the wrong pass
 check_wrong_pass() ->
@@ -339,3 +340,11 @@ check_env() ->
     A = <<>>,
     B = ex:f(),
     <<A/binary, B/binary>>.
+
+%% Check that succeeded-instructions can be matched.
+check_succeeded(L) ->
+%ssa% (L) when post_ssa_opt ->
+%ssa% X = bif:hd(L),
+%ssa% Y = succeeded:body(X),
+%ssa% ret(X).
+    hd(L).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/ss_depth_limit.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/ss_depth_limit.erl
@@ -16,18 +16,21 @@ do(N) ->
 	    "-export([f/0]).\n\n",
 	    "f() ->\n",
 	    "%ssa% fail () when post_ssa_opt ->\n"
-	    "%ssa% ret(X) { unique => [X] }.\n"
+	    "%ssa% ret(Y) { aliased => [Y] }.\n"
+            "  Y = e:f(),\n",
 	    "  X0 = e:f(),\n",
 	    [io_lib:format("  X~p = {X~p,e:f()},~n", [X, X-1])
 	     || X<- lists:seq(1, N)],
-	    io_lib:format("  X~p.~n", [N])
+	    io_lib:format("  e:f(X~p),~n", [N]),
+            "  Y.\n"
 	   ],
     file:write_file("ss_depth_limit.erl", Data).
 -endif.
 
 f() ->
 %ssa% fail () when post_ssa_opt ->
-%ssa% ret(X) { unique => [X] }.
+%ssa% ret(Y) { aliased => [Y] }.
+  Y = e:f(),
   X0 = e:f(),
   X1 = {X0,e:f()},
   X2 = {X1,e:f()},
@@ -60,4 +63,5 @@ f() ->
   X29 = {X28,e:f()},
   X30 = {X29,e:f()},
   X31 = {X30,e:f()},
-  X31.
+  e:f(X31),
+  Y.

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_checks.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_checks.erl
@@ -56,7 +56,7 @@ r0([], Acc) ->
 -record(ds,{a}).
 
 make_ds(a) ->
-%ssa% (K) when post_ssa_opt ->
+%ssa% xfail (K) when post_ssa_opt ->
 %ssa% switch(K, Fail, [{a,IsA},{b,IsB}]),
 %ssa% label IsB,
 %ssa% ret({0,0}),
@@ -70,7 +70,7 @@ make_ds(b) ->
 
 %% Check that #ds{} is updated using update_record+inplace
 work_ds([X|Rest], {A,B,C=#ds{a=F}}) ->
-%ssa% (Ls, Acc) when post_ssa_opt ->
+%ssa% xfail (Ls, Acc) when post_ssa_opt ->
 %ssa% Size = bif:tuple_size(Acc),
 %ssa% switch(Size, Fail, [{2,_},{3,RecordLbl}]),
 %ssa% label RecordLbl,

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_checks.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/tuple_inplace_checks.erl
@@ -56,7 +56,7 @@ r0([], Acc) ->
 -record(ds,{a}).
 
 make_ds(a) ->
-%ssa% xfail (K) when post_ssa_opt ->
+%ssa% (K) when post_ssa_opt ->
 %ssa% switch(K, Fail, [{a,IsA},{b,IsB}]),
 %ssa% label IsB,
 %ssa% ret({0,0}),
@@ -70,7 +70,7 @@ make_ds(b) ->
 
 %% Check that #ds{} is updated using update_record+inplace
 work_ds([X|Rest], {A,B,C=#ds{a=F}}) ->
-%ssa% xfail (Ls, Acc) when post_ssa_opt ->
+%ssa% (Ls, Acc) when post_ssa_opt ->
 %ssa% Size = bif:tuple_size(Acc),
 %ssa% switch(Size, Fail, [{2,_},{3,RecordLbl}]),
 %ssa% label RecordLbl,


### PR DESCRIPTION
This series of patches improves the performance of the alias analysis pass to roughly halve the time required for the analysis when measured by `scripts/diffable`.

The improvement comes from a combination of an improved strategy for deciding on which functions requiring repeated analysis when alias information changes, changes to the aliasing state database to reduce its size but increase its expressiveness, and an adaptive strategy for pruning aliasing state database states.

Outside of the alias analysis pass this PR extends the beam_digraph module with new functions for use by the pass, otherwise its changes are limited to the `beam_ssa_alias` and `beam_ssa_ss` modules. Where, apart from the improvement in performance, it also improves the debuggability by dumping the internal structures in Graphviz-format when trace printouts are enabled.

~The commit f4803189ca7c08483829bd359b36fcafc9371ca6 is already under review in  in #8686 respectively, I will refresh this PR when it is merged.~ The prerequisites  are now merged.
