### PR TITLE
Propagates ToS / Tclass socket options to peeled off SCTP diameter socket

### DIFF
--- a/lib/diameter/src/transport/diameter_sctp.erl
+++ b/lib/diameter/src/transport/diameter_sctp.erl
@@ -1005,6 +1005,8 @@ id(#sctp_adaptation_event{assoc_id = Id}) ->
 
 peeloff(LSock, Id, TPid) ->
     {ok, Sock} = gen_sctp:peeloff(LSock, Id),
+    {ok, ToSTC} = inet:getopts(LSock, [tos, tclass]),
+    ok = inet:setopts(Sock, ToSTC),
     ok = gen_sctp:controlling_process(Sock, TPid),
     Sock.
 


### PR DESCRIPTION
If you instrument a diameter TCP transport with `diameter:add_transport`, a TCP listening socket is created.
Upon connection, a new socket is created by accepting the connection. 
Upon inspecting the communucation with wireskark, the new accepted socket inherits the tos/tclass values specified as options.

The same behavior does not seem to apply when the transport type is SCTP. In this case, only the listening socket is using the tos/tclass value, whereas the accepted one skips the option.

![image](https://github.com/user-attachments/assets/7eaac7f1-b81f-4472-80c4-781a59ee8474)

The change ensures the propagation to peeled off sockets of diameter SCTP server-side sockets communication.
Maybe there's a better way I'm not aware of .. in case I'd like to know about it.
