### PR TITLE
ssh: Add bannerfun to the server role

### DIFF
--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1143,11 +1143,16 @@ in the User's Guide chapter.
 
 - **`failfun`** - Provides a fun to implement your own logging when a user fails
   to authenticate.
+
+- **`bannerfun`** - Provides a fun to implement the construction of a banner
+  text that is sent at the beginning of the user authentication. The banner will
+  not be sent if the function does not return a binary.
 """.
 -doc(#{title => <<"Daemon Options">>}).
 -type callbacks_daemon_options() ::
         {failfun, fun((User::string(), Peer::{inet:ip_address(), inet:port_number()}, Reason::term()) -> _)}
-      | {connectfun, fun((User::string(), Peer::{inet:ip_address(), inet:port_number()}, Method::string()) ->_)} .
+      | {connectfun, fun((User::string(), Peer::{inet:ip_address(), inet:port_number()}, Method::string()) ->_)}
+      | {bannerfun, fun((User::string()) -> binary())}.
 
 -doc(#{title => <<"Other data types">>}).
 -type opaque_daemon_options()  ::
@@ -1246,7 +1251,8 @@ in the User's Guide chapter.
 	  userauth_preference,
 	  available_host_keys,
 	  pwdfun_user_state,
-	  authenticated = false
+	  authenticated = false,
+	  userauth_banner_sent = false
 	 }).
 
 -record(alg,

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -589,7 +589,7 @@ default(server) ->
            },
 
       bannerfun =>
-          #{default => undefined,
+          #{default => fun(_) -> <<>> end,
             chk => fun(V) -> check_function1(V) end,
             class => user_option
            },

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -588,6 +588,12 @@ default(server) ->
             class => user_option
            },
 
+      bannerfun =>
+          #{default => undefined,
+            chk => fun(V) -> check_function1(V) end,
+            class => user_option
+           },
+
 %%%%% Undocumented
       infofun =>
           #{default => fun(_,_,_) -> void end,

--- a/lib/ssh/test/ssh_to_openssh_SUITE.erl
+++ b/lib/ssh/test/ssh_to_openssh_SUITE.erl
@@ -285,8 +285,12 @@ eserver_oclient_renegotiate_helper1(Config) ->
     SystemDir = proplists:get_value(data_dir, Config),
     PrivDir = proplists:get_value(priv_dir, Config),
 
+    %% Having the erlang sending a banner is accepted by openssh
+    BannerFun = fun(_U) -> <<"Banner to the client">> end,
+
     {Pid, Host, Port} = ssh_test_lib:daemon([{system_dir, SystemDir},
-                                             {failfun, fun ssh_test_lib:failfun/2}]),
+                                             {failfun, fun ssh_test_lib:failfun/2},
+                                             {bannerfun, BannerFun}]),
     ct:sleep(500),
 
     RenegLimitK = 3,


### PR DESCRIPTION
bannerfun/1 enables the server to send a SSH_MSG_USERAUTH_BANNER at the beginning of user authentication, immediately after receiving the first SSH_MSG_USERAUTH_BANNER