### PR TITLE
inet_config: Tolerate atoms as `inetrc` kernel argument

### DIFF
--- a/lib/kernel/src/inet_config.erl
+++ b/lib/kernel/src/inet_config.erl
@@ -426,17 +426,15 @@ valid_type(win32) ->             true;
 valid_type(_) ->                 false.
 
 read_inetrc() ->
-   case application:get_env(inetrc) of
-       {ok,File} ->
-	   try_get_rc(File);
-       _ ->
-	   case os:getenv("ERL_INETRC") of
-	       false ->
-		   {nofile,[]};
-	       File ->
-		   try_get_rc(File)
-	   end
-   end.
+    File = case application:get_env(inetrc) of
+               {ok, Value} when is_list(Value) -> Value;
+               {ok, Value} when is_atom(Value) -> atom_to_list(Value);
+               undefined -> os:getenv("ERL_INETRC")
+           end,
+    case is_list(File) of
+        true -> try_get_rc(File);
+        false -> {nofile,[]}
+    end.
 
 try_get_rc(File) ->
     case get_rc(File) of


### PR DESCRIPTION
Many RabbitMQ users provided atoms instead of strings as the `inetrc` file path because of an error in their documentation. This was tolerated by accident until atom filename support was removed from `erl_prim_loader`.

We did the latter for good reason, but tolerating this specifically in `inet_config` is no big deal.

-------

Fixes #8899. I figured that simply tolerating it was better than raising an error as it's difficult to present it in a way that makes sense, given how this argument is often provided on the command line.