### PR TITLE
Fix documentation in mnesia.erl

### DIFF
--- a/lib/mnesia/src/mnesia.erl
+++ b/lib/mnesia/src/mnesia.erl
@@ -4158,7 +4158,7 @@ create_table(Arg) ->
 -doc """
 Create a table.
 
-Creates a Mnesia table called `Name` according to argument `TabDef`. This list
+Creates a Mnesia table called `Name` according to argument `Opts`. This list
 must be a list of `{Item, Value}` tuples, where the following values are
 allowed:
 


### PR DESCRIPTION
There was a wrongly named parameter in the documentation for the create_table function.

The code is now 

```erlang
-spec create_table(Name::table(), Opts::[create_option()]) -> t_result('ok').
create_table(Name, Arg) when is_list(Arg) ->
    mnesia_schema:create_table([{name, Name}| Arg]);
create_table(Name, Arg) ->
    {aborted, {badarg, Name, Arg}}.
```
    
So the documentation should be changed accordingly. It's the only occurency of `TabDef` I found.