### PR TITLE
erts: Fix cc.sh -MM on wsl 2

### DIFF
--- a/erts/etc/win32/wsl_tools/vc/cc.sh
+++ b/erts/etc/win32/wsl_tools/vc/cc.sh
@@ -307,7 +307,7 @@ while (<FH>) {
 }
 flushDeps();
 ' $MSG_FILE "$MPATH"
-
+    RES=$?
     rm -f $ERR_FILE $MSG_FILE
 else
     # Compile


### PR DESCRIPTION
cl.exe can return an error code with LNK1561 error. This error is ok as the correct result is still printed, so we reset the RES variable so that cc.sh does not exit with an error reason.