### PR TITLE
win32: Fix crash on zero-sized REG_SZ values

### DIFF
--- a/erts/emulator/drivers/win32/registry_drv.c
+++ b/erts/emulator/drivers/win32/registry_drv.c
@@ -374,8 +374,11 @@ fix_value_result(RegPort* rp, LONG result, DWORD type,
     switch (type) {
     case REG_SZ:
     case REG_EXPAND_SZ:
-	valueSize--;		/* No reason to send the '\0' to Erlang. */
-	break;
+        /* No reason to send the trailing '\0', if present, to Erlang. */
+        if (valueSize > 0 && value[valueSize - 1] == '\0') {
+            valueSize--;
+        }
+        break;
     case REG_DWORD_LITTLE_ENDIAN:
     case REG_DWORD_BIG_ENDIAN:
 	/*


### PR DESCRIPTION
Fixes #8903