### PR TITLE
Fix spec for json:format/3

### DIFF
--- a/lib/stdlib/src/json.erl
+++ b/lib/stdlib/src/json.erl
@@ -617,7 +617,7 @@ ok
 """.
 -doc(#{since => ~"OTP 27.1"}).
 
--spec format(Term :: encode_value(), Encoder::formatter(), Options :: map()) -> iodata().
+-spec format(Term :: dynamic(), Encoder::formatter(), Options :: map()) -> iodata().
 format(Term, Encoder, Options) when is_function(Encoder, 3) ->
     Def = #{level => 0,
             col => 0,


### PR DESCRIPTION
Was wrong, the purpose of that function is to take any term.

Fixes #8880