### PR TITLE
Ingela/ssl/handle terminate alert/otp 19311

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1888,11 +1888,12 @@ log_alert(Level, Role, ProtocolName, StateName,  Alert) ->
                                     statename => StateName,
                                     alert => Alert,
                                     alerter => peer}, Alert#alert.where).
-terminate_alert(normal) ->
+terminate_alert(Reason) when Reason == normal;
+                             Reason == shutdown;
+                             Reason == close ->
     ?ALERT_REC(?WARNING, ?CLOSE_NOTIFY);
-terminate_alert({Reason, _}) when Reason == close;
-                                  Reason == shutdown ->
-    ?ALERT_REC(?WARNING, ?CLOSE_NOTIFY);
+terminate_alert({Reason, _}) ->
+    terminate_alert(Reason);
 terminate_alert(_) ->
     ?ALERT_REC(?FATAL, ?INTERNAL_ERROR).
 

--- a/lib/ssl/test/ssl_trace_SUITE.erl
+++ b/lib/ssl/test/ssl_trace_SUITE.erl
@@ -204,9 +204,12 @@ tc_api_profile(Config) ->
     check_trace_map(Ref, TracesAfterConnect, UnhandledTraceCnt1),
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client),
+    %% terminate_alert will get called twice by both client and
+    %% server to strip away Details from {shutdown::Reason, Detatils}
+    %% before matching the Reason
     UnhandledTraceCnt2 =
-        #{call => 0, processed => no_trace_received, exception_from => 0,
-          return_from => 0},
+        #{call => 2, processed => no_trace_received, exception_from => 0,
+          return_from => 2},
     check_trace_map(Ref, TracesAfterDisconnect, UnhandledTraceCnt2),
     ssl_trace:stop(),
     ok.

--- a/lib/ssl/test/tls_api_SUITE.erl
+++ b/lib/ssl/test/tls_api_SUITE.erl
@@ -63,6 +63,8 @@
          tls_shutdown_both/1,
          tls_shutdown_error/0,
          tls_shutdown_error/1,
+         tls_sup_shutdown/0,
+         tls_sup_shutdown/1,
          tls_client_closes_socket/0,
          tls_client_closes_socket/1,
          tls_closed_in_active_once/0,
@@ -164,6 +166,7 @@ api_tests() ->
      tls_shutdown_write,
      tls_shutdown_both,
      tls_shutdown_error,
+     tls_sup_shutdown,
      tls_password_correct,
      tls_password_incorrect,
      tls_password_badarg,
@@ -781,6 +784,36 @@ tls_tcp_error_propagation_in_active_mode(Config) when is_list(Config) ->
     Pid ! {tcp_error, Socket, etimedout},
 
     ssl_test_lib:check_result(Client, {ssl_closed, SslSocket}).
+
+%%--------------------------------------------------------------------
+tls_sup_shutdown() ->
+    [{doc,"Test that terminate behaves correctly for exit(shutdown) as done by supervisor at application shutdown"}].
+tls_sup_shutdown(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+
+    Server  = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+					 {from, self()},
+					 {mfa, {?MODULE, receive_msg, []}},
+					 {options, ServerOpts}]),
+    Port = ssl_test_lib:inet_port(Server),
+
+    {_, #sslsocket{pid=[Pid|_]}} = ssl_test_lib:start_client([return_socket,
+                                                                   {node, ClientNode}, {port, Port},
+                                                                   {host, Hostname},
+                                                                   {from, self()},
+                                                                   {mfa, {ssl_test_lib, no_result, []}},
+                                                                   {options, [{active, false} | ClientOpts]}]),
+    exit(Pid, shutdown),
+
+    receive
+        {Server, {ssl_closed, _}} ->
+            ok;
+        Msg ->
+          ct:fail(Msg)
+    end.
 
 %%--------------------------------------------------------------------
 tls_reject_warning_alert_in_initial_hs() ->


### PR DESCRIPTION
Fix bug  also in older version of  OTP when shutdown happens from the supervisor. 
Solution will be piggybacked on other patches to OTP 26 and 25  eventually. 