### PR TITLE
Add `SIGWINCH` and `SIGINFO` support

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -675,6 +675,7 @@ atom sigsegv
 atom sigtstp
 atom sigquit
 atom sigwinch
+atom siginfo
 atom silent
 atom size
 atom skip

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -674,6 +674,7 @@ atom sigint
 atom sigsegv
 atom sigtstp
 atom sigquit
+atom sigwinch
 atom silent
 atom size
 atom skip

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -688,6 +688,7 @@ static RETSIGTYPE suspend_signal(int signum)
  !SIGTTIN    Stop     Terminal input for background process
  !SIGTTOU    Stop     Terminal output for background process
   SIGWINCH   Ign      Window size change
+  SIGINFO    Ign      Status request from keyboard
 */
 
 
@@ -709,6 +710,9 @@ signalterm_to_signum(Eterm signal)
     case am_sigstop: return SIGSTOP;
     case am_sigtstp: return SIGTSTP;
     case am_sigwinch: return SIGWINCH;
+#ifdef SIGINFO
+    case am_siginfo: return SIGINFO;
+#endif /* defined(SIGINFO) */
     default:         return 0;
     }
 }
@@ -731,6 +735,9 @@ signum_to_signalterm(int signum)
     case SIGSTOP: return am_sigstop;
     case SIGTSTP: return am_sigtstp;   /* ^z */
     case SIGWINCH: return am_sigwinch;
+#ifdef SIGINFO
+    case SIGINFO: return am_siginfo;  /* ^t */
+#endif /* defined(SIGINFO) */
     default:      return am_error;
     }
 }

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -687,6 +687,7 @@ static RETSIGTYPE suspend_signal(int signum)
   SIGTSTP    Stop     Stop typed at terminal
  !SIGTTIN    Stop     Terminal input for background process
  !SIGTTOU    Stop     Terminal output for background process
+  SIGWINCH   Ign      Window size change
 */
 
 
@@ -707,6 +708,7 @@ signalterm_to_signum(Eterm signal)
     case am_sigchld: return SIGCHLD;
     case am_sigstop: return SIGSTOP;
     case am_sigtstp: return SIGTSTP;
+    case am_sigwinch: return SIGWINCH;
     default:         return 0;
     }
 }
@@ -728,6 +730,7 @@ signum_to_signalterm(int signum)
     case SIGCHLD: return am_sigchld;
     case SIGSTOP: return am_sigstop;
     case SIGTSTP: return am_sigtstp;   /* ^z */
+    case SIGWINCH: return am_sigwinch;
     default:      return am_error;
     }
 }

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -41,7 +41,8 @@
          t_sigterm/1,
          t_sigalrm/1,
          t_sigchld/1,
-         t_sigchld_fork/1]).
+         t_sigchld_fork/1,
+         t_sigwinch/1]).
 
 -define(signal_server, erl_signal_server).
 
@@ -59,6 +60,7 @@ all() ->
               t_sigalrm,
               t_sigchld,
               t_sigchld_fork,
+              t_sigwinch,
               set_unset]
     end.
 
@@ -296,6 +298,35 @@ sigchld_fork() ->
     42 = Status,
     %% reset to ignore (it's the default)
     os:set_signal(sigchld, ignore),
+    ok.
+
+t_sigwinch(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    os:set_signal(sigwinch, handle),
+    ok = kill("WINCH", OsPid),
+    ok = kill("WINCH", OsPid),
+    ok = kill("WINCH", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigwinch},
+     {notify,sigwinch},
+     {notify,sigwinch}] = Msgs1,
+    %% no proc
+    ok = kill("WINCH", OsPid),
+    ok = kill("WINCH", OsPid),
+    ok = kill("WINCH", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    os:set_signal(sigwinch, ignore),
+    ok = kill("WINCH", OsPid),
+    ok = kill("WINCH", OsPid),
+    ok = kill("WINCH", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to ignore (it's the default)
+    os:set_signal(sigwinch, ignore),
     ok.
 
 

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -42,7 +42,8 @@
          t_sigalrm/1,
          t_sigchld/1,
          t_sigchld_fork/1,
-         t_sigwinch/1]).
+         t_sigwinch/1,
+         t_siginfo/1]).
 
 -define(signal_server, erl_signal_server).
 
@@ -61,6 +62,7 @@ all() ->
               t_sigchld,
               t_sigchld_fork,
               t_sigwinch,
+              t_siginfo,
               set_unset]
     end.
 
@@ -327,6 +329,47 @@ t_sigwinch(_Config) ->
     [] = Msgs2,
     %% reset to ignore (it's the default)
     os:set_signal(sigwinch, ignore),
+    ok.
+
+t_siginfo(_Config) ->
+    SiginfoSupported = try
+                           os:set_signal(siginfo, default),
+                           true
+                       catch
+                           error:badarg ->
+                               false
+                       end,
+    case SiginfoSupported of
+        true ->
+            Pid1 = setup_service(),
+            OsPid = os:getpid(),
+            os:set_signal(siginfo, handle),
+            ok = kill("INFO", OsPid),
+            ok = kill("INFO", OsPid),
+            ok = kill("INFO", OsPid),
+            Msgs1 = fetch_msgs(Pid1),
+            io:format("Msgs1: ~p~n", [Msgs1]),
+            [{notify,siginfo},
+             {notify,siginfo},
+             {notify,siginfo}] = Msgs1,
+            %% no proc
+            ok = kill("INFO", OsPid),
+            ok = kill("INFO", OsPid),
+            ok = kill("INFO", OsPid),
+            %% ignore
+            Pid2 = setup_service(),
+            os:set_signal(siginfo, ignore),
+            ok = kill("INFO", OsPid),
+            ok = kill("INFO", OsPid),
+            ok = kill("INFO", OsPid),
+            Msgs2 = fetch_msgs(Pid2),
+            io:format("Msgs2: ~p~n", [Msgs2]),
+            [] = Msgs2,
+            %% reset to ignore (it's the default)
+            os:set_signal(siginfo, ignore);
+        false ->
+            ok
+    end,
     ok.
 
 

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -86,6 +86,8 @@ Any event handler added to `erl_signal_server` must handle the following events.
 
 - **`sigtstp`** - Stop typed at terminal
 
+- **`sigwinch`** - Window size change
+
 Setting OS signals are described in `os:set_signal/2`.
 
 ## Configuration

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -88,6 +88,10 @@ Any event handler added to `erl_signal_server` must handle the following events.
 
 - **`sigwinch`** - Window size change
 
+- **`siginfo`** - Status request from keyboard. Note several operating systems
+  (Linux in particular) do not support this signal. `os:set_signal/2` will thow
+  a `badarg` exception if support is missing.
+
 Setting OS signals are described in `os:set_signal/2`.
 
 ## Configuration

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -302,7 +302,7 @@ Each signal my be set to one of the following options:
 -spec set_signal(Signal, Option) -> 'ok' when
       Signal :: 'sighup'  | 'sigquit' | 'sigabrt' | 'sigalrm' |
                 'sigterm' | 'sigusr1' | 'sigusr2' | 'sigchld' |
-                'sigstop' | 'sigtstp' | 'sigwinch',
+                'sigstop' | 'sigtstp' | 'sigwinch' | 'siginfo',
       Option :: 'default' | 'handle' | 'ignore'.
 
 set_signal(_Signal, _Option) ->

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -302,7 +302,7 @@ Each signal my be set to one of the following options:
 -spec set_signal(Signal, Option) -> 'ok' when
       Signal :: 'sighup'  | 'sigquit' | 'sigabrt' | 'sigalrm' |
                 'sigterm' | 'sigusr1' | 'sigusr2' | 'sigchld' |
-                'sigstop' | 'sigtstp',
+                'sigstop' | 'sigtstp' | 'sigwinch',
       Option :: 'default' | 'handle' | 'ignore'.
 
 set_signal(_Signal, _Option) ->


### PR DESCRIPTION
## `SIGWINCH`

This signal is emitted when the terminal window is resized to allow an application to redraw its content.

## `SIGINFO`

This signal is emitted when a user types Ctrl+T in a terminal. This is only supported by few operating systems such as *BSD and OSX.

By default, the operating system displays on stdout the system process PID, the system load and the duration the process is running. The signal allows the application to display more details about its status and progress.