### PR TITLE
Make scanner accept based floating point literals

### DIFF
--- a/system/doc/reference_manual/data_types.md
+++ b/system/doc/reference_manual/data_types.md
@@ -40,11 +40,17 @@ conventional notation, there are two Erlang-specific notations:
 
 - `$`_`char`_  
   ASCII value or unicode code-point of the character _`char`_.
-- _`base`_`#`_`value`_  
+- _`base`_`#`_`digits`_  
   Integer with the base _`base`_, which must be an integer in the range 2
-  through 36. This notation can also be found in the Ada programming
+  through 36. _`digits`_ are `0`-`9` plus letters `A`-`Z` (upper or lower case).
+  This notation can also be found in the Ada programming
   language. Erlang does _not_ support prefixes such as `0x` for hexadecimal
   or `077` for octal.
+- _`base`_`#`_`digits`_`.`_`digits`_`#e`_`exponent`_  
+  Based floating point number, for example `16#ff.fe#e+6`. Using a base
+  like 16 or 2 allows for an exact text representation of a floating
+  point number. Like the base, the exponent is always a decimal number.
+
 
 Leading zeroes are ignored. Single underscore characters (`_`) can be
 inserted between digits as a visual separator.

--- a/system/doc/reference_manual/data_types.md
+++ b/system/doc/reference_manual/data_types.md
@@ -42,10 +42,16 @@ conventional notation, there are two Erlang-specific notations:
   ASCII value or unicode code-point of the character _`char`_.
 - _`base`_`#`_`value`_  
   Integer with the base _`base`_, which must be an integer in the range 2
-  through 36.
+  through 36. This notation can also be found in the Ada programming
+  language. Erlang does _not_ support prefixes such as `0x` for hexadecimal
+  or `077` for octal.
 
 Leading zeroes are ignored. Single underscore characters (`_`) can be
 inserted between digits as a visual separator.
+
+Also note that floating point numbers must start with a digit, and must
+contain a `.`. In other words, literals such as `.01` and `1e6` are not
+allowed, and must be written `0.01` and `1.0e6` respectively.
 
 _Examples:_
 


### PR DESCRIPTION
Similar to based float literals in Ada and hex float literals in C 99, using Erlang's Base#Literal notation (inspired by Ada), for example, 2#0.10101#e8, or 16#fefe.fefe#e-16. The # before the exponent is required. The exponent, like the base, is always a decimal number.

These can be useful for code generators and other cases where you want to preserve an exact bit representation of a float.

Currently missing: documentation, io formatting, list_to_float/2 implementation.

Based on #9104, which improves pinpointing of errors in numerical literals.