### PR TITLE
Add support for `SIGCONT` system signal

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -673,6 +673,7 @@ atom sigstop
 atom sigint
 atom sigsegv
 atom sigtstp
+atom sigcont
 atom sigquit
 atom sigwinch
 atom siginfo

--- a/erts/emulator/sys/unix/sys.c
+++ b/erts/emulator/sys/unix/sys.c
@@ -682,7 +682,7 @@ static RETSIGTYPE suspend_signal(int signum)
   SIGUSR1    Term     User-defined signal 1
   SIGUSR2    Term     User-defined signal 2
  !SIGCHLD    Ign      Child stopped or terminated
- !SIGCONT    Cont     Continue if stopped
+  SIGCONT    Cont     Continue if stopped
   SIGSTOP    Stop     Stop process
   SIGTSTP    Stop     Stop typed at terminal
  !SIGTTIN    Stop     Terminal input for background process
@@ -709,6 +709,7 @@ signalterm_to_signum(Eterm signal)
     case am_sigchld: return SIGCHLD;
     case am_sigstop: return SIGSTOP;
     case am_sigtstp: return SIGTSTP;
+    case am_sigcont: return SIGCONT;
     case am_sigwinch: return SIGWINCH;
 #ifdef SIGINFO
     case am_siginfo: return SIGINFO;
@@ -734,6 +735,7 @@ signum_to_signalterm(int signum)
     case SIGCHLD: return am_sigchld;
     case SIGSTOP: return am_sigstop;
     case SIGTSTP: return am_sigtstp;   /* ^z */
+    case SIGCONT: return am_sigcont;
     case SIGWINCH: return am_sigwinch;
 #ifdef SIGINFO
     case SIGINFO: return am_siginfo;  /* ^t */

--- a/erts/emulator/test/os_signal_SUITE.erl
+++ b/erts/emulator/test/os_signal_SUITE.erl
@@ -42,6 +42,7 @@
          t_sigalrm/1,
          t_sigchld/1,
          t_sigchld_fork/1,
+         t_sigcont/1,
          t_sigwinch/1,
          t_siginfo/1]).
 
@@ -95,7 +96,7 @@ set_unset(_Config) ->
                sigalrm, sigterm,
                sigusr1, sigusr2,
                sigchld,
-               sigstop, sigtstp],
+               sigstop, sigtstp, sigcont],
     F1 = fun(Sig) -> ok = os:set_signal(Sig,handle) end,
     F2 = fun(Sig) -> ok = os:set_signal(Sig,default) end,
     F3 = fun(Sig) -> ok = os:set_signal(Sig,ignore) end,
@@ -300,6 +301,35 @@ sigchld_fork() ->
     42 = Status,
     %% reset to ignore (it's the default)
     os:set_signal(sigchld, ignore),
+    ok.
+
+t_sigcont(_Config) ->
+    Pid1 = setup_service(),
+    OsPid = os:getpid(),
+    os:set_signal(sigcont, handle),
+    ok = kill("CONT", OsPid),
+    ok = kill("CONT", OsPid),
+    ok = kill("CONT", OsPid),
+    Msgs1 = fetch_msgs(Pid1),
+    io:format("Msgs1: ~p~n", [Msgs1]),
+    [{notify,sigcont},
+     {notify,sigcont},
+     {notify,sigcont}] = Msgs1,
+    %% no proc
+    ok = kill("CONT", OsPid),
+    ok = kill("CONT", OsPid),
+    ok = kill("CONT", OsPid),
+    %% ignore
+    Pid2 = setup_service(),
+    os:set_signal(sigcont, ignore),
+    ok = kill("CONT", OsPid),
+    ok = kill("CONT", OsPid),
+    ok = kill("CONT", OsPid),
+    Msgs2 = fetch_msgs(Pid2),
+    io:format("Msgs2: ~p~n", [Msgs2]),
+    [] = Msgs2,
+    %% reset to ignore (it's the default)
+    os:set_signal(sigcont, ignore),
     ok.
 
 t_sigwinch(_Config) ->

--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -86,6 +86,8 @@ Any event handler added to `erl_signal_server` must handle the following events.
 
 - **`sigtstp`** - Stop typed at terminal
 
+- **`sigcont`** - Continue after stop
+
 - **`sigwinch`** - Window size change
 
 - **`siginfo`** - Status request from keyboard. Note several operating systems

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -302,7 +302,8 @@ Each signal my be set to one of the following options:
 -spec set_signal(Signal, Option) -> 'ok' when
       Signal :: 'sighup'  | 'sigquit' | 'sigabrt' | 'sigalrm' |
                 'sigterm' | 'sigusr1' | 'sigusr2' | 'sigchld' |
-                'sigstop' | 'sigtstp' | 'sigwinch' | 'siginfo',
+                'sigstop' | 'sigtstp' | 'sigcont' | 'sigwinch' |
+                'siginfo',
       Option :: 'default' | 'handle' | 'ignore'.
 
 set_signal(_Signal, _Option) ->


### PR DESCRIPTION
This signal is used after `SIGSTOP` or `SIGTSTP` to resume a system process. Shell job control relies on these signals.