### PR TITLE
Enable openssf compiler options

### DIFF
--- a/.github/dockerfiles/Dockerfile.64-bit
+++ b/.github/dockerfiles/Dockerfile.64-bit
@@ -13,11 +13,30 @@ RUN cd /buildroot && tar -xzf ./otp.tar.gz
 WORKDIR /buildroot/otp/
 
 ENV CFLAGS="-O2 -g -Werror -DwxSTC_DISABLE_MACRO_DEPRECATIONS=1"
+ENV CFLAGS="${CFLAGS} -Wall -Wformat -Wformat=2 -Wno-conversion -Wimplicit-fallthrough \
+    -Werror=format-security -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS \
+    -fstack-clash-protection -fstack-protector-strong -Wtrampolines \
+    -fcf-protection=full -fexceptions -fno-strict-overflow -fno-delete-null-pointer-checks \
+    -D_GLIBCXX_ASSERTIONS"
+## OpenSSF recommended CFLAGS, skipped are:
+##  -Wconversion -Wextra -Wsign-conversion - As we have way too many of these warnings
+##  -fstrict-flex-arrays=3 -Wbidi-chars=any - As gcc 11 does not support it
+##  -mbranch-protection=standard - Only on arm
+##  -Werror=implicit -Wincompatible-pointer-types -Wint-conversion - As these do not work on c++ code
+ENV SKIPPED_OSSF_CFLAGS="-Wconversion -mbranch-protection=standard \
+    -Wextra  -Werror=implicit -Werror=incompatible-pointer-types -Werror=int-conversion \
+    -Wsign-conversion"
+ENV LDFLAGS="-Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -Wl,--no-copy-dt-needed-entries"
+## OpenSSF recommended LDFLAGS, skipped are:
+## -Wl,-z,nodlopen - as opening drivers/nifs needs this
+## -fPIE - not needed with gcc 11
+## -fPIC -shared - only needed for .so files
+ENV SKIPPED_OSSF_LDFLAGS="-Wl,-z,nodlopen -fPIE -fPIC -shared"
 
 ## Configure (if not cached), check that no application are disabled and then make
 RUN if [ ! -f Makefile ]; then \
       touch README.md && \
-      ./configure --prefix="/Erlang ∅⊤℞" && \
+      ./configure --prefix="/Erlang ∅⊤℞" --enable-pie && \
       if cat lib/*/CONF_INFO || cat lib/*/SKIP || cat lib/SKIP-APPLICATIONS; then exit 1; fi && \
       find . -type f -newer README.md | xargs tar --transform 's:^./:otp/:' -cf ../otp_cache.tar; \
     fi && \
@@ -26,6 +45,7 @@ RUN if [ ! -f Makefile ]; then \
 
 ## Disable -Werror as testcases do not compile with it on
 ENV CFLAGS="-O2 -g"
+ENV LDFLAGS=""
 
 ## Update init.sh with correct env vars
 RUN echo "export MAKEFLAGS=$MAKEFLAGS" > /buildroot/env.sh && \

--- a/.github/scripts/ossf-sarif-generator.es
+++ b/.github/scripts/ossf-sarif-generator.es
@@ -1,0 +1,106 @@
+#!/usr/bin/env escript
+
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+
+%% This script takes a json string as argument and checks that all the compiler flags defined by the OSSF
+%% are used.
+
+main([CompilerFlagsJson]) ->
+    io:format(standard_error,"~p",[os:env()]),
+    CFLAGS = proplists:get_value(cflags, erlang:system_info(compile_info)) ++ " " ++ os:getenv("SKIPPED_OSSF_CFLAGS"),
+    LDFLAGS = proplists:get_value(ldflags, erlang:system_info(compile_info)) ++ " " ++ os:getenv("SKIPPED_OSSF_LDFLAGS"),
+    {gnuc, {Vsn, _, _} } = erlang:system_info(c_compiler_used),
+    #{ ~"options" := #{ ~"recommended" := Opts } } = json:decode(unicode:characters_to_binary(CompilerFlagsJson)),
+    io:format(standard_error, ~s'CFLAGS="~ts"~nLDFLAGS="~ts"~n',[CFLAGS, LDFLAGS]),
+    Missing = [Opt || Opt <- Opts, check_option(Opt, string:split(CFLAGS, " ", all), string:split(LDFLAGS, " ", all), Vsn)],
+    io:format("~ts~n",[sarif(Missing)]),
+    ok.
+check_option(#{ ~"requires" := #{ ~"gcc" := GccVsn }, ~"opt" := Opt }, CFLAGS, _LDFLAGS, CurrentGccVsn) ->
+    io:format(standard_error, "Looking for ~ts...",[Opt]),
+    case binary_to_integer(hd(string:split(GccVsn, "."))) > CurrentGccVsn of
+        true -> io:format(standard_error, "skipped!~n",[]), false;
+        false ->
+            check_for_flags(Opt, CFLAGS)
+    end;
+check_option(#{ ~"requires" := #{ ~"binutils" := _ }, ~"opt" := Opt }, _CFLAGS, LDFLAGS, _CurrentGccVsn) ->
+    io:format(standard_error, "Looking for ~ts...",[Opt]),
+    check_for_flags(Opt, LDFLAGS);
+check_option(#{ ~"requires" := #{ ~"libstdc++" := _ }, ~"opt" := Opt }, _CFLAGS, LDFLAGS, _CurrentGccVsn) ->
+    io:format(standard_error, "Looking for ~ts...",[Opt]),
+    check_for_flags(Opt, LDFLAGS);
+check_option(#{ ~"requires" := Tool, ~"opt" := Opt }, _CFLAGS, _LDFLAGS, _CurrentGccVsn) ->
+    io:format(standard_error, "~ts not implemented yet using ~p!~n",[Opt, Tool]),
+    true.
+
+check_for_flags(Flag, Flags) ->
+    case lists:any(fun(O) -> lists:search(fun(A) -> string:equal(string:trim(O), string:trim(A)) end, Flags) =:= false end, string:split(Flag, " ", all) ) of
+        true -> io:format(standard_error, "missing!~n",[]), true;
+        false -> io:format(standard_error, "found!~n",[]), false
+    end.
+
+sarif(Missing) ->
+    Zip = lists:zip(lists:seq(1,length(Missing)), Missing),
+    json:encode(
+      #{ ~"version" => ~"2.1.0",
+         ~"$schema" => ~"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+         ~"runs" =>
+             [ #{
+                 ~"tool" =>
+                     #{ ~"driver" =>
+                            #{ ~"informationUri" => ~"https://github.com/erlang/otp/.github/workflow/ossf-scanner",
+                               ~"name" => ~"ossf-scanner",
+                               ~"rules" =>
+                                   [ #{ ~"id" => base64:encode(erlang:md5(Opt)),
+                                        ~"name" => ~"MissingCompilerFlag",
+                                        ~"shortDescription" =>
+                                            #{ ~"text" => <<"Missing CFLAGS ", Opt/binary>> },
+                                        ~"helpUri" => ~"https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++",
+                                        ~"fullDescription" =>
+                                            #{
+                                              ~"text" => <<Desc/binary,"\nA OSSF C/C++ compiler hardening flag is missing from the tests. "
+                                                           "Please check https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++ for details.">>
+                                             }
+                                      }
+                                     || {_Id, #{ ~"desc" := Desc, ~"opt" := Opt }} <- Zip],
+                               ~"version" => ~"1.0"
+                             }
+                      },
+                 ~"artifacts" =>
+                     [ #{
+                         ~"location" => #{
+                                          ~"uri" => ~".github/docker/Dockerfile.64-bit"
+                                         },
+                         ~"length" => -1
+                        }
+                     ],
+                 ~"results" =>
+                     [ #{
+                         ~"ruleId" => base64:encode(erlang:md5(Opt)),
+                         ~"ruleIndex" => Id,
+                         ~"level" => ~"warning",
+                         ~"message" => #{ ~"text" => <<"Missing CFLAGS ", Opt/binary>> },
+                         ~"locations" =>
+                             [ #{ ~"physicalLocation" =>
+                                      #{ ~"artifactLocation" =>
+                                             #{ ~"uri" => ~".github/docker/Dockerfile.64-bit" }
+                                       }
+                                } ]
+                        } || {Id, #{ ~"opt" := Opt }} <- Zip]
+                } ]
+       }).

--- a/.github/workflows/ossf-compiler-flags-scanner.yaml
+++ b/.github/workflows/ossf-compiler-flags-scanner.yaml
@@ -1,0 +1,81 @@
+## %CopyrightBegin%
+##
+## Copyright Ericsson AB 2024. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## %CopyrightEnd%
+
+## This workflow continually scan the master branch to make sure that
+## the correct compiler flags are used when testing Erlang/OTP on github.
+
+name: Open Source Security Foundation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 1 * * *
+
+permissions:
+  # Required to upload SARIF file to CodeQL.
+  # See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  schedule-scan:
+    runs-on: ubuntu-latest
+    if: github.repository == 'erlang/otp'
+    steps:
+      - uses: actions/checkout@v4.2.1
+      - name: Create initial pre-release tar
+        run: .github/scripts/init-pre-release.sh otp_src.tar.gz
+      - uses: actions/checkout@v4.2.1
+        with:
+            repository: ossf/wg-best-practices-os-developers
+            sparse-checkout: docs/Compiler-Hardening-Guides/compiler-options-scraper
+            path: ossf
+    
+      - name: Setup compiler options scraper
+        run: |
+          pip3 install -r ossf/docs/Compiler-Hardening-Guides/compiler-options-scraper/requirements.txt
+          python3 ossf/docs/Compiler-Hardening-Guides/compiler-options-scraper/main.py
+          cat compiler-options.json
+
+      - uses: ./.github/actions/build-base-image
+        with:
+          BASE_BRANCH: master
+          BUILD_IMAGE: true
+      
+      - name: Run compiler flag comparison
+        run: |
+          docker run -v `pwd`/.github/scripts:/github --entrypoint "" otp \
+            bash -c "/github/ossf-sarif-generator.es '$(cat compiler-options.json)'" > results.sarif
+
+      - name: "Upload artifact"
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4 # v4.4.3
+        with:
+            name: SARIF file
+            path: results.sarif
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+            sarif_file: results.sarif
+          

--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -672,6 +672,10 @@
    '-Waddress-of-packed-member'') */
 #undef HAVE_GCC_DIAG_IGNORE_WADDRESS_OF_PACKED_MEMBER
 
+/* define if compiler support _Pragma('GCC diagnostic ignored
+   '-Wformat-nonliteral'') */
+#undef HAVE_GCC_DIAG_IGNORE_WFORMAT_NONLITERAL
+
 /* Define to 1 if you have a good `getaddrinfo' function. */
 #undef HAVE_GETADDRINFO
 

--- a/erts/configure
+++ b/erts/configure
@@ -26895,6 +26895,30 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 CFLAGS="$saved_CFLAGS"
 
+saved_CFLAGS="$CFLAGS"
+CFLAGS="-Werror $CFLAGS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+_Pragma("GCC diagnostic push")
+         _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
+         _Pragma("GCC diagnostic pop")
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+printf "%s\n" "#define HAVE_GCC_DIAG_IGNORE_WFORMAT_NONLITERAL 1" >>confdefs.h
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+CFLAGS="$saved_CFLAGS"
 
 
 if test "x$GCC" = xyes; then

--- a/erts/configure
+++ b/erts/configure
@@ -702,7 +702,6 @@ PROFILE_COMPILER
 USE_PGO
 XCRUN
 LLVM_PROFDATA
-WERRORFLAGS
 WFLAGS
 DEBUG_FLAGS
 ERTS_CONFIG_H_IDIR
@@ -3530,6 +3529,11 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
+
+
 
 
 
@@ -8298,7 +8302,6 @@ printf "%s\n" "no" >&6; }
 esac
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-
 
 
 
@@ -26921,8 +26924,9 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 CFLAGS="$saved_CFLAGS"
 
 
+
 if test "x$GCC" = xyes; then
-  CFLAGS="$WERRORFLAGS $CFLAGS"
+    CFLAGS="$WERRORFLAGS $CFLAGS"
 fi
 
 

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -29,14 +29,7 @@ m4_include([otp.m4])
 
 LM_PRECIOUS_VARS
 
-dnl We check if -Werror was given on command line and if so
-dnl we disable it for the configure and only use it when
-dnl actually building erts
-no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
-if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
-   CFLAGS="$no_werror_CFLAGS"
-   WERRORFLAGS=-Werror
-fi
+ERL_PUSH_WERROR
 
 dnl How to set srcdir absolute is taken from the GNU Emacs distribution
 #### Make srcdir absolute, if it isn't already.  It's important to
@@ -630,7 +623,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]],[[
 dnl DEBUG_FLAGS is obsolete (I hope)
 AC_SUBST(DEBUG_FLAGS)
 AC_SUBST(WFLAGS)
-AC_SUBST(WERRORFLAGS)
 
 ## Check if we can do profile guided optimization of beam_emu
 LM_CHECK_RUN_CFLAG([-fprofile-generate -Werror],[PROFILE_GENERATE])
@@ -3637,9 +3629,7 @@ dnl ----------------------------------------------------------------------
 dnl Enable any -Werror flags
 dnl ----------------------------------------------------------------------
 
-if test "x$GCC" = xyes; then
-  CFLAGS="$WERRORFLAGS $CFLAGS"
-fi
+ERL_POP_WERROR
 
 dnl ----------------------------------------------------------------------
 dnl Enable build determinism flag

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -3621,6 +3621,17 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[_Pragma("GCC diagnostic push")
            define if compiler support _Pragma('GCC diagnostic ignored '-Waddress-of-packed-member''))],[])
 CFLAGS="$saved_CFLAGS"
 
+dnl ----------------------------------------------------------------------
+dnl Check for GCC diagnostic ignored "-Wformat-nonliteral"
+dnl ----------------------------------------------------------------------
+saved_CFLAGS="$CFLAGS"
+CFLAGS="-Werror $CFLAGS"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[_Pragma("GCC diagnostic push")
+         _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
+         _Pragma("GCC diagnostic pop")
+         ]])],[AC_DEFINE(HAVE_GCC_DIAG_IGNORE_WFORMAT_NONLITERAL,1,
+           define if compiler support _Pragma('GCC diagnostic ignored '-Wformat-nonliteral''))],[])
+CFLAGS="$saved_CFLAGS"
 
 dnl ----------------------------------------------------------------------
 dnl Enable any -Werror flags

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -944,7 +944,7 @@ $(OBJDIR)/%.o: nifs/$(ERLANG_OSTYPE)/%.c
 # included before any other directives, including other #includes.
 #
 ASMJIT_FLAGS=-DASMJIT_EMBED=1 -DASMJIT_NO_BUILDER=1 -DASMJIT_NO_DEPRECATED=1 -DASMJIT_STATIC=1 -DASMJIT_NO_FOREIGN=1
-
+ASMJIT_CXXFLAGS=$(filter-out -Wformat -Wformat=2, $(CXXFLAGS))
 ASMJIT_PCH_OBJ=$(TTF_DIR)/asmjit/asmjit.hpp.gch
 ASMJIT_PCH_SRC=$(TTF_DIR)/asmjit/asmjit.hpp
 
@@ -960,7 +960,7 @@ $(OBJDIR)/%.o: beam/jit/$(JIT_ARCH)/%.cpp beam/jit/$(JIT_ARCH)/beam_asm.hpp $(AS
 
 $(OBJDIR)/asmjit/%.o: asmjit/%.cpp $(ASMJIT_PCH_OBJ) $(dir $@)
 	$(V_CXX) $(ASMJIT_FLAGS) $(INCLUDES)                        \
-          $(subst -O2, $(GEN_OPT_FLGS), $(CXXFLAGS))                \
+          $(subst -O2, $(GEN_OPT_FLGS), $(ASMJIT_CXXFLAGS))         \
           -include $(ASMJIT_PCH_SRC) -c $< -o $@
 
 ## The dependency on erl_bif_info.c is in order to trigger a rebuild when

--- a/erts/emulator/beam/beam_bp.c
+++ b/erts/emulator/beam/beam_bp.c
@@ -221,12 +221,15 @@ erts_bp_match_functions(BpFunctions* f, ErtsCodeMFA *mfa, int specified)
             case 3:
                 if (ci->mfa.arity != mfa->arity)
                     continue;
+                ERTS_FALLTHROUGH();
             case 2:
                 if (ci->mfa.function != mfa->function)
                     continue;
+                ERTS_FALLTHROUGH();
             case 1:
                 if (ci->mfa.module != mfa->module)
                     continue;
+                ERTS_FALLTHROUGH();
             case 0:
                 break;
             }
@@ -259,12 +262,15 @@ erts_bp_match_export(BpFunctions* f, ErtsCodeMFA *mfa, int specified)
         case 3:
             if (mfa->arity != ep->info.mfa.arity)
                 continue;
+            ERTS_FALLTHROUGH();
         case 2:
             if (mfa->function != ep->info.mfa.function)
                 continue;
+            ERTS_FALLTHROUGH();
         case 1:
             if (mfa->module != ep->info.mfa.module)
                 continue;
+            ERTS_FALLTHROUGH();
         case 0:
             break;
         default:

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -3295,6 +3295,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 		break;
 	    case EXP0:		/* example: "2.3e--" */
 		LOAD_E(i, i_mem, list, list_mem);
+                ERTS_FALLTHROUGH();
 	    default:		/* unexpected - done */
 		part = END;
 	    }
@@ -3308,6 +3309,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 		break;
 	    case EXP0:		/* example: "2.3e++" */
 		LOAD_E(i, i_mem, list, list_mem);
+                ERTS_FALLTHROUGH();
 	    default:		/* unexpected - done */
 		part = END;
 	    }
@@ -3318,8 +3320,10 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 		break;
 	    case EXP_SIGN:	/* example: "2.3e." */
 		LOAD_E(i, i_mem, list, list_mem);
+                ERTS_FALLTHROUGH();
 	    case EXP0:		/* example: "2.3e+." */
 		LOAD_E(i, i_mem, list, list_mem);
+                ERTS_FALLTHROUGH();
 	    default:		/* unexpected - done */
 		part = END;
 	    }
@@ -3336,6 +3340,7 @@ BIF_RETTYPE string_list_to_float_1(BIF_ALIST_1)
 	    case EXP0:		/* example: "2.3e+e" */
 	    case EXP_SIGN:	/* example: "2.3ee" */
 		LOAD_E(i, i_mem, list, list_mem);
+                ERTS_FALLTHROUGH();
 	    case INT:		/* would like this to be ok, example "2e2",
 				   but it's not compatible with list_to_float */
 	    default:		/* unexpected - done */

--- a/erts/emulator/beam/break.c
+++ b/erts/emulator/beam/break.c
@@ -127,32 +127,28 @@ process_killer(void)
     for (i = max-1; i >= 0; i--) {
 	rp = erts_pix2proc(i);
 	if (rp && rp->i != ENULL) {
-	    int br;
 	    print_process_info(ERTS_PRINT_STDOUT, NULL, rp, 0);
 	    erts_printf("(k)ill (n)ext (r)eturn:\n");
-	    while(1) {
-		if ((j = sys_get_key(0)) <= 0)
-		    erts_exit(0, "");
-		switch(j) {
-                case 'k':
-                {
-                    Process *init_proc;
+            if ((j = sys_get_key(0)) <= 0)
+                erts_exit(0, "");
+            switch(j) {
+            case 'k':
+            {
+                Process *init_proc;
 
-                    ASSERT(erts_init_process_id != ERTS_INVALID_PID);
-                    init_proc = erts_proc_lookup_raw(erts_init_process_id);
+                ASSERT(erts_init_process_id != ERTS_INVALID_PID);
+                init_proc = erts_proc_lookup_raw(erts_init_process_id);
 
-                    /* Send a 'kill' exit signal from init process */
-                    erts_proc_sig_send_exit(&init_proc->common,
-                                            erts_init_process_id,
-                                            rp->common.id,
-                                            am_kill, NIL, 0);
-                }
-		case 'n': br = 1; break;
-		case 'r': return;
-		default: return;
-		}
-		if (br == 1) break;
-	    }
+                /* Send a 'kill' exit signal from init process */
+                erts_proc_sig_send_exit(&init_proc->common,
+                                        erts_init_process_id,
+                                        rp->common.id,
+                                        am_kill, NIL, 0);
+                break;
+            }
+            case 'n': break;
+            default: return;
+            }
 	}
     }
 }

--- a/erts/emulator/beam/copy.c
+++ b/erts/emulator/beam/copy.c
@@ -898,6 +898,7 @@ Eterm copy_struct_x(Eterm obj, Uint sz, Eterm** hpp, ErlOffHeap* off_heap,
 		    case MAP_HEADER_TAG_HAMT_HEAD_BITMAP :
 		    case MAP_HEADER_TAG_HAMT_HEAD_ARRAY :
 			*htop++ = *objp++;
+                        ERTS_FALLTHROUGH();
 		    case MAP_HEADER_TAG_HAMT_NODE_BITMAP :
 			i = 1 + hashmap_bitcount(MAP_HEADER_VAL(hdr));
 			while (i--)  { *htop++ = *objp++; }
@@ -1601,6 +1602,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                     case MAP_HEADER_TAG_HAMT_HEAD_BITMAP :
                     case MAP_HEADER_TAG_HAMT_HEAD_ARRAY :
 			*hp++ = *++ptr; /* total map size */
+                        ERTS_FALLTHROUGH();
                     case MAP_HEADER_TAG_HAMT_NODE_BITMAP : {
                          Uint n = hashmap_bitcount(MAP_HEADER_VAL(hdr));
                          while (n--)  {
@@ -1987,7 +1989,7 @@ Eterm* copy_shallow_x(Eterm *ERTS_RESTRICT ptr, Uint sz, Eterm **hpp,
 		    erts_refc_inc(&mreft->mb->intern.refc, 2);
 		    goto off_heap_common;
 		}
-		/* Fall through... */
+		ERTS_FALLTHROUGH();
 	    }
 	    default:
 		{
@@ -2101,6 +2103,7 @@ move_one_frag(Eterm** hpp, ErlHeapFragment* frag, ErlOffHeap* off_heap, int lite
                 if (!is_magic_ref_thing(hdr)) {
                     break;
                 }
+                ERTS_FALLTHROUGH();
             case BIN_REF_SUBTAG:
             case EXTERNAL_PID_SUBTAG:
             case EXTERNAL_PORT_SUBTAG:

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -383,6 +383,7 @@ con_monitor_link_seq_cleanup(void *vcmlcp)
 
         ASSERT(!cmlcp->yield_state);
         cmlcp->state = ERTS_CML_CLEANUP_STATE_MONITORS;
+        ERTS_FALLTHROUGH();
     case ERTS_CML_CLEANUP_STATE_MONITORS:
         reds = erts_monitor_list_foreach_delete_yielding(&dist->monitors,
                                                          monitor_connection_down,
@@ -393,6 +394,7 @@ con_monitor_link_seq_cleanup(void *vcmlcp)
 
         ASSERT(!cmlcp->yield_state);
         cmlcp->state = ERTS_CML_CLEANUP_STATE_ONAME_MONITORS;
+        ERTS_FALLTHROUGH();
     case ERTS_CML_CLEANUP_STATE_ONAME_MONITORS:
         reds = erts_monitor_tree_foreach_delete_yielding(&dist->orig_name_monitors,
                                                          monitor_connection_down,
@@ -403,6 +405,7 @@ con_monitor_link_seq_cleanup(void *vcmlcp)
 
         ASSERT(!cmlcp->yield_state);
         cmlcp->state = ERTS_CML_CLEANUP_STATE_PEND_SPAWN_EXIT_MONITORS;
+        ERTS_FALLTHROUGH();
     case ERTS_CML_CLEANUP_STATE_PEND_SPAWN_EXIT_MONITORS:
         reds = erts_monitor_tree_foreach_delete_yielding(&dist->dist_pend_spawn_exit,
                                                          dist_pend_spawn_exit_connection_down,
@@ -416,6 +419,7 @@ con_monitor_link_seq_cleanup(void *vcmlcp)
 
         ASSERT(!cmlcp->yield_state);
         cmlcp->state = ERTS_CML_CLEANUP_STATE_SEQUENCES;
+        ERTS_FALLTHROUGH();
     case ERTS_CML_CLEANUP_STATE_SEQUENCES:
         reds = erts_dist_seq_tree_foreach_delete_yielding(&cmlcp->seq,
                                                           &cmlcp->yield_state,
@@ -425,6 +429,7 @@ con_monitor_link_seq_cleanup(void *vcmlcp)
 
         ASSERT(!cmlcp->yield_state);
         cmlcp->state = ERTS_CML_CLEANUP_STATE_NODE_MONITORS;
+        ERTS_FALLTHROUGH();
     case ERTS_CML_CLEANUP_STATE_NODE_MONITORS:
         if (cmlcp->trigger_node_monitors) {
             Process* waiter;
@@ -2114,6 +2119,7 @@ int erts_net_message(Port *prt,
         }
 
         /* fall through, the first fragment in the sequence was the last fragment */
+        ERTS_FALLTHROUGH();
     case ERTS_PREP_DIST_EXT_FRAG_CONT: {
         DistSeqNode *seq;
         erts_de_rlock(dep);
@@ -3274,6 +3280,7 @@ erts_dsig_send(ErtsDSigSendContext *ctx)
             }
 
             ctx->phase = ERTS_DSIG_SEND_PHASE_MSG_SIZE;
+            ERTS_FALLTHROUGH();
 	case ERTS_DSIG_SEND_PHASE_MSG_SIZE: {
             Sint reds, *redsp;
             if (!ctx->no_trap)
@@ -3311,6 +3318,7 @@ erts_dsig_send(ErtsDSigSendContext *ctx)
             }
 
 	    ctx->phase = ERTS_DSIG_SEND_PHASE_ALLOC;
+            ERTS_FALLTHROUGH();
         }
 	case ERTS_DSIG_SEND_PHASE_ALLOC: {
 
@@ -3356,6 +3364,7 @@ erts_dsig_send(ErtsDSigSendContext *ctx)
             }
 
             ctx->phase = ERTS_DSIG_SEND_PHASE_MSG_ENCODE;
+            ERTS_FALLTHROUGH();
         }
         case ERTS_DSIG_SEND_PHASE_MSG_ENCODE: {
             Sint reds, *redsp;
@@ -3387,6 +3396,7 @@ erts_dsig_send(ErtsDSigSendContext *ctx)
             }
 
             ctx->phase = ERTS_DSIG_SEND_PHASE_FIN;
+            ERTS_FALLTHROUGH();
         }
 	case ERTS_DSIG_SEND_PHASE_FIN: {
             Uint fid = ctx->fragments;
@@ -3456,6 +3466,7 @@ erts_dsig_send(ErtsDSigSendContext *ctx)
                 retval = ERTS_DSIG_SEND_CONTINUE;
                 goto done;
             }
+            ERTS_FALLTHROUGH();
         }
         case ERTS_DSIG_SEND_PHASE_SEND: {
             /*

--- a/erts/emulator/beam/emu/bs_instrs.tab
+++ b/erts/emulator/beam/emu/bs_instrs.tab
@@ -1343,22 +1343,22 @@ i_bs_read_bits.execute() {
 #ifdef ARCH_64
     case 9:
     case 8:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
     case 7:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
     case 6:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
     case 5:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
 #else
     case 5:
 #endif
     case 4:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
     case 3:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
     case 2:
-        bitdata = bitdata << 8 | *byte_ptr++;
+        bitdata = bitdata << 8 | *byte_ptr++; ERTS_FALLTHROUGH();
     case 1:
         bitdata = bitdata << 8 | *byte_ptr++;
     }

--- a/erts/emulator/beam/erl_arith.c
+++ b/erts/emulator/beam/erl_arith.c
@@ -370,7 +370,7 @@ erts_mixed_plus(Process* p, Eterm arg1, Eterm arg2)
 	case (_TAG_HEADER_POS_BIG >> _TAG_PRIMARY_SIZE):
 	case (_TAG_HEADER_NEG_BIG >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
-	    case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
+	    case TAG_PRIMARY_IMMED1:
 		switch ((arg2 & _TAG_IMMED1_MASK) >> _TAG_PRIMARY_SIZE) {
 		case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
 		    if (arg2 == SMALL_ZERO) {
@@ -408,7 +408,9 @@ erts_mixed_plus(Process* p, Eterm arg1, Eterm arg2)
 		default:
 		    goto badarith;
 		}
-	    }
+            default:
+                goto badarith;
+        }
 	case (_TAG_HEADER_FLOAT >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
 	    case TAG_PRIMARY_IMMED1:
@@ -576,7 +578,7 @@ erts_mixed_minus(Process* p, Eterm arg1, Eterm arg2)
 	case (_TAG_HEADER_POS_BIG >> _TAG_PRIMARY_SIZE):
 	case (_TAG_HEADER_NEG_BIG >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
-	    case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
+	    case TAG_PRIMARY_IMMED1:
 		switch ((arg2 & _TAG_IMMED1_MASK) >> _TAG_PRIMARY_SIZE) {
 		case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
 		    if (arg2 == SMALL_ZERO) {
@@ -615,6 +617,8 @@ erts_mixed_minus(Process* p, Eterm arg1, Eterm arg2)
 		default:
 		    goto badarith;
 		}
+            default:
+                    goto badarith;
 	    }
 	case (_TAG_HEADER_FLOAT >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
@@ -744,17 +748,19 @@ erts_mixed_times(Process* p, Eterm arg1, Eterm arg2)
 		default:
 		    goto badarith;
 		}
-	    }
-	default:
+            default:
+	        goto badarith;
+        }
+        default:
 	    goto badarith;
-	}
+    }
     case TAG_PRIMARY_BOXED:
 	hdr = *boxed_val(arg1);
 	switch ((hdr & _TAG_HEADER_MASK) >> _TAG_PRIMARY_SIZE) {
 	case (_TAG_HEADER_POS_BIG >> _TAG_PRIMARY_SIZE):
 	case (_TAG_HEADER_NEG_BIG >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
-	    case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
+	    case TAG_PRIMARY_IMMED1:
 		switch ((arg2 & _TAG_IMMED1_MASK) >> _TAG_PRIMARY_SIZE) {
 		case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
 		    if (arg2 == SMALL_ZERO)
@@ -810,7 +816,9 @@ erts_mixed_times(Process* p, Eterm arg1, Eterm arg2)
 		default:
 		    goto badarith;
 		}
-	    }
+            default:
+                goto badarith;
+	}
 	case (_TAG_HEADER_FLOAT >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
 	    case TAG_PRIMARY_IMMED1:
@@ -998,7 +1006,7 @@ erts_mixed_div(Process* p, Eterm arg1, Eterm arg2)
 	case (_TAG_HEADER_POS_BIG >> _TAG_PRIMARY_SIZE):
 	case (_TAG_HEADER_NEG_BIG >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
-	    case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
+	    case TAG_PRIMARY_IMMED1:
 		switch ((arg2 & _TAG_IMMED1_MASK) >> _TAG_PRIMARY_SIZE) {
 		case (_TAG_IMMED1_SMALL >> _TAG_PRIMARY_SIZE):
 		    if (big_to_double(arg1, &f1.fd) < 0) {
@@ -1028,7 +1036,9 @@ erts_mixed_div(Process* p, Eterm arg1, Eterm arg2)
 		default:
 		    goto badarith;
 		}
-	    }
+            default:
+                goto badarith;
+	}
 	case (_TAG_HEADER_FLOAT >> _TAG_PRIMARY_SIZE):
 	    switch (arg2 & _TAG_PRIMARY_MASK) {
 	    case TAG_PRIMARY_IMMED1:

--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -1361,7 +1361,8 @@ handle_iodata:
         case PCRE_ERROR_BADUTF8_OFFSET:
             BUMP_ALL_REDS(p); /* Unknown amount of work done... */
             /* Fall through for badarg... */
-            
+            ERTS_FALLTHROUGH();
+
             /* Bad pre-compiled regexp... */
         case PCRE_ERROR_BADMAGIC:
         case PCRE_ERROR_BADENDIANNESS:

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -2666,6 +2666,7 @@ erts_finish_breakpointing(void)
 	}
         /* Nothing to do here. Fall through to next stage. */
         finish_bp.current++;
+        ERTS_FALLTHROUGH();
     case 1:
 	/*
 	 * Switch index for the breakpoint data, activating the staged
@@ -2702,6 +2703,7 @@ erts_finish_breakpointing(void)
         }
         /* Nothing done here. Fall through to next stage. */
         finish_bp.current++;
+        ERTS_FALLTHROUGH();
     case 3:
 	/*
 	 * Now all breakpoints have either been inserted or removed.

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -246,13 +246,13 @@ Process *p, Uint num_bits, unsigned flags, ErlSubBits *sb)
 	 */
 	switch (BYTE_OFFSET(n)) {
 #if defined(ARCH_64)
-	case 7: w = (w << 8) | *bp++;
-	case 6: w = (w << 8) | *bp++;
-	case 5: w = (w << 8) | *bp++;
-	case 4: w = (w << 8) | *bp++;
+	case 7: w = (w << 8) | *bp++; ERTS_FALLTHROUGH();
+	case 6: w = (w << 8) | *bp++; ERTS_FALLTHROUGH();
+	case 5: w = (w << 8) | *bp++; ERTS_FALLTHROUGH();
+	case 4: w = (w << 8) | *bp++; ERTS_FALLTHROUGH();
 #endif
-	case 3: w = (w << 8) | *bp++;
-	case 2: w = (w << 8) | *bp++;
+	case 3: w = (w << 8) | *bp++; ERTS_FALLTHROUGH();
+	case 2: w = (w << 8) | *bp++; ERTS_FALLTHROUGH();
 	case 1: w = (w << 8) | *bp++;
 	}
 	n = BIT_OFFSET(n);
@@ -537,21 +537,21 @@ erts_bs_get_binary_all_2(Process *p, ErlSubBits *sb)
  * dst and val are updated.
  */
 
-#define FMT_COPY_VAL(dst,ddir,val,sz) do {                      \
-   Uint __sz = (sz);                                            \
-   while (__sz) {                                               \
-     switch(__sz) {                                             \
-     default:                                                   \
-     case 8: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 7: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 6: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 5: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 4: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 3: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 2: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     case 1: *dst = val; dst += ddir; val >>= 8; __sz--;        \
-     }                                                          \
-   }                                                            \
+#define FMT_COPY_VAL(dst,ddir,val,sz) do {                                   \
+   Uint __sz = (sz);                                                         \
+   while (__sz) {                                                            \
+     switch(__sz) {                                                          \
+     default:                                                                \
+     case 8: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 7: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 6: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 5: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 4: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 3: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 2: *dst = val; dst += ddir; val >>= 8; __sz--; ERTS_FALLTHROUGH(); \
+     case 1: *dst = val; dst += ddir; val >>= 8; __sz--;                     \
+     }                                                                       \
+   }                                                                         \
  } while(0)
 
 static void

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -3902,6 +3902,7 @@ static Sint do_cmp_partly_bound(Eterm a, Eterm b, int *done)
 	    return 0;
 	}
 	/* Drop through */
+        ERTS_FALLTHROUGH();
       default:
 	  return CMP(a,b);
     }

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -2562,6 +2562,7 @@ erts_copy_one_frag(Eterm** hpp, ErlOffHeap* off_heap,
 	    case REF_SUBTAG:
 		if (!is_magic_ref_thing(fhp - 1))
 		    goto the_default;
+                ERTS_FALLTHROUGH();
 	    case BIN_REF_SUBTAG:
 	    case EXTERNAL_PID_SUBTAG:
 	    case EXTERNAL_PORT_SUBTAG:
@@ -3058,7 +3059,7 @@ sweep_off_heap(Process *p, int fullsweep)
 		    bin_vheap += size / sizeof(Eterm);
                 else
 		    p->bin_old_vheap += size / sizeof(Eterm); /* for binary gc (words)*/
-                /* fall through... */
+                ERTS_FALLTHROUGH();
             }
             default:
                 if (is_external_header(ptr->thing_word)) {
@@ -3312,6 +3313,7 @@ offset_heap(Eterm* hp, Uint sz, Sint offs, char* area, Uint area_size)
 	      case REF_SUBTAG:
 		  if (!is_magic_ref_thing(hp))
 		      break;
+                  ERTS_FALLTHROUGH();
 	      case BIN_REF_SUBTAG:
 	      case EXTERNAL_PID_SUBTAG:
 	      case EXTERNAL_PORT_SUBTAG:
@@ -4023,7 +4025,7 @@ check_all_heap_terms_in_range(int (*check_eterm)(Eterm),
                 if (is_magic_ref_thing(rtp)) {
                     goto off_heap_common;
                 }
-                /* Fall through... */
+                ERTS_FALLTHROUGH();
             }
             default:
                 {

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -528,7 +528,7 @@ load_preloaded(void)
 }
 
 /* be helpful (or maybe downright rude:-) */
-void erts_usage(void)
+__decl_noreturn void __noreturn  erts_usage(void)
 {
     int this_rel = this_rel_num();
     erts_fprintf(stderr, "Usage: %s [flags] [ -- [init_args] ]\n", progname(program));
@@ -1033,6 +1033,7 @@ early_init(int *argc, char **argv) /*
 			    case 1:
 				onln = tot < dirty_cpu_scheds_online ?
 				    tot : dirty_cpu_scheds_online;
+                                ERTS_FALLTHROUGH();
 			    case 2:
 			    chk_SDcpu:
 				if (tot > 0)
@@ -1103,6 +1104,7 @@ early_init(int *argc, char **argv) /*
 			    }
 			case 1:
 			    onln = tot < schdlrs_onln ? tot : schdlrs_onln;
+                            ERTS_FALLTHROUGH();
 			case 2:
 			chk_S:
 			    if (tot > 0)

--- a/erts/emulator/beam/erl_map.c
+++ b/erts/emulator/beam/erl_map.c
@@ -1656,7 +1656,7 @@ recurse:
                 sp->abm = 0xffff;
                 break;
             }
-            case HAMT_SUBTAG_HEAD_BITMAP: sp->srcA++;
+            case HAMT_SUBTAG_HEAD_BITMAP: sp->srcA++; ERTS_FALLTHROUGH();
             case HAMT_SUBTAG_NODE_BITMAP: {
                 ASSERT(ctx->lvl < HAMT_MAX_LEVEL);
                 sp->abm = MAP_HEADER_VAL(hdrA);
@@ -1693,7 +1693,7 @@ recurse:
                 sp->bbm = 0xffff;
                 break;
             }
-            case HAMT_SUBTAG_HEAD_BITMAP: sp->srcB++;
+            case HAMT_SUBTAG_HEAD_BITMAP: sp->srcB++; ERTS_FALLTHROUGH();
             case HAMT_SUBTAG_NODE_BITMAP: {
                 ASSERT(ctx->lvl < HAMT_MAX_LEVEL);
                 sp->bbm = MAP_HEADER_VAL(hdrB);
@@ -2329,6 +2329,7 @@ Uint hashmap_node_size(Eterm hdr, Eterm **nodep)
 	break;
     case HAMT_SUBTAG_HEAD_BITMAP:
         if (nodep) ++*nodep;
+        ERTS_FALLTHROUGH();
     case HAMT_SUBTAG_NODE_BITMAP:
         sz = hashmap_bitcount(MAP_HEADER_VAL(hdr));
         ASSERT(sz < 17);
@@ -2711,6 +2712,7 @@ Eterm erts_hashmap_insert_up(Eterm *hp, Eterm key, Eterm value,
 		/* subnodes, fake it */
 		fake = node;
 		node  = make_boxed(&fake);
+                ERTS_FALLTHROUGH();
 	    case TAG_PRIMARY_BOXED:
 		ptr = boxed_val(node);
 		hdr = *ptr;
@@ -3442,6 +3444,7 @@ BIF_RETTYPE erts_internal_map_hashmap_children_1(BIF_ALIST_1) {
                 BIF_ERROR(BIF_P, BADARG);
             case HAMT_SUBTAG_HEAD_BITMAP:
                 ptr++;
+                ERTS_FALLTHROUGH();
             case HAMT_SUBTAG_NODE_BITMAP:
                 ptr++;
                 sz = hashmap_bitcount(MAP_HEADER_VAL(hdr));

--- a/erts/emulator/beam/erl_message.c
+++ b/erts/emulator/beam/erl_message.c
@@ -1509,7 +1509,7 @@ void erts_factory_trim_and_close(ErtsHeapFactory* factory,
 	    /*else we don't trim multi fragmented messages for now (off_heap...) */
 	    break;
 	}
-	/* Fall through... */
+	ERTS_FALLTHROUGH();
     }
     case FACTORY_HEAP_FRAGS:
 	bp = factory->heap_frags;

--- a/erts/emulator/beam/erl_monitor_link.c
+++ b/erts/emulator/beam/erl_monitor_link.c
@@ -894,7 +894,8 @@ erts_monitor_create(Uint16 type, Eterm ref, Eterm orgn, Eterm trgt, Eterm name, 
             mdp->u.target.type = type;
             erts_atomic32_init_nob(&mdp->refc, 2);
             break;
-        }
+        } /* end of "if (is_nil(name))"" */
+        ERTS_FALLTHROUGH();
     case ERTS_MON_TYPE_DIST_PROC:
     case ERTS_MON_TYPE_DIST_PORT:
     case ERTS_MON_TYPE_RESOURCE:

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -2707,10 +2707,10 @@ ErlNifResourceType* open_resource_type(ErlNifEnv* env,
 	ort->type = type;
         sys_memzero(&ort->new_callbacks, sizeof(ErlNifResourceTypeInit));
         switch (init_members) {
-        case 4: ort->new_callbacks.dyncall = init->dyncall;
-        case 3: ort->new_callbacks.down = init->down;
-        case 2: ort->new_callbacks.stop = init->stop;
-        case 1: ort->new_callbacks.dtor = init->dtor;
+        case 4: ort->new_callbacks.dyncall = init->dyncall; ERTS_FALLTHROUGH();
+        case 3: ort->new_callbacks.down = init->down; ERTS_FALLTHROUGH();
+        case 2: ort->new_callbacks.stop = init->stop; ERTS_FALLTHROUGH();
+        case 1: ort->new_callbacks.dtor = init->dtor; ERTS_FALLTHROUGH();
         case 0:
             break;
         default:

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -14161,6 +14161,7 @@ restart:
 
         trap_state->phase = ERTS_CONTINUE_EXIT_BLCKD_MSHED;
         if (reds <= 0) goto yield;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_BLCKD_MSHED:
 
         if (p->flags & F_HAVE_BLCKD_MSCHED) {
@@ -14181,6 +14182,7 @@ restart:
 
         trap_state->phase = ERTS_CONTINUE_EXIT_BLCKD_NMSHED;
         if (reds <= 0) goto yield;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_BLCKD_NMSHED:
 
         if (p->flags & F_HAVE_BLCKD_NMSCHED) {
@@ -14202,6 +14204,7 @@ restart:
         trap_state->yield_state = NULL;
         trap_state->phase = ERTS_CONTINUE_EXIT_USING_DB;
         if (reds <= 0) goto yield;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_USING_DB:
 
         if (p->flags & F_USING_DB) {
@@ -14211,6 +14214,7 @@ restart:
         }
 
         trap_state->phase = ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS:
 
         state = erts_atomic32_read_acqb(&p->state);
@@ -14246,6 +14250,7 @@ restart:
         }
 
         trap_state->phase = ERTS_CONTINUE_EXIT_FREE;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_FREE:
 
 #ifdef DEBUG
@@ -14320,6 +14325,7 @@ restart:
         erts_proc_unlock(p, ERTS_PROC_LOCKS_ALL_MINOR);
         curr_locks = ERTS_PROC_LOCK_MAIN;
         trap_state->phase = ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS_AFTER;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_CLEAN_SYS_TASKS_AFTER:
         /*
          * It might show up signal prio elevation tasks until we
@@ -14383,6 +14389,7 @@ restart:
         trap_state->yield_state = NULL;
         trap_state->phase = ERTS_CONTINUE_EXIT_LINKS;
         if (reds <= 0) goto yield;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_LINKS:
 
         reds = erts_link_tree_foreach_delete_yielding(
@@ -14397,6 +14404,7 @@ restart:
         ASSERT(!trap_state->links);
         trap_state->yield_state = NULL;
         trap_state->phase = ERTS_CONTINUE_EXIT_MONITORS;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_MONITORS:
 
     reds = erts_monitor_tree_foreach_delete_yielding(
@@ -14411,6 +14419,7 @@ restart:
         ASSERT(!trap_state->monitors);
         trap_state->yield_state = NULL;
         trap_state->phase = ERTS_CONTINUE_EXIT_LT_MONITORS;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_LT_MONITORS:
 
         reds = erts_monitor_list_foreach_delete_yielding(
@@ -14424,6 +14433,7 @@ restart:
 
         ASSERT(!trap_state->lt_monitors);
         trap_state->phase = ERTS_CONTINUE_EXIT_HANDLE_PROC_SIG;
+        ERTS_FALLTHROUGH();
     case ERTS_CONTINUE_EXIT_HANDLE_PROC_SIG: {
         Sint r = reds;
 
@@ -14434,6 +14444,7 @@ restart:
         reds -= r;
 
         trap_state->phase = ERTS_CONTINUE_EXIT_DIST_SEND;
+        ERTS_FALLTHROUGH();
     }
     case ERTS_CONTINUE_EXIT_DIST_SEND: {
 
@@ -14472,6 +14483,7 @@ restart:
         }
 
         trap_state->phase = ERTS_CONTINUE_EXIT_DIST_LINKS;
+        ERTS_FALLTHROUGH();
     }
     case ERTS_CONTINUE_EXIT_DIST_LINKS: {
 
@@ -14488,6 +14500,7 @@ restart:
             goto yield;
 
         trap_state->phase = ERTS_CONTINUE_EXIT_DIST_MONITORS;
+        ERTS_FALLTHROUGH();
     }
     case ERTS_CONTINUE_EXIT_DIST_MONITORS: {
 
@@ -14504,6 +14517,7 @@ restart:
             goto yield;
 
         trap_state->phase = ERTS_CONTINUE_EXIT_DIST_PEND_SPAWN_MONITORS;
+        ERTS_FALLTHROUGH();
     }
     case ERTS_CONTINUE_EXIT_DIST_PEND_SPAWN_MONITORS: {
 
@@ -14529,6 +14543,7 @@ restart:
             goto yield;
 
         trap_state->phase = ERTS_CONTINUE_EXIT_DONE;
+        ERTS_FALLTHROUGH();
     }
     case ERTS_CONTINUE_EXIT_DONE: {
         erts_aint_t state;

--- a/erts/emulator/beam/erl_term_hashing.c
+++ b/erts/emulator/beam/erl_term_hashing.c
@@ -462,17 +462,17 @@ Uint32 block_hash_final_bytes(byte *buf,
     ctx->c += full_length;
     switch(len)
     { /* all the case statements fall through */      
-    case 11: ctx->c+=((Uint32)k[10]<<24);
-    case 10: ctx->c+=((Uint32)k[9]<<16);
-    case 9 : ctx->c+=((Uint32)k[8]<<8);
+    case 11: ctx->c+=((Uint32)k[10]<<24); ERTS_FALLTHROUGH();
+    case 10: ctx->c+=((Uint32)k[9]<<16); ERTS_FALLTHROUGH();
+    case 9 : ctx->c+=((Uint32)k[8]<<8); ERTS_FALLTHROUGH();
     /* the first byte of c is reserved for the length */
-    case 8 : ctx->b+=((Uint32)k[7]<<24);
-    case 7 : ctx->b+=((Uint32)k[6]<<16);
-    case 6 : ctx->b+=((Uint32)k[5]<<8);
-    case 5 : ctx->b+=k[4];
-    case 4 : ctx->a+=((Uint32)k[3]<<24);
-    case 3 : ctx->a+=((Uint32)k[2]<<16);
-    case 2 : ctx->a+=((Uint32)k[1]<<8);
+    case 8 : ctx->b+=((Uint32)k[7]<<24); ERTS_FALLTHROUGH();
+    case 7 : ctx->b+=((Uint32)k[6]<<16); ERTS_FALLTHROUGH();
+    case 6 : ctx->b+=((Uint32)k[5]<<8); ERTS_FALLTHROUGH();
+    case 5 : ctx->b+=k[4]; ERTS_FALLTHROUGH();
+    case 4 : ctx->a+=((Uint32)k[3]<<24); ERTS_FALLTHROUGH();
+    case 3 : ctx->a+=((Uint32)k[2]<<16); ERTS_FALLTHROUGH();
+    case 2 : ctx->a+=((Uint32)k[1]<<8); ERTS_FALLTHROUGH();
     case 1 : ctx->a+=k[0];
     /* case 0: nothing left to add */
     }
@@ -1964,12 +1964,12 @@ make_internal_hash(Eterm term, erts_ihash_t salt)
                     value = 0;
                     switch(BYTE_SIZE(size) % sizeof(Uint64[2]))
                     {
-                    case 15: value ^= ((Uint64)bytes[it + 14]) << 0x30;
-                    case 14: value ^= ((Uint64)bytes[it + 13]) << 0x28;
-                    case 13: value ^= ((Uint64)bytes[it + 12]) << 0x20;
-                    case 12: value ^= ((Uint64)bytes[it + 11]) << 0x18;
-                    case 11: value ^= ((Uint64)bytes[it + 10]) << 0x10;
-                    case 10: value ^= ((Uint64)bytes[it +  9]) << 0x08;
+                    case 15: value ^= ((Uint64)bytes[it + 14]) << 0x30; ERTS_FALLTHROUGH();
+                    case 14: value ^= ((Uint64)bytes[it + 13]) << 0x28; ERTS_FALLTHROUGH();
+                    case 13: value ^= ((Uint64)bytes[it + 12]) << 0x20; ERTS_FALLTHROUGH();
+                    case 12: value ^= ((Uint64)bytes[it + 11]) << 0x18; ERTS_FALLTHROUGH();
+                    case 11: value ^= ((Uint64)bytes[it + 10]) << 0x10; ERTS_FALLTHROUGH();
+                    case 10: value ^= ((Uint64)bytes[it +  9]) << 0x08; ERTS_FALLTHROUGH();
                     case  9: value ^= ((Uint64)bytes[it +  8]) << 0x00;
                         {
                             value *= IHASH_C2;
@@ -1977,15 +1977,15 @@ make_internal_hash(Eterm term, erts_ihash_t salt)
                             value *= IHASH_C1;
                             hash_beta ^= value;
                             value = 0;
-                            /* !! FALL THROUGH !! */
+                            ERTS_FALLTHROUGH();
                         }
-                    case  8: value ^= ((Uint64)bytes[it + 7]) << 0x38;
-                    case  7: value ^= ((Uint64)bytes[it + 6]) << 0x30;
-                    case  6: value ^= ((Uint64)bytes[it + 5]) << 0x28;
-                    case  5: value ^= ((Uint64)bytes[it + 4]) << 0x20;
-                    case  4: value ^= ((Uint64)bytes[it + 3]) << 0x18;
-                    case  3: value ^= ((Uint64)bytes[it + 2]) << 0x10;
-                    case  2: value ^= ((Uint64)bytes[it + 1]) << 0x08;
+                    case  8: value ^= ((Uint64)bytes[it + 7]) << 0x38; ERTS_FALLTHROUGH();
+                    case  7: value ^= ((Uint64)bytes[it + 6]) << 0x30; ERTS_FALLTHROUGH();
+                    case  6: value ^= ((Uint64)bytes[it + 5]) << 0x28; ERTS_FALLTHROUGH();
+                    case  5: value ^= ((Uint64)bytes[it + 4]) << 0x20; ERTS_FALLTHROUGH();
+                    case  4: value ^= ((Uint64)bytes[it + 3]) << 0x18; ERTS_FALLTHROUGH();
+                    case  3: value ^= ((Uint64)bytes[it + 2]) << 0x10; ERTS_FALLTHROUGH();
+                    case  2: value ^= ((Uint64)bytes[it + 1]) << 0x08; ERTS_FALLTHROUGH();
                     case  1: value ^= ((Uint64)bytes[it + 0]) << 0x00;
                         {
                             value *= IHASH_C1;

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -1226,7 +1226,7 @@ erts_call_trace(Process* p, ErtsCodeInfo *info, Binary *match_spec,
                                     &tnif, TRACE_FUN_ENABLED,
                                     am_trace_status, p->common.id)) {
         default:
-        case am_remove: *tracer_p = erts_tracer_nil;
+        case am_remove: *tracer_p = erts_tracer_nil; ERTS_FALLTHROUGH();
         case am_discard: return 0;
         case am_trace:
             switch (call_enabled_tracer(tracer,

--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -2164,6 +2164,7 @@ Eterm erts_convert_native_to_filename(Process *p, size_t size, byte *bytes)
 	goto noconvert;
     case ERL_FILENAME_UTF8_MAC:
 	mac = 1;
+        ERTS_FALLTHROUGH();
     case ERL_FILENAME_UTF8:
 	if (size == 0)
 	    return NIL;
@@ -2334,6 +2335,7 @@ L_Again:   /* Restart with sublist, old listend was pushed on stack */
 				need += 2;
 				break;
 			    } /* else fall through to error */
+                            ERTS_FALLTHROUGH();
 			default:
 			    DESTROY_ESTACK(stack);
 			    return ((Sint) -1);

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -633,10 +633,13 @@ Sint erts_encode_ext_dist_header_finalize(ErtsDistOutputBuf* ob,
 		switch (flgs_bytes) {
 		case 4:
 		    *--ep = (byte) ((flgs >> 24) & 0xff);
+                    ERTS_FALLTHROUGH();
 		case 3:
 		    *--ep = (byte) ((flgs >> 16) & 0xff);
+                    ERTS_FALLTHROUGH();
 		case 2:
 		    *--ep = (byte) ((flgs >> 8) & 0xff);
+                    ERTS_FALLTHROUGH();
 		case 1:
 		    *--ep = (byte) (flgs & 0xff);
 		}
@@ -1044,9 +1047,11 @@ erts_prepare_dist_ext(ErtsDistExternal *edep,
 			case 6:
 			case 5:
 			    flgs |= (((Uint32) flgsp[2]) << 16);
+                            ERTS_FALLTHROUGH();
 			case 4:
 			case 3:
 			    flgs |= (((Uint32) flgsp[1]) << 8);
+                            ERTS_FALLTHROUGH();
 			case 2:
 			case 1:
 			    flgs |= ((Uint32) flgsp[0]);
@@ -3089,11 +3094,11 @@ dec_atom(ErtsDistExternal *edep, const byte* ep, Eterm* objp, int internal_nc)
 	*objp = make_atom(n);
 	break;
     case NIL_EXT:
-        if (internal_nc) {
-            *objp = INTERNAL_LOCAL_SYSNAME;
-            break;
+        if (!internal_nc) {
+            goto error;
         }
-        /* else: fail... */
+        *objp = INTERNAL_LOCAL_SYSNAME;
+        break;
     default:
     error:
 	*objp = NIL;	/* Don't leave a hole in the heap */

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -5431,10 +5431,13 @@ erts_stale_drv_select(Eterm port,
     switch (mode) {
     case ERL_DRV_READ | ERL_DRV_WRITE:
 	type = "Input/Output";
+        break;
     case ERL_DRV_WRITE:
 	type = "Output";
+        break;
     case ERL_DRV_READ:
 	type = "Input";
+        break;
     default:
         type = "";
     }

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -3198,6 +3198,7 @@ static int flush_linebuf(LineBufContext *bp)
 	    resize_linebuf(bp->b);
 	LINEBUF_DATA(*bp)[((*bp->b)->ovlen)++] = '\r';
 	++bp->retlen; /* fall through instead of switching state... */
+        ERTS_FALLTHROUGH();
     case LINEBUF_MAIN:
     case LINEBUF_FULL:
 	(*bp->b)->ovlen = 0;

--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -388,6 +388,7 @@ int packet_get_length(enum PacketParseType htype,
     case TCP_PB_HTTPH:
     case TCP_PB_HTTPH_BIN:
         *statep = !0;
+        ERTS_FALLTHROUGH();
     case TCP_PB_HTTP:
     case TCP_PB_HTTP_BIN:
         /* TCP_PB_HTTP:  data \r\n(SP data\r\n)*  */

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -309,6 +309,16 @@ __decl_noreturn void __noreturn erl_assert_error(const char* expr, const char *f
     } while (0)
 #endif
 
+/* Taken from https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#warn-about-implicit-fallthrough-in-switch-statements */
+#ifdef __has_attribute
+#  if __has_attribute(__fallthrough__)
+#    define ERTS_FALLTHROUGH()                    __attribute__((__fallthrough__))
+#  endif
+#endif
+#ifndef ERTS_FALLTHROUGH
+# define ERTS_FALLTHROUGH()                    do {} while (0)  /* fallthrough */
+#endif
+
 /* C99: bool, true and false */
 #include <stdbool.h>
 

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -1450,6 +1450,7 @@ tailrecur_ne:
                         if (aa[0] != bb[0])
                             goto not_equal;
 			aa++; bb++;
+                        ERTS_FALLTHROUGH();
 		    case HAMT_SUBTAG_NODE_BITMAP:
 			sz = hashmap_bitcount(MAP_HEADER_VAL(hdr));
 			ASSERT(sz > 0 && sz < 17);
@@ -1803,7 +1804,8 @@ tailrecur_ne:
 		goto mixed_types;
 	    }
 	}
-	}
+    }
+    ERTS_ASSERT(0 && "unreachable");
     case TAG_PRIMARY_LIST:
 	if (is_not_list(b)) {
 	    a_tag = LIST_DEF;

--- a/erts/emulator/pcre/pcre.mk
+++ b/erts/emulator/pcre/pcre.mk
@@ -49,7 +49,7 @@ PCRE_OBJDIR = $(ERL_TOP)/erts/emulator/pcre/obj/$(TARGET)/$(TYPE)
 
 PCRE_DIR =  $(ERL_TOP)/erts/emulator/pcre
 
-PCRE_CFLAGS = $(filter-out -DDEBUG,$(CFLAGS)) -DERLANG_INTEGRATION
+PCRE_CFLAGS = $(filter-out -DDEBUG -Wimplicit-fallthrough,$(CFLAGS)) -DERLANG_INTEGRATION
 
 ifeq ($(TARGET), win32)
 $(EPCRE_LIB): $(PCRE_OBJS)

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -589,8 +589,8 @@ abort_tasks(ErtsDrvEventState *state, int mode)
 	    return;
 	default:
 	    ASSERT(state->type == ERTS_EV_TYPE_DRV_SEL);
-	    /* Fall through */
 	}
+        ERTS_FALLTHROUGH();
     case ERL_DRV_READ|ERL_DRV_WRITE:
     case ERL_DRV_WRITE:
 	ASSERT(state->type == ERTS_EV_TYPE_DRV_SEL);
@@ -599,6 +599,7 @@ abort_tasks(ErtsDrvEventState *state, int mode)
 		   state->type);
 	if (mode == ERL_DRV_WRITE)
 	    break;
+        ERTS_FALLTHROUGH();
     case ERL_DRV_READ:
 	ASSERT(state->type == ERTS_EV_TYPE_DRV_SEL);
 	abort_task(state->driver.select->inport,

--- a/erts/epmd/src/epmd.c
+++ b/erts/epmd/src/epmd.c
@@ -523,7 +523,9 @@ static void free_all_nodes(EpmdVars *g)
 	free(tmp);
     }
 }
-void epmd_cleanup_exit(EpmdVars *g, int exitval)
+
+__decl_noreturn void __noreturn
+epmd_cleanup_exit(EpmdVars *g, int exitval)
 {
   int i;
 

--- a/erts/epmd/src/epmd_int.h
+++ b/erts/epmd/src/epmd_int.h
@@ -97,6 +97,21 @@
 #define ASSERT(Cnd)
 #endif
 
+#if __GNUC__
+#  define __decl_noreturn
+#  ifndef __noreturn
+#     define __noreturn __attribute__((noreturn))
+#  endif
+#else
+#  if defined(__WIN32__) && defined(_MSC_VER)
+#    define __noreturn
+#    define __decl_noreturn __declspec(noreturn)
+#  else
+#    define __noreturn
+#    define __decl_noreturn
+#  endif
+#endif
+
 #if defined(HAVE_IN6) && defined(AF_INET6) && defined(HAVE_INET_PTON)
 #  define EPMD6
 #endif
@@ -343,7 +358,7 @@ void dbg_perror(EpmdVars*,const char*,...);
 void kill_epmd(EpmdVars*);
 void epmd_call(EpmdVars*,int);
 void run(EpmdVars*);
-void epmd_cleanup_exit(EpmdVars*, int);
+__decl_noreturn void __noreturn epmd_cleanup_exit(EpmdVars*, int);
 int epmd_conn_close(EpmdVars*,Connection*);
 void stop_cli(EpmdVars *g, char *name);
 

--- a/erts/include/internal/ethread.h
+++ b/erts/include/internal/ethread.h
@@ -105,6 +105,15 @@ ethr_assert_failed(const char *file, int line, const char *func, const char *a);
 #define ETHR_ASSERT(A) ((void) 1)
 #endif
 
+/* Taken from https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#warn-about-implicit-fallthrough-in-switch-statements */
+#ifdef __has_attribute
+#  if __has_attribute(__fallthrough__)
+#    define ETHR_FALLTHROUGH()                    __attribute__((__fallthrough__))
+#  endif
+#endif
+#ifndef ETHR_FALLTHROUGH
+# define ETHR_FALLTHROUGH()                    do {} while (0)  /* fallthrough */
+#endif
 
 #if defined(ETHR_PTHREADS)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\

--- a/erts/lib_src/common/erl_printf_format.c
+++ b/erts/lib_src/common/erl_printf_format.c
@@ -426,7 +426,14 @@ static int fmt_double(fmtfn_t fn,void*arg,double val,
 	}
     }
 
+#ifdef HAVE_GCC_DIAG_IGNORE_WFORMAT_NONLITERAL
+_Pragma("GCC diagnostic push");
+_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"");
+#endif
     size = sprintf(bufp, format_str, precision, val);
+#ifdef HAVE_GCC_DIAG_IGNORE_WFORMAT_NONLITERAL
+_Pragma("GCC diagnostic pop");
+#endif
     if (size < 0) {
 	if (errno > 0)
 	    res = -errno;

--- a/erts/lib_src/common/erl_printf_format.c
+++ b/erts/lib_src/common/erl_printf_format.c
@@ -575,6 +575,7 @@ int erts_printf_format(fmtfn_t fn, void* arg, char* fmt, va_list ap)
 #else
 #error No 16-bit integer datatype found
 #endif
+                        break;
 		    case 8:
 #if SIZEOF_CHAR == 1
 			fmt |= FMTL_hh;

--- a/erts/lib_src/common/erl_printf_format.c
+++ b/erts/lib_src/common/erl_printf_format.c
@@ -45,6 +45,17 @@
 #include "erl_printf.h"
 #include "erl_printf_format.h"
 
+
+/* Taken from https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#warn-about-implicit-fallthrough-in-switch-statements */
+#ifdef __has_attribute
+#  if __has_attribute(__fallthrough__)
+#   define FALLTHROUGH()                    __attribute__((__fallthrough__))
+#  endif
+#endif
+#ifndef FALLTHROUGH
+# define FALLTHROUGH()                    do {} while (0)  /* fallthrough */
+#endif
+
 #ifdef DEBUG
 #include <assert.h>
 #define ASSERT(X) assert(X)
@@ -234,6 +245,7 @@ static int fmt_uword(fmtfn_t fn,void* arg,int sign,ErlPfUWord uval,
 	break;
     case FMTC_X:
 	dc = heX;
+        FALLTHROUGH();
     case FMTC_x:
 	base = 16;
 	break;
@@ -286,6 +298,7 @@ static int fmt_long_long(fmtfn_t fn,void* arg,int sign,
 	break;
     case FMTC_X:
 	dc = heX;
+        FALLTHROUGH();
     case FMTC_x:
 	base = 16;
 	break;

--- a/erts/lib_src/common/ethr_mutex.c
+++ b/erts/lib_src/common/ethr_mutex.c
@@ -2657,6 +2657,7 @@ ethr_rwmutex_init_opt(ethr_rwmutex *rwmtx, ethr_rwmutex_opt *opt)
 	    rwmtx->type = ETHR_RWMUTEX_TYPE_EXTREMELY_FREQUENT_READ;
 	}
 	/* Fall through */
+        ETHR_FALLTHROUGH();
     case ETHR_RWMUTEX_TYPE_EXTREMELY_FREQUENT_READ: {
 	int length;
 
@@ -2688,6 +2689,7 @@ ethr_rwmutex_init_opt(ethr_rwmutex *rwmtx, ethr_rwmutex_opt *opt)
 	    break;
 	}
     }
+        ETHR_FALLTHROUGH();
     case ETHR_RWMUTEX_TYPE_NORMAL:
 	rwmtx->tdata.rs = 0;
 	break;

--- a/lib/common_test/configure
+++ b/lib/common_test/configure
@@ -1921,6 +1921,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
+
+
+
   # Make sure we can run config.sub.
 $SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
   as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
@@ -2123,6 +2134,11 @@ fi
 
 TARGET=$host
 
+
+
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
+fi
 
 ac_config_files="$ac_config_files priv/$host/Makefile:priv/Makefile.in"
 

--- a/lib/common_test/configure.ac
+++ b/lib/common_test/configure.ac
@@ -5,10 +5,14 @@ m4_include([otp.m4])
 
 AC_CONFIG_AUX_DIR([${ERL_TOP}/make/autoconf])
 
+ERL_PUSH_WERROR
+
 ERL_CANONICAL_SYSTEM_TYPE
 
 TARGET=$host
 AC_SUBST(TARGET)
+
+ERL_POP_WERROR
 
 AC_CONFIG_FILES([priv/$host/Makefile:priv/Makefile.in])
 AC_OUTPUT

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -3040,6 +3040,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
+
+
+
   # Make sure we can run config.sub.
 $SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
   as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
@@ -8045,6 +8056,13 @@ fi
 CFLAGS="$saveCFLAGS"
 LDFLAGS="$saveLDFLAGS"
 LIBS="$saveLIBS"
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
 
 
 

--- a/lib/crypto/configure.ac
+++ b/lib/crypto/configure.ac
@@ -30,6 +30,8 @@ m4_include([otp.m4])
 
 AC_CONFIG_AUX_DIR([${ERL_TOP}/make/autoconf])
 
+ERL_PUSH_WERROR
+
 ERL_CANONICAL_SYSTEM_TYPE
 
 AC_LANG(C)
@@ -921,6 +923,8 @@ AS_IF([test $have_crypto_memcmp_decl = yes],
 CFLAGS="$saveCFLAGS"
 LDFLAGS="$saveLDFLAGS"
 LIBS="$saveLIBS"
+
+ERL_PUSH_WERROR
 
 AC_SUBST(SSL_INCLUDE)
 AC_SUBST(SSL_INCDIR)

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -2899,6 +2899,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
 #### Make srcdir absolute, if it isn't already.  It's important to
 #### avoid running the path through pwd unnecessary, since pwd can
 #### give you automounter prefixes, which can go away.
@@ -9944,7 +9955,7 @@ esac
 # ---------------------------------------------------------------------------
 
 
-WFLAGS="$DED_WERRORFLAGS $DED_WARN_FLAGS"
+WFLAGS="$WERRORFLAGS $DED_WERRORFLAGS $DED_WARN_FLAGS"
 if test "x$GCC" = xyes
 then :
   WFLAGS="$WFLAGS -Wmissing-declarations -Wnested-externs -Winline"
@@ -10036,6 +10047,11 @@ printf "%s\n" "no" >&6; }
 esac
 fi
 
+
+
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
+fi
 
 # ---------------------------------------------------------------------------
 # XXX

--- a/lib/erl_interface/configure.ac
+++ b/lib/erl_interface/configure.ac
@@ -31,6 +31,8 @@ AC_PREREQ([2.72])
 
 m4_include([otp.m4])
 
+ERL_PUSH_WERROR
+
 dnl How to set srcdir absolute is taken from the GNU Emacs distribution
 #### Make srcdir absolute, if it isn't already.  It's important to
 #### avoid running the path through pwd unnecessary, since pwd can
@@ -325,7 +327,7 @@ AS_CASE(["$threads_disabled"],
 # ---------------------------------------------------------------------------
 AC_SUBST(WFLAGS)
 
-WFLAGS="$DED_WERRORFLAGS $DED_WARN_FLAGS"
+WFLAGS="$WERRORFLAGS $DED_WERRORFLAGS $DED_WARN_FLAGS"
 AS_IF([test "x$GCC" = xyes],
       [WFLAGS="$WFLAGS -Wmissing-declarations -Wnested-externs -Winline"])
 
@@ -337,6 +339,8 @@ AS_IF([test "x$GCC" = xyes],
 LM_TRY_ENABLE_CFLAG([-fno-common], [CFLAGS])
 # No strict aliasing until we determined it is safe...
 LM_TRY_ENABLE_CFLAG([-fno-strict-aliasing], [CFLAGS])
+
+ERL_POP_WERROR
 
 # ---------------------------------------------------------------------------
 # XXX

--- a/lib/erl_interface/src/misc/ei_format.c
+++ b/lib/erl_interface/src/misc/ei_format.c
@@ -116,6 +116,7 @@ static int eiformat(const char** fmt, union arg** args, ei_x_buff* x)
 	    ei_x_free(&x2);
 	    break;
 	}
+        EI_FALLTHROUGH();
     default:
 	if (isdigit((int)*p))
 	    res = pdigit(&p, x);

--- a/lib/erl_interface/src/misc/eidef.h
+++ b/lib/erl_interface/src/misc/eidef.h
@@ -58,6 +58,16 @@ typedef int socklen_t;
 #  define HAVE_ISFINITE
 #endif
 
+/* Taken from https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#warn-about-implicit-fallthrough-in-switch-statements */
+#ifdef __has_attribute
+#  if __has_attribute(__fallthrough__)
+#    define EI_FALLTHROUGH()                    __attribute__((__fallthrough__))
+#  endif
+#endif
+#ifndef EI_FALLTHROUGH
+# define EI_FALLTHROUGH()                    do {} while (0)  /* fallthrough */
+#endif
+
 typedef unsigned char  uint8;	/* FIXME use configure */
 typedef unsigned short uint16;
 typedef unsigned int   uint32;

--- a/lib/erl_interface/src/misc/get_type.c
+++ b/lib/erl_interface/src/misc/get_type.c
@@ -38,12 +38,14 @@ int ei_get_type(const char *buf, const int *index, int *type, int *len)
   case ERL_SMALL_ATOM_EXT:
   case ERL_SMALL_ATOM_UTF8_EXT:
     *type = ERL_ATOM_EXT;
+     EI_FALLTHROUGH();
   case ERL_SMALL_TUPLE_EXT:
     *len = get8(s);
     break;
 
   case ERL_ATOM_UTF8_EXT:
     *type = ERL_ATOM_EXT;
+    EI_FALLTHROUGH();
   case ERL_ATOM_EXT:
   case ERL_STRING_EXT:
     *len = get16be(s);

--- a/lib/erl_interface/src/misc/show_msg.c
+++ b/lib/erl_interface/src/misc/show_msg.c
@@ -157,6 +157,7 @@ int ei_show_sendmsg(FILE *stream, const char *header, const char *msgbuf)
 	if (ei_decode_pid(header,&index,&msg.from) 
 	    || ei_decode_pid(header,&index,&msg.to)) return -1;
 	mbuf = header+index;
+        break;
 
     case ERL_EXIT_TT:
     case ERL_EXIT2_TT:

--- a/lib/erl_interface/src/prog/erl_call.c
+++ b/lib/erl_interface/src/prog/erl_call.c
@@ -78,6 +78,27 @@
 #include <fcntl.h>
 #include <signal.h>
 
+/* In VC++, noreturn is a declspec that has to be before the types,
+ * but in GNUC it is an attribute to be placed between return type
+ * and function name, hence __decl_noreturn <types> __noreturn <function name>
+ *
+ * at some platforms (e.g. Android) __noreturn is defined at sys/cdef.h
+ */
+#if __GNUC__
+#  define __decl_noreturn
+#  ifndef __noreturn
+#     define __noreturn __attribute__((noreturn))
+#  endif
+#else
+#  if defined(__WIN32__) && defined(_MSC_VER)
+#    define __noreturn
+#    define __decl_noreturn __declspec(noreturn)
+#  else
+#    define __noreturn
+#    define __decl_noreturn
+#  endif
+#endif
+
 #include "ei.h"
 #include "ei_resolve.h"
 
@@ -125,9 +146,9 @@ struct call_flags {
 /* start an erlang system */
 int erl_start_sys(ei_cnode *ec, char *alive, Erl_IpAddr addr, int flags,
 		  char *erl, char *add_args[]);
-static void usage_arg(const char *progname, const char *switchname);
-static void usage_error(const char *progname, const char *switchname);
-static void usage(const char *progname);
+__decl_noreturn static void __noreturn usage_arg(const char *progname, const char *switchname);
+__decl_noreturn static void __noreturn usage_error(const char *progname, const char *switchname);
+__decl_noreturn static void __noreturn usage(const char *progname);
 static int get_module(char **mbuf, char **mname);
 static int do_connect(ei_cnode *ec, char *nodename, struct call_flags *flags);
 static int read_stdin(char **buf);
@@ -140,7 +161,9 @@ static char* ei_chk_strdup(char *s);
 static int rpc_print_node_stdout(ei_cnode* ec, int fd, char *mod,
                                  char *fun, const char* inbuf,
                                  int inbuflen, ei_x_buff* x);
-static void exit_free_flags_fields(int exit_status, struct call_flags* flags);
+__decl_noreturn static void __noreturn exit_free_flags_fields(
+                int exit_status,
+                struct call_flags* flags);
 
 /* Converts the given hostname to a shortname, if required. */
 static void format_node_hostname(const struct call_flags *flags,
@@ -1032,19 +1055,19 @@ static void usage_noexit(const char *progname) {
   fprintf(stderr,"         -x  use specified erl start script, default is erl\n");
 }
 
-static void usage_arg(const char *progname, const char *switchname) {
+__decl_noreturn static void __noreturn usage_arg(const char *progname, const char *switchname) {
   fprintf(stderr, "Missing argument(s) for \'%s\'.\n", switchname);
   usage_noexit(progname);
   exit(1);
 }
 
-static void usage_error(const char *progname, const char *switchname) {
+__decl_noreturn static void __noreturn usage_error(const char *progname, const char *switchname) {
   fprintf(stderr, "Illegal argument \'%s\'.\n", switchname);
   usage_noexit(progname);
   exit(1);
 }
 
-static void usage(const char *progname) {
+void __noreturn usage(const char *progname) {
   usage_noexit(progname);
   exit(0);
 }
@@ -1181,7 +1204,8 @@ ebadmsg:
 }
 
 
-void exit_free_flags_fields(int exit_status, struct call_flags* flags) {
+__decl_noreturn static void __noreturn
+exit_free_flags_fields(int exit_status, struct call_flags* flags) {
     if (flags->script != NULL) {
         free(flags->script);
     }

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -2784,6 +2784,10 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+
+
   # Make sure we can run config.sub.
 $SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
   as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
@@ -2983,6 +2987,13 @@ then :
           " "$LINENO" 5
 fi
 
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
 
 
 
@@ -5969,6 +5980,11 @@ fi
 
 if test "$PERL" = no_perl; then
   as_fn_error $? "Perl is required to build the flex scanner!" "$LINENO" 5
+fi
+
+
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
 fi
 
 ac_config_files="$ac_config_files examples/meas/Makefile:examples/meas/Makefile.in"

--- a/lib/megaco/configure.ac
+++ b/lib/megaco/configure.ac
@@ -33,6 +33,8 @@ AC_CONFIG_AUX_DIR([${ERL_TOP}/make/autoconf])
 
 ERL_CANONICAL_SYSTEM_TYPE
 
+ERL_PUSH_WERROR
+
 dnl ----------------------------------------------------------------------
 dnl Checks for programs.
 dnl ----------------------------------------------------------------------
@@ -168,6 +170,8 @@ AC_CHECK_PROG(PERL, perl, perl, no_perl)
 if test "$PERL" = no_perl; then
   AC_MSG_ERROR([Perl is required to build the flex scanner!])
 fi
+
+ERL_POP_WERROR
 
 AC_CONFIG_FILES([examples/meas/Makefile:examples/meas/Makefile.in])
 AC_OUTPUT

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -645,8 +645,15 @@ static db_result_msg db_query(byte *sql, db_state *state)
 	    diagnos =  get_diagnos(SQL_HANDLE_STMT, statement_handle(state), extended_errors(state));
 	    if(strcmp((char *)diagnos.sqlState, INFO) == 0) { 
 		    is_error[0] = 0;
-		    strncat((char *)is_error, (char *)diagnos.error_msg, 
-			    5);
+#ifdef HAVE_GCC_DIAG_IGNORE_WSTRINGOP_TRUNCATION
+_Pragma("GCC diagnostic push");
+_Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"");
+#endif
+		    strncat((char *)is_error, (char *)diagnos.error_msg,
+                            5);
+#ifdef HAVE_GCC_DIAG_IGNORE_WSTRINGOP_TRUNCATION
+_Pragma("GCC diagnostic pop");
+#endif
 		    str_tolower((char *)&is_error, 5);
 		    /* The ODBC error handling could have been more
 		       predictable but alas ... we try to make the best of

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -2882,6 +2882,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
+
+
+
   # Make sure we can run config.sub.
 $SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
   as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
@@ -6069,6 +6080,11 @@ esac
 fi
 
 
+fi
+
+
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
 fi
 
 ac_config_files="$ac_config_files c_src/$host/Makefile:c_src/Makefile.in"

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -6035,6 +6035,31 @@ fi
   ;;
 esac
 fi
+saved_CFLAGS="$CFLAGS"
+CFLAGS="-Werror $CFLAGS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+_Pragma("GCC diagnostic push")
+         _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
+         _Pragma("GCC diagnostic pop")
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+
+printf "%s\n" "#define HAVE_GCC_DIAG_IGNORE_WSTRINGOP_TRUNCATION 1" >>confdefs.h
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+CFLAGS="$saved_CFLAGS"
+
 if test "x$GCC" = xyes
 then :
 

--- a/lib/odbc/configure.ac
+++ b/lib/odbc/configure.ac
@@ -252,6 +252,18 @@ AC_SUBST(ODBC_INCLUDE)
 
  ]) dnl "$with_odbc" != "no"
 
+dnl ----------------------------------------------------------------------
+dnl Check for GCC diagnostic ignored "-Wstringop-truncation"
+dnl ----------------------------------------------------------------------
+saved_CFLAGS="$CFLAGS"
+CFLAGS="-Werror $CFLAGS"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[_Pragma("GCC diagnostic push")
+         _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
+         _Pragma("GCC diagnostic pop")
+         ]])],[AC_DEFINE(HAVE_GCC_DIAG_IGNORE_WSTRINGOP_TRUNCATION,1,
+           define if compiler support _Pragma('GCC diagnostic ignored '-Wstringop-truncation''))],[])
+CFLAGS="$saved_CFLAGS"
+
 AS_IF([test "x$GCC" = xyes],
   [
     # Treat certain GCC warnings as errors

--- a/lib/odbc/configure.ac
+++ b/lib/odbc/configure.ac
@@ -31,6 +31,8 @@ m4_include([otp.m4])
 
 AC_CONFIG_AUX_DIR([${ERL_TOP}/make/autoconf])
 
+ERL_PUSH_WERROR
+
 ERL_CANONICAL_SYSTEM_TYPE
 
 AC_ARG_WITH(odbc,
@@ -255,6 +257,8 @@ AS_IF([test "x$GCC" = xyes],
     # Treat certain GCC warnings as errors
     LM_TRY_ENABLE_CFLAG([-Werror=return-type], [CFLAGS])
   ])
+
+ERL_POP_WERROR
 
 AC_CONFIG_FILES([c_src/$host/Makefile:c_src/Makefile.in])
 AC_OUTPUT

--- a/lib/os_mon/c_src/memsup.c
+++ b/lib/os_mon/c_src/memsup.c
@@ -288,7 +288,6 @@ get_mem_procfs(memory_ext *me){
     int fd, nread;
     char buffer[4097];
     char *bp;
-    unsigned long value;
     
     me->flag = 0;
     
@@ -494,7 +493,7 @@ get_extended_mem(memory_ext *me) {
 static void 
 get_basic_mem(unsigned long *tot, unsigned long *used, unsigned long *pagesize){
 #if defined(_SC_AVPHYS_PAGES)	/* Does this exist on others than Solaris2? */
-    unsigned long avPhys, phys, pgSz;
+    unsigned long avPhys, phys;
     
     phys = sysconf(_SC_PHYS_PAGES);
     avPhys = sysconf(_SC_AVPHYS_PAGES);

--- a/lib/runtime_tools/c_src/trace_file_drv.c
+++ b/lib/runtime_tools/c_src/trace_file_drv.c
@@ -377,17 +377,15 @@ static void trace_file_outputv(ErlDrvData handle, ErlIOVec *ev)
 static void trace_file_output(ErlDrvData handle, char *buff,
 			      ErlDrvSizeT bufflen)
 {
-    int heavy = 0;
     TraceFileData *data = (TraceFileData *) handle;
     unsigned char b[5] = "";
     put_be((unsigned) bufflen, b + 1);
     switch (my_write(data, (unsigned char *) b, sizeof(b))) {
     case 1:
-	heavy = !0;
     case 0:
 	switch (my_write(data, (unsigned char *) buff, bufflen)) {
 	case 1:
-	    heavy = !0;
+            break;
 	case 0:
 	    break;
 	case -1:
@@ -408,11 +406,7 @@ static void trace_file_output(ErlDrvData handle, char *buff,
 		driver_failure_posix(data->port, errno); /* XXX */
 		return;
 	    }
-	    heavy = !0;
 	}
-    }
-    if (heavy) {
-	set_port_control_flags(data->port, PORT_CONTROL_FLAG_HEAVY);
     }
 }
 
@@ -577,7 +571,6 @@ static int my_write(TraceFileData *data, unsigned char *buff, int siz)
     } 
     memcpy(data->buff, buff + wrote, siz - wrote);
     data->buff_pos = siz - wrote;
-    set_port_control_flags(data->port, PORT_CONTROL_FLAG_HEAVY);
     return 1;
 }
 

--- a/lib/snmp/configure
+++ b/lib/snmp/configure
@@ -1917,6 +1917,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
+
+
+
+
   # Make sure we can run config.sub.
 $SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
   as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
@@ -2189,6 +2200,11 @@ printf "%s\n" "$as_me: Default (snmp) empty pdu size set to $with_snmp_empty_pdu
 fi
 
 
+
+
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
+fi
 
 
 ac_config_files="$ac_config_files mibs/Makefile:mibs/Makefile.in"

--- a/lib/snmp/configure.ac
+++ b/lib/snmp/configure.ac
@@ -31,6 +31,8 @@ m4_include([otp.m4])
 
 AC_CONFIG_AUX_DIRS([${ERL_TOP}/make/autoconf])
 
+ERL_PUSH_WERROR
+
 dnl ----------------------------------------------------------------------
 dnl Checks for programs.
 dnl ----------------------------------------------------------------------
@@ -63,6 +65,8 @@ fi
 
 
 dnl ----------------------------------------------------------------------
+
+ERL_POP_WERROR
 
 AC_SUBST(SNMP_EMPTY_PDU_SIZE_DEFAULT)
 AC_CONFIG_FILES([mibs/Makefile:mibs/Makefile.in])

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -3094,6 +3094,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
 ## Delete previous failed configure results
 if test -f ./CONF_INFO; then
    rm ./CONF_INFO
@@ -7332,6 +7343,11 @@ mkdir -p $WXERL_SYS_TYPE
 CONFIG_STATUS=$WXERL_SYS_TYPE/config.status
 
 
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
+fi
+
+
 ac_config_files="$ac_config_files config.mk c_src/Makefile"
 
 
@@ -8492,7 +8508,4 @@ CORES=`ls core* 2>/dev/null`
 if test X"$CORES" != X"" ; then
    echo "Configure dumped core files" > ignore_core_files
 fi
-
-
-
 

--- a/lib/wx/configure.ac
+++ b/lib/wx/configure.ac
@@ -26,6 +26,8 @@ AC_CONFIG_AUX_DIR([${ERL_TOP}/make/autoconf])
 
 AC_PREREQ([2.71])
 
+ERL_PUSH_WERROR
+
 ## Delete previous failed configure results
 if test -f ./CONF_INFO; then
    rm ./CONF_INFO
@@ -749,6 +751,8 @@ AC_SUBST(WXERL_SYS_TYPE)
 mkdir -p $WXERL_SYS_TYPE
 CONFIG_STATUS=$WXERL_SYS_TYPE/config.status
 
+ERL_POP_WERROR
+
 dnl
 
 AC_CONFIG_FILES([ 
@@ -762,6 +766,3 @@ CORES=`ls core* 2>/dev/null`
 if test X"$CORES" != X"" ; then
    echo "Configure dumped core files" > ignore_core_files
 fi
-
-
-

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -30,6 +30,23 @@ dnl macros specific dnl to the Erlang system are prefixed ERL_ (this is
 dnl not always consistently made...).
 dnl
 
+dnl We check if -Werror was given on command line and if so
+dnl we disable it for the configure and only use it when
+dnl actually building erts
+AC_DEFUN([ERL_PUSH_WERROR],
+[
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi])
+
+AC_DEFUN([ERL_POP_WERROR],
+[
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
+fi])
+
 AC_DEFUN([ERL_CANONICAL_SYSTEM_TYPE],
 [
     AC_CANONICAL_HOST

--- a/make/configure
+++ b/make/configure
@@ -3307,6 +3307,17 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
+
+
+
+no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
+if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
+   CFLAGS="$no_werror_CFLAGS"
+   WERRORFLAGS=-Werror
+fi
+
 default_cache_file=./config.cache
 
 if test "x$no_recursion" != "xyes" -a "x$OVERRIDE_CONFIG_CACHE" = "x"; then
@@ -7277,6 +7288,11 @@ fi
 
 
 
+
+
+if test "x$GCC" = xyes; then
+    CFLAGS="$WERRORFLAGS $CFLAGS"
+fi
 
 ac_config_files="$ac_config_files ../Makefile output.mk ../make/$host/otp_ded.mk:../make/otp_ded.mk.in"
 

--- a/make/configure.ac
+++ b/make/configure.ac
@@ -26,6 +26,8 @@ m4_include([otp.m4])
 
 LM_PRECIOUS_VARS
 
+ERL_PUSH_WERROR
+
 default_cache_file=./config.cache
 
 if test "x$no_recursion" != "xyes" -a "x$OVERRIDE_CONFIG_CACHE" = "x"; then
@@ -371,6 +373,8 @@ if test X${enable_m32_build} = Xyes; then
 fi
 
 ERL_DED
+
+ERL_POP_WERROR
 
 AC_CONFIG_FILES([../Makefile output.mk ../make/$host/otp_ded.mk:../make/otp_ded.mk.in])
 


### PR DESCRIPTION
This PR enabled the [OpenSSF compiler hardening options](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#warn-about-implicit-fallthrough-in-switch-statements) on github actions and fixes a bunch of warnings found when enabling it.