### PR TITLE
Deprecate old catch

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -138,7 +138,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # FLAGS
 # ----------------------------------------------------
 
-ERL_COMPILE_FLAGS += -Werror
+ERL_COMPILE_FLAGS += -Werror +warn_deprecated_catch
 ERL_COMPILE_FLAGS += +inline +warn_unused_import \
  -I../../stdlib/include -I$(EGEN) -W +warn_missing_spec
 

--- a/lib/compiler/src/core_scan.erl
+++ b/lib/compiler/src/core_scan.erl
@@ -46,6 +46,8 @@
 -module(core_scan).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -export([string/1, string/2, format_error/1]).
 
 -import(lists, [reverse/1]).

--- a/lib/kernel/src/Makefile
+++ b/lib/kernel/src/Makefile
@@ -186,7 +186,7 @@ APPUP_TARGET= $(EBIN)/$(APPUP_FILE)
 # FLAGS
 # ----------------------------------------------------
 
-ERL_COMPILE_FLAGS += -Werror
+ERL_COMPILE_FLAGS += -Werror +warn_deprecated_catch
 ERL_COMPILE_FLAGS += -I../include
 
 

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -20,6 +20,8 @@
 -module(application_controller).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% External exports
 -export([start/1, 
 	 load_application/1, unload_application/1, 

--- a/lib/kernel/src/application_master.erl
+++ b/lib/kernel/src/application_master.erl
@@ -20,6 +20,8 @@
 -module(application_master).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% External exports
 -export([start_link/2, start_type/0, stop/1]).
 -export([get_child/1]).

--- a/lib/kernel/src/application_starter.erl
+++ b/lib/kernel/src/application_starter.erl
@@ -27,6 +27,8 @@
 -module(application_starter).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -export([start/3]).
 
 %%%=============================================================================

--- a/lib/kernel/src/auth.erl
+++ b/lib/kernel/src/auth.erl
@@ -28,6 +28,8 @@ Manual.
 -moduledoc(#{ deprecated => ~"See each function for what to use instead" }).
 -behaviour(gen_server).
 
+-compile(nowarn_deprecated_catch).
+
 -export([start_link/0]).
 
 %% Old documented interface - deprecated

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -343,6 +343,8 @@ common reasons.
 - **`sticky_directory`** - The object code resides in a sticky directory.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -include_lib("kernel/include/logger.hrl").
 -include("eep48.hrl").
 

--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -20,6 +20,8 @@
 -module(code_server).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% This file holds the server part of the code_server.
 
 -export([start_link/1,

--- a/lib/kernel/src/disk_log.erl
+++ b/lib/kernel/src/disk_log.erl
@@ -133,6 +133,8 @@ Nothing is said about whether the disk log files exist or not.
 `m:file`, `m:wrap_log_reader`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% Efficient file based log - process part
 
 -export([start/0, istart_link/1, 

--- a/lib/kernel/src/disk_log_1.erl
+++ b/lib/kernel/src/disk_log_1.erl
@@ -20,6 +20,8 @@
 -module(disk_log_1).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Efficient file based log - implementation part
 
 -export([int_open/4, ext_open/4, logl/1, close/3, truncate/3, chunk/5, 

--- a/lib/kernel/src/dist_ac.erl
+++ b/lib/kernel/src/dist_ac.erl
@@ -20,6 +20,8 @@
 -module(dist_ac).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_server).
 
 %% External exports

--- a/lib/kernel/src/erl_boot_server.erl
+++ b/lib/kernel/src/erl_boot_server.erl
@@ -52,6 +52,8 @@ and `m:erl_prim_loader` in ERTS.
 [`erts:init`](`m:init`), [`erts:erl_prim_loader`](`m:erl_prim_loader`)
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -include("inet_boot.hrl").
 
 -behaviour(gen_server).

--- a/lib/kernel/src/erl_ddll.erl
+++ b/lib/kernel/src/erl_ddll.erl
@@ -154,6 +154,8 @@ follows:
 [`erl_driver(4)`](`e:erts:erl_driver.md`), [`driver_entry(4)`](`e:erts:driver_entry.md`)
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([load_driver/2, load/2, 
 	 unload_driver/1, unload/1, reload/2, reload_driver/2, 
 	 format_error/1,info/1,info/0, start/0, stop/0]).

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -27,6 +27,8 @@ To implement your own epmd module please see
 """.
 -moduledoc(#{since => "OTP R14B"}).
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_server).
 
 -ifdef(DEBUG).

--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -20,6 +20,8 @@
 -module(file_io_server).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% A simple file server for io to one file instance per server instance.
 
 -export([format_error/1]).

--- a/lib/kernel/src/file_server.erl
+++ b/lib/kernel/src/file_server.erl
@@ -28,6 +28,8 @@
 -module(file_server).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_server).
 
 %% External exports

--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -243,6 +243,8 @@ way, option `send_timeout` comes in handy.
 """.
 
 
+-compile(nowarn_deprecated_catch).
+
 -export([connect/2, connect/3, connect/4,
          listen/2,
          accept/1, accept/2,

--- a/lib/kernel/src/gen_udp_socket.erl
+++ b/lib/kernel/src/gen_udp_socket.erl
@@ -22,6 +22,8 @@
 -moduledoc false.
 -behaviour(gen_statem).
 
+-compile(nowarn_deprecated_catch).
+
 -compile({no_auto_import, [monitor/1]}).
 
 %% gen_udp

--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -116,6 +116,8 @@ network problem.
 """.
 -behaviour(gen_server).
 
+-compile(nowarn_deprecated_catch).
+
 %% Global provides global registration of process names. The names are
 %% dynamically kept up to date with the entire network. Global can
 %% operate in two modes: in a fully connected network, or in a

--- a/lib/kernel/src/global_group.erl
+++ b/lib/kernel/src/global_group.erl
@@ -67,6 +67,8 @@ global group as the local node.
 `m:global`, [`erl`](`e:erts:erl_cmd.md`)
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% Groups nodes into global groups with an own global name space.
 
 -behaviour(gen_server).

--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -20,6 +20,8 @@
 -module(group).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -include_lib("kernel/include/logger.hrl").
 
 %% A group leader process for user io.

--- a/lib/kernel/src/heart.erl
+++ b/lib/kernel/src/heart.erl
@@ -104,6 +104,8 @@ In the following descriptions, all functions fail with reason `badarg` if
 `heart` is not started.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %%%--------------------------------------------------------------------
 %%% This is a rewrite of pre_heart from BS.3.
 %%%

--- a/lib/kernel/src/inet_config.erl
+++ b/lib/kernel/src/inet_config.erl
@@ -20,6 +20,8 @@
 -module(inet_config).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -include("inet_config.hrl").
 -include("inet.hrl").
 

--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -21,6 +21,8 @@
 -module(inet_db).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Store info about ip addresses, names, aliases host files resolver
 %% options.
 %% Also miscellaneous "stuff" related to sockets.

--- a/lib/kernel/src/inet_gethost_native.erl
+++ b/lib/kernel/src/inet_gethost_native.erl
@@ -21,6 +21,8 @@
 -moduledoc false.
 -behaviour(supervisor_bridge).
 
+-compile(nowarn_deprecated_catch).
+
 %% Supervisor bridge exports
 -export([start_link/0, init/1, terminate/2]).
 

--- a/lib/kernel/src/inet_parse.erl
+++ b/lib/kernel/src/inet_parse.erl
@@ -20,6 +20,8 @@
 -module(inet_parse).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Parser for all kinds of ineternet configuration files
 
 %% Avoid warning for local function error/2 clashing with autoimported BIF.

--- a/lib/kernel/src/kernel_config.erl
+++ b/lib/kernel/src/kernel_config.erl
@@ -20,6 +20,8 @@
 -module(kernel_config).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_server).
 
 %% External exports

--- a/lib/kernel/src/net_adm.erl
+++ b/lib/kernel/src/net_adm.erl
@@ -42,6 +42,9 @@ _Example:_
 ^ (new line)
 ```
 """.
+
+-compile(nowarn_deprecated_catch).
+
 -export([host_file/0,
 	 localhost/0,
 	 names/0, names/1,

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -68,6 +68,8 @@ in the Erlang Reference Manual.
 > for details on how to setup a secure distributed node.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_server).
 
 -define(nodedown(N, State), verbose({?MODULE, ?LINE, nodedown, N}, 1, State)).

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -33,6 +33,8 @@ a program to run on most platforms.
 > Types" section.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% Provides a common operating system interface.
 
 -export([type/0, version/0, cmd/1, cmd/2, find_executable/1, find_executable/2]).

--- a/lib/kernel/src/rpc.erl
+++ b/lib/kernel/src/rpc.erl
@@ -65,6 +65,8 @@ some specific side effects on the remote node.
 
 -behaviour(gen_server).
 
+-compile(nowarn_deprecated_catch).
+
 -export([start/0, start_link/0, stop/0,
 	 call/4, call/5,
 	 block_call/4, block_call/5,

--- a/lib/kernel/src/standard_error.erl
+++ b/lib/kernel/src/standard_error.erl
@@ -21,6 +21,8 @@
 -moduledoc false.
 -behaviour(supervisor_bridge).
 
+-compile(nowarn_deprecated_catch).
+
 -include_lib("kernel/include/logger.hrl").
 
 %% Basic standard i/o server for user interface port.

--- a/lib/kernel/src/wrap_log_reader.erl
+++ b/lib/kernel/src/wrap_log_reader.erl
@@ -55,6 +55,8 @@ logged items in the log file, as the opened index file was truncated by
 -define(FORMAT(P, A), ok).
 -endif.
 
+-compile(nowarn_deprecated_catch).
+
 -export([open/1, open/2, chunk/1, chunk/2, close/1]).
 
 -export_type([continuation/0]).

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -171,7 +171,7 @@ endif
 # FLAGS
 # ----------------------------------------------------
 
-ERL_COMPILE_FLAGS += -Werror
+ERL_COMPILE_FLAGS += -Werror  +warn_deprecated_catch
 ERL_COMPILE_FLAGS += -I../include -I../../kernel/include
 
 ifeq ($(ERL_DETERMINISTIC),yes)

--- a/lib/stdlib/src/beam_lib.erl
+++ b/lib/stdlib/src/beam_lib.erl
@@ -148,6 +148,8 @@ providing one key for module `t` and another key for all other modules:
 """.
 -behaviour(gen_server).
 
+-compile(nowarn_deprecated_catch).
+
 -include_lib("kernel/include/eep48.hrl").
 
 %% Avoid warning for local function error/1 clashing with autoimported BIF.

--- a/lib/stdlib/src/c.erl
+++ b/lib/stdlib/src/c.erl
@@ -34,6 +34,8 @@ commands.
 `m:filename`, `m:compile`, `m:erlang`, `m:yecc`, `m:xref`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -include_lib("kernel/include/eep48.hrl").
 
 %% Utilities to use from shell.

--- a/lib/stdlib/src/dets.erl
+++ b/lib/stdlib/src/dets.erl
@@ -86,6 +86,8 @@ message.
 `m:ets`, `m:mnesia`, `m:qlc`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% Disk based linear hashing lookup dictionary.
 
 %% Public.

--- a/lib/stdlib/src/dets_utils.erl
+++ b/lib/stdlib/src/dets_utils.erl
@@ -20,6 +20,8 @@
 -module(dets_utils).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Utility functions common to several dets file formats.
 %% To be used from modules dets and dets_v9 only.
 

--- a/lib/stdlib/src/dets_v9.erl
+++ b/lib/stdlib/src/dets_v9.erl
@@ -21,6 +21,8 @@
 -moduledoc false.
 -compile([{nowarn_deprecated_function, [{erlang,phash,2}]}]).
 
+-compile(nowarn_deprecated_catch).
+
 %% Dets files, implementation part. This module handles version 9.
 %% To be called from dets.erl only.
 

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -177,6 +177,8 @@ supports multiple lines.
 """.
 -moduledoc(#{since => "OTP 26.1"}).
 
+-compile(nowarn_deprecated_catch).
+
 %% A simple Emacs-like line editor.
 %% About Latin-1 characters: see the beginning of erl_scan.erl.
 

--- a/lib/stdlib/src/edlin_type_suggestion.erl
+++ b/lib/stdlib/src/edlin_type_suggestion.erl
@@ -19,6 +19,9 @@
 %%
 -module(edlin_type_suggestion).
 -moduledoc false.
+
+-compile(nowarn_deprecated_catch).
+
 -include_lib("kernel/include/eep48.hrl").
 -export([type_tree/4, get_arity/3, get_atoms/3, get_types/3, get_types/4, get_function_type/4, print_type/3]).
 

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -64,6 +64,8 @@ Module:format_error(ErrorDescriptor)
 `m:erl_parse`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% An Erlang code preprocessor.
 
 -export([open/1,open/2,open/3,close/1,format_error/1]).

--- a/lib/stdlib/src/erl_eval.erl
+++ b/lib/stdlib/src/erl_eval.erl
@@ -125,6 +125,8 @@ the local function handler argument. A possible use is to call
 to be called.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% An evaluator for Erlang abstract syntax.
 
 -export([exprs/2,exprs/3,exprs/4,expr/2,expr/3,expr/4,expr/5,

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -595,6 +595,13 @@ format_error_1({deprecated_builtin_type, {Name, Arity},
            end,
     {~"type ~w/~w is deprecated and will be removed in ~s; use ~s",
      [Name, Arity, Rel, UseS]};
+format_error_1(deprecated_catch) ->
+    ~"""
+     'catch ...' is deprecated and will be removed in OTP 30;
+     please use 'try ... catch ... end' instead.
+     Compile directive nowarn_deprecated_catch can be used to suppress
+     warnings in selected modules but will stop working in OTP 29.
+     """;
 format_error_1({not_exported_opaque, {TypeName, Arity}}) ->
     {~"opaque type ~tw~s is not exported",
                   [TypeName, gen_type_paren(Arity)]};
@@ -818,6 +825,7 @@ parse_options([], Enabled) ->
 
 bool_options() ->
     [{unused_vars,true},
+     {deprecated_catch,false},
      {underscore_match,true},
      {export_all,true},
      {export_vars,false},
@@ -2823,7 +2831,11 @@ expr({'try',Anno,Es,Scs,Ccs,As}, Vt, St0) ->
 expr({'catch',Anno,E}, Vt, St0) ->
     %% No new variables added, flag new variables as unsafe.
     {Evt,St} = expr(E, Vt, St0),
-    {vtupdate(vtunsafe({'catch',Anno}, Evt, Vt), Evt),St};
+    St1 = case is_warn_enabled(deprecated_catch, St) of
+              true -> add_warning(Anno, deprecated_catch, St);
+              false -> St
+          end,
+    {vtupdate(vtunsafe({'catch',Anno}, Evt, Vt), Evt),St1};
 expr({match,_Anno,P,E}, Vt, St0) ->
     {Evt,St1} = expr(E, Vt, St0),
     {Pvt,Pnew,St} = pattern(P, vtupdate(Evt, Vt), St1),

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -778,6 +778,8 @@ This function is usually called implicitly when an ErrorInfo structure is
 processed (see section [Error Information](#module-error-information)).
 """).
 
+-compile(nowarn_deprecated_catch).
+
 -export([parse_form/1,parse_exprs/1,parse_term/1]).
 -export([normalise/1,abstract/1,tokens/1,tokens/2]).
 -export([abstract/2]).

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -226,6 +226,8 @@ A match specifications with excessive nesting will cause a
 [`system_limit`](`m:ets#ets_failures`) error exception to be raised.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% Interface to the Term store BIF's
 %% ets == Erlang Term Store
 

--- a/lib/stdlib/src/eval_bits.erl
+++ b/lib/stdlib/src/eval_bits.erl
@@ -21,6 +21,8 @@
 -module(eval_bits).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Avoid warning for local function error/1 clashing with autoimported BIF.
 -compile({no_auto_import,[error/1]}).
 -export([expr_grp/3,expr_grp/4,match_bits/6,

--- a/lib/stdlib/src/file_sorter.erl
+++ b/lib/stdlib/src/file_sorter.erl
@@ -172,6 +172,8 @@ The possible values of `Reason` returned when an error occurs are:
   term.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% Avoid warning for local function error/2 clashing with autoimported BIF.
 -compile({no_auto_import,[error/2]}).
 -export([sort/1, sort/2, sort/3, 

--- a/lib/stdlib/src/filelib.erl
+++ b/lib/stdlib/src/filelib.erl
@@ -49,6 +49,8 @@ For more information about raw filenames, see the `m:file` module.
 > filenames.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% File utilities.
 -export([wildcard/1, wildcard/2, is_dir/1, is_file/1, is_regular/1]).
 -export([fold_files/5, last_modified/1, file_size/1, ensure_dir/1, ensure_path/1]).

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -128,6 +128,8 @@ or if bad arguments are specified.
 %%%       above monitor_return() in gen.erl!
 %%%
 
+-compile(nowarn_deprecated_catch).
+
 -export([start/0, start/1, start/2,
          start_link/0, start_link/1, start_link/2,
          start_monitor/0, start_monitor/1, start_monitor/2,

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -359,6 +359,8 @@ that implements the state machine.
 %%%
 %%% ---------------------------------------------------
 
+-compile(nowarn_deprecated_catch).
+
 -include("logger.hrl").
 
 -export([start/3, start/4,

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -182,6 +182,8 @@ using exit signals.
 %%%
 %%% ---------------------------------------------------
 
+-compile(nowarn_deprecated_catch).
+
 %% API
 -export([start/3, start/4,
 	 start_link/3, start_link/4,

--- a/lib/stdlib/src/io.erl
+++ b/lib/stdlib/src/io.erl
@@ -66,6 +66,8 @@ Module:format_error(ErrorDescriptor)
 ```
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([put_chars/1,put_chars/2,nl/0,nl/1,
 	 get_chars/2,get_chars/3,get_line/1,get_line/2,
 	 get_password/0, get_password/1,

--- a/lib/stdlib/src/io_lib.erl
+++ b/lib/stdlib/src/io_lib.erl
@@ -69,6 +69,8 @@ functions are flat, they can be deep lists. Function `lists:flatten/1` can be
 used for flattening deep lists.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([fwrite/2,fwrite/3,fread/2,fread/3,format/2,format/3]).
 -export([scan_format/2,unscan_format/1,build_text/1,build_text/2]).
 -export([print/1,print/4,indentation/2]).

--- a/lib/stdlib/src/io_lib_format.erl
+++ b/lib/stdlib/src/io_lib_format.erl
@@ -20,6 +20,8 @@
 -module(io_lib_format).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Formatting functions of io library.
 
 -export([fwrite/2,fwrite/3,fwrite_g/1,indentation/2,scan/2,unscan/1,

--- a/lib/stdlib/src/io_lib_fread.erl
+++ b/lib/stdlib/src/io_lib_fread.erl
@@ -20,6 +20,8 @@
 -module(io_lib_fread).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %% Formatted input functions of io library.
 
 -export([fread/2,fread/3]).

--- a/lib/stdlib/src/log_mf_h.erl
+++ b/lib/stdlib/src/log_mf_h.erl
@@ -35,6 +35,8 @@ one file called `index`, and report files `1, 2, ...`.
 `m:gen_event`, `m:rb`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_event).
 
 -export([init/3, init/4]).

--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -20,6 +20,8 @@
 -module(ms_transform).
 -moduledoc({file, "../doc/src/ms_transform.md"}).
 
+-compile(nowarn_deprecated_catch).
+
 -export([format_error/1,transform_from_shell/3,
          parse_transform/2,parse_transform_info/0]).
 

--- a/lib/stdlib/src/peer.erl
+++ b/lib/stdlib/src/peer.erl
@@ -52,6 +52,8 @@
 -moduledoc(#{since => "OTP 25.0"}).
 -endif.
 
+-compile(nowarn_deprecated_catch).
+
 %% API
 -export([
          start_link/0,

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -60,6 +60,8 @@ processes that terminate as a result of this process terminating.
 `m:logger`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 %% This module is used to set some initial information
 %% in each created process. 
 %% Then a process terminates the Reason is checked and

--- a/lib/stdlib/src/qlc.erl
+++ b/lib/stdlib/src/qlc.erl
@@ -26,6 +26,8 @@
 
 %% External exports 
 
+-compile(nowarn_deprecated_catch).
+
 %% Avoid warning for local function error/1 clashing with autoimported BIF.
 -compile({no_auto_import,[error/1]}).
 -export([parse_transform/2,

--- a/lib/stdlib/src/qlc_pt.erl
+++ b/lib/stdlib/src/qlc_pt.erl
@@ -20,6 +20,8 @@
 -module(qlc_pt).
 -moduledoc false.
 
+-compile(nowarn_deprecated_catch).
+
 %%% Purpose: Implements the qlc Parse Transform.
 
 -export([parse_transform/2, transform_from_evaluator/2,

--- a/lib/stdlib/src/re.erl
+++ b/lib/stdlib/src/re.erl
@@ -23,6 +23,8 @@
 
 -export_type([mp/0, compile_options/0, options/0]).
 
+-compile(nowarn_deprecated_catch).
+
 -doc """
 Opaque data type containing a compiled regular expression.
 

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -20,6 +20,8 @@
 -module(shell).
 -moduledoc({file, "../doc/src/shell.md"}).
 
+-compile(nowarn_deprecated_catch).
+
 -export([start/0, start/1, start/2, server/1, server/2, history/1, results/1]).
 -export([get_state/0, get_function/2]).
 -export([start_restricted/1, stop_restricted/0]).

--- a/lib/stdlib/src/slave.erl
+++ b/lib/stdlib/src/slave.erl
@@ -68,6 +68,8 @@ The master node must be alive.
 %% (the example is for tcsh)
 
 
+-compile(nowarn_deprecated_catch).
+
 -export([pseudo/1,
 	 pseudo/2,
 	 start/1, start/2, start/3,

--- a/lib/stdlib/src/sofs.erl
+++ b/lib/stdlib/src/sofs.erl
@@ -20,6 +20,8 @@
 -module(sofs).
 -moduledoc({file, "../doc/src/sofs.md"}).
 
+-compile(nowarn_deprecated_catch).
+
 -export([from_term/1, from_term/2, from_external/2, empty_set/0,
          is_type/1, set/1, set/2, from_sets/1, relation/1, relation/2,
          a_function/1, a_function/2, family/1, family/2,

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -277,6 +277,8 @@ but the map is preferred.
 `m:gen_event`, `m:gen_statem`, `m:gen_server`, `m:sys`
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -behaviour(gen_server).
 
 %% External exports

--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -77,6 +77,8 @@ the process itself to format these events.
                  [{function,<<"Process Implementation Functions">>},
                   {callback,<<"Process Implementation Functions">>}]}).
 
+-compile(nowarn_deprecated_catch).
+
 %% External exports
 -export([suspend/1, suspend/2, resume/1, resume/2,
 	 get_status/1, get_status/2,

--- a/lib/stdlib/src/unicode.erl
+++ b/lib/stdlib/src/unicode.erl
@@ -57,6 +57,8 @@ normalization can be found in the
 [Unicode FAQ](http://unicode.org/faq/normalization.html).
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([characters_to_list/1, characters_to_list_int/2,
 	 characters_to_binary/1, characters_to_binary_int/2,
 	 characters_to_binary/3,

--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -62,6 +62,8 @@ convention, add `.zip` to the filename.
 -define(ERL_TAR_COMPATIBILITY, ~"erl_tar compatibility functions").
 -moduledoc(#{ titles => [{function, ?ERL_TAR_COMPATIBILITY}]}).
 
+-compile(nowarn_deprecated_catch).
+
 %% Basic api
 -export([unzip/1, unzip/2, extract/1, extract/2,
 	 zip/2, zip/3, create/2, create/3, foldl/3,


### PR DESCRIPTION
`try...catch...end` has been available for a very long time now, and the old, simplistic `catch Expr` should be dropped from the language. In most places where it is used, it carries with it some unwanted (and often unknown) corner case behaviour, such as discarding the original error location, conflating errors, exits, and throws, and mixing up thrown values with normally returned values in a way that makes it very hard to see what the author intended, and whether the implementation really does what they hoped. Maintainance of such code is very hard.

I suggest the following schedule: 1) Add a deprecation warning, turned off by default, allowing users to start eliminating old catches from their own code as soon as possible. 2) Enable the warning by default in OTP 28 but allow it to be turned off selectively per module or application, so users do not have to tackle the entire code base at once. 3) Remove the option to disable the warning in OTP 29. 4) Remove the support for `catch Expr` completely in OTP 30.

This patch implements the warning in step 1 and marks up the applications kernel, stdlib, and compiler to prevent new old-style catches from being added.