### PR TITLE
fix redirection links in docs

### DIFF
--- a/lib/kernel/doc/references/app.md
+++ b/lib/kernel/doc/references/app.md
@@ -170,7 +170,7 @@ The other keys are ignored by `systools`.
 
   This implies that for an included application, the set of start phases must be
   a subset of the set of phases defined for the primary application. For more
-  information, see [OTP Design Principles](`e:system:applications.md`).
+  information, see [_Applications_ in _OTP Design Principles_](`e:system:applications.md`).
 
 - **`runtime_dependencies`{: #runtime_dependencies }** - A list of application
   versions that the application depends on. An example of such an application

--- a/lib/sasl/doc/references/appup.md
+++ b/lib/sasl/doc/references/appup.md
@@ -78,9 +78,8 @@ this example works for, for example, `2.1.1`, but not for `2.1.1.1`.
 ## Release Upgrade Instructions
 
 Release upgrade instructions are interpreted by the release handler when an
-upgrade or downgrade is made. For more information about release handling, see
-[OTP Design Principles](`e:system:release_handling.md`) in _System
-Documentation_.
+upgrade or downgrade is made. For more information, see
+[_Release Handling_ in _OTP Design Principles_](`e:system:release_handling.md`).
 
 A process is said to _use_ a module `Mod` if `Mod` is listed in the `Modules`
 part of the child specification used to start the process, see `m:supervisor`.

--- a/lib/sasl/src/release_handler.erl
+++ b/lib/sasl/src/release_handler.erl
@@ -25,9 +25,8 @@ The _release handler_ process belongs to the SASL application, which is
 responsible for _release handling_, that is, unpacking, installation, and
 removal of release packages.
 
-An introduction to release handling and an example is provided in
-[OTP Design Principles](`e:system:release_handling.md`) in _System
-Documentation_.
+An introduction to release handling and an example is provided by
+[Release Handling section in OTP Design Principles](`e:system:release_handling.md`).
 
 A _release package_ is a compressed tar file containing code for a certain
 version of a release, created by calling

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -28,7 +28,7 @@ event handlers that are added and deleted dynamically.
 An event manager implemented using this module has a standard set of
 interface functions and includes functionality for tracing
 and error reporting.  It also fits into an OTP supervision tree.
-For more information, see [OTP Design Principles](`e:system:events.md`).
+For more information, see [gen_event section in OTP Design Principles](`e:system:events.md`).
 
 Each event handler is implemented as a callback module
 exporting a predefined set of functions. The relationship between

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -206,7 +206,7 @@ A generic finite state machine process (`gen_fsm`) implemented
 using this module has a standard set of interface functions
 and includes functionality for tracing and error reporting.
 It also fits into an OTP supervision tree.  For more information,
-see [OTP Design Principles](`e:system:design_principles`).
+see [OTP Design Principles](`e:system:design_principles.md`).
 
 A `gen_fsm` process assumes all specific parts to be located
 in a callback module exporting a predefined set of functions.
@@ -679,8 +679,7 @@ its internal [*state data*](#state-data)
 during a release upgrade/downgrade, that is,
 when instruction `{update, Module, Change, ...}`,
 where `Change = {advanced, Extra}`, is given in the appup file;
-see section Release Handling Instructions in OTP Design Principles.
-[OTP Design Principles](`e:system:release_handling.md#instr`).
+see [Release Handling Instructions in OTP Design Principles](`e:system:release_handling.md#instr`).
 
 For an upgrade, `OldVsn` is `Vsn`, and for a downgrade,
 `OldVsn` is `{down, Vsn}`. `Vsn` is defined by the vsn attribute(s)

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -30,7 +30,7 @@ A generic state machine server process (`gen_statem`) implemented
 using this module has a standard set of interface functions
 and includes functionality for tracing and error reporting.
 It also fits into an OTP supervision tree.  For more information,
-see [OTP Design Principles](`e:system:statem.md`).
+see [gen_statem section in OTP Design Principles](`e:system:statem.md`).
 
 > #### Note {: .info }
 >
@@ -1739,7 +1739,7 @@ its internal state during a release upgrade/downgrade, that is,
 when the instruction `{update, Module, Change, ...}`,
 where `Change = {advanced, Extra}`, is specified in
 the [`appup`](`e:sasl:appup.md`) file.  For more information, see
-[OTP Design Principles](`e:system:release_handling.md#instr`).
+[Release Handling Instructions in OTP Design Principles](`e:system:release_handling.md#instr`).
 
 For an upgrade, `OldVsn` is `Vsn`, and for a downgrade, `OldVsn` is
 `{down, Vsn}`. `Vsn` is defined by the `vsn` attribute(s)

--- a/system/doc/reference_manual/modules.md
+++ b/system/doc/reference_manual/modules.md
@@ -164,7 +164,7 @@ is to be preferred since the extra type information can be used by tools to
 produce documentation or find discrepancies.
 
 Read more about behaviours and callback modules in
-[OTP Design Principles](`e:system:spec_proc.md#behaviours`).
+[OTP Design Principles](`e:system:design_principles.md#behaviours`).
 
 ### Record Definitions
 

--- a/system/doc/system_principles/system_principles.md
+++ b/system/doc/system_principles/system_principles.md
@@ -138,7 +138,7 @@ This requires that the source code is structured as applications
 according to the OTP design principles.
 
 For more information about `.rel` files, see
-[OTP Design Principles](`e:system:release_handling.md`) and the
+[Release Handling](`e:system:release_handling.md`) and the
 [rel](`e:sasl:rel.md`) page in SASL.
 
 To generate the binary boot script file `Name.boot` the boot script file


### PR DESCRIPTION
Hello,

- here are commits for fixing redirection links
- it started from noticing that, in [`gen_statem`](https://www.erlang.org/doc/apps/stdlib/gen_statem), the Note didn't point to the _Design Principles_
- noticed the same pattern in other files.

```shell
# git grep -Pn '\[OTP Design Principles\]'

lib/kernel/doc/kernel_app.md:50:manager (see [OTP Design Principles](`e:system:design_principles.md`) and
lib/kernel/doc/references/app.md:173:  information, see [OTP Design Principles](`e:system:applications.md`).
lib/kernel/doc/references/config.md:150:[OTP Design Principles](`e:system:design_principles.md`)
lib/kernel/src/application.erl:43:[OTP Design Principles](`e:system:design_principles.md`).
lib/kernel/src/application.erl:47:[OTP Design Principles](`e:system:design_principles.md`),
lib/kernel/src/error_logger.erl:38:[OTP Design Principles](`e:system:design_principles.md`) and `m:gen_event`),
lib/sasl/doc/guides/sasl_intro.md:36:section [OTP Design Principles](`e:system:index.html`) in _System
lib/sasl/doc/references/appup.md:82:[OTP Design Principles](`e:system:release_handling.md`) in _System
lib/sasl/src/release_handler.erl:29:[OTP Design Principles](`e:system:release_handling.md`) in _System
lib/sasl/src/release_handler.erl:215:[OTP Design Principles](`e:system:index.html`),
lib/stdlib/src/gen_event.erl:31:For more information, see [OTP Design Principles](`e:system:events.md`).
lib/stdlib/src/gen_event.erl:366:For more information, see [OTP Design Principles](`e:system:index.html`).
lib/stdlib/src/gen_fsm.erl:209:see [OTP Design Principles](`e:system:design_principles`).
lib/stdlib/src/gen_fsm.erl:683:[OTP Design Principles](`e:system:release_handling.md#instr`).
lib/stdlib/src/gen_statem.erl:33:see [OTP Design Principles](`e:system:statem.md`).
lib/stdlib/src/gen_statem.erl:40:> the User's Guide [OTP Design Principles](`e:system:index.html`)
lib/stdlib/src/gen_statem.erl:1742:[OTP Design Principles](`e:system:release_handling.md#instr`).
lib/stdlib/src/proc_lib.erl:26:[OTP Design Principles](`e:system:design_principles.md`). Specifically, the
system/doc/README.md:12:* [OTP Design Principles](design_principles/design_principles.md) -
system/doc/getting_started/conc_prog.md:626:  [OTP Design Principles](`e:system:design_principles.md`)).
system/doc/reference_manual/modules.md:167:[OTP Design Principles](`e:system:spec_proc.md#behaviours`).
system/doc/reference_manual/ref_man_processes.md:504:[OTP Design Principles](`e:system:design_principles.md`)
system/doc/system_principles/system_principles.md:141:[OTP Design Principles](`e:system:release_handling.md`) and the
```