### PR TITLE
Optimize lists:flatmap/2 for filtering

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -2113,7 +2113,12 @@ flatmap(F, List) when is_function(F, 1) ->
     flatmap_1(F, List).
 
 flatmap_1(F, [Hd | Tail]) ->
-    F(Hd) ++ flatmap_1(F, Tail);
+    case F(Hd) of
+        %% The two first clauses are an optimization.
+        [] -> flatmap_1(F, Tail);
+        [Elem] -> [Elem | flatmap_1(F, Tail)];
+        List -> List ++ flatmap_1(F, Tail)
+    end;
 flatmap_1(_F, []) ->
     [].
 


### PR DESCRIPTION
In case there is an interest, I'm proposing this optimization we added to elixir (https://github.com/elixir-lang/elixir/pull/13793), since the implementation and the expected improvement are the same. Feel free to close if you feel it is unnecessary.

This could especially generate important speedups ([1.5~3x](https://github.com/sabiwara/elixir_benches/commit/f5970d7a920784822cc4566a8eebdd9abcc952dd#diff-13fc229dfd6e6808b62ab13c29b0f362a124a8bb85106d4efc2159f527195a6bR60-R84)) for cases where `flatmap` is used as a `filtermap`, like [this](https://github.com/erlang/otp/blob/1afaa459eaae8d51585acc2a363dd2714b98c9c2/lib/stdlib/doc/src/qlc.md?plain=1#L324) or [this](https://github.com/erlang/otp/blob/1afaa459eaae8d51585acc2a363dd2714b98c9c2/lib/observer/src/crashdump_viewer.erl#L2035), but should benefit any case which returns some amount of empty lists or size-1 lists.