### PR TITLE
Introduce binary types to RFC3339 functions

### DIFF
--- a/lib/stdlib/test/Makefile
+++ b/lib/stdlib/test/Makefile
@@ -16,6 +16,7 @@ MODULES= \
 	binref \
 	c_SUITE \
 	calendar_SUITE \
+	calendar_prop_SUITE \
 	dets_SUITE \
 	dict_SUITE \
 	dict_test_lib \

--- a/lib/stdlib/test/calendar_prop_SUITE.erl
+++ b/lib/stdlib/test/calendar_prop_SUITE.erl
@@ -1,0 +1,50 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(calendar_prop_SUITE).
+
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
+	 init_per_group/2, end_per_group/2,
+         rfc3339_lists_binaries/1]).
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]}].
+
+all() ->
+    [rfc3339_lists_binaries].
+
+groups() ->
+    [].
+
+init_per_suite(Config) ->
+    ct_property_test:init_per_suite(Config).
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+rfc3339_lists_binaries(Config) when is_list(Config) ->
+    ct_property_test:quickcheck(
+        calendar_prop:rfc3339_lists_binaries(),
+        Config).

--- a/lib/stdlib/test/property_test/calendar_prop.erl
+++ b/lib/stdlib/test/property_test/calendar_prop.erl
@@ -1,0 +1,46 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(calendar_prop).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("common_test/include/ct_property_test.hrl").
+
+%%%%%%%%%%%%%%%%%%
+%%% Properties %%%
+%%%%%%%%%%%%%%%%%%
+
+between_40_years_ago_and_in_40_years() ->
+    integer(erlang:system_time(millisecond) - 40*1000*60*60*24*365,
+            erlang:system_time(millisecond) + 40*1000*60*60*24*365).
+
+rfc3339_lists_binaries() ->
+    Ms = [{unit, millisecond}],
+    ?FORALL(
+        TS,
+        between_40_years_ago_and_in_40_years(),
+        begin
+            DateTimeString = calendar:system_time_to_rfc3339(TS, Ms),
+            DateTimeBin = calendar:system_time_to_rfc3339(TS, [{return, binary} | Ms]),
+            ListToBinary = erlang:list_to_binary(DateTimeString),
+            FromStr = calendar:rfc3339_to_system_time(DateTimeString, Ms),
+            FromBin = calendar:rfc3339_to_system_time(DateTimeBin, Ms),
+            DateTimeBin =:= ListToBinary andalso FromStr =:= FromBin
+        end
+    ).


### PR DESCRIPTION
Far too often I've found myself working with binaries, to then have to convert back and forth from and to lists before I can use the RFC3339 functionality. So I'm adding here support for them.

Some examples only in MongooseIM:
- https://github.com/esl/MongooseIM/blob/9c1cdf8b3e5d6507d67030282958f306271b88fe/src/offline/mod_offline.erl#L519
- https://github.com/esl/MongooseIM/blob/9c1cdf8b3e5d6507d67030282958f306271b88fe/src/mam/mod_mam_utils.erl#L170

---

And a bit of benchmarks, using good old benchee:
TL;DR: list_to_binary/binary_to_list back and forth is usually ~20% slower, all other variations of the old and new code are very similar, if not having a slightly bit better performance.

`old` means code from master, `string` and `binary` are the new versions that handle such types respectively. `string_to_binary` is the old version having to then run list_to_binary/binary_to_list to operate with binaries.

### rfc3339_to_system_time
```
CPU Information: Apple M3 Pro
Number of Available Cores: 12
Available memory: 36 GB
Elixir 1.17.2
Erlang 27.0.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 30 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 2 min 8 s

Benchmarking binary ...
Benchmarking old ...
Benchmarking string ...
Benchmarking string_to_binary ...
Calculating statistics...
Formatting results...
Opened report using open

Name                       ips        average  deviation         median         99th %
string                  3.53 M      282.94 ns ±10413.42%         209 ns        1084 ns
old                     3.32 M      301.33 ns  ±7512.54%         209 ns        1084 ns
binary                  3.26 M      306.51 ns  ±8994.79%         250 ns        1125 ns
string_to_binary        2.87 M      347.92 ns  ±8248.59%         250 ns        1166 ns

Comparison: 
string                  3.53 M
old                     3.32 M - 1.07x slower +18.39 ns
binary                  3.26 M - 1.08x slower +23.57 ns
string_to_binary        2.87 M - 1.23x slower +64.97 ns

Extended statistics: 

Name                     minimum        maximum    sample size                     mode
string                    125 ns   137721230 ns        34.33 M                   208 ns
old                       125 ns    91555542 ns        32.62 M                   208 ns
binary                    166 ns   118339125 ns        31.03 M                   250 ns
string_to_binary          125 ns    78877442 ns        32.01 M                   250 ns
```

### system_time_to_rfc3339

```
Operating System: macOS
CPU Information: Apple M3 Pro
Number of Available Cores: 12
Available memory: 36 GB
Elixir 1.17.2
Erlang 27.0.1
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 30 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 2 min 8 s

Benchmarking binary ...
Benchmarking old ...
Benchmarking string ...
Benchmarking string_to_binary ...
Calculating statistics...
Formatting results...
Opened report using open

Name                       ips        average  deviation         median         99th %
string                894.01 K        1.12 μs ±12078.06%        0.71 μs        1.75 μs
binary                888.03 K        1.13 μs ±11991.90%        0.75 μs        1.79 μs
old                   865.27 K        1.16 μs ±13429.69%        0.71 μs        1.71 μs
string_to_binary      773.47 K        1.29 μs ±10962.04%        0.79 μs        1.88 μs

Comparison: 
string                894.01 K
binary                888.03 K - 1.01x slower +0.00752 μs
old                   865.27 K - 1.03x slower +0.0371 μs
string_to_binary      773.47 K - 1.16x slower +0.174 μs

Extended statistics: 

Name                     minimum        maximum    sample size                     mode
string                   0.58 μs   170797.39 μs        22.49 M                  0.71 μs
binary                   0.58 μs   178573.83 μs        22.25 M                  0.75 μs
old                      0.54 μs   242742.58 μs        21.78 M                  0.71 μs
string_to_binary         0.67 μs   127539.14 μs        19.93 M                  0.79 μs
```