### PR TITLE
Update the status of the maybe_expr in the docs to "approved"

### DIFF
--- a/system/doc/reference_manual/features.md
+++ b/system/doc/reference_manual/features.md
@@ -127,7 +127,7 @@ the code base that might collide with keywords in features not yet enabled.
 
 The following configurable features exist:
 
-- **`maybe_expr` (experimental)** - Implementation of the
+- **`maybe_expr` (approved)** - Implementation of the
   [`maybe`](expressions.md#maybe) expression proposed in
   [EEP 49](https://www.erlang.org/eeps/eep-0049).
   It was approved in Erlang/OTP 27.


### PR DESCRIPTION
Minor fix in the documentation.

(I submitted this first as part of #8625 but after the decision to not implement EEP 70 as an experimental feature it can be broken out to its own PR.)