### PR TITLE
public_key: Do not hide crypto runtime exceptions

### DIFF
--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -833,12 +833,7 @@ sign(DigestOrPlainText, DigestType, Key, Options) ->
 	badarg ->
 	    erlang:error(badarg, [DigestOrPlainText, DigestType, Key, Options]);
 	{Algorithm, CryptoKey} ->
-	    try crypto:sign(Algorithm, DigestType, DigestOrPlainText, CryptoKey, Options)
-            catch %% Compatible with old error schema
-                error:{notsup,_,_} -> error(notsup);
-                error:{error,_,_} -> error(error);
-                error:{badarg,_,_} -> error(badarg)
-            end
+	    crypto:sign(Algorithm, DigestType, DigestOrPlainText, CryptoKey, Options)
     end.
 
 %%--------------------------------------------------------------------
@@ -868,12 +863,7 @@ verify(DigestOrPlainText, DigestType, Signature, Key, Options) when is_binary(Si
 	badarg ->
 	    erlang:error(badarg, [DigestOrPlainText, DigestType, Signature, Key, Options]);
 	{Algorithm, CryptoKey} ->
-	    try crypto:verify(Algorithm, DigestType, DigestOrPlainText, Signature, CryptoKey, Options)
-            catch %% Compatible with old error schema
-                error:{notsup,_,_} -> error(notsup);
-                error:{error,_,_} -> error(error);
-                error:{badarg,_,_} -> error(badarg)
-            end
+	    crypto:verify(Algorithm, DigestType, DigestOrPlainText, Signature, CryptoKey, Options)
     end;
 verify(_,_,_,_,_) ->
     %% If Signature is a bitstring and not a binary we know already at this


### PR DESCRIPTION
This type of runtime error hiding is not considered something that is part of the API that needs to be backwards compatible. This only hides the real error and does not help prevent bugs. This exceptions occur when input data is not correct and should be clearly reported when it occurs.