### PR TITLE
Add the ERL_SYS_SHELL env variable to point to system shell for os:cmd()

### DIFF
--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -512,6 +512,10 @@ For more information about configuration parameters, see file
   [Escripts and non-interactive I/O in Unicode Usage in Erlang](`e:stdlib:unicode_usage.md#escripts-and-non-interactive-i-o`)
   for more details.
 
+- **`os_cmd_shell = string()`{: #os_cmd_shell }** - Specifies which shell to
+  use when invoking system commands via `os:cmd/2`. By default the shell is detected
+  automatically.
+
 ## Deprecated Configuration Parameters
 
 In Erlang/OTP 21.0, a new API for logging was added. The old `error_logger`

--- a/lib/kernel/src/kernel.erl
+++ b/lib/kernel/src/kernel.erl
@@ -49,6 +49,7 @@ stop(_State) ->
 %% Some configuration parameters for kernel are changed
 %%-------------------------------------------------------------------
 config_change(Changed, New, Removed) ->
+    ok = os:internal_init_cmd_shell(),
     do_distribution_change(Changed, New, Removed),
     do_global_groups_change(Changed, New, Removed),
     ok.

--- a/lib/kernel/src/kernel.erl
+++ b/lib/kernel/src/kernel.erl
@@ -33,6 +33,7 @@
 start(_, []) ->
     %% Setup the logger and configure the kernel logger environment
     ok = logger:internal_init_logger(),
+    ok = os:internal_init_cmd_shell(),
     case supervisor:start_link({local, kernel_sup}, kernel, []) of
 	{ok, Pid} ->
             ok = erl_signal_handler:start(),

--- a/lib/kernel/test/os_SUITE.erl
+++ b/lib/kernel/test/os_SUITE.erl
@@ -469,21 +469,15 @@ error_info(Config) ->
         ],
     error_info_lib:test_error_info(os, L).
 
-os_cmd_shell(Config) ->
-    DataDir = proplists:get_value(data_dir, Config),
-    SysShell = filename:join(DataDir, "sys_shell"),
+%% Check that is *not* possible to change shell after startup
+os_cmd_shell(_Config) ->
 
-    {ok, OldShell} = application:get_env(kernel, os_cmd_shell),
-    try
-        application:set_env(kernel, os_cmd_shell, SysShell),
+    application:set_env(kernel, os_cmd_shell, "broken shell"),
 
-        %% os:cmd should not try to detect the shell location rather than use
-        %% the value from kernel:os_cmd_shell parameter
-        comp("sys_shell", os:cmd("ls"))
-    after
-        application:set_env(kernel, os_cmd_shell, OldShell)
-    end.
+    %% os:cmd should continue to work as normal
+    comp("hello", os:cmd("echo hello")).
 
+%% When started with os_cmd_shell set, we make sure that it is used.
 os_cmd_shell_peer(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     SysShell = "\"" ++ filename:join(DataDir, "sys_shell") ++ "\"",

--- a/lib/kernel/test/os_SUITE_data/Makefile.src
+++ b/lib/kernel/test/os_SUITE_data/Makefile.src
@@ -3,7 +3,7 @@ LD = @LD@
 CFLAGS = @CFLAGS@ -I@erl_include@ @DEFS@
 CROSSLDFLAGS = @CROSSLDFLAGS@
 
-PROGS = my_echo@exe@ my_fds@exe@
+PROGS = my_echo@exe@ my_fds@exe@ sys_shell@exe@
 
 all: $(PROGS)
 
@@ -18,3 +18,9 @@ my_fds@exe@: my_fds@obj@
 
 my_fds@obj@: my_fds.c
 	$(CC) -c -o my_fds@obj@ $(CFLAGS) my_fds.c
+
+sys_shell@exe@: sys_shell@obj@
+	$(LD) $(CROSSLDFLAGS) -o sys_shell sys_shell@obj@ @LIBS@
+
+sys_shell@obj@: sys_shell.c
+	$(CC) -c -o sys_shell@obj@ $(CFLAGS) sys_shell.c

--- a/lib/kernel/test/os_SUITE_data/sys_shell.c
+++ b/lib/kernel/test/os_SUITE_data/sys_shell.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main(void)
+{
+    printf("sys_shell");
+    return 0;
+}


### PR DESCRIPTION
A fix for #8944 