### PR TITLE
kernel: Fix logger overlapping domains

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -170,7 +170,7 @@ equal to or below the configured log level.
 -type level() :: emergency | alert | critical | error |
                  warning | notice | info | debug.
 -doc "A log report.".
--type report() :: map() | [{atom(),term()}].
+-type report() :: map() | [{atom(),term()}, ...].
 -doc """
 A fun which converts a [`report()`](`t:report/0`) to a format string and
 arguments, or directly to a string.


### PR DESCRIPTION
Fix `logger:report/0` to mandate at least one element in the report. This fixes an issue with overlapping `spec` domains in all `logger` functions that use `logger:report/0`.