### PR TITLE
stdlib: supervisor unlink_flush improvement

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -1521,16 +1521,25 @@ shutdown(#child{pid=Pid, shutdown=Time} = Child) ->
         end
     end.
 
-unlink_flush(Pid, DefaultReason) ->
-    %% We call unlink in order to guarantee that the 'EXIT' has arrived
-    %% from the dead process. See the unlink docs for details.
+unlink_flush(Pid, noproc) ->
+    {links, Ls} = process_info(self(),links),
+    Timeout = case lists:member(Pid, Ls) of
+                  true -> infinity;
+                  false -> 0
+              end,
+    receive
+        {'EXIT', Pid, ExitReason} ->
+            ExitReason
+    after Timeout ->
+            naughty_child
+    end;
+unlink_flush(Pid, ExitReason) ->
     unlink(Pid),
     receive
-        {'EXIT', Pid, Reason} ->
-            Reason
-    after 0 ->
-        DefaultReason
-    end.
+        {'EXIT', Pid, _} -> ok
+    after 0 -> ok
+    end,
+    ExitReason.
 
 %%-----------------------------------------------------------------
 %% Func: terminate_dynamic_children/1


### PR DESCRIPTION
- handling race between orderly shutdown from supervisor termination + and worker termination
- make sure to report and correct error reason if possible