### PR TITLE
Update configure scripts for `local-aarch64-*-windows`

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -3836,6 +3836,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -3850,6 +3857,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -3864,6 +3878,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -3875,18 +3896,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/common_test/configure
+++ b/lib/common_test/configure
@@ -2041,6 +2041,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -2055,6 +2062,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -2069,6 +2083,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -2080,18 +2101,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -3160,6 +3160,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -3174,6 +3181,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -3188,6 +3202,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -3199,18 +3220,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -3044,6 +3044,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -3058,6 +3065,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -3072,6 +3086,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -3083,18 +3104,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -2904,6 +2904,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -2918,6 +2925,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -2932,6 +2946,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -2943,18 +2964,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -3002,6 +3002,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -3016,6 +3023,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -3030,6 +3044,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -3041,18 +3062,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/snmp/configure
+++ b/lib/snmp/configure
@@ -2037,6 +2037,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -2051,6 +2058,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -2065,6 +2079,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -2076,18 +2097,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -3232,6 +3232,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -3246,6 +3253,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -3260,6 +3274,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -3271,18 +3292,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -35,6 +35,13 @@ AC_DEFUN([ERL_CANONICAL_SYSTEM_TYPE],
     AC_CANONICAL_HOST
     # Adjust for local legacy windows hack...
     AS_CASE([$host],
+            [local-aarch64-*-windows],
+            [
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+            ],
             [local-*-windows],
             [
                 host=win32
@@ -46,6 +53,13 @@ AC_DEFUN([ERL_CANONICAL_SYSTEM_TYPE],
     AC_CANONICAL_BUILD
     # Adjust for local legacy windows hack...
     AS_CASE([$build],
+            [local-aarch64-*-windows],
+            [
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+            ],
             [local-*-windows],
             [
                 build=win32
@@ -57,6 +71,13 @@ AC_DEFUN([ERL_CANONICAL_SYSTEM_TYPE],
     AC_CANONICAL_TARGET
     # Adjust for local legacy windows hack...
     AS_CASE([$target],
+            [local-aarch64-*-windows],
+            [
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+            ],
             [local-*-windows],
             [
                 target=win32
@@ -65,17 +86,18 @@ AC_DEFUN([ERL_CANONICAL_SYSTEM_TYPE],
                 target_cpu=
             ])
 
-    AS_IF([test "$cross_compiling" = "yes" -a "$build" = "$host"],
+    AS_IF([test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"],
           [AC_MSG_ERROR([
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.

--- a/make/configure
+++ b/make/configure
@@ -3486,6 +3486,13 @@ test -n "$target_alias" &&
 
     # Adjust for local legacy windows hack...
     case $host in #(
+  local-aarch64-*-windows) :
+
+                host=win32
+                host_os=win32
+                host_vendor=
+                host_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 host=win32
@@ -3500,6 +3507,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $build in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 build=win32
@@ -3514,6 +3528,13 @@ esac
 
     # Adjust for local legacy windows hack...
     case $target in #(
+  local-aarch64-*-windows) :
+
+                build=win32
+                build_os=win32
+                build_vendor=
+                build_cpu=aarch64
+             ;; #(
   local-*-windows) :
 
                 target=win32
@@ -3525,18 +3546,19 @@ esac
      ;;
 esac
 
-    if test "$cross_compiling" = "yes" -a "$build" = "$host"
+    if test "$cross_compiling" = "yes" -a "$build" = "$host"  -a "$build_cpu" = "$host_cpu"
 then :
   as_fn_error $? "
-           Cross compiling with the same canonicalized 'host' value
-           as the canonicalized 'build' value.
+           Cross compiling with the same canonicalized 'host' and 'host_cpu'
+           values as the canonicalized 'build' and 'build_cpu' values
 
            We are cross compiling since the '--host=$host_alias'
            and the '--build=$build_alias' arguments differ. When
            cross compiling Erlang/OTP, also the canonicalized values of
            the '--build' and the '--host' arguments *must* differ. The
            canonicalized values of these arguments however both equals:
-           $host
+           host = build = $host,
+           host_cpu = build_cpu = $host_cpu
 
            You can check the canonical value by passing a value as
            argument to the 'make/autoconf/config.sub' script.


### PR DESCRIPTION
Hi there, this is one of the smaller PRs seperated from the original PR https://github.com/erlang/otp/pull/8142 that attempts to add initial support for ARM64 windows. In this PR, 

- it will set the `host_cpu`, `build_cpu` or `target_cpu` to `aarch64` when `host`, `build` or `target` matches `local-aarch64-*-windows`;
- it also checks if `build_cpu` = `target_cpu` when detecting if the user is cross-compiling.