### PR TITLE
Fix: httpc set_options override

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -700,13 +700,11 @@ Sets options to be used for subsequent requests.
       DomainDesc :: string(),
       HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
-    {ok, IpFamily} = get_option(ipfamily, Profile),
-    {ok, UnixSock} = get_option(unix_socket, Profile),
-    case validate_options(Options, IpFamily, UnixSock) of
-	{ok, Opts} ->
-	    httpc_manager:set_options(Opts, profile_name(Profile));
-	{error, Reason} ->
-	    {error, Reason}
+    maybe
+        {ok, IpFamily} ?= get_option(ipfamily, Profile),
+        {ok, UnixSock} ?= get_option(unix_socket, Profile),
+        {ok, Opts} ?= validate_options(Options, IpFamily, UnixSock),
+	httpc_manager:set_options(Opts, profile_name(Profile))
     end.
 
 -doc false.

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -700,8 +700,8 @@ Sets options to be used for subsequent requests.
       DomainDesc :: string(),
       HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
-    IpFamily = httpc_manager:get_option(ipfamily, Profile),
-    UnixSock = httpc_manager:get_option(unix_socket, Profile),
+    {ok, IpFamily} = get_option(ipfamily, Profile),
+    {ok, UnixSock} = get_option(unix_socket, Profile),
     case validate_options(Options, IpFamily, UnixSock) of
 	{ok, Opts} ->
 	    httpc_manager:set_options(Opts, profile_name(Profile));

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -1626,7 +1626,7 @@ validate_options(Options0, CurrIpFamily, CurrUnixSock) ->
         validate_ipfamily_unix_socket(Options0, CurrIpFamily, CurrUnixSock),
         validate_options(Options0, [])
     catch
-        error:Reason ->
+        throw:Reason ->
             {error, Reason}
     end.
 %%

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -700,7 +700,9 @@ Sets options to be used for subsequent requests.
       DomainDesc :: string(),
       HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
-    case validate_options(Options) of
+    IpFamily = httpc_manager:get_option(ipfamily, Profile),
+    UnixSock = httpc_manager:get_option(unix_socket, Profile),
+    case validate_options(Options, IpFamily, UnixSock) of
 	{ok, Opts} ->
 	    httpc_manager:set_options(Opts, profile_name(Profile));
 	{error, Reason} ->
@@ -1605,28 +1607,24 @@ request_options_sanity_check(Opts) ->
     end,
     ok.
 
-validate_ipfamily_unix_socket(Options0) ->
-    IpFamily = proplists:get_value(ipfamily, Options0, inet),
-    UnixSocket = proplists:get_value(unix_socket, Options0, undefined),
-    Options1 = proplists:delete(ipfamily, Options0),
-    Options2 = proplists:delete(ipfamily, Options1),
-    validate_ipfamily_unix_socket(IpFamily, UnixSocket, Options2,
-                                  [{ipfamily, IpFamily}, {unix_socket, UnixSocket}]).
-%%
-validate_ipfamily_unix_socket(local, undefined, _Options, _Acc) ->
-    bad_option(unix_socket, undefined);
-validate_ipfamily_unix_socket(IpFamily, UnixSocket, _Options, _Acc)
-  when IpFamily =/= local, UnixSocket =/= undefined ->
-    bad_option(ipfamily, IpFamily);
-validate_ipfamily_unix_socket(IpFamily, UnixSocket, Options, Acc) ->
-    validate_ipfamily(IpFamily),
-    validate_unix_socket(UnixSocket),
-    {Options, Acc}.
+validate_ipfamily_unix_socket(Options0, CurrIpFamily, CurrUnixSock) ->
+    IpFamily = proplists:get_value(ipfamily, Options0, CurrIpFamily),
+    UnixSocket = proplists:get_value(unix_socket, Options0, CurrUnixSock),
+    validate_ipfamily_unix_socket(IpFamily, UnixSocket).
 
-validate_options(Options0) ->
+validate_ipfamily_unix_socket(local, undefined) ->
+    throw({error, {bad_ipfamily_unix_socket_combination, local, undefined}});
+validate_ipfamily_unix_socket(IpFamily, UnixSocket)
+  when IpFamily =/= local, UnixSocket =/= undefined ->
+    throw({error, {bad_ipfamily_unix_socket_combination, IpFamily, UnixSocket}});
+validate_ipfamily_unix_socket(IpFamily, UnixSocket) ->
+    validate_ipfamily(IpFamily),
+    validate_unix_socket(UnixSocket).
+
+validate_options(Options0, CurrIpFamily, CurrUnixSock) ->
     try
-        {Options, Acc} = validate_ipfamily_unix_socket(Options0),
-        validate_options(Options, Acc)
+        validate_ipfamily_unix_socket(Options0, CurrIpFamily, CurrUnixSock),
+        validate_options(Options0, [])
     catch
         error:Reason ->
             {error, Reason}

--- a/lib/inets/src/http_client/httpc_manager.erl
+++ b/lib/inets/src/http_client/httpc_manager.erl
@@ -1029,19 +1029,7 @@ get_cookies(Opts, #options{cookies = Default}) ->
     proplists:get_value(cookies, Opts, Default).
 
 get_ipfamily(Opts, #options{ipfamily = IpFamily}) ->
-    case lists:keysearch(ipfamily, 1, Opts) of
-	false -> 
-	    case proplists:get_value(ipv6, Opts) of
-		enabled ->
-		    inet6fb4;
-		disabled ->
-		    inet;
-		_ ->
-		    IpFamily
-	    end;
-	{value, {_, Value}} ->
-	    Value
-    end.
+    proplists:get_value(ipfamily, Opts, IpFamily).
 
 get_ip(Opts, #options{ip = Default}) ->
     proplists:get_value(ip, Opts, Default).

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -2021,7 +2021,6 @@ invalid_ipfamily_unix_socket(Config) when is_list(Config) ->
     ok = httpc:set_options([{unix_socket, undefined}, {ipfamily, inet}], Profile),
     ?assertMatch({error, _}, httpc:set_option(unix_socket, ?UNIX_SOCKET, Profile)).
 
-
 %%-------------------------------------------------------------------------
 delete_no_body() ->
     [{doc, "Test that a DELETE request without Body does not send a Content-Type header - Solves ERL-536"}].

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -154,7 +154,8 @@ real_requests_esi() ->
     [slow_connection].
 
 simulated_unix_socket() ->
-    [unix_domain_socket].
+    [unix_domain_socket,
+    invalid_ipfamily_unix_socket].
 
 only_simulated() ->
     [
@@ -2005,6 +2006,21 @@ unix_domain_socket(Config) when is_list(Config) ->
 	= httpc:request(put, {URL, [], [], ""}, [], [], Profile),
     {ok, {{_,200,_}, [_ | _], _}}
         = httpc:request(get, {URL, []}, [], [], Profile).
+
+invalid_ipfamily_unix_socket() ->
+    [{doc, "Test that httpc profile can't end up having invalid combination of ipfamily and unix_socket options"}].
+invalid_ipfamily_unix_socket(Config) when is_list(Config) ->
+    Profile = ?profile(Config),
+
+    ct:log("Using profile ~w", [Profile]),
+    {ok,[{unix_socket,?UNIX_SOCKET}, {ipfamily, local}]} =
+        httpc:get_options([unix_socket, ipfamily], Profile),
+    ?assertMatch({error, _}, httpc:set_option(unix_socket, undefined, Profile)),
+    ?assertMatch({error, _}, httpc:set_option(ipfamily, inet, Profile)),
+    ?assertMatch({error, _}, httpc:set_option(ipfamily, inetv6, Profile)),
+    ok = httpc:set_options([{unix_socket, undefined}, {ipfamily, inet}], Profile),
+    ?assertMatch({error, _}, httpc:set_option(unix_socket, ?UNIX_SOCKET, Profile)).
+
 
 %%-------------------------------------------------------------------------
 delete_no_body() ->


### PR DESCRIPTION
The bug was due to invalid validation of options that was acting like the user always passed `ipfamily` and `unix_socket` options, so each time when calling `set_option(s)` those options would get overridden by default values (if option values weren't present in the new options list).

Validation of `ipfamily` and `unix_socket` combination was not just buggy, but also insufficient because the httpc state could end up with invalid combination of those options which I proved in the `httpc_SUITE:invalid_ipfamily_unix_socket/1` testcase (which fails on the current code). I also believe that there was a typo in `httpc:validate_ipfamily_unix_socket/1` where `ipfamily` option got deleted twice, but `unix_socket` was not, so we could end up having two `unix_socket` entries after validation....

With the new behavior that checks current and new options `httpc` can't end up having invalid ipfamily-unix_socket combo. I also believe that new error is more informative to the user on what's going on and why validation failed.

I also removed deprecated `ipv6` handling in `httpc_manager` because `ipv6` gets translated to `ipfamily` option in `httpc:validate_options/3` so there is no way that `ipv6` entry can ever be passed to `httpc_manager`. `httpc_manager:set_options` is called only from `httpc:set_options` which validates (and translates) `ipv6` option so this should be safe.

Closes #8829 