### PR TITLE
erts: Do not annotate nif API functions on windows

### DIFF
--- a/erts/emulator/beam/erl_drv_nif.h
+++ b/erts/emulator/beam/erl_drv_nif.h
@@ -182,7 +182,7 @@ typedef struct {
  * D: Has 1-to-1 Deallocator function with ptr argument. ((malloc(DTOR,PTRPOS)))
  */
 
-#ifdef __has_attribute
+#if defined(__has_attribute) && !defined(__WIN32__)
 #  if __has_attribute(warn_unused_result)
 #    undef  ERL_NAPI_ATTR_WUR
 #    define ERL_NAPI_ATTR_WUR __attribute__((warn_unused_result))

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -89,6 +89,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
On windows nifs can be compiled with gcc/clang which means that __has_attribute(malloc) is defined. This was never intended to work so we disable it on Windows.

closes #9015