### PR TITLE
compiler: Use strict generators in comprehensions

### DIFF
--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -214,7 +214,7 @@ build_file(Code, Attr, Dict, NumLabels, NumFuncs, ExtraChunks0, CompileInfo, Com
 
     %% Compile all extra chunks.
 
-    CheckedChunks = [chunk(Key, Value) || {Key, Value} <- ExtraChunks],
+    CheckedChunks = [chunk(Key, Value) || {Key, Value} <:- ExtraChunks],
 
     %% Create IFF chunk.
 
@@ -291,7 +291,7 @@ build_atom_table(Options, Dict) ->
     case member(no_long_atoms, Options) of
         false ->
             %% Build an atom table for Erlang/OTP 28 and later.
-            AtomTab = [[encode(?tag_u, Len),Text] || [Len,Text] <- AtomTab0],
+            AtomTab = [[encode(?tag_u, Len),Text] || [Len,Text] <:- AtomTab0],
             chunk(<<"AtU8">>, <<-NumAtoms:32>>, AtomTab);
         true ->
             %% Build an atom table compatible with Erlang/OTP 27

--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -203,7 +203,7 @@ will_succeed(Mod, Func, Args) ->
 
 max_tuple_size(#t_union{tuple_set=[_|_]=Set}=Union) ->
     Union = meet(Union, #t_tuple{}),            %Assertion.
-    Arities = [Arity || {{Arity, _Tag}, _Record} <- Set],
+    Arities = [Arity || {{Arity, _Tag}, _Record} <:- Set],
     lists:max(Arities);
 max_tuple_size(#t_tuple{exact=true,size=Size}) ->
     Size;

--- a/lib/compiler/src/beam_clean.erl
+++ b/lib/compiler/src/beam_clean.erl
@@ -31,8 +31,8 @@
 
 module({Mod,Exp,Attr,Fs0,_}, Opts) ->
     Fs1 = move_out_funs(Fs0),
-    Order = [Lbl || {function,_,_,Lbl,_} <- Fs1],
-    All = #{Lbl => Func || {function,_,_,Lbl,_}=Func <- Fs1},
+    Order = [Lbl || {function,_,_,Lbl,_} <:- Fs1],
+    All = #{Lbl => Func || {function,_,_,Lbl,_}=Func <:- Fs1},
     WorkList = rootset(Fs1, Exp, Attr),
     Used = find_all_used(WorkList, All, sets:from_list(WorkList)),
     Fs2 = remove_unused(Order, Used, All),
@@ -49,7 +49,7 @@ rootset(Fs, Root0, Attr) ->
 		[OnLoad] -> [OnLoad|Root0]
 	   end,
     Root = sofs:set(Root1, [function]),
-    Map0 = [{{Name,Arity},Lbl} || {function,Name,Arity,Lbl,_} <- Fs],
+    Map0 = [{{Name,Arity},Lbl} || {function,Name,Arity,Lbl,_} <:- Fs],
     Map = sofs:relation(Map0, [{function,label}]),
     sofs:to_external(sofs:image(Map, Root)).
 

--- a/lib/compiler/src/beam_core_to_ssa.erl
+++ b/lib/compiler/src/beam_core_to_ssa.erl
@@ -321,7 +321,7 @@ expr(#c_let{vars=Cvs,arg=Ca,body=Cb}, Sub0, St0) ->
     %% Break known multiple values into separate sets.
     Sets = case Ka of
                #ivalues{args=Kas} ->
-                   [#iset{vars=[V],arg=Val} || {V,Val} <- zip(Kps, Kas)];
+                   [#iset{vars=[V],arg=Val} || {V,Val} <:- zip(Kps, Kas)];
                _Other ->
                    [#iset{vars=Kps,arg=Ka}]
            end,
@@ -1451,7 +1451,7 @@ reorder_bin_ints(Cs0) ->
     %% * The patterns that follow are also safe to re-order.
     try
         Cs = sort([{reorder_bin_int_sort_key(C),C} || C <- Cs0]),
-        [C || {_,C} <- Cs]
+        [C || {_,C} <:- Cs]
     catch
         throw:not_possible ->
             Cs0
@@ -1692,7 +1692,7 @@ new_clauses(Cs, #b_var{name=U}) ->
                            #cg_bin_int{next=N} ->
                                [N|As];
                            #cg_map{op=exact,es=Es} ->
-                               Vals = [V || #cg_map_pair{val=V} <- Es],
+                               Vals = [V || #cg_map_pair{val=V} <:- Es],
                                Vals ++ As;
                            _Other ->
                                As
@@ -1802,7 +1802,7 @@ do_squeeze_clauses(Cs, Size, Count) when Count >= 16; Size =< 1 ->
     Cs;
 do_squeeze_clauses(Cs, Size, _Count) ->
     [C#iclause{pats=[squeeze_segments(P, Size)|Pats]} ||
-        #iclause{pats=[P|Pats]}=C <- Cs].
+        #iclause{pats=[P|Pats]}=C <:- Cs].
 
 squeeze_segments(BinSeg, Size) ->
     squeeze_segments(BinSeg, 0, 0, Size).
@@ -1919,7 +1919,7 @@ arg_val(Arg, C) ->
                          %% Literals will sort before variables
                          %% as intended.
                          erts_internal:cmp_term(A, B) < 0
-                 end, [Key || #cg_map_pair{key=Key} <- Es])
+                 end, [Key || #cg_map_pair{key=Key} <:- Es])
     end.
 
 %%%

--- a/lib/compiler/src/beam_digraph.erl
+++ b/lib/compiler/src/beam_digraph.erl
@@ -142,7 +142,7 @@ in_edges(#dg{in_es=InEsMap}, V) ->
 
 -spec in_neighbours(graph(), vertex()) -> [vertex()].
 in_neighbours(#dg{in_es=InEsMap}, V) ->
-    [From || {From,_,_} <- maps:get(V, InEsMap, [])].
+    [From || {From,_,_} <:- maps:get(V, InEsMap, [])].
 
 -spec is_path(graph(), vertex(), vertex()) -> boolean().
 is_path(G, From, To) ->
@@ -180,7 +180,7 @@ out_edges(#dg{out_es=OutEsMap}, V) ->
 
 -spec out_neighbours(graph(), vertex()) -> [vertex()].
 out_neighbours(#dg{out_es=OutEsMap}, V) ->
-    [To || {_,To,_} <- maps:get(V, OutEsMap, [])].
+    [To || {_,To,_} <:- maps:get(V, OutEsMap, [])].
 
 -spec no_vertices(graph()) -> non_neg_integer().
 no_vertices(#dg{vs=Vs}) ->

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -307,7 +307,7 @@ beam_disasm_code(<<_SS:32, % Sub-Size (length of information before code)
 	    [function__code_update(Function,
 				   resolve_names(Is, Imports, Str,
 						 Labels, Lambdas, Literals, M))
-	     || Function = #function{code=Is} <- Functions]
+	     || Function = #function{code=Is} <:- Functions]
     catch
 	error:Rsn ->
 	    ?NO_DEBUG('code disassembling failed: ~p~n', [Rsn]),
@@ -1410,7 +1410,8 @@ decode_field_flags(FieldFlags) when is_integer(FieldFlags) ->
 %%-----------------------------------------------------------------------
 
 mk_imports(ImportList) ->
-    gb_trees:from_orddict([{I,{extfunc,M,F,A}} || {I,M,F,A} <- ImportList]).
+    gb_trees:from_orddict([{I,{extfunc,M,F,A}} ||
+                              {I,M,F,A} <:- ImportList]).
 
 mk_atoms(AtomList) ->
     gb_trees:from_orddict(AtomList).

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -293,7 +293,7 @@ insert_on_edges_1([], Blocks, Count) ->
 
 insert_on_edges_reroute(#b_switch{fail=Fail0,list=List0}=Sw, Old, New) ->
     Fail = rename_label(Fail0, Old, New),
-    List = [{Value, rename_label(Dst, Old, New)} || {Value, Dst} <- List0],
+    List = [{Value, rename_label(Dst, Old, New)} || {Value, Dst} <:- List0],
     Sw#b_switch{fail=Fail,list=List};
 insert_on_edges_reroute(#b_br{succ=Succ0,fail=Fail0}=Br, Old, New) ->
     Succ = rename_label(Succ0, Old, New),
@@ -358,7 +358,7 @@ successors(#b_blk{last=Terminator}) ->
         #b_br{succ=Succ,fail=Fail} ->
             [Fail,Succ];
         #b_switch{fail=Fail,list=List} ->
-            [Fail|[L || {_,L} <- List]];
+            [Fail|[L || {_,L} <:- List]];
         #b_ret{} ->
             []
     end.
@@ -943,7 +943,7 @@ fix_phis([{L,Blk0}|Bs], S) ->
 fix_phis([], _) -> [].
 
 fix_phis_1([#b_set{op=phi,args=Args0}=I|Is], L, S) ->
-    Args = [{Val,Pred} || {Val,Pred} <- Args0,
+    Args = [{Val,Pred} || {Val,Pred} <:- Args0,
                           is_successor(L, Pred, S)],
     [I#b_set{args=Args}|fix_phis_1(Is, L, S)];
 fix_phis_1(Is, _, _) -> Is.
@@ -982,7 +982,7 @@ trim_phis(#b_blk{is=[#b_set{op=phi}|_]=Is0}=Blk, Seen) ->
 trim_phis(Blk, _Seen) -> Blk.
 
 trim_phis_1([#b_set{op=phi,args=Args0}=I|Is], Seen) ->
-    Args = [P || {_,L}=P <- Args0, sets:is_element(L, Seen)],
+    Args = [P || {_,L}=P <:- Args0, sets:is_element(L, Seen)],
     [I#b_set{args=Args}|trim_phis_1(Is, Seen)];
 trim_phis_1(Is, _Seen) -> Is.
 
@@ -1095,7 +1095,7 @@ split_blocks_is([I|Is], P, Acc) ->
 split_blocks_is([], _, _) -> no.
 
 update_phi_labels_is([#b_set{op=phi,args=Args0}=I0|Is], Old, New) ->
-    Args = [{Arg,rename_label(Lbl, Old, New)} || {Arg,Lbl} <- Args0],
+    Args = [{Arg,rename_label(Lbl, Old, New)} || {Arg,Lbl} <:- Args0],
     I = I0#b_set{args=Args},
     [I|update_phi_labels_is(Is, Old, New)];
 update_phi_labels_is(Is, _, _) -> Is.

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -144,7 +144,7 @@ opt(StMap0, FuncDb0) ->
 
 killsets(Funs, StMap) ->
     OptStates = [{F,map_get(F, StMap)} || F <- Funs],
-    #{ F=>killsets_fun(reverse(SSA)) || {F,#opt_st{ssa=SSA}} <- OptStates }.
+    #{ F=>killsets_fun(reverse(SSA)) || {F,#opt_st{ssa=SSA}} <:- OptStates }.
 
 killsets_fun(Blocks) ->
     %% Pre-calculate the live-ins due to Phi-instructions.
@@ -655,7 +655,7 @@ aa_terminator(#b_ret{arg=Arg,anno=Anno0}, SS, Lbl2SS0) ->
     Lbl2SS = Lbl2SS0#{ returns => Type2Status },
     {Lbl2SS, []};
 aa_terminator(#b_switch{fail=F,list=Ls}, _SS, Lbl2SS) ->
-    {Lbl2SS,[F|[L || {_,L} <- Ls]]}.
+    {Lbl2SS,[F|[L || {_,L} <:- Ls]]}.
 
 %% Store the updated SS for the point where execution leaves the
 %% block.
@@ -1069,7 +1069,7 @@ aa_construct_tuple(Dst, IdxValues, Types, SS, AAS) ->
         [Dst, [#{idx=>Idx,v=>V,status=>aa_get_status(V, SS, Types),
                  killed=>aa_dies(V, Types, KillSet),
                  plain=>aa_is_plain_value(V, Types)}
-               || {Idx,V} <- IdxValues]]),
+               || {Idx,V} <:- IdxValues]]),
     ?DP("~s~n", [beam_ssa_ss:dump(SS)]),
     aa_build_tuple_or_pair(Dst, IdxValues, Types, KillSet, SS, []).
 
@@ -1168,7 +1168,7 @@ aa_bif(Dst, Bif, Args, SS, _AAS) ->
 
 aa_phi(Dst, Args0, SS0, #aas{cnt=Cnt0}=AAS) ->
     %% TODO: Use type info?
-    Args = [V || {V,_} <- Args0],
+    Args = [V || {V,_} <:- Args0],
     ?DP("Phi~n"),
     SS1 = aa_alias_surviving_args(Args, {phi,Dst}, SS0, AAS),
     ?DP("  after aa_alias_surviving_args:~n~s.~n", [beam_ssa_ss:dump(SS1)]),

--- a/lib/compiler/src/beam_ssa_bsm.erl
+++ b/lib/compiler/src/beam_ssa_bsm.erl
@@ -525,7 +525,7 @@ cm_handle_priors(Src, DstCtx, Bool, Acc, MatchSeq, Lbl, State0) ->
                         %% we can only consider the ones whose success path
                         %% dominate us.
                         Dominators = maps:get(Lbl, State0#cm.dominators, []),
-                        [Ctx || {ValidAfter, Ctx} <- Priors,
+                        [Ctx || {ValidAfter, Ctx} <:- Priors,
                                 member(ValidAfter, Dominators)];
                     error ->
                         []
@@ -776,7 +776,7 @@ aca_cs_is([], Counter, VRs, _BRs, Acc) ->
     {VRs, reverse(Acc), Counter}.
 
 aca_cs_last(#b_switch{arg=Arg0,list=Switch0,fail=Fail0}=Sw, VRs, BRs) ->
-    Switch = [{Literal, maps:get(Lbl, BRs)} || {Literal, Lbl} <- Switch0],
+    Switch = [{Literal, maps:get(Lbl, BRs)} || {Literal, Lbl} <:- Switch0],
     Sw#b_switch{arg=aca_cs_arg(Arg0, VRs),
                 fail=maps:get(Fail0, BRs),
                 list=Switch};
@@ -821,7 +821,7 @@ aca_cs_arg(Arg, VRs) ->
 %% contexts to us.
 
 allow_context_passthrough({Fs, ModInfo0}) ->
-    FsUses = [{F, beam_ssa:uses(beam_ssa:rpo(Bs), Bs)} || #b_function{bs=Bs}=F <- Fs],
+    FsUses = [{F, beam_ssa:uses(beam_ssa:rpo(Bs), Bs)} || #b_function{bs=Bs}=F <:- Fs],
     ModInfo = acp_forward_params(FsUses, ModInfo0),
     {Fs, ModInfo}.
 

--- a/lib/compiler/src/beam_ssa_check.erl
+++ b/lib/compiler/src/beam_ssa_check.erl
@@ -346,7 +346,7 @@ build_map_key({list,_,Elems}, Env) ->
 build_map_key({tuple,_,Elems}, Env) ->
     list_to_tuple([build_map_key(E, Env) || E <- Elems]);
 build_map_key({map,_,Elems}, Env) ->
-    #{build_map_key(K, Env) => build_map_key(V, Env) || {K,V} <- Elems};
+    #{build_map_key(K, Env) => build_map_key(V, Env) || {K,V} <:- Elems};
 build_map_key({var,_,V}, Env) ->
     map_get(V, Env);
 build_map_key(_Key, _Env) ->

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -2028,7 +2028,7 @@ force_reg({Kind,_}=R, _) when Kind =:= x; Kind =:= y ->
 successors(#cg_br{succ=Succ,fail=Fail}) ->
     ordsets:from_list([Succ,Fail]);
 successors(#cg_switch{fail=Fail,list=List}) ->
-    ordsets:from_list([Fail|[Lbl || {_,Lbl} <- List]]);
+    ordsets:from_list([Fail|[Lbl || {_,Lbl} <:- List]]);
 successors(#cg_ret{}) -> [].
 
 %% linearize(Blocks) -> [{BlockLabel,#cg_blk{}}].
@@ -2134,7 +2134,7 @@ translate_phis(L, #cg_br{succ=Target,fail=Target}, Blocks) ->
 translate_phis(_, _, _) -> [].
 
 phi_copies([#b_set{dst=Dst,args=PhiArgs}|Sets], L) ->
-    CopyArgs = [V || {V,Target} <- PhiArgs, Target =:= L],
+    CopyArgs = [V || {V,Target} <:- PhiArgs, Target =:= L],
     [#cg_set{op=copy,dst=Dst,args=CopyArgs}|phi_copies(Sets, L)];
 phi_copies([], _) -> [].
 

--- a/lib/compiler/src/beam_ssa_destructive_update.erl
+++ b/lib/compiler/src/beam_ssa_destructive_update.erl
@@ -837,7 +837,7 @@ patch_is([I0=#b_set{dst=Dst}|Rest], PD0, Cnt0, Acc, BlockAdditions0)
                        end,
             {OpArgs0, Other} = splitwith(Splitter, Patches),
             OpArgs = [{Idx,Lit,Element}
-                      || {opargs,_D,Idx,Lit,Element} <- OpArgs0],
+                      || {opargs,_D,Idx,Lit,Element} <:- OpArgs0],
             Ps = keysort(1, OpArgs),
             {Is,Cnt} = patch_opargs(I0, Ps, Cnt0),
             patch_is([hd(Is)|Rest], PD#{Dst=>Other}, Cnt,
@@ -888,7 +888,7 @@ no_reuse(I) ->
 %% literal.
 patch_ret(Last=#b_ret{arg=#b_literal{val=Lit}}, Patches, Cnt0) ->
     ?DP("patch_appends_ret:~n  lit: ~p~n  Patches: ~p~n", [Lit, Patches]),
-    Element = aggregate_ret_patches(keysort(1, [E || {ret,_,E} <- Patches])),
+    Element = aggregate_ret_patches(keysort(1, [E || {ret,_,E} <:- Patches])),
     ?DP("  element: ~p~n", [Element]),
     {V,Extra,Cnt} = patch_literal_term(Lit, Element, Cnt0),
     {Last#b_ret{arg=V}, Extra, Cnt}.
@@ -976,7 +976,7 @@ patch_phi(I0=#b_set{op=phi,args=Args0}, Patches, Cnt0) ->
 
 %% Should return the instructions in reversed order
 patch_literal_term(Tuple, {tuple_elements,Elems}, Cnt) ->
-    Es = [{tuple_element,I,E,0} || {I,E} <- keysort(1, Elems)],
+    Es = [{tuple_element,I,E,0} || {I,E} <:- keysort(1, Elems)],
     patch_literal_tuple(Tuple, Es, Cnt);
 patch_literal_term(Tuple, E={tuple_element,_,_,_}, Cnt) ->
     patch_literal_tuple(Tuple, [E], Cnt);
@@ -1017,7 +1017,7 @@ patch_literal_list(Lit, {hd,_,_}, Cnt) ->
 patch_literal_tuple(Tuple, Elements0, Cnt) ->
     ?DP("Will patch literal tuple~n  tuple:~p~n  elements: ~p~n",
         [Tuple,Elements0]),
-    Elements = [ E || {tuple_element,_,_,_}=E <- Elements0],
+    Elements = [ E || {tuple_element,_,_,_}=E <:- Elements0],
     patch_literal_tuple(erlang:tuple_to_list(Tuple), Elements, [], [], 0, Cnt).
 
 patch_literal_tuple([Lit|LitElements],

--- a/lib/compiler/src/beam_ssa_pp.erl
+++ b/lib/compiler/src/beam_ssa_pp.erl
@@ -97,12 +97,12 @@ format_anno(parameter_info, Map) when is_map(Map) ->
                             [format_var(V),
                              Break,
                              format_param_info(I, Break)]) ||
-                 {V,I} <- Params]]
+                 {V,I} <:- Params]]
     end;
 format_anno(Key, Map) when is_map(Map) ->
     Sorted = maps:to_list(maps:iterator(Map, ordered)),
     [io_lib:format("%% ~s:\n", [Key]),
-     [io_lib:format("%%    ~kw => ~kw\n", [K,V]) || {K,V} <- Sorted]];
+     [io_lib:format("%%    ~kw => ~kw\n", [K,V]) || {K,V} <:- Sorted]];
 format_anno(Key, Value) ->
     io_lib:format("%% ~s: ~kp\n", [Key,Value]).
 
@@ -241,7 +241,7 @@ format_arg(Other, _) ->
 
 format_switch_list(List, FuncAnno) ->
     Ss = [io_lib:format("{ ~ts, ~ts }", [format_arg(Val, FuncAnno),
-                                         format_label(L)]) || {Val,L} <- List],
+                                         format_label(L)]) || {Val,L} <:- List],
     io_lib:format("[\n    ~ts\n  ]", [lists:join(",\n    ", Ss)]).
 
 format_label(L) ->
@@ -268,7 +268,7 @@ format_instr_anno(#{arg_types:=Ts}=Anno0, FuncAnno, Args) ->
     Formatted0 = [[format_arg(Arg, FuncAnno), " => ",
                    format_type(map_get(Idx, Ts),
                    Break)]
-                  || {Idx, Arg} <- lists:zip(Iota, Args), is_map_key(Idx, Ts)],
+                  || {Idx, Arg} <:- lists:zip(Iota, Args), is_map_key(Idx, Ts)],
     Formatted = lists:join(Break, Formatted0),
 
     [io_lib:format("  %% Argument types:~s~ts\n",
@@ -299,7 +299,7 @@ format_live_interval(#b_var{}=Dst, #{live_intervals:=Intervals}) ->
     case Intervals of
         #{Dst:=Rs0} ->
             Rs1 = [io_lib:format("~p..~p", [Start,End]) ||
-                      {Start,End} <- Rs0],
+                      {Start,End} <:- Rs0],
             Rs = lists:join(" ", Rs1),
             io_lib:format("  %% ~ts: ~s\n", [format_var_1(Dst),Rs]);
         #{} ->

--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -667,7 +667,7 @@ intersect_uses(UsageMap, RefMap, Graph) ->
                               [begin
                                    Vertex = {FuncId, Lbl},
                                    {Vertex, Ref}
-                               end || {Lbl, _I, Ref} <- Uses] ++ Acc
+                               end || {Lbl, _I, Ref} <:- Uses] ++ Acc
                       end, [], UsageMap),
     intersect_uses_1(Roots, RefMap, Graph, #{}).
 
@@ -723,7 +723,7 @@ plan_markers(Candidates, UsageMap) ->
               end, #{}, Candidates).
 
 plan_markers_1(MakeRefs0, FuncId, UsageMap) ->
-    [Marker || {_, _, _, ExtractedAt, Ref}=Marker <- MakeRefs0,
+    [Marker || {_, _, _, ExtractedAt, Ref}=Marker <:- MakeRefs0,
                case UsageMap of
                    #{ {FuncId, ExtractedAt} := Refs } ->
                        sets:is_element(Ref, Refs);

--- a/lib/compiler/src/beam_ssa_share.erl
+++ b/lib/compiler/src/beam_ssa_share.erl
@@ -215,7 +215,7 @@ are_equivalent(_, _, _, _, _) -> false.
 share_switch(#b_switch{fail=Fail0,list=List0}=Sw, Blocks) ->
     Prep = share_prepare_sw([{value,Fail0}|List0], Blocks, 0, []),
     Res = do_share_switch(Prep, Blocks, []),
-    [{_,Fail}|List] = [VL || {_,VL} <- sort(Res)],
+    [{_,Fail}|List] = [VL || {_,VL} <:- sort(Res)],
     Sw#b_switch{fail=Fail,list=List}.
 
 share_prepare_sw([{V,L0}|T], Blocks, N, Acc) ->
@@ -245,7 +245,7 @@ share_switch_2([[{done,{_,{_,Common}}}|_]=Eqs|T], Blocks, Acc0) ->
     %% are either terminated with a `ret` or a `br` to the same target
     %% block. Replace the labels in the `switch` for all of those
     %% blocks with the label for the first of the blocks.
-    Acc = [{N,{V,Common}} || {done,{N,{V,_}}} <- Eqs] ++ Acc0,
+    Acc = [{N,{V,Common}} || {done,{N,{V,_}}} <:- Eqs] ++ Acc0,
     share_switch_2(T, Blocks, Acc);
 share_switch_2([[{_,_}|_]=Prep|T], Blocks, Acc0) ->
     %% Two or more blocks are semantically equivalent, but they have

--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -556,7 +556,7 @@ prune_by_add([{Depth0,V}|Wanted], Edges, New0, Old) ->
             %% Add all incoming edges to this node.
             InEdges = beam_digraph:in_edges(Old, V),
             Depth = Depth0 + 1,
-            InNodes = [{Depth, From} || {From,_,_} <- InEdges],
+            InNodes = [{Depth, From} || {From,_,_} <:- InEdges],
             prune_by_add(InNodes ++ Wanted, InEdges ++ Edges, New, Old);
         false ->
             %% We're in too deep, give up. This case will probably
@@ -664,7 +664,7 @@ size(State) ->
 
 -spec variables(sharing_state()) -> [beam_ssa:b_var()].
 variables(State) ->
-    [V || {V,_Lbl} <- beam_digraph:vertices(State)].
+    [V || {V,_Lbl} <:- beam_digraph:vertices(State)].
 
 -type call_in_arg_status() :: no_info
                             | unique
@@ -930,7 +930,7 @@ assert_state(State) ->
 %% Check that we don't have edges between non-existing nodes
 assert_bad_edges(State) ->
     [{assert_variable_exists(F, State), assert_variable_exists(T, State)}
-     || {F,T,_} <- beam_digraph:edges(State)].
+     || {F,T,_} <:- beam_digraph:edges(State)].
 
 
 %% Check that extracted and embedded elements of an aliased variable
@@ -940,7 +940,7 @@ assert_aliased_parent_implies_aliased(State) ->
 
 assert_apia(Parent, State) ->
     Children = [Child
-                || {_,Child,Info} <- beam_digraph:out_edges(State, Parent),
+                || {_,Child,Info} <:- beam_digraph:out_edges(State, Parent),
                    case Info of
                        {extract,_} -> true;
                        embed -> true;
@@ -993,7 +993,7 @@ assert_mefa(V, State) ->
 
 %% Check that elements which are extracted twice are aliased.
 assert_multiple_extractions_force_aliasing(State) ->
-    [assert_mxfa(V, State) || {V,_} <- beam_digraph:vertices(State)].
+    [assert_mxfa(V, State) || {V,_} <:- beam_digraph:vertices(State)].
 
 assert_mxfa(V, State) ->
     %% Build a map of the extracted values keyed by element.

--- a/lib/compiler/src/beam_ssa_throw.erl
+++ b/lib/compiler/src/beam_ssa_throw.erl
@@ -401,7 +401,7 @@ ois_1([], _Blocks, _Ts) ->
     true.
 
 ois_successors(#b_switch{fail=Fail,list=List}, _Ts) ->
-    Lbls = [Lbl || {_, Lbl} <- List],
+    Lbls = [Lbl || {_, Lbl} <:- List],
     [Fail | Lbls];
 ois_successors(#b_br{bool=Bool,succ=Succ,fail=Fail}, Ts) ->
     case beam_types:get_singleton_value(ois_get_type(Bool, Ts)) of

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -973,7 +973,7 @@ simplify_terminator(#b_switch{arg=Arg0,fail=Fail,list=List0}=Sw0,
     Arg = simplify_arg(Arg0, Ts, Sub),
     %% Ensure that no label in the switch list is the same as the
     %% failure label.
-    List = [{Val,Lbl} || {Val,Lbl} <- List0, Lbl =/= Fail],
+    List = [{Val,Lbl} || {Val,Lbl} <:- List0, Lbl =/= Fail],
     case beam_ssa:normalize(Sw0#b_switch{arg=Arg,list=List}) of
         #b_switch{}=Sw ->
             case beam_types:is_boolean_type(concrete_type(Arg, Ts)) of
@@ -1959,7 +1959,7 @@ st_filter_reachable([], CallArgs, Deferred, Acc) ->
             %% We have no reachable self calls, so we know our argument types
             %% can't expand any further. Filter out our reachable sites and
             %% return.
-            [ST || {SuccArgs, _}=ST <- Acc, st_is_reachable(SuccArgs, CallArgs)]
+            [ST || {SuccArgs, _}=ST <:- Acc, st_is_reachable(SuccArgs, CallArgs)]
     end.
 
 st_join_return_types([{_SuccArgs, SuccRet} | Rest], Acc0) ->
@@ -2644,7 +2644,7 @@ infer_relop('=/=', [LHS,RHS], [LType,RType], Ds) ->
     %% as it may be too specific. See beam_type_SUITE:type_subtraction/1
     %% for details.
     {[{V,beam_types:subtract(ThisType, OtherType)} ||
-         {V, ThisType, OtherType} <- [{RHS, RType, LType}, {LHS, LType, RType}],
+         {V, ThisType, OtherType} <:- [{RHS, RType, LType}, {LHS, LType, RType}],
          beam_types:is_singleton_type(OtherType)], NeTypes};
 infer_relop(Op, Args, Types, _Ds) ->
     {infer_relop(Op, Args, Types), []}.

--- a/lib/compiler/src/beam_trim.erl
+++ b/lib/compiler/src/beam_trim.erl
@@ -394,7 +394,7 @@ frame_layout(N, Killed, {U,_}) ->
     Is = [[{R,{live,R}} || R <- U],
           [{R,{dead,R}} || R <- Dead],
           [{R,{kill,R}} || R <- Killed]],
-    [I || {_,I} <- lists:merge(Is)].
+    [I || {_,I} <:- lists:merge(Is)].
 
 %% usage([Instruction], SafeLabels) -> {FrameSize,[UsedYRegs]}
 %%  Find out the frame size and usage information by looking at the

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -446,7 +446,7 @@ subtract(#t_union{list=List}=A, B) when ?IS_LIST_TYPE(B) ->
     shrink_union(A#t_union{list=subtract(List, B)});
 subtract(#t_union{tuple_set=[_|_]=Records0}=A, #t_tuple{}=B) ->
     %% Filter out all records that are more specific than B.
-    NewSet = case [{Key, T} || {Key, T} <- Records0, meet(T, B) =/= T] of
+    NewSet = case [{Key, T} || {Key, T} <:- Records0, meet(T, B) =/= T] of
                  [_|_]=Records -> Records;
                  [] -> none
              end,
@@ -1480,7 +1480,7 @@ convert_ext(?BEAM_TYPES_VERSION_25, Types0) ->
                        <<TypeBits:16,Min:64/signed,Max:64/signed>>;
                    false ->
                        <<TypeBits0:16>>
-               end || <<TypeBits0:16,Min:64/signed,Max:64/signed>> <= Types0 >>,
+               end || <<TypeBits0:16,Min:64/signed,Max:64/signed>> <:= Types0 >>,
     convert_ext(?BEAM_TYPES_VERSION_26, Types);
 convert_ext(_Version, _Types) ->
     none.

--- a/lib/compiler/src/cerl.erl
+++ b/lib/compiler/src/cerl.erl
@@ -651,7 +651,7 @@ _See also: _`c_module/4`.
 -spec module_vars(Node :: c_module()) -> [cerl()].
 
 module_vars(Node) ->
-    [F || {F, _} <- module_defs(Node)].
+    [F || {F, _} <:- module_defs(Node)].
 
 %% ---------------------------------------------------------------------
 
@@ -2561,7 +2561,7 @@ _See also: _`c_letrec/2`.
 -spec letrec_vars(Node :: c_letrec()) -> [cerl()].
 
 letrec_vars(Node) ->
-    [F || {F, _} <- letrec_defs(Node)].
+    [F || {F, _} <:- letrec_defs(Node)].
 
 
 %% ---------------------------------------------------------------------
@@ -4027,16 +4027,16 @@ meta_1('catch', Node) ->
 meta_1(letrec, Node) ->
     meta_call(c_letrec,
 	      [make_list([c_tuple([meta(N), meta(F)])
-			  || {N, F} <- letrec_defs(Node)]),
+			  || {N, F} <:- letrec_defs(Node)]),
 	       meta(letrec_body(Node))]);
 meta_1(module, Node) ->
     meta_call(c_module,
 	      [meta(module_name(Node)),
 	       make_list(meta_list(module_exports(Node))),
 	       make_list([c_tuple([meta(A), meta(V)])
-			  || {A, V} <- module_attrs(Node)]),
+			  || {A, V} <:- module_attrs(Node)]),
 	       make_list([c_tuple([meta(N), meta(F)])
-			  || {N, F} <- module_defs(Node)])]).
+			  || {N, F} <:- module_defs(Node)])]).
 
 meta_call(F, As) ->
     c_call(c_atom(?MODULE), c_atom(F), As).

--- a/lib/compiler/src/cerl_inline.erl
+++ b/lib/compiler/src/cerl_inline.erl
@@ -835,8 +835,8 @@ add_match_bindings(Bs, E) ->
 	true ->
 	    E;
 	false ->
-	    Vs = [V || {V, E} <- Bs, E =/= any],
-	    Es = [hd(get_ann(E)) || {_V, E} <- Bs, E =/= any],
+	    Vs = [V || {V, E} <:- Bs, E =/= any],
+	    Es = [hd(get_ann(E)) || {_V, E} <:- Bs, E =/= any],
 	    c_let(Vs, c_values(Es), E)
     end.
 
@@ -935,7 +935,7 @@ i_letrec(Es, B, Xs, Ctxt, Ren, Env, NoInline, S) ->
                            S, Es),
 
     %% Then we make recursive bindings for the definitions.
-    {Rs, Ren1, Env1, S2} = bind_recursive([F || {F, _} <- Es],
+    {Rs, Ren1, Env1, S2} = bind_recursive([F || {F, _} <:- Es],
                                           Opnds, Ren, Env, S1),
     
     %% For the function variables listed in Xs (none for a

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1279,9 +1279,9 @@ print_pass_times(File, Times) ->
 
 print_subpass_times(Times0, Name) ->
     Fam0 = rel2fam(Times0),
-    Fam1 = [{W,lists:sum(Times)} || {W,Times} <- Fam0],
+    Fam1 = [{W,lists:sum(Times)} || {W,Times} <:- Fam0],
     Fam = reverse(lists:keysort(2, Fam1)),
-    Total = case lists:sum([T || {_,T} <- Fam]) of
+    Total = case lists:sum([T || {_,T} <:- Fam]) of
                 0 -> 1;
                 Total0 -> Total0
             end,
@@ -1367,7 +1367,7 @@ werror(#compile{options=Opts,warnings=Ws}) ->
 
 %% messages_per_file([{File,[Message]}]) -> [{File,[Message]}]
 messages_per_file(Ms) ->
-    T = lists:sort([{File,M} || {File,Messages} <- Ms, M <- Messages]),
+    T = lists:sort([{File,M} || {File,Messages} <:- Ms, M <- Messages]),
     PrioMs = [erl_scan, epp, erl_parse],
     {Prio0, Rest} =
         lists:mapfoldl(fun(M, A) ->
@@ -1381,7 +1381,7 @@ messages_per_file(Ms) ->
 
 mpf(Ms) ->
     [{File,[M || {F,M} <- Ms, F =:= File]} ||
-	File <- lists:usort([F || {F,_} <- Ms])].
+	File <- lists:usort([F || {F,_} <:- Ms])].
 
 %% passes(forms|file, [Option]) -> {Extension,[{Name,PassFun}]}
 %%  Figure out the extension of the input file and which passes
@@ -2575,7 +2575,7 @@ beam_asm(Code0, #compile{ifile=File,extra_chunks=ExtraChunks,options=CompilerOpt
 
 beam_strip_types(Beam0, #compile{}=St) ->
     {ok,_Module,Chunks0} = beam_lib:all_chunks(Beam0),
-    Chunks = [{Tag,Contents} || {Tag,Contents} <- Chunks0,
+    Chunks = [{Tag,Contents} || {Tag,Contents} <:- Chunks0,
                                 Tag =/= "Type"],
     {ok,Beam} = beam_lib:build_module(Chunks),
     {ok,Beam,St}.
@@ -2834,7 +2834,7 @@ output_encoding(F, #compile{encoding = Encoding}) ->
 diffable(Code0, St) ->
     {Mod,Exp,Attr,Fs0,NumLabels} = Code0,
     EntryLabels = #{Entry => {Name,Arity} ||
-                      {function,Name,Arity,Entry,_} <- Fs0},
+                      {function,Name,Arity,Entry,_} <:- Fs0},
     Fs = [diffable_fix_function(F, EntryLabels) || F <- Fs0],
     Code = {Mod,Exp,Attr,Fs,NumLabels},
     {ok,Code,St}.

--- a/lib/compiler/src/sys_core_bsm.erl
+++ b/lib/compiler/src/sys_core_bsm.erl
@@ -56,7 +56,7 @@ bsm_reorder_1(Vs0, #c_case{clauses=Cs0}=Case) ->
         Pos when Pos > 0, Pos =/= none ->
             Vs = core_lib:make_values(move_from_col(Pos, Vs0)),
             Cs = [C#c_clause{pats=move_from_col(Pos, Ps)}
-                  || #c_clause{pats=Ps}=C <- Cs0],
+                  || #c_clause{pats=Ps}=C <:- Cs0],
             Case#c_case{arg=Vs,clauses=Cs};
         _ ->
             Case

--- a/lib/compiler/src/sys_core_inline.erl
+++ b/lib/compiler/src/sys_core_inline.erl
@@ -123,7 +123,7 @@ inline(Fs0, St0) ->
     %% Use fixed inline functions on all functions.
     Fs = [inline_func(F, Is1) || F <- Fs2],
     %% Regenerate module body.
-    [Def || #fstat{def=Def} <- Fs].
+    [Def || #fstat{def=Def} <:- Fs].
 
 %% is_inlineable(Fstat, Thresh, [Inline]) -> boolean().
 

--- a/lib/compiler/src/sys_messages.erl
+++ b/lib/compiler/src/sys_messages.erl
@@ -119,7 +119,7 @@ quote_source_2(Bin, Enc, StartLine, StartCol, EndLine, EndCol, Ctx) ->
                         Before ++ [{0, "..."}] ++ After
                 end,
             Lines2 = decorate(Lines1, StartLine, StartCol, EndLine, EndCol),
-            [[fmt_line(L, Text) || {L, Text} <- Lines2], $\n]
+            [[fmt_line(L, Text) || {L, Text} <:- Lines2], $\n]
     end.
 
 line_prefix() ->

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -200,7 +200,7 @@ module(Forms0, Opts) ->
 	      true -> defined_functions(Forms);
 	      false -> Exp0
 	  end,
-    Cexp = [#c_var{name=FA} || {_,_}=FA <- Exp],
+    Cexp = [#c_var{name=FA} || {_,_}=FA <:- Exp],
     Kfs1 = reverse(Kfs0),
     Kfs = if LoadNif and (Nifs =:= none) ->
                   insert_nif_start(Kfs1);
@@ -3172,7 +3172,7 @@ upat_element(#ibitstr{val=H0,size=Sz0}=Seg, Ks, Bs0, St0) ->
             {Seg#ibitstr{val=H1,size=Sz1},Hg,Hv,Us,Bs1,St2};
         Expr when is_list(Expr) ->
             Sz1 = [#iset{var=#c_var{name=Old},arg=#c_var{name=New}} ||
-                      {Old,New} <- Bs0] ++ Expr,
+                      {Old,New} <:- Bs0] ++ Expr,
             {Sz2,_,St2} = uexprs(Sz1, Ks, St1),
             Us = used_in_expr(Sz2),
             {Seg#ibitstr{val=H1,size=Sz2},Hg,Hv,Us,Bs1,St2}


### PR DESCRIPTION
Since the compiler is an important application, it is worthwhile using strict generator operators where possible to help find mistakes quicker, and also make it clearer at a glance whether a generator with a pattern is filtering based on the pattern or is keeping all elements.

If I have counted correctly, there are now 130 strict list and map generators with failable patterns and 73 relaxed map and list generators with failable patterns. There is one strict binary generator.