### PR TITLE
fix `target*` variables for ARM64 Windows

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -3886,10 +3886,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/common_test/configure
+++ b/lib/common_test/configure
@@ -2096,10 +2096,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -3215,10 +3215,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -3099,10 +3099,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -2952,10 +2952,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -3057,10 +3057,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/snmp/configure
+++ b/lib/snmp/configure
@@ -2092,10 +2092,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -3287,10 +3287,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -90,10 +90,10 @@ AC_DEFUN([ERL_CANONICAL_SYSTEM_TYPE],
     AS_CASE([$target],
             [local-aarch64-*-windows],
             [
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
             ],
             [local-*-windows],
             [

--- a/make/configure
+++ b/make/configure
@@ -3541,10 +3541,10 @@ esac
     case $target in #(
   local-aarch64-*-windows) :
 
-                build=win32
-                build_os=win32
-                build_vendor=
-                build_cpu=aarch64
+                target=win32
+                target_os=win32
+                target_vendor=
+                target_cpu=aarch64
              ;; #(
   local-*-windows) :
 


### PR DESCRIPTION
Sorry that due to a copy-paste error I set the wrong set of variables for ARM64 Windows under `AC_CANONICAL_TARGET` in the previous PR https://github.com/erlang/otp/pull/8734.