### PR TITLE
Ingela/crypto/public key/deprecation revert/otp 19163

### DIFF
--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -193,11 +193,7 @@ end
 
 %%%----------------------------------------------------------------
 %% Deprecated functions
--deprecated([{private_encrypt, 4, "use public_key:sign/3 instead"},
-             {private_decrypt, 4, "do not use"},
-             {public_encrypt,  4,  "do not use"},
-             {public_decrypt,  4,  "use public_key:verify/4 instead"}
-            ]).
+
 %%%----------------------------------------------------------------
 %% Removed functions.
 %%

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -2568,7 +2568,6 @@ Options for public key encrypt/decrypt. Only RSA is supported.
 -doc(#{title => <<"Public Key Ciphers">>}).
 -type rsa_padding() :: rsa_pkcs1_padding
                      | rsa_pkcs1_oaep_padding
-                     | rsa_sslv23_padding
                      | rsa_x931_padding
                      | rsa_no_padding.
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -156,7 +156,7 @@ end
                   {function,<<"Random API">>},
                   {function,<<"Utility Functions">>},
                   {function,<<"Engine API">>},
-                  {function,<<"Deprecated API">>},
+                  {function,<<"Legacy RSA Encryption API">>},
                   {type,<<"Ciphers">>},
                   {type,<<"Digests and hash">>},
                   {type,<<"Elliptic Curves">>},
@@ -2593,11 +2593,10 @@ Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons do not use.
+> This is a legacy function, for security reasons do not use together with rsa_pkcs1_padding.
 
 """.
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Do not use",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R16B01">>}).
 -spec public_encrypt(Algorithm, PlainText, PublicKey, Options) ->
                             CipherText when Algorithm :: pk_encrypt_decrypt_algs(),
@@ -2623,12 +2622,11 @@ Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons do not use.
+> This is a legacy function, for security reasons do not use with rsa_pkcs1_padding.
 
 """.
 
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Do not use",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R16B01">>}).
 -spec private_decrypt(Algorithm, CipherText, PrivateKey, Options) ->
                              PlainText when Algorithm :: pk_encrypt_decrypt_algs(),
@@ -2655,13 +2653,13 @@ Public-key decryption using the private key. See also `crypto:private_decrypt/4`
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons use [`sign/4`](`sign/4`) together
-> with [`verify/5`](`verify/5`) instead.
+> This is a legacy function, for security reasons do not use with rsa_pkcs1_padding.
+> For digital signatures use of [`sign/4`](`sign/4`) together
+> with [`verify/5`](`verify/5`) is the prefered solution.
 
 """.
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Use sign and verify instead",
-       since => <<"OTP R16B01">>}).
+-doc(#{title => <<"Legacy RSA Encryption API">>,
+        since => <<"OTP R16B01">>}).
 -spec private_encrypt(Algorithm, PlainText, PrivateKey, Options) ->
                             CipherText when Algorithm :: pk_encrypt_decrypt_algs(),
                                             PlainText :: binary(),
@@ -2686,12 +2684,12 @@ Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons use [`verify/5`](`verify/5`) together
-> with [`sign/4`](`sign/4`) instead.
+> This is a legacy function, for security reasons do not use with rsa_pkcs1_padding.
+> For digital signatures use of [`verify/5`](`verify/5`) together
+> with [`sign/4`](`sign/4`) is the prefered solution.
 
 """.
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Use verify and sign instead",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R16B01">>}).
 -spec public_decrypt(Algorithm, CipherText, PublicKey, Options) ->
                              PlainText when Algorithm :: pk_encrypt_decrypt_algs(),

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -55,7 +55,7 @@ macros described here and in the User's Guide:
                   {function,<<"Certificate Revocation API">>},
                   {function,<<"ASN.1 Encoding API">>},
                   {function,<<"Test Data API">>},
-                  {function,<<"Deprecated API">>}
+                  {function,<<"Legacy RSA Encryption API">>}
                  ]}).
 
 -feature(maybe_expr,enable).
@@ -814,8 +814,7 @@ pkix_encode(Asn1Type, Term0, otp) when is_atom(Asn1Type) ->
 
 %%--------------------------------------------------------------------
 -doc(#{equiv => decrypt_private(CipherText, Key, []),
-       deprecated => ~"Do not use",
-       title => <<"Deprecated API">>,
+       title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R14B">>}).
 -spec decrypt_private(CipherText, Key) ->
                              PlainText when CipherText :: binary(),
@@ -824,15 +823,14 @@ pkix_encode(Asn1Type, Term0, otp) when is_atom(Asn1Type) ->
 decrypt_private(CipherText, Key) ->
     decrypt_private(CipherText, Key, []).
 
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Do not use",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R14B">>}).
 -doc """
 Public-key decryption using the private key. See also `crypto:private_decrypt/4`
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons do not use.
+> This is a legacy function, for security reasons do not use with rsa_pkcs1_padding.
 """.
 -spec decrypt_private(CipherText, Key, Options) ->
                              PlainText when CipherText :: binary(),
@@ -850,8 +848,7 @@ decrypt_private(CipherText,
 %% Description: Public key decryption using the public key.
 %%--------------------------------------------------------------------
 -doc(#{equiv => decrypt_public(CipherText, Key, []),
-       deprecated => ~"Use sign and verify instead",
-       title => <<"Deprecated API">>,
+       title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R14B">>}).
 -spec decrypt_public(CipherText, Key) ->
 			    PlainText
@@ -861,17 +858,16 @@ decrypt_private(CipherText,
 decrypt_public(CipherText, Key) ->
     decrypt_public(CipherText, Key, []).
 
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Use sign and verify instead",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R14B">>}).
 -doc """
 Public-key decryption using the public key. See also `crypto:public_decrypt/4`
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons use [`verify/4`](`verify/4`) together
-> with [`sign/3`](`sign/3`) instead.
-.
+> This is a legacy function, for security reasons do not use  with rsa_pkcs1_padding.
+> For digital signatures the use of [`verify/4`](`verify/4`) together
+> with [`sign/3`](`sign/3`) is a prefered solution.
 """.
 -spec decrypt_public(CipherText, Key, Options) ->
 			    PlainText
@@ -887,8 +883,7 @@ decrypt_public(CipherText, #'RSAPublicKey'{modulus = N, publicExponent = E},
 %% Description: Public key encryption using the public key.
 %%--------------------------------------------------------------------
 -doc(#{equiv => encrypt_public(PlainText, Key, []),
-       deprecated => ~"Do not use",
-       title => <<"Deprecated API">>,
+       title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R14B">>}).
 -spec encrypt_public(PlainText, Key) ->
 			     CipherText
@@ -898,15 +893,14 @@ decrypt_public(CipherText, #'RSAPublicKey'{modulus = N, publicExponent = E},
 encrypt_public(PlainText, Key) ->
     encrypt_public(PlainText, Key, []).
 
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Do not use",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP 21.1">>}).
 -doc """
 Public-key encryption using the public key. See also `crypto:public_encrypt/4`.
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons do not use.
+> This is a legacy function, for security reasons do not use with rsa_pkcs1_padding.
 """.
 -spec encrypt_public(PlainText, Key, Options) ->
 			     CipherText
@@ -920,8 +914,7 @@ encrypt_public(PlainText, #'RSAPublicKey'{modulus=N,publicExponent=E},
 
 %%--------------------------------------------------------------------
 -doc(#{equiv => encrypt_private(PlainText, Key, []),
-       deprecated => ~"Use sign and verify instead",
-       title => <<"Deprecated API">>,
+       title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP R14B">>}).
 -spec encrypt_private(PlainText, Key) ->
 			     CipherText
@@ -931,8 +924,7 @@ encrypt_public(PlainText, #'RSAPublicKey'{modulus=N,publicExponent=E},
 encrypt_private(PlainText, Key) ->
     encrypt_private(PlainText, Key, []).
 
--doc(#{title => <<"Deprecated API">>,
-       deprecated => ~"Use sign and verify instead",
+-doc(#{title => <<"Legacy RSA Encryption API">>,
        since => <<"OTP 21.1">>}).
 -doc """
 Public-key encryption using the private key.
@@ -945,7 +937,9 @@ or trusted platform modules (TPM).
 
 > #### Warning {: .warning }
 >
-> This is a legacy function, for security reasons use [`sign/3`](`sign/3`) together with [`verify/4`](`verify/4`)  instead.
+> This is a legacy function, for security reasons do not use with rsa_pkcs1_padding.
+> For digital signatures use of [`sign/3`](`sign/3`) together with [`verify/4`](`verify/4`)  is
+> the prefered solution.
 """.
 -spec encrypt_private(PlainText, Key, Options) ->
 			     CipherText

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -110,17 +110,6 @@ macros described here and in the User's Guide:
 
 %%----------------
 %% Moved to ssh
-
--deprecated([{encrypt_private, 2, "use public_key:sign/3 instead"},
-             {encrypt_private, 3, "use public_key:sign 4 instead"},
-             {decrypt_private, 2, "do not use"},
-             {decrypt_private, 3, "do not use"},
-             {encrypt_public, 2,  "do not use"},
-             {encrypt_public, 3,  "do not use"},
-             {decrypt_public, 2,  "use public_key:verify/4 instead"},
-             {decrypt_public, 3,  "use public_key:verify/5 instead"}
-            ]).
-
 -removed([{ssh_decode,2, "use ssh_file:decode/2 instead"},
           {ssh_encode,2, "use ssh_file:encode/2 instead"},
           {ssh_hostkey_fingerprint,1, "use ssh:hostkey_fingerprint/1 instead"},

--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -36,14 +36,6 @@ obsolete(calendar, local_time_to_universal_time, 1) ->
     {deprecated, "use calendar:local_time_to_universal_time_dst/1 instead"};
 obsolete(code, lib_dir, 2) ->
     {deprecated, "this functionality will be removed in a future release"};
-obsolete(crypto, private_decrypt, 4) ->
-    {deprecated, "do not use"};
-obsolete(crypto, private_encrypt, 4) ->
-    {deprecated, "use public_key:sign/3 instead"};
-obsolete(crypto, public_decrypt, 4) ->
-    {deprecated, "use public_key:verify/4 instead"};
-obsolete(crypto, public_encrypt, 4) ->
-    {deprecated, "do not use"};
 obsolete(crypto, rand_uniform, 2) ->
     {deprecated, "use rand:uniform/1 instead"};
 obsolete(dbg, stop_clear, 0) ->
@@ -70,22 +62,6 @@ obsolete(net, ping, 1) ->
     {deprecated, "use net_adm:ping/1 instead"};
 obsolete(net, sleep, 1) ->
     {deprecated, "use 'receive after T -> ok end' instead"};
-obsolete(public_key, decrypt_private, 2) ->
-    {deprecated, "do not use"};
-obsolete(public_key, decrypt_private, 3) ->
-    {deprecated, "do not use"};
-obsolete(public_key, decrypt_public, 2) ->
-    {deprecated, "use public_key:verify/4 instead"};
-obsolete(public_key, decrypt_public, 3) ->
-    {deprecated, "use public_key:verify/5 instead"};
-obsolete(public_key, encrypt_private, 2) ->
-    {deprecated, "use public_key:sign/3 instead"};
-obsolete(public_key, encrypt_private, 3) ->
-    {deprecated, "use public_key:sign 4 instead"};
-obsolete(public_key, encrypt_public, 2) ->
-    {deprecated, "do not use"};
-obsolete(public_key, encrypt_public, 3) ->
-    {deprecated, "do not use"};
 obsolete(queue, lait, 1) ->
     {deprecated, "use queue:liat/1 instead"};
 obsolete(ssl, prf, 5) ->

--- a/system/doc/general_info/DEPRECATIONS
+++ b/system/doc/general_info/DEPRECATIONS
@@ -24,18 +24,6 @@ mnesia_registry:create_table/_ since=27 remove=28
 code:lib_dir/2 since=27
 ssl:prf/5 since=27
 ssl:prf_random/0 since=27 remove=28
-public_key:decrypt_public/3 since=27
-public_key:decrypt_public/2 since=27
-public_key:encrypt_public/3 since=27
-public_key:encrypt_public/2 since=27
-public_key:decrypt_private/3 since=27
-public_key:decrypt_private/2 since=27
-public_key:encrypt_private/3 since=27
-public_key:encrypt_private/2 since=27
-crypto:public_decrypt/4 since=27
-crypto:public_encrypt/4 since=27
-crypto:private_decrypt/4 since=27
-crypto:private_encrypt/4 since=27
 
 #
 # Added in OTP 26.


### PR DESCRIPTION
OTB: Decided to revert deprecation of crypto and public_key functions using legacy RSA encryption. Reason is that there exists other paddings than rsa-pcks1-padding that can still have valid uses cases, and that rsa-pkcs1-padding use case can be used for offline reasons or with mitigated OpenSSL versions and is then likely secure, we leave it up to the user if they want to trust OpenSSL implementation.

I rephrased the warnings and still recommend against using this functions with rsa-pkcs1-padding, we want to be secure by default and let it be the users responsibility to ensure that if they use the algorithm it will be secure for their setup.

Note that best practices for the web-socket protocol using these functions (and that is the main reason for reverting) explicitly recommends to only support an other padding than rsa-pcks1 one.

Avoid all RSA-PKCS1 v1.5 encryption algorithms ([[RFC8017](https://www.rfc-editor.org/rfc/rfc8725#RFC8017)], [Section 7.2](https://www.rfc-editor.org/rfc/rfc8017#section-7.2)), preferring RSAES-OAEP ([[RFC8017](https://www.rfc-editor.org/rfc/rfc8725#RFC8017)], [Section 7.1](https://www.rfc-editor.org/rfc/rfc8017#section-7.1)).

Form: https://www.rfc-editor.org/rfc/rfc8725#RFC7515

We  also remove rsa_sslv23_padding form the documentation as, from OpenSSL doc:

RSA_SSLV23_PADDING
PKCS https://github.com/erlang/otp-internal/pull/1 v1.5 padding with an SSL-specific modification that denotes that the server is SSL3 capable.

Translated to English , this means that the SSL implementation that implements SSL-2.0 (First protocol version designed by Netscape and never released to the public due to its many vulnerabilities) signals that it also supports SSL-3.0 (First IETF standardized version) .
So OTP has never had an SSL implementation that supports SSL-2.0 not even when we wrapped OpenSSL. And for several years we have not supported SSL-3.0. And I do not think that we need to think that there are any other Erlang implementations in the wild of legacy SSL version 2.0 and 3.0 that we need to support, especially not in OTP-27. It can be considered a documentation bug.