### PR TITLE
Allow setting certificates via application config

### DIFF
--- a/lib/public_key/src/pubkey_os_cacerts.erl
+++ b/lib/public_key/src/pubkey_os_cacerts.erl
@@ -37,7 +37,15 @@
 get() ->
     case persistent_term:get(?MODULE, not_loaded) of
         not_loaded ->
-            case load() of
+            _ = application:load(public_key),
+
+            Result =
+                case application:get_env(public_key, cacerts_path) of
+                    {ok, EnvVar} -> load([EnvVar]);
+                    undefined -> load()
+                end,
+
+            case Result of
                 ok ->
                     persistent_term:get(?MODULE);
                 {error, Reason} ->

--- a/lib/public_key/src/public_key.erl
+++ b/lib/public_key/src/public_key.erl
@@ -2214,7 +2214,20 @@ cacerts_get() ->
 %%--------------------------------------------------------------------
 -doc(#{title => <<"Certificate API">>,
        since => <<"OTP 25.0">>}).
--doc "Loads the OS supplied trusted CA certificates.".
+-doc """
+Loads the OS supplied trusted CA certificates.
+
+This can be overridden by setting the `cacerts_path`
+environment key of the `public_key` application with
+the location of an alternative certificate.
+You can set it via the command line as:
+
+    erl -public_key cacerts_path '"/path/to/certs.pem"'
+
+Use it with care. It is your responsibility to ensure
+that the certificates found in this alternative path
+can be trusted by the running system.
+""".
 
 -spec cacerts_load() -> ok | {error, Reason::term()}.
 %%--------------------------------------------------------------------

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -1607,6 +1607,12 @@ cacerts_load(Config) ->
             ok
     end,
 
+    %% Load from application environment
+    application:set_env(public_key, cacerts_path, filename:join(Datadir, "cacerts.pem")),
+    2 = length(public_key:cacerts_get()),
+    application:unset_env(public_key, cacerts_path),
+    true = public_key:cacerts_clear(),
+
     %% Load default OS certs
     %%    there is no default installed OS certs on netbsd
     %%    can be installed with 'pkgin install mozilla-rootcerts'
@@ -1624,7 +1630,7 @@ cacerts_load(Config) ->
     ok = public_key:cacerts_load(filename:join(Datadir, "cacerts.pem")),
     [_TestCert1, _TestCert2] = public_key:cacerts_get(),
 
-    %% Re-Load default OS certs
+    %% Reload default OS certs
     try
         process_flag(trap_exit, true),
         flush(),


### PR DESCRIPTION
This pull request allows setting a custom location for certificates via the application config.

Currently we are seeing a proliferation of env vars for reading certificates from in the Elixir community. Here are some examples:

* https://github.com/hexpm/hex/blob/eec7a266f6e1b1c754798ee9a9c17b4b6201fff2/lib/hex/state.ex#L111 
* https://github.com/elixir-lang/elixir_make/blob/67ef8c1e249d1562fee9247320a602908f0094c6/lib/elixir_make/downloader/httpc.ex#L53
* https://github.com/elixir-nx/bumblebee/blob/b01e0da989a39b594990f8023bebb3751663fb19/lib/bumblebee/utils/http.ex#L191

This means anyone using Elixir/Erlang behind a proxy needs to setup several env vars, carefully reading the docs of each package that may do external HTTP requests.

For this reason, I believe a solution upstream in Erlang itself would be better, as it would avoid the same issue (of several multiple env vars or application config) happening in both Erlang and Elixir packages, escripts, etc.

I understand it is possible to call `public_key:cacerts_load/1` but I don't believe it fully solves the problem:

1. If we leave it up for each package to call `public_key:cacerts_load/1`, then we land in the same problem described here, but even worse, as one package would globally override the defaults of others

2. If we leave it up for users of the packages to call it, then it means they need to add logic to each of their applications and packages that they use. And doing so for escripts is even harder.

This is a follow up to #8874.