### PR TITLE
sasl: Fix release_handler_SUITE:client1 trace allow list

### DIFF
--- a/lib/sasl/test/installer.erl
+++ b/lib/sasl/test/installer.erl
@@ -885,6 +885,9 @@ trace_disallowed_calls(Node) ->
 
 check_disallowed_calls(TestNode,Line) ->
     receive
+        {trace,_,call,{file,read_file_info,["/bin/sh",[raw]]},{os,internal_init_cmd_shell,1}} ->
+            %% This call is done when kernel is started/reloaded and is ok
+            ok;
 	Trace when element(1,Trace)==trace ->
 	    ?print_line(Line,["Disallowed function called",Trace]),
 	    exit({disallowed_function_call,Trace})


### PR DESCRIPTION
The PR #8744 instroduced a call to read_file_info that needs to be allowed for the testcase to pass.