### PR TITLE
Implement `read_ahead` option (OTP-19199)

### DIFF
--- a/lib/kernel/src/gen_tcp_socket.erl
+++ b/lib/kernel/src/gen_tcp_socket.erl
@@ -1350,7 +1350,8 @@ server_read_opts() ->
         header => 0,
         deliver => term,
         start_opts => [], % Just to make it settable
-        line_delimiter => $\n},
+        line_delimiter => $\n,
+        read_ahead => false},
       server_read_write_opts()).
 -compile({inline, [server_write_opts/0]}).
 server_write_opts() ->
@@ -1955,16 +1956,23 @@ handle_event(Type, Content, #connect{} = State, P_D) ->
 
 %% State: #connect{}
 %% -------
-%% State: 'connected'
+%% State: 'connected' | #recv{}
 
 handle_event(
   {call, From}, {recv, Length, Timeout}, State, {P, D}) ->
     %% ?DBG([recv, {length, Length}, {timeout, Timeout}, {state, State}]),
     case State of
         'connected' ->
-            handle_recv(
-              P, D#{recv_length => Length, recv_from => From},
-              [{{timeout, recv}, Timeout, recv}]);
+            Packet = maps:get(packet, D),
+            if
+                Packet =/= raw, Packet =/= 0, 0 < Length ->
+                    %% Nonzero Length not allowed in packet mode (non-raw)
+                    {keep_state_and_data, [{reply, From, {error, einval}}]};
+                true ->
+                    handle_recv(
+                      P, D#{recv_length => Length, recv_from => From},
+                      [{{timeout, recv}, Timeout, recv}])
+            end;
         #recv{} ->
             case maps:get(active, D) of
                 false ->
@@ -1977,7 +1985,7 @@ handle_event(
             end
     end;
 
-%% State: 'connected'
+%% State: 'connected' | #recv{}
 %% -------
 %% State: #recv{}
 
@@ -2000,16 +2008,7 @@ handle_event(
   #recv{info = ?completion_info(CompletionRef)} = _State,
   {#params{socket = Socket} = P, D}) ->
     %% ?DBG(['completion msg', {socket, Socket}, {ref, CompletionRef}]),
-    case CompletionStatus of
-        {ok, <<Data/binary>>} ->
-            D_1 = D#{buffer := buffer(Data, maps:get(buffer, D))},
-            handle_recv(P, D_1, []);
-        {error, {Reason, <<Data/binary>>}} ->
-            D_1 = D#{buffer := buffer(Data, maps:get(buffer, D))},
-            handle_recv_error(P, D_1, [], Reason);
-        {error, Reason} ->
-            handle_recv_error(P, D, [], Reason)
-    end;
+    handle_recv(P, D, [], CompletionStatus);
 
 handle_event(
   info, ?socket_abort(Socket, CompletionRef, Reason),
@@ -2259,6 +2258,294 @@ handle_connected(P, D, ActionsR) ->
     end.
 
 
+handle_recv(P, D, ActionsR) ->
+    handle_recv(P, D, ActionsR, recv).
+
+handle_recv(
+  P, #{packet := Packet, recv_length := Length} = D, ActionsR, CS) ->
+    if
+        Packet =:= raw;
+        Packet =:= 0 ->
+            %% Length is 0 meaning "what's available"
+            %% or > 0 meaning exactly that many bytes
+            handle_recv_raw(P, D, ActionsR, Length, CS);
+        true ->
+            handle_recv_packet(P, D, ActionsR, CS)
+    end.
+
+handle_recv_raw(P, #{buffer := Buffer} = D, ActionsR, Length, CS) ->
+    handle_recv_raw(P, D, ActionsR, Length, Buffer, CS).
+
+handle_recv_raw(P, D, ActionsR, Length, Buffer, recv) ->
+    Size = iolist_size(Buffer),
+    if
+        0 < Length, Length =< Size ->
+            %% We have more buffered than requested
+            %%
+            {Data, NewBuffer} =
+                split_binary(condense_buffer(Buffer), Length),
+            handle_recv_deliver(P, D#{buffer := NewBuffer}, [], Data);
+
+        Length == 0, 0 < Size ->
+            %% We have some buffered and "what's available" requested
+            handle_recv_deliver(
+              P, D#{buffer := <<>>}, ActionsR, condense_buffer(Buffer));
+
+        true ->
+            %% Less buffered than requested
+            %% or empty buffer and "what's available" requested
+            %%
+            %% i.e Length == 0, Size == 0;
+            %%     0 < Length, Size < Length
+            %% In both cases this works:
+            N = Length - Size,
+            case socket_recv(P#params.socket, N) of
+                {ok, <<Data/binary>>} ->
+                    handle_recv_deliver(
+                      P, D#{buffer := <<>>}, ActionsR,
+                      condense_buffer(Data, Buffer));
+
+                {select, {?select_info(_) = SelectInfo, Data}} ->
+                    if
+                        0 < Length ->
+                            %% Need to wait for the rest of the data
+                            {next_state,
+                             #recv{info = SelectInfo},
+                             {P, D#{buffer := buffer(Data, Buffer)}},
+                             reverse(ActionsR)};
+                        true -> %% Length == 0, Size == 0
+                            %% We take what we just got
+                            %% and cancel the async recv
+                            Socket = P#params.socket,
+                            case socket:cancel(Socket, SelectInfo) of
+                                ok ->
+                                    handle_recv_deliver(
+                                      P, D, ActionsR, Data);
+                                {error, Reason} ->
+                                    handle_recv_error(
+                                      P, D, ActionsR, Reason, Data)
+                            end
+                    end;
+
+                {select, ?select_info(_) = SelectInfo} ->
+                    %% ?DBG(['recv select']),
+                    {next_state,
+                     #recv{info = SelectInfo}, {P, D}, reverse(ActionsR)};
+
+                {completion, ?completion_info(_) = CompletionInfo} ->
+                    %% ?DBG(['recv completion']),
+                    {next_state,
+                     #recv{info = CompletionInfo}, {P, D}, reverse(ActionsR)};
+
+                {error, {Reason, <<Data/binary>>}} ->
+                    %% ?DBG({'recv error', Reason, byte_size(Data)}),
+                    if
+                        0 < Length ->
+                            %% We didn't get all data we requested
+                            handle_recv_error(
+                              P, D#{buffer := buffer(Data, Buffer)},
+                              ActionsR, Reason);
+                        true ->
+                            %% Deliver what we got, then error
+                            handle_recv_error(P, D, ActionsR, Reason, Data)
+                    end;
+                {error, Reason} ->
+                    %% ?DBG({'recv error', Reason}),
+                    handle_recv_error(P, D, ActionsR, Reason)
+            end
+    end;
+handle_recv_raw(P, D, ActionsR, Length, Buffer, CompletionStatus) ->
+    case CompletionStatus of
+        {ok, <<Data/binary>>} ->
+            handle_recv_raw(
+              P, D, ActionsR, Length, buffer(Data, Buffer), recv);
+        {error, {Reason, <<Data/binary>>}} ->
+            if
+                0 < Length ->
+                    %% We didn't get all data we requested
+                    handle_recv_error(
+                      P, D#{buffer := buffer(Data, Buffer)},
+                      ActionsR, Reason);
+                true ->
+                    %% Deliver "what's available", then error
+                    handle_recv_error(P, D, ActionsR, Reason, Data)
+            end;
+        {error, Reason} ->
+            handle_recv_error(P, D#{buffer := Buffer}, [], Reason)
+    end.
+
+
+handle_recv_packet(
+  P, #{recv_length := Length, buffer := Buffer} = D, ActionsR, recv) ->
+    if
+        0 < Length ->
+            %% We know how much we need for a packet
+            handle_recv_more(P, D, ActionsR, Length, Buffer);
+        true ->
+            handle_recv_decode(P, D, ActionsR, condense_buffer(Buffer))
+    end;
+handle_recv_packet(P, #{buffer := Buffer} = D, ActionsR, CompletionStatus) ->
+    case CompletionStatus of
+        {ok, <<Data/binary>>} ->
+            handle_recv_decode(
+              P, D, ActionsR, condense_buffer(Data, Buffer));
+        {error, {Reason, <<Data/binary>>}} ->
+            handle_recv_error_decode(
+              P, D, ActionsR, Reason, condense_buffer(Data, Buffer));
+        {error, Reason} ->
+            handle_recv_error(P, D, ActionsR, Reason)
+    end.
+
+handle_recv_more(P, D, ActionsR, Length, Buffer) ->
+    Size = iolist_size(Buffer),
+    if
+        Length =< Size ->
+            %% We have more buffered than we need
+            %%
+            handle_recv_decode(P, D, ActionsR, condense_buffer(Buffer));
+        true ->
+            N = Length - Size,
+            case socket_recv(P#params.socket, N) of
+                {ok, <<Data/binary>>} ->
+                    handle_recv_decode(
+                      P, D, ActionsR, condense_buffer(Data, Buffer));
+
+                {select, {?select_info(_) = SelectInfo, Data}} ->
+                    %% Need to wait for the rest of the data
+                    {next_state,
+                     #recv{info = SelectInfo},
+                     {P, D#{buffer := buffer(Data, Buffer)}},
+                     reverse(ActionsR)};
+
+                {select, ?select_info(_) = SelectInfo} ->
+                    %% ?DBG(['recv select']),
+                    {next_state,
+                     #recv{info = SelectInfo},
+                     {P, D#{buffer := Buffer}},
+                     reverse(ActionsR)};
+
+                {completion, ?completion_info(_) = CompletionInfo} ->
+                    %% ?DBG(['recv completion']),
+                    {next_state,
+                     #recv{info = CompletionInfo},
+                     {P, D#{buffer := Buffer}},
+                     reverse(ActionsR)};
+
+                {error, {Reason, <<Data/binary>>}} ->
+                    %% ?DBG({'recv error', Reason, byte_size(Data)}),
+                    handle_recv_error_decode(
+                      P, D, ActionsR, Reason, condense_buffer(Data, Buffer));
+                {error, Reason} ->
+                    %% ?DBG({'recv error', Reason}),
+                    handle_recv_error(P, D, ActionsR, Reason)
+            end
+    end.
+
+handle_recv_decode(P, D, ActionsR, Data) ->
+    %% ?DBG({}),
+    case decode_packet(D, Data) of
+        {D_1, ok, Decoded} ->
+            handle_recv_deliver(P, D_1, ActionsR, Decoded);
+        {D_1, more, Length} ->
+            handle_recv_more(P, D_1, ActionsR, Length, Data);
+        {D_1, error, invalid} ->
+            handle_recv_error(P, D_1, ActionsR, emsgsize);
+        {D_1, error, Reason} ->
+            handle_recv_error(P, D_1, ActionsR, Reason)
+    end.
+
+handle_recv_error_decode(P, D, ActionsR, Reason, Data) ->
+    case decode_packet(D, Data) of
+        {D_1, ok, Decoded} ->
+            handle_recv_error(P, D_1, ActionsR, Reason, Decoded);
+        {D_1, error, invalid} ->
+            handle_recv_error(P, D_1, ActionsR, emsgsize);
+        {D_1, _, _} ->
+            handle_recv_error(P, D_1, ActionsR, Reason)
+    end.
+
+decode_packet(
+  #{packet         := (PacketType = line),
+    line_delimiter := LineDelimiter,
+    packet_size    := PacketSize} = D,
+  Data) ->
+    %%
+    decode_packet(
+      D, Data, PacketType,
+      [{packet_size,    PacketSize},
+       {line_delimiter, LineDelimiter},
+       {line_length,    PacketSize}]);
+decode_packet(
+  #{packet         := http,
+    recv_httph     := true,
+    packet_size    := PacketSize} = D,
+  Data) ->
+    %%
+    decode_packet(D, Data, httph, [{packet_size, PacketSize}]);
+decode_packet(
+  #{packet         := http_bin,
+    recv_httph     := true,
+    packet_size    := PacketSize} = D,
+  Data) ->
+    %%
+    decode_packet(D, Data, httph_bin, [{packet_size, PacketSize}]);
+decode_packet(
+  #{packet         := PacketType,
+    packet_size    := PacketSize} = D,
+  Data) ->
+    %%
+    decode_packet(D, Data, PacketType, [{packet_size, PacketSize}]).
+
+decode_packet(D, Data, PacketType, Options) ->
+    case
+        erlang:decode_packet(PacketType, Data, Options)
+    of
+        {ok, Decoded, Rest} ->
+            %% ?DBG({ok, PacketType, byte_size(Decoded)}),
+            {D#{buffer := Rest}, ok, Decoded};
+        Other ->
+            decode_packet_common(D, Data, PacketType, Other)
+    end.
+
+decode_packet_common(D, Data, PacketType, Other) ->
+    case Other of
+        {more, undefined} ->
+            Length = packet_header_length(PacketType, Data),
+            {D, more, Length};
+        {more, Length} ->
+            {D#{recv_length := Length}, more, Length};
+        {error, Reason} ->
+            {D, error, Reason}
+    end.
+
+packet_header_length(PacketType, Data) ->
+    case PacketType of
+        raw     -> error(badarg, [PacketType, Data]);
+        0       -> error(badarg, [PacketType, Data]);
+        1       -> 1;
+        2       -> 2;
+        4       -> 4;
+        cdr     -> 12;
+        sunrm   -> 4;
+        fcgi    -> 8;
+        tpkt    -> 4;
+        ssl     -> 5;
+        ssl_tls -> 5;
+        %% For these variable length headers/footers we guess one more
+        %% since this function is only called if Data is too short,
+        %% which can be very inefficient, but we consider it to be
+        %% misuse to combine read_ahead=false with such header types
+        asn1    ->
+            max(2, iolist_size(Data) + 1);
+        _       -> % http, line, etc
+            iolist_size(Data) + 1
+    end.
+
+
+
+
+
+-ifdef(undefined).
 handle_recv(
   P, #{packet := Packet, recv_length := Length, buffer := Buffer} = D,
   ActionsR)
@@ -2409,14 +2696,14 @@ decode_packet(D, Other) ->
         {error, Reason} ->
             {D, error, Reason}
     end.
+-endif.
+
+
 
 handle_recv_deliver(P, D, ActionsR, Data) ->
     handle_connected(P, recv_data_deliver(P, D, ActionsR, Data)).
 
 
-handle_recv_error(P, {D, ActionsR}, Reason) ->
-    handle_recv_error(P, D, ActionsR, Reason).
-%%
 handle_recv_error(P, D, ActionsR, Reason) ->
     handle_recv_error(P, D, ActionsR, Reason, undefined).
 %%
@@ -2545,8 +2832,18 @@ handle_active(P, D, State, ActionsR) ->
     case State of
         'connected' ->
             handle_connected(P, D, reverse(ActionsR));
+        #recv{info = Info} ->
+            case D of
+                #{active := false} ->
+                    %% Cancel recv in progress
+                    _ = socket_cancel(P#params.socket, Info),
+                    {next_state, 'connected',
+                     {P, D}, reverse(ActionsR)};
+                #{active := _} ->
+                    {keep_state, {P, D}, reverse(ActionsR)}
+            end;
         _ ->
-            {next_state, State, {P, D}, reverse(ActionsR)}
+            {keep_state, {P, D}, reverse(ActionsR)}
     end.
 
 %% -------------------------------------------------------------------------
@@ -2652,14 +2949,23 @@ next_packet(D, Packet, Data, Active) ->
 buffer(Data, <<>>) ->
     Data;
 buffer(Data, Buffer) ->
-    [Data | Buffer].
+    if
+        is_binary(Buffer) ->
+            [Data, Buffer];
+        is_list(Buffer) ->
+            [Data | Buffer]
+    end.
 
 %% Condense buffer into a Binary
 -compile({inline, [condense_buffer/1]}).
 condense_buffer(Bin) when is_binary(Bin) -> Bin;
 condense_buffer([Bin]) when is_binary(Bin) -> Bin;
 condense_buffer(Buffer) ->
-    iolist_to_binary(reverse_improper(Buffer, [])).
+    iolist_to_binary(reverse(Buffer)).
+
+condense_buffer(Data, Buffer) ->
+    condense_buffer(buffer(Data, Buffer)).
+
 
 deliver_data(Data, Mode, Header, Packet) ->
     if
@@ -3117,11 +3423,13 @@ reverse([A], L) -> [A | L];
 reverse([A, B], L) -> [B, A | L];
 reverse(L1, L2) -> lists:reverse(L1, L2).
 
+-ifdef(undefined).
 %% Reverse but allow improper list
 reverse_improper([H | T], Acc) ->
     reverse_improper(T, [H | Acc]);
 reverse_improper([], Acc) -> Acc;
 reverse_improper(T, Acc) -> [T | Acc].
+-endif.
 
 
 is_map_keys([], #{}) -> false;

--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -1300,6 +1300,27 @@ The following options are available:
 
 - **`{raw, Protocol, OptionNum, ValueBin}`** - See below.
 
+- **`{read_ahead, Boolean}`** [](){: #option-read_ahead } -
+  If set to `false` avoids reading ahead from the OS socket layer.
+  The default for this option is `true` which speeds up packet header parsing.
+  Setting `false` has a performance penalty because the packet header
+  has to be read first, to know exactly how many bytes to read for the body,
+  which roughly doubles the number of read operations.
+
+  The use of this option is essential for example before switching to kTLS
+  which activates OS socket layer encryption and decryption by setting
+  special (raw) socket options.  So if the Erlang socket layer has read ahead,
+  it has read bytes that was for the OS socket layer to decrypt,
+  which makes packet decryption derail for the connection.
+
+  > #### Warning {: .warning }
+  >
+  > For packet modes that doesn't have the packet length at a fixed location
+  > in a packet header, such as `line` or `asn1`, not reading ahead
+  > can become very inefficient since sometimes the only way to accomplish
+  > this is to read one byte at the time until the length
+  > or packet end is found.
+
 - **`{read_packets, Integer}` (UDP sockets)** [](){: #option-read_packets } -
   Sets the maximum number of UDP packets to read without intervention
   from the socket when data is available.  When this many packets

--- a/lib/kernel/test/gen_tcp_echo_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_echo_SUITE.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %% 
-%% Copyright Ericsson AB 1997-2021. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2024. All Rights Reserved.
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -35,17 +35,35 @@
 -define(LINE_LENGTH, 1023). % (default value of gen_tcp option 'recbuf') - 1
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
-     {timetrap,{minutes,5}}].
+    [{ct_hooks, [ts_install_cth]},
+     {timetrap, {minutes,1}}].
 
-all() -> 
+all() ->
+    case kernel_test_lib:test_inet_backends() of
+        true ->
+            [{group, inet_backend_inet},
+             {group, inet_backend_socket}];
+        false ->
+            [{group, inet_backend_default}]
+    end.
+
+groups() ->
+    [{inet_backend_default, [{group, read_ahead}, {group, no_read_ahead}]},
+     {inet_backend_socket,  [{group, read_ahead}, {group, no_read_ahead}]},
+     {inet_backend_inet,    [{group, read_ahead}, {group, no_read_ahead}]},
+     %%
+     {read_ahead,       [{group, no_delay_send}, {group, delay_send}]},
+     {no_read_ahead,    [{group, no_delay_send}, {group, delay_send}]},
+     %%
+     {no_delay_send,    testcases()},
+     {delay_send,       testcases()}].
+
+testcases() ->
     [active_echo, passive_echo, active_once_echo,
      slow_active_echo, slow_passive_echo, limit_active_echo,
      limit_passive_echo, large_limit_active_echo,
      large_limit_passive_echo].
 
-groups() -> 
-    [].
 
 init_per_suite(Config) ->
     Config.
@@ -53,140 +71,183 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_group(_GroupName, Config) ->
+
+init_per_group(Name, Config) ->
+    case Name of
+        inet_backend_default ->
+            kernel_test_lib:config_inet_backend(Config, default);
+        inet_backend_socket ->
+            init_per_group_inet_backend(socket, Config);
+        inet_backend_inet ->
+            init_per_group_inet_backend(inet, Config);
+        %%
+        no_read_ahead   -> [{read_ahead, false} | Config];
+        delay_send      -> [{delay_send, true}  | Config];
+        _ -> Config
+    end.
+
+init_per_group_inet_backend(Backend, Config) ->
+    case kernel_test_lib:explicit_inet_backend() of
+        true ->
+            %% Contradicting kernel variables - skip group
+            {skip, "explicit inet backend"};
+        false ->
+            kernel_test_lib:config_inet_backend(Config, Backend)
+    end.
+
+end_per_group(Name, Config) ->
+    case Name of
+        no_read_ahead   -> lists:keydelete(read_ahead, 1, Config);
+        delay_send      -> lists:keydelete(delay_send, 1, Config);
+        _ -> Config
+    end.
+
+
+init_per_testcase(Name, Config) ->
+    _ =
+        case Name of
+            slow_active_echo    -> ct:timetrap({minutes, 5});
+            slow_passive_echo   -> ct:timetrap({minutes, 5});
+            _ -> ok
+        end,
     Config.
 
-end_per_group(_GroupName, Config) ->
-    Config.
-
-
-init_per_testcase(_Func, Config) ->
-    Config.
-
-end_per_testcase(_Func, _Config) ->
+end_per_testcase(_Name, _Config) ->
     ok.
+
+
+sockopts(Config) ->
+    [Option ||
+        {Name, _} = Option <- Config,
+        lists:member(Name, [read_ahead, delay_send])].
+
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in active mode).
 active_echo(Config) when is_list(Config) ->
-    echo_test([], fun active_echo/4, [{echo, fun echo_server/0}]).
+    echo_test(Config, [], fun active_echo/4, [{echo, fun echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in passive mode).
 passive_echo(Config) when is_list(Config) ->
-    echo_test([{active, false}], fun passive_echo/4,
-	      [{echo, fun echo_server/0}]).
+    echo_test(
+      Config, [{active, false}], fun passive_echo/4,
+      [{echo, fun echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in active once mode).
 active_once_echo(Config) when is_list(Config) ->
-    echo_test([{active, once}], fun active_once_echo/4,
-	      [{echo, fun echo_server/0}]).
+    echo_test(
+      Config, [{active, once}], fun active_once_echo/4,
+      [{echo, fun echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in active mode).
 %% The echo server is a special one that delays between every character.
 slow_active_echo(Config) when is_list(Config) ->
-    echo_test([], fun active_echo/4,
-	      [slow_echo, {echo, fun slow_echo_server/0}]).
+    echo_test(
+      Config, [], fun active_echo/4,
+      [slow_echo, {echo, fun slow_echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to an echo server and receiving them again (socket in passive mode).
 %% The echo server is a special one that delays between every character.
 slow_passive_echo(Config) when is_list(Config) ->
-    echo_test([{active, false}], fun passive_echo/4,
-	      [slow_echo, {echo, fun slow_echo_server/0}]).
+    echo_test(
+      Config, [{active, false}], fun passive_echo/4,
+      [slow_echo, {echo, fun slow_echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in active mode)
 %% with packet_size limitation.
 limit_active_echo(Config) when is_list(Config) ->
-    echo_test([{packet_size, 10}],
-	      fun active_echo/4,
-	      [{packet_size, 10}, {echo, fun echo_server/0}]).
+    echo_test(
+      Config, [{packet_size, 10}], fun active_echo/4,
+      [{packet_size, 10}, {echo, fun echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in passive mode)
 %% with packet_size limitation.
 limit_passive_echo(Config) when is_list(Config) ->
-    echo_test([{packet_size, 10},{active, false}],
-	      fun passive_echo/4,
-	      [{packet_size, 10}, {echo, fun echo_server/0}]).
+    echo_test(
+      Config, [{packet_size, 10},{active, false}], fun passive_echo/4,
+      [{packet_size, 10}, {echo, fun echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in active mode)
 %% with large packet_size limitation.
 large_limit_active_echo(Config) when is_list(Config) ->
-    echo_test([{packet_size, 10}],
-	      fun active_echo/4,
-	      [{packet_size, (1 bsl 32)-1},
-	       {echo, fun echo_server/0}]).
+    echo_test(
+      Config, [{packet_size, 10}], fun active_echo/4,
+      [{packet_size, (1 bsl 32)-1}, {echo, fun echo_server/0}]).
 
 %% Test sending packets of various sizes and various packet types
 %% to the echo port and receiving them again (socket in passive mode)
 %% with large packet_size limitation.
 large_limit_passive_echo(Config) when is_list(Config) ->
-    echo_test([{packet_size, 10},{active, false}],
-	      fun passive_echo/4,
-	      [{packet_size, (1 bsl 32) -1},
-	       {echo, fun echo_server/0}]).
+    echo_test(
+      Config, [{packet_size, 10},{active, false}], fun passive_echo/4,
+      [{packet_size, (1 bsl 32) -1}, {echo, fun echo_server/0}]).
 
-echo_test(SockOpts, EchoFun, Config0) ->
-    echo_test_1(SockOpts, EchoFun, Config0),
-    io:format("\nrepeating test with {delay_send,true}"),
-    echo_test_1([{delay_send,true}|SockOpts], EchoFun, Config0).
-
-echo_test_1(SockOpts, EchoFun, Config0) ->
-    EchoSrvFun = proplists:get_value(echo, Config0),
+echo_test(Config, SockOpts_0, EchoFun, EchoOpts_0) ->
+    SockOpts = SockOpts_0 ++ sockopts(Config),
+    ct:log("SockOpts = ~p.", [SockOpts]),
+    EchoSrvFun = proplists:get_value(echo, EchoOpts_0),
     {ok, EchoPort} = EchoSrvFun(),
-    Config = [{echo_port, EchoPort}|Config0],
+    EchoOpts = [{echo_port, EchoPort}|EchoOpts_0],
 
-    echo_packet([{packet, 1}|SockOpts], EchoFun, Config),
-    echo_packet([{packet, 2}|SockOpts], EchoFun, Config),
-    echo_packet([{packet, 4}|SockOpts], EchoFun, Config),
-    echo_packet([{packet, sunrm}|SockOpts], EchoFun, Config),
-    echo_packet([{packet, cdr}|SockOpts], EchoFun,
-		[{type, {cdr, big}}|Config]),
-    echo_packet([{packet, cdr}|SockOpts], EchoFun,
-		[{type, {cdr, little}}|Config]),
+    echo_packet(Config, [{packet, 1}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, 2}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, 4}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, sunrm}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, cdr}|SockOpts], EchoFun,
+		[{type, {cdr, big}}|EchoOpts]),
+    echo_packet(Config, [{packet, cdr}|SockOpts], EchoFun,
+		[{type, {cdr, little}}|EchoOpts]),
     case lists:keymember(packet_size, 1, SockOpts) of
 	false ->
 	    %% This is cheating, we should test that packet_size
 	    %% also works for line and http.
-	    echo_packet([{packet, line}|SockOpts], EchoFun, Config),
-	    echo_packet([{packet, http}|SockOpts], EchoFun, Config),
-	    echo_packet([{packet, http_bin}|SockOpts], EchoFun, Config);
+	    echo_packet(
+              Config, [{packet, line}|SockOpts], EchoFun, EchoOpts),
+	    echo_packet(
+              Config, [{packet, http}|SockOpts], EchoFun, EchoOpts),
+	    echo_packet(
+              Config, [{packet, http_bin}|SockOpts], EchoFun, EchoOpts);
 
 	true -> ok
     end,
-    echo_packet([{packet, tpkt}|SockOpts], EchoFun, Config),
+    echo_packet(Config, [{packet, tpkt}|SockOpts], EchoFun, EchoOpts),
 
     ShortTag = [16#E0],
     LongTag = [16#1F, 16#83, 16#27],
-    echo_packet([{packet, asn1}|SockOpts], EchoFun,
-		[{type, {asn1, short, ShortTag}}|Config]),
-    echo_packet([{packet, asn1}|SockOpts], EchoFun,
-		[{type, {asn1, long, ShortTag}}|Config]),
-    echo_packet([{packet, asn1}|SockOpts], EchoFun,
-		[{type, {asn1, short, LongTag}}|Config]),
-    echo_packet([{packet, asn1}|SockOpts], EchoFun,
-		[{type, {asn1, long, LongTag}}|Config]),
+    echo_packet(Config, [{packet, asn1}|SockOpts], EchoFun,
+		[{type, {asn1, short, ShortTag}}|EchoOpts]),
+    echo_packet(Config, [{packet, asn1}|SockOpts], EchoFun,
+		[{type, {asn1, long, ShortTag}}|EchoOpts]),
+    echo_packet(Config, [{packet, asn1}|SockOpts], EchoFun,
+		[{type, {asn1, short, LongTag}}|EchoOpts]),
+    echo_packet(Config, [{packet, asn1}|SockOpts], EchoFun,
+		[{type, {asn1, long, LongTag}}|EchoOpts]),
     ok.
 
-echo_packet(SockOpts, EchoFun, Opts) ->
-    Type = case lists:keysearch(type, 1, Opts) of
-	       {value, {type, T}} ->
+echo_packet(Config, SockOpts, EchoFun, EchoOpts) ->
+    Type = case lists:keyfind(type, 1, EchoOpts) of
+	       {_, T} ->
 		   T;
-	       _ ->
-		   {value, {packet, T}} = lists:keysearch(packet, 1, SockOpts),
+	       false ->
+		   {_, T} = lists:keyfind(packet, 1, SockOpts),
 		   T
 	   end,
 
     %% Connect to the echo server.
-    EchoPort = proplists:get_value(echo_port, Opts),
-    {ok, Echo} = gen_tcp:connect(localhost, EchoPort, SockOpts),
+    EchoPort = proplists:get_value(echo_port, EchoOpts),
+    {ok, Echo} =
+        kernel_test_lib:connect(Config, localhost, EchoPort, SockOpts),
 
-    SlowEcho = lists:member(slow_echo, Opts),
+    ct:pal("Echo socket: ~w", [Echo]),
+
+    SlowEcho = lists:member(slow_echo, EchoOpts),
 
     case Type of
 	http ->
@@ -194,7 +255,7 @@ echo_packet(SockOpts, EchoFun, Opts) ->
 	http_bin ->
 	    echo_packet_http(Echo, Type, EchoFun);
 	_ ->
-	    echo_packet0(Echo, Type, EchoFun, SlowEcho, Opts)
+	    echo_packet0(Echo, Type, EchoFun, SlowEcho, EchoOpts)
     end.
 
 echo_packet_http(Echo, Type, EchoFun) ->
@@ -205,11 +266,11 @@ echo_packet_http(Echo, Type, EchoFun) ->
     P2 = http_response(),
     EchoFun(Echo, Type, P2, http_reply(P2, Type)).
 
-echo_packet0(Echo, Type, EchoFun, SlowEcho, Opts) ->
+echo_packet0(Echo, Type, EchoFun, SlowEcho, EchoOpts) ->
     PacketSize =
-	case lists:keysearch(packet_size, 1, Opts) of
-	    {value,{packet_size,Sz}} when Sz < 10 -> Sz;
-	    {value,{packet_size,_}} -> 10;
+	case lists:keyfind(packet_size, 1, EchoOpts) of
+	    {_,Sz} when Sz < 10 -> Sz;
+	    {_,_} -> 10;
 	    false -> 0
 	end,
     ct:log("echo_packet0[~w] ~p", [self(), PacketSize]),
@@ -265,7 +326,7 @@ echo_packet1(EchoSock, Type, EchoFun, Size) ->
 	false ->
 	    ok;
 	Packet ->
-	    io:format("Type ~p, size ~p, time ~p",
+	    ct:log("Type ~p, size ~p, time ~p",
 		      [Type, Size, time()]),
 	    case EchoFun(EchoSock, Type, Packet, [Packet]) of
 		ok ->
@@ -278,7 +339,7 @@ echo_packet1(EchoSock, Type, EchoFun, Size) ->
 		{error, emsgsize} ->
 		    case Size of
 			{N, Max} when N > Max ->
-			    io:format(" Blocked!");
+			    ct:log(" Blocked!");
 			_ ->
 			    ct:fail(
 			      {packet_blocked, Size})
@@ -301,7 +362,7 @@ active_recv(Sock, Type, [PacketEcho|Tail]) ->
 	      _ -> tcp
 	  end,
     receive Recv->Recv end,
-    %%io:format("Active received: ~p\n",[Recv]),
+    %%ct:log("Active received: ~p\n",[Recv]),
     case Recv of
 	{Tag, Sock, PacketEcho} ->
 	    active_recv(Sock, Type, Tail);
@@ -323,12 +384,12 @@ passive_recv(_, []) ->
     ok;
 passive_recv(Sock, [PacketEcho | Tail]) ->
     Recv = gen_tcp:recv(Sock, 0),
-    %%io:format("Passive received: ~p\n",[Recv]),
+    %%ct:log("Passive received: ~p\n",[Recv]),
     case Recv of
 	{ok, PacketEcho} ->
 	    passive_recv(Sock, Tail);
 	{ok, Bad} ->
-	    io:format("Expected: ~p\nGot: ~p\n",[PacketEcho,Bad]),
+	    ct:log("Expected: ~p\nGot: ~p\n",[PacketEcho,Bad]),
 	    ct:fail({wrong_data, Bad, PacketEcho});
 	{error,PacketEcho} ->
 	    passive_recv(Sock, Tail); % expected error
@@ -575,7 +636,7 @@ http_reply(Bin, Type) ->
 		http_bin -> httph_bin
 	    end,
     Ret = lists:reverse(http_reply(Rest,[Line],HType)),
-    io:format("HTTP: ~p\n",[Ret]),
+    ct:log("HTTP: ~p\n",[Ret]),
     Ret.
 
 http_reply(<<>>, Acc, _) ->


### PR DESCRIPTION
Continuation of PR #8690 that implements the `read_ahead` option in `inet:setopts/2`, that is; also for `inet_backend=socket` (`gen_tcp_socket`), with documentation, and test cases.