### PR TITLE
Fix potential lock order conflict in NIF monitor down callbacks

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -13483,7 +13483,9 @@ erts_proc_exit_handle_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
             break;
         }
         case ERTS_MON_TYPE_RESOURCE:
+            erts_proc_unlock(c_p, ERTS_PROC_LOCK_MAIN);
             erts_fire_nif_monitor(mon);
+            erts_proc_lock(c_p, ERTS_PROC_LOCK_MAIN);
             mon = NULL;
             break;
         case ERTS_MON_TYPE_DIST_PORT:

--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2855,6 +2855,16 @@ static void monitor_resource_down(ErlNifEnv* env, void* obj, ErlNifPid* pid,
     enif_send(env, &rsrc->receiver, msg_env, msg);
     if (msg_env)
         enif_free_env(msg_env);
+
+    /* OTP-19330 GH-8983:
+     * Verify calling enif_whereis_pid/port in down callback
+     * without lock order violation. */
+    {
+        ErlNifPid pid;
+        ErlNifPid port;
+        enif_whereis_pid(env, atom_null, &pid);
+        enif_whereis_port(env, atom_null, &port);
+    }
 }
 
 static ERL_NIF_TERM alloc_monitor_resource_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])


### PR DESCRIPTION
Fix #8983.

### Problem
Calling `enif_whereis_pid` in NIF monitor `down` callback would cause lock order violation detected by lock checker in `debug` build.

### Solution
Release main lock of the exiting process while calling NIF `down` callback.