### PR TITLE
Clarify burst mode protection and non file based logging

### DIFF
--- a/lib/kernel/doc/guides/logger_chapter.md
+++ b/lib/kernel/doc/guides/logger_chapter.md
@@ -1082,6 +1082,10 @@ period of time - can potentially cause problems, such as:
 - Circular logs wrap too quickly so that important data is overwritten.
 - Write buffers grow large, which slows down file sync operations.
 
+Note that these examples apply to file-based logging. If you're logging to
+the console the protections discussed below should be safe to disable or
+tweak, as long as your system can handle the load of them.
+
 For this reason, both built-in handlers offer the possibility to specify the
 maximum number of events to be handled within a certain time frame. With this
 burst control feature enabled, the handler can avoid choking the log with


### PR DESCRIPTION
Reading the docs my impression was that the reasons mentioned for burst mode protection do only apply to file-based logging or at least the examples only do.

Locking to the console is fairly common in cloud-based environments.
I have deactivated the burst mode protection (that had swallowed about 2/3s of our log messages) and the system is running fine without any impact on CPU or memory that I could spot.

So, this is part me wanting to clarify this in the doc but also part me checking in about my understanding of the interplay of this.

Thank you all so much for your work :green_heart: 