### PR TITLE
erts: Fix global literal to correctly use erts_mem_guard

### DIFF
--- a/erts/emulator/beam/erl_global_literals.c
+++ b/erts/emulator/beam/erl_global_literals.c
@@ -122,19 +122,20 @@ Eterm *erts_global_literal_allocate(Uint heap_size, struct erl_off_heap_header *
         expand_shared_global_literal_area(heap_size + GLOBAL_LITERAL_EXPAND_SIZE);
     }
 
-    *ohp = &global_literal_chunk->area.off_heap;
-    hp = global_literal_chunk->hp;
-    global_literal_chunk->hp += heap_size;
-
 #ifdef DEBUG
     {
         struct global_literal_chunk *chunk = global_literal_chunk;
-        erts_mem_guard(&chunk->area.start[0], 
-                       (chunk->area.end - &chunk->area.start[0]) * sizeof(Eterm), 
+        erts_mem_guard(chunk,
+                       (chunk->area.end - (Eterm*)chunk) * sizeof(Eterm),
                        1, 
                        1);
     }
 #endif
+
+
+    *ohp = &global_literal_chunk->area.off_heap;
+    hp = global_literal_chunk->hp;
+    global_literal_chunk->hp += heap_size;
 
     return hp;
 }
@@ -145,8 +146,8 @@ void erts_global_literal_register(Eterm *variable, Eterm *hp, Uint heap_size) {
 #ifdef DEBUG
     {
         struct global_literal_chunk *chunk = global_literal_chunk;
-        erts_mem_guard(&chunk->area.start[0], 
-                       (chunk->area.end - &chunk->area.start[0]) * sizeof(Eterm), 
+        erts_mem_guard(chunk,
+                       (chunk->area.end - (Eterm*)chunk) * sizeof(Eterm),
                        1, 
                        0);
     }

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -33,11 +33,12 @@
 #endif
 
 int erts_mem_guard(void *p, UWord size, int readable, int writable) {
-    
+
 #if defined(WIN32)
     DWORD oldProtect;
     DWORD newProtect = PAGE_NOACCESS;
     BOOL success;
+
     if (readable && writable) {
         newProtect = PAGE_READWRITE;
     } else if (readable) {
@@ -53,6 +54,9 @@ int erts_mem_guard(void *p, UWord size, int readable, int writable) {
     return success ? 0 : -1;
 #elif defined(HAVE_SYS_MMAN_H)
     int flags = 0;
+
+    /* Check that the ptr is aligned at page boundary */
+    ASSERT((Uint)p % sys_page_size == 0);
     
     if (writable) {
         flags |= PROT_WRITE;


### PR DESCRIPTION
The ptr given to erts_mem_guard needs to be aligned to a page boundary for memprotect to work. Also we need to unguard the memory before we update the heap_size.