### PR TITLE
added support for search and setup WSL for `[amd64_]arm64`

### DIFF
--- a/erts/etc/win32/wsl_tools/SetupWSLcross.bat
+++ b/erts/etc/win32/wsl_tools/SetupWSLcross.bat
@@ -4,6 +4,9 @@ rem Usage: eval `cmd.exe /c SetupWSLcross.bat x64`
 
 IF "%~1"=="x86" GOTO search
 IF "%~1"=="x64" GOTO search
+IF "%~1"=="arm64" GOTO search
+IF "%~1"=="amd64_arm64" GOTO search
+IF "%~1"=="x64_arm64" GOTO search
 
 GOTO badarg
 
@@ -67,7 +70,12 @@ GOTO no_vcvars
 
 :continue
 
-FOR /F "delims==" %%F IN ('where cl.exe') DO SET _cl_exec_=%%F
+FOR /F "delims==" %%F IN ('where cl.exe') DO (
+   SET _cl_exec_=%%F
+   goto set_cl_path
+)
+
+:set_cl_path
 FOR %%F IN ("%_cl_exec_%") DO SET CL_PATH=%%~dpF
 
 FOR /F "delims==" %%F IN ('where rc.exe') DO SET _rc_exec_=%%F
@@ -87,7 +95,7 @@ wsl.exe echo "# Eval this file eval \`cmd.exe /c SetupWSLcross.bat\`"
 exit
 
 :badarg
-echo "Bad TARGET or not specified: %~1 expected x86 or x64"
+echo "Bad TARGET or not specified: %~1 expected x86, x64, arm64 or amd64_arm64(x64_arm64)"
 exit
 
 :no_vcvars


### PR DESCRIPTION
This PR is one of the smaller PRs separated from the original PR https://github.com/erlang/otp/pull/8142 that attempts to add initial support for ARM64 windows. 

In this PR,

- `SetupWSLcross.bat` can also accept either `arm64` or `amd64_arm64` (`x64_arm64`) for its first parameter

  `arm64`, `amd64_arm64` and `x64_arm64` are the official values used in the `vcvarsall.bat` script, [vcvarsall syntax](https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170#vcvarsall-syntax).

  `arm64` means to set up the environment when compiling natively, whereas `amd64_arm64` and `x64_arm64` means to set up the cross-compiling environment on an amd64 host machine for the arm64 target machine.

- Updated relevant lines for setting the path for `cl.exe` 

  When cross-compiling, e.g., after executing `vcvarsall.bat amd64_arm64`, we can see two `cl.exe` in PATH with the first one being the cross-compiler for the arm64 target, and the second one being the native compiler for the amd64 host machine.

  ```
  > where cl.exe
  INFO: Could not find files for the given pattern(s).
  > C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat amd64_arm64
  > where cl.exe
  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\Hostx64\arm64\cl.exe
  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.39.33519\bin\Hostx64\x64\cl.exe
  ```

  In this script, `CL_PATH` should be set to the directory that contains the cross-compiler, therefore, we need to remember the first one in `_cl_exec_` and then break from the for-loop.