### PR TITLE
Remove demand of unicode support for tprof:format/2

### DIFF
--- a/lib/tools/src/tprof.erl
+++ b/lib/tools/src/tprof.erl
@@ -1137,7 +1137,7 @@ format_each(Device, call_count, _Total, Inspected) ->
     [format_out(Device, Fmt, Line) || Line <- lists:reverse(Lines)],
     format_out(Device, Fmt, [" ", " ", "100.0"]);
 format_each(Device, call_time, Total, Inspected) ->
-    format_labelled(Device, "TIME (μs)", Total, Inspected);
+    format_labelled(Device, "TIME (us)", Total, Inspected);
 format_each(Device, call_memory, Total, Inspected) ->
     format_labelled(Device, "WORDS", Total, Inspected).
 


### PR DESCRIPTION
### Problem
`tprof:format(IoDevice, ...)` would fail if `IoDevice` did not support unicode encoding.

### Solution
Replace printed unicode character "μ" with an ASCII "u".