### PR TITLE
Ingela/ssl/public key/verify fun 4/otp 19169

### DIFF
--- a/lib/ssl/src/ssl.app.src
+++ b/lib/ssl/src/ssl.app.src
@@ -92,6 +92,6 @@
     {applications, [crypto, public_key, kernel, stdlib]},
     {env, []},
     {mod, {ssl_app, []}},
-    {runtime_dependencies, ["stdlib-6.0","public_key-1.15","kernel-9.0",
+    {runtime_dependencies, ["stdlib-6.0","public_key-@OTP-19169@","kernel-9.0",
                             "erts-15.0","crypto-5.0", "inets-5.10.7",
                             "runtime_tools-1.15.1"]}]}.

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -800,13 +800,13 @@ Common certificate related options to both client and server.
   Default option `verify_fun` in `verify_peer mode`:
 
   ```erlang
-  {fun(_,{bad_cert, _} = Reason, _) ->
+  {fun(_, _, {bad_cert, _} = Reason, _) ->
 	 {fail, Reason};
-      (_,{extension, _}, UserState) ->
+      (_, _, {extension, _}, UserState) ->
 	 {unknown, UserState};
-      (_, valid, UserState) ->
+      (_, _, valid, UserState) ->
 	 {valid, UserState};
-      (_, valid_peer, UserState) ->
+      (_, _, valid_peer, UserState) ->
          {valid, UserState}
    end, []}
   ```
@@ -814,15 +814,15 @@ Common certificate related options to both client and server.
   Default option `verify_fun` in mode `verify_none`:
 
   ```erlang
-   {fun(_,{bad_cert, _}, UserState) ->
+   {fun(_, _, {bad_cert, _}, UserState) ->
 	 {valid, UserState};
-      (_,{extension, #'Extension'{critical = true}}, UserState) ->
+      (_, _, {extension, #'Extension'{critical = true}}, UserState) ->
 	 {valid, UserState};
-      (_,{extension, _}, UserState) ->
+      (_, _, {extension, _}, UserState) ->
 	 {unknown, UserState};
-      (_, valid, UserState) ->
+      (_, _, valid, UserState) ->
 	 {valid, UserState};
-      (_, valid_peer, UserState) ->
+      (_, _, valid_peer, UserState) ->
          {valid, UserState}
    end, []}
   ```


### PR DESCRIPTION
Enhance pkix_path_validation/3 callback so user fun can access both the encoded and decoded version of certificates.  Can enhance both efficiency and interoperability, the latter as many encoders make mistakes that there exists workarounds for in the decoder.  