### PR TITLE
Fix pubkey_os_cacerts:load() on DragonFly

### DIFF
--- a/lib/public_key/src/pubkey_os_cacerts.erl
+++ b/lib/public_key/src/pubkey_os_cacerts.erl
@@ -61,6 +61,8 @@ load() ->
             load(bsd_paths(), undefined);
         {unix, freebsd} ->
             load(bsd_paths(), undefined);
+        {unix, dragonfly} ->
+            load(bsd_paths(), undefined);
         {unix, netbsd} ->
             load(bsd_paths(), undefined);
         {unix, sunos} ->


### PR DESCRIPTION
Fixes an exception thrown when running "mix setup" on Elixir 1.18.0-dev:

    ** (EXIT from #PID<0.93.0>) an exception was raised:
	** (MatchError) no match of right hand side value:
           {:error, {:enotsup, {:unix, :dragonfly}}}