### PR TITLE
Support ERL_CACERTS_PATH env var when reading certificates

### DIFF
--- a/lib/public_key/src/pubkey_os_cacerts.erl
+++ b/lib/public_key/src/pubkey_os_cacerts.erl
@@ -37,7 +37,12 @@
 get() ->
     case persistent_term:get(?MODULE, not_loaded) of
         not_loaded ->
-            case load() of
+            Result =
+                case os:getenv("ERL_CACERTS_PATH") of
+                    false -> load();
+                    EnvVar -> load([EnvVar])
+                end,
+            case Result of
                 ok ->
                     persistent_term:get(?MODULE);
                 {error, Reason} ->

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -2238,7 +2238,12 @@ cacerts_get() ->
 %%--------------------------------------------------------------------
 -doc(#{title => <<"Certificate API">>,
        since => <<"OTP 25.0">>}).
--doc "Loads the OS supplied trusted CA certificates.".
+-doc """
+Loads the OS supplied trusted CA certificates.
+
+If the ERL_CACERTS_PATH environment variable is set,
+it overrides the location of the OS supplied certificate.
+""".
 
 -spec cacerts_load() -> ok | {error, Reason::term()}.
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This pull request allows setting an env var with the location of certificates.

Currently we are seeing a proliferation of env vars for reading certificates from in the Elixir community. Here are some examples:

* https://github.com/hexpm/hex/blob/eec7a266f6e1b1c754798ee9a9c17b4b6201fff2/lib/hex/state.ex#L111 
* https://github.com/elixir-lang/elixir_make/blob/67ef8c1e249d1562fee9247320a602908f0094c6/lib/elixir_make/downloader/httpc.ex#L53
* https://github.com/elixir-nx/bumblebee/blob/b01e0da989a39b594990f8023bebb3751663fb19/lib/bumblebee/utils/http.ex#L191

This means anyone using Elixir/Erlang behind a proxy needs to setup several env vars, carefully reading the docs of each package that may do external HTTP requests.

For this reason, I was thinking about unifying them all in Elixir and provide a `ELIXIR_CACERTS_PATH` that is read at boot time. However, I believe a solution upstream in Erlang itself would be even better, as it would avoid the same issue (of several multiple env vars) happening within Erlang packages, escripts, etc.

I understand it is possible to call `public_key:cacerts_load/1` but I don't believe it fully solves the problem:

1. If we leave it up for each package to call `public_key:cacerts_load/1`, then we land in the same problem described here, but even worse, as one package would globally override the defaults of others

2. If we leave it up for users of the packages to call it, then it means they need to add logic to each of their applications and packages that they use. And doing so for escripts is even harder.

I also think an env var is better than the application environment for running escripts and so on, where setting the application environment is not as straight-forward (it could be set via the ERL_AFLAGS/ERL_ZFLAGS but it is more verbose).

If this is accepted, please double check the environment variable name to see if it adheres to Erlang/OTP's standards.