### PR TITLE
set proper triplets for Windows

### DIFF
--- a/erts/emulator/utils/make_version
+++ b/erts/emulator/utils/make_version
@@ -52,6 +52,16 @@ my $architecture = shift;
 defined $architecture or die "No architecture specified";
 $architecture =~ s&^.*[/\\]&&;	# Remove directory part if any
 
+if ($architecture eq "win32") {
+  if ($ENV{"CONFIG_SUBTYPE"} eq "arm64" || $ENV{"CONFIG_SUBTYPE"} eq "x64_arm64") {
+    $architecture = "aarch64-pc-windows";
+  } elsif ($ENV{"CONFIG_SUBTYPE"} eq "win64") {
+    $architecture = "x86_64-pc-windows";
+  } elsif ($ENV{"CONFIG_SUBTYPE"} eq "win32") {
+    $architecture = "i686-pc-windows";
+  }
+}
+
 open(FILE, ">$outputfile") or die "Can't create $outputfile: $!";
 
 print FILE <<EOF;


### PR DESCRIPTION
This PR should partially address the issue reported in https://github.com/erlang/otp/issues/8767.

As described in #8767, ideally the following should return a triple like `x86_64-pc-windows`.

```erlang
1> erlang:system_info(system_architecture).
"x86_64-pc-windows"
```

As this is what's described in the [official docs](https://www.erlang.org/doc/man/erlang.html#system_info_system_architecture):

> ```
> system_architecture
>  Returns a string containing the processor and OS architecture the emulator is built for.
> ```

But changing this from `win32` to `x86_64-pc-windows` for AMD64 Windows and `i686-pc-windows` for 32-bit Windows could lead to a large blast radius -- I can imagine that many libraries would have to update their code.

However, it's still fixable for ARM64 Windows as there isn't an official build/release of Erlang/OTP for ARM64 Windows yet, so newer and existing libraries can adapt to this if they decide to support ARM64 Windows.

![Screenshot 2024-10-27 161949](https://github.com/user-attachments/assets/384c87ed-3584-404c-9535-d3270e7cba8e)