### PR TITLE
stdlib: added key command to shell to improve help

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -882,8 +882,13 @@ get_line_edlin({search,Cs,Cont,Rs}, Drv, State) ->
     get_line_edlin(edlin:edit_line1(Cs, Ncont), Drv,
                    State#get_line_edlin_state{ search = new_search,
                                                search_quit_prompt = Cont});
-get_line_edlin({help, Before, Cs0, Cont, Rs}, Drv, State) ->
+get_line_edlin({Help, Before, Cs0, Cont, Rs}, Drv, State)
+    when Help =:= help; Help =:= help_full ->
     send_drv_reqs(Drv, Rs),
+    NLines = case Help of
+        help -> 7;
+        help_full -> 0
+    end,
     {_,Word,_} = edlin:over_word(Before, [], 0),
     {R,Docs} = case edlin_context:get_context(Before) of
                    {function, Mod} when Word =/= [] -> try
@@ -911,11 +916,11 @@ get_line_edlin({help, Before, Cs0, Cont, Rs}, Drv, State) ->
         {module, _} ->
             Docs1 = "  "++string:trim(lists:nthtail(3, Docs),both),
             send_drv(Drv, {put_expand, unicode,
-                           [unicode:characters_to_binary(Docs1)], 7});
+                           [unicode:characters_to_binary(Docs1)], NLines});
         {function, _} ->
             Docs1 = "  "++string:trim(Docs,both),
             send_drv(Drv, {put_expand, unicode,
-                           [unicode:characters_to_binary(Docs1)], 7})
+                           [unicode:characters_to_binary(Docs1)], NLines})
     end,
     get_line_edlin(edlin:edit_line(Cs0, Cont), Drv, State);
 get_line_edlin({Expand, Before, Cs0, Cont,Rs}, Drv, State = #get_line_edlin_state{ expand_fun = ExpandFun })

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -1298,7 +1298,13 @@ shell_help(Config) ->
         send_tty(Term, "application:put_env(kernel, shell_docs_ansi, false).\n"),
         send_tty(Term, "lists"),
         send_tty(Term, "\^[h"),
+        %% Check we can see the first line
         check_content(Term, "List processing functions."),
+        check_not_in_content(Term, "less than or equal to"),
+        %% Expand the help area to take up the whole buffer.
+        send_tty(Term, "\^[h"),
+        %% Check that we can see the last line (lists help should fit in the window)
+        check_content(Term, "less than or equal to"),
         send_tty(Term, ":all"),
         send_tty(Term, "\^[h"),
         check_content(Term, ~S"all\(Pred, List\)"),

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -109,6 +109,9 @@ supports multiple lines.
 - **`help`** - Display help for the module or function closest on the left of
   the cursor.
 
+- **`help_full`** - Display the whole help text for the module or function closest on the left of
+  the cursor.
+
 - **`history_down`** - Move to the next item in the history.
 
 - **`history_up`** - Move to the previous item in the history.
@@ -260,7 +263,7 @@ keymap() ->
           {done, continuation(), Rest :: unicode:chardata(), [user_drv:request()]} |
           {open_editor | format_expression | history_up | history_down | search,
            Cs :: unicode:chardata(), continuation(), [user_drv:request()]} |
-          {help | expand | expand_full,
+          {help | help_full | expand | expand_full,
            Before :: unicode:chardata(),
            Cs :: unicode:chardata(), continuation(),
            [user_drv:request()]} |
@@ -381,6 +384,9 @@ edit(Buf, P, {LB, {Bef,Aft}, LA}=MultiLine, {ShellMode1, EscapePrefix}, Rs0) ->
                     edit(Cs, P, MultiLine, {NextMode, none}, Rs);
                 help ->
                     {help, chars_before(MultiLine), Cs,{line, P, MultiLine, {help, none}},
+                    reverse(Rs0)};
+                help_full ->
+                    {help_full, chars_before(MultiLine), Cs,{line, P, MultiLine, {help, none}},
                     reverse(Rs0)};
                 tab_expand ->
                     {expand, chars_before(MultiLine), Cs,

--- a/lib/stdlib/src/edlin_key.erl
+++ b/lib/stdlib/src/edlin_key.erl
@@ -188,6 +188,7 @@ key_map() -> #{
             "\^[[B" => move_expand_down,
             "\^[[6~" => scroll_expand_down,
             "\^[[5~" => scroll_expand_up,
+            "\^[h" => help_full,
             default => tab_expand_quit %% go to normal mode and evaluate key input again
         }
     }.


### PR DESCRIPTION
pressing ^[h once, give you 7 lines of help text,
pressing ^[h again, gives you as many lines that fits the current window height