### PR TITLE
stdlib: Fix argparse:format_help/2 crash on 'hidden' command

### DIFF
--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -1674,6 +1674,8 @@ collect_options(CmdName, Command, [Cmd|Tail], Args) ->
     collect_options(CmdName ++ " " ++ Cmd, SubCmd, Tail, Args ++ maps:get(arguments, Command, [])).
 
 %% gets help for sub-command
+get_help(#{help := hidden}, []) ->
+    "";
 get_help(Command, []) ->
     maps:get(help, Command, "");
 get_help(Command, [Cmd|Tail]) ->

--- a/lib/stdlib/test/argparse_SUITE.erl
+++ b/lib/stdlib/test/argparse_SUITE.erl
@@ -816,6 +816,22 @@ usage(Config) when is_list(Config) ->
         "  ---extra    extra option very deep\n",
     ?assertEqual(CrawlerStatus, unicode:characters_to_list(argparse:help(Cmd,
         #{progname => "erl", command => ["erl", "status", "crawler"]}))),
+    RestartCmd = "Usage:\n  erl restart [-rfv] [--force] [-i <interval>] [--req <weird>] [--float <float>]\n"
+        "      [-d <duo>] [--duo <duo>] <server>\n"
+        "\n"
+        "Arguments:\n"
+        "  server      server to restart\n"
+        "\n"
+        "Optional arguments:\n"
+        "  -r          recursive\n"
+        "  -f, --force force\n"
+        "  -v          verbosity level\n"
+        "  -i          interval set (int >= 1)\n"
+        "  --req       required optional, right?\n"
+        "  --float     floating-point long form argument (float), default: 3.14\n"
+        "  -d, --duo   dual option\n",
+    ?assertEqual(RestartCmd, unicode:characters_to_list(argparse:help(Cmd,
+        #{progname => "erl", command => ["restart"]}))),
     ok.
 
 usage_required_args() ->


### PR DESCRIPTION
Fixes #9150

