### PR TITLE
Do not trigger SSL CLIET ALERT Fatal Internal Error when shutdown

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1924,11 +1924,12 @@ log_alert(Level, Role, ProtocolName, StateName,  Alert) ->
                                     statename => StateName,
                                     alert => Alert,
                                     alerter => peer}, Alert#alert.where).
-terminate_alert(normal) ->
+terminate_alert(Reason) when Reason == normal;
+                             Reason == shutdown;
+                             Reason == close ->
     ?ALERT_REC(?WARNING, ?CLOSE_NOTIFY);
-terminate_alert({Reason, _}) when Reason == close;
-                                  Reason == shutdown ->
-    ?ALERT_REC(?WARNING, ?CLOSE_NOTIFY);
+terminate_alert({Reason, _}) ->
+    terminate_alert(Reason);
 terminate_alert(_) ->
     ?ALERT_REC(?FATAL, ?INTERNAL_ERROR).
 


### PR DESCRIPTION
Noticed during a normal shutdown (SIGTERM), client will send a `Fatal - Ineternal Error` alert.

Server side may log: `{tls_alert,{internal_error,"TLS server: In state connection received CLIENT ALERT: Fatal - Internal Error\n"}}`