### PR TITLE
asn1: Fix feature interaction with +undec_rest and +asn1config

### DIFF
--- a/lib/asn1/test/Makefile
+++ b/lib/asn1/test/Makefile
@@ -102,6 +102,7 @@ MODULES= \
 	testDER \
 	test_selective_decode \
 	test_special_decode_performance \
+	test_exclusive_decode_rest \
 	testTCAP \
 	testSSLspecs \
 	testSelectionTypes \

--- a/lib/asn1/test/asn1_SUITE.erl
+++ b/lib/asn1/test/asn1_SUITE.erl
@@ -59,6 +59,7 @@ all() ->
      test_undecoded_rest,
      specialized_decodes,
      special_decode_performance,
+     exclusive_decode_rest,
 
      testMegaco,
      testConstraints,
@@ -966,6 +967,13 @@ special_decode_performance(Config, Rule, Opts) ->
     Files = ["MEDIA-GATEWAY-CONTROL", "PartialDecSeq"],
     asn1_test_lib:compile_all(Files, Config, [Rule, asn1config|Opts]),
     test_special_decode_performance:go(all).
+
+exclusive_decode_rest(Config) ->
+    test(Config, fun exclusive_decode_rest/3, [ber]).
+exclusive_decode_rest(Config, Rule, Opts) ->
+    asn1_test_lib:compile("SwCDR.py", Config,
+                          [Rule, undec_rest, asn1config|Opts]),
+    test_exclusive_decode_rest:test().
 
 test_ParamTypeInfObj(Config) ->
     asn1_test_lib:compile("IN-CS-1-Datatypes", Config, [ber]).

--- a/lib/asn1/test/asn1_SUITE_data/SwCDR.asn1config
+++ b/lib/asn1/test/asn1_SUITE_data/SwCDR.asn1config
@@ -1,0 +1,6 @@
+{exclusive_decode,
+      {'SwCDR',
+            [{decode_cdr,
+                  ['SwCDR',
+                        [{origSvcCallRecord, undecoded},
+                        {termSvcCallRecord, undecoded}]]}]}}.

--- a/lib/asn1/test/test_exclusive_decode_rest.erl
+++ b/lib/asn1/test/test_exclusive_decode_rest.erl
@@ -1,0 +1,35 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2003-2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+%%
+-module(test_exclusive_decode_rest).
+-export([test/0]).
+
+test() ->
+	{ok, CDR} = 'SwCDR':encode('SwCDR', {origSvcCallRecord, orig_cdr()}),
+	Bin = <<CDR/binary, CDR/binary>>,
+	{ok, {origSvcCallRecord, _}, CDR} = 'SwCDR':decode_cdr(Bin).
+	
+orig_cdr() ->
+	{'OrigSvcCallRecord', 1, 2, 3, <<145,65,97,85,21,50,244>>,
+			<<145,65,97,85,85,118,248>>, <<145,65,97,85,85,118,248>>,
+			<<2,0,2,4,1,0,0,5>>, <<2,0,3,2,4,5>>, 35000, 0, 0, 0, 3600,
+			3600, 3600, 3600, 48, 48, 64, 64, 20, 20, 12, 12, 20, 20,
+			4, 4, 1, 1, 3600, 3600, asn1_NOVALUE}.
+


### PR DESCRIPTION
Compiling an ASN.1 specification Module using the `+undec_rest` option causes the result of `Module:decode/2` to be `{ok, Value, Rest}`, however when combined with `+asn1config` option to create exclusive decode functions those are not effected by the `+undec_rest` option.

This commit fixes this so exclusive decode functions return the expected result when the `+undec_rest` option is provided.