### PR TITLE
os_mon: Fix use available mem for system_memory_high_watermark alarm

### DIFF
--- a/lib/os_mon/src/memsup.erl
+++ b/lib/os_mon/src/memsup.erl
@@ -29,7 +29,9 @@ Periodically performs a memory check:
 
 - If more than a certain amount of available system memory is allocated, as
   reported by the underlying operating system, the alarm
-  `{system_memory_high_watermark, []}` is set.
+  `{system_memory_high_watermark, []}` is set. How the amount of available
+  memory is determined depends on the underlying OS and may change as better
+  values become available.
 - If any Erlang process `Pid` in the system has allocated more than a certain
   amount of total system memory, the alarm
   `{process_memory_high_watermark, Pid}` is set.

--- a/lib/os_mon/test/memsup_SUITE.erl
+++ b/lib/os_mon/test/memsup_SUITE.erl
@@ -758,6 +758,9 @@ improved_system_memory_data(Config) when is_list(Config) ->
                 _ ->
                     {comment, "No available_memory present in result"}
             end;
+        {unix,darwin} ->
+            true = AvailableMemoryPresent,
+            {comment, "available_memory present in result"};
         _ ->
             ok
     end.


### PR DESCRIPTION
Fixes #8759

* Use `available memory` (when available) to calculate how much memory a system has used. 
* Add `available_memory` to `memsup:get_system_memory_data/1` result on Apple.

Fixes are for Linux` and Apple.