### PR TITLE
[common_test] Fix total execution time in case of timetrap_timeout

### DIFF
--- a/lib/common_test/src/test_server_ctrl.erl
+++ b/lib/common_test/src/test_server_ctrl.erl
@@ -3951,6 +3951,7 @@ run_test_case1(Ref, Num, Mod, Func, Args, RunInit,
         {_,failed} ->
             DiedTime = case Time of
                            died -> case RetVal of
+                                       {timetrap_timeout, T} -> T/1000;
                                        {_,T} when is_number(T) -> T;
                                        _ -> 0
                                    end;


### PR DESCRIPTION
Hi!

We noticed that when a test case fails with timetrap_timeout, the generated html log the time correctly shows the time in seconds but then the time itself is incorrectly added to the total execution time in milliseconds.
![image](https://github.com/user-attachments/assets/5e569bfd-572f-434e-8b84-75efb39c5a2c)

Divided the 'DiedTime' by 1000 when the cause is timetrap_timeout

If it is possible we would like to have this change released on 26.2.5.2 as 26.2.5.3.

Best Regards,
Domonkos Say