### PR TITLE
Fix behavior of `re:split/3` with `trim` option for empty subjects

### DIFF
--- a/lib/stdlib/src/re.erl
+++ b/lib/stdlib/src/re.erl
@@ -1081,6 +1081,8 @@ split(Subject,RE,Options) ->
     case compile_split(RE,NewOpt) of
 	{error,_Err} ->
 	    throw(badre);
+	{_PreCompiled, _NumSub, _RunOpt} when FlatSubject =:= <<>> ->
+	    [];
 	{PreCompiled, NumSub, RunOpt} ->
 	    %% OK, lets run
 	    case re:run(FlatSubject,PreCompiled,RunOpt ++ [global]) of

--- a/lib/stdlib/test/re_SUITE.erl
+++ b/lib/stdlib/test/re_SUITE.erl
@@ -476,6 +476,10 @@ split_autogen(Config) when is_list(Config) ->
 
 %% Test special options to split.
 split_options(Config) when is_list(Config) ->
+    ok = splittest("", "", [trim], []),
+    ok = splittest("", " ", [trim], []),
+    ok = splittest("", "()", [group, trim], []),
+    ok = splittest("", "( )", [group, trim], []),
     ok = splittest("a b c ","( )",[group,trim],[[<<"a">>,<<" ">>],[<<"b">>,<<" ">>],[<<"c">>,<<" ">>]]),
     ok = splittest("a b c ","( )",[group,{parts,0}],[[<<"a">>,<<" ">>],[<<"b">>,<<" ">>],[<<"c">>,<<" ">>]]),
     ok = splittest("a b c ","( )",[{parts,infinity},group],[[<<"a">>,<<" ">>],[<<"b">>,<<" ">>],[<<"c">>,<<" ">>],[<<>>]]),


### PR DESCRIPTION
Fixes #8868.