### PR TITLE
Update EUnit assert macro tests

### DIFF
--- a/lib/eunit/doc/guides/chapter.md
+++ b/lib/eunit/doc/guides/chapter.md
@@ -655,6 +655,9 @@ these macros have no effect when testing is also disabled; see
   `assertException` with a `ClassPattern` of `error`, `exit`, or `throw`,
   respectively.
 
+- **`assertNotException(ClassPattern, TermPattern)`** - The inverse case
+  of assertException, for convenience.
+
   Examples:
 
   ```text

--- a/lib/eunit/include/eunit.hrl
+++ b/lib/eunit/include/eunit.hrl
@@ -133,7 +133,7 @@
 
 -define(_test(Expr), {?LINE, fun () -> (Expr) end}).
 -define(_assert(BoolExpr), ?_test(?assert(BoolExpr))).
--define(_assertNot(BoolExpr), ?_assert(not (BoolExpr))).
+-define(_assertNot(BoolExpr), ?_test(?assertNot(BoolExpr))).
 -define(_assertMatch(Guard, Expr), ?_test(?assertMatch(Guard, Expr))).
 -define(_assertNotMatch(Guard, Expr), ?_test(?assertNotMatch(Guard, Expr))).
 -define(_assertEqual(Expect, Expr), ?_test(?assertEqual(Expect, Expr))).
@@ -141,9 +141,9 @@
 	?_test(?assertNotEqual(Unexpected, Expr))).
 -define(_assertException(Class, Term, Expr),
 	?_test(?assertException(Class, Term, Expr))).
--define(_assertError(Term, Expr), ?_assertException(error, Term, Expr)).
--define(_assertExit(Term, Expr), ?_assertException(exit, Term, Expr)).
--define(_assertThrow(Term, Expr), ?_assertException(throw, Term, Expr)).
+-define(_assertError(Term, Expr), ?_test(?assertError(Term, Expr))).
+-define(_assertExit(Term, Expr), ?_test(?assertExit(Term, Expr))).
+-define(_assertThrow(Term, Expr), ?_test(?assertThrow(Term, Expr))).
 -define(_assertNotException(Class, Term, Expr),
 	?_test(?assertNotException(Class, Term, Expr))).
 

--- a/lib/eunit/src/eunit_test.erl
+++ b/lib/eunit/src/eunit_test.erl
@@ -95,7 +95,7 @@ macro_test_() ->
  	     end),
       ?_test(begin
  		 {?LINE, F} = ?_assert(false),
- 		 {error,{error,{assertion_failed,
+		 {error,{error,{assert,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -106,12 +106,12 @@ macro_test_() ->
  	     end),
       ?_test(begin
  		 {?LINE, F} = ?_assert([]),
- 		 {error,{error,{assertion_failed,
+		 {error,{error,{assert,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
 				 {expected,true},
-				 {value,{not_a_boolean,[]}}]},
+				 {not_boolean,[]}]},
 			 _}}
 		     = run_testfun(F)
  	     end),
@@ -121,7 +121,7 @@ macro_test_() ->
  	     end),
       ?_test(begin
  		 {?LINE, F} = ?_assertNot(true),
- 		 {error,{error,{assertion_failed,
+		 {error,{error,{assert,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -136,7 +136,7 @@ macro_test_() ->
  	     end),
       ?_test(begin
  		 {?LINE, F} = ?_assertMatch([_], []),
- 		 {error,{error,{assertMatch_failed,
+		 {error,{error,{assertMatch,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -151,7 +151,7 @@ macro_test_() ->
 	     end),
       ?_test(begin
 		 {?LINE, F} = ?_assertNotMatch([_], [42]),
-		 {error,{error,{assertNotMatch_failed,
+		 {error,{error,{assertNotMatch,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -166,7 +166,7 @@ macro_test_() ->
  	     end),
       ?_test(begin
  		 {?LINE, F} = ?_assertEqual(id(3), id(1+1)),
- 		 {error,{error,{assertEqual_failed,
+		 {error,{error,{assertEqual,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -181,7 +181,7 @@ macro_test_() ->
 	     end),
       ?_test(begin
 		 {?LINE, F} = ?_assertNotEqual(2, 1+1),
-		 {error,{error,{assertNotEqual_failed,
+		 {error,{error,{assertNotEqual,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -196,7 +196,7 @@ macro_test_() ->
  	     end),
       ?_test(begin
  		 {?LINE, F} = ?_assertException(error, badarith, ok),
- 		 {error,{error,{assertException_failed,
+		 {error,{error,{assertException,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -208,7 +208,7 @@ macro_test_() ->
       ?_test(begin
  		 {?LINE, F} = ?_assertException(error, badarg,
  						erlang:error(badarith)),
- 		 {error,{error,{assertException_failed,
+		 {error,{error,{assertException,
 				[{module,_},
 				 {line,_},
 				 {expression,_},
@@ -243,7 +243,7 @@ macro_test_() ->
       ?_test(begin
 		 {?LINE, F} = ?_assertNotException(error, badarith,
 						   erlang:error(badarith)),
-		 {error,{error,{assertNotException_failed,
+		 {error,{error,{assertNotException,
 				[{module,_},
 				 {line,_},
 				 {expression,_},

--- a/lib/eunit/src/eunit_test.erl
+++ b/lib/eunit/src/eunit_test.erl
@@ -125,8 +125,19 @@ macro_test_() ->
 				[{module,_},
 				 {line,_},
 				 {expression,_},
-				 {expected,true},
-				 {value,false}]},
+				 {expected,false},
+				 {value,true}]},
+			 _}}
+		     = run_testfun(F)
+	     end),
+      ?_test(begin
+		 {?LINE, F} = ?_assertNot([]),
+		 {error,{error,{assert,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {expected,false},
+				 {not_boolean,[]}]},
 			 _}}
 		     = run_testfun(F)
  	     end),
@@ -224,12 +235,82 @@ macro_test_() ->
 		 {ok, ok} = run_testfun(F)
 	     end),
       ?_test(begin
+		 {?LINE, F} = ?_assertError(badarith, ok),
+		 {error,{error,{assertException,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {pattern,_},
+				 {unexpected_success,ok}]},
+			 _}}
+		     = run_testfun(F)
+	     end),
+      ?_test(begin
+		 {?LINE, F} = ?_assertError(badarith,
+					    erlang:error(badarg)),
+		 {error,{error,{assertException,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {pattern,_},
+				 {unexpected_exception,
+				  {error,badarg,_}}]},
+			 _}}
+		     = run_testfun(F)
+	     end),
+      ?_test(begin
 		 {?LINE, F} = ?_assertExit(normal, exit(normal)),
 		 {ok, ok} = run_testfun(F)
 	     end),
       ?_test(begin
+		 {?LINE, F} = ?_assertExit(normal, ok),
+		 {error,{error,{assertException,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {pattern,_},
+				 {unexpected_success,ok}]},
+			 _}}
+		     = run_testfun(F)
+	     end),
+      ?_test(begin
+		 {?LINE, F} = ?_assertExit(normal, exit(shutdown)),
+		 {error,{error,{assertException,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {pattern,_},
+				 {unexpected_exception,
+				  {exit,shutdown,_}}]},
+			 _}}
+		     = run_testfun(F)
+	     end),
+      ?_test(begin
 		 {?LINE, F} = ?_assertThrow(foo, throw(foo)),
 		 {ok, ok} = run_testfun(F)
+	     end),
+      ?_test(begin
+		 {?LINE, F} = ?_assertThrow(foo, ok),
+		 {error,{error,{assertException,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {pattern,_},
+				 {unexpected_success,ok}]},
+			 _}}
+		     = run_testfun(F)
+	     end),
+      ?_test(begin
+		 {?LINE, F} = ?_assertThrow(foo, throw(bar)),
+		 {error,{error,{assertException,
+				[{module,_},
+				 {line,_},
+				 {expression,_},
+				 {pattern,_},
+				 {unexpected_exception,
+				  {throw,bar,_}}]},
+			 _}}
+		     = run_testfun(F)
 	     end),
       ?_test(begin
 		 {?LINE, F} = ?_assertNotException(error, badarith, 42),

--- a/lib/eunit/test/eunit_SUITE.erl
+++ b/lib/eunit/test/eunit_SUITE.erl
@@ -66,7 +66,7 @@ appup_test(Config) when is_list(Config) ->
 
 eunit_test(Config) when is_list(Config) ->
     ok = file:set_cwd(code:lib_dir(eunit)),
-    ok = eunit:test(eunit).
+    ok = eunit:test({application, eunit}).
 
 eunit_exact_test(Config) when is_list(Config) ->
     ok = file:set_cwd(code:lib_dir(eunit)),


### PR DESCRIPTION
These changes run EUnit application tests from eunit_SUITE, update assert macro tests, and ensure that _assert* and assert* use the same error terms.