### PR TITLE
fix: kernel logger guide md typos

### DIFF
--- a/lib/kernel/doc/guides/logger_chapter.md
+++ b/lib/kernel/doc/guides/logger_chapter.md
@@ -428,8 +428,8 @@ The primary Logger configuration is a map with the following keys:
 
 - **`filters = [{FilterId,Filter}]`** - Specifies the primary filters.
 
-  - `FilterId = ``t:logger:filter_id/0`
-  - `Filter = ``t:logger:filter/0`
+  - `FilterId = ` `t:logger:filter_id/0`
+  - `Filter = ` `t:logger:filter/0`
 
   The initial value of this option is set by the Kernel configuration parameter
   [`logger`](#logger_parameter). During runtime, primary
@@ -470,7 +470,7 @@ Logger API functions that apply to handler configuration are:
 
 The configuration for a handler is a map with the following keys:
 
-- **`id = ``t:logger_handler:id/0`** - Automatically inserted by Logger. The
+- **`id =` `t:logger_handler:id/0`** - Automatically inserted by Logger. The
   value is the same as the `HandlerId` specified when adding the handler, and it
   cannot be changed.
 
@@ -478,7 +478,7 @@ The configuration for a handler is a map with the following keys:
   same as the `Module` specified when adding the handler, and it cannot be
   changed.
 
-- **`level = ``t:logger:level/0`` | all | none`** - Specifies the log level for
+- **`level =` `t:logger:level/0` ` | all | none`** - Specifies the log level for
   the handler, that is, log events that are equally or more severe than this
   level, are forwarded to the handler filters for this handler.
 
@@ -493,8 +493,8 @@ The configuration for a handler is a map with the following keys:
 
 - **`filters = [{FilterId,Filter}]`** - Specifies the handler filters.
 
-  - `FilterId = ``t:logger:filter_id/0`
-  - `Filter = ``t:logger:filter/0`
+  - `FilterId = ` `t:logger:filter_id/0`
+  - `Filter = ` `t:logger:filter/0`
 
   Handler filters are specified when adding the handler, or added or removed
   during runtime with `logger:add_handler_filter/3` and
@@ -517,7 +517,7 @@ The configuration for a handler is a map with the following keys:
   string.
 
   - `FormatterModule = module()`
-  - `FormatterConfig = ``t:logger:formatter_config/0`
+  - `FormatterConfig =` `t:logger:formatter_config/0`
 
   The formatter information is specified when adding the handler. The formatter
   configuration can be changed during runtime with

--- a/lib/kernel/src/logger_formatter.erl
+++ b/lib/kernel/src/logger_formatter.erl
@@ -83,7 +83,7 @@ following keys can be set as configuration parameters:
 
   Defaults to `unlimited`.
 
-- **`report_cb = ``t:logger:report_cb/0`** - A report callback is used by the
+- **`report_cb = ` `t:logger:report_cb/0`** - A report callback is used by the
   formatter to transform log messages on report form to a format string and
   arguments. The report callback can be specified in the metadata for the log
   event. If no report callback exists in metadata, `logger_formatter` will use

--- a/lib/ssh/src/ssh_client_channel.erl
+++ b/lib/ssh/src/ssh_client_channel.erl
@@ -148,7 +148,7 @@ to the channel.
 Possible Erlang 'EXIT' messages is to be handled by this function and all
 channels are to handle the following message.
 
-- **`{ssh_channel_up, ``t:ssh:channel_id/0``, ``t:ssh:connection_ref/0``}`** -
+- **`{ssh_channel_up,` `t:ssh:channel_id/0` `,` `t:ssh:connection_ref/0` `}`** -
   This is the first message that the channel receives. It is sent just before
   the `init/1` function returns successfully. This is especially useful if the
   server wants to send a message to the client without first receiving a message
@@ -165,7 +165,7 @@ attention. For details, see `t:ssh_connection:event/0`.
 
 The following message is taken care of by the `ssh_client_channel` behavior.
 
-- **`{closed, ``t:ssh:channel_id/0``}`** - The channel behavior sends a close
+- **`{closed,` `t:ssh:channel_id/0` `}`** - The channel behavior sends a close
   message to the other side, if such a message has not already been sent. Then
   it terminates the channel with reason `normal`.
 """.
@@ -372,10 +372,10 @@ The following options must be present:
 - **`{init_args(), list()}`** - The list of arguments to the `init` function of
   the callback module.
 
-- **`{cm, ``t:ssh:connection_ref/0``}`** - Reference to the `ssh` connection as
+- **`{cm,` `t:ssh:connection_ref/0` `}`** - Reference to the `ssh` connection as
   returned by `ssh:connect/3`.
 
-- **`{channel_id, ``t:ssh:channel_id/0``}`** - Id of the `ssh` channel as
+- **`{channel_id,` `t:ssh:channel_id/0` `}`** - Id of the `ssh` channel as
   returned by
   [ssh_connection:session_channel/2,4](`ssh_connection:session_channel/2`).
 

--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -36,7 +36,7 @@ events, which are received as messages by the remote channel handling the remote
 channel. The Erlang format of thoose messages is (see also
 [below](`t:event/0`)):
 
-`{ssh_cm, ``t:ssh:connection_ref/0``, ``t:channel_msg/0``}`
+`{ssh_cm,` `t:ssh:connection_ref/0` `,` `t:channel_msg/0` `}`
 
 If the `m:ssh_client_channel` behavior is used to implement the channel process,
 these messages are handled by

--- a/lib/ssh/src/ssh_server_channel.erl
+++ b/lib/ssh/src/ssh_server_channel.erl
@@ -89,7 +89,7 @@ to the channel.
 Possible Erlang 'EXIT' messages is to be handled by this function and all
 channels are to handle the following message.
 
-- **`{ssh_channel_up, ``t:ssh:channel_id/0``, ``t:ssh:connection_ref/0``}`** -
+- **`{ssh_channel_up,` `t:ssh:channel_id/0` `,` `t:ssh:connection_ref/0` `}`** -
   This is the first message that the channel receives. This is especially useful
   if the server wants to send a message to the client without first receiving a
   message from it. If the message is not useful for your particular scenario,
@@ -104,7 +104,7 @@ attention. For details, see `t:ssh_connection:event/0`.
 
 The following message is taken care of by the `ssh_server_channel` behavior.
 
-- **`{closed, ``t:ssh:channel_id/0``}`** - The channel behavior sends a close
+- **`{closed,` `t:ssh:channel_id/0` `}`** - The channel behavior sends a close
   message to the other side, if such a message has not already been sent. Then
   it terminates the channel with reason `normal`.
 """.

--- a/lib/ssl/doc/ssl_app.md
+++ b/lib/ssl/doc/ssl_app.md
@@ -51,13 +51,13 @@ The environment parameters can be set on the command line, for example:
 
 `erl -ssl protocol_version "['tlsv1.2', 'tlsv1.1']"`
 
-- **`protocol_version = ``t:ssl:tls_version/0` | [`t:ssl:tls_version/0`]
+- **`protocol_version = ` `t:ssl:tls_version/0` | [`t:ssl:tls_version/0`]
   `<optional>`** - Protocol supported by started clients and servers. If this
   option is not set, it defaults to all TLS protocols currently supported, more
   might be configurable, by the SSL application. This option can be overridden
   by the version option to `ssl:connect/2,3` and `ssl:listen/2`.
 
-- **`dtls_protocol_version = ``t:ssl:dtls_version/0` | [`t:ssl:dtls_version/0`]
+- **`dtls_protocol_version = ` `t:ssl:dtls_version/0` | [`t:ssl:dtls_version/0`]
   `<optional>`** - Protocol supported by started clients and servers. If this
   option is not set, it defaults to all DTLS protocols currently supported, more
   might be configurable, by the SSL application. This option can be overridden

--- a/lib/stdlib/src/dets.erl
+++ b/lib/stdlib/src/dets.erl
@@ -504,11 +504,11 @@ from_ets_fun(LC, ETab) ->
 Returns information about table `Name` as a list of tuples:
 
 - `{file_size, integer() >= 0}}` \- The file size, in bytes.
-- `{filename, ``t:file:name/0``}` \- The name of the file where objects are
+- `{filename,` `t:file:name/0` `}` \- The name of the file where objects are
   stored.
-- `{keypos, ``t:keypos/0``}` \- The key position.
+- `{keypos,` `t:keypos/0` `}` \- The key position.
 - `{size, integer() >= 0}` \- The number of objects stored in the table.
-- `{type, ``t:type/0``}` \- The table type.
+- `{type,` `t:type/0` `}` \- The table type.
 """.
 -spec info(Name) -> InfoList | 'undefined' when
       Name :: tab_name(),
@@ -531,8 +531,8 @@ info(Tab) ->
 Returns the information associated with `Item` for table `Name`. In addition to
 the `{Item, Value}` pairs defined for `info/1`, the following items are allowed:
 
-- `{access, ``t:access/0``}` \- The access mode.
-- `{auto_save, ``t:auto_save/0``}` \- The autosave interval.
+- `{access,` `t:access/0` `}` \- The access mode.
+- `{auto_save,` `t:auto_save/0` `}` \- The autosave interval.
 - `{bchunk_format, binary()}` \- An opaque binary describing the format of the
   objects returned by [`bchunk/2`](`bchunk/2`). The binary can be used as
   argument to
@@ -1045,28 +1045,28 @@ second user closes it.
 Argument `Args` is a list of `{Key, Val}` tuples, where the following values are
 allowed:
 
-- `{access, ``t:access/0``}` \- Existing tables can be opened in read-only mode.
+- `{access,` `t:access/0` `}` \- Existing tables can be opened in read-only mode.
   A table that is opened in read-only mode is not subjected to the automatic
   file reparation algorithm if it is later opened after a crash. Defaults to
   `read_write`.
-- `{auto_save, ``t:auto_save/0``}` \- The autosave interval. If the interval is
+- `{auto_save,` `t:auto_save/0` `}` \- The autosave interval. If the interval is
   an integer `Time`, the table is flushed to disk whenever it is not accessed
   for `Time` milliseconds. A table that has been flushed requires no reparation
   when reopened after an uncontrolled emulator halt. If the interval is the atom
   `infinity`, autosave is disabled. Defaults to 180000 (3 minutes).
-- `{estimated_no_objects, ``t:no_slots/0``}` \- Equivalent to option
+- `{estimated_no_objects,` `t:no_slots/0` `}` \- Equivalent to option
   `min_no_slots`.
-- `{file, ``t:file:name/0``}` \- The name of the file to be opened. Defaults to
+- `{file,` `t:file:name/0` `}` \- The name of the file to be opened. Defaults to
   the table name.
-- `{max_no_slots, ``t:no_slots/0``}` \- The maximum number of slots to be used.
+- `{max_no_slots,` `t:no_slots/0` `}` \- The maximum number of slots to be used.
   Defaults to 32 M, which is the maximal value. Notice that a higher value can
   increase the table fragmentation, and a smaller value can decrease the
   fragmentation, at the expense of execution time.
-- `{min_no_slots, ``t:no_slots/0``}` \- Application performance can be enhanced
+- `{min_no_slots,` `t:no_slots/0` `}` \- Application performance can be enhanced
   with this flag by specifying, when the table is created, the estimated number
   of different keys to be stored in the table. Defaults to 256, which is the
   minimum value.
-- `{keypos, ``t:keypos/0``}` \- The position of the element of each object to be
+- `{keypos,` `t:keypos/0` `}` \- The position of the element of each object to be
   used as key. Defaults to 1. The ability to explicitly state the key position
   is most convenient when we want to store Erlang records in which the first
   position of the record is the name of the record type.
@@ -1086,7 +1086,7 @@ allowed:
 
   Option `repair` is ignored if the table is already open.
 
-- `{type, ``t:type/0``}` \- The table type. Defaults to `set`.
+- `{type,` `t:type/0` `}` \- The table type. Defaults to `set`.
 """.
 -spec open_file(Name, Args) -> {'ok', Name} | {'error', Reason} when
       Name :: tab_name(),
@@ -1379,7 +1379,7 @@ the whole table is traversed. Option `traverse` determines how this is done:
     [`select/3`](`select/3`) given a match specification that matches all
     objects.
 
-- `{select, ``t:match_spec/0``}` \- As for `select`, the table is traversed by
+- `{select,` `t:match_spec/0` `}` \- As for `select`, the table is traversed by
   calling `dets:select/3` and `dets:select/1`. The difference is that the match
   specification is specified explicitly. This is how to state match
   specifications that cannot easily be expressed within the syntax provided by


### PR DESCRIPTION
Those were rendered as text, not as a link to a type.