### PR TITLE
ssl: Correct own alert handling

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1161,9 +1161,9 @@ terminate({shutdown, own_alert}, _StateName, #state{
     handle_trusted_certs_db(State),
     case application:get_env(ssl, alert_timeout) of
 	{ok, Timeout} when is_integer(Timeout) ->
-	    Connection:close({timeout, Timeout}, Socket, Transport, undefined);
+	    Connection:close({close, Timeout}, Socket, Transport, undefined);
 	_ ->
-	    Connection:close({timeout, ?DEFAULT_TIMEOUT}, Socket, Transport, undefined)
+	    Connection:close({close, ?DEFAULT_TIMEOUT}, Socket, Transport, undefined)
     end;
 terminate(Reason, connection, #state{static_env = #static_env{
                                                      protocol_cb = Connection,
@@ -1176,7 +1176,7 @@ terminate(Reason, connection, #state{static_env = #static_env{
     Alert = terminate_alert(Reason),
     %% Send the termination ALERT if possible
     catch Connection:send_alert_in_connection(Alert, State),
-    Connection:close({timeout, ?DEFAULT_TIMEOUT}, Socket, Transport, ConnectionStates);
+    Connection:close({close, ?DEFAULT_TIMEOUT}, Socket, Transport, ConnectionStates);
 terminate(Reason, _StateName, #state{static_env = #static_env{transport_cb = Transport,
                                                               protocol_cb = Connection,
                                                               socket = Socket}

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -535,15 +535,6 @@ send_sync_alert(
 
 %% User closes or recursive call!
 close({close, Timeout}, Socket, Transport = gen_tcp, _) ->
-    tls_socket:setopts(Transport, Socket, [{active, false}]),
-    Transport:shutdown(Socket, write),
-    _ = Transport:recv(Socket, 0, Timeout),
-    ok;
-%% Peer closed socket
-close({shutdown, transport_closed}, Socket, Transport = gen_tcp, ConnectionStates) ->
-    close({close, 0}, Socket, Transport, ConnectionStates);
-%% We generate fatal alert
-close({shutdown, own_alert}, Socket, Transport = gen_tcp, ConnectionStates) ->
     %% Standard trick to try to make sure all
     %% data sent to the tcp port is really delivered to the
     %% peer application before tcp port is closed so that the peer will
@@ -552,7 +543,13 @@ close({shutdown, own_alert}, Socket, Transport = gen_tcp, ConnectionStates) ->
     %% e.g. we do not want to hang if something goes wrong
     %% with the network but we want to maximise the odds that
     %% peer application gets all data sent on the tcp connection.
-    close({close, ?DEFAULT_TIMEOUT}, Socket, Transport, ConnectionStates);
+    tls_socket:setopts(Transport, Socket, [{active, false}]),
+    Transport:shutdown(Socket, write),
+    _ = Transport:recv(Socket, 0, Timeout),
+    ok;
+%% Peer closed socket
+close({shutdown, transport_closed}, Socket, Transport = gen_tcp, ConnectionStates) ->
+    close({close, 0}, Socket, Transport, ConnectionStates);
 %% Other
 close(_, Socket, Transport, _) ->
     tls_socket:close(Transport, Socket).


### PR DESCRIPTION
When making ssl application environment setting alert_timeout, to allow user to configure this value,
the own_alrt timeout handling became broken.