### PR TITLE
inets: fix httpc:set_options override with defaults

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -382,7 +382,9 @@ set_options(Options) ->
       DomainDesc :: string(),
       HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
-    case validate_options(Options) of
+    IpFamily = httpc_manager:get_option(ipfamily, Profile),
+    UnixSock = httpc_manager:get_option(unix_socket, Profile),
+    case validate_options(Options, IpFamily, UnixSock) of
 	{ok, Opts} ->
 	    httpc_manager:set_options(Opts, profile_name(Profile));
 	{error, Reason} ->
@@ -1170,28 +1172,24 @@ request_options_sanity_check(Opts) ->
     end,
     ok.
 
-validate_ipfamily_unix_socket(Options0) ->
-    IpFamily = proplists:get_value(ipfamily, Options0, inet),
-    UnixSocket = proplists:get_value(unix_socket, Options0, undefined),
-    Options1 = proplists:delete(ipfamily, Options0),
-    Options2 = proplists:delete(ipfamily, Options1),
-    validate_ipfamily_unix_socket(IpFamily, UnixSocket, Options2,
-                                  [{ipfamily, IpFamily}, {unix_socket, UnixSocket}]).
-%%
-validate_ipfamily_unix_socket(local, undefined, _Options, _Acc) ->
-    bad_option(unix_socket, undefined);
-validate_ipfamily_unix_socket(IpFamily, UnixSocket, _Options, _Acc)
-  when IpFamily =/= local, UnixSocket =/= undefined ->
-    bad_option(ipfamily, IpFamily);
-validate_ipfamily_unix_socket(IpFamily, UnixSocket, Options, Acc) ->
-    validate_ipfamily(IpFamily),
-    validate_unix_socket(UnixSocket),
-    {Options, Acc}.
+validate_ipfamily_unix_socket(Options0, CurrIpFamily, CurrUnixSock) ->
+    IpFamily = proplists:get_value(ipfamily, Options0, CurrIpFamily),
+    UnixSocket = proplists:get_value(unix_socket, Options0, CurrUnixSock),
+    validate_ipfamily_unix_socket(IpFamily, UnixSocket).
 
-validate_options(Options0) ->
+validate_ipfamily_unix_socket(local, undefined) ->
+    throw({error, {bad_ipfamily_unix_socket_combination, local, undefined}});
+validate_ipfamily_unix_socket(IpFamily, UnixSocket)
+  when IpFamily =/= local, UnixSocket =/= undefined ->
+    throw({error, {bad_ipfamily_unix_socket_combination, IpFamily, UnixSocket}});
+validate_ipfamily_unix_socket(IpFamily, UnixSocket) ->
+    validate_ipfamily(IpFamily),
+    validate_unix_socket(UnixSocket).
+
+validate_options(Options0, CurrIpFamily, CurrUnixSock) ->
     try
-        {Options, Acc} = validate_ipfamily_unix_socket(Options0),
-        validate_options(Options, Acc)
+        validate_ipfamily_unix_socket(Options0, CurrIpFamily, CurrUnixSock),
+        validate_options(Options0, [])
     catch
         error:Reason ->
             {error, Reason}

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -382,13 +382,11 @@ set_options(Options) ->
       DomainDesc :: string(),
       HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
-    {ok, IpFamily} = get_option(ipfamily, Profile),
-    {ok, UnixSock} = get_option(unix_socket, Profile),
-    case validate_options(Options, IpFamily, UnixSock) of
-	{ok, Opts} ->
-	    httpc_manager:set_options(Opts, profile_name(Profile));
-	{error, Reason} ->
-	    {error, Reason}
+    maybe
+        {ok, IpFamily} ?= get_option(ipfamily, Profile),
+        {ok, UnixSock} ?= get_option(unix_socket, Profile),
+        {ok, Opts} ?= validate_options(Options, IpFamily, UnixSock),
+	httpc_manager:set_options(Opts, profile_name(Profile))
     end.
 
 -spec set_option(atom(), term()) -> ok | {error, term()}.

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -382,8 +382,8 @@ set_options(Options) ->
       DomainDesc :: string(),
       HostName :: uri_string:uri_string().
 set_options(Options, Profile) when is_atom(Profile) orelse is_pid(Profile) ->
-    IpFamily = httpc_manager:get_option(ipfamily, Profile),
-    UnixSock = httpc_manager:get_option(unix_socket, Profile),
+    {ok, IpFamily} = get_option(ipfamily, Profile),
+    {ok, UnixSock} = get_option(unix_socket, Profile),
     case validate_options(Options, IpFamily, UnixSock) of
 	{ok, Opts} ->
 	    httpc_manager:set_options(Opts, profile_name(Profile));

--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -1191,7 +1191,7 @@ validate_options(Options0, CurrIpFamily, CurrUnixSock) ->
         validate_ipfamily_unix_socket(Options0, CurrIpFamily, CurrUnixSock),
         validate_options(Options0, [])
     catch
-        error:Reason ->
+        throw:Reason ->
             {error, Reason}
     end.
 %%

--- a/lib/inets/src/http_client/httpc_manager.erl
+++ b/lib/inets/src/http_client/httpc_manager.erl
@@ -1028,19 +1028,7 @@ get_cookies(Opts, #options{cookies = Default}) ->
     proplists:get_value(cookies, Opts, Default).
 
 get_ipfamily(Opts, #options{ipfamily = IpFamily}) ->
-    case lists:keysearch(ipfamily, 1, Opts) of
-	false -> 
-	    case proplists:get_value(ipv6, Opts) of
-		enabled ->
-		    inet6fb4;
-		disabled ->
-		    inet;
-		_ ->
-		    IpFamily
-	    end;
-	{value, {_, Value}} ->
-	    Value
-    end.
+    proplists:get_value(ipfamily, Opts, IpFamily).
 
 get_ip(Opts, #options{ip = Default}) ->
     proplists:get_value(ip, Opts, Default).

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -1862,7 +1862,7 @@ unix_domain_socket(Config) when is_list(Config) ->
 invalid_ipfamily_unix_socket() ->
     [{doc, "Test that httpc profile can't end up having invalid combination of ipfamily and unix_socket options"}].
 invalid_ipfamily_unix_socket(Config) when is_list(Config) ->
-    Profile = ?profile(Config),
+    Profile = proplists:get_value(profile, Config, httpc:default_profile()),
 
     ct:log("Using profile ~w", [Profile]),
     {ok,[{unix_socket,?UNIX_SOCKET}, {ipfamily, local}]} =

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -145,7 +145,8 @@ real_requests_esi() ->
     [slow_connection].
 
 simulated_unix_socket() ->
-    [unix_domain_socket].
+    [unix_domain_socket,
+    invalid_ipfamily_unix_socket].
 
 only_simulated() ->
     [
@@ -1857,6 +1858,21 @@ unix_domain_socket(Config) when is_list(Config) ->
 	= httpc:request(put, {URL, [], [], ""}, [], []),
     {ok, {{_,200,_}, [_ | _], _}}
         = httpc:request(get, {URL, []}, [], []).
+
+invalid_ipfamily_unix_socket() ->
+    [{doc, "Test that httpc profile can't end up having invalid combination of ipfamily and unix_socket options"}].
+invalid_ipfamily_unix_socket(Config) when is_list(Config) ->
+    Profile = ?profile(Config),
+
+    ct:log("Using profile ~w", [Profile]),
+    {ok,[{unix_socket,?UNIX_SOCKET}, {ipfamily, local}]} =
+        httpc:get_options([unix_socket, ipfamily], Profile),
+    ?assertMatch({error, _}, httpc:set_option(unix_socket, undefined, Profile)),
+    ?assertMatch({error, _}, httpc:set_option(ipfamily, inet, Profile)),
+    ?assertMatch({error, _}, httpc:set_option(ipfamily, inetv6, Profile)),
+    ok = httpc:set_options([{unix_socket, undefined}, {ipfamily, inet}], Profile),
+    ?assertMatch({error, _}, httpc:set_option(unix_socket, ?UNIX_SOCKET, Profile)).
+
 
 %%-------------------------------------------------------------------------
 delete_no_body(doc) ->

--- a/lib/inets/test/httpc_SUITE.erl
+++ b/lib/inets/test/httpc_SUITE.erl
@@ -1873,7 +1873,6 @@ invalid_ipfamily_unix_socket(Config) when is_list(Config) ->
     ok = httpc:set_options([{unix_socket, undefined}, {ipfamily, inet}], Profile),
     ?assertMatch({error, _}, httpc:set_option(unix_socket, ?UNIX_SOCKET, Profile)).
 
-
 %%-------------------------------------------------------------------------
 delete_no_body(doc) ->
     ["Test that a DELETE request without Body does not send a Content-Type header - Solves ERL-536"];


### PR DESCRIPTION
this is #8878 made compatible with older supported versions