### PR TITLE
Crypto with --enable-fips accepts OpenSSL 3 lib without fips provider

### DIFF
--- a/lib/crypto/c_src/algorithms.c
+++ b/lib/crypto/c_src/algorithms.c
@@ -277,15 +277,16 @@ void init_curve_types(ErlNifEnv* env) {
     if (FIPS_MODE()) {
         // FIPS enabled
         get_curve_cnt(env, 1);
-        FIPS_mode_set(0); // disable
+        (void) FIPS_mode_set(0); // disable
         get_curve_cnt(env, 0);
-        FIPS_mode_set(1); // re-enable
+        (void) FIPS_mode_set(1); // re-enable
     } else {
         // FIPS disabled but available
         get_curve_cnt(env, 0);
-        FIPS_mode_set(1); // enable
-        get_curve_cnt(env, 1);
-        FIPS_mode_set(0); // re-disable
+        if (FIPS_mode_set(1)) { // enable
+            get_curve_cnt(env, 1);
+            (void) FIPS_mode_set(0); // re-disable
+        }
     }
 #else
     // FIPS mode is not available

--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -492,7 +492,9 @@ do {                                                    \
 #if defined(FIPS_SUPPORT) && \
     defined(HAS_3_0_API)
 # define FIPS_mode() EVP_default_properties_is_fips_enabled(NULL)
-# define FIPS_mode_set(enable) EVP_default_properties_enable_fips(NULL, enable)
+# define FIPS_mode_set(enable) \
+    ((!enable || OSSL_PROVIDER_available(NULL, "fips"))            \
+     && EVP_default_properties_enable_fips(NULL, enable))
 #endif
 
 


### PR DESCRIPTION
Fix #8562

`crypto` built with `--enable-fips` will work with OpenSSL 3 without fips provider as long as fips mode is not enabled.
