### PR TITLE
Fix notes links

### DIFF
--- a/erts/doc/notes.md
+++ b/erts/doc/notes.md
@@ -86,7 +86,7 @@ This document describes the changes made to the ERTS application.
 
 - The `erl -man example` has been corrected to not consider values set in `ERL_ZFLAGS` and stop parsing arguments when a `--` is encountered.
 
-  Own Id: OTP-19098 Aux Id: [PR-8478] [GH-8477]
+  Own Id: OTP-19098 Aux Id: [PR-8478], [GH-8477]
 
 - Compiler warnings for  Windows I/O back-end have been silenced.
 
@@ -159,7 +159,7 @@ This document describes the changes made to the ERTS application.
     'The I/O operation has been aborted because of either a thread exit or an application request.'}.
   ```
 
-  Own Id: OTP-19220 Aux Id: [PR-8774] [GH-7621]
+  Own Id: OTP-19220 Aux Id: [PR-8774], [GH-7621]
 
 [PR-8478]: https://github.com/erlang/otp/pull/8478
 [GH-8477]: https://github.com/erlang/otp/issues/8477

--- a/lib/compiler/doc/notes.md
+++ b/lib/compiler/doc/notes.md
@@ -46,7 +46,7 @@ This document describes the changes made to the Compiler application.
 
 - Fix `+deterministic` to work properly with documentation attributes.
 
-  Own Id: OTP-19142 Aux Id: [PR-8585] [GH-8579]
+  Own Id: OTP-19142 Aux Id: [PR-8585], [GH-8579]
 
 [PR-8567]: https://github.com/erlang/otp/pull/8567
 [PR-8585]: https://github.com/erlang/otp/pull/8585

--- a/lib/kernel/doc/notes.md
+++ b/lib/kernel/doc/notes.md
@@ -148,7 +148,7 @@ This document describes the changes made to the Kernel application.
 
 - Fix reading a line when reading from `t:io:user/0` to not consider `\r` without `\n` to be a new line when `erl` is started with `-noshell`.
 
-  Own Id: OTP-19088 Aux Id: [PR-8396] [GH-8360]
+  Own Id: OTP-19088 Aux Id: [PR-8396], [GH-8360]
 
 [PR-7220]: https://github.com/erlang/otp/pull/7220
 [GH-7718]: https://github.com/erlang/otp/issues/7718

--- a/lib/ssl/doc/notes.md
+++ b/lib/ssl/doc/notes.md
@@ -147,7 +147,7 @@ This document describes the changes made to the SSL application.
 
 - Improved error checking on the API functions.
 
-  Own Id: OTP-18992 Aux Id: [GH-8066] [PR-8156]
+  Own Id: OTP-18992 Aux Id: [GH-8066], [PR-8156]
 
 [GH-7493]: https://github.com/erlang/otp/issues/7493
 [PR-7918]: https://github.com/erlang/otp/pull/7918

--- a/lib/stdlib/doc/notes.md
+++ b/lib/stdlib/doc/notes.md
@@ -63,7 +63,7 @@ This document describes the changes made to the STDLIB application.
 
 - The help printout for incorrect `t:io:format/0` strings now handles the `k` modifier correctly.
 
-  Own Id: OTP-19146 Aux Id: [PR-8611] [GH-8568]
+  Own Id: OTP-19146 Aux Id: [PR-8611], [GH-8568]
 
 - Fixed a bug that caused the shell completion to crash when keyword and tuple appeared on the same line.
 
@@ -161,7 +161,7 @@ This document describes the changes made to the STDLIB application.
 
 - Fixed `m:json` bugs, `json:encode_key_value_list/2` did not generate arrays and `json:decode/3` did not invoke the user callback for `0`.
 
-  Own Id: OTP-19106 Aux Id: [PR-8581] [GH-8580] [PR-8519]
+  Own Id: OTP-19106 Aux Id: [PR-8581], [GH-8580], [PR-8519]
 
 [PR-8542]: https://github.com/erlang/otp/pull/8542
 [PR-8581]: https://github.com/erlang/otp/pull/8581
@@ -210,7 +210,7 @@ This document describes the changes made to the STDLIB application.
 
 - Fix shell expansion to not crash when expanding a map with non-atom keys and to not list zero arity functions when an argument has been given.
 
-  Own Id: OTP-19073 Aux Id: [PR-8375] [GH-8366] [GH-8365] [GH-8364]
+  Own Id: OTP-19073 Aux Id: [PR-8375], [GH-8366], [GH-8365], [GH-8364]
 
 [PR-7481]: https://github.com/erlang/otp/pull/7481
 [PR-7607]: https://github.com/erlang/otp/pull/7607
@@ -357,7 +357,7 @@ This document describes the changes made to the STDLIB application.
 - Functions `shell:default_multiline_prompt/1`, `shell:inverted_space_prompt/1`, and 
   `shell:prompt_width/1` have been exported to help with custom prompt implementations.
 
-  Own Id: OTP-18834 Aux Id: [PR-7675] [PR-7816]
+  Own Id: OTP-18834 Aux Id: [PR-7675], [PR-7816]
 
 - The shell now pages long output from the documentation help command ([`h(Module)`](`c:h/1`)), auto completions and the search command.
 

--- a/lib/tools/doc/notes.md
+++ b/lib/tools/doc/notes.md
@@ -27,7 +27,7 @@ This document describes the changes made to the Tools application.
 
 - `m:tprof` no longer crashes when using pause/restart/continue when profiling all modules.
 
-  Own Id: OTP-19136 Aux Id: [GH-8472] [PR-8472] [PR-8541]
+  Own Id: OTP-19136 Aux Id: [GH-8472], [PR-8472], [PR-8541]
 
 - On systems supporting native coverage, calls to `m:cover` could hang or crash if cover-compiled module had been reloaded from outside `cover`. This has been corrected so that `cover` now recovers from the error and and sends a report to the logger about the failure to retrieve coverage information.
 


### PR DESCRIPTION
ex_doc (or rather EarmarkParser) does not consider the whitespace between reference links significant so joins multiple references into a single link. Many MD standards seem to work this way, though the majority do not.

Anyway we need to fix this so that the links render properly, see https://github.com/RobertDober/earmark_parser/issues/159 for details on when/if this issue is solved.