### PR TITLE
erts: Fix erroneous splitting of emulator path

### DIFF
--- a/erts/etc/common/dialyzer.c
+++ b/erts/etc/common/dialyzer.c
@@ -60,7 +60,6 @@ static void* emalloc(size_t size);
 static void efree(void *p);
 #endif
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
@@ -213,7 +212,7 @@ int main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     if (emulator != env) {
         free(emulator);
     }
@@ -287,27 +286,6 @@ int main(int argc, char** argv)
 
     PUSH(NULL);
     return run_erlang(eargv[0], eargv);
-}
-
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
 }
 
 #ifdef __WIN32__

--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -83,7 +83,6 @@ static void* emalloc(size_t size);
 static void efree(void *p);
 #endif
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static void call_compile_server(char** argv);
 static void encode_env(ei_x_buff* buf);
@@ -276,7 +275,7 @@ int main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -469,27 +468,6 @@ get_env_compile_server(void)
     }
     fprintf(stderr, "erlc: Warning: Ignoring unrecognized value '%s' "
             "for environment value ERLC_USE_SERVER\n", us);
-}
-
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
 }
 
 #ifdef __WIN32__

--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -258,6 +258,9 @@ int main(int argc, char** argv)
     {
         char* full_path_emulator = find_executable(emulator);
         set_env("ERLC_CONFIGURATION", full_path_emulator);
+        if (full_path_emulator != emulator) {
+            free(full_path_emulator);
+        }
     }
 #endif
 
@@ -276,6 +279,9 @@ int main(int argc, char** argv)
     eargv = eargv_base;
     eargc = 0;
     PUSH(strsave(emulator));
+    if (emulator != env) {
+        free(emulator);
+    }
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
     eargc = 0;
@@ -1053,7 +1059,7 @@ get_default_emulator(char* progname)
     char* s;
 
     if (strlen(progname) >= sizeof(sbuf))
-        return ERL_NAME;
+        return strsave(ERL_NAME);
 
     strcpy(sbuf, progname);
     for (s = sbuf+strlen(sbuf); s >= sbuf; s--) {
@@ -1064,7 +1070,7 @@ get_default_emulator(char* progname)
 	    break;
 	}
     }
-    return ERL_NAME;
+    return strsave(ERL_NAME);
 }
 
 

--- a/erts/etc/common/typer.c
+++ b/erts/etc/common/typer.c
@@ -60,7 +60,6 @@ static void* emalloc(size_t size);
 static void efree(void *p);
 #endif
 static char* strsave(char* string);
-static void push_words(char* src);
 static int run_erlang(char* name, char** argv);
 static char* get_default_emulator(char* progname);
 #ifdef __WIN32__
@@ -162,7 +161,7 @@ main(int argc, char** argv)
     eargv_base = (char **) emalloc(eargv_size*sizeof(char*));
     eargv = eargv_base;
     eargc = 0;
-    push_words(emulator);
+    PUSH(strsave(emulator));
     free(emulator);
     eargc_base = eargc;
     eargv = eargv + eargv_size/2;
@@ -216,26 +215,6 @@ main(int argc, char** argv)
     return run_erlang(eargv[0], eargv);
 }
 
-static void
-push_words(char* src)
-{
-    char sbuf[MAXPATHLEN];
-    char* dst;
-
-    dst = sbuf;
-    while ((*dst++ = *src++) != '\0') {
-	if (isspace((int)*src)) {
-	    *dst = '\0';
-	    PUSH(strsave(sbuf));
-	    dst = sbuf;
-	    do {
-		src++;
-	    } while (isspace((int)*src));
-	}
-    }
-    if (sbuf[0])
-	PUSH(strsave(sbuf));
-}
 #ifdef __WIN32__
 wchar_t *make_commandline(char **argv)
 {

--- a/erts/test/erlc_SUITE.erl
+++ b/erts/test/erlc_SUITE.erl
@@ -1188,7 +1188,7 @@ run_command(Dir, {win32, _}, Cmd) ->
     {BatchFile,
      Run,
      ["@echo off\r\n",
-      "set ERLC_EMULATOR=", ct:get_progname(), "\r\n",
+      "set ERLC_EMULATOR=", os:find_executable("erl"), "\r\n",
       Cmd, "\r\n",
       "if errorlevel 1 echo _ERROR_\r\n",
       "if not errorlevel 1 echo _OK_\r\n"]};
@@ -1197,7 +1197,7 @@ run_command(Dir, {unix, _}, Cmd) ->
     {Name,
      "/bin/sh " ++ Name,
      ["#!/bin/sh\n",
-      "ERLC_EMULATOR='", ct:get_progname(), "'\n",
+      "ERLC_EMULATOR='",  os:find_executable("erl"), "'\n",
       "export ERLC_EMULATOR\n",
       Cmd, "\n",
       "case $? in\n",


### PR DESCRIPTION
Reapply https://github.com/erlang/otp/pull/849 which was reverted previously, without indication to why.
Should make it possible to run erlc, dialyzer and typer when they have been installed in a path with spaces.

Related issue https://github.com/erlang/otp/issues/8845