### PR TITLE
cover: Fix a race condition in how the server is started as part of a call

### DIFF
--- a/lib/tools/src/cover.erl
+++ b/lib/tools/src/cover.erl
@@ -1143,7 +1143,10 @@ call(Request) ->
     Ref = erlang:monitor(process,?SERVER),
     receive {'DOWN', Ref, _Type, _Object, noproc} -> 
 	    erlang:demonitor(Ref),
-            {ok,_} = start(),
+            case start() of
+                {ok,_} -> ok;
+                {error,{already_started,_}} -> ok
+            end,
 	    call(Request)
     after 0 ->
 	    ?SERVER ! {self(),Request},


### PR DESCRIPTION
## Why

Before sending a message to the cover server, the `call` function checks if the server is running, starting it if it does not.

However, there is no locking/atomicity between the check and the start. If there is a concurrent call, the server might be started in parallel by another process and the `start()` call would return `{error, {already_started, _}}`. This causes the function to fail with a `badmatch` exception.

## How

The code now accepts that the server is running after seeing the server as stopped and retrying the call.