### PR TITLE
os_mon - include HAMMER2-FS in df(1) for DragonFly

### DIFF
--- a/lib/os_mon/src/disksup.erl
+++ b/lib/os_mon/src/disksup.erl
@@ -442,7 +442,7 @@ run_df(Path, {unix, linux}, Port) ->
 run_df(Path, {unix, posix}, Port) ->
     my_cmd("df -k -P " ++ Path, Port);
 run_df(Path, {unix, dragonfly}, Port) ->
-    my_cmd("/bin/df -k -t ufs,hammer " ++ Path, Port);
+    my_cmd("/bin/df -k -t ufs,hammer,hammer2 " ++ Path, Port);
 run_df(Path, {unix, freebsd}, Port) ->
     my_cmd("/bin/df -k -l " ++ Path, Port);
 run_df(Path, {unix, openbsd}, Port) ->


### PR DESCRIPTION
HAMMER2 is the default file-system on DragonFly.

Running:

    /bin/df -k -t ufs,hammer /

results in empty output (on my DragonFly system), while running:

    /bin/df -k -t ufs,hammer,hammer2 /

results in:

    Filesystem     1K-blocks     Used     Avail Capacity  Mounted on
    dev/da0s1d     697244672 68285248 628959424    10%    /