### PR TITLE
stdlib: fix typo in typespec for gen_fsm:send_all_state_event/2

### DIFF
--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -1113,7 +1113,7 @@ send_all_state_event(Name, Event) ->
 -doc #{ equiv => sync_send_all_state_event(FsmRef, Event, 5000) }.
 -spec sync_send_all_state_event(FsmRef, Event) -> Reply when
       FsmRef :: fsm_ref(),
-      Event  :: term,
+      Event  :: term(),
       Reply  :: term().
 sync_send_all_state_event(Name, Event) ->
     case catch gen:call(Name, '$gen_sync_all_state_event', Event) of


### PR DESCRIPTION
Missing parenthesis in the type specification for `Event` in `gen_fsm:send_all_state_event/2` had me fighting with `dialyzer` for quite some time.
