### PR TITLE
ci: Add otp_win.zip to releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -587,7 +587,7 @@ jobs:
     name: Release Erlang/OTP
     runs-on: ubuntu-latest
     needs: documentation
-    if: startsWith(github.ref, 'refs/tags/') # && github.repository == 'erlang/otp'
+    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'erlang/otp'
     ## Needed to create releases
     permissions:
       contents: write


### PR DESCRIPTION
I'd like to propose including Windows .zip release besides the .exe installer in GitHub releases.

I'm building a CLI tool that allows easily installing multiple OTP versions. I'd prefer not to use the installers for the following reasons:

- They write to Windows registry. While most registry entries are nicely namespaced so there would not be any conflicts, I'd prefer not to leave things behind. Worth mentioning there are global entries for windows features like the `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP` and `HKCR ".erl"`.
- At the moment, installers require admin permissions (https://github.com/erlang/otp/issues/8531)

After downloading the .zip, users can manually run the included `Install.exe`.

Btw, the release requires vc_redist.x64.exe (also mentioned in https://github.com/erlang/otp/issues/8531) so if this proposal is accepted, the question is whether it should be included in the .zip.

FWIW, in my tool I'm downloading and running it myself:

<details>

```sh
ensure_vcredist() {
  if [ -f /c/windows/system32/vcruntime140.dll ]; then
    return
  fi

  url="https://aka.ms/vs/17/release/vc_redist.x64.exe"
  file="vc_redist.x64.exe"

  echo "downloading VC++ Redistributable $url..."
  curl --retry 3 --fail -L -o "$file" "$url"
  echo "installing VC++ Redistributable $url..."
  ./"$file" /quiet /norestart
}
```

</details>

Another idea for not writing to windows registry would be to add a flag to generated installer, we can allegedly read it with [`${GetParameters} $R0`](https://nsis.sourceforge.io/Reference/GetParameters), something it would perhaps be something like `otp_win64_27.1.exe /NOWINREG`.

cc @tsloughter