### PR TITLE
shell: Add more explicit handling of when to save shell history

### DIFF
--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -453,7 +453,7 @@ to control what the terminal inputs or outputs.
 
 `terminal` is an alias for `stdout`.
 
-See `setopts/1` for a description of the other options.
+See `setopts/2` for a description of the other options.
 """.
 -spec getopts(IoDevice) -> [getopt()] | {'error', Reason} when
       IoDevice :: device(),
@@ -521,6 +521,11 @@ The options and values supported by the OTP I/O devices are as follows:
   fun("") -> {yes, "quit", []};
      (_) -> {no, "", ["quit"]} end
   ```
+
+  This option is only supported by the standard shell (`group.erl`).
+
+- **`{line_history, true | false}`** - Specifies if `get_line` and `get_until`
+  I/O requests should be saved in the `m:shell` history buffer.
 
   This option is only supported by the standard shell (`group.erl`).
 


### PR DESCRIPTION
This addresses the issue found [here](https://erlangforums.com/t/command-history-on-custom-elixir-cli-not-working-with-otp-26-but-was-with-otp-25/3950) and in #6896 by adding way for the shell to toggle whether an I/O 'get' request should be saved in history or not.

@josevalim things should continue work as always for Elixir, but I think it would be a good idea to check just in case. Maybe you want to do what we do and disable saving to history for any `get` commands run from within a shell session.