### PR TITLE
Update rand.erl Documentation bug: exs928ss does not work, perhaps ex…

### DIFF
--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -201,14 +201,14 @@ R1 = rand:uniform(),
 Use a specified algorithm:
 
 ```erlang
-_ = rand:seed(exs928ss),
+_ = rand:seed(exro928ss),
 R2 = rand:uniform(),
 ```
 
 Use a specified algorithm with a fixed seed:
 
 ```erlang
-_ = rand:seed(exs928ss, {123, 123534, 345345}),
+_ = rand:seed(exro928ss, {123, 123534, 345345}),
 R3 = rand:uniform(),
 ```
 


### PR DESCRIPTION
My first attempt at contributing.
I tried the code in the documentation and it did not work with Erlang/OTP 24 [erts-12.2.1] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:1] [jit].
Tested it with Erlang/OTP 27 and that did not work either.
Changing it at least ran and I got random numbers but not starting with a fixed PRNG.
(Got different random numbers each time despite calling seed with an algorithm and a seed.)