### PR TITLE
erts: Disallow unused variables in ops.tab

### DIFF
--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -56,8 +56,8 @@ int_func_start Lbl Line M F A => label Lbl | i_func_info u M F A | line Line
 
 # The end of a function.
 int_func_end/2
-int_func_end Func Entry | needs_nif_padding() => i_nif_padding
-int_func_end Func Entry => _
+int_func_end _Func _Entry | needs_nif_padding() => i_nif_padding
+int_func_end _Func _Entry => _
 
 i_nif_padding
 
@@ -72,14 +72,14 @@ padding
 # BIF, so we can omit the line instruction for non-BIFs.
 #
 
-move S X0=x==0 | line Loc | call_ext_last Ar Func=u$is_not_bif D =>
+move S X0=x==0 | line _Loc | call_ext_last Ar Func=u$is_not_bif D =>
      move S X0 | call_ext_last Ar Func D
-move S X0=x==0 | line Loc | call_ext_only Ar Func=u$is_not_bif =>
+move S X0=x==0 | line _Loc | call_ext_only Ar Func=u$is_not_bif =>
      move S X0 | call_ext_only Ar Func
 
-move S X0=x==0 | line Loc | call_last Ar Func D =>
+move S X0=x==0 | line _Loc | call_last Ar Func D =>
      move S X0 | call_last Ar Func D
-move S X0=x==0 | line Loc | call_only Ar Func =>
+move S X0=x==0 | line _Loc | call_only Ar Func =>
      move S X0 | call_only Ar Func
 
 # To ensure that a "move Src x(0)" instruction can be combined with
@@ -95,7 +95,7 @@ move S X0=x==0 | line Loc => line Loc | move S X0
 line n => _
 line I
 
-executable_line Id Line => _
+executable_line _Id _Line => _
 
 # For the JIT, the init_yregs/1 instruction allows generation of better code.
 # For the BEAM interpreter, though, it will probably be more efficient to
@@ -119,8 +119,8 @@ i_init y
 # there is a stack frame.
 deallocate Q
 
-move Src=y Dst=x | trim N Remaining => move_trim Src Dst N
-trim N Remaining => i_trim N
+move Src=y Dst=x | trim N _Remaining => move_trim Src Dst N
+trim N _Remaining => i_trim N
 
 move_trim y x t
 i_trim t
@@ -246,7 +246,7 @@ i_get_tuple_element3 x P x
 is_number f? xy
 %hot
 
-is_number Fail=f i => _
+is_number _Fail=f i => _
 
 is_number Fail=f na => jump Fail
 is_number Fail Literal=q => move Literal x | is_number Fail x
@@ -332,7 +332,7 @@ move Y1=y X1=x | move Y2=y X2=x | succ(Y1, Y2) =>
 
 move_src_window Y1 Y2 X1 X2 | move Y3=y X3=x | succ(Y2, Y3) =>
     move_src_window Y1 Y3 X1 X2 X3
-move_src_window Y1 Y2 X1 X2 | move Y3=y X3=x | move Y4=y X4=x | succ(Y3, Y4) =>
+move_src_window Y1 _Y2 X1 X2 | move Y3=y X3=x | move Y4=y X4=x | succ(Y3, Y4) =>
     move_src_window2 Y1 X1 X2 | move_src_window Y3 Y4 X3 X4
 move_src_window Y1 Y2 X1 X2 | move Y3=y X3=x =>
     move3 Y1 X1 Y2 X2 Y3 X3
@@ -485,7 +485,7 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl LHS RHS | equal(LHS, RHS) => _
+is_eq_exact _Lbl LHS RHS | equal(LHS, RHS) => _
 
 is_eq_exact Lbl C1=c C2=c => move C1 x | is_eq_exact Lbl x C2
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
@@ -654,7 +654,7 @@ test_heap_1_put_list I y
 
 is_tagged_tuple Fail Literal=q Arity Atom =>
     move Literal x | is_tagged_tuple Fail x Arity Atom
-is_tagged_tuple Fail=f c Arity Atom  => jump Fail
+is_tagged_tuple Fail=f c _Arity _Atom  => jump Fail
 
 is_tagged_tuple f? rxy A a
 
@@ -671,7 +671,7 @@ is_tuple_of_arity f? rxy A
 is_tuple f? rxy
 
 test_arity Fail Literal=q Arity => move Literal x | test_arity Fail x Arity
-test_arity Fail=f c Arity => jump Fail
+test_arity Fail=f c _Arity => jump Fail
 test_arity Fail Tuple=x Arity | get_tuple_element Tuple2 Pos Dst=x |
     equal(Tuple, Tuple2) =>
     test_arity_get_tuple_element Fail Tuple Arity Pos Dst
@@ -712,7 +712,7 @@ get_tuple_element Reg=x P1 D1=y | get_tuple_element Reg2=x P2 D2=y |
 
 get_tuple_element Reg P Dst => i_get_tuple_element Reg P Dst
 
-is_integer Fail=f i => _
+is_integer _Fail=f i => _
 is_integer Fail=f an => jump Fail
 is_integer Fail Literal=q => move Literal x | is_integer Fail x
 
@@ -723,7 +723,7 @@ is_integer_allocate f? x t t
 
 is_integer f? xy
 
-is_list Fail=f n => _
+is_list _Fail=f n => _
 is_list Fail Literal=q => move Literal x | is_list Fail x
 is_list Fail=f c => jump Fail
 is_list f? x
@@ -758,7 +758,7 @@ is_atom f? x
 %cold
 is_atom f? y
 %hot
-is_atom Fail=f a => _
+is_atom _Fail=f a => _
 is_atom Fail=f niq => jump Fail
 
 is_float f? x
@@ -768,7 +768,7 @@ is_float f? y
 is_float Fail=f nai => jump Fail
 is_float Fail Literal=q => move Literal x | is_float Fail x
 
-is_nil Fail=f n => _
+is_nil _Fail=f n => _
 is_nil Fail=f qia => jump Fail
 
 is_nil f? xy
@@ -808,8 +808,8 @@ is_port f? x
 is_port f? y
 %hot
 
-is_boolean Fail=f a==am_true => _
-is_boolean Fail=f a==am_false => _
+is_boolean _Fail=f a==am_true => _
+is_boolean _Fail=f a==am_false => _
 is_boolean Fail=f ac => jump Fail
 
 %cold
@@ -881,7 +881,7 @@ call_ext_only u==0 u$func:erlang:yield/0 => i_yield | return
 # The hibernate/3 BIF is an instruction.
 #
 call_ext u==3 u$func:erlang:hibernate/3 => i_hibernate
-call_ext_last u==3 u$func:erlang:hibernate/3 D => i_hibernate
+call_ext_last u==3 u$func:erlang:hibernate/3 _D => i_hibernate
 call_ext_only u==3 u$func:erlang:hibernate/3 => i_hibernate
 
 call_ext u==0 u$func:os:perf_counter/0 =>
@@ -909,7 +909,7 @@ call_ext_only Ar=u Bif=u$is_bif | is_heavy_bif(Bif) =>
 
 call_ext u Bif=u$is_bif => call_light_bif Bif
 call_ext_last u Bif=u$is_bif D => call_light_bif_last Bif D
-call_ext_only Ar=u Bif=u$is_bif => call_light_bif_only Bif
+call_ext_only _Ar=u Bif=u$is_bif => call_light_bif_only Bif
 
 #
 # Any remaining calls are calls to Erlang functions, not BIFs.
@@ -918,16 +918,16 @@ call_ext_only Ar=u Bif=u$is_bif => call_light_bif_only Bif
 # with call instructions.
 #
 
-move S=c x==0 | call_ext Ar=u Func=u$is_not_bif =>
+move S=c x==0 | call_ext _Ar=u Func=u$is_not_bif =>
     i_move_call_ext S Func
-move S=c x==0 | call_ext_last Ar=u Func=u$is_not_bif D =>
+move S=c x==0 | call_ext_last _Ar=u Func=u$is_not_bif D =>
     i_move_call_ext_last Func D S
-move S=c x==0 | call_ext_only Ar=u Func=u$is_not_bif =>
+move S=c x==0 | call_ext_only _Ar=u Func=u$is_not_bif =>
     i_move_call_ext_only Func S
 
-call_ext Ar Func        => i_call_ext Func
-call_ext_last Ar Func D => i_call_ext_last Func D
-call_ext_only Ar Func   => i_call_ext_only Func
+call_ext _Ar Func        => i_call_ext Func
+call_ext_last _Ar Func D => i_call_ext_last Func D
+call_ext_only _Ar Func   => i_call_ext_only Func
 
 i_apply
 i_apply_last Q
@@ -971,12 +971,12 @@ i_perf_counter
 bif0 u$bif:erlang:self/0 Dst=d => self Dst
 bif0 u$bif:erlang:node/0 Dst=d => node Dst
 
-bif1 Fail=f Bif=u$bif:erlang:hd/1 Src=x Dst=x =>
+bif1 Fail=f _Bif=u$bif:erlang:hd/1 Src=x Dst=x =>
     is_nonempty_list_get_hd Fail Src Dst
-bif1 Fail=f Bif=u$bif:erlang:tl/1 Src=x Dst=x =>
+bif1 Fail=f _Bif=u$bif:erlang:tl/1 Src=x Dst=x =>
     is_nonempty_list_get_tl Fail Src Dst
 
-bif1 Fail Bif=u$bif:erlang:get/1 Src=s Dst=d =>
+bif1 _Fail _Bif=u$bif:erlang:get/1 Src=s Dst=d =>
     get(Src, Dst)
 
 bif2 Jump=j u$bif:erlang:element/2 S1=s S2=xy Dst=d =>
@@ -1015,24 +1015,24 @@ i_bif3_body s s s b d
 # Internal calls.
 #
 
-move S=cxy x==0 | call Ar P=f => move_call S P
+move S=cxy x==0 | call _Ar P=f => move_call S P
 
 move_call/2
 move_call cxy f
 
-move S x==0 | call_last Ar P=f D => move_call_last S P D
+move S x==0 | call_last _Ar P=f D => move_call_last S P D
 
 move_call_last/3
 move_call_last cxy f Q
 
-move S=cx x==0 | call_only Ar P=f => move_call_only S P
+move S=cx x==0 | call_only _Ar P=f => move_call_only S P
 
 move_call_only/2
 move_call_only cx f
 
-call Ar Func        => i_call Func
-call_last Ar Func D => i_call_last Func D
-call_only Ar Func   => i_call_only Func
+call _Ar Func        => i_call Func
+call_last _Ar Func D => i_call_last Func D
+call_only _Ar Func   => i_call_only Func
 
 i_call f
 i_call_last f Q
@@ -1140,7 +1140,7 @@ i_bs_ensure_bits Ctx1 u==32 Fail | i_bs_read_bits Ctx2 u==32 |
 # is encountered.
 #
 bad_bs_match/1
-bad_bs_match A | never() => _
+bad_bs_match _A | never() => _
 
 # ================================================================
 # Bit syntax matching (from R11B).
@@ -1183,7 +1183,7 @@ i_bs_get_binary_all2 xy f? t t d
 bs_get_float2 Fail=f Ms=xy Live=u Sz=s Unit=u Flags=u Dst=d =>
     get_float2(Fail, Ms, Live, Sz, Unit, Flags, Dst)
 
-bs_get_float2 Fail=f Ms=x Live=u Sz=q Unit=u Flags=u Dst=d => jump Fail
+bs_get_float2 Fail=f _Ms=x _Live=u _Sz=q _Unit=u _Flags=u _Dst=d => jump Fail
 
 i_bs_get_float2 xy f? t s t d
 
@@ -1195,14 +1195,14 @@ bs_skip_bits2 Fail=f Ms=xy Sz=sq Unit=u Flags=u =>
 i_bs_skip_bits_imm2 f? xy W
 i_bs_skip_bits2 xy xy f? t
 
-bs_test_tail2 Fail=f Ms=xy o => jump Fail
-bs_test_tail2 Fail=f Ms=xy Bits=u==0 => bs_test_zero_tail2 Fail Ms
+bs_test_tail2 Fail=f _Ms=xy o => jump Fail
+bs_test_tail2 Fail=f Ms=xy _Bits=u==0 => bs_test_zero_tail2 Fail Ms
 bs_test_tail2 Fail=f Ms=xy Bits=u => bs_test_tail_imm2 Fail Ms Bits
 
 bs_test_zero_tail2 f? xy
 bs_test_tail_imm2 f? xy W
 
-bs_test_unit F Ms Unit=u==8 => bs_test_unit8 F Ms
+bs_test_unit F Ms _Unit=u==8 => bs_test_unit8 F Ms
 bs_test_unit f? xy t
 bs_test_unit8 f? xy
 
@@ -1223,10 +1223,10 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d =>
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Ctx Dst | equal(Ctx, Dst) => _
-bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
+bs_start_match4 a==am_resume _Live Ctx Dst | equal(Ctx, Dst) => _
+bs_start_match4 a==am_resume _Live Ctx Dst => move Ctx Dst
 
-bs_start_match3 Fail Bin Live Ctx | bs_get_position Ctx2 Pos=x Ignored |
+bs_start_match3 Fail Bin Live Ctx | bs_get_position Ctx2 Pos=x _Ignored |
   equal(Ctx, Ctx2) =>
     i_bs_start_match3_gp Bin Live Fail Ctx Pos
 i_bs_start_match3_gp xy t j d x
@@ -1238,7 +1238,7 @@ bs_start_match4 a==am_resume Live Ctx Dst =>
 
 %endif
 
-bs_start_match3 Fail=j ica Live Dst => jump Fail
+bs_start_match3 Fail=j ica _Live _Dst => jump Fail
 bs_start_match3 Fail Bin Live Dst => i_bs_start_match3 Bin Live Fail Dst
 
 i_bs_start_match3 xy t j d
@@ -1247,7 +1247,7 @@ i_bs_start_match3 xy t j d
 # fit into an unsigned small.
 
 %if ARCH_64
-    bs_get_position Src Dst Live => i_bs_get_position Src Dst
+    bs_get_position Src Dst _Live => i_bs_get_position Src Dst
     i_bs_get_position xy xy
     bs_set_position xy xy
 %else
@@ -1340,7 +1340,7 @@ apply_last t Q
 # always preceded by an is_map test. That means that put_map_assoc can
 # never fail and does not need any failure label.
 
-put_map_assoc Fail Map Dst Live Size Rest=* =>
+put_map_assoc _Fail Map Dst Live Size Rest=* =>
     i_put_map_assoc Map Dst Live Size Rest
 
 i_put_map_assoc/4
@@ -1373,7 +1373,7 @@ i_new_small_map_lit d t q *
 update_map_assoc xyc d t I *
 update_map_exact xy j? d t I *
 
-is_map Fail Lit=q | literal_is_map(Lit) => _
+is_map _Fail Lit=q | literal_is_map(Lit) => _
 is_map Fail cq => jump Fail
 is_map f? xy
 
@@ -1409,7 +1409,7 @@ gc_bif1 Fail Live u$bif:erlang:splus/1 Src Dst =>
 gc_bif2 Fail Live u$bif:erlang:splus/2 S1 S2 Dst =>
     gen_plus Fail Live S1 S2 Dst
 
-gc_bif1 Fail Live u$bif:erlang:sminus/1 Src Dst =>
+gc_bif1 Fail _Live u$bif:erlang:sminus/1 Src Dst =>
     i_unary_minus Src Fail Dst
 gc_bif2 Fail Live u$bif:erlang:sminus/2 S1 S2 Dst =>
     gen_minus Fail Live S1 S2 Dst
@@ -1419,12 +1419,12 @@ gc_bif2 Fail Live u$bif:erlang:sminus/2 S1 S2 Dst =>
 # the i_increment/3 instruction (in bodies, not in guards).
 #
 
-gen_plus p Live Int=i Reg=d Dst =>
+gen_plus p _Live Int=i Reg=d Dst =>
     increment(Reg, Int, Dst)
-gen_plus p Live Reg=d Int=i Dst =>
+gen_plus p _Live Reg=d Int=i Dst =>
     increment(Reg, Int, Dst)
 
-gen_minus p Live Reg=d Int=i Dst | negation_is_small(Int) =>
+gen_minus p _Live Reg=d Int=i Dst | negation_is_small(Int) =>
     increment_from_minus(Reg, Int, Dst)
 
 #
@@ -1433,40 +1433,40 @@ gen_minus p Live Reg=d Int=i Dst | negation_is_small(Int) =>
 
 # It is OK to swap arguments for '+' in a guard. It is also
 # OK to turn minus into plus in a guard.
-gen_plus Fail=f Live S1=c S2 Dst => i_plus S2 S1 Fail Dst
+gen_plus Fail=f _Live S1=c S2 Dst => i_plus S2 S1 Fail Dst
 gen_minus Fail=f Live S1 S2=i Dst | negation_is_small(S2) =>
     plus_from_minus(Fail, Live, S1, S2, Dst)
 
-gen_plus Fail Live S1 S2 Dst => i_plus S1 S2 Fail Dst
+gen_plus Fail _Live S1 S2 Dst => i_plus S1 S2 Fail Dst
 
-gen_minus Fail Live S1 S2 Dst => i_minus S1 S2 Fail Dst
+gen_minus Fail _Live S1 S2 Dst => i_minus S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:stimes/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:stimes/2 S1 S2 Dst =>
     i_times Fail S1 S2 Dst
 
-gc_bif2 Fail Live u$bif:erlang:div/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:div/2 S1 S2 Dst =>
     i_m_div Fail S1 S2 Dst
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:intdiv/2 S1 S2 Dst =>
     i_int_div Fail S1 S2 Dst
 
-gc_bif2 Fail Live u$bif:erlang:rem/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:rem/2 S1 S2 Dst =>
     i_rem S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:bsl/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bsl/2 S1 S2 Dst =>
     i_bsl S1 S2 Fail Dst
-gc_bif2 Fail Live u$bif:erlang:bsr/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bsr/2 S1 S2 Dst =>
     i_bsr S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:band/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:band/2 S1 S2 Dst =>
     i_band S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:bor/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bor/2 S1 S2 Dst =>
     i_bor Fail S1 S2 Dst
 
-gc_bif2 Fail Live u$bif:erlang:bxor/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bxor/2 S1 S2 Dst =>
     i_bxor Fail S1 S2 Dst
 
-gc_bif1 Fail Live u$bif:erlang:bnot/1 Src Dst=d =>
+gc_bif1 Fail _Live u$bif:erlang:bnot/1 Src Dst=d =>
     i_int_bnot Fail Src Dst
 
 i_increment rxy W d
@@ -1524,14 +1524,14 @@ i_length j? t d
 #
 # Guard BIFs.
 #
-gc_bif1 p Live Bif Src Dst           => i_bif1_body Src Bif Dst
-gc_bif1 Fail=f Live Bif Src Dst      => i_bif1 Src Fail Bif Dst
+gc_bif1 p _Live Bif Src Dst           => i_bif1_body Src Bif Dst
+gc_bif1 Fail=f _Live Bif Src Dst      => i_bif1 Src Fail Bif Dst
 
-gc_bif2 p Live Bif S1 S2 Dst         => i_bif2_body S2 S1 Bif Dst
-gc_bif2 Fail=f Live Bif S1 S2 Dst    => i_bif2 S2 S1 Fail Bif Dst
+gc_bif2 p _Live Bif S1 S2 Dst         => i_bif2_body S2 S1 Bif Dst
+gc_bif2 Fail=f _Live Bif S1 S2 Dst    => i_bif2 S2 S1 Fail Bif Dst
 
-gc_bif3 p Live Bif S1 S2 S3 Dst      => i_bif3_body S3 S2 S1 Bif Dst
-gc_bif3 Fail=f Live Bif S1 S2 S3 Dst => i_bif3 S3 S2 S1 Fail Bif Dst
+gc_bif3 p _Live Bif S1 S2 S3 Dst      => i_bif3_body S3 S2 S1 Bif Dst
+gc_bif3 Fail=f _Live Bif S1 S2 S3 Dst => i_bif3 S3 S2 S1 Fail Bif Dst
 
 #
 # The following instruction is specially handled in beam_load.c
@@ -1539,7 +1539,7 @@ gc_bif3 Fail=f Live Bif S1 S2 S3 Dst => i_bif3 S3 S2 S1 Fail Bif Dst
 # encountered.
 #
 unsupported_guard_bif/3
-unsupported_guard_bif A B C | never() => _
+unsupported_guard_bif _A _B _C | never() => _
 
 #
 # R13B03
@@ -1562,8 +1562,8 @@ raw_raise
 
 # move_x1, move_x2
 
-move C=aiq X=x==1 => move_x1 C
-move C=aiq X=x==2 => move_x2 C
+move C=aiq _X=x==1 => move_x1 C
+move C=aiq _X=x==2 => move_x2 C
 
 move n D=y => i_init D
 

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -67,14 +67,14 @@ return
 # BIF, so we can omit the line instruction for non-BIFs.
 #
 
-move S X0=x==0 | line Loc | call_ext_last Ar Func=u$is_not_bif D =>
+move S X0=x==0 | line _Loc | call_ext_last Ar Func=u$is_not_bif D =>
     move S X0 | call_ext_last Ar Func D
-move S X0=x==0 | line Loc | call_ext_only Ar Func=u$is_not_bif =>
+move S X0=x==0 | line _Loc | call_ext_only Ar Func=u$is_not_bif =>
     move S X0 | call_ext_only Ar Func
 
-move S X0=x==0 | line Loc | call_last Ar Func D =>
+move S X0=x==0 | line _Loc | call_last Ar Func D =>
     move S X0 | call_last Ar Func D
-move S X0=x==0 | line Loc | call_only Ar Func =>
+move S X0=x==0 | line _Loc | call_only Ar Func =>
     move S X0 | call_only Ar Func
 
 # The line number in int_func_start/5 can be NIL.
@@ -185,8 +185,8 @@ try_end y
 
 try_case_end s
 
-try_end Y | deallocate N => try_end_deallocate N
-try_end Y | move Src Dst | deallocate N => try_end_move_deallocate Src Dst N
+try_end _Y | deallocate N => try_end_deallocate N
+try_end _Y | move Src Dst | deallocate N => try_end_move_deallocate Src Dst N
 
 try_end_deallocate t
 try_end_move_deallocate s d t
@@ -210,11 +210,11 @@ current_tuple/1
 current_tuple/2
 
 is_tuple Fail=f Src | test_arity Fail2 Src2 Arity |
-  equal(Fail, Fail2) | equal(Src, Src) =>
+  equal(Fail, Fail2) | equal(Src, Src2) =>
     i_is_tuple_of_arity Fail Src Arity | current_tuple Src
 
 is_tuple Fail1=f Src | test_arity Fail2 Src2 Arity |
-  equal(Src, Src) =>
+  equal(Src, Src2) =>
     i_is_tuple_of_arity_ff Fail1 Fail2 Src Arity | current_tuple Src
 
 test_arity Fail Src Arity => i_test_arity Fail Src Arity | current_tuple Src
@@ -260,7 +260,7 @@ i_get_tuple_element Tuple Pos Tuple2 | current_tuple Tuple3 |
 # This is a current_tuple instruction not followed by
 # get_tuple_element. Invalidate the current tuple pointer.
 
-current_tuple Tuple => _
+current_tuple _Tuple => _
 
 i_get_tuple_element Tuple Pos Dst | current_tuple d | swap R1 R2 =>
     i_get_tuple_element Tuple Pos Dst | swap R1 R2
@@ -280,7 +280,7 @@ i_get_tuple_element Tuple Pos1 Dst1 |
 
 # Drop the current_tuple instruction if the tuple is overwritten.
 current_tuple Tuple Tuple2 | equal(Tuple, Tuple2) => _
-current_tuple Tuple Dst => current_tuple Tuple
+current_tuple Tuple _Dst => current_tuple Tuple
 
 # The first operand will only be used in the debug-compiled runtime
 # system to verify that the register holding the tuple pointer agrees
@@ -465,7 +465,7 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl LHS RHS | equal(LHS, RHS) => _
+is_eq_exact _Lbl LHS RHS | equal(LHS, RHS) => _
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
 is_eq_exact Lbl R=xy n => is_nil Lbl R
@@ -573,7 +573,7 @@ is_list f s
 is_atom f s
 is_float f s
 
-is_nil Fail=f n => _
+is_nil _Fail=f n => _
 is_nil Fail=f qia => jump Fail
 is_nil f S
 
@@ -656,7 +656,7 @@ call_ext_only u==0 u$func:erlang:yield/0 => i_yield | return
 # The hibernate/3 BIF is an instruction.
 #
 call_ext u==3 u$func:erlang:hibernate/3 => i_hibernate
-call_ext_last u==3 u$func:erlang:hibernate/3 D => i_hibernate
+call_ext_last u==3 u$func:erlang:hibernate/3 _D => i_hibernate
 call_ext_only u==3 u$func:erlang:hibernate/3 => i_hibernate
 
 call_ext u==0 u$func:os:perf_counter/0 =>
@@ -707,9 +707,9 @@ call_ext_only Ar=u Bif=u$is_bif =>
 # with call instructions.
 #
 
-call_ext Ar Func        => i_call_ext Func
-call_ext_last Ar Func D => i_call_ext_last Func D
-call_ext_only Ar Func   => i_call_ext_only Func
+call_ext _Ar Func        => i_call_ext Func
+call_ext_last _Ar Func D => i_call_ext_last Func D
+call_ext_only _Ar Func   => i_call_ext_only Func
 
 i_validate t
 
@@ -738,50 +738,50 @@ i_perf_counter
 bif0 u$bif:erlang:self/0 Dst=d => self Dst
 bif0 u$bif:erlang:node/0 Dst=d => node Dst
 
-bif1 Fail=f Bif=u$bif:erlang:hd/1 Src=xy Dst =>
+bif1 Fail=f _Bif=u$bif:erlang:hd/1 Src=xy Dst =>
     is_nonempty_list Fail Src | get_hd Src Dst
-bif1 Fail=p Bif=u$bif:erlang:hd/1 Src Dst =>
+bif1 _Fail=p _Bif=u$bif:erlang:hd/1 Src Dst =>
     bif_hd Src Dst
 
 bif_hd s d
 
-bif1 Fail=f Bif=u$bif:erlang:tl/1 Src=xy Dst =>
+bif1 Fail=f _Bif=u$bif:erlang:tl/1 Src=xy Dst =>
     is_nonempty_list Fail Src | get_tl Src Dst
-bif1 Fail=p Bif=u$bif:erlang:tl/1 Src Dst =>
+bif1 _Fail=p _Bif=u$bif:erlang:tl/1 Src Dst =>
     bif_tl Src Dst
 
 bif_tl s d
 
-bif1 Fail Bif=u$bif:erlang:get/1 Src=s Dst=d => get(Src, Dst)
+bif1 _Fail _Bif=u$bif:erlang:get/1 Src=s Dst=d => get(Src, Dst)
 
 bif2 Fail u$bif:erlang:element/2 S1 S2 Dst => bif_element Fail S1 S2 Dst
 bif_element j s s d
 
-bif2 Fail Bif=u$bif:erlang:and/2 Src1 Src2 Dst=d => bif_and Fail Src1 Src2 Dst
+bif2 Fail _Bif=u$bif:erlang:and/2 Src1 Src2 Dst=d => bif_and Fail Src1 Src2 Dst
 bif_and j s s d
 
-bif2 Fail Bif=u$bif:erlang:or/2 Src1 Src2 Dst=d => bif_or Fail Src1 Src2 Dst
+bif2 Fail _Bif=u$bif:erlang:or/2 Src1 Src2 Dst=d => bif_or Fail Src1 Src2 Dst
 bif_or j s s d
 
-bif1 Fail Bif=u$bif:erlang:not/1 Src=d Dst=d => bif_not Fail Src Dst
+bif1 Fail _Bif=u$bif:erlang:not/1 Src=d Dst=d => bif_not Fail Src Dst
 bif_not j S d
 
-bif1 Fail Bif=u$bif:erlang:node/1 Src=d Dst=d => bif_node Fail Src Dst
+bif1 Fail _Bif=u$bif:erlang:node/1 Src=d Dst=d => bif_node Fail Src Dst
 bif_node j S d
 
-gc_bif1 Fail Live Bif=u$bif:erlang:bit_size/1 Src Dst=d =>
+gc_bif1 Fail _Live _Bif=u$bif:erlang:bit_size/1 Src Dst=d =>
     bif_bit_size Fail Src Dst
 bif_bit_size j s d
 
-gc_bif1 Fail Live Bif=u$bif:erlang:byte_size/1 Src Dst=d =>
+gc_bif1 Fail _Live _Bif=u$bif:erlang:byte_size/1 Src Dst=d =>
     bif_byte_size Fail Src Dst
 bif_byte_size j s d
 
-bif1 Fail Bif=u$bif:erlang:tuple_size/1 Src=d Dst=d =>
+bif1 Fail _Bif=u$bif:erlang:tuple_size/1 Src=d Dst=d =>
     bif_tuple_size Fail Src Dst
 bif_tuple_size j S d
 
-bif2 Fail Bif=u$bif:erlang:map_get/2 Src1 Src2=xy Dst=d =>
+bif2 Fail _Bif=u$bif:erlang:map_get/2 Src1 Src2=xy Dst=d =>
     bif_map_get Fail Src1 Src2 Dst
 bif_map_get j s s d
 
@@ -789,15 +789,15 @@ bif2 Fail Bif=u$bif:erlang:is_map_key/2 Key Map=xy Dst=d =>
     bif_is_map_key Bif Fail Key Map Dst
 bif_is_map_key b j s s d
 
-bif2 Fail Bif=u$bif:erlang:max/2 Src1 Src2 Dst =>
+bif2 _Fail _Bif=u$bif:erlang:max/2 Src1 Src2 Dst =>
     bif_max Src1 Src2 Dst
-bif2 Fail Bif=u$bif:erlang:min/2 Src1 Src2 Dst =>
+bif2 _Fail _Bif=u$bif:erlang:min/2 Src1 Src2 Dst =>
     bif_min Src1 Src2 Dst
 bif_max s s d
 bif_min s s d
 
-bif1 Fail Bif S1 Dst | never_fails(Bif) => nofail_bif1 S1 Bif Dst
-bif2 Fail Bif S1 S2 Dst | never_fails(Bif) => nofail_bif2 S1 S2 Bif Dst
+bif1 _Fail Bif S1 Dst | never_fails(Bif) => nofail_bif1 S1 Bif Dst
+bif2 _Fail Bif S1 S2 Dst | never_fails(Bif) => nofail_bif2 S1 S2 Bif Dst
 
 bif1 Fail Bif S1 Dst    => i_bif1 S1 Fail Bif Dst
 bif2 Fail Bif S1 S2 Dst => i_bif2 S1 S2 Fail Bif Dst
@@ -830,15 +830,16 @@ bif_is_lt s s d
 # Internal calls.
 #
 
-i_move S=y Dst | call_last Ar P D => move_call_last S Dst P D
-i_move S=y Dst | call_ext_last Ar P=u$is_not_bif D => move_call_ext_last S Dst P D
+i_move S=y Dst | call_last _Ar P D => move_call_last S Dst P D
+i_move S=y Dst | call_ext_last _Ar P=u$is_not_bif D =>
+    move_call_ext_last S Dst P D
 
 move_call_last y d f t
 move_call_ext_last y d e t
 
-call Ar Func        => i_call Func
-call_last Ar Func D => i_call_last Func D
-call_only Ar Func   => i_call_only Func
+call _Ar Func        => i_call Func
+call_last _Ar Func D => i_call_last Func D
+call_only _Ar Func   => i_call_only Func
 
 i_call f
 i_call_last f t
@@ -956,7 +957,7 @@ i_bs_match_test_heap f S I t *
 # is encountered.
 #
 bad_bs_match/1
-bad_bs_match A | never() => _
+bad_bs_match _A | never() => _
 
 # ================================================================
 # Bit syntax matching (from R11B).
@@ -983,7 +984,7 @@ i_bs_get_binary_all2 S f t t d
 bs_get_float2 Fail=f Ms=xy Live=u Sz=s Unit=u Flags=u Dst=d =>
     get_float2(Fail, Ms, Live, Sz, Unit, Flags, Dst)
 
-bs_get_float2 Fail=f Ms=x Live=u Sz=q Unit=u Flags=u Dst=d => jump Fail
+bs_get_float2 Fail=f _Ms=x _Live=u _Sz=q _Unit=u _Flags=u _Dst=d => jump Fail
 
 i_bs_get_float2 S f t s t d
 
@@ -995,7 +996,7 @@ bs_skip_bits2 Fail=f Ms=xy Sz=sq Unit=u Flags=u =>
 i_bs_skip_bits_imm2 f S W
 i_bs_skip_bits2 S S f t
 
-bs_test_tail2 Fail=f Ms=xy o => jump Fail
+bs_test_tail2 Fail=f _Ms=xy o => jump Fail
 
 bs_test_tail2 f S W
 
@@ -1018,8 +1019,8 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d =>
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Ctx Dst | equal(Ctx, Dst) => _
-bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
+bs_start_match4 a==am_resume _Live Ctx Dst | equal(Ctx, Dst) => _
+bs_start_match4 a==am_resume _Live Ctx Dst => move Ctx Dst
 
 %else
 
@@ -1028,7 +1029,7 @@ bs_start_match4 a==am_resume Live Ctx Dst =>
 
 %endif
 
-bs_start_match3 Fail=j ica Live Dst => jump Fail
+bs_start_match3 Fail=j ica _Live _Dst => jump Fail
 bs_start_match3 Fail Bin Live Dst => i_bs_start_match3 Bin Live Fail Dst
 
 i_bs_start_match3 S t j d
@@ -1037,7 +1038,7 @@ i_bs_start_match3 S t j d
 # fit into an unsigned small.
 
 %if ARCH_64
-    bs_get_position Src Dst Live => i_bs_get_position Src Dst
+    bs_get_position Src Dst _Live => i_bs_get_position Src Dst
     i_bs_get_position S S
     bs_set_position S S
 %else
@@ -1129,7 +1130,7 @@ apply_last t t
 # always preceded by an is_map test. That means that put_map_assoc can
 # never fail and does not need any failure label.
 
-put_map_assoc Fail Map Dst Live Size Rest=* =>
+put_map_assoc _Fail Map Dst Live Size Rest=* =>
     i_put_map_assoc Map Dst Live Size Rest
 i_put_map_assoc/4
 
@@ -1185,21 +1186,21 @@ i_get_map_element f S S S
 # Arithmetic instructions.
 #
 
-gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
-  gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
+gc_bif2 Fail1 _Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
+  gc_bif2 Fail2 _Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S3) |
   equal(Dst1, Dst2) |
   equal(Fail1, Fail2) =>
     i_mul_add Fail1 S1 S2 S3 S4 Dst1
 
-gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
-  gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
+gc_bif2 Fail1 _Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
+  gc_bif2 Fail2 _Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S4) |
   equal(Dst1, Dst2) |
   equal(Fail1, Fail2) =>
     i_mul_add Fail1 S1 S2 S4 S3 Dst1
 
-gc_bif2 Fail Live u$bif:erlang:stimes/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:stimes/2 S1 S2 Dst =>
     i_mul_add Fail S1 S2 Dst i Dst
 
 gc_bif2 Fail Live u$bif:erlang:splus/2 Src1 Src2 Dst =>
@@ -1216,7 +1217,7 @@ gc_bif2 Fail Live u$bif:erlang:div/2 S1 S2 Dst =>
 
 # Fused 'rem'/'div' pair.
 gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
-  gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
+  gc_bif2 _A _B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Remainder) |
@@ -1225,8 +1226,8 @@ gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
 
 # As above but with a `line` in between
 gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
-  line Loc |
-  gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
+  line _Loc |
+  gc_bif2 _A _B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Remainder) |
@@ -1235,7 +1236,7 @@ gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
 
 # Fused 'div'/'rem' pair
 gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
-  gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
+  gc_bif2 _A _B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Quotient) |
@@ -1244,8 +1245,8 @@ gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
 
 # As above but with a `line` in between
 gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
-  line Loc |
-  gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
+  line _Loc |
+  gc_bif2 _A _B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Quotient) |
@@ -1311,15 +1312,16 @@ i_length j t d
 # Specialized guard BIFs.
 #
 
-gc_bif1 Fail Live Bif=u$bif:erlang:map_size/1 Src Dst=d => bif_map_size Fail Src Dst
+gc_bif1 Fail _Live _Bif=u$bif:erlang:map_size/1 Src Dst=d =>
+    bif_map_size Fail Src Dst
 bif_map_size j s d
 
 #
 # Guard BIFs.
 #
-gc_bif1 Fail Live Bif Src Dst      => i_bif1 Src Fail Bif Dst
-gc_bif2 Fail Live Bif S1 S2 Dst    => i_bif2 S1 S2 Fail Bif Dst
-gc_bif3 Fail Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
+gc_bif1 Fail _Live Bif Src Dst      => i_bif1 Src Fail Bif Dst
+gc_bif2 Fail _Live Bif S1 S2 Dst    => i_bif2 S1 S2 Fail Bif Dst
+gc_bif3 Fail _Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
 
 #
 # The following instruction is specially handled in beam_load.c
@@ -1327,7 +1329,7 @@ gc_bif3 Fail Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
 # encountered.
 #
 unsupported_guard_bif/3
-unsupported_guard_bif A B C | never() => _
+unsupported_guard_bif _A _B _C | never() => _
 
 #
 # R13B03

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -67,14 +67,14 @@ return
 # BIF, so we can omit the line instruction for non-BIFs.
 #
 
-move S X0=x==0 | line Loc | call_ext_last Ar Func=u$is_not_bif D =>
+move S X0=x==0 | line _Loc | call_ext_last Ar Func=u$is_not_bif D =>
      move S X0 | call_ext_last Ar Func D
-move S X0=x==0 | line Loc | call_ext_only Ar Func=u$is_not_bif =>
+move S X0=x==0 | line _Loc | call_ext_only Ar Func=u$is_not_bif =>
      move S X0 | call_ext_only Ar Func
 
-move S X0=x==0 | line Loc | call_last Ar Func D =>
+move S X0=x==0 | line _Loc | call_last Ar Func D =>
      move S X0 | call_last Ar Func D
-move S X0=x==0 | line Loc | call_only Ar Func =>
+move S X0=x==0 | line _Loc | call_only Ar Func =>
      move S X0 | call_only Ar Func
 
 # The line number in int_func_start/5 can be NIL.
@@ -93,7 +93,7 @@ allocate_heap t I t
 
 deallocate t
 
-trim N Remaining => i_trim N
+trim N _Remaining => i_trim N
 
 i_trim t
 
@@ -196,7 +196,7 @@ try_end y
 
 try_case_end s
 
-try_end Y | deallocate N => try_end_deallocate N
+try_end _Y | deallocate N => try_end_deallocate N
 
 try_end_deallocate t
 
@@ -218,7 +218,7 @@ is_tuple Fail=f Src | test_arity Fail2 Src2 Arity |
     i_is_tuple_of_arity Fail Src Arity | current_tuple Src
 
 is_tuple Fail1=f Src | test_arity Fail2 Src2 Arity |
-  equal(Src, Src) =>
+  equal(Src, Src2) =>
     i_is_tuple_of_arity_ff Fail1 Fail2 Src Arity | current_tuple Src
 
 test_arity Fail Src Arity => i_test_arity Fail Src Arity | current_tuple Src
@@ -263,7 +263,7 @@ i_get_tuple_element Tuple Pos Tuple2 | current_tuple Tuple3 |
 # This is a current_tuple instruction not followed by
 # get_tuple_element. Invalidate the current tuple pointer.
 
-current_tuple Tuple => _
+current_tuple _Tuple => _
 
 load_tuple_ptr s
 
@@ -284,7 +284,7 @@ i_get_tuple_element Tuple Pos1 Dst1 | current_tuple Tuple2 |
 
 # Drop the current_tuple instruction if the tuple is overwritten.
 current_tuple Tuple Tuple2 | equal(Tuple, Tuple2) => _
-current_tuple Tuple Dst => current_tuple Tuple
+current_tuple Tuple _Dst => current_tuple Tuple
 
 # The first operand will only be used in the debug-compiled runtime
 # system to verify that the register holding the tuple pointer agrees
@@ -409,7 +409,7 @@ send
 # Optimized comparisons with one immediate/literal operand.
 #
 
-is_eq_exact Lbl LHS RHS | equal(LHS, RHS) => _
+is_eq_exact _Lbl LHS RHS | equal(LHS, RHS) => _
 is_eq_exact Lbl C=c R=xy => is_eq_exact Lbl R C
 
 is_eq_exact Lbl R=xy n => is_nil Lbl R
@@ -519,7 +519,7 @@ is_list f s
 is_atom f s
 is_float f s
 
-is_nil Fail=f n => _
+is_nil _Fail=f n => _
 is_nil Fail=f qia => jump Fail
 is_nil f S
 
@@ -602,7 +602,7 @@ call_ext_only u==0 u$func:erlang:yield/0 => i_yield | return
 # The hibernate/3 BIF is an instruction.
 #
 call_ext u==3 u$func:erlang:hibernate/3 => i_hibernate
-call_ext_last u==3 u$func:erlang:hibernate/3 D => i_hibernate
+call_ext_last u==3 u$func:erlang:hibernate/3 _D => i_hibernate
 call_ext_only u==3 u$func:erlang:hibernate/3 => i_hibernate
 
 call_ext u==0 u$func:os:perf_counter/0 =>
@@ -651,9 +651,9 @@ call_ext_only Ar=u Bif=u$is_bif =>
 # with call instructions.
 #
 
-call_ext Ar Func        => i_call_ext Func
-call_ext_last Ar Func D => i_call_ext_last Func D
-call_ext_only Ar Func   => i_call_ext_only Func
+call_ext _Ar Func        => i_call_ext Func
+call_ext_last _Ar Func D => i_call_ext_last Func D
+call_ext_only _Ar Func   => i_call_ext_only Func
 
 i_validate t
 
@@ -682,29 +682,29 @@ i_perf_counter
 bif0 u$bif:erlang:self/0 Dst=d => self Dst
 bif0 u$bif:erlang:node/0 Dst=d => node Dst
 
-bif1 Fail=f Bif=u$bif:erlang:hd/1 Src=xy Dst =>
+bif1 Fail=f _Bif=u$bif:erlang:hd/1 Src=xy Dst =>
     is_nonempty_list Fail Src | get_hd Src Dst
-bif1 Fail=p Bif=u$bif:erlang:hd/1 Src Dst =>
+bif1 _Fail=p _Bif=u$bif:erlang:hd/1 Src Dst =>
     bif_hd Src Dst
 
 bif_hd s d
 
-bif1 Fail=f Bif=u$bif:erlang:tl/1 Src=xy Dst =>
+bif1 Fail=f _Bif=u$bif:erlang:tl/1 Src=xy Dst =>
     is_nonempty_list Fail Src | get_tl Src Dst
 
-bif1 Fail Bif=u$bif:erlang:get/1 Src=s Dst=d => get(Src, Dst)
+bif1 _Fail _Bif=u$bif:erlang:get/1 Src=s Dst=d => get(Src, Dst)
 
 bif2 Fail u$bif:erlang:element/2 S1=ixy S2 Dst => bif_element Fail S1 S2 Dst
 bif_element j s s d
 
-bif1 Fail Bif=u$bif:erlang:node/1 Src=d Dst=d => bif_node Fail Src Dst
+bif1 Fail _Bif=u$bif:erlang:node/1 Src=d Dst=d => bif_node Fail Src Dst
 bif_node j S d
 
-gc_bif1 Fail Live Bif=u$bif:erlang:bit_size/1 Src Dst=d =>
+gc_bif1 Fail _Live Bif=u$bif:erlang:bit_size/1 Src Dst=d =>
     bif_bit_size Bif Fail Src Dst
 bif_bit_size b j s d
 
-gc_bif1 Fail Live Bif=u$bif:erlang:byte_size/1 Src Dst=d =>
+gc_bif1 Fail _Live Bif=u$bif:erlang:byte_size/1 Src Dst=d =>
     bif_byte_size Bif Fail Src Dst
 bif_byte_size b j s d
 
@@ -712,7 +712,7 @@ bif1 Fail Bif=u$bif:erlang:tuple_size/1 Src=d Dst=d =>
     bif_tuple_size Bif Fail Src Dst
 bif_tuple_size b j S d
 
-bif2 Fail Bif=u$bif:erlang:map_get/2 Src1 Src2=xy Dst=d =>
+bif2 Fail _Bif=u$bif:erlang:map_get/2 Src1 Src2=xy Dst=d =>
     bif_map_get Fail Src1 Src2 Dst
 bif_map_get j s s d
 
@@ -720,15 +720,15 @@ bif2 Fail Bif=u$bif:erlang:is_map_key/2 Key Map=xy Dst=d =>
     bif_is_map_key Bif Fail Key Map Dst
 bif_is_map_key b j s s d
 
-bif2 Fail Bif=u$bif:erlang:max/2 Src1 Src2 Dst =>
+bif2 _Fail _Bif=u$bif:erlang:max/2 Src1 Src2 Dst =>
     bif_max Src1 Src2 Dst
-bif2 Fail Bif=u$bif:erlang:min/2 Src1 Src2 Dst =>
+bif2 _Fail _Bif=u$bif:erlang:min/2 Src1 Src2 Dst =>
     bif_min Src1 Src2 Dst
 bif_max s s d
 bif_min s s d
 
-bif1 Fail Bif S1 Dst | never_fails(Bif) => nofail_bif1 S1 Bif Dst
-bif2 Fail Bif S1 S2 Dst | never_fails(Bif) => nofail_bif2 S1 S2 Bif Dst
+bif1 _Fail Bif S1 Dst | never_fails(Bif) => nofail_bif1 S1 Bif Dst
+bif2 _Fail Bif S1 S2 Dst | never_fails(Bif) => nofail_bif2 S1 S2 Bif Dst
 
 bif1 Fail Bif S1 Dst    => i_bif1 S1 Fail Bif Dst
 bif2 Fail Bif S1 S2 Dst => i_bif2 S1 S2 Fail Bif Dst
@@ -761,9 +761,9 @@ bif_is_lt s s d
 # Internal calls.
 #
 
-call Ar Func        => i_call Func
-call_last Ar Func D => i_call_last Func D
-call_only Ar Func   => i_call_only Func
+call _Ar Func        => i_call Func
+call_last _Ar Func D => i_call_last Func D
+call_only _Ar Func   => i_call_only Func
 
 i_call f
 i_call_last f t
@@ -878,7 +878,7 @@ i_bs_match_test_heap f S I t *
 # is encountered.
 #
 bad_bs_match/1
-bad_bs_match A | never() => _
+bad_bs_match _A | never() => _
 
 # ================================================================
 # Bit syntax matching (from R11B).
@@ -905,7 +905,7 @@ i_bs_get_binary_all2 S f t t d
 bs_get_float2 Fail=f Ms=xy Live=u Sz=s Unit=u Flags=u Dst=d =>
     get_float2(Fail, Ms, Live, Sz, Unit, Flags, Dst)
 
-bs_get_float2 Fail=f Ms=x Live=u Sz=q Unit=u Flags=u Dst=d => jump Fail
+bs_get_float2 Fail=f _Ms=x _Live=u _Sz=q _Unit=u _Flags=u _Dst=d => jump Fail
 
 i_bs_get_float2 S f t s t d
 
@@ -917,7 +917,7 @@ bs_skip_bits2 Fail=f Ms=xy Sz=sq Unit=u Flags=u =>
 i_bs_skip_bits_imm2 f S W
 i_bs_skip_bits2 S S f t
 
-bs_test_tail2 Fail=f Ms=xy o => jump Fail
+bs_test_tail2 Fail=f _Ms=xy o => jump Fail
 
 bs_test_tail2 f S W
 
@@ -940,8 +940,8 @@ bs_start_match4 Fail=f Live=u Src=xy Ctx=d =>
 %if ARCH_64
 
 # This instruction nops on 64-bit platforms
-bs_start_match4 a==am_resume Live Ctx Dst | equal(Ctx, Dst) => _
-bs_start_match4 a==am_resume Live Ctx Dst => move Ctx Dst
+bs_start_match4 a==am_resume _Live Ctx Dst | equal(Ctx, Dst) => _
+bs_start_match4 a==am_resume _Live Ctx Dst => move Ctx Dst
 
 %else
 
@@ -950,7 +950,7 @@ bs_start_match4 a==am_resume Live Ctx Dst =>
 
 %endif
 
-bs_start_match3 Fail=j ica Live Dst => jump Fail
+bs_start_match3 Fail=j ica _Live _Dst => jump Fail
 bs_start_match3 Fail Bin Live Dst => i_bs_start_match3 Bin Live Fail Dst
 
 i_bs_start_match3 S t j d
@@ -959,7 +959,7 @@ i_bs_start_match3 S t j d
 # fit into an unsigned small.
 
 %if ARCH_64
-    bs_get_position Src Dst Live => i_bs_get_position Src Dst
+    bs_get_position Src Dst _Live => i_bs_get_position Src Dst
     i_bs_get_position S S
     bs_set_position S S
 %else
@@ -1048,7 +1048,7 @@ apply_last t t
 # always preceded by an is_map test. That means that put_map_assoc can
 # never fail and does not need any failure label.
 
-put_map_assoc Fail Map Dst Live Size Rest=* =>
+put_map_assoc _Fail Map Dst Live Size Rest=* =>
     i_put_map_assoc Map Dst Live Size Rest
 
 i_put_map_assoc/4
@@ -1112,7 +1112,7 @@ gc_bif1 Fail Live u$bif:erlang:splus/1 Src Dst =>
 gc_bif2 Fail Live u$bif:erlang:splus/2 S1 S2 Dst =>
     gen_plus Fail Live S1 S2 Dst
 
-gc_bif1 Fail Live u$bif:erlang:sminus/1 Src Dst =>
+gc_bif1 Fail _Live u$bif:erlang:sminus/1 Src Dst =>
     i_unary_minus Src Fail Dst
 gc_bif2 Fail Live u$bif:erlang:sminus/2 S1 S2 Dst =>
     gen_minus Fail Live S1 S2 Dst
@@ -1121,33 +1121,33 @@ gc_bif2 Fail Live u$bif:erlang:sminus/2 S1 S2 Dst =>
 # Arithmetic instructions.
 #
 
-gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
-  gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
+gc_bif2 Fail1 _Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
+  gc_bif2 Fail2 _Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S3) |
   equal(Dst1, Dst2) |
   equal(Fail1, Fail2) =>
     i_mul_add Fail1 S1 S2 S3 S4 Dst1
 
-gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
-  gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
+gc_bif2 Fail1 _Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
+  gc_bif2 Fail2 _Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S4) |
   equal(Dst1, Dst2) |
   equal(Fail1, Fail2) =>
     i_mul_add Fail1 S1 S2 S4 S3 Dst1
 
-gc_bif2 Fail Live u$bif:erlang:stimes/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:stimes/2 S1 S2 Dst =>
     i_mul_add Fail S1 S2 Dst i Dst
 
-gen_plus Fail Live S1 S2 Dst => i_plus S1 S2 Fail Dst
+gen_plus Fail _Live S1 S2 Dst => i_plus S1 S2 Fail Dst
 
-gen_minus Fail Live S1 S2 Dst => i_minus S1 S2 Fail Dst
+gen_minus Fail _Live S1 S2 Dst => i_minus S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:div/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:div/2 S1 S2 Dst =>
     i_m_div Fail S1 S2 Dst
 
 # Fused 'rem'/'div' pair.
-gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
-  gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
+gc_bif2 Fail _Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
+  gc_bif2 _A _B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Remainder) |
@@ -1155,9 +1155,9 @@ gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
     i_rem_div LHS1 RHS1 Fail Remainder Quotient
 
 # As above but with a `line` in between
-gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
-  line Loc |
-  gc_bif2 A B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
+gc_bif2 Fail _Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
+  line _Loc |
+  gc_bif2 _A _B u$bif:erlang:intdiv/2 LHS2 RHS2 Quotient |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Remainder) |
@@ -1165,8 +1165,8 @@ gc_bif2 Fail Live u$bif:erlang:rem/2 LHS1 RHS1 Remainder |
     i_rem_div LHS1 RHS1 Fail Remainder Quotient
 
 # Fused 'div'/'rem' pair
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
-  gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
+gc_bif2 Fail _Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
+  gc_bif2 _A _B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Quotient) |
@@ -1174,35 +1174,35 @@ gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
     i_div_rem LHS1 RHS1 Fail Quotient Remainder
 
 # As above but with a `line` in between
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
-  line Loc |
-  gc_bif2 A B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
+gc_bif2 Fail _Live u$bif:erlang:intdiv/2 LHS1 RHS1 Quotient |
+  line _Loc |
+  gc_bif2 _A _B u$bif:erlang:rem/2 LHS2 RHS2 Remainder |
   equal(LHS1, LHS2) |
   equal(RHS1, RHS2) |
   distinct(LHS1, Quotient) |
   distinct(RHS1, Quotient) =>
     i_div_rem LHS1 RHS1 Fail Quotient Remainder
 
-gc_bif2 Fail Live u$bif:erlang:intdiv/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:intdiv/2 S1 S2 Dst =>
     i_int_div Fail S1 S2 Dst
-gc_bif2 Fail Live u$bif:erlang:rem/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:rem/2 S1 S2 Dst =>
     i_rem S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:bsl/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bsl/2 S1 S2 Dst =>
     i_bsl S1 S2 Fail Dst
-gc_bif2 Fail Live u$bif:erlang:bsr/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bsr/2 S1 S2 Dst =>
     i_bsr S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:band/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:band/2 S1 S2 Dst =>
     i_band S1 S2 Fail Dst
 
-gc_bif2 Fail Live u$bif:erlang:bor/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bor/2 S1 S2 Dst =>
     i_bor Fail S1 S2 Dst
 
-gc_bif2 Fail Live u$bif:erlang:bxor/2 S1 S2 Dst =>
+gc_bif2 Fail _Live u$bif:erlang:bxor/2 S1 S2 Dst =>
     i_bxor Fail S1 S2 Dst
 
-gc_bif1 Fail Live u$bif:erlang:bnot/1 Src Dst =>
+gc_bif1 Fail _Live u$bif:erlang:bnot/1 Src Dst =>
     i_bnot Fail Src Dst
 
 i_plus s s j d
@@ -1242,15 +1242,16 @@ i_length j t d
 # Specialized guard BIFs.
 #
 
-gc_bif1 Fail Live Bif=u$bif:erlang:map_size/1 Src Dst=d => bif_map_size Fail Src Dst
+gc_bif1 Fail _Live _Bif=u$bif:erlang:map_size/1 Src Dst=d =>
+    bif_map_size Fail Src Dst
 bif_map_size j s d
 
 #
 # Guard BIFs.
 #
-gc_bif1 Fail Live Bif Src Dst      => i_bif1 Src Fail Bif Dst
-gc_bif2 Fail Live Bif S1 S2 Dst    => i_bif2 S1 S2 Fail Bif Dst
-gc_bif3 Fail Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
+gc_bif1 Fail _Live Bif Src Dst      => i_bif1 Src Fail Bif Dst
+gc_bif2 Fail _Live Bif S1 S2 Dst    => i_bif2 S1 S2 Fail Bif Dst
+gc_bif3 Fail _Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
 
 #
 # The following instruction is specially handled in beam_load.c
@@ -1258,7 +1259,7 @@ gc_bif3 Fail Live Bif S1 S2 S3 Dst => i_bif3 S1 S2 S3 Fail Bif Dst
 # encountered.
 #
 unsupported_guard_bif/3
-unsupported_guard_bif A B C | never() => _
+unsupported_guard_bif _A _B _C | never() => _
 
 #
 # R13B03

--- a/erts/emulator/internal_doc/beam_makeops.md
+++ b/erts/emulator/internal_doc/beam_makeops.md
@@ -891,10 +891,16 @@ a variable must begin with an uppercase letter.  In constrast to Erlang,
 variables must **not** be repeated.
 
 Variables that have been bound on the left-hand side can be used on
-the right-hand side.  For example, this rule will rewrite all `move`
-instructions to `assign` instructions with the operands swapped:
+the right-hand side or in predicates.  For example, this rule will rewrite all
+`move` instructions to `assign` instructions with the operands swapped:
 
     move Src Dst => assign Dst Src
+
+To help catch issues caused by unused variables (such as GH-8875), they are
+considered errors. If you wish to give an operand a name for documentation
+purposes, prefix it with an underscore (`_Foobar`) to mark the variable as
+intentionally unused. Conversely, using a variable marked in this manner is
+also an error.
 
 If we only want to match operands of a certain type, we can
 use a type constraint.  A type constraint consists of one or more

--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -2555,7 +2555,7 @@ sub tr_parse_op {
 
     # Get the variable name if any.
 
-    if (/^([A-Z]\w*)(.*)/) {
+    if (/^(_?[A-Z]\w*)(.*)/) {
 	$var = $1;
 	$_ = $2;
 	error("garbage after variable")
@@ -3039,6 +3039,7 @@ END
 sub tr_gen_from {
     my($line,@tr) = @_;
     my(%var) = ();
+    my(%unused) = ();
     my(%var_type);
     my($var_num) = 0;
     my(@code);
@@ -3076,6 +3077,7 @@ sub tr_gen_from {
                 }
 		error($where, "'$var' unbound")
 		    unless defined $var{$var};
+                delete $unused{$var};
                 push @vars, $var;
 		if ($var_type{$var} eq 'scalar') {
 		    push(@args, "v$var{$var}");
@@ -3167,6 +3169,8 @@ sub tr_gen_from {
 		    $var_num++;
 		    push(@code, make_op($var, 'set_var', $var{$var}));
 		}
+
+                $unused{$var} = 1;
 	    }
             push(@code, make_op('', 'next_arg'));
 	}
@@ -3184,13 +3188,14 @@ sub tr_gen_from {
 
     $te_max_vars = $var_num
 	if $te_max_vars < $var_num;
-    [\%var, \%var_type, \@instrs, \@code];
+    [\%var, \%unused, \%var_type, \@instrs, \@code];
 }
 
 sub tr_gen_to {
     my($line, $orig_transform, $so_far, @tr) = @_;
-    my($var_ref, $var_type_ref, $instrs_ref, $code_ref) = @$so_far;
+    my($var_ref, $unused_ref, $var_type_ref, $instrs_ref, $code_ref) = @$so_far;
     my(%var) = %$var_ref;
+    my(%unused) = %$unused_ref;
     my(%var_type) = %$var_type_ref;
     my(@code) = @$code_ref;
     my($op, $ref);		# Loop variables.
@@ -3216,6 +3221,8 @@ sub tr_gen_to {
 	    foreach $var (@ops) {
 		error($where, "variable '$var' unbound")
 		    unless defined $var{$var};
+                delete $unused{$var};
+
 		if ($var_type{$var} eq 'scalar') {
 		    push @args, "v$var{$var}";
                     push @param_types, 'BeamOpArg';
@@ -3255,6 +3262,9 @@ sub tr_gen_to {
 	    if ($type eq '*') {
 		push(@code, make_op($var, 'store_rest_args'));
 	    } elsif ($var ne '') {
+                error($where, "using explicitly unused variable '$var'. " .
+                      "Remove the '_' prefix if this is intentional.")
+                    unless !($var =~ /^_/);
 		error($where, "variable '$var' unbound")
 		    unless defined $var{$var};
 		my $op = make_op($var, 'store_var', $var{$var});
@@ -3268,8 +3278,18 @@ sub tr_gen_to {
                 my $next_arg = make_op('', 'next_arg');
                 push @code, $store_val, $next_arg;
 	    }
+
+            delete $unused{$var};
 	}
+
 	pop(@code) if is_instr($code[$#code], 'next_arg');
+    }
+
+    foreach my $unused (keys %unused) {
+        error($where,
+              "variable '$unused' is unused. Prefix with '_' if this is " .
+              "intentional")
+            unless $unused =~ /^_/;
     }
 
     push(@code, make_op('', 'end'));


### PR DESCRIPTION
This PR catches issues like #8875 by raising an error for unused variables in transformations.