### PR TITLE
asn1: Don't pass on the undec_rest option to the Erlang compiler

### DIFF
--- a/lib/asn1/src/asn1ct.erl
+++ b/lib/asn1/src/asn1ct.erl
@@ -1382,7 +1382,7 @@ is_asn1_flag(no_ok_wrapper) -> true;
 is_asn1_flag(optimize) -> true;
 is_asn1_flag(per) -> true;
 is_asn1_flag({record_name_prefix,_}) -> true;
-is_asn1_flag(undec_rec) -> true;
+is_asn1_flag(undec_rest) -> true;
 is_asn1_flag(uper) -> true;
 is_asn1_flag(verbose) -> true;
 %% 'warnings_as_errors' is intentionally passed through to the compiler.


### PR DESCRIPTION
Closes #8779