### PR TITLE
Load mermaid asynchronously in docs

### DIFF
--- a/make/ex_doc.exs
+++ b/make/ex_doc.exs
@@ -197,9 +197,8 @@ config = [
   before_closing_body_tag: fn
     :html ->
       """
-      <script src="https://cdn.jsdelivr.net/npm/mermaid@10.9.0/dist/mermaid.min.js"></script>
       <script>
-        document.addEventListener("DOMContentLoaded", function () {
+        function mermaidLoaded() {
           mermaid.initialize({
             startOnLoad: false,
             theme: document.body.className.includes("dark") ? "dark" : "default"
@@ -217,8 +216,9 @@ config = [
               preEl.remove();
             });
           }
-        });
+        }
       </script>
+      <script async src="https://cdn.jsdelivr.net/npm/mermaid@10.2.3/dist/mermaid.min.js" onload="mermaidLoaded();"></script>
       """
 
     _ ->


### PR DESCRIPTION
Submitting so this doesn't get forgotten.

If mermaid is synchronously loaded, a slow load can prevent the sidebar from displaying since it loads async and must wait for mermaid. Instead, load mermaid asynchronously and then call `mermaidLoaded()` when loading is finished. See elixir-lang/ex_doc#1941

Thanks to @vlad-ngn and @Benjamin-Philip for finding/triaging this bug.

Can someone with the toolchain set up test to make sure it works? It works in the Elixir docs, but I haven't tested it for Erlang docs.