### PR TITLE
Refactor the code for bit syntax construction

### DIFF
--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -373,7 +373,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
     const BeamInstr* p;
     Uint alloc = $Alloc;
     Eterm new_binary;
-    ERL_BITS_DECLARE_STATEP; /* Has to be last declaration */
+    ErlBitsState* EBS = ERL_BITS_EBS_FROM_REG(reg);
 
     /* We count the total number of bits in an unsigned integer. To avoid
      * having to check for overflow when adding to `num_bits`, we ensure that
@@ -546,7 +546,6 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
     }
 
     /* Allocate binary. */
-    ERL_BITS_RELOAD_STATEP(c_p);
     p = p_start;
     if (p[0] == BSC_APPEND) {
         Uint live = $Live;
@@ -565,15 +564,13 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         }
         p_start += BSC_NUM_ARGS;
     } else if (p[0] == BSC_PRIVATE_APPEND) {
-        Uint unit;
         Eterm Src;
 
         $test_heap(alloc, $Live);
 
-        $BS_LOAD_UNIT(p, unit);
         $BS_LOAD_SRC(p, Src);
 
-        new_binary = erts_bs_private_append_checked(c_p, Src, num_bits, unit);
+        new_binary = erts_bs_private_append_checked(EBS, c_p, Src, num_bits);
 
         if (is_non_value(new_binary)) {
             $BS_FAIL_INFO($Fail, c_p->freason, c_p->fvalue, Src);
@@ -589,7 +586,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         /* num_bits = Number of bits to build
          * alloc = Total number of words to allocate on heap
          */
-        erts_bin_offset = 0;
+        EBS->erts_bin_offset = 0;
         if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
             ErlHeapBits *hb;
 
@@ -598,7 +595,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             HTOP += heap_bits_size(num_bits);
             hb->thing_word = header_heap_bits(num_bits);
             hb->size = num_bits;
-            erts_current_bin = (byte *) hb->data;
+            EBS->erts_current_bin = (byte *) hb->data;
             new_binary = make_bitstring(hb);
         } else {
             Binary* bptr;
@@ -608,7 +605,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
                             $Live);
 
             bptr = erts_bin_nrml_alloc(NBYTES(num_bits));
-            erts_current_bin = (byte *)bptr->orig_bytes;
+            EBS->erts_current_bin = (byte *)bptr->orig_bytes;
 
             LIGHT_SWAPOUT;
 
@@ -616,7 +613,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
                                                   &MSO(c_p).overhead,
                                                   &HEAP_TOP(c_p),
                                                   bptr,
-                                                  erts_current_bin,
+                                                  EBS->erts_current_bin,
                                                   0,
                                                   num_bits);
 
@@ -640,7 +637,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             byte* string;
             $BS_LOAD_STRING_SRC(p, string);
             $BS_LOAD_FIXED_SIZE(p, Size);
-            erts_new_bs_put_string(ERL_BITS_ARGS_2(string, Size));
+            erts_bs_put_string(EBS, string, Size);
             continue;
         }
 
@@ -649,7 +646,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         switch (p[0]) {
         case BSC_BINARY_ALL:
             $BS_LOAD_UNIT(p, unit);
-            if (!erts_new_bs_put_binary_all(c_p, Src, unit)) {
+            if (!erts_bs_put_binary_all(EBS, c_p, Src, unit)) {
                 $BS_FAIL_INFO($Fail, BADARG, am_unit, Src);
             }
             break;
@@ -658,14 +655,14 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             $BS_LOAD_FLAGS(p, flags);
             $BS_LOAD_SIZE(p, Size);
             $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
-            if (!erts_new_bs_put_binary(c_p, Src, _size)) {
+            if (!erts_bs_put_binary(EBS, c_p, Src, _size)) {
                 Eterm reason = is_bitstring(Src) ? am_short : am_type;
                 $BS_FAIL_INFO($Fail, BADARG, reason, Src);
             }
             break;
         case BSC_BINARY_FIXED_SIZE:
             $BS_LOAD_FIXED_SIZE(p, Size);
-            if (!erts_new_bs_put_binary(c_p, Src, Size)) {
+            if (!erts_bs_put_binary(EBS, c_p, Src, Size)) {
                 Eterm reason = is_bitstring(Src) ? am_short : am_type;
                 $BS_FAIL_INFO($Fail, BADARG, reason, Src);
             }
@@ -675,7 +672,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
             $BS_LOAD_FLAGS(p, flags);
             $BS_LOAD_SIZE(p, Size);
             $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
-            Src = erts_new_bs_put_float(c_p, Src, _size, flags);
+            Src = erts_bs_put_float(EBS, c_p, Src, _size, flags);
             if (is_value(Src)) {
                 $BS_FAIL_INFO($Fail, BADARG, c_p->fvalue, Src);
             }
@@ -683,7 +680,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         case BSC_FLOAT_FIXED_SIZE:
             $BS_LOAD_FLAGS(p, flags);
             $BS_LOAD_FIXED_SIZE(p, Size);
-            Src = erts_new_bs_put_float(c_p, Src, Size, flags);
+            Src = erts_bs_put_float(EBS, c_p, Src, Size, flags);
             if (is_value(Src)) {
                 $BS_FAIL_INFO($Fail, BADARG, c_p->fvalue, Src);
             }
@@ -696,7 +693,7 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
                 $BS_LOAD_FLAGS(p, flags);
                 $BS_LOAD_SIZE(p, Size);
                 $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
-                if (!erts_new_bs_put_integer(ERL_BITS_ARGS_3(Src, _size, flags))) {
+                if (!erts_bs_put_integer(EBS, Src, _size, flags)) {
                     $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
                 }
             }
@@ -705,19 +702,19 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         case BSC_UTF32:
             $BS_LOAD_FLAGS(p, flags);
             $BS_LOAD_FIXED_SIZE(p, Size);
-            if (!erts_new_bs_put_integer(ERL_BITS_ARGS_3(Src, Size, flags))) {
+            if (!erts_bs_put_integer(EBS, Src, Size, flags)) {
                 $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
             }
             break;
         case BSC_UTF8:
-            if (!erts_bs_put_utf8(ERL_BITS_ARGS_1(Src))) {
+            if (!erts_bs_put_utf8(EBS, Src)) {
                 $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
             }
             break;
         case BSC_UTF16:
             $BS_LOAD_FLAGS(p, flags);
             $BS_LOAD_SRC(p, Src);
-            if (!erts_bs_put_utf16(ERL_BITS_ARGS_2(Src, flags))) {
+            if (!erts_bs_put_utf16(EBS, Src, flags)) {
                 $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
             }
             break;

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -688,22 +688,37 @@ i_bs_create_bin(Fail, Alloc, Live, Dst, N) {
         case BSC_INTEGER:
             {
                 Sint _size;
+                int result;
 
                 $BS_LOAD_UNIT(p, unit);
                 $BS_LOAD_FLAGS(p, flags);
                 $BS_LOAD_SIZE(p, Size);
                 $BS_GET_UNCHECKED_FIELD_SIZE(Size, unit, $BADARG($Fail), _size);
-                if (!erts_bs_put_integer(EBS, Src, _size, flags)) {
+                if (flags & BSF_LITTLE) {
+                    result = erts_bs_put_integer_le(EBS, Src, _size);
+                } else {
+                    result = erts_bs_put_integer_be(EBS, Src, _size);
+                }
+                if (!result) {
                     $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
                 }
             }
             break;
         case BSC_INTEGER_FIXED_SIZE:
         case BSC_UTF32:
-            $BS_LOAD_FLAGS(p, flags);
-            $BS_LOAD_FIXED_SIZE(p, Size);
-            if (!erts_bs_put_integer(EBS, Src, Size, flags)) {
-                $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+            {
+                int result;
+
+                $BS_LOAD_FLAGS(p, flags);
+                $BS_LOAD_FIXED_SIZE(p, Size);
+                if (flags & BSF_LITTLE) {
+                    result = erts_bs_put_integer_le(EBS, Src, Size);
+                } else {
+                    result = erts_bs_put_integer_be(EBS, Src, Size);
+                }
+                if (!result) {
+                    $BS_FAIL_INFO($Fail, BADARG, am_type, Src);
+                }
             }
             break;
         case BSC_UTF8:

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -216,8 +216,8 @@ Eterm erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlSubBits
 Eterm erts_bs_get_binary_all_2(Process *p, ErlSubBits* sb);
 
 /* Binary construction, new instruction set. */
-int erts_bs_put_integer(ErlBitsState *EBS, Eterm Integer, Uint num_bits,
-                        unsigned flags);
+int erts_bs_put_integer_be(ErlBitsState *EBS, Eterm Integer, Uint num_bits);
+int erts_bs_put_integer_le(ErlBitsState *EBS, Eterm Integer, Uint num_bits);
 #if !defined(BEAMASM)
 int erts_bs_put_utf8(ErlBitsState *EBS, Eterm Integer);
 #endif

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -245,8 +245,10 @@ copy_binary_to_buffer(byte *dst_base, Uint dst_offset,
                       const byte *src_base, Uint src_offset,
                       Uint size);
 
-void erts_copy_bits(const byte* src, size_t soffs, int sdir,
-                    byte* dst, size_t doffs, int ddir, size_t n);
+void erts_copy_bits_fwd(const byte* src, size_t soffs,
+                        byte* dst, size_t doffs, size_t n);
+void erts_copy_bits_rev(const byte* src, size_t soffs,
+                        byte* dst, size_t doffs, size_t n);
 
 ERTS_GLB_INLINE int erts_cmp_bits(const byte* a_ptr,
                                   Uint a_offs,
@@ -532,9 +534,9 @@ copy_binary_to_buffer(byte *dst_base, Uint dst_offset,
         if (((dst_offset | src_offset | size) & 7) == 0) {
             sys_memcpy(dst_base, src_base, BYTE_SIZE(size));
         } else {
-            erts_copy_bits(src_base, BIT_OFFSET(src_offset), 1,
-                           dst_base, BIT_OFFSET(dst_offset), 1,
-                           size);
+            erts_copy_bits_fwd(src_base, BIT_OFFSET(src_offset),
+                               dst_base, BIT_OFFSET(dst_offset),
+                               size);
         }
     }
 }
@@ -606,7 +608,7 @@ erts_get_aligned_binary_bytes_extra(Eterm bin,
                                                 NBYTES(size) + extra);
                 *base_ptr = bytes;
 
-                erts_copy_bits(base, offset, 1, &bytes[extra], 0, 1, size);
+                erts_copy_bits_fwd(base, offset, &bytes[extra], 0, size);
                 return &bytes[extra];
             }
 

--- a/erts/emulator/beam/erl_bits.h
+++ b/erts/emulator/beam/erl_bits.h
@@ -168,43 +168,28 @@ struct erl_bits_state {
     /*
      * Pointer to the beginning of the current binary.
      */
-    byte* erts_current_bin_;
+    byte* erts_current_bin;
 
     /*
      * Offset in bits into the current binary.
      */
-    Uint erts_bin_offset_;
+    Uint erts_bin_offset;
 };
 
+typedef struct erl_bits_state ErlBitsState;
+
 /*
- * Reentrant API with the state passed as a parameter.
- * (Except when the current Process* already is a parameter.)
+ * The bit syntax construction state resides in the current process's
+ * schduler data. The following macro retrieves the pointer to that
+ * state given a pointer to the X register array.
  */
-/* the state resides in the current process' scheduler data */
-#define ERL_BITS_DECLARE_STATEP struct erl_bits_state *EBS
 
-#define ERL_BITS_RELOAD_STATEP(P)                                              \
-    do {                                                                       \
-        EBS = &erts_proc_sched_data((P))->registers->aux_regs.d.erl_bits_state;  \
-    } while(0)
-
-#define ERL_BITS_DEFINE_STATEP(P) \
-    struct erl_bits_state *EBS = \
-        &erts_proc_sched_data((P))->registers->aux_regs.d.erl_bits_state
-
-#define ErlBitsState				(*EBS)
-
-#define ERL_BITS_PROTO_0			struct erl_bits_state *EBS
-#define ERL_BITS_PROTO_1(PARM1)			struct erl_bits_state *EBS, PARM1
-#define ERL_BITS_PROTO_2(PARM1,PARM2)		struct erl_bits_state *EBS, PARM1, PARM2
-#define ERL_BITS_PROTO_3(PARM1,PARM2,PARM3)	struct erl_bits_state *EBS, PARM1, PARM2, PARM3
-#define ERL_BITS_ARGS_0				EBS
-#define ERL_BITS_ARGS_1(ARG1)			EBS, ARG1
-#define ERL_BITS_ARGS_2(ARG1,ARG2)		EBS, ARG1, ARG2
-#define ERL_BITS_ARGS_3(ARG1,ARG2,ARG3)		EBS, ARG1, ARG2, ARG3
-
-#define erts_bin_offset		(ErlBitsState.erts_bin_offset_)
-#define erts_current_bin	(ErlBitsState.erts_current_bin_)
+#define ERL_BITS_EBS_FROM_REG(Reg)                              \
+    ((ErlBitsState *) ((char *)(Reg) +                          \
+                       (offsetof(ErtsSchedulerRegisters,        \
+                                 aux_regs.d.erl_bits_state) -   \
+                        offsetof(ErtsSchedulerRegisters,        \
+                                 x_reg_array.d))))
 
 /*
  * Return number of Eterm words needed for allocation with HAlloc(),
@@ -231,22 +216,25 @@ Eterm erts_bs_get_binary_2(Process *p, Uint num_bits, unsigned flags, ErlSubBits
 Eterm erts_bs_get_binary_all_2(Process *p, ErlSubBits* sb);
 
 /* Binary construction, new instruction set. */
-int erts_new_bs_put_integer(ERL_BITS_PROTO_3(Eterm Integer, Uint num_bits, unsigned flags));
+int erts_bs_put_integer(ErlBitsState *EBS, Eterm Integer, Uint num_bits,
+                        unsigned flags);
 #if !defined(BEAMASM)
-int erts_bs_put_utf8(ERL_BITS_PROTO_1(Eterm Integer));
+int erts_bs_put_utf8(ErlBitsState *EBS, Eterm Integer);
 #endif
-int erts_bs_put_utf16(ERL_BITS_PROTO_2(Eterm Integer, Uint flags));
-int erts_new_bs_put_binary(Process *c_p, Eterm Bin, Uint num_bits);
-int erts_new_bs_put_binary_all(Process *c_p, Eterm Bin, Uint unit);
-Eterm erts_new_bs_put_float(Process *c_p, Eterm Float, Uint num_bits, int flags);
-void erts_new_bs_put_string(ERL_BITS_PROTO_2(byte* iptr, Uint num_bytes));
+int erts_bs_put_utf16(ErlBitsState *EBS, Eterm Integer, Uint flags);
+int erts_bs_put_binary(ErlBitsState *EBS, Process *c_p, Eterm Bin, Uint num_bits);
+int erts_bs_put_binary_all(ErlBitsState* EBS, Process *c_p, Eterm Bin, Uint unit);
+Eterm erts_bs_put_float(ErlBitsState *EBS, Process *c_p, Eterm Float,
+                        Uint num_bits, int flags);
+void erts_bs_put_string(ErlBitsState *EBS, byte* iptr, Uint num_bytes);
 
 Uint32 erts_bs_get_unaligned_uint32(ErlSubBits* sb);
 Eterm erts_bs_get_utf8(ErlSubBits* sb);
 Eterm erts_bs_get_utf16(ErlSubBits* sb, Uint flags);
 Eterm erts_bs_append_checked(Process* p, Eterm* reg, Uint live, Uint size,
                              Uint extra_words, Uint unit);
-Eterm erts_bs_private_append_checked(Process* p, Eterm bin, Uint size, Uint unit);
+Eterm erts_bs_private_append_checked(ErlBitsState* EBS, Process* p,
+                                     Eterm bin, Uint size);
 Eterm erts_bs_init_writable(Process* p, Eterm sz);
 
 /* ************************************************************************* */

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1352,7 +1352,7 @@ int enif_inspect_binary(ErlNifEnv* env, Eterm bin_term, ErlNifBinary* bin)
                 env->tmp_obj_list = tmp_obj;
 
                 bin->data = (byte*)&tmp_obj[1];
-                erts_copy_bits(base, offset, 1, bin->data, 0, 1, size);
+                erts_copy_bits_fwd(base, offset, bin->data, 0, size);
             } else {
                 bin->data = &base[BYTE_OFFSET(offset)];
             }

--- a/erts/emulator/beam/erl_term_hashing.c
+++ b/erts/emulator/beam/erl_term_hashing.c
@@ -1276,8 +1276,8 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
                     byte *buf = erts_alloc(ERTS_ALC_T_TMP, nr_of_bytes);
                     Uint nr_of_bits_to_copy = ctx.sz*BYTE_BITS+ctx.bitsize;
                     if (can_trap) iterations_until_trap -= iters_for_bin;
-                    erts_copy_bits(ctx.bptr,
-                                   ctx.bitoffs, 1, buf, 0, 1, nr_of_bits_to_copy);
+                    erts_copy_bits_fwd(ctx.bptr, ctx.bitoffs,
+                                       buf, 0, nr_of_bits_to_copy);
                     hash = block_hash(buf, ctx.sz, con);
                     if (ctx.bitsize > 0) {
                         UINT32_HASH_2(ctx.bitsize,
@@ -1312,9 +1312,9 @@ make_hash2_helper(Eterm term_param, const int can_trap, Eterm* state_mref_write_
                         Uint nr_of_bits_to_copy =
                             MIN(nr_of_bits_left, BINARY_BUF_SIZE_BITS);
                         ctx.done = nr_of_bits_left == nr_of_bits_to_copy;
-                        erts_copy_bits(ctx.bptr + ctx.no_bytes_processed,
-                                       ctx.bitoffs, 1, ctx.buf, 0, 1,
-                                       nr_of_bits_to_copy);
+                        erts_copy_bits_fwd(ctx.bptr + ctx.no_bytes_processed,
+                                           ctx.bitoffs, ctx.buf, 0,
+                                           nr_of_bits_to_copy);
                         block_hash_buffer(ctx.buf,
                                           bytes_to_process,
                                           block_hash_ctx);
@@ -1948,7 +1948,7 @@ make_internal_hash(Eterm term, erts_ihash_t salt)
                     if (BIT_OFFSET(offset) != 0) {
                         byte *tmp = (byte*)erts_alloc(ERTS_ALC_T_TMP,
                                                       NBYTES(size));
-                        erts_copy_bits(data, offset, 1, tmp, 0, 1, size);
+                        erts_copy_bits_fwd(data, offset, tmp, 0, size);
                         bytes = tmp;
                     } else {
                         bytes = &data[BYTE_OFFSET(offset)];

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -1199,7 +1199,7 @@ void BeamModuleAssembler::update_bin_state(a64::Gp bin_offset,
                                            Sint size,
                                            a64::Gp size_reg) {
     int cur_bin_offset = offsetof(ErtsSchedulerRegisters,
-                                  aux_regs.d.erl_bits_state.erts_current_bin_);
+                                  aux_regs.d.erl_bits_state.erts_current_bin);
     arm::Mem mem_bin_base = arm::Mem(scheduler_registers, cur_bin_offset);
     arm::Mem mem_bin_offset =
             arm::Mem(scheduler_registers, cur_bin_offset + sizeof(Eterm));
@@ -1207,8 +1207,8 @@ void BeamModuleAssembler::update_bin_state(a64::Gp bin_offset,
     if (bit_offset % 8 != 0) {
         /* The bit offset is unknown or not byte-aligned. */
         ERTS_CT_ASSERT_FIELD_PAIR(struct erl_bits_state,
-                                  erts_current_bin_,
-                                  erts_bin_offset_);
+                                  erts_current_bin,
+                                  erts_bin_offset);
         a.ldp(TMP2, bin_offset, mem_bin_base);
 
         if (size_reg.isValid()) {
@@ -2021,14 +2021,14 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         BscSegment seg = segments[0];
         comment("private append to binary");
         ASSERT(Alloc.get() == 0);
-        mov_arg(ARG2, seg.src);
+        load_erl_bits_state(ARG1);
+        a.mov(ARG2, c_p);
+        mov_arg(ARG3, seg.src);
         if (sizeReg.isValid()) {
-            a.mov(ARG3, sizeReg);
+            a.mov(ARG4, sizeReg);
         } else {
-            mov_imm(ARG3, num_bits);
+            mov_imm(ARG4, num_bits);
         }
-        a.mov(ARG4, seg.unit);
-        a.mov(ARG1, c_p);
         emit_enter_runtime(Live.get());
         runtime_call<4>(erts_bs_private_append_checked);
         emit_leave_runtime(Live.get());
@@ -2036,7 +2036,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
     } else if (estimated_num_bits <= ERL_ONHEAP_BITS_LIMIT) {
         static constexpr auto cur_bin_offset =
                 offsetof(ErtsSchedulerRegisters, aux_regs.d.erl_bits_state) +
-                offsetof(struct erl_bits_state, erts_current_bin_);
+                offsetof(struct erl_bits_state, erts_current_bin);
         Uint need;
 
         arm::Mem mem_bin_base = arm::Mem(scheduler_registers, cur_bin_offset);
@@ -2104,8 +2104,8 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
 
             /* Initialize the erl_bin_state struct. */
             ERTS_CT_ASSERT_FIELD_PAIR(struct erl_bits_state,
-                                      erts_current_bin_,
-                                      erts_bin_offset_);
+                                      erts_current_bin,
+                                      erts_bin_offset);
             a.stp(HTOP, ZERO, mem_bin_base);
 
             /* Update HTOP. */
@@ -2158,11 +2158,12 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             comment("construct a binary segment");
             if (seg.effectiveSize >= 0) {
                 /* The segment has a literal size. */
-                mov_imm(ARG3, seg.effectiveSize);
-                mov_arg(ARG2, seg.src);
-                a.mov(ARG1, c_p);
+                load_erl_bits_state(ARG1);
+                a.mov(ARG2, c_p);
+                mov_arg(ARG3, seg.src);
+                mov_imm(ARG4, seg.effectiveSize);
                 emit_enter_runtime<Update::eReductions>(Live.get());
-                runtime_call<3>(erts_new_bs_put_binary);
+                runtime_call<4>(erts_bs_put_binary);
                 emit_leave_runtime<Update::eReductions>(Live.get());
                 error_info = beam_jit_update_bsc_reason_info(seg.error_info,
                                                              BSC_REASON_BADARG,
@@ -2172,12 +2173,13 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                        seg.size.as<ArgAtom>().get() == am_all) {
                 /* Include the entire binary/bitstring in the
                  * resulting binary. */
-                a.mov(ARG3, seg.unit);
-                mov_arg(ARG2, seg.src);
-                a.mov(ARG1, c_p);
+                load_erl_bits_state(ARG1);
+                a.mov(ARG2, c_p);
+                mov_arg(ARG3, seg.src);
+                mov_imm(ARG4, seg.unit);
 
                 emit_enter_runtime<Update::eReductions>(Live.get());
-                runtime_call<3>(erts_new_bs_put_binary_all);
+                runtime_call<4>(erts_bs_put_binary_all);
                 emit_leave_runtime<Update::eReductions>(Live.get());
 
                 error_info = beam_jit_update_bsc_reason_info(seg.error_info,
@@ -2195,17 +2197,18 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                  * the value is a non-negative small in the
                  * appropriate range. Multiply the size with the
                  * unit. */
-                auto r = load_source(seg.size, ARG3);
-                a.asr(ARG3, r.reg, imm(_TAG_IMMED1_SIZE));
+                auto r = load_source(seg.size, ARG4);
+                a.asr(ARG4, r.reg, imm(_TAG_IMMED1_SIZE));
                 if (seg.unit != 1) {
                     mov_imm(TMP1, seg.unit);
-                    a.mul(ARG3, ARG3, TMP1);
+                    a.mul(ARG4, ARG4, TMP1);
                 }
-                mov_arg(ARG2, seg.src);
-                a.mov(ARG1, c_p);
+                load_erl_bits_state(ARG1);
+                a.mov(ARG2, c_p);
+                mov_arg(ARG3, seg.src);
 
                 emit_enter_runtime<Update::eReductions>(Live.get());
-                runtime_call<3>(erts_new_bs_put_binary);
+                runtime_call<4>(erts_bs_put_binary);
                 emit_leave_runtime<Update::eReductions>(Live.get());
 
                 error_info = beam_jit_update_bsc_reason_info(seg.error_info,
@@ -2225,21 +2228,22 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         case am_float:
             comment("construct float segment");
             if (seg.effectiveSize >= 0) {
-                mov_imm(ARG3, seg.effectiveSize);
+                mov_imm(ARG4, seg.effectiveSize);
             } else {
-                auto r = load_source(seg.size, ARG3);
-                a.asr(ARG3, r.reg, imm(_TAG_IMMED1_SIZE));
+                auto r = load_source(seg.size, ARG4);
+                a.asr(ARG4, r.reg, imm(_TAG_IMMED1_SIZE));
                 if (seg.unit != 1) {
                     mov_imm(TMP1, seg.unit);
-                    a.mul(ARG3, ARG3, TMP1);
+                    a.mul(ARG4, ARG4, TMP1);
                 }
             }
-            mov_arg(ARG2, seg.src);
-            mov_imm(ARG4, seg.flags);
-            a.mov(ARG1, c_p);
+            load_erl_bits_state(ARG1);
+            a.mov(ARG2, c_p);
+            mov_arg(ARG3, seg.src);
+            mov_imm(ARG5, seg.flags);
 
             emit_enter_runtime(Live.get());
-            runtime_call<4>(erts_new_bs_put_float);
+            runtime_call<5>(erts_bs_put_float);
             emit_leave_runtime(Live.get());
 
             if (Fail.get() == 0) {
@@ -2490,12 +2494,12 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                 } else {
                     /* Call the helper function to fetch and store the
                      * integer into the binary. */
+                    load_erl_bits_state(ARG1);
                     mov_arg(ARG2, seg.src);
                     mov_imm(ARG4, seg.flags);
-                    load_erl_bits_state(ARG1);
 
                     emit_enter_runtime(Live.get());
-                    runtime_call<4>(erts_new_bs_put_integer);
+                    runtime_call<4>(erts_bs_put_integer);
                     emit_leave_runtime(Live.get());
 
                     if (exact_type<BeamTypeId::Integer>(seg.src)) {
@@ -2522,12 +2526,12 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
 
             comment("insert string");
             ASSERT(seg.effectiveSize >= 0);
-            mov_imm(ARG3, seg.effectiveSize / 8);
-            mov_arg(ARG2, string_ptr);
             load_erl_bits_state(ARG1);
+            mov_arg(ARG2, string_ptr);
+            mov_imm(ARG3, seg.effectiveSize / 8);
 
             emit_enter_runtime(Live.get());
-            runtime_call<3>(erts_new_bs_put_string);
+            runtime_call<3>(erts_bs_put_string);
             emit_leave_runtime(Live.get());
             break;
         }
@@ -2556,13 +2560,13 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             a.cbz(ARG1, resolve_label(error, disp1MB));
             break;
         case am_utf32:
+            load_erl_bits_state(ARG1);
             mov_arg(ARG2, seg.src);
             mov_imm(ARG3, 4 * 8);
             a.mov(ARG4, seg.flags);
-            load_erl_bits_state(ARG1);
 
             emit_enter_runtime(Live.get());
-            runtime_call<4>(erts_new_bs_put_integer);
+            runtime_call<4>(erts_bs_put_integer);
             emit_leave_runtime(Live.get());
 
             if (Fail.get() == 0) {

--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -2496,10 +2496,13 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                      * integer into the binary. */
                     load_erl_bits_state(ARG1);
                     mov_arg(ARG2, seg.src);
-                    mov_imm(ARG4, seg.flags);
 
                     emit_enter_runtime(Live.get());
-                    runtime_call<4>(erts_bs_put_integer);
+                    if (seg.flags & BSF_LITTLE) {
+                        runtime_call<3>(erts_bs_put_integer_le);
+                    } else {
+                        runtime_call<3>(erts_bs_put_integer_be);
+                    }
                     emit_leave_runtime(Live.get());
 
                     if (exact_type<BeamTypeId::Integer>(seg.src)) {
@@ -2563,10 +2566,13 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             load_erl_bits_state(ARG1);
             mov_arg(ARG2, seg.src);
             mov_imm(ARG3, 4 * 8);
-            a.mov(ARG4, seg.flags);
 
             emit_enter_runtime(Live.get());
-            runtime_call<4>(erts_bs_put_integer);
+            if (seg.flags & BSF_LITTLE) {
+                runtime_call<3>(erts_bs_put_integer_le);
+            } else {
+                runtime_call<3>(erts_bs_put_integer_be);
+            }
             emit_leave_runtime(Live.get());
 
             if (Fail.get() == 0) {

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -808,7 +808,7 @@ void beam_jit_bs_add_argument_error(Process *c_p, Eterm A, Eterm B) {
 
 Eterm beam_jit_bs_init_bits(Process *c_p,
                             Eterm *reg,
-                            ERL_BITS_DECLARE_STATEP,
+                            ErlBitsState *EBS,
                             Uint num_bits,
                             Uint alloc,
                             unsigned Live) {
@@ -818,7 +818,7 @@ Eterm beam_jit_bs_init_bits(Process *c_p,
         alloc += ERL_REFC_BITS_SIZE;
     }
 
-    erts_bin_offset = 0;
+    EBS->erts_bin_offset = 0;
 
     if (num_bits <= ERL_ONHEAP_BITS_LIMIT) {
         ErlHeapBits *hb;
@@ -830,7 +830,7 @@ Eterm beam_jit_bs_init_bits(Process *c_p,
         hb->thing_word = header_heap_bits(num_bits);
         hb->size = num_bits;
 
-        erts_current_bin = (byte *)hb->data;
+        EBS->erts_current_bin = (byte *)hb->data;
         return make_bitstring(hb);
     } else {
         const Uint num_bytes = NBYTES(num_bits);
@@ -839,13 +839,13 @@ Eterm beam_jit_bs_init_bits(Process *c_p,
         test_bin_vheap(c_p, reg, num_bytes / sizeof(Eterm), alloc, Live);
 
         new_binary = erts_bin_nrml_alloc(num_bytes);
-        erts_current_bin = (byte *)new_binary->orig_bytes;
+        EBS->erts_current_bin = (byte *)new_binary->orig_bytes;
 
         return erts_wrap_refc_bitstring(&MSO(c_p).first,
                                         &MSO(c_p).overhead,
                                         &HEAP_TOP(c_p),
                                         new_binary,
-                                        erts_current_bin,
+                                        EBS->erts_current_bin,
                                         0,
                                         num_bits);
     }

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -600,7 +600,7 @@ void beam_jit_bs_field_size_argument_error(Process *c_p, Eterm size);
 void beam_jit_bs_add_argument_error(Process *c_p, Eterm A, Eterm B);
 Eterm beam_jit_bs_init_bits(Process *c_p,
                             Eterm *reg,
-                            ERL_BITS_DECLARE_STATEP,
+                            ErlBitsState *EBS,
                             Uint num_bits,
                             Uint alloc,
                             unsigned Live);

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -2599,9 +2599,12 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                      * integer into the binary. */
                     runtime_entered = bs_maybe_enter_runtime(runtime_entered);
                     mov_arg(ARG2, seg.src);
-                    mov_imm(ARG4, seg.flags);
                     load_erl_bits_state(ARG1);
-                    runtime_call<4>(erts_bs_put_integer);
+                    if (seg.flags & BSF_LITTLE) {
+                        runtime_call<3>(erts_bs_put_integer_le);
+                    } else {
+                        runtime_call<3>(erts_bs_put_integer_be);
+                    }
                     if (exact_type<BeamTypeId::Integer>(seg.src)) {
                         comment("skipped test for success because construction "
                                 "can't fail");
@@ -2660,9 +2663,12 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             runtime_entered = bs_maybe_enter_runtime(runtime_entered);
             mov_arg(ARG2, seg.src);
             mov_imm(ARG3, 4 * 8);
-            a.mov(ARG4, seg.flags);
             load_erl_bits_state(ARG1);
-            runtime_call<4>(erts_bs_put_integer);
+            if (seg.flags & BSF_LITTLE) {
+                runtime_call<3>(erts_bs_put_integer_le);
+            } else {
+                runtime_call<3>(erts_bs_put_integer_be);
+            }
             if (Fail.get() == 0) {
                 mov_arg(ARG1, seg.src);
                 mov_imm(ARG4,

--- a/erts/emulator/beam/jit/x86/instr_bs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bs.cpp
@@ -1262,10 +1262,10 @@ void BeamModuleAssembler::update_bin_state(x86::Gp bin_offset,
     const int x_reg_offset = offsetof(ErtsSchedulerRegisters, x_reg_array.d);
     const int cur_bin_base =
             offsetof(ErtsSchedulerRegisters, aux_regs.d.erl_bits_state) +
-            offsetof(struct erl_bits_state, erts_current_bin_);
+            offsetof(struct erl_bits_state, erts_current_bin);
     const int cur_bin_offset =
             offsetof(ErtsSchedulerRegisters, aux_regs.d.erl_bits_state) +
-            offsetof(struct erl_bits_state, erts_bin_offset_);
+            offsetof(struct erl_bits_state, erts_bin_offset);
 
     x86::Mem mem_bin_base =
             x86::Mem(registers, cur_bin_base - x_reg_offset, sizeof(UWord));
@@ -1822,10 +1822,10 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                 offsetof(ErtsSchedulerRegisters, x_reg_array.d);
         const int cur_bin_base =
                 offsetof(ErtsSchedulerRegisters, aux_regs.d.erl_bits_state) +
-                offsetof(struct erl_bits_state, erts_current_bin_);
+                offsetof(struct erl_bits_state, erts_current_bin);
         const int cur_bin_offset =
                 offsetof(ErtsSchedulerRegisters, aux_regs.d.erl_bits_state) +
-                offsetof(struct erl_bits_state, erts_bin_offset_);
+                offsetof(struct erl_bits_state, erts_bin_offset);
         x86::Mem mem_bin_base =
                 x86::qword_ptr(registers, cur_bin_base - x_reg_offset);
         x86::Mem mem_bin_offset =
@@ -2195,14 +2195,14 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
         runtime_entered = bs_maybe_enter_runtime(runtime_entered);
         comment("private append to binary");
         ASSERT(Alloc.get() == 0);
-        mov_arg(ARG2, seg.src);
+        mov_arg(ARG3, seg.src);
         if (sizeReg.isValid()) {
-            a.mov(ARG3, sizeReg);
+            a.mov(ARG4, sizeReg);
         } else {
-            mov_imm(ARG3, num_bits);
+            mov_imm(ARG4, num_bits);
         }
-        a.mov(ARG4, seg.unit);
-        a.mov(ARG1, c_p);
+        a.mov(ARG2, c_p);
+        load_erl_bits_state(ARG1);
         runtime_call<4>(erts_bs_private_append_checked);
         /* There is no way the call can fail on a 64-bit architecture. */
         a.mov(TMP_MEM1q, RET);
@@ -2251,10 +2251,11 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             comment("construct a binary segment");
             if (seg.effectiveSize >= 0) {
                 /* The segment has a literal size. */
-                mov_imm(ARG3, seg.effectiveSize);
-                mov_arg(ARG2, seg.src);
-                a.mov(ARG1, c_p);
-                runtime_call<3>(erts_new_bs_put_binary);
+                mov_imm(ARG4, seg.effectiveSize);
+                mov_arg(ARG3, seg.src);
+                a.mov(ARG2, c_p);
+                load_erl_bits_state(ARG1);
+                runtime_call<4>(erts_bs_put_binary);
                 error_info = beam_jit_update_bsc_reason_info(seg.error_info,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_DEPENDS,
@@ -2263,10 +2264,11 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                        seg.size.as<ArgAtom>().get() == am_all) {
                 /* Include the entire binary/bitstring in the
                  * resulting binary. */
-                a.mov(ARG3, seg.unit);
-                mov_arg(ARG2, seg.src);
-                a.mov(ARG1, c_p);
-                runtime_call<3>(erts_new_bs_put_binary_all);
+                mov_imm(ARG4, seg.unit);
+                mov_arg(ARG3, seg.src);
+                a.mov(ARG2, c_p);
+                load_erl_bits_state(ARG1);
+                runtime_call<4>(erts_bs_put_binary_all);
                 error_info = beam_jit_update_bsc_reason_info(seg.error_info,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_UNIT,
@@ -2282,16 +2284,17 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                  * the value is a non-negative small in the
                  * appropriate range. Multiply the size with the
                  * unit. */
-                mov_arg(ARG3, seg.size);
-                a.sar(ARG3, imm(_TAG_IMMED1_SIZE));
+                mov_arg(ARG4, seg.size);
+                a.sar(ARG4, imm(_TAG_IMMED1_SIZE));
                 if (seg.unit != 1) {
                     mov_imm(RET, seg.unit);
-                    a.mul(ARG3); /* CLOBBERS RDX = ARG3! */
-                    a.mov(ARG3, RET);
+                    a.mul(ARG4); /* CLOBBERS RDX = ARG3! */
+                    a.mov(ARG4, RET);
                 }
-                mov_arg(ARG2, seg.src);
-                a.mov(ARG1, c_p);
-                runtime_call<3>(erts_new_bs_put_binary);
+                mov_arg(ARG3, seg.src);
+                a.mov(ARG2, c_p);
+                load_erl_bits_state(ARG1);
+                runtime_call<4>(erts_bs_put_binary);
                 error_info = beam_jit_update_bsc_reason_info(seg.error_info,
                                                              BSC_REASON_BADARG,
                                                              BSC_INFO_DEPENDS,
@@ -2311,20 +2314,21 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             runtime_entered = bs_maybe_enter_runtime(runtime_entered);
             comment("construct float segment");
             if (seg.effectiveSize >= 0) {
-                mov_imm(ARG3, seg.effectiveSize);
+                mov_imm(ARG4, seg.effectiveSize);
             } else {
-                mov_arg(ARG3, seg.size);
-                a.sar(ARG3, imm(_TAG_IMMED1_SIZE));
+                mov_arg(ARG4, seg.size);
+                a.sar(ARG4, imm(_TAG_IMMED1_SIZE));
                 if (seg.unit != 1) {
                     mov_imm(RET, seg.unit);
-                    a.mul(ARG3); /* CLOBBERS RDX = ARG3! */
-                    a.mov(ARG3, RET);
+                    a.mul(ARG4); /* CLOBBERS RDX = ARG3! */
+                    a.mov(ARG4, RET);
                 }
             }
-            mov_arg(ARG2, seg.src);
-            mov_imm(ARG4, seg.flags);
-            a.mov(ARG1, c_p);
-            runtime_call<4>(erts_new_bs_put_float);
+            mov_arg(ARG3, seg.src);
+            mov_imm(ARG5, seg.flags);
+            a.mov(ARG2, c_p);
+            load_erl_bits_state(ARG1);
+            runtime_call<5>(erts_bs_put_float);
             if (Fail.get() == 0) {
                 mov_imm(ARG4,
                         beam_jit_update_bsc_reason_info(seg.error_info,
@@ -2597,7 +2601,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
                     mov_arg(ARG2, seg.src);
                     mov_imm(ARG4, seg.flags);
                     load_erl_bits_state(ARG1);
-                    runtime_call<4>(erts_new_bs_put_integer);
+                    runtime_call<4>(erts_bs_put_integer);
                     if (exact_type<BeamTypeId::Integer>(seg.src)) {
                         comment("skipped test for success because construction "
                                 "can't fail");
@@ -2628,7 +2632,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             mov_imm(ARG3, seg.effectiveSize / 8);
             mov_arg(ARG2, string_ptr);
             load_erl_bits_state(ARG1);
-            runtime_call<3>(erts_new_bs_put_string);
+            runtime_call<3>(erts_bs_put_string);
         } break;
         case am_utf8: {
             runtime_entered = bs_maybe_enter_runtime(runtime_entered);
@@ -2658,7 +2662,7 @@ void BeamModuleAssembler::emit_i_bs_create_bin(const ArgLabel &Fail,
             mov_imm(ARG3, 4 * 8);
             a.mov(ARG4, seg.flags);
             load_erl_bits_state(ARG1);
-            runtime_call<4>(erts_new_bs_put_integer);
+            runtime_call<4>(erts_bs_put_integer);
             if (Fail.get() == 0) {
                 mov_arg(ARG1, seg.src);
                 mov_imm(ARG4,


### PR DESCRIPTION
Refactor and clean up code for the construction of integer segments of dynamic size. See the description of each commit for more details.
