### PR TITLE
erl_lint: Warn on remote-calling non-exported functions

### DIFF
--- a/lib/eunit/src/eunit_test.erl
+++ b/lib/eunit/src/eunit_test.erl
@@ -29,6 +29,7 @@
 
 -export([run_testfun/1, mf_wrapper/2, enter_context/4, multi_setup/1]).
 
+-compile(nowarn_unexported_function).
 
 -include("eunit.hrl").
 -include("eunit_internal.hrl").


### PR DESCRIPTION
Fixes #9092