### PR TITLE
Make assignment (match) in comprehension work as strict generator

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -2064,6 +2064,7 @@ get_nomatch_total(NomatchModes) ->
             end
         end.
 
+is_generator({match,_,_,_}) -> true;
 is_generator({generate,_,_,_}) -> true;
 is_generator({generate_strict,_,_,_}) -> true;
 is_generator({b_generate,_,_,_}) -> true;
@@ -2102,6 +2103,8 @@ get_qual_anno(Abstract) -> element(2, Abstract).
 %% generator(Line, Generator, Guard, State) -> {Generator',State}.
 %%  Transform a given generator into its #igen{} representation.
 
+generator(Line, {match,L,P,E}, Gs, St0) ->
+    generator(Line, {generate_strict,L,P,{cons,L,E,{nil,L}}}, Gs, St0);
 generator(Line, {Generate,Lg,P0,E}, Gs, St0) when Generate =:= generate;
                                                   Generate =:= generate_strict ->
     LA = lineno_anno(Line, St0),


### PR DESCRIPTION
It would be useful to be able to easily bind variables in the qualifiers of a comprehension, for example:
```
[Z || X <- Ls,
      {foo, Y} = g(X),
      Z <- f(Y, h(Y))].
```
You can do this today by writing a singleton generator:
```
[Z || X <- Ls,
      {foo, Y} <- [g(X)],  % produce single element
      Z <- f(Y, h(Y))].
```
but this has some drawbacks: the intent is not clear to the reader; you have to remember to write a single element list around the right hand side argument (which itself could be a list); you probably want it to be a strict generator so typos don't just silently yield no elements; and someone might edit the code later and accidentally add extra elements to the right hand side, causing unintended Cartesian combinations.

It is in fact already allowed syntactically to have a `=` match expression in the qualifiers, but this is just interpreted as any other expression - thus expected to produce a boolean value, and if false, the current element will be skipped. Hence, any qualifier to the right of a `V = Expr` match will only execute if V is true. We can therefore expect that no such uses exist in practice. (The OTP code base has been checked and does not contain any.) To be completely safe, matches in a comprehension qualifier position can first be made an error, and then allowed with these binding semantics in the following major release.

This is related but orthogonal to #9134. It would make those few cases where variables have been exported from subexpressions of qualifiers much nicer to rewrite than requiring them to be singleton generators.