### PR TITLE
Include jinterface in prebuild

### DIFF
--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -14,9 +14,12 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ## Install build tools
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y build-essential m4 autoconf clang-format \
-    default-jdk flex pkg-config locales tzdata sudo ${INSTALL_LIBS} && \
+    flex pkg-config locales tzdata sudo ${INSTALL_LIBS} && \
     sed -i 's@# en_US.UTF-8@en_US.UTF-8@g' /etc/locale.gen && locale-gen && \
-    update-alternatives --set wx-config /usr/lib/x86_64-linux-gnu/wx/config/gtk3-unicode-3.0
+    update-alternatives --set wx-config /usr/lib/x86_64-linux-gnu/wx/config/gtk3-unicode-3.0 && \
+    apt-get install -y openjdk-8-jdk-headless && apt-get install -y openjdk-11-jdk-headless && \
+    (update-java-alternatives -s java-1.8.0-openjdk-amd64 || true) && \
+    java -version 2>&1 | grep 'version "1[.]8' > /dev/null || exit 1
 
 ARG MAKEFLAGS=-j4
 ENV MAKEFLAGS=$MAKEFLAGS \

--- a/.github/workflows/actions-updater.yaml
+++ b/.github/workflows/actions-updater.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'erlang/otp'
 
     steps:
       - name: Generate token

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -418,6 +418,8 @@ jobs:
           FROM otp
           ENV BASE_URL=$BASE_URL
           RUN ./otp_build download_ex_doc
+          ## Need later jdk to create correct anchors in html docs
+          RUN sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
           RUN make release docs release_docs && sudo make install-docs
           EOF
       - name: Release docs to publish

--- a/lib/jinterface/prebuild.keep
+++ b/lib/jinterface/prebuild.keep
@@ -1,1 +1,2 @@
 doc
+priv


### PR DESCRIPTION
Include a jdk-8 compiled version of jinterface in the prebuild to speed up the build process.