### PR TITLE
erts: to_erl screen should not be cleared

### DIFF
--- a/erts/etc/unix/run_erl.c
+++ b/erts/etc/unix/run_erl.c
@@ -711,8 +711,8 @@ static void pass_on(pid_t childpid)
 #endif
 		    }
 		}
-
-		if (!got_some && wfd && buf[0] == '\014') {
+    if (!got_some && wfd && buf[0] == '\033' &&
+         buf[1] == 'l') {
 		    char wbuf[30];
 		    int wlen = sn_printf(wbuf,sizeof(wbuf),"[run_erl v%u-%u]\n",
 					 RUN_ERL_HI_VER, RUN_ERL_LO_VER);

--- a/erts/etc/unix/to_erl.c
+++ b/erts/etc/unix/to_erl.c
@@ -351,16 +351,12 @@ int main(int argc, char **argv)
     show_terminal_settings(&tty_smode);
 #endif
     /*
-     * 	 "Write a ^L to the FIFO which causes the other end to redisplay
-     *    the input line."
-     * This does not seem to work as was intended in old comment above.
-     * However, this control character is now (R12B-3) used by run_erl
-     * to trigger the version handshaking between to_erl and run_erl
-     * at the start of every new to_erl-session.
+     * Write ^[l to the FIFO. This trigger the version handshaking
+     * between to_erl and run_erl and a redraw in erl, at the start
+     * of every new to_erl-session.
      */
-
-    if (write(wfd, "\014", 1) < 0) {
-	fprintf(stderr, "Error in writing ^L to FIFO.\n");
+    if (write(wfd, "\033l", 2) < 0) {
+        fprintf(stderr, "Error in writing ^[l to FIFO.\n");
     }
 
     /*

--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -1180,6 +1180,9 @@ edit_line_dumb([Erase|Cs],[], Rs) when Erase =:= $\177; Erase =:= $\^H ->
     edit_line_dumb(Cs,[], Rs);
 edit_line_dumb([Erase|Cs],[_|Chars], Rs) when Erase =:= $\177; Erase =:= $\^H ->
     edit_line_dumb(Cs,Chars, [{delete_chars, -1}|Rs]);
+edit_line_dumb([$\e, $l |Cs],Chars, Rs) ->
+    %% this is a key sequence sent by to_erl to refresh the screen
+    edit_line_dumb(Cs,Chars, Rs);
 edit_line_dumb([CtrlChar|Cs],Chars, Rs) when CtrlChar < 32 ->
     edit_line_dumb(Cs,Chars,Rs);
 edit_line_dumb([Char|Cs],Chars, Rs) ->

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -2213,7 +2213,8 @@ noshell_raw(Config) ->
                                     %% Make sure we are in unicode encoding
                                     unicode = proplists:get_value(encoding, io:getopts()),
 
-                                    "\fhello\n" = io:get_line("1> "),
+                                    %% "\el" is an artifact from the attaching to_erl program
+                                    "\el" ++ "hello\n" = io:get_line("1> "),
                                     io:format(TCGl, "TC Line: ~p~n", [?LINE]),
                                     ok = shell:start_interactive({noshell, raw}),
 


### PR DESCRIPTION
When you connect with to_erl, the screen should
not be cleared. Instead the input line should be
redrawn. Changing ^L to ^[l achieves this.