### PR TITLE
Take make(1) executable name from `$MAKE` environment variable

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -976,7 +976,8 @@ bootstrap_clean:
 .PHONY: test dialyzer
 
 test: all release release_tests
-	$(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
+	MAKE="$(MAKE)" \
+	  $(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
 
 ifeq ($(TYPE),)
 dialyzer: all

--- a/lib/common_test/test_server/configure
+++ b/lib/common_test/test_server/configure
@@ -4745,7 +4745,7 @@ if test -n "$JAVAC"; then
   :
 fi
 
-for ac_prog in make gmake
+for ac_prog in gmake make
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/lib/common_test/test_server/configure.ac
+++ b/lib/common_test/test_server/configure.ac
@@ -498,7 +498,7 @@ if test -n "$JAVAC"; then
   :
 fi
 
-AC_CHECK_PROGS([make_command], [make gmake], [false])
+AC_CHECK_PROGS([make_command], [gmake make], [false])
 AC_SUBST(make_command)
 
 if test "$GCC" = yes; then

--- a/make/app_targets.mk
+++ b/make/app_targets.mk
@@ -24,7 +24,7 @@ APPLICATION ?= $(basename $(notdir $(PWD)))
 
 ifndef NO_TEST_TARGET
 test:
-	TEST_NEEDS_RELEASE=$(TEST_NEEDS_RELEASE) TYPE=$(TYPE) \
+	TEST_NEEDS_RELEASE=$(TEST_NEEDS_RELEASE) TYPE=$(TYPE) MAKE="$(MAKE)" \
 	  $(ERL_TOP)/make/test_target_script.sh $(ERL_TOP)
 endif
 

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -112,7 +112,7 @@ EOM
 
 release_erlang () {
     local RELEASE_ROOT="${1}"
-    if ! (cd $ERL_TOP && make release TYPE= release_docs DOC_TARGETS=chunks RELEASE_ROOT="${RELEASE_ROOT}"); then
+    if ! (cd $ERL_TOP && ${MAKE:-make} release TYPE= release_docs DOC_TARGETS=chunks RELEASE_ROOT="${RELEASE_ROOT}"); then
         return 1
     fi
     if ! (cd "$RELEASE_ROOT" && ./Install -minimal "`pwd`"); then
@@ -120,7 +120,7 @@ release_erlang () {
     fi
     ## Need to release both TYPE= and TYPE=$TYPE for tests to work
     if [ "$TYPE" != "" ]; then
-        if ! (cd $ERL_TOP && make release TYPE=$TYPE RELEASE_ROOT="${RELEASE_ROOT}"); then
+        if ! (cd $ERL_TOP && ${MAKE:-make} release TYPE=$TYPE RELEASE_ROOT="${RELEASE_ROOT}"); then
             return 1
         fi
     fi
@@ -231,7 +231,7 @@ then
     fi
 fi
 
-make RELEASE_PATH=$MAKE_TEST_DIR release_tests_spec > $RELEASE_TEST_SPEC_LOG 2>&1
+${MAKE:-make} RELEASE_PATH=$MAKE_TEST_DIR release_tests_spec > $RELEASE_TEST_SPEC_LOG 2>&1
 
 if [ $? != 0 ]
 then
@@ -271,7 +271,7 @@ fi
 # Compile test server and configure
 if [ ! -f "$ERL_TOP/lib/common_test/test_server/variables" ]; then
     cd "$ERL_TOP/lib/common_test/test_server"
-    ( make && erl -noshell -eval "ts:install()." -s init stop )  > "$INSTALL_TEST_LOG" 2>&1
+    ( ${MAKE:-make} && erl -noshell -eval "ts:install()." -s init stop )  > "$INSTALL_TEST_LOG" 2>&1
     if [ $? != 0 ]
     then
         cat "$INSTALL_TEST_LOG"


### PR DESCRIPTION
## Why

A few places have the executable name hard-coded to `make`. However, the Makefiles require GNU make, which is might be available as another name. For instance, on *BSD where make(1) is another implementation, GNU make is available ase `gmake`.

This was not a problem when building Erlang/OTP. But it was when running the tests.

## How

The make variable `$(MAKE)` which always contain the name of (or path to) the make executable being used, is passed to the shell scripts. The shell scripts then use this variable, defaulting to `make` if necessary.

In `lib/common_test/test_server/configure.ac`, the order in which the make executable is detected is swapped: `gmake` is tried first, then `make`.