### PR TITLE
Update attributes in EEP 48

### DIFF
--- a/lib/kernel/doc/guides/eep48_chapter.md
+++ b/lib/kernel/doc/guides/eep48_chapter.md
@@ -105,8 +105,8 @@ For each entry in Docs, we have:
   `callback`. Other languages will add their own. For instance, Elixir and LFE
   might add `macro`.
 
-- **`Anno`** - annotation (line, column, file) of the module documentation or of
-  the definition itself (see `m:erl_anno`).
+- **`Anno`** - annotation (line, column, file) of the module documentation
+  (see `m:erl_anno`).
 
 - **`Signature`** - the signature of the entity. It is is a list of binaries.
   Each entry represents a binary in the signature that can be joined with
@@ -134,6 +134,9 @@ information to each entry. This EEP documents the following metadata keys:
 
 - **`authors := [binary()]`** - a list of authors as binaries.
 
+- **`behaviours := [module()]`** - a list of the behaviours implemented by
+  this module.
+
 - **`cross_references := [module() | {module(), {Kind, Name, Arity}}]`** - a
   list of modules or module entries that can be used as cross references when
   generating documentation.
@@ -145,8 +148,11 @@ information to each entry. This EEP documents the following metadata keys:
 - **`since := binary()`** - a binary representing the version such entry was
   added, such as `<<"1.3.0">>` or `<<"20.0">>`.
 
-- **`edit_url := binary()`** - a binary representing a URL to change the
-  documentation itself.
+- **`source := binary()`** - the location of the source file for this module.
+  Applies only to the module metadata.
+
+- **`source_anno := erl_anno:anno()`** - annotation metadata of the source
+  code (opposite to the annotation of the documentation attribute).
 
 Any key may be added to Metadata at any time. Keys that are frequently used by
 the community can be standardized in future versions.


### PR DESCRIPTION
Currently, editors and documentation tooling must
parse metadata from several chunks in order to
function properly. The source is in the compilation chunk.
The behaviours a module implements is in the attributes
chunk. And the annotation of any definition requires
traversing abstract code.

With this commit, we introduce three new attributes,
`:behaviours`, `:source`, and `:source_anno`, so
this additional data can be standardized and easily located.

We also remove `edit_url` from the standard. As it is not
used by any of the official tooling, languages, or libraries.