### PR TITLE
Kuba/ssh/receive exit fix options construct fix/otp 19246/otp 19247

### DIFF
--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -355,7 +355,7 @@ connect(Host0, Port, UserOptions, NegotiationTimeout)
             {error, Reason};
 
         Options ->
-            SocketOpts = [{active,false} | ?GET_OPT(socket_options,Options)],
+            SocketOpts = ?GET_OPT(socket_options,Options) ++ [{active,false}],
             Host = mangle_connect_address(Host0, Options),
             try
                 transport_connect(Host, Port, SocketOpts, Options)

--- a/lib/ssh/src/ssh_acceptor.erl
+++ b/lib/ssh/src/ssh_acceptor.erl
@@ -87,7 +87,6 @@ acceptor_init(Parent, SystemSup,
                     proc_lib:init_ack(Parent, {ok, self()}),
                     request_ownership(LSock, SockOwner),
                     acceptor_loop(Port, Address, Opts, LSock, AcceptTimeout, SystemSup);
-
                 {error,_Error} ->
                     %% Not open, a restart
                     %% Allow gen_tcp:listen to fail 4 times if eaddrinuse (It is a bug fix):
@@ -100,7 +99,6 @@ acceptor_init(Parent, SystemSup,
                             proc_lib:init_fail(Parent, {error,Error}, {exit, normal})
                     end
             end;
-
         undefined ->
             %% No listening socket (nor fd option) was provided; open a listening socket:
             case try_listen(Port, Opts, 4) of
@@ -111,7 +109,6 @@ acceptor_init(Parent, SystemSup,
                     proc_lib:init_fail(Parent, {error,Error}, {exit, normal})
             end
     end.
-
 
 try_listen(Port, Opts, NtriesLeft) ->
     try_listen(Port, Opts, 1, NtriesLeft).
@@ -124,7 +121,6 @@ try_listen(Port, Opts, N, Nmax) ->
         Other ->
             Other
     end.
-
 
 request_ownership(LSock, SockOwner) ->
     SockOwner ! {request_control,LSock,self()},
@@ -141,7 +137,8 @@ acceptor_loop(Port, Address, Opts, ListenSocket, AcceptTimeout, SystemSup) ->
                 MaxSessions = ?GET_OPT(max_sessions, Opts),
                 NumSessions = number_of_connections(SystemSup),
                 ParallelLogin = ?GET_OPT(parallel_login, Opts),
-                case handle_connection(Address, Port, PeerName, Opts, Socket, MaxSessions, NumSessions, ParallelLogin) of
+                case handle_connection(Address, Port, PeerName, Opts, Socket,
+                                       MaxSessions, NumSessions, ParallelLogin) of
                     {error,Error} ->
                         catch close(Socket, Opts),
                         handle_error(Error, Address, Port, PeerName);
@@ -158,18 +155,19 @@ acceptor_loop(Port, Address, Opts, ListenSocket, AcceptTimeout, SystemSup) ->
     ?MODULE:acceptor_loop(Port, Address, Opts, ListenSocket, AcceptTimeout, SystemSup).
 
 %%%----------------------------------------------------------------
-handle_connection(_Address, _Port, _Peer, _Options, _Socket, MaxSessions, NumSessions, _ParallelLogin)
+handle_connection(_Address, _Port, _Peer, _Options, _Socket,
+                  MaxSessions, NumSessions, _ParallelLogin)
   when NumSessions >= MaxSessions->
     {error,{max_sessions,MaxSessions}};
-
-handle_connection(_Address, _Port, {error,Error}, _Options, _Socket, _MaxSessions, _NumSessions, _ParallelLogin) ->
+handle_connection(_Address, _Port, {error,Error}, _Options, _Socket,
+                  _MaxSessions, _NumSessions, _ParallelLogin) ->
     {error,Error};
-
-handle_connection(Address, Port, _Peer, Options, Socket, _MaxSessions, _NumSessions, ParallelLogin)
+handle_connection(Address, Port, _Peer, Options, Socket,
+                  _MaxSessions, _NumSessions, ParallelLogin)
   when ParallelLogin == false ->
     handle_connection(Address, Port, Options, Socket);
-
-handle_connection(Address, Port, _Peer, Options, Socket, _MaxSessions, _NumSessions, ParallelLogin)
+handle_connection(Address, Port, _Peer, Options, Socket,
+                  _MaxSessions, _NumSessions, ParallelLogin)
   when ParallelLogin == true ->
     Ref = make_ref(),
     Pid = spawn_link(
@@ -185,8 +183,6 @@ handle_connection(Address, Port, _Peer, Options, Socket, _MaxSessions, _NumSessi
     catch gen_tcp:controlling_process(Socket, Pid),
     Pid ! {start,Ref},
     ok.
-
-
 
 handle_connection(Address, Port, Options0, Socket) ->
     Options = ?PUT_INTERNAL_OPT([{user_pid, self()}

--- a/lib/ssh/src/ssh_acceptor.erl
+++ b/lib/ssh/src/ssh_acceptor.erl
@@ -48,7 +48,7 @@ start_link(SystemSup, Address, Options) ->
 %%%----------------------------------------------------------------
 listen(Port, Options) ->
     {_, Callback, _} = ?GET_OPT(transport, Options),
-    SockOpts = [{active, false}, {reuseaddr,true} | ?GET_OPT(socket_options, Options)],
+    SockOpts = ?GET_OPT(socket_options, Options) ++ [{active, false}, {reuseaddr,true}],
     case Callback:listen(Port, SockOpts) of
 	{error, nxdomain} ->
 	    Callback:listen(Port, lists:delete(inet6, SockOpts));

--- a/lib/ssh/src/ssh_app.erl
+++ b/lib/ssh/src/ssh_app.erl
@@ -23,11 +23,11 @@
 %%%=========================================================================
 %%% Purpose : Application master and top supervisors for SSH.
 %%%
-%%%  -----> ssh_sup -----+-----> sshc_sup --+--> "system sup" (etc)
+%%%  -----> ssh_sup -----+-----> sshc_sup --+--> "connection sup" (etc)
 %%%                      |                  |
-%%%                      |                  +--> "system sup" (etc)
+%%%                      |                  +--> "connection sup" (etc)
 %%%                      |                  :
-%%%                      |                  +--> "system sup" (etc)
+%%%                      |                  +--> "connection sup" (etc)
 %%%                      |
 %%%                      +-----> sshc_sup --+--> "system sup" (etc)
 %%%                                         |

--- a/lib/ssh/src/ssh_info.erl
+++ b/lib/ssh/src/ssh_info.erl
@@ -140,7 +140,7 @@ format_sup(client,
            Indent) when is_reference(Ref) ->
     [io_lib:format("~sLocal: ~s~n"
                    "~sRemote: ~s (Version: ~s)~n"
-                   "~sConnectionRef=~s, subsys_sup=~s~n",
+                   "~sConnectionRef=~s, connection_sup=~s~n",
                    [indent(Indent), local_addr(ConnPid),
                     indent(Indent), peer_addr(ConnPid), peer_version(client,ConnPid),
                     indent(Indent), print_pid(ConnPid), print_pid(ConnSup)
@@ -157,7 +157,7 @@ format_sup(server,
            },
            Indent) when is_reference(Ref) ->
     [io_lib:format("~sRemote: ~s (Version: ~s)~n"
-                   "~sConnectionRef=~s, subsys_sup=~s~n",
+                   "~sConnectionRef=~s, connection_sup=~s~n",
                    [indent(Indent), peer_addr(ConnPid), peer_version(server,ConnPid),
                     indent(Indent), print_pid(ConnPid), print_pid(ConnSup)
                    ]),

--- a/lib/ssh/src/ssh_tcpip_forward_acceptor.erl
+++ b/lib/ssh/src/ssh_tcpip_forward_acceptor.erl
@@ -36,9 +36,8 @@ supervised_start(FwdSup, {ListenAddrStr, ListenPort}, ConnectToAddr, ChanType, C
     case get_fwd_listen_opts(ListenAddrStr) of
         {ok,Opts} ->
             %% start listening on Addr:BoundPort
-            case gen_tcp:listen(ListenPort, [binary,
-                                             {reuseaddr,true},
-                                             {active,false} | Opts]) of
+            case gen_tcp:listen(ListenPort,
+                                Opts ++ [binary, {reuseaddr,true}, {active,false}]) of
                 {ok,LSock} ->
                     {ok,{_, TrueListenPort}} = inet:sockname(LSock),
                     ssh_tcpip_forward_acceptor_sup:start_child(FwdSup,

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -1250,18 +1250,23 @@ find_handshake_parent([{{ssh_acceptor_sup,{address,_,Port,_}},
                        Port, {AccP,AccC,AccH}) ->
     ParentHandshakers =
         [{PidW,PidH} ||
-            {{ssh_acceptor_sup,{address,_,Port1,_}}, PidW, worker, [ssh_acceptor]} <-
-                supervisor:which_children(PidS),
+            {{ssh_acceptor_sup,{address,_,Port1,_}}, PidW, worker,
+             [ssh_acceptor]} <- supervisor:which_children(PidS),
             Port1 == Port,
             PidH <- element(2, process_info(PidW,links)),
             is_pid(PidH),
-            process_info(PidH,current_function) == {current_function,{ssh_connection_handler,handshake,3}}],
+            process_info(PidH,current_function) ==
+                {current_function,
+                 {ssh_connection_handler,handshake,4}}],
     {Parents,Handshakers} = lists:unzip(ParentHandshakers),
     find_handshake_parent(T, Port, {AccP++Parents, AccC, AccH++Handshakers});
 
-find_handshake_parent([{_Ref,PidS,supervisor,[ssh_connection_sup]}|T], Port, {AccP,AccC,AccH}) ->
+find_handshake_parent([{_Ref,PidS,supervisor,[ssh_connection_sup]}|T],
+                      Port, {AccP,AccC,AccH}) ->
     Connections =
-        [Pid || {connection,Pid,worker,[ssh_connection_handler]} <- supervisor:which_children(PidS)],
+        [Pid ||
+            {connection,Pid,worker,[ssh_connection_handler]} <-
+                supervisor:which_children(PidS)],
     find_handshake_parent(T, Port, {AccP, AccC++Connections, AccH});
 
 find_handshake_parent([_|T], Port, Acc) ->


### PR DESCRIPTION
Fix for GH-8223 and also append `{active, false}` at the end of socket options.

Server supervision tree improvements are planned to be done in other PR.