### PR TITLE
gh: Fix triggering upload-windows-zip.yaml workflow

### DIFF
--- a/.github/scripts/sync-github-releases.sh
+++ b/.github/scripts/sync-github-releases.sh
@@ -244,7 +244,7 @@ _upload_artifacts() {
             if echo "${RI[@]}" | grep "otp_${2}_${stripped_name}.zip" > /dev/null; then
                 if [ ${#MISSING_WIN_ZIP[@]} -lt 20 ]; then
                     MISSING_WIN_ZIP=("${MISSING_WIN_ZIP[@]}" "${stripped_name}")
-                    _curl_post "${REPO}/actions/workflows/upload-windows-zip.yaml/dispatches" -d '{"version":"'"${stripped_name}"'", "target":"'"${2}"'"}'
+                    _curl_post "${REPO}/actions/workflows/upload-windows-zip.yaml/dispatches" -d '{"ref":"master","inputs":{"version":"'"${stripped_name}"'", "target":"'"${2}"'"}}'
                 fi
             fi
             ## See if we need to re-build any prebuilds


### PR DESCRIPTION
I was able to reproduce the error we got on CI:

    $ gh api repos/wojtekmach/otp/actions/workflows/upload-windows-zip.yaml/dispatches --input <(echo '{"version":"'"OTP-27.0.1"'", "target":"'"win64"'"}')
    {
      "message": "Invalid request.\n\n\"target\", \"version\" are not permitted keys.\n\"ref\" wasn't supplied.",
      "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event",
      "status": "422"
    }

The inputs need to be under inputs key but that's still not enough:

    $ gh api repos/wojtekmach/otp/actions/workflows/upload-windows-zip.yaml/dispatches --input <(echo '{"inputs":{"version":"'"OTP-27.0.1"'", "target":"'"win64"'"}}')
    {
      "message": "Invalid request.\n\n\"ref\" wasn't supplied.",
      "documentation_url": "https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event",
      "status": "422"
    }

Passing `ref`, which per docs is "The branch or tag name which contains the version of the workflow file you'd like to run":

    $ gh api repos/wojtekmach/otp/actions/workflows/upload-windows-zip.yaml/dispatches --input <(echo '{"ref":"master", "inputs":{"version":"'"OTP-27.0.1"'", "target":"'"win64"'"}}')
    $

Fixed it.
