### PR TITLE
win32(arm64): call the function pointer used by erts_sys_perf_counter

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -3109,7 +3109,14 @@ void BeamModuleAssembler::emit_i_perf_counter() {
     Label next = a.newLabel(), small = a.newLabel();
 
     emit_enter_runtime_frame();
+
+#ifdef WIN32
+    /* Call the function pointer used by erts_sys_perf_counter */
+    runtime_call<0>(erts_sys_time_data__.r.o.sys_hrtime);
+#else
     runtime_call<0>(erts_sys_time_data__.r.o.perf_counter);
+#endif
+
     emit_leave_runtime_frame();
 
     a.asr(TMP1, ARG1, imm(SMALL_BITS - 1));


### PR DESCRIPTION
This PR is one of the smaller PRs separated from the original PR https://github.com/erlang/otp/pull/8142 that attempts to add initial support for ARM64 windows.

This PR fixes the following compiling errors on ARM64 Windows, and I copy-pasted the same lines from `erts/emulator/beam/jit/x86/instr_common.cpp` to here.

```
CXX    obj/win32/opt/jit/instr_common.o
beam\jit\arm\instr_common.cpp(3112): error C2039: 'perf_counter': is not a member of 'erts_sys_time_read_only_data__'
C:\src\erts\emulator\sys\win32\erl_win_sys.h(185): note: see declaration of 'erts_sys_time_read_only_data__'
beam\jit\arm\instr_common.cpp(3112): error C2672: 'BeamModuleAssembler::runtime_call': no matching overloaded function found
C:\src\erts\emulator\beam\jit\arm\beam_asm.hpp(1430): note: could be 'void BeamModuleAssembler::runtime_call(T *)'
Failed: cl.exe -nologo -D__WIN32__ -DWIN32 -DWINDOWS -D_WIN32 -DNT -D_CRT_SECURE_NO_DEPRECATE -D__aarch64__ -MD -Ox -Z7 /std:c++17 /Zc:__cplusplus -DASMJIT_EMBED=1 -DASMJIT_NO_BUILDER=1 -DASMJIT_NO_DEPRECATED=1 -DASMJIT_STATIC=1 -DASMJIT_NO_FOREIGN=1 -Iwin32/opt/jit -Ibeam -Isys/win32 -Isys/common -Iwin32 -Izlib -Ipcre -Iryu -Iopenssl/include -I../include -I../include/win32 -I../include/internal -I../include/internal/win32 -Ibeam/jit -Ibeam/jit/arm -I"C:\src\erts\win32" -D_WIN32_WINNT=0x0600 -DWINVER=0x0600 -DERTS_MIXED_VC -DSTATIC_ERLANG_DRIVER -DHAVE_CONFIG_H -DUSE_THREADS -DWIN32_THREADS -DBEAMASM=1 /std:c++17 /Zc:__cplusplus /EHsc /FS -c -FoC:\src\erts\emulator\obj\win32\opt\jit\instr_common.o beam\jit\arm\instr_common.cpp
make[4]: *** [win32/Makefile:957: obj/win32/opt/jit/instr_common.o] Error 2
make[4]: Leaving directory '/mnt/c/src/erts/emulator'
make[3]: *** [/mnt/c/src/make/run_make.mk:35: opt] Error 2
make[3]: Leaving directory '/mnt/c/src/erts/emulator'
make[2]: *** [Makefile:45: opt] Error 2
make[2]: Leaving directory '/mnt/c/src/erts'
make[1]: *** [Makefile:60: jit] Error 2
make[1]: Leaving directory '/mnt/c/src/erts'
make: *** [Makefile:483: emulator] Error 2
```

And good news is, with this fix we can successfully compile the ARM64 version with JIT support for Windows --

![Screenshot 2024-10-24 141009](https://github.com/user-attachments/assets/417d9332-52db-4879-93d1-507021c6e643)

There're likely some functions not working properly at the moment, but being able to compile it will definitely help anyone who's interested in running these test suites and fixing these issues.

I'll submit another PR which documents how to compile for ARM64 Windows.