### PR TITLE
gen_udp:send may block on UDS when Path non-existing

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -14693,17 +14693,22 @@ static void packet_inet_command(ErlDrvData e, char* buf, ErlDrvSizeT len)
               "\r\n", __LINE__,
               desc->s, driver_caller(desc->port), err, errno_str(err)) );
 
-        if ((err != ERRNO_BLOCK) && (err != EINTR)) {
+        if (IS_UDP(desc)) {
             inet_reply_error(desc, err);
             return;
-        }
-        else {
-            /* XXX if(! INET_IGNORED(INETP(desc))) */
-            sock_select(desc, (FD_WRITE|FD_CLOSE), 1);
-            set_busy_port(desc->port, 1);
-            /* XXX add_multi_timer(... desc->send_timeout, ...); */
-            inet_reply_caller_ref(desc);
-            return;
+        } else {
+            if ((err != ERRNO_BLOCK) && (err != EINTR)) {
+                inet_reply_error(desc, err);
+                return;
+            }
+            else {
+                /* XXX if(! INET_IGNORED(INETP(desc))) */
+                sock_select(desc, (FD_WRITE|FD_CLOSE), 1);
+                set_busy_port(desc->port, 1);
+                /* XXX add_multi_timer(... desc->send_timeout, ...); */
+                inet_reply_caller_ref(desc);
+                return;
+            }
         }
     }
     else {

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -1334,6 +1334,10 @@ static struct erl_drv_entry tcp_inet_driver_entry =
 
 
 #ifdef HAVE_UDP
+
+/* "IS_UDP": tells the difference between a UDP and an SCTP socket: */
+#   define IS_UDP(desc)((desc)->sprotocol==IPPROTO_UDP)
+
 static int        packet_inet_init(void);
 static void       packet_inet_stop(ErlDrvData);
 static void       packet_inet_command(ErlDrvData, char*, ErlDrvSizeT);
@@ -1384,6 +1388,11 @@ static struct erl_drv_entry udp_inet_driver_entry =
     inet_stop_select,
     inet_emergency_close
 };
+
+#else
+
+#   define IS_UDP(desc) 0
+
 #endif
 
 #ifdef HAVE_SCTP
@@ -14485,17 +14494,43 @@ static void packet_inet_command(ErlDrvData e, char* buf, ErlDrvSizeT len)
     long code;
     inet_address other;
 
+    DDBG(desc,
+         ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+          "packet_inet_command -> entry"
+          "\r\n",
+          __LINE__,
+          desc->s, driver_caller(desc->port)) );
+
     if (! init_caller(&desc->caller, &desc->caller_ref,
                       desc->port, &buf, &len)) {
+
+        DDBG(desc,
+             ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+              "packet_inet_command -> init caller failed"
+              "\r\n", __LINE__, desc->s, driver_caller(desc->port)) );
+
         driver_failure_posix(desc->port, EINVAL);
 	return;
     }
     ptr = buf;
 
     if (!IS_OPEN(desc)) {
+
+        DDBG(desc,
+             ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+              "packet_inet_command -> not open"
+              "\r\n", __LINE__, desc->s, driver_caller(desc->port)) );
+
 	inet_reply_error(desc, EINVAL);
 	return;
     }
+
+    DDBG(desc,
+         ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+          "packet_inet_command -> data size: %u"
+          "\r\n",
+          __LINE__,
+          desc->s, driver_caller(desc->port), len) );
 
 #ifdef HAVE_SCTP
     if (IS_SCTP(desc))
@@ -14539,6 +14574,12 @@ static void packet_inet_command(ErlDrvData e, char* buf, ErlDrvSizeT len)
 	inet_output_count(desc, data_len);
 	/* Now do the actual sending. NB: "flags" in "sendmsg" itself are NOT
 	   used: */
+
+        DDBG(desc,
+             ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+              "packet_inet_command -> try sendmsg"
+              "\r\n", __LINE__, desc->s, driver_caller(desc->port)) );
+            
 	code = sock_sendmsg(desc->s, &mhdr, 0);
 
         goto check_result_code;
@@ -14571,9 +14612,21 @@ static void packet_inet_command(ErlDrvData e, char* buf, ErlDrvSizeT len)
             inet_output_count(desc, len);
             if (desc->state & INET_F_ACTIVE) {
                 /* connected (ignore address) */
+
+                DDBG(desc,
+                     ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+                      "packet_inet_command -> try send (connected)"
+                      "\r\n", __LINE__, desc->s, driver_caller(desc->port)) );
+            
                 code = sock_send(desc->s, ptr, len, 0);
             }
             else {
+
+                DDBG(desc,
+                     ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+                      "packet_inet_command -> try sendto"
+                      "\r\n", __LINE__, desc->s, driver_caller(desc->port)) );
+            
                 code = sock_sendto(desc->s, ptr, len, 0, &other.sa, sz);
             }
         }
@@ -14614,6 +14667,12 @@ static void packet_inet_command(ErlDrvData e, char* buf, ErlDrvSizeT len)
             mhdr.msg_iovlen = 1;
             mhdr.msg_flags = 0;
             inet_output_count(desc, len);
+
+            DDBG(desc,
+                 ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+                  "packet_inet_command -> try sendmsg"
+                  "\r\n", __LINE__, desc->s, driver_caller(desc->port)) );
+            
             code = sock_sendmsg(desc->s, &mhdr, 0);
 #endif
         }
@@ -14627,6 +14686,13 @@ static void packet_inet_command(ErlDrvData e, char* buf, ErlDrvSizeT len)
 #endif
     if (IS_SOCKET_ERROR(code)) {
         int err = sock_errno();
+
+        DDBG(desc,
+             ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+              "packet_inet_command -> error: %d (%s)"
+              "\r\n", __LINE__,
+              desc->s, driver_caller(desc->port), err, errno_str(err)) );
+
         if ((err != ERRNO_BLOCK) && (err != EINTR)) {
             inet_reply_error(desc, err);
             return;

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -3376,7 +3376,7 @@ get_localaddr([Localhost|Ls]) ->
 
 is_docker(Config) ->
     case lists:keysearch(label, 1, Config) of
-        {value, {lable, docker}} ->
+        {value, {label, docker}} ->
             ok;
         _ ->
             skip("Is not running in a Docker")

--- a/lib/kernel/test/kernel_test_lib.erl
+++ b/lib/kernel/test/kernel_test_lib.erl
@@ -1742,9 +1742,9 @@ analyze_and_print_solaris_host_info(Version) ->
             IS ->
                 IS
         end,
-    PtrConf = [list_to_tuple([string:trim(S) || S <- Items]) || Items <- [string:tokens(S, [$:]) || S <- string:tokens(os:cmd("prtconf"), [$\n])], length(Items) > 1],
+    PrtConf = [list_to_tuple([string:trim(S) || S <- Items]) || Items <- [string:tokens(S, [$:]) || S <- string:tokens(os:cmd("prtconf"), [$\n])], length(Items) > 1],
     SysConf =
-        case lists:keysearch("System Configuration", 1, PtrConf) of
+        case lists:keysearch("System Configuration", 1, PrtConf) of
             {value, {_, SC}} ->
                 SC;
             _ ->
@@ -1782,7 +1782,7 @@ analyze_and_print_solaris_host_info(Version) ->
                 "-"
         end,
     MemSz =
-        case lists:keysearch("Memory size", 1, PtrConf) of
+        case lists:keysearch("Memory size", 1, PrtConf) of
             {value, {_, MS}} ->
                 MS;
             _ ->


### PR DESCRIPTION
The error handling was common for both UDP and SCTP.
Added a test if UDP and if so, simple error handling (just return the error).
Based on 26.2.5