### PR TITLE
Add missing newline at the end of the slogan for Ctrl-c A

### DIFF
--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -613,7 +613,7 @@ do_break(void)
 		   */
 	    erts_exit(0, "");
 	case 'A':		/* Halt generating crash dump */
-	    erts_exit(ERTS_ERROR_EXIT, "Crash dump requested by user");
+	    erts_exit(ERTS_ERROR_EXIT, "Crash dump requested by user\n");
 	case 'c':
 	    return;
 	case 'p':


### PR DESCRIPTION
When going to BREAK mode (by pressing Ctrl-c) and then aborting with dump (by pressing A), the generated `erl_crash.dump` before this change looked like this:

```erlang
=erl_crash_dump:0.5
Thu Sep  5 15:34:20 2024
Slogan: Crash dump requested by userSystem version: Erlang/OTP 27 [erts-15.0.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit]
Taints:
Atoms: 10683
Calling Thread: erts_aux_1
=scheduler:1
…
```

…and after this change…

```erlang
=erl_crash_dump:0.5
Thu Sep  5 15:34:20 2024
Slogan: Crash dump requested by user
System version: Erlang/OTP 27 [erts-15.0.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit]
Taints:
Atoms: 10683
Calling Thread: erts_aux_1
=scheduler:1
…
```

For reference, call dumps with other slogans look like this…

```erlang
=erl_crash_dump:0.5
Thu Sep  5 15:34:20 2024
Slogan: My Slogan™️
System version: Erlang/OTP 27 [erts-15.0.1] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit]
Taints:
Atoms: 10683
Calling Thread: scheduler:1
=scheduler:1
…
```

That crash dump was generated like this…

```erlang
1> halt("My Slogan™️").
My Slogan™️

Crash dump is being written to: erl_crash.dump...done
```