### PR TITLE
doc: add shasum to check has on OSX

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -97,7 +97,11 @@ also find the utilities needed for building the documentation.
     but any version after that should work just as well.
 
     You can also use `./otp_build download_ex_doc` to download the correct version
-    from github.
+    from github. One of the following dependencies are needed to check the documentation:
+    
+    - sha256sum, or
+    - sha1sum, or
+    - shasum
 
 How to Build and Install Erlang/OTP
 -----------------------------------

--- a/otp_build
+++ b/otp_build
@@ -1025,8 +1025,13 @@ do_download_ex_doc ()
             echo "The sha1sum check of $ERL_TOP/bin/ex_doc failed!" >&2
             exit 1
         fi
+    elif command -v shasum > /dev/null; then
+        if ! (cd "$ERL_TOP/make" && shasum -a 1 --status -c "ex_doc.sha1sum"); then
+            echo "The shasum check of $ERL_TOP/bin/ex_doc failed!" >&2
+            exit 1
+        fi
     else
-        echo "Neither sha1sum nor sha256sum found to verify $ERL_TOP/bin/ex_doc" >&2
+        echo "Neither sha1sum nor sha256sum nor shasum found to verify $ERL_TOP/bin/ex_doc" >&2
         echo "Please check manually that the correct ex_doc was downloaded." >&2
         exit 1
     fi


### PR DESCRIPTION
adds the dependency `shasum` to check the checksum of ex_doc. 
this was necessary because OSX does not come with sha256sum nor sha1sum.

Closes #8656 