### PR TITLE
erlang:system_info - add snifs to the spec

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -9695,6 +9695,7 @@ the `CpuTopology` type to change.
          (scheduler_id) -> SchedulerId :: pos_integer();
          (schedulers | schedulers_online) -> pos_integer();
          (smp_support) -> boolean();
+         (snifs) -> [mfa()];
          (start_time) -> integer();
          (system_architecture) -> string();
          (system_logger) -> logger | undefined | pid();


### PR DESCRIPTION
(Found with eqWAlizer when type-checking an internal project - `erlang:system_info(snifs)` was flagged)
snifs implementation: https://github.com/erlang/otp/commit/091c65e81be487d3cf69822d181996e6ebbfd502