### PR TITLE
Provide an overview of logger overload protection

### DIFF
--- a/lib/kernel/doc/guides/logger_chapter.md
+++ b/lib/kernel/doc/guides/logger_chapter.md
@@ -973,10 +973,23 @@ do_log(Fd, LogEvent, #{formatter := {FModule, FConfig}}) ->
 
 ## Protecting the Handler from Overload
 
-The default handlers, `m:logger_std_h` and `m:logger_disk_log_h`, feature an
-overload protection mechanism, which makes it possible for the handlers to
-survive, and stay responsive, during periods of high load (when huge numbers of
-incoming log requests must be handled). The mechanism works as follows:
+The default handlers, `m:logger_std_h` and `m:logger_disk_log_h`, feature
+multiple overload protection mechanisms, which make it possible for the
+handlers to survive, and stay responsive, during periods of high load
+(when huge numbers of incoming log requests must be handled).
+
+The mechanisms are as follows:
+* [**message queue length**](#message-queue-length): the handler process tracks
+its message queue length and takes actions depending on its size, from turning
+on a sync mode to dropping messages.
+* [**limit the number of logs emitted**](#controlling-bursts-of-log-requests):
+the handlers will handle a maximum number of log events per time unit,
+defaulting to 500 per second.
+* [**terminate an overloaded handler**](#terminating-an-overloaded-handler):
+a handler can be terminated and restarted automatically if it exceeds message
+queue length or memory thresholds - this is disabled by default.
+
+These mechanisms are described in more detail in the following sections.
 
 ### Message Queue Length
 


### PR DESCRIPTION
Digging into the topic of logger overload protection I found it somewhat hard to follow and keep track of what all the systems do on a high level.

It probably doesn't solve this for everything, but I think providing a high level overview of the measures in place can help others to better understand the mechanisms and dive into the one they care the most about.

Thank you all so much for your work :green_heart: 