### PR TITLE
ssl: Convey alert information to passive socket operations recv and s…

### DIFF
--- a/lib/ssl/src/ssl_connection.hrl
+++ b/lib/ssl/src/ssl_connection.hrl
@@ -31,6 +31,7 @@
 -include("ssl_handshake.hrl").
 -include("ssl_srp.hrl").
 -include("ssl_cipher.hrl").
+-include("ssl_alert.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
 -record(static_env, {
@@ -108,7 +109,7 @@
                           user_application      :: {Monitor::reference(), User::pid()},
                           downgrade             :: {NewController::pid(), From::gen_statem:from()} | 'undefined',
                           socket_terminated = false                          ::boolean(),
-                          socket_tls_closed = false                          ::boolean(),
+                          socket_tls_closed = false                          ::boolean() | #alert{},
                           negotiated_version    :: ssl_record:ssl_version() | 'undefined',
                           erl_dist_handle = undefined :: erlang:dist_handle() | 'undefined',
                           cert_key_alts  = undefined ::  #{eddsa => list(),

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -566,14 +566,12 @@ config_error(_Type, _Event, _State) ->
 			gen_statem:state_function_result().
 %%--------------------------------------------------------------------
 connection({call, RecvFrom}, {recv, N, Timeout},
-	   #state{static_env = #static_env{protocol_cb = Connection},
-                  recv = Recv,
+	   #state{recv = Recv,
                   socket_options = #socket_options{active = false}
                  } = State0) ->
     passive_receive(State0#state{recv = Recv#recv{from = RecvFrom,
                                                   bytes_to_read = N}},
-                    ?STATE(connection), Connection,
-                    [{{timeout, recv}, Timeout, timeout}]);
+                    ?STATE(connection), [{{timeout, recv}, Timeout, timeout}]);
 connection({call, From}, peer_certificate,
 	   #state{session = #session{peer_certificate = Cert}} = State) ->
     hibernate_after(?STATE(connection), State, [{reply, From,  {ok, Cert}}]);
@@ -597,6 +595,18 @@ connection({call, From}, negotiated_protocol,
                                                  negotiated_protocol = undefined}} = State) ->
     hibernate_after(?STATE(connection), State,
 		    [{reply, From, {ok, SelectedProtocol}}]);
+connection({call, From}, 
+           {close,{_NewController, _Timeout}},
+           #state{static_env = #static_env{role = Role,
+                                           socket = Socket,
+                                           trackers = Trackers,
+                                           transport_cb = Transport,
+                                           protocol_cb = Connection},
+                  connection_env = #connection_env{socket_tls_closed = #alert{} = Alert}
+                 } = State) ->
+    Pids = Connection:pids(State),
+    alert_user(Pids, Transport, Trackers, Socket, From, Alert, Role, ?STATE(connection), Connection),
+    {stop, {shutdown, normal}, State};
 connection({call, From}, 
            {close,{NewController, Timeout}},
            #state{connection_states = ConnectionStates,
@@ -689,9 +699,8 @@ connection(cast, {dist_handshake_complete, DHandle},
 connection(info, Msg, #state{static_env = #static_env{protocol_cb = Connection}} = State) ->
     Connection:handle_info(Msg, ?STATE(connection), State);
 connection(internal, {recv, RecvFrom},
-           #state{recv = #recv{from=RecvFrom},
-                  static_env = #static_env{protocol_cb = Connection}} = State) ->
-    passive_receive(State, ?STATE(connection), Connection, []);
+           #state{recv = #recv{from=RecvFrom}} = State) ->
+    passive_receive(State, ?STATE(connection), []);
 connection(Type, Msg, State) ->
     handle_common_event(Type, Msg, ?STATE(connection), State).
 
@@ -876,7 +885,7 @@ handle_info({ErrorTag, Socket, econnaborted}, StateName,
                   } = State)  when StateName =/= connection ->
     maybe_invalidate_session(Version, Type, Role, Host, Port, Session),
     Pids = Connection:pids(State),
-    alert_user(Pids, Transport, Trackers,Socket,
+    alert_user(Pids, Transport, Trackers, Socket,
                StartFrom, ?ALERT_REC(?FATAL, ?CLOSE_NOTIFY), Role, StateName, Connection),
     {stop, {shutdown, normal}, State};
 
@@ -958,10 +967,22 @@ read_application_data(Data,
             end
     end.
 
+passive_receive(#state{static_env = #static_env{role = Role,
+                                                socket = Socket,
+                                                trackers = Trackers,
+                                                transport_cb = Transport,
+                                                protocol_cb = Connection},
+                       recv = #recv{from = RecvFrom},
+                       connection_env = #connection_env{socket_tls_closed = #alert{} = Alert}} = State, 
+                StateName, _) ->
+    Pids = Connection:pids(State),
+    alert_user(Pids, Transport, Trackers, Socket, RecvFrom, Alert, Role, StateName, Connection),
+    {stop, {shutdown, normal}, State};
 passive_receive(#state{user_data_buffer = {Front,BufferSize,Rear},
                        %% Assert! Erl distribution uses active sockets
+                       static_env = #static_env{protocol_cb = Connection},
                        connection_env = #connection_env{erl_dist_handle = undefined}}
-                = State0, StateName, Connection, StartTimerAction) ->
+                = State0, StateName, StartTimerAction) ->
     case BufferSize of
 	0 ->
 	    Connection:next_event(StateName, no_record, State0, StartTimerAction);
@@ -1396,8 +1417,21 @@ handle_active_option(_, connection = StateName, To, Reply,
     Alert = ?ALERT_REC(?FATAL, ?CLOSE_NOTIFY, all_data_delivered),
     handle_normal_shutdown(Alert#alert{role = Role}, StateName, State),
     {stop_and_reply,{shutdown, peer_close}, [{reply, To, Reply}]};
-handle_active_option(_, connection = StateName0, To, Reply, #state{static_env = #static_env{protocol_cb = Connection},
-                                                                   user_data_buffer = {_,0,_}} = State0) ->
+handle_active_option(_, connection = StateName, To, _Reply,
+                     #state{static_env = #static_env{role = Role,
+                                                     socket = Socket,
+                                                     trackers = Trackers,
+                                                     transport_cb = Transport,
+                                                     protocol_cb = Connection},
+                            connection_env =
+                                #connection_env{socket_tls_closed = Alert = #alert{}},
+                            user_data_buffer = {_,0,_}} = State) ->
+    Pids = Connection:pids(State),
+    alert_user(Pids, Transport, Trackers, Socket, To, Alert, Role, StateName, Connection),
+    {stop, {shutdown, normal}, State};
+handle_active_option(_, connection = StateName0, To, Reply,
+                     #state{static_env = #static_env{protocol_cb = Connection},
+                            user_data_buffer = {_,0,_}} = State0) ->
     case Connection:next_event(StateName0, no_record, State0) of
 	{next_state, StateName, State} ->
             gen_statem:reply(To, Reply),

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -908,12 +908,17 @@ handle_alerts([], Result) ->
 handle_alerts(_, {stop, _, _} = Stop) ->
     Stop;
 handle_alerts([#alert{level = ?WARNING, description = ?CLOSE_NOTIFY} | _Alerts], 
-              {next_state, connection = StateName,
-               #state{connection_env = CEnv,
-                      socket_options = #socket_options{active = false},
-                      recv = #recv{from = From}} = State}) when From == undefined ->
-    {next_state, StateName,
-     State#state{connection_env = CEnv#connection_env{socket_tls_closed = true}}};
+              {next_state, connection = StateName, #state{connection_env = CEnv, 
+                                                          socket_options = #socket_options{active = false},
+                                                          recv =  #recv{from = From}} = State}) when From == undefined ->
+    %% Linger to allow recv and setopts to possibly fetch data not yet delivered to user to be fetched
+    {next_state, StateName, State#state{connection_env = CEnv#connection_env{socket_tls_closed = true}}};
+handle_alerts([#alert{level = ?FATAL} = Alert | _Alerts], 
+              {next_state, connection = StateName, #state{connection_env = CEnv, 
+                                                          socket_options = #socket_options{active = false},
+                                                          recv = #recv{from = From}} = State}) when From == undefined ->
+    %% Linger to allow recv and setopts to retrieve alert reason 
+    {next_state, StateName, State#state{connection_env = CEnv#connection_env{socket_tls_closed = Alert}}};
 handle_alerts([Alert | Alerts], {next_state, StateName, State}) ->
     handle_alerts(Alerts, ssl_gen_statem:handle_alert(Alert, StateName, State));
 handle_alerts([Alert | Alerts], {next_state, StateName, State, _Actions}) ->


### PR DESCRIPTION
…etopts

If a TLS-1.3 server fails client certification the alert might arrive in the connection state and even after data has been sent. Make sure the alert information will be available in error reason returned from passive socket API functions recv and setopt.