### PR TITLE
Add an example of the log message emitted when going to drop mode

### DIFF
--- a/lib/kernel/doc/guides/logger_chapter.md
+++ b/lib/kernel/doc/guides/logger_chapter.md
@@ -1013,6 +1013,8 @@ actions, exist:
   message queue is reduced to a level below the threshold, synchronous or
   asynchronous mode is resumed. Notice that when the handler activates or
   deactivates drop mode, information about it is printed in the log.
+  The emitted log message looks something like this:
+  `[notice] Handler :default switched from :sync to :drop mode`
 
   Defaults to `200` messages.
 


### PR DESCRIPTION
I think it's very helpful to have this documented, as I had been looking for it and while you can just try and search your logs for `:drop` having the concrete message as an example is helpful (and other people looking into this had asked me about it).

As per usual, thank you for your excellent work! :green_heart: 

edit: I was unsure whether this should go against `maint` or `master` - I decided for the latter but I'm happy to switch it around.