### PR TITLE
Allow channel handler to control adjust_window message sending

### DIFF
--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -61,8 +61,7 @@ these messages are handled by
 -export([session_channel/2, session_channel/4,
 	 exec/4, shell/2, subsystem/4, send/3, send/4, send/5, 
 	 send_eof/2, adjust_window/3, setenv/5, close/2, reply_request/4,
-	 ptty_alloc/3, ptty_alloc/4,
-	 set_window_handling_mode/3]).
+	 ptty_alloc/3, ptty_alloc/4]).
 
 %% Potential API currently unsupported and not tested
 -export([window_change/4, window_change/6,
@@ -558,27 +557,6 @@ server-side channel processes.
 %%--------------------------------------------------------------------
 adjust_window(ConnectionRef, Channel, Bytes) ->
     ssh_connection_handler:adjust_window(ConnectionRef, Channel, Bytes).
-
-%%--------------------------------------------------------------------
--doc """
-Sets the SSH flow control mode. This can be done by the client- or server-side
-channel process.
-
-If the flow control mode is set to `auto` (default) then the channel process
-does not need to take any action with regard to flow control.
-If the flow control mode is set to `manual` then it is up to the channel process
-to send the window adjust messages by use of
-[ssh_connection:adjust_window/3](`adjust_window/3`).
-The flow control mode can be changed at any time when the corresponding channel
-is open.
-""".
-%%
--spec set_window_handling_mode(ConnectionRef, ChannelId, Mode) -> ok when
-      ConnectionRef :: ssh:connection_ref(),
-      ChannelId :: ssh:channel_id(),
-      Mode :: auto | manual.
-set_window_handling_mode(ConnectionRef, ChannelId, Mode) ->
-    ssh_connection_handler:set_window_handling_mode(ConnectionRef, ChannelId, Mode).
 
 %%--------------------------------------------------------------------
 -doc """

--- a/lib/ssh/test/ssh_echo_server.erl
+++ b/lib/ssh/test/ssh_echo_server.erl
@@ -56,14 +56,13 @@ handle_ssh_msg({ssh_cm, CM, {data, ChannelId, 0, Data}}, #state{n = N} = State) 
     M = N - size(Data),
     case M > 0 of
 	true ->
-            <<DWord:32, _/binary>> = Data,
-	    ?DBG(State, "ssh_cm data(~p) Cid=~p size(Data)=~p M=~p",[DWord, ChannelId,size(Data),M]),
+	    ?DBG(State, "ssh_cm data Cid=~p size(Data)=~p M=~p",[ChannelId,size(Data),M]),
+            ssh_connection:adjust_window(CM, ChannelId, size(Data)),
 	    ssh_connection:send(CM, ChannelId, Data),
 	    {ok, State#state{n = M}};
 	false ->
 	    <<SendData:N/binary, _/binary>> = Data,
-	    ?DBG(State, "ssh_cm data Cid=~p size(Data)=~p M=~p size(SendData)=~p~nSend eof",
-                [ChannelId, size(Data), M, size(SendData)]),
+	    ?DBG(State, "ssh_cm data Cid=~p size(Data)=~p M=~p size(SendData)=~p~nSend eof",[ChannelId,size(Data),M,size(SendData)]),
 	    ssh_connection:send(CM, ChannelId, SendData),
 	    ssh_connection:send_eof(CM, ChannelId),
 	    {stop, ChannelId, State}


### PR DESCRIPTION
The channel handler callback module can implement the get_adjust/0 function returning either 'immediate' or 'delayed' values.
In the latter case the channel handler module is responsible for invoking ssh_connection:adjust_window/3 to send ssh_msg_adjust_window to the peer.