### PR TITLE
Small cosmetic fixes in "Using SSL" docs

### DIFF
--- a/lib/ssl/doc/guides/using_ssl.md
+++ b/lib/ssl/doc/guides/using_ssl.md
@@ -22,12 +22,12 @@ limitations under the License.
 To see relevant version information for ssl, call `ssl:versions/0` .
 
 To see all supported cipher suites, call
-[`ssl:cipher_suites(all, 'tlsv1.3')` ](`ssl:cipher_suites/2`). The available
+[`ssl:cipher_suites(all, 'tlsv1.3')`](`ssl:cipher_suites/2`). The available
 cipher suites for a connection depend on the TLS version and prior to TLS-1.3 also on
 the certificate. To see the default cipher suite list change `all` to `default`.
 Note that TLS 1.3 and previous versions do not have any cipher suites in common,
 for listing cipher suites for a specific version use
-[`ssl:cipher_suites(exclusive, 'tlsv1.3')` ](`ssl:cipher_suites/2`). Specific
+[`ssl:cipher_suites(exclusive, 'tlsv1.3')`](`ssl:cipher_suites/2`). Specific
 cipher suites that you want your connection to use can also be specified.
 Default is to use the strongest available.
 
@@ -92,8 +92,8 @@ _Step 3:_ Do a transport accept on the TLS listen socket:
 
 > #### Note {: .info }
 >
-> ssl:transport_accept/1 and ssl:handshake/2 are separate functions so that the
-> handshake part can be called in a new erlang process dedicated to handling the
+> `ssl:transport_accept/1` and `ssl:handshake/2` are separate functions so that the
+> handshake part can be called in a new Erlang process dedicated to handling the
 > connection
 
 _Step 4:_ Start the client side:
@@ -122,8 +122,8 @@ _Step 5:_ Do the TLS handshake:
 
 > #### Note {: .info }
 >
-> A real server should use ssl:handshake/2 that has a timeout to avoid DoS
-> attacks. In the example the timeout defaults to infinty.
+> A real server should use `ssl:handshake/2`, which accepts a timeout, to avoid DoS
+> attacks. In the example the timeout defaults to `infinity`.
 
 _Step 6:_ Send a message over TLS:
 


### PR DESCRIPTION
Mostly backticks for correctly rendering code snippets. 🙃 