### PR TITLE
wx: add support for ARM64 Windows

### DIFF
--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -6764,22 +6764,30 @@ printf "%s\n" "$as_me: OptionCheck: $with_wxdir $with_wx_prefix" >&6;}
     CWX_DOCUMENTED="$DOC_OPT2/wxWidgets-3.*.* $DOC_OPT2/wxMSW-3.*.* $CWX_DOCUMENTED"
 
     case $ac_cv_sizeof_void_p in
-    	 8)
-                VC_LIB=lib/vc_x64_lib
-                WX_ARCH=x64
-		DOC_OPT64_1=/opt/local64/pgm
-		DOC_OPT64_2=/mnt/c/opt/local64/pgm
-		CWX_DOCUMENTED="$DOC_OPT64_1/wxWidgets-3.*.* $DOC_OPT64_1/wxMSW-3.*.* $CWX_DOCUMENTED"
-		CWX_DOCUMENTED="$DOC_OPT64_2/wxWidgets-3.*.* $DOC_OPT64_2/wxMSW-3.*.* $CWX_DOCUMENTED"
-		;;
-         *)
-                VC_LIB=lib/vc_lib
-                WX_ARCH=x86
-		DOC_OPT3=/opt/local32/pgm
-		DOC_OPT4=/mnt/c/opt/local32/pgm
-		CWX_DOCUMENTED="$DOC_OPT3/wxWidgets-3.*.* $DOC_OPT3/wxMSW-3.*.* $CWX_DOCUMENTED"
-		CWX_DOCUMENTED="$DOC_OPT4/wxWidgets-3.*.* $DOC_OPT4/wxMSW-3.*.* $CWX_DOCUMENTED"
-		;;
+      8)
+        case $host_cpu in
+          aarch64)
+            VC_LIB=lib/vc_arm64_lib
+            WX_ARCH=aarch64
+            ;;
+          *)
+            VC_LIB=lib/vc_x64_lib
+            WX_ARCH=x64
+            ;;
+        esac
+        DOC_OPT64_1=/opt/local64/pgm
+        DOC_OPT64_2=/mnt/c/opt/local64/pgm
+        CWX_DOCUMENTED="$DOC_OPT64_1/wxWidgets-3.*.* $DOC_OPT64_1/wxMSW-3.*.* $CWX_DOCUMENTED"
+        CWX_DOCUMENTED="$DOC_OPT64_2/wxWidgets-3.*.* $DOC_OPT64_2/wxMSW-3.*.* $CWX_DOCUMENTED"
+        ;;
+      *)
+        VC_LIB=lib/vc_lib
+        WX_ARCH=x86
+        DOC_OPT3=/opt/local32/pgm
+        DOC_OPT4=/mnt/c/opt/local32/pgm
+        CWX_DOCUMENTED="$DOC_OPT3/wxWidgets-3.*.* $DOC_OPT3/wxMSW-3.*.* $CWX_DOCUMENTED"
+        CWX_DOCUMENTED="$DOC_OPT4/wxWidgets-3.*.* $DOC_OPT4/wxMSW-3.*.* $CWX_DOCUMENTED"
+        ;;
     esac
 
     CWXPATH="$CWXWIN0 $CWXWIN1 $CWXWIN2 $CWX_DOCUMENTED $CWXWIN3 $CWXWIN4"

--- a/lib/wx/configure.ac
+++ b/lib/wx/configure.ac
@@ -488,22 +488,30 @@ AS_IF(
     CWX_DOCUMENTED="$DOC_OPT2/wxWidgets-3.*.* $DOC_OPT2/wxMSW-3.*.* $CWX_DOCUMENTED"
 
     case $ac_cv_sizeof_void_p in
-    	 8)
-                VC_LIB=lib/vc_x64_lib
-                WX_ARCH=x64
-		DOC_OPT64_1=/opt/local64/pgm
-		DOC_OPT64_2=/mnt/c/opt/local64/pgm
-		CWX_DOCUMENTED="$DOC_OPT64_1/wxWidgets-3.*.* $DOC_OPT64_1/wxMSW-3.*.* $CWX_DOCUMENTED"
-		CWX_DOCUMENTED="$DOC_OPT64_2/wxWidgets-3.*.* $DOC_OPT64_2/wxMSW-3.*.* $CWX_DOCUMENTED"
-		;;
-         *)
-                VC_LIB=lib/vc_lib
-                WX_ARCH=x86
-		DOC_OPT3=/opt/local32/pgm
-		DOC_OPT4=/mnt/c/opt/local32/pgm
-		CWX_DOCUMENTED="$DOC_OPT3/wxWidgets-3.*.* $DOC_OPT3/wxMSW-3.*.* $CWX_DOCUMENTED"
-		CWX_DOCUMENTED="$DOC_OPT4/wxWidgets-3.*.* $DOC_OPT4/wxMSW-3.*.* $CWX_DOCUMENTED"
-		;;
+      8)
+        case $host_cpu in
+          aarch64)
+            VC_LIB=lib/vc_arm64_lib
+            WX_ARCH=aarch64
+            ;;
+          *)
+            VC_LIB=lib/vc_x64_lib
+            WX_ARCH=x64
+            ;;
+        esac
+        DOC_OPT64_1=/opt/local64/pgm
+        DOC_OPT64_2=/mnt/c/opt/local64/pgm
+        CWX_DOCUMENTED="$DOC_OPT64_1/wxWidgets-3.*.* $DOC_OPT64_1/wxMSW-3.*.* $CWX_DOCUMENTED"
+        CWX_DOCUMENTED="$DOC_OPT64_2/wxWidgets-3.*.* $DOC_OPT64_2/wxMSW-3.*.* $CWX_DOCUMENTED"
+        ;;
+      *)
+        VC_LIB=lib/vc_lib
+        WX_ARCH=x86
+        DOC_OPT3=/opt/local32/pgm
+        DOC_OPT4=/mnt/c/opt/local32/pgm
+        CWX_DOCUMENTED="$DOC_OPT3/wxWidgets-3.*.* $DOC_OPT3/wxMSW-3.*.* $CWX_DOCUMENTED"
+        CWX_DOCUMENTED="$DOC_OPT4/wxWidgets-3.*.* $DOC_OPT4/wxMSW-3.*.* $CWX_DOCUMENTED"
+        ;;
     esac
 
     CWXPATH="$CWXWIN0 $CWXWIN1 $CWXWIN2 $CWX_DOCUMENTED $CWXWIN3 $CWXWIN4"


### PR DESCRIPTION
This PR is one of the smaller PRs separated from the original PR https://github.com/erlang/otp/pull/8142 that attempts to add initial support for ARM64 windows, and hopefully, this should be the last technical one 🤞

wxWidgets produces static libs for ARM64 in the `vc_arm64_lib` directory with the following command

```
nmake TARGET_CPU=arm64 BUILD=release SHARED=0 DIR_SUFFIX_CPU= -f makefile.vc
```

So we only need a tiny tweak to make it work:

![Screenshot 2024-10-27 002355](https://github.com/user-attachments/assets/f3abe072-0418-4fea-a052-df697ebc1a1d)
