### PR TITLE
Fix error information for `code:get_coverage/2`

### DIFF
--- a/lib/kernel/src/erl_kernel_errors.erl
+++ b/lib/kernel/src/erl_kernel_errors.erl
@@ -50,7 +50,8 @@ format_code_error(get_coverage, [What,Module]) ->
               Error = case What of
                           function -> [];
                           line -> [];
-                          _ -> <<"must be one of: function or line">>
+                          cover_line_id -> [];
+                          _ -> coverage_level
                       end,
               case Error of
                   [] ->
@@ -367,6 +368,8 @@ expand_error(bad_tracer) ->
     <<"invalid tracer">>;
 expand_error(coverage_disabled) ->
     <<"not loaded with coverage enabled">>;
+expand_error(coverage_level) ->
+    <<"must be one of: function, line, or cover_line_id">>;
 expand_error(eq_in_list) ->
     <<"\"=\" characters is not allowed in environment variable names">>;
 expand_error(zero_in_list) ->

--- a/lib/kernel/test/code_coverage_SUITE.erl
+++ b/lib/kernel/test/code_coverage_SUITE.erl
@@ -270,6 +270,7 @@ error_info(_Config) ->
          {get_coverage, [line,42]},
          {get_coverage, [line,NotLoaded]},
          {get_coverage, [line,?MODULE]},
+         {get_coverage, [cover_line_id,NotLoaded]},
          {get_coverage, [whatever,?MODULE]},
 
          {reset_coverage, [42]},


### PR DESCRIPTION
If `code:get_coverage(cover_line_id, Module)` failed, the first argument would be unjustly blamed for the failure, instead of the second argument ("the atom does not refer to a loaded module" or "not loaded with coverage enabled").