### PR TITLE
Print hint for when shell is stuck

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -465,10 +465,10 @@ handle_info(_State, {'EXIT', Drv, interrupt}, #state{ driver = Drv }  = Data) ->
     io_reply(Data, {error, interrupted}),
     pop_state(Data#state{ buf = [] });
 
-handle_info(_State, {'EXIT',Drv,R}, #state{ driver = Drv } = Data) ->
+handle_info(_State, {'EXIT',Drv,_R}, #state{ driver = Drv } = Data) ->
     [ exit(Data#state.shell, kill)
       || is_pid(Data#state.shell) andalso Data#state.input =/= undefined],
-    {stop, R};
+    {stop, normal};
 handle_info(_State, {'EXIT',Shell,R}, #state{ shell = Shell, driver = Drv }) ->
     %% We propagate the error reason from the shell to the driver, but we don't
     %% want to exit ourselves with that reason as it will generate crash report

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -608,7 +608,7 @@ switch_loop(internal, init, State) ->
                           groups = gr_add_cur(Gr1, NewGroup, {shell,start,[]})}};
 	jcl ->
             NewTTYState =
-                io_requests([{insert_chars,unicode,<<"\nUser switch command (type h for help)\n">>}],
+                io_requests([{insert_chars,unicode,<<"\nUser switch command (enter 'h' for help)\n">>}],
                             State#state.tty),
 	    %% init edlin used by switch command and have it copy the
 	    %% text buffer from current group process
@@ -708,11 +708,14 @@ switch_cmd({c, I}, Gr0, _Dumb) ->
     end;
 switch_cmd({i, I}, Gr, _Dumb) ->
     case gr_get_num(Gr, I) of
-	{pid,Pid} ->
-	    exit(Pid, interrupt),
-	    {retry, []};
-	undefined ->
-	    unknown_group()
+        {pid,Pid} ->
+            exit(Pid, interrupt),
+
+            {retry, [{put_chars, unicode,
+                      unicode:characters_to_binary(
+                        io_lib:format("Interrupted job ~p, enter 'c' to resume.~n",[I]))}]};
+        undefined ->
+            unknown_group()
     end;
 switch_cmd({k, I}, Gr, _Dumb) ->
     case gr_get_num(Gr, I) of

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -2389,6 +2389,8 @@ job_control_local(Config) when is_list(Config) ->
                {expect,  "\r\n35\r\n"},
                {expect,  "2> $"},
                {putline, "receive M -> M end.\r\n"},
+               {sleep, 6000},
+               {expect, "Command is taking a long time"},
                {putline, "\^g"},
                {expect,  "--> $"},
                {putline, "i 3"},

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -728,6 +728,8 @@ shell_cmd(Es, Eval, Bs, RT, FT, Ds, W) ->
     shell_rep(Eval, Bs, RT, FT, Ds).
 
 shell_rep(Ev, Bs0, RT, FT, Ds0) ->
+    shell_rep(Ev, Bs0, RT, FT, Ds0, 5000).
+shell_rep(Ev, Bs0, RT, FT, Ds0, Timeout) ->
     receive
         {shell_rep,Ev,{value,V,Bs,Ds}} ->
             {V,Ev,Bs,Ds};
@@ -774,6 +776,9 @@ shell_rep(Ev, Bs0, RT, FT, Ds0) ->
         _Other ->                               % Ignore everything else
             io:format("Throwing ~p~n", [_Other]),
             shell_rep(Ev, Bs0, RT, FT, Ds0)
+        after Timeout ->
+            io:format("Command is taking a long time, type Ctrl+G, then enter 'i' to interrupt~n"),
+            shell_rep(Ev, Bs0, RT, FT, Ds0, infinity)
     end.
 
 nocatch(throw, {Term,Stack}) ->
@@ -1981,8 +1986,6 @@ results(L) when is_integer(L), L >= 0 ->
     set_env(stdlib, shell_saved_results, L, ?DEF_RESULTS).
 
 -doc """
-catch_exception(Bool) -> boolean()
-
 Sets the exception handling of the evaluator process. The previous exception
 handling is returned. The default (`false`) is to kill the evaluator process
 when an exception occurs, which causes the shell to create a new evaluator


### PR DESCRIPTION
This PR prints a help message when the command in the shell does not complete within 5 seconds telling the user how to interrupt the current job.