### PR TITLE
Fix bug in NIF loading of function traced by multiple sessions

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -5046,8 +5046,10 @@ static void patch_call_nif_early(ErlNifEntry* entry,
                  * Function traced, patch the original instruction word
                  * Code write permission protects against racing breakpoint writes.
                  */
-                GenericBp* g = ci_rw->gen_bp;
-                g->orig_instr = BeamSetCodeAddr(g->orig_instr, call_nif_early);
+                for (GenericBp* g = ci_rw->gen_bp; g; g = g->next) {
+                    ASSERT(!g->to_insert);
+                    g->orig_instr = BeamSetCodeAddr(g->orig_instr, call_nif_early);
+                }
                 if (BeamIsOpCode(code_ptr[0], op_i_generic_breakpoint))
                     continue;
             } else {
@@ -5190,10 +5192,11 @@ static void load_nif_2nd_finisher(void* vlib)
                     /*
                     * Function traced, patch the original instruction word
                     */
-                    GenericBp* g = ci_rw->gen_bp;
-                    ASSERT(BeamIsOpCode(g->orig_instr, op_call_nif_early));
-                    g->orig_instr = BeamOpCodeAddr(op_call_nif_WWW);
-
+                    for (GenericBp* g = ci_rw->gen_bp; g; g = g->next) {
+                        ASSERT(BeamIsOpCode(g->orig_instr, op_call_nif_early));
+                        ASSERT(!g->to_insert);
+                        g->orig_instr = BeamOpCodeAddr(op_call_nif_WWW);
+                    }
                     if (BeamIsOpCode(code_ptr[0], op_i_generic_breakpoint)) {
                         continue;
                     }

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.c
@@ -391,6 +391,12 @@ static ERL_NIF_TERM monitor_process(ErlNifEnv* env, int argc, const ERL_NIF_TERM
 }
 #endif
 
+static ERL_NIF_TERM trace_me(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ADD_CALL("lib_version");
+    return enif_make_int(env, NIF_LIB_VER);
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"lib_version", 0, lib_version},
@@ -407,6 +413,7 @@ static ErlNifFunc nif_funcs[] =
 #if NIF_LIB_VER == 5
     {"make_new_resource", 2, get_resource}, /* error: duplicate */
 #endif
+    {"trace_me", 1, trace_me},
 
     /* Keep lib_version_check last to maximize the loading "patch distance"
        between it and lib_version */

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.erl
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.erl
@@ -23,7 +23,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -export([load_nif_lib/2, load_nif_lib/3, start/0,
-         lib_version/0, lib_version_check/0,
+         lib_version/0, lib_version_check/0, trace_me/1,
 	 get_priv_data_ptr/0, make_new_resource/2, get_resource/2,
          monitor_process/3]).
 
@@ -32,7 +32,7 @@
 -define(nif_stub,nif_stub_error(?LINE)).
 
 -ifdef(USE_NIFS_ATTRIB).
--nifs([lib_version/0, nif_api_version/0, get_priv_data_ptr/0]).
+-nifs([lib_version/0, nif_api_version/0, get_priv_data_ptr/0, trace_me/1]).
 -if(?USE_NIFS_ATTRIB > 1).
 -nifs([make_new_resource/2, get_resource/2, monitor_process/3]).
 -if(?USE_NIFS_ATTRIB > 2).
@@ -103,6 +103,9 @@ get_priv_data_ptr() -> ?nif_stub.
 make_new_resource(_,_) -> ?nif_stub.
 get_resource(_,_) -> ?nif_stub.
 monitor_process(_,_,_) -> ?nif_stub.
+
+trace_me(_) ->  % NIF
+    undefined.
 
 lib_version_check() ->
     %% Do a recursive call to test that we are able to return


### PR DESCRIPTION
Affects only non-JIT beam.
Requires exotic case of loading NIF over Erlang function that is already traced by more than one trace session.
Caused beam VM crash.
