### PR TITLE
ssl: help message refers to nonexistent function

### DIFF
--- a/erts/preloaded/src/zlib.erl
+++ b/erts/preloaded/src/zlib.erl
@@ -80,8 +80,8 @@ Typical `Reason`s:
 
 -export([on_load/0]).
 
--removed([{inflateChunk, 1, "use safeInflate/2 instead"},
-          {inflateChunk, 2, "use safeInflate/2 instead"},
+-removed([{inflateChunk, 1, "use zlib:safeInflate/2 instead"},
+          {inflateChunk, 2, "use zlib:safeInflate/2 instead"},
           {getBufSize, 1, "this function has been removed"},
           {setBufSize, 2, "this function has been removed"},
           {crc32, 1, "use erlang:crc32/1 on the uncompressed data instead"},

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -200,8 +200,8 @@ end
 %% Old interface. Now implemented with the New interface.
 %% Removed in OTP-24.0 See OTP-16232 (deprecation) and OTP-16656 (removal)
 
--removed([{crypto_dyn_iv_init, 3, "not supported, use crypto_init/4"},
-          {crypto_dyn_iv_update, 3, "not supported, use crypto_update/2"},
+-removed([{crypto_dyn_iv_init, 3, "not supported, use crypto:crypto_init/4"},
+          {crypto_dyn_iv_update, 3, "not supported, use crypto:crypto_update/2"},
           {next_iv, '_', "see the 'New and Old API' chapter of the CRYPTO User's guide"},
           {hmac, 3, "use crypto:mac/4 instead"},
           {hmac, 4, "use crypto:macN/5 instead"},

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -154,15 +154,15 @@ Special Erlang node configuration for the application can be found in
 -deprecated_type([{prf_random, 0,"Only used in deprecated function prf/5 and will no longer be needed."}]).
 
 -removed({ssl_accept, '_', 
-          "use ssl_handshake/1,2,3 instead"}).
+          "use ssl:handshake/1,2,3 instead"}).
 -removed({cipher_suites, 0, 
-          "use cipher_suites/2,3 instead"}).
+          "use ssl:cipher_suites/2,3 instead"}).
 -removed({cipher_suites, 1, 
-          "use cipher_suites/2,3 instead"}).
+          "use ssl:cipher_suites/2,3 instead"}).
 -removed([{negotiated_next_protocol,1,
            "use ssl:negotiated_protocol/1 instead"}]).
 -removed([{connection_info,1,
-           "use ssl:connection_information/[1,2] instead"}]).
+           "use ssl:connection_information/1,2 instead"}]).
 
 -export_type([active_msgs/0,
               cert_key_conf/0,


### PR DESCRIPTION
No such function - ```ssl_handshake```. Obviously the intention was to refer to ```handshake```