### PR TITLE
eldap: Enable missing doc spec warnings

### DIFF
--- a/lib/eldap/src/Makefile
+++ b/lib/eldap/src/Makefile
@@ -60,7 +60,7 @@ APP_TARGET = $(EBIN)/$(APP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -I../include -I../ebin -Werror +nowarn_missing_spec_documented
+ERL_COMPILE_FLAGS += -I../include -I../ebin -Werror
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
Spec are fixed so warnings should be enabled.