### PR TITLE
Do not compress individual chunks

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -2424,7 +2424,7 @@ beam_docs(Code, #compile{dir = Dir, options = Options,
     SourceName = deterministic_filename(St),
     case beam_doc:main(Dir, SourceName, Code, Options) of
         {ok, Docs, Ws} ->
-            Binary = term_to_binary(Docs, [deterministic, compressed]),
+            Binary = term_to_binary(Docs, [deterministic]),
             MetaDocs = [{?META_DOC_CHUNK, Binary} | ExtraChunks],
             {ok, Code, St#compile{extra_chunks = MetaDocs,
                                   warnings = St#compile.warnings ++ Ws}};
@@ -2481,7 +2481,7 @@ debug_info_chunk(#compile{mod_options=ModOpts0,
                 {erl_abstract_code,{none,AbstOpts},ModOpts0}
         end,
     DebugInfo = term_to_binary({debug_info_v1,Backend,Metadata},
-                               ensure_deterministic(CompOpts, [compressed])),
+                               ensure_deterministic(CompOpts, [])),
     {DebugInfo, ModOpts}.
 
 encrypt_debug_info(DebugInfo, Key, Opts) ->


### PR DESCRIPTION
This is a small pull request which I am submitting
for comments. I'd love to hear your thoughts on
which direction we should optimize .beam files
and if you think if this change can have a negative
impact on actual code loading.

Today we compress both Docs and Dbgi chunks,
which allows us to optimize for space, but it is
best to optimize for loading time instead. If space
is important, one can compress the whole chunk
with the compressed option.

The labels chunk is also compressed but we cannot
decompress it transparently. We would need to
change how they are read too.