### PR TITLE
ssl:  Refactor sslsocket to ease maintenance and extension

### DIFF
--- a/lib/ssl/src/dtls_packet_demux.erl
+++ b/lib/ssl/src/dtls_packet_demux.erl
@@ -173,8 +173,9 @@ handle_call({new_connection, Old, _Pid}, _,
     end;
 
 handle_call({get_sock_opts, {SocketOptNames, EmOptNames}}, _, #state{listener = Socket,
+                                                                     transport = TransportInfo,
                                                                      emulated_options = EmOpts} = State) ->
-    case get_socket_opts(Socket, SocketOptNames) of
+    case get_socket_opts(Socket, SocketOptNames,  element(1, TransportInfo)) of
         {ok, Opts} ->
             {reply, {ok, emulated_opts_list(EmOpts, EmOptNames, []) ++ Opts}, State};
         {error, Reason} ->
@@ -183,15 +184,17 @@ handle_call({get_sock_opts, {SocketOptNames, EmOptNames}}, _, #state{listener = 
 handle_call(get_all_opts, _, #state{dtls_options = DTLSOptions,
                                     emulated_options = EmOpts} = State) ->
     {reply, {ok, EmOpts, DTLSOptions}, State};
-handle_call({set_sock_opts, {SocketOpts, NewEmOpts}}, _, #state{listener = Socket, emulated_options = EmOpts0} = State) ->
-    set_socket_opts(Socket, SocketOpts),
+handle_call({set_sock_opts, {SocketOpts, NewEmOpts}}, _, #state{listener = Socket, emulated_options = EmOpts0,
+                                                                transport = TransportInfo} = State) ->
+    set_socket_opts(Socket, SocketOpts, element(1, TransportInfo)),
     EmOpts = do_set_emulated_opts(NewEmOpts, EmOpts0),
     {reply, ok, State#state{emulated_options = EmOpts}};
-handle_call({set_all_opts, {SocketOpts, NewEmOpts, SslOpts}}, _, #state{listener = Socket} = State) ->
-    set_socket_opts(Socket, SocketOpts),
+handle_call({set_all_opts, {SocketOpts, NewEmOpts, SslOpts}}, _, #state{listener = Socket,
+                                                                        transport = TransportInfo} = State) ->
+    set_socket_opts(Socket, SocketOpts, element(1, TransportInfo)),
     {reply, ok, State#state{emulated_options = NewEmOpts, dtls_options = SslOpts}};
-handle_call({getstat, Options}, _,  #state{listener = Socket, transport =  {TransportCb, _,_,_,_}} = State) ->
-    Stats = dtls_socket:getstat(TransportCb, Socket, Options),
+handle_call({getstat, Options}, _,  #state{listener = Socket, transport =  TransportInfo} = State) ->
+    Stats = dtls_socket:getstat(element(1, TransportInfo), Socket, Options),
     {reply, Stats, State}.
 
 handle_cast({active_once, Client, Pid}, State0) ->
@@ -386,15 +389,19 @@ call(Server, Msg) ->
             {error, closed}
     end.
 
-set_socket_opts(_, []) ->
+set_socket_opts(_, [], _) ->
     ok;
-set_socket_opts(Socket, SocketOpts) ->
-    inet:setopts(Socket, SocketOpts).
+set_socket_opts(Socket, SocketOpts, gen_udp) ->
+    inet:setopts(Socket, SocketOpts);
+set_socket_opts(Socket, SocketOpts, Cb) ->
+    Cb:setopts(Socket, SocketOpts).
 
-get_socket_opts(_, []) ->
+get_socket_opts(_, [], _) ->
      {ok, []};
-get_socket_opts(Socket, SocketOpts) ->
-    inet:getopts(Socket, SocketOpts).
+get_socket_opts(Socket, SocketOpts, gen_udp) ->
+    inet:getopts(Socket, SocketOpts);
+get_socket_opts(Socket, SocketOpts, Cb) ->
+    Cb:getopts(Socket, SocketOpts).
 
 do_set_emulated_opts([], Opts) ->
     Opts;

--- a/lib/ssl/src/dtls_socket.erl
+++ b/lib/ssl/src/dtls_socket.erl
@@ -70,7 +70,7 @@ listen(Port, #config{inet_ssl = SockOpts,
     end.
 
 accept({Listener,_}, #config{transport_info = Info,
-                     connection_cb = ConnectionCb}, _Timeout) ->
+                             connection_cb = ConnectionCb}, _Timeout) ->
     Transport = element(1, Info),
     case dtls_packet_demux:accept(Listener, self()) of
 	{ok, Pid, Socket} ->
@@ -80,10 +80,10 @@ accept({Listener,_}, #config{transport_info = Info,
     end.
 
 connect(Address, Port, #config{transport_info = {Transport, _, _, _, _} = CbInfo,
-				connection_cb = ConnectionCb,
-				ssl = SslOpts,
-				emulated = EmOpts,
-				inet_ssl = SocketOpts}, Timeout) ->
+                               connection_cb = ConnectionCb,
+                               ssl = SslOpts,
+                               emulated = EmOpts,
+                               inet_ssl = SocketOpts}, Timeout) ->
     case Transport:open(0, SocketOpts ++ internal_inet_values()) of
 	{ok, Socket} ->
 	    ssl_gen_statem:connect(ConnectionCb, Address, Port, {{Address, Port},Socket},
@@ -94,8 +94,8 @@ connect(Address, Port, #config{transport_info = {Transport, _, _, _, _} = CbInfo
 	    Error
     end.
 
-close_listen(#sslsocket{pid = {dtls, #config{dtls_handler = {Pid, Port0},
-                                             inet_ssl = SockOpts}}}, Timeout) ->
+close_listen(#sslsocket{socket_handle = {Pid, Port0},
+                        listener_config = #config{inet_ssl = SockOpts}}, Timeout) ->
     IP = proplists:get_value(ip, SockOpts, default_ip(SockOpts)),
     Port = get_real_port(Pid, Port0),
     dtls_listener_sup:register_listener({undefined, Pid}, IP, Port),
@@ -124,16 +124,25 @@ close(gen_udp, {_Client, _Socket}) ->
 close(Transport, {_Client, Socket}) ->
     Transport:close(Socket).
 
-socket(Pids, gen_udp = Transport,
+
+%% Note that gen_udp:send is not blocking as gen_tcp:send is.
+%% So normal DTLS can safely have the same connection handler
+%% as payload sender
+socket([Pid], gen_udp = Transport,
        PeerAndSock = {{_Host, _Port}, _Socket}, ConnectionCb) ->
-    #sslsocket{pid = Pids, 
-	       %% "The name "fd" is kept for backwards compatibility
-	       fd = {Transport, PeerAndSock, ConnectionCb}};
-socket(Pids, Transport, Socket, ConnectionCb) ->
-    #sslsocket{pid = Pids, 
-	       %% "The name "fd" is kept for backwards compatibility
-	       fd = {Transport, Socket, ConnectionCb}}.
-setopts(_, Socket = #sslsocket{pid = {dtls, #config{dtls_handler = {ListenPid, _}}}}, Options) ->
+      #sslsocket{socket_handle = PeerAndSock,
+                 connection_handler = Pid,
+                 payload_sender = Pid,
+                 transport_cb = Transport,
+                 connection_cb = ConnectionCb};
+socket([Pid], Transport, Socket, ConnectionCb) ->
+    #sslsocket{socket_handle = Socket,
+               connection_handler = Pid,
+               payload_sender = Pid,
+               transport_cb = Transport,
+               connection_cb = ConnectionCb}.
+setopts(_, Socket = #sslsocket{socket_handle = {ListenPid, _},
+                               listener_config = #config{}}, Options) ->
     SplitOpts = {_, EmOpts} = tls_socket:split_options(Options),
     check_active_n(EmOpts, Socket),
     dtls_packet_demux:set_sock_opts(ListenPid, SplitOpts);
@@ -143,7 +152,8 @@ setopts(gen_udp, Socket, Options) ->
 setopts(Transport, Socket, Options) ->
     Transport:setopts(Socket, Options).
 
-check_active_n(EmulatedOpts, Socket = #sslsocket{pid = {dtls, #config{dtls_handler = {ListenPid, _}}}}) ->
+check_active_n(EmulatedOpts, Socket = #sslsocket{socket_handle = {ListenPid, _},
+                                                 listener_config = #config{}}) ->
     %% We check the resulting options to send an ssl_passive message if necessary.
     case proplists:lookup(active, EmulatedOpts) of
         %% The provided value is out of bound.
@@ -169,7 +179,7 @@ check_active_n(EmulatedOpts, Socket = #sslsocket{pid = {dtls, #config{dtls_handl
             ok
     end.
 
-getopts(_, #sslsocket{pid = {dtls, #config{dtls_handler = {ListenPid, _}}}}, Options) ->
+getopts(_, #sslsocket{socket_handle = {ListenPid, _}, listener_config =#config{}}, Options) ->
     SplitOpts = tls_socket:split_options(Options),
     dtls_packet_demux:get_sock_opts(ListenPid, SplitOpts);
 %%% Following clauses will not be called for emulated options, they are  handled in the connection process
@@ -325,7 +335,7 @@ start_dtls_packet_demux(#config{
 create_dtls_socket(#config{emulated = EmOpts} = Config,
                    Listener, Port) ->
     Socket = #sslsocket{
-                pid = {dtls, Config#config{dtls_handler = {Listener, Port}}}},
+                socket_handle = {Listener, Port},
+                listener_config = Config},
     check_active_n(EmOpts, Socket),
     Socket.
-

--- a/lib/ssl/src/ssl.appup.src
+++ b/lib/ssl/src/ssl.appup.src
@@ -1,25 +1,13 @@
 %% -*- erlang -*-
 {"%VSN%",
-[
+ [
   {<<"11\\..*">>, [{restart_application, ssl}]},
   {<<"10\\..*">>, [{restart_application, ssl}]},
-  {<<"9\\..*">>, [{restart_application, ssl}]},
-  {<<"8\\..*">>, [{restart_application, ssl}]},
-  {<<"7\\..*">>, [{restart_application, ssl}]},
-  {<<"6\\..*">>, [{restart_application, ssl}]},
-  {<<"5\\..*">>, [{restart_application, ssl}]},
-  {<<"4\\..*">>, [{restart_application, ssl}]},
-  {<<"3\\..*">>, [{restart_application, ssl}]}
+  {<<"9\\..*">>, [{restart_application, ssl}]}
  ], 
  [
   {<<"11\\..*">>, [{restart_application, ssl}]},
   {<<"10\\..*">>, [{restart_application, ssl}]},
-  {<<"9\\..*">>, [{restart_application, ssl}]},
-  {<<"8\\..*">>, [{restart_application, ssl}]},
-  {<<"7\\..*">>, [{restart_application, ssl}]},
-  {<<"6\\..*">>, [{restart_application, ssl}]},
-  {<<"5\\..*">>, [{restart_application, ssl}]},
-  {<<"4\\..*">>, [{restart_application, ssl}]},
-  {<<"3\\..*">>, [{restart_application, ssl}]}
+  {<<"9\\..*">>, [{restart_application, ssl}]}
  ]
 }.

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -205,7 +205,6 @@ Special Erlang node configuration for the application can be found in
 
 -doc(#{title => <<"Socket">>}).
 -doc """
-
 A socket that can be used to perform a so-called "START-TLS", which
 means using an already connected socket previously used for plain TCP
 traffic and upgrading it to use TLS.
@@ -1168,7 +1167,7 @@ There are two implementations available:
   automatically fetched through HTTP if the following argument is
   specified:
 
-  - **`{http, timeout()}`**
+- **`{http, timeout()}`**
 
     Enables fetching of CRLs specified as http URIs in [X.509 certificate
     extensions](`e:public_key:public_key_records.md`). Requires the
@@ -2080,7 +2079,10 @@ start(Type) ->
 	    Other
     end.
 %%--------------------------------------------------------------------
--doc "Stops the SSL application.".
+-doc """
+Stops the SSL application.
+""".
+
 -doc(#{title => <<"Utility Functions">>,
        since => <<"OTP R14B">>}).
 -spec stop() -> ok.
@@ -2186,6 +2188,7 @@ If the `active` option is set to `once`, `true`, or an integer value, the proces
 owning the SSL socket will receive messages of type
 [`active_msgs()`](`t:active_msgs/0`).
 """.
+
 -spec connect(Host, Port, TLSOptions, Timeout) ->
           {ok, sslsocket()} |
           {ok, sslsocket(),Ext :: protocol_extensions()} |
@@ -2273,8 +2276,8 @@ connection is accepted within the given time, `{error, timeout}` is returned.
       SslSocket :: sslsocket(),
       Reason :: reason().
 
-transport_accept(#sslsocket{pid = {ListenSocket,
-				   #config{connection_cb = ConnectionCb} = Config}}, Timeout)
+transport_accept(#sslsocket{socket_handle = ListenSocket,
+                            listener_config = #config{connection_cb = ConnectionCb} = Config}, Timeout)
   when ?IS_TIMEOUT(Timeout) ->
     case ConnectionCb of
 	tls_gen_connection ->
@@ -2333,8 +2336,8 @@ handshake(HsSocket, Options, infinity).
       Ext :: protocol_extensions(),
       Reason :: closed | timeout | error_alert().
 
-handshake(#sslsocket{} = Socket, Timeout)
-  when ?IS_TIMEOUT(Timeout) ->
+handshake(#sslsocket{connection_handler = Pid} = Socket, Timeout)
+  when ?IS_TIMEOUT(Timeout), is_pid(Pid) ->
     ssl_gen_statem:handshake(Socket, Timeout);
 
 handshake(ListenSocket, SslOptions) ->
@@ -2389,8 +2392,9 @@ owning the [`sslsocket()`](`t:sslsocket/0`) will receive messages of type
 handshake(#sslsocket{} = Socket, [], Timeout)
   when ?IS_TIMEOUT(Timeout) ->
     handshake(Socket, Timeout);
-handshake(#sslsocket{fd = {_, _, _, Trackers}} = Socket, SslOpts, Timeout)
-  when is_list(SslOpts), ?IS_TIMEOUT(Timeout) ->
+handshake(#sslsocket{connection_cb = tls_gen_connection,
+                     listener_config = Trackers} = Socket, SslOpts, Timeout)
+  when is_list(SslOpts), is_list(Trackers), ?IS_TIMEOUT(Timeout) ->
     try
         Tracker = proplists:get_value(option_tracker, Trackers),
 	{ok, EmOpts, _} = tls_socket:get_all_opts(Tracker),
@@ -2399,7 +2403,7 @@ handshake(#sslsocket{fd = {_, _, _, Trackers}} = Socket, SslOpts, Timeout)
     catch
 	Error = {error, _Reason} -> Error
     end;
-handshake(#sslsocket{pid = [Pid|_], fd = {_, _, _}} = Socket, SslOpts, Timeout)
+handshake(#sslsocket{socket_handle = {Pid,_}, connection_cb = dtls_gen_connection} = Socket, SslOpts, Timeout)
   when is_list(SslOpts), ?IS_TIMEOUT(Timeout) ->
     try
         {ok, EmOpts, _} = dtls_packet_demux:get_all_opts(Pid),
@@ -2474,12 +2478,15 @@ handshake_cancel(Socket) ->
       SslSocket :: sslsocket(),
       Reason :: any().
 %%--------------------------------------------------------------------
-close(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
-    ssl_gen_statem:close(Pid, {close, ?DEFAULT_TIMEOUT});
-close(#sslsocket{pid = {dtls, #config{dtls_handler = {_, _}}}} = DTLSListen) ->
+close(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection}} = DTLSListen) ->
     dtls_socket:close_listen(DTLSListen, ?DEFAULT_TIMEOUT);
-close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}) ->
-    Transport:close(ListenSocket).
+close(#sslsocket{socket_handle = ListenSocket,
+                 listener_config = #config{connection_cb = tls_gen_connection,
+                                           transport_info = Info}}) ->
+    Transport = element(1, Info),
+    Transport:close(ListenSocket);
+close(#sslsocket{connection_handler = Pid}) when is_pid(Pid) ->
+    ssl_gen_statem:close(Pid, {close, ?DEFAULT_TIMEOUT}).
 
 %%--------------------------------------------------------------------
 -doc """
@@ -2503,7 +2510,7 @@ connection.
       Reason :: any().
 
 %%--------------------------------------------------------------------
-close(#sslsocket{pid = [TLSPid|_]}, {Pid, Timeout} = DownGrade)
+close(#sslsocket{connection_handler = TLSPid}, {Pid, Timeout} = DownGrade)
   when is_pid(TLSPid), is_pid(Pid), ?IS_TIMEOUT(Timeout) ->
     case ssl_gen_statem:close(TLSPid, {close, DownGrade}) of
         ok -> %% In normal close {error, closed} is regarded as ok, as it is not interesting which side
@@ -2512,13 +2519,16 @@ close(#sslsocket{pid = [TLSPid|_]}, {Pid, Timeout} = DownGrade)
         Other ->
             Other
     end;
-close(#sslsocket{pid = [TLSPid|_]}, Timeout)
+close(#sslsocket{connection_handler = TLSPid}, Timeout)
   when is_pid(TLSPid), ?IS_TIMEOUT(Timeout) ->
     ssl_gen_statem:close(TLSPid, {close, Timeout});
-close(#sslsocket{pid = {dtls, #config{dtls_handler = {_, _}}}} = DTLSListen, Timeout)
+close(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection}} = DTLSListen, Timeout)
   when ?IS_TIMEOUT(Timeout) ->
     dtls_socket:close_listen(DTLSListen, Timeout);
-close(#sslsocket{pid = {ListenSocket, #config{transport_info={Transport,_,_,_,_}}}}, _) ->
+close(#sslsocket{socket_handle = ListenSocket, 
+                 listener_config = #config{connection_cb = tls_gen_connection,
+                                           transport_info = Info}}, _) ->
+    Transport = element(1, Info),
     tls_socket:close(Transport, ListenSocket).
 
 %%--------------------------------------------------------------------
@@ -2533,15 +2543,16 @@ A notable return value is `{error, closed}` indicating that the socket is
 closed.
 """.
 %%--------------------------------------------------------------------
-send(#sslsocket{pid = [Pid]}, Data) when is_pid(Pid) ->
+send(#sslsocket{payload_sender = Pid,
+                connection_cb = dtls_gen_connection}, Data) when is_pid(Pid) ->
     ssl_gen_statem:send(Pid, Data);
-send(#sslsocket{pid = [_, Pid]}, Data) when is_pid(Pid) ->
+send(#sslsocket{payload_sender = Pid,
+                connection_cb = tls_gen_connection}, Data) when is_pid(Pid) ->
     tls_sender:send_data(Pid,  erlang:iolist_to_iovec(Data));
-send(#sslsocket{pid = {_, #config{transport_info={_, udp, _, _}}}}, _) ->
+send(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection}}, _) ->
     {error,enotconn}; %% Emulate connection behaviour
-send(#sslsocket{pid = {dtls,_}}, _) ->
-    {error,enotconn};  %% Emulate connection behaviour
-send(#sslsocket{pid = {ListenSocket, #config{transport_info = Info}}}, Data) ->
+send(#sslsocket{socket_handle = ListenSocket, 
+                listener_config = #config{transport_info = Info}}, Data) ->
     Transport = element(1, Info),
     tls_socket:send(Transport, ListenSocket, Data). %% {error,enotconn}
 
@@ -2580,13 +2591,13 @@ Optional argument `Timeout` specifies a time-out in milliseconds. The default
 value is `infinity`.
 """.
 
-recv(#sslsocket{pid = [Pid|_]}, Length, Timeout)
+recv(#sslsocket{connection_handler = Pid}, Length, Timeout)
   when is_pid(Pid), (is_integer(Length) andalso Length >= 0), ?IS_TIMEOUT(Timeout) ->
     ssl_gen_statem:recv(Pid, Length, Timeout);
-recv(#sslsocket{pid = {dtls,_}}, _, _) ->
+recv(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection}}, _, _) ->
     {error,enotconn};
-recv(#sslsocket{pid = {Listen,
-		       #config{transport_info = Info}}},_,_) ->
+recv(#sslsocket{socket_handle = Listen,
+                listener_config = #config{transport_info = Info}},_,_) ->
     Transport = element(1, Info),
     Transport:recv(Listen, 0). %% {error,enotconn}
 
@@ -2606,16 +2617,17 @@ messages from the socket.
 %% Description: Changes process that receives the messages when active = true
 %% or once.
 %%--------------------------------------------------------------------
-controlling_process(#sslsocket{pid = [Pid|_]}, NewOwner)
+controlling_process(#sslsocket{connection_handler = Pid}, NewOwner)
   when is_pid(Pid), is_pid(NewOwner) ->
     ssl_gen_statem:new_user(Pid, NewOwner);
-controlling_process(#sslsocket{pid = {dtls, _}}, NewOwner)
+controlling_process(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection}}, NewOwner)
   when is_pid(NewOwner) ->
     ok; %% Meaningless but let it be allowed to conform with TLS 
-controlling_process(#sslsocket{pid = {Listen,
-				      #config{transport_info = {Transport,_,_,_,_}}}},
+controlling_process(#sslsocket{socket_handle = Listen,
+                               listener_config = #config{transport_info = Info}},
 		    NewOwner)
   when is_pid(NewOwner) ->
+    Transport = element(1, Info),
     %% Meaningless but let it be allowed to conform with normal sockets
     Transport:controlling_process(Listen, NewOwner).
 
@@ -2640,14 +2652,14 @@ that affect the security of the connection will be returned.
 %%
 %% Description: Return SSL information for the connection
 %%--------------------------------------------------------------------
-connection_information(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) -> 
+connection_information(#sslsocket{connection_handler = Pid}) when is_pid(Pid) ->
     case ssl_gen_statem:connection_information(Pid, false) of
 	{ok, Info} ->
 	    {ok, [Item || Item = {_Key, Value} <- Info,  Value =/= undefined]};
 	Error ->
             Error
     end;
-connection_information(#sslsocket{pid = {_Listen, #config{}}}) ->
+connection_information(#sslsocket{listener_config = #config{}}) ->
     {error, enotconn}.
 %%--------------------------------------------------------------------
 -doc """
@@ -2674,7 +2686,7 @@ set to `true`.
 %%
 %% Description: Return SSL information for the connection
 %%--------------------------------------------------------------------
-connection_information(#sslsocket{pid = [Pid|_]}, Items)
+connection_information(#sslsocket{connection_handler = Pid}, Items)
   when is_pid(Pid), is_list(Items) ->
     case ssl_gen_statem:connection_information(Pid, include_security_info(Items)) of
         {ok, Info} ->
@@ -2695,16 +2707,23 @@ connection_information(#sslsocket{pid = [Pid|_]}, Items)
 %%
 %% Description: same as inet:peername/1.
 %%--------------------------------------------------------------------
-peername(#sslsocket{pid = [Pid|_], fd = {Transport, Socket,_}}) when is_pid(Pid)->
+peername(#sslsocket{connection_handler = Pid, connection_cb = dtls_gen_connection,
+                    transport_cb = Transport,
+                    socket_handle = Socket}) when is_pid(Pid)->
     dtls_socket:peername(Transport, Socket);
-peername(#sslsocket{pid = [Pid|_], fd = {Transport, Socket,_,_}}) when is_pid(Pid)->
+peername(#sslsocket{connection_handler = Pid, connection_cb = tls_gen_connection,
+                    transport_cb = Transport,
+                    socket_handle = Socket}) when is_pid(Pid)->
     tls_socket:peername(Transport, Socket);
-peername(#sslsocket{pid = {dtls, #config{dtls_handler = {_Pid,_}}}}) ->
-    dtls_socket:peername(dtls, undefined);
-peername(#sslsocket{pid = {ListenSocket,  #config{transport_info = {Transport,_,_,_,_}}}}) ->
-    tls_socket:peername(Transport, ListenSocket); %% Will return {error, enotconn}
-peername(#sslsocket{pid = {dtls,_}}) ->
-    {error,enotconn}.
+peername(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection,
+                                              transport_info = Info}}) ->
+    Transport = element(1, Info),
+    dtls_socket:peername(Transport, undefined);  %% Will return {error, enotconn}
+peername(#sslsocket{socket_handle = ListenSocket,  
+                    listener_config = #config{connection_cb = tls_gen_connection,
+                                             transport_info = Info}}) ->
+    Transport = element(1, Info),
+    tls_socket:peername(Transport, ListenSocket). %% Will return {error, enotconn}
 
 %%--------------------------------------------------------------------
 -doc(#{title => <<"Utility Functions">>}).
@@ -2722,16 +2741,14 @@ and [SSL User's Guide](standards_compliance.md).
 %%
 %% Description: Returns the peercert.
 %%--------------------------------------------------------------------
-peercert(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
+peercert(#sslsocket{connection_handler = Pid}) when is_pid(Pid) ->
     case ssl_gen_statem:peer_certificate(Pid) of
 	{ok, undefined} ->
 	    {error, no_peercert};
         Result ->
 	    Result
     end;
-peercert(#sslsocket{pid = {dtls, _}}) ->
-    {error, enotconn};
-peercert(#sslsocket{pid = {_Listen, #config{}}}) ->
+peercert(#sslsocket{listener_config = #config{}}) ->
     {error, enotconn}.
 
 %%--------------------------------------------------------------------
@@ -2746,7 +2763,7 @@ peercert(#sslsocket{pid = {_Listen, #config{}}}) ->
 %% Description: Returns the protocol that has been negotiated. If no
 %% protocol has been negotiated will return {error, protocol_not_negotiated}
 %%--------------------------------------------------------------------
-negotiated_protocol(#sslsocket{pid = [Pid|_]}) when is_pid(Pid) ->
+negotiated_protocol(#sslsocket{connection_handler = Pid}) when is_pid(Pid) ->
     ssl_gen_statem:negotiated_protocol(Pid).
 
 %%--------------------------------------------------------------------
@@ -3061,17 +3078,21 @@ groups(default) ->
 
 %%--------------------------------------------------------------------
 -doc(#{title => <<"Utility Functions">>}).
--doc "Gets the values of the specified socket options.".
+-doc """
+Gets the values of the specified socket options.
+""".
 -spec getopts(SslSocket, OptionNames) ->
           {ok, [gen_tcp:option()]} | {error, reason()} when
       SslSocket :: sslsocket(),
       OptionNames :: [gen_tcp:option_name()].
 %%--------------------------------------------------------------------
-getopts(#sslsocket{pid = [Pid|_]}, OptionTags) when is_pid(Pid), is_list(OptionTags) ->
+getopts(#sslsocket{connection_handler = Pid}, OptionTags) when is_pid(Pid), is_list(OptionTags) ->
     ssl_gen_statem:get_opts(Pid, OptionTags);
-getopts(#sslsocket{pid = {dtls, #config{transport_info = {Transport,_,_,_,_}}}} = ListenSocket,
+getopts(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection,
+                                             transport_info = Info}} = ListenSocket,
         OptionTags)
   when is_list(OptionTags) ->
+    Transport = element(1, Info),
     try dtls_socket:getopts(Transport, ListenSocket, OptionTags) of
         {ok, _} = Result ->
             Result;
@@ -3081,8 +3102,10 @@ getopts(#sslsocket{pid = {dtls, #config{transport_info = {Transport,_,_,_,_}}}} 
 	_:Error ->
 	    {error, {options, {socket_options, OptionTags, Error}}}
     end;
-getopts(#sslsocket{pid = {_,  #config{transport_info = {Transport,_,_,_,_}}}} = ListenSocket,
+getopts(#sslsocket{listener_config = #config{connection_cb = tls_gen_connection,
+                                             transport_info = Info}} = ListenSocket,
 	OptionTags) when is_list(OptionTags) ->
+    Transport = element(1, Info),
     try tls_socket:getopts(Transport, ListenSocket, OptionTags) of
 	{ok, _} = Result ->
 	    Result;
@@ -3102,9 +3125,10 @@ getopts(#sslsocket{}, OptionTags) ->
       SslSocket :: sslsocket(),
       Options :: [gen_tcp:option()].
 %%--------------------------------------------------------------------
-setopts(#sslsocket{pid = [Pid|_]}, [{active, _}] = Active) when is_pid(Pid) ->
+setopts(#sslsocket{connection_handler = Pid}, [{active, _}] = Active) when is_pid(Pid) ->
     ssl_gen_statem:set_opts(Pid, Active);
-setopts(#sslsocket{pid = [Pid, Sender]}, Options0) when is_pid(Pid), is_list(Options0)  ->
+setopts(#sslsocket{connection_handler = Pid, payload_sender = Sender,
+                   connection_cb = tls_gen_connection}, Options0) when is_pid(Pid), is_list(Options0)  ->
     try proplists:expand([{binary, [{mode, binary}]},
 			  {list, [{mode, list}]}], Options0) of
         Options ->
@@ -3123,7 +3147,7 @@ setopts(#sslsocket{pid = [Pid, Sender]}, Options0) when is_pid(Pid), is_list(Opt
         _:_ ->
             {error, {options, {not_a_proplist, Options0}}}
     end;
-setopts(#sslsocket{pid = [Pid|_]}, Options0) when is_pid(Pid), is_list(Options0)  ->
+setopts(#sslsocket{connection_handler = Pid}, Options0) when is_pid(Pid), is_list(Options0)  ->
     try proplists:expand([{binary, [{mode, binary}]},
 			  {list, [{mode, list}]}], Options0) of
 	Options ->
@@ -3132,9 +3156,11 @@ setopts(#sslsocket{pid = [Pid|_]}, Options0) when is_pid(Pid), is_list(Options0)
 	_:_ ->
 	    {error, {options, {not_a_proplist, Options0}}}
     end;
-setopts(#sslsocket{pid = {dtls, #config{transport_info = {Transport,_,_,_,_}}}} = ListenSocket,
+setopts(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection,
+                                             transport_info = Info}} = ListenSocket,
         Options)
   when is_list(Options) ->
+    Transport = element(1, Info),
     try dtls_socket:setopts(Transport, ListenSocket, Options) of
 	ok ->
 	    ok;
@@ -3144,8 +3170,10 @@ setopts(#sslsocket{pid = {dtls, #config{transport_info = {Transport,_,_,_,_}}}} 
 	_:Error ->
 	    {error, {options, {socket_options, Options, Error}}}
     end;
-setopts(#sslsocket{pid = {_, #config{transport_info = {Transport,_,_,_,_}}}} = ListenSocket, Options)
+setopts(#sslsocket{listener_config = #config{connection_cb = tls_gen_connection,
+                                             transport_info = Info}} = ListenSocket, Options)
   when is_list(Options) ->
+    Transport = element(1, Info),
     try tls_socket:setopts(Transport, ListenSocket, Options) of
 	ok ->
 	    ok;
@@ -3186,19 +3214,26 @@ See `inet:getstat/2` for further details.
       Options :: [inet:stat_option()],
       OptionValues :: [{inet:stat_option(), integer()}].
 %%--------------------------------------------------------------------
-getstat(#sslsocket{pid = {dtls, #config{transport_info = Info,
-                                        dtls_handler = {Listener, _}}}},
+getstat(#sslsocket{socket_handle = {Listener, _},
+                   listener_config = #config{transport_info = Info}},
         Options) when is_list(Options) ->
     Transport = element(1, Info),
     dtls_socket:getstat(Transport, Listener, Options);
-getstat(#sslsocket{pid = {Listen,  #config{transport_info = Info}}},
+getstat(#sslsocket{socket_handle = Listen, 
+                   listener_config = #config{transport_info = Info}},
         Options) when is_list(Options) ->
     Transport = element(1, Info),
     tls_socket:getstat(Transport, Listen, Options);
-getstat(#sslsocket{pid = [Pid|_], fd = {Transport, Socket, _, _}},
+getstat(#sslsocket{connection_handler = Pid,
+                   connection_cb = tls_gen_connection,
+                   socket_handle = Socket,
+                   transport_cb = Transport},
         Options) when is_pid(Pid), is_list(Options) ->
     tls_socket:getstat(Transport, Socket, Options);
-getstat(#sslsocket{pid = [Pid|_], fd = {Transport, Socket, _}},
+getstat(#sslsocket{connection_handler = Pid,
+                   connection_cb = dtls_gen_connection,
+                   socket_handle = Socket,
+                   transport_cb = Transport},
         Options) when is_pid(Pid), is_list(Options) ->
     dtls_socket:getstat(Transport, Socket, Options).
 
@@ -3218,7 +3253,8 @@ To handle siutations where the peer has performed a shutdown on the
 write side, option `{exit_on_close, false}` is useful.
 """.
 %%--------------------------------------------------------------------
-shutdown(#sslsocket{pid = {dtls, #config{transport_info = Info}}}, _) ->
+shutdown(#sslsocket{listener_config = #config{connection_cb = dtls_gen_connection,
+                                              transport_info = Info}}, _) ->
     Transport = element(1, Info),
     %% enotconn is what gen_tcp:shutdown on a listen socket will result with.
     %% shutdown really is handling TCP functionality not present
@@ -3233,10 +3269,12 @@ shutdown(#sslsocket{pid = {dtls, #config{transport_info = Info}}}, _) ->
         _  ->
             {error, enotconn}
     end;
-shutdown(#sslsocket{pid = {Listen, #config{transport_info = Info}}}, How) ->
+shutdown(#sslsocket{socket_handle = Listen, 
+                    listener_config = #config{connection_cb = tls_gen_connection,
+                                              transport_info = Info}}, How) ->
     Transport = element(1, Info),
     Transport:shutdown(Listen, How);    
-shutdown(#sslsocket{pid = [Pid|_]}, How) when is_pid(Pid) ->
+shutdown(#sslsocket{connection_handler = Pid}, How) when is_pid(Pid) ->
     ssl_gen_statem:shutdown(Pid, How).
 
 %%--------------------------------------------------------------------
@@ -3248,14 +3286,23 @@ shutdown(#sslsocket{pid = [Pid|_]}, How) when is_pid(Pid) ->
       Address :: inet:ip_address(),
       Port :: inet:port_number().
 %%--------------------------------------------------------------------
-sockname(#sslsocket{pid = {dtls, #config{dtls_handler = {Pid, _}}}}) ->
+sockname(#sslsocket{socket_handle = {Pid, _},
+                    listener_config = #config{connection_cb = dtls_gen_connection}}) ->
     dtls_packet_demux:sockname(Pid);
-sockname(#sslsocket{pid = {Listen,  #config{transport_info = Info}}}) ->
+sockname(#sslsocket{socket_handle = Listen,  
+                    listener_config = #config{connection_cb = tls_gen_connection,
+                                              transport_info = Info}}) ->
     Transport = element(1, Info),
     tls_socket:sockname(Transport, Listen);
-sockname(#sslsocket{pid = [Pid|_], fd = {Transport, Socket,_}}) when is_pid(Pid) ->
+sockname(#sslsocket{connection_handler = Pid,
+                    connection_cb = dtls_gen_connection,
+                    transport_cb = Transport,
+                    socket_handle = Socket}) when is_pid(Pid) ->
     dtls_socket:sockname(Transport, Socket);
-sockname(#sslsocket{pid = [Pid| _], fd = {Transport, Socket,_,_}}) when is_pid(Pid) ->
+sockname(#sslsocket{connection_handler = Pid,
+                    connection_cb = tls_gen_connection,
+                    transport_cb = Transport,
+                    socket_handle = Socket}) when is_pid(Pid) ->
     tls_socket:sockname(Transport, Socket).
 
 %%---------------------------------------------------------------
@@ -3343,8 +3390,10 @@ plaintext limit and can be configured using the `key_update_at` option
 in `t:common_option_tls13/0`.
 """.
 %%--------------------------------------------------------------------
-renegotiate(#sslsocket{pid = [Pid, Sender |_]} = Socket) when is_pid(Pid),
-                                                              is_pid(Sender) ->
+renegotiate(#sslsocket{connection_handler = Pid,
+                       payload_sender = Sender,
+                       connection_cb = tls_gen_connection} = Socket) when is_pid(Pid),
+                                                                          is_pid(Sender) ->
     case ssl:connection_information(Socket, [protocol]) of
         {ok, [{protocol, 'tlsv1.3'}]} ->
             {error, notsup};
@@ -3356,11 +3405,10 @@ renegotiate(#sslsocket{pid = [Pid, Sender |_]} = Socket) when is_pid(Pid),
                     Error
             end
     end;
-renegotiate(#sslsocket{pid = [Pid |_]}) when is_pid(Pid) ->
+renegotiate(#sslsocket{connection_handler = Pid,
+                       connection_cb = dtls_gen_connection}) when is_pid(Pid) ->
     tls_dtls_gen_connection:renegotiation(Pid);
-renegotiate(#sslsocket{pid = {dtls,_}}) ->
-    {error, enotconn};
-renegotiate(#sslsocket{pid = {_Listen, #config{}}}) ->
+renegotiate(#sslsocket{listener_config = #config{}}) ->
     {error, enotconn}.
 
 %%---------------------------------------------------------------
@@ -3385,10 +3433,12 @@ reading and writing keys are updated.
 %%
 %% Description: Initiate a key update.
 %%--------------------------------------------------------------------
-update_keys(#sslsocket{pid = [Pid, Sender |_]}, Type0) when is_pid(Pid) andalso
-                                                            is_pid(Sender) andalso
-                                                            (Type0 =:= write orelse
-                                                             Type0 =:= read_write) ->
+update_keys(#sslsocket{connection_handler = Pid,
+                       payload_sender = Sender,
+                       connection_cb = tls_gen_connection}, Type0) when is_pid(Pid) andalso
+                                                                        is_pid(Sender) andalso
+                                                                        (Type0 =:= write orelse
+                                                                         Type0 =:= read_write) ->
     Type = case Type0 of
                write ->
                    update_not_requested;
@@ -3412,9 +3462,9 @@ update_keys(_, Type) ->
       WantedLengths :: [non_neg_integer()],
       ExportKeyMaterials :: [binary()].
 %%--------------------------------------------------------------------
-export_key_materials(#sslsocket{pid = [Pid|_]}, Labels, Contexts, WantedLengths) when is_pid(Pid) ->
+export_key_materials(#sslsocket{connection_handler = Pid}, Labels, Contexts, WantedLengths) when is_pid(Pid) ->
     ssl_gen_statem:call(Pid, {export_key_materials, Labels, Contexts, WantedLengths, true});
-export_key_materials(#sslsocket{pid = {_Listen, #config{}}}, _,_,_) ->
+export_key_materials(#sslsocket{listener_config = #config{}}, _,_,_) ->
     {error, enotconn}.
 
 %%--------------------------------------------------------------------
@@ -3428,7 +3478,8 @@ export_key_materials(#sslsocket{pid = {_Listen, #config{}}}, _,_,_) ->
       WantedLengths :: [non_neg_integer()],
       ConsumeSecret :: boolean(),
       ExportKeyMaterials :: [binary()].
--doc """
+-doc
+"""
 Uses a Pseudo-Random Function (PRF prior to TLS-1.3) or a Key
 Derivation Function (HKDF in TLS-1.3) for a TLS connection to
 generate and export keying materials.
@@ -3442,11 +3493,12 @@ TLS-1.3 `exporter_master_secret` to be consumed, thereby making it
 unavailable and increasing security. Further attempts to call this
 function will fail.
 """.
+
 %%--------------------------------------------------------------------
-export_key_materials(#sslsocket{pid = [Pid|_]}, Labels, Contexts, WantedLengths, ConsumeSecret)
+export_key_materials(#sslsocket{connection_handler = Pid}, Labels, Contexts, WantedLengths, ConsumeSecret)
   when is_pid(Pid) ->
     ssl_gen_statem:call(Pid, {export_key_materials, Labels, Contexts, WantedLengths, ConsumeSecret});
-export_key_materials(#sslsocket{pid = {_Listen, #config{}}}, _,_,_, _) ->
+export_key_materials(#sslsocket{socket_handle ={_Listen, #config{}}}, _,_,_, _) ->
     {error, enotconn}.
 
 %%--------------------------------------------------------------------
@@ -3460,7 +3512,8 @@ export_key_materials(#sslsocket{pid = {_Listen, #config{}}}, _,_,_, _) ->
       Seed :: [binary() | prf_random()],
       WantedLength :: non_neg_integer().
 %%
--doc """
+-doc
+"""
 Uses the Pseudo-Random Function (PRF) of a TLS session to generate extra key
 material.
 
@@ -3481,7 +3534,7 @@ called in a TLS-1.3 context it will now behave as
 """.
 
 %%--------------------------------------------------------------------
-prf(#sslsocket{pid = [Pid|_]} = Socket,
+prf(#sslsocket{connection_handler = Pid} = Socket,
     master_secret, Label, [client_random, server_random], WantedLength) when is_pid(Pid) ->
     case export_key_materials(Socket, [Label], [no_context], [WantedLength], true) of
         {ok, [KeyMaterial]} ->
@@ -3489,7 +3542,7 @@ prf(#sslsocket{pid = [Pid|_]} = Socket,
         Error ->
             Error
     end;
-prf(#sslsocket{pid = [Pid|_]} = Socket,
+prf(#sslsocket{connection_handler = Pid} = Socket,
     master_secret, Label, [client_random, server_random, Context], WantedLength) when is_pid(Pid),
                                                                                       is_binary(Context) ->
     case export_key_materials(Socket, [Label], [Context], [WantedLength], true) of
@@ -3498,7 +3551,7 @@ prf(#sslsocket{pid = [Pid|_]} = Socket,
         Error ->
             Error
     end;
-prf(#sslsocket{pid = {_Listen, #config{}}}, _,_,_,_) ->
+prf(#sslsocket{listener_config = #config{}}, _,_,_,_) ->
     {error, enotconn};
 %% Legacy backwards compatible clause. This makes no sense, was probably added for
 %% testing purposes by contributor, but these tests does not really test the correct thing.
@@ -3631,7 +3684,8 @@ supported_suites(exclusive_anonymous, Version) when ?TLS_1_X(Version) ->
 supported_suites(exclusive_anonymous, Version) when ?DTLS_1_X(Version) ->
     dtls_v1:exclusive_anonymous_suites(Version).
 
-do_listen(Port, #config{transport_info = {Transport, _, _, _,_}} = Config, tls_gen_connection) ->
+do_listen(Port, #config{transport_info = Info} = Config, tls_gen_connection) ->
+    Transport = element(1, Info),
     tls_socket:listen(Transport, Port, Config);
 
 do_listen(Port,  Config, dtls_gen_connection) ->

--- a/lib/ssl/src/ssl_api.hrl
+++ b/lib/ssl/src/ssl_api.hrl
@@ -21,7 +21,14 @@
 -ifndef(ssl_api).
 -define(ssl_api, true).
 
-%% Looks like it does for backwards compatibility reasons
--record(sslsocket, {fd = nil, pid = nil}).
+%% Opaque to the user of ssl application, but
+%% is allowed to be matched for equality
+-record(sslsocket, {socket_handle,     %% Depends on transport module
+                    connection_handler,%% pid()
+                    payload_sender,    %% pid()
+                    transport_cb,      %% ssl:transport_option()
+                    connection_cb,     %% :: tls_gen_connection | dtls_gen_connection
+                    listener_config    %% :: #config{} (listen socket) | [pid()] list of trackers
+                 }).
 
 -endif. % -ifdef(ssl_api).

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -311,7 +311,7 @@ handshake(Connection, Port, Socket, Opts, User, CbInfo, Timeout) ->
 %%
 %% Description: Starts ssl handshake.
 %%--------------------------------------------------------------------
-handshake(#sslsocket{pid = [Pid|_]} = Socket, Timeout) ->
+handshake(#sslsocket{connection_handler = Pid} = Socket, Timeout) ->
     case call(Pid, {start, Timeout}) of
 	connected ->
 	    {ok, Socket};
@@ -327,7 +327,7 @@ handshake(#sslsocket{pid = [Pid|_]} = Socket, Timeout) ->
 %%
 %% Description: Starts ssl handshake with some new options
 %%--------------------------------------------------------------------
-handshake(#sslsocket{pid = [Pid|_]} = Socket, SslOptions, Timeout) ->
+handshake(#sslsocket{connection_handler = Pid} = Socket, SslOptions, Timeout) ->
     case call(Pid, {start, SslOptions, Timeout}) of
 	connected ->
 	    {ok, Socket};
@@ -341,7 +341,7 @@ handshake(#sslsocket{pid = [Pid|_]} = Socket, SslOptions, Timeout) ->
 %%
 %% Description: Continues handshake with new options
 %%--------------------------------------------------------------------
-handshake_continue(#sslsocket{pid = [Pid|_]} = Socket, SslOptions, Timeout) ->
+handshake_continue(#sslsocket{connection_handler = Pid} = Socket, SslOptions, Timeout) ->
     case call(Pid, {handshake_continue, SslOptions, Timeout}) of
 	connected ->
 	    {ok, Socket};
@@ -353,7 +353,7 @@ handshake_continue(#sslsocket{pid = [Pid|_]} = Socket, SslOptions, Timeout) ->
 %%
 %% Description: Cancels connection
 %%--------------------------------------------------------------------
-handshake_cancel(#sslsocket{pid = [Pid|_]}) ->
+handshake_cancel(#sslsocket{connection_handler = Pid}) ->
     case call(Pid, cancel) of
 	closed ->
             ok;

--- a/lib/ssl/src/ssl_internal.hrl
+++ b/lib/ssl/src/ssl_internal.hrl
@@ -150,7 +150,6 @@
 		 inet_user,         %% User set inet options
 		 emulated,          %% Emulated option list or 
                  trackers, 
-		 dtls_handler,
 		 inet_ssl,          %% inet options for internal ssl socket
 		 transport_info,                 %% Callback info
 		 connection_cb

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -254,7 +254,7 @@ empty_connection_state(ConnectionEnd) ->
 %%====================================================================	     
 
 socket(Pids,  Transport, Socket, Trackers) ->
-    tls_socket:socket(Pids, Transport, Socket, tls_connection, Trackers).
+    tls_socket:socket(Pids, Transport, Socket, ?MODULE, Trackers).
 
 setopts(Transport, Socket, Other) ->
     tls_socket:setopts(Transport, Socket, Other).

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -1384,12 +1384,14 @@ hibernate_helper(Version, CheckServer, StartServerOpts, StartClientOpts,
     AllClientOpts = StartClientOpts ++
         [{port, Port},
          {options, [{hibernate_after, ClientHibernateAfter} | ClientOpts0]}],
-    {Client, #sslsocket{pid = [ClientReceiverPid | ClientPotentialSenderPid]}} =
+    {Client, #sslsocket{connection_handler = ClientReceiverPid,
+                        payload_sender = ClientPotentialSenderPid}} =
         ssl_test_lib:start_client(AllClientOpts),
     Results = ssl_test_lib:get_result([Client, Server]),
     {ok, ServerAcceptSocket} = proplists:get_value(Server, Results),
     ok = proplists:get_value(Client, Results),
-    #sslsocket{pid = [ServerReceiverPid | ServerPotentialSenderPid]} =
+    #sslsocket{connection_handler = ServerReceiverPid,
+               payload_sender = ServerPotentialSenderPid} =
         ServerAcceptSocket,
     {ReceiverPid, PotentialSenderPid, HibernateAfter} =
         case CheckServer of
@@ -1402,11 +1404,11 @@ hibernate_helper(Version, CheckServer, StartServerOpts, StartClientOpts,
     ?CT_LOG("HibernateAfter = ~w SleepAmount = ~w", [HibernateAfter, SleepAmount]),
     ct:sleep(SleepAmount), %% Schedule out
     {current_function, {erlang, hibernate, 3}} =
-	process_info(ReceiverPid, current_function),
-    IsTls = ssl_test_lib:is_tls_version(Version),
+        process_info(ReceiverPid, current_function),
+     IsTls = ssl_test_lib:is_tls_version(Version),
     case IsTls of
         true ->
-            [SenderPid] = PotentialSenderPid,
+            SenderPid = PotentialSenderPid,
             {current_function, {erlang, hibernate, 3}} =
                 process_info(SenderPid, current_function);
         _ -> %% DTLS (no sender process)

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -1405,7 +1405,7 @@ hibernate_helper(Version, CheckServer, StartServerOpts, StartClientOpts,
     ct:sleep(SleepAmount), %% Schedule out
     {current_function, {erlang, hibernate, 3}} =
         process_info(ReceiverPid, current_function),
-     IsTls = ssl_test_lib:is_tls_version(Version),
+    IsTls = ssl_test_lib:is_tls_version(Version),
     case IsTls of
         true ->
             SenderPid = PotentialSenderPid,

--- a/lib/ssl/test/ssl_basic_SUITE.erl
+++ b/lib/ssl/test/ssl_basic_SUITE.erl
@@ -891,7 +891,8 @@ version_info_result(Socket) ->
     {ok, [{version, Version}]} = ssl:connection_information(Socket, [version]),
     {ok, Version}.
 
-min_heap_size_info(#sslsocket{pid = [Receiver, Sender]}) ->
+min_heap_size_info(#sslsocket{connection_handler = Receiver,
+                              payload_sender = Sender}) ->
     {garbage_collection, ReceiverGc} = process_info(Receiver, garbage_collection),
     {garbage_collection, SenderGc} = process_info(Sender, garbage_collection),
     {ok, proplists:get_value(min_heap_size, ReceiverGc), proplists:get_value(min_heap_size, SenderGc)}.

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -780,7 +780,7 @@ tls_tcp_error_propagation_in_active_mode(Config) when is_list(Config) ->
 					 {mfa, {ssl_test_lib, no_result, []}},
 					 {options, ServerOpts}]),
     Port = ssl_test_lib:inet_port(Server),
-    {Client, #sslsocket{pid=[Pid|_]} = SslSocket} = ssl_test_lib:start_client([return_socket,
+    {Client, #sslsocket{connection_handler = Pid} = SslSocket} = ssl_test_lib:start_client([return_socket,
                                                                                {node, ClientNode}, {port, Port},
                                                                                {host, Hostname},
                                                                                {from, self()},


### PR DESCRIPTION
Backwards compatibility of this internal data structure is no longer needed and nowadays only makes it hard to understand the intent of the code. So this is a refactor long overdue.