### PR TITLE
Fix mnesia crash when checkpoint initialization fails

### DIFF
--- a/lib/mnesia/src/mnesia_checkpoint.erl
+++ b/lib/mnesia/src/mnesia_checkpoint.erl
@@ -617,24 +617,28 @@ init(Cp) ->
     Name = Cp#checkpoint_args.name,
     Props = [set, public, {keypos, 2}],
     try ?ets_new_table(mnesia_pending_checkpoint, Props) of
-	PendingTab ->
-	    Rs = [prepare_tab(Cp, R) || R <- Cp#checkpoint_args.retainers],
-	    Cp2 = Cp#checkpoint_args{retainers = Rs,
-				pid = self(),
-				pending_tab = PendingTab},
-	    add(pending_checkpoint_pids, self()),
-	    add(pending_checkpoints, PendingTab),
-	    set({checkpoint, Name}, self()),
-	    add(checkpoints, Name),
-	    dbg_out("Checkpoint ~p (~p) started~n", [Name, self()]),
-	    proc_lib:init_ack(Cp2#checkpoint_args.supervisor, {ok, self()}),
-	    retainer_loop(Cp2)
+        PendingTab ->
+            try [prepare_tab(Cp, R) || R <- Cp#checkpoint_args.retainers] of
+                Rs ->
+                    Cp2 = Cp#checkpoint_args{retainers = Rs,
+                                             pid = self(),
+                                             pending_tab = PendingTab},
+                    add(pending_checkpoint_pids, self()),
+                    add(pending_checkpoints, PendingTab),
+                    set({checkpoint, Name}, self()),
+                    add(checkpoints, Name),
+                    dbg_out("Checkpoint ~p (~p) started~n", [Name, self()]),
+                    proc_lib:init_ack(Cp2#checkpoint_args.supervisor, {ok, self()}),
+                    retainer_loop(Cp2)
+            catch exit:Reason ->
+                    proc_lib:init_ack(Cp#checkpoint_args.supervisor, {error, Reason})
+            end
     catch error:Reason -> %% system limit
 	    Msg = "Cannot create an ets table for pending transactions",
 	    Error = {error, {system_limit, Name, Msg, Reason}},
 	    proc_lib:init_ack(Cp#checkpoint_args.supervisor, Error)
     end.
-    
+
 prepare_tab(Cp, R) ->
     Tab = R#retainer.tab_name,
     prepare_tab(Cp, R, val({Tab, storage_type})).


### PR DESCRIPTION
If a table is deleted just when a checkpoint is starting, the checkpoint creation could fail so that mnesia crashed.