### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Erlang** is a programming language and runtime system for building massively scalable soft real-time systems with requirements on high availability. 
 
-**OTP** is a set of Erlang libraries, which consists of the Erlang runtime system, a number of ready-to-use components mainly written in Erlang, and a set of design principles for Erlang programs. [Learn more about Erlang and OTP](https://www.erlang.org/doc/system/getting_started.html).
+The Open Telecom Platform (**OTP**) is a set of Erlang libraries, which consists of the Erlang runtime system, a number of ready-to-use components mainly written in Erlang, and a set of design principles for Erlang programs. [Learn more about Erlang and OTP](https://www.erlang.org/doc/system/getting_started.html).
 
 [Learn how to program in Erlang](http://learnyousomeerlang.com/).
 


### PR DESCRIPTION
New users may not know what OTP stands for.

"OTP" means "one true pair/pairing," according to Merriam-Webster. 

This PR adds once what OTP stands for in the README.md file.