### PR TITLE
gh: Upload Windows build zip to GitHub releases

### DIFF
--- a/.github/workflows/upload-windows-zip.yaml
+++ b/.github/workflows/upload-windows-zip.yaml
@@ -1,0 +1,71 @@
+name: Upload windows .zip
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+      target:
+        required: true
+
+## Needed to upload assets to releases
+permissions:
+  contents: write
+
+jobs:
+  upload-windows-zip:
+    runs-on: windows-2022
+    env:
+      basename: otp_${{ inputs.target }}_${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v4.1.7
+
+      - name: Install OTP
+        shell: cmd
+        run: |
+          curl.exe --fail -Lo otp.exe https://github.com/erlang/otp/releases/download/OTP-${{ inputs.version }}/${{ env.basename }}.exe
+          otp.exe /S /D=%CD%\${{ env.basename }}
+
+      - name: Download vc_redist.exe
+        shell: bash
+        run: |
+          case "${{ inputs.target }}" in
+            win32)
+              vc_redist_target=x86
+              ;;
+            win64)
+              vc_redist_target=x64
+              ;;
+            *)
+              echo "invalid target $target"
+              exit 1
+              ;;
+          esac
+          curl --fail -Lo vc_redist.exe "https://aka.ms/vs/17/release/vc_redist.$vc_redist_target.exe"
+
+      - name: Create .zip
+        shell: pwsh
+        run: |
+          $root = Get-Location
+
+          cd ${{ env.basename }}
+          rm bin\erl.ini
+          rm Install.exe
+          rm Install.ini
+          rm Uninstall.exe
+          $sha256 = Get-FileHash $root\otp.exe -Algorithm SHA256
+          $sha256.Hash.ToLower() | Out-File -FilePath installer.sha256
+          cp $root/vc_redist.exe .
+          cp $root/erts/etc/win32/INSTALL.txt .
+          Compress-Archive -Path * -DestinationPath $root\${{ env.basename }}.zip
+
+          cd $root
+          Expand-Archive -Path ${{ env.basename }}.zip -DestinationPath .\otp_test
+          .\otp_test\bin\erl.exe +V
+
+      - name: Upload
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload -R $env:GITHUB_REPOSITORY --clobber OTP-${{ inputs.version }} ${{ env.basename }}.zip

--- a/erts/etc/win32/INSTALL.txt
+++ b/erts/etc/win32/INSTALL.txt
@@ -1,0 +1,10 @@
+Welcome to Erlang/OTP!
+
+This Erlang installation requires "Microsoft Visual C++ Redistributable". Unless it is already
+present on your system, you can install vc_redist.exe that is included with this installation.
+For scripts, CIs, etc you may want to install it in "passive" mode:
+
+    .\vc_redist.exe /install /quiet /norestart
+
+For an installation that is more integrated with Windows (Adds Erlang to Start menu, Add/Remove
+Programs, etc), download a "Windows installer" from https://www.erlang.org/downloads.


### PR DESCRIPTION
Follow-up on https://github.com/erlang/otp/pull/8729

The workflow can be triggered like this:

```
$ gh workflow run -R wojtekmach/otp upload-windows-zip.yaml -f version=27.0.1
```

Here's an example workflow run: https://github.com/wojtekmach/otp/actions/runs/10738249662

This command can be used to attach zips to already existing releases.

There is one caveat with these zip builds. They have a runtime dependency on vc_redist.exe (https://github.com/erlang/otp/issues/8531). This is not a problem for Windows exe installers as they ship with _that_ and run it as part of the installation. In my personal opinion this is not a deal breaker for Windows zip builds, whoever ends up using them just needs to be aware of this (and/or #8531 is addressed). The tool I'd like to use these Windows zip builds for, https://elixir-install.org, handles that, for example.