### PR TITLE
erts: Improve Float16 type checking

### DIFF
--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -1903,6 +1903,18 @@ AC_CHECK_SIZEOF(time_t)
 AC_CHECK_SIZEOF(suseconds_t)
 AC_CHECK_SIZEOF(_Float16)
 
+dnl Check that _Float16 is not only exists but also is usable. The check is
+dnl mainly for x86 platform which requires -msse2 flag.
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[_Float16 x = 0.0;]],[[]])],
+	[AC_MSG_CHECKING([for _Float16 convertible])
+	AC_MSG_RESULT([yes])
+	AC_DEFINE([FLOAT16_IS_CONVERTIBLE],[1],
+		  [Define to 1 if _Float16 can be converted from/to double.])
+	],
+	[AC_MSG_CHECKING([for _Float16 convertible])
+	AC_MSG_RESULT([no])
+	])
+
 BITS64=
 
 if test $ac_cv_sizeof_void_p = 8; then

--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -40,7 +40,7 @@
 
 #define BIT_IS_MACHINE_ENDIAN(x) (((x)&BSF_LITTLE) == BIT_ENDIAN_MACHINE)
 
-#if (SIZEOF__FLOAT16 == 2)
+#if (SIZEOF__FLOAT16 == 2) && defined(FLOAT16_IS_CONVERTIBLE)
 typedef _Float16 erlfp16;
 #define FP16_FROM_FP64(x) ((_Float16) x)
 #define FP16_TO_FP64(x) ((double) x)


### PR DESCRIPTION
At least gcc 14.2 at x86 platform correctly returns `sizeof(_Float16)` value, but then the compilation is failed as the following:

```
    beam/erl_bits.c: In function ‘erts_bs_get_float_2’:
    beam/erl_bits.c:485:9: error: invalid conversion from type ‘_Float16’ without option ‘-msse2’
      485 |         f.fd = FP16_TO_FP64(f16);
          |         ^
```

Add the new check in order to fix build at x86 platform. Please note, that the patch correctly check the compiler behaviour when

    CFLAGS="-msse2" ./configure

is run.