### PR TITLE
Disable support for Linux THP on architectures other than amd64

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -25692,8 +25692,8 @@ printf "%s\n" "no" >&6; }
 	;;
 esac
 
-case $OPSYS in #(
-  linux*) :
+case $ARCH-$OPSYS in #(
+  amd64-linux*) :
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the Transparent Huge Pages interface is available" >&5
 printf %s "checking whether the Transparent Huge Pages interface is available... " >&6; }

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -3036,9 +3036,9 @@ case $host_os in
 esac
 
 dnl Checks for the Transparent Huge pages (THP) availability on Linux
-AS_CASE([$OPSYS],
-  [linux*],
   [      
+AS_CASE([$ARCH-$OPSYS],
+  [amd64-linux*],
     AC_CACHE_CHECK(
       [whether the Transparent Huge Pages interface is available],
       erts_cv_linux_thp,


### PR DESCRIPTION
THP seems to be causing problems on 32-bit and 64-bit ARM hosts.  This change disables the test for THP on everything except 64-bit x86 hosts which are known to work.