### PR TITLE
stdlib: Fix argparse:format_help for sub-commands

### DIFF
--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -1628,7 +1628,7 @@ format_help({ProgName, Root}, Format) ->
     %% usage line has hardcoded format for now
     Usage = [ProgName, ShortCmd, FlagsForm, Opts, Args],
     %% format usage according to help template
-    Template0 = maps:get(help, Root, ""),
+    Template0 = get_help(Root, Nested),
     %% when there is no help defined for the command, or help is a string,
     %% use the default format (original argparse behaviour)
     Template =
@@ -1658,6 +1658,14 @@ collect_options(CmdName, Command, [Cmd|Tail], Args) ->
     Sub = maps:get(commands, Command),
     SubCmd = maps:get(Cmd, Sub),
     collect_options(CmdName ++ " " ++ Cmd, SubCmd, Tail, Args ++ maps:get(arguments, Command, [])).
+
+%% gets help for sub-command
+get_help(Command, []) ->
+    maps:get(help, Command, "");
+get_help(Command, [Cmd|Tail]) ->
+    Sub = maps:get(commands, Command),
+    SubCmd = maps:get(Cmd, Sub),
+    get_help(SubCmd, Tail).
 
 %% conditionally adds text and empty lines
 maybe_add(_ToAdd, [], _Element, Template) ->

--- a/lib/stdlib/test/argparse_SUITE.erl
+++ b/lib/stdlib/test/argparse_SUITE.erl
@@ -751,6 +751,8 @@ usage(Config) when is_list(Config) ->
         "      [-t <t>] ---maybe-req -y <y> --yyy <y> [-u <u>] [-c <choice>] [-q <fc>]\n"
         "      [-w <ac>] [--unsafe <au>] [--safe <as>] [-foobar <long>] <server> [<optpos>]\n"
         "\n"
+        "verifies configuration and starts server\n"
+        "\n"
         "Subcommands:\n"
         "  crawler      controls crawler behaviour\n"
         "  doze         dozes a bit\n\n"
@@ -799,6 +801,8 @@ usage(Config) when is_list(Config) ->
         #{progname => erl}))),
     CrawlerStatus = "Usage:\n  erl status crawler [-rfv] [--force] [-i <interval>] [--req <weird>]\n"
         "      [--float <float>] [---extra <extra>]\n\n"
+        "crawler status\n"
+        "\n"
         "Optional arguments:\n"
         "  -r          recursive\n"
         "  -f, --force force\n"


### PR DESCRIPTION
When running this script:
```
#!/usr/bin/env escript

main(Args) ->
    argparse:run(Args, cli(), #{progname => cmd}).

cli() ->
    #{  
        commands => #{
            "sub-1" => #{
                commands => #{
                    "sub-1-1" => #{
                        arguments => [#{name => arg}],
                        help => "Help of sub-1-1 command"
                    }
                },
                help => "Help of sub-1 command"
            }
        },
        help => "Help of main command"
    }.
```
with these commands:
* ```./cmd```
* ```./cmd sub-1```
* ```./cmd sub-1 sub-1-1```

after _Usage_ section I'm always getting:
```
Help of main command
```
like:
```
$ ./cmd sub-1
error: cmd sub-1: subcommand expected
Usage:
  cmd sub-1 {sub-1-1}

Help of main command

Subcommands:
  sub-1-1 Help of sub-1-1 command

```
This commit fixes that so sub-commands help is used when possible, like:
```
$ ./cmd sub-1                                                                                                                                                                                
error: cmd sub-1: subcommand expected                                                                                                                                                        
Usage:                                                                                                                                                                                       
  cmd sub-1 {sub-1-1}                                                                                                                                                                        
                                                                                                                                                                                             
Help of sub-1 command                          

Subcommands:                                   
  sub-1-1 Help of sub-1-1 command              

```