### PR TITLE
Stdlib/argparse handle binary arguments and binary command help

### DIFF
--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -727,8 +727,9 @@ parse(Args, Command, Options) ->
     Prog = validate(Command, Options),
     %% use maps and not sets v2, because sets:is_element/2 cannot be used in guards (unlike is_map_key)
     Prefixes = maps:from_list([{P, true} || P <- maps:get(prefixes, Options, [$-])]),
+    Args2 = [unicode:characters_to_list(Arg) || Arg <- Args],
     try
-        parse_impl(Args, merge_arguments(Prog, Command, init_parser(Prefixes, Command, Options)))
+        parse_impl(Args2, merge_arguments(Prog, Command, init_parser(Prefixes, Command, Options)))
     catch
         %% Parser error may happen at any depth, and bubbling the error is really
         %% cumbersome. Use exceptions and catch it before returning from `parse/2,3' instead.

--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -499,6 +499,11 @@ corresponding key is not present in the resulting map.
 %% Arguments map: argument name to a term, produced by parser. Supplied to the command handler
 
 -doc """
+List of command line arguments to be parsed.
+""".
+-type args() :: [string() | unicode:chardata()].
+
+-doc """
 Command handler specification. Called by [`run/3` ](`run/3`)upon successful
 parser return.
 
@@ -599,7 +604,7 @@ elements are nested command names.
 %% Command path, for nested commands
 
 -export_type([arg_type/0, argument_help/0, argument/0,
-    command/0, handler/0, cmd_path/0, arg_map/0]).
+    command/0, handler/0, cmd_path/0, arg_map/0, args/0]).
 
 -doc """
 Returned from [`parse/2,3`](`parse/3`) when the user input cannot be parsed
@@ -703,7 +708,7 @@ validate(Command, Options) ->
 %% @equiv parse(Args, Command, #{})
 -doc(#{equiv => parse/3}).
 -doc(#{since => <<"OTP 26.0">>}).
--spec parse(Args :: [string()], command()) -> parse_result().
+-spec parse(args(), command()) -> parse_result().
 parse(Args, Command) ->
     parse(Args, Command, #{}).
 
@@ -722,7 +727,7 @@ makes `parse/2,3` to return a tuple
 This function does not call command handler.
 """.
 -doc(#{since => <<"OTP 26.0">>}).
--spec parse(Args :: [string()], command(), Options :: parser_options()) -> parse_result().
+-spec parse(args(), command(), Options :: parser_options()) -> parse_result().
 parse(Args, Command, Options) ->
     Prog = validate(Command, Options),
     %% use maps and not sets v2, because sets:is_element/2 cannot be used in guards (unlike is_map_key)
@@ -773,7 +778,7 @@ specification or user-provided command line input.
 > may result in an unexpected shutdown of a remote node.
 """.
 -doc(#{since => <<"OTP 26.0">>}).
--spec run(Args :: [string()], command(), parser_options()) -> term().
+-spec run(args(), command(), parser_options()) -> term().
 run(Args, Command, Options) ->
     try parse(Args, Command, Options) of
         {ok, ArgMap, Path, SubCmd} ->

--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -1661,7 +1661,10 @@ collect_options(CmdName, Command, [Cmd|Tail], Args) ->
 
 %% gets help for sub-command
 get_help(Command, []) ->
-    maps:get(help, Command, "");
+    case maps:get(help, Command, "") of
+        Help when is_binary(Help) -> unicode:characters_to_list(Help);
+        Help -> Help
+    end;
 get_help(Command, [Cmd|Tail]) ->
     Sub = maps:get(commands, Command),
     SubCmd = maps:get(Cmd, Sub),

--- a/lib/stdlib/test/argparse_SUITE.erl
+++ b/lib/stdlib/test/argparse_SUITE.erl
@@ -43,6 +43,7 @@
     proxy_arguments/0, proxy_arguments/1,
 
     usage/0, usage/1,
+    usage_help_binary/0, usage_help_binary/1,
     usage_required_args/0, usage_required_args/1,
     usage_template/0, usage_template/1,
     usage_args_ordering/0, usage_args_ordering/1,
@@ -72,7 +73,7 @@ groups() ->
             very_short, multi_short, proxy_arguments
         ]},
         {usage, [parallel], [
-            usage, usage_required_args, usage_template, usage_args_ordering,
+            usage, usage_help_binary, usage_required_args, usage_template, usage_args_ordering,
             parser_error_usage, command_usage, usage_width
         ]},
         {validator, [parallel], [
@@ -814,6 +815,33 @@ usage(Config) when is_list(Config) ->
     ?assertEqual(CrawlerStatus, unicode:characters_to_list(argparse:help(Cmd,
         #{progname => "erl", command => ["status", "crawler"]}))),
     ok.
+
+usage_help_binary() ->
+    [{doc, "Test binary command help string"}].
+
+usage_help_binary(Config) when is_list(Config) ->
+    Cmd2 = #{arguments => [#{ 
+        name => shard,
+        type => integer,
+        default => 0,
+        help => <<"help binary for shard">>}],
+        commands => #{"somecommand" => #{ help => <<"help binary for somecommand">> }},
+        help => "help binary for command"
+    },
+
+    Expected = "Usage:\n"
+        "  erl {somecommand} <shard>\n"
+        "\n"
+        "help binary for command\n"
+        "\n"
+        "Subcommands:\n"
+        "  somecommand help binary for somecommand\n"
+        "\n"
+        "Arguments:\n"
+        "  shard help binary for shard (int), default: 0\n",
+
+    ?assertEqual(Expected,
+        unicode:characters_to_list(argparse:help(Cmd2, #{}))).
 
 usage_required_args() ->
     [{doc, "Verify that required args are printed as required in usage"}].


### PR DESCRIPTION
When using `argparse` from Elixir, it's common to use `unicode:chardata()` (aka binaries) rather than charlists. However, handling of binary data in `argparse` is inconsistent, and leads to confusing error messages

## Fix `command()` type `help` field not accepting binary

The [docs for `command()`](https://www.erlang.org/doc/apps/stdlib/argparse.html#t:command/0) state that it accepts `unicode:chardata()` values. However, this causes errors when calling `help/1`/`help/2` when done on the root command (it currently works on subcommands however).

```erlang
%% works ok with charlist
1> iolist_to_binary(argparse:help(#{help => "top level help"})).
%% <<"Usage:\n  erl\n\ntop level help\n">>

%% does NOT work with binary help 
2> iolist_to_binary(argparse:help(#{help => <<"top level help">>})).
%% ** exception error: bad generator <<"top level help">>
%%     in function  argparse:'-format_help/2-lc$^1/1-1-'/3 (argparse.erl, line 1652)
%%     in call from argparse:format_help/2 (argparse.erl, line 1652)
```

A fix is provided for this:

```erlang
1> iolist_to_binary(argparse:help(#{help => <<"top level help">>})).
%% <<"Usage:\n  erl\n\ntop level help\n">>
```

## Handle binary args

Currently `parse/2`/`parse/3` and `run/3` expect a list of charlist args. When called from Elixir, this will be provided by [`System.argv/0`](https://hexdocs.pm/elixir/1.17.2/System.html#argv/0) as a list of binaries which needs to be converted. This is doable, but is confusing for those less familiar with the differences in string handling between Erlang and Elixir.

```erlang
1> argparse:parse(["123"], #{arguments => [#{name => myarg, type => integer}]}).
%% {ok,#{myarg => 123},
%%     ["erl"],
%%     #{arguments => [#{name => myarg,type => integer}]}}

2> argparse:parse([<<"123">>], #{arguments => [#{name => myarg, type => integer}]}).
%% {error,{["erl"],
%%     #{name => myarg,type => integer},
%%     <<"123">>,<<"is not an integer">>}}
```

This PR adds ability to handle them

```erlang
1> argparse:parse([<<"123">>], #{arguments => [#{name => myarg, type => integer}]}).
%% {ok,#{myarg => 123},
%%     ["erl"],
%%     #{arguments => [#{name => myarg,type => integer}]}}
```

To support this, added `args()` type as a union of `string()` and `unicode:chardata()`, and use it on the spec for `parse/2`/`parse/3` and `run/3`