### PR TITLE
Restrict github action releases on tags named "OTP-*"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -569,12 +569,12 @@ jobs:
           path: |
             make_test_dir/*_junit.xml
 
-  ## If this is a tag that has been pushed we do some release work
+  ## If this is an "OTP-*" tag that has been pushed we do some release work
   release:
     name: Release Erlang/OTP
     runs-on: ubuntu-latest
     needs: documentation
-    if: startsWith(github.ref, 'refs/tags/') && github.repository == 'erlang/otp'
+    if: startsWith(github.ref, 'refs/tags/OTP-') && github.repository == 'erlang/otp'
     ## Needed to create releases
     permissions:
       contents: write


### PR DESCRIPTION
Do not create releases on utility tags "patch-base-*".
