### PR TITLE
tests: Limit the number of parallel processes on 32-bit systems

### DIFF
--- a/lib/asn1/test/asn1_test_lib.erl
+++ b/lib/asn1/test/asn1_test_lib.erl
@@ -307,16 +307,18 @@ ber_get_len(<<1:1,Octets:7,T0/binary>>) ->
 
 p_run(Test, List) ->
     %% Limit the number of parallel processes to avoid running out of
-    %% memory.
+    %% virtual address space or memory. This is especially important
+    %% on 32-bit Windows, where only 2 GB of virtual address space is
+    %% available.
     S = case {erlang:system_info(schedulers),erlang:system_info(wordsize)} of
-            {S0,4} ->
-                min(S0, 2);
+            {_,4} ->
+                1;
             {S0,_} ->
                 min(S0, 8)
         end,
     N = case test_server:is_cover() of
 	    false ->
-		S + 1;
+		S;
 	    true ->
 		%% Cover is running. Using too many processes
 		%% could slow us down.

--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -163,14 +163,15 @@ highest_opcode(Beam) ->
 
 p_run(Test, List) ->
     %% Limit the number of parallel processes to avoid running out of
-    %% memory.
-    S = case {erlang:system_info(schedulers),erlang:system_info(wordsize)} of
-            {S0,4} ->
-                min(S0, 2);
-            {S0,8} ->
-                min(S0, 8)
+    %% virtual address space or memory. This is especially important
+    %% on 32-bit Windows, where only 2 GB of virtual address space is
+    %% available.
+    N = case {erlang:system_info(schedulers),erlang:system_info(wordsize)} of
+            {_,4} ->
+                1;
+            {N0,8} ->
+                min(N0, 8)
         end,
-    N = S + 1,
     p_run(Test, List, N).
 
 p_run(Test, List, N) ->


### PR DESCRIPTION
When running tests for the `asn1` and `compiler` applications on 32-bit systems, limit the number of concurrent processes that the `p_run/2` helper will spawn to a single process. This should make it less likely that virtual address space or memory is exhausted, especially on Windws, where only 2 GB of virtual address space is available.