### PR TITLE
kernel: Add possibility to disable prompt redrawing

### DIFF
--- a/lib/stdlib/doc/src/stdlib_app.xml
+++ b/lib/stdlib/doc/src/stdlib_app.xml
@@ -62,6 +62,13 @@
           <p>Sets where the tab expansion text should appear in the shell.
             The default is <c>below</c>.</p>
       </item>
+      <tag><marker id="shell_redraw_prompt_on_output"/><c>shell_redraw_prompt_on_output = boolean()</c></tag>
+      <item>
+          <p>Sets whether the shell should redraw the prompt when it receives output from other processes.
+            This setting can be useful if you use <c>run_erl</c> to for logging as redrawing the prompt will
+            emit a lot of ANSI escape characters that you normally do not want in a log.
+            The default is <c>true</c>.</p>
+      </item>
       <tag><marker id="shell_history_length"/><c>shell_history_length = integer() >= 0</c></tag>
       <item>
         <p>Can be used to determine how many commands are saved by the Erlang


### PR DESCRIPTION
When stdout is used as both a terminal and as the main logging mechanism, redrawing the prompt will cause a lot of ANSI characters to be printed to the log when the prompt is redrawn. So we add this options for systems that have a hard time migrating away. It is only available in Erlang/OTP 26 as a temporary measure as in the long run no system should be using stdout as a logging mechanism and terminal at the same time.

Supersedes #8644 