### PR TITLE
erts: Require both stdin and stdout to be ttys to restore

### DIFF
--- a/erts/emulator/sys/unix/erl_child_setup.c
+++ b/erts/emulator/sys/unix/erl_child_setup.c
@@ -528,7 +528,7 @@ main(int argc, char *argv[])
 
     SET_CLOEXEC(uds_fd);
 
-    if (isatty(0)) {
+    if (isatty(0) && isatty(1)) {
         ssize_t res = read_all(uds_fd, (char*)&initial_tty_mode, sizeof(struct termios));
         if (res <= 0) {
             ABORT("Failed to read initial_tty_mode: %d (%d)", res, errno);
@@ -560,7 +560,7 @@ main(int argc, char *argv[])
                                     pipes, 3, MSG_DONTWAIT)) < 0) {
                 if (errno == EINTR)
                     continue;
-                if (isatty(0)) {
+                if (isatty(0) && isatty(1)) {
                     tcsetattr(0,TCSANOW,&initial_tty_mode);
                 }
                 DEBUG_PRINT("erl_child_setup failed to read from uds: %d, %d", res, errno);
@@ -569,7 +569,7 @@ main(int argc, char *argv[])
 
             if (res == 0) {
                 DEBUG_PRINT("uds was closed!");
-                if (isatty(0)) {
+                if (isatty(0) && isatty(1)) {
                     tcsetattr(0,TCSANOW,&initial_tty_mode);
                 }
                 _exit(0);

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -182,7 +182,7 @@ void sys_tty_reset(int exit_code)
   if (using_oldshell && !replace_intr) {
     SET_BLOCKING(0);
   }
-  else if (isatty(0)) {
+  else if (isatty(0) && isatty(1)) {
     tcsetattr(0,TCSANOW,&erl_sys_initial_tty_mode);
   }
 }

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -1666,7 +1666,7 @@ static ErlDrvData forker_start(ErlDrvPort port_num, char* name,
     /* If stdin is a tty then we need to restore its settings when we exit.
        So we send the tty mode to erl_child_setup so that it can cleanup
        in case the emulator is terminated with SIGKILL. */
-    if (isatty(0)) {
+    if (isatty(0) && isatty(1)) {
         ssize_t res, pos = 0;
         size_t size = sizeof(struct termios);
         byte *buff = (byte *)&erl_sys_initial_tty_mode;


### PR DESCRIPTION
If stdout is not a tty, then it might be a program that does its own alterations of the tty which means that we should not touch it and leave restoration to that program.

Closes #8487