### PR TITLE
kernel: bypass unicode translation in group for latin1 putc_requests

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -608,36 +608,16 @@ putc_request({put_chars,unicode,M,F,As}, Drv, From) ->
                     {reply,{error,F}}
             end
     end;
-putc_request({put_chars,latin1,Binary}, Drv, From) when is_binary(Binary) ->
-    send_drv(Drv, {put_chars_sync, unicode,
-                   unicode:characters_to_binary(Binary,latin1),
-                   From}),
+putc_request({put_chars,latin1,Output}, Drv, From) ->
+    send_drv(Drv, {put_chars_sync, latin1, Output, From}),
     noreply;
-putc_request({put_chars,latin1,Chars}, Drv, From) ->
-    case catch unicode:characters_to_binary(Chars,latin1) of
-        Binary when is_binary(Binary) ->
-            send_drv(Drv, {put_chars_sync, unicode, Binary, From}),
-            noreply;
-        _ ->
-            {reply,{error,{put_chars,latin1,Chars}}}
-    end;
 putc_request({put_chars,latin1,M,F,As}, Drv, From) ->
     case catch apply(M, F, As) of
-        Binary when is_binary(Binary) ->
-            send_drv(Drv, {put_chars_sync, unicode,
-                           unicode:characters_to_binary(Binary,latin1),
-                           From}),
-            noreply;
-        Chars ->
-            case catch unicode:characters_to_binary(Chars,latin1) of
-                B when is_binary(B) ->
-                    send_drv(Drv, {put_chars_sync, unicode, B, From}),
-                    noreply;
-                _ ->
-                    {reply,{error,F}}
-            end
+        Ret when is_list(Ret) =:= false, is_binary(Ret) =:= false ->
+            {reply, {error, F}};
+        Chars -> send_drv(Drv, {put_chars_sync, latin1, Chars, From}),
+            noreply
     end;
-
 putc_request({requests,Reqs}, Drv, From) ->
     putc_requests(Reqs, {reply, ok}, Drv, From);
 

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -111,7 +111,7 @@
          npwcwidth/1, npwcwidth/2,
          ansi_regexp/0, ansi_color/2]).
 -export([reader_stop/1, disable_reader/1, enable_reader/1, read/1, read/2,
-         is_reader/2, is_writer/2]).
+         is_reader/2, is_writer/2, output_mode/1]).
 
 -nifs([isatty/1, tty_create/0, tty_init/2, setlocale/1,
        tty_select/2, tty_window_size/1,
@@ -475,6 +475,11 @@ is_writer(#state{ writer = {WriterPid, _} }, WriterPid) ->
     true;
 is_writer(_, _) ->
     false.
+
+-spec output_mode(state()) -> cooked | raw.
+output_mode(State) ->
+    #{output := Output} = State#state.options,
+    Output.
 
 -spec unicode(state()) -> boolean().
 unicode(State) ->

--- a/lib/stdlib/test/escript_SUITE_data/bypass_unicode_conversion
+++ b/lib/stdlib/test/escript_SUITE_data/bypass_unicode_conversion
@@ -1,0 +1,7 @@
+#!/usr/bin/env escript
+
+main([Enc]) ->
+  Data = {tuple, {list, lists:seq(1,1000000)}},
+  io:setopts(group_leader(), [{encoding, list_to_atom(Enc)}]),
+  file:write(group_leader(), term_to_binary(Data)),
+  ok.


### PR DESCRIPTION
Group checks that user_drv is in raw output mode and latin1 encoding mode
if true then the request is sent as latin1 and outputted by user_drv as is
if false then the request is converted to a unicode binary before its sent to user_drv.