### PR TITLE
compiler: Do strength reduction of the hint for update_record

### DIFF
--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -32,6 +32,7 @@
          annotation_checks/1,
          appendable_checks/1,
          bs_size_unit_checks/1,
+         no_reuse_hint_checks/1,
          private_append_checks/1,
          ret_annotation_checks/1,
          sanity_checks/1,
@@ -47,6 +48,7 @@ groups() ->
       [alias_checks,
        annotation_checks,
        appendable_checks,
+       no_reuse_hint_checks,
        private_append_checks,
        ret_annotation_checks,
        sanity_checks,
@@ -98,6 +100,9 @@ appendable_checks(Config) when is_list(Config) ->
 
 bs_size_unit_checks(Config) when is_list(Config) ->
     gen_and_run_post_ssa_opt(bs_size_unit_checks, Config).
+
+no_reuse_hint_checks(Config) when is_list(Config) ->
+    run_post_ssa_opt(no_reuse_hint, Config).
 
 private_append_checks(Config) when is_list(Config) ->
     run_post_ssa_opt(private_append, Config).

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -1071,7 +1071,7 @@ update_record0() ->
 
 update_record0([Val|Ls], Acc=#r0{not_aliased=N}) ->
 %ssa% (_, Rec) when post_ssa_opt ->
-%ssa% _ = update_record(reuse, 3, Rec, 3, A, 2, NA) {unique => [Rec, NA], aliased => [A]}.
+%ssa% _ = update_record(copy, 3, Rec, 3, A, 2, NA) {unique => [Rec, NA], aliased => [A]}.
     R = Acc#r0{not_aliased=N+1,aliased=Val},
     update_record0(Ls, R);
 update_record0([], Acc) ->
@@ -1084,7 +1084,7 @@ update_record1() ->
 
 update_record1([Val|Ls], Acc=#r1{not_aliased0=N0,not_aliased1=N1}) ->
 %ssa% (_, Rec) when post_ssa_opt ->
-%ssa% _ = update_record(reuse, 3, Rec, 3, NA0, 2, NA1) {unique => [Rec, NA1, NA0], source_dies => true}.
+%ssa% _ = update_record(copy, 3, Rec, 3, NA0, 2, NA1) {unique => [Rec, NA1, NA0], source_dies => true}.
     R = Acc#r1{not_aliased0=N0+1,not_aliased1=[Val|N1]},
     update_record1(Ls, R);
 update_record1([], Acc) ->

--- a/lib/compiler/test/beam_ssa_check_SUITE_data/no_reuse_hint.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/no_reuse_hint.erl
@@ -1,0 +1,102 @@
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%% This module tests the ssa_opt_no_reuse compiler pass. The test
+%% strategy is to ensure 100% coverage of the pass and to check for
+%% correct functioning for each of the different categories of
+%% operations inhibiting reuse: phis, known bifs, functions and
+%% instructions.
+%%
+
+-module(no_reuse_hint).
+
+-export([coverage0/0,
+         inhibit_by_known_bif/2,
+         inhibit_by_known_fun/1,
+         inhibit_by_known_op/2,
+         inhibit_by_map/4,
+         inhibit_by_map_key/2,
+         inhibit_by_map_value/2,
+         inhibit_by_phi/1]).
+
+inhibit_by_known_bif({_}=X, Y) ->
+%ssa% (X, Y) when post_ssa_opt ->
+%ssa% Bif = bif:'+'(...),
+%ssa% R = update_record(copy, 1, X, 1, Bif),
+%ssa% ret(R).
+    setelement(1, X, Y + 1).
+
+inhibit_by_known_fun(X) ->
+    case X of
+	{_} ->
+%ssa% (X) when post_ssa_opt ->
+%ssa% KnownFun = call(fun erlang:'++'/2, ...),
+%ssa% R = update_record(copy, 1, X, 1, KnownFun),
+%ssa% ret(R).
+	    setelement(1, X, e:f() ++ e:f())
+    end.
+
+inhibit_by_known_op({_, _}=X, Y) ->
+%ssa% (X, Y) when post_ssa_opt ->
+%ssa% Op = put_tuple(...),
+%ssa% R = update_record(copy, 2, X, 1, Op),
+%ssa% ret(R).
+    setelement(1, X, {Y}).
+
+inhibit_by_map(A, B, C, {_}=D) ->
+%ssa% (A, B, C, D) when post_ssa_opt ->
+%ssa% Map1 = put_map(_, C, B, _),
+%ssa% Map = put_map(_, Map1, A, _),
+%ssa% R = update_record(copy, 1, D, 1, Map),
+%ssa% ret(R).
+    setelement(1, D, C#{B => {e:f()}, A => e:f()}).
+
+inhibit_by_map_key({Y0}=Z, K) ->
+%ssa% (X, Y) when post_ssa_opt ->
+%ssa% Key = put_tuple(...),
+%ssa% Map = put_map(_, _, Key, value),
+%ssa% R = update_record(copy, 1, Z, 1, Map),
+%ssa% ret(R).
+    Y = Y0#{{K} => value},
+    setelement(1, Z, Y).
+
+inhibit_by_map_value(X, {Y}=Z) ->
+%ssa% (X, Y) when post_ssa_opt ->
+%ssa% T = put_tuple(...),
+%ssa% Map = put_map(_, _, key, T),
+%ssa% R = update_record(copy, 1, Z, 1, Map),
+%ssa% ret(R).
+    M = Y#{key => {X}},
+    setelement(1, Z, M).
+
+inhibit_by_phi({_}=X) ->
+%ssa% (X) when post_ssa_opt ->
+%ssa% Phi = phi(...),
+%ssa% R = update_record(copy, 1, X, 1, Phi),
+%ssa% ret(R).
+    Y = case e:f() of
+            a -> {e:f(), 1};
+            b -> {e:f(), 2}
+        end,
+    setelement(1, X, Y).
+
+%%
+%% Ensure full coverage of the functions in the ssa_opt_no_reuse pass.
+%%
+coverage0() ->
+    erlang:send_after(500, self(), fun() -> ok end).


### PR DESCRIPTION
Change the hint from `reuse` to `copy` when reusing clearly will not work.