### PR TITLE
ssh: improvements for connection information

### DIFF
--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1147,7 +1147,8 @@ in the User's Guide chapter.
 -doc(#{title => <<"Daemon Options">>}).
 -type callbacks_daemon_options() ::
         {failfun, fun((User::string(), PeerAddress::inet:ip_address(), Reason::term()) -> _)}
-      | {connectfun, fun((User::string(), PeerAddress::inet:ip_address(), Method::string()) ->_)} .
+      | {connectfun, fun((User::string(), PeerAddress::inet:ip_address(), Method::string()) ->_)
+        | fun((User::string(), PeerAddress::inet:ip_address(), Method::string(), Info::proplists:proplist()) ->_)} .
 
 -doc(#{title => <<"Other data types">>}).
 -type opaque_daemon_options()  ::

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1247,7 +1247,8 @@ in the User's Guide chapter.
 	  userauth_preference,
 	  available_host_keys,
 	  pwdfun_user_state,
-	  authenticated = false
+	  authenticated = false,
+	  last_userauth_tried = "none" %% Not used for server role
 	 }).
 
 -record(alg,

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1854,7 +1854,8 @@ conn_info_keys() ->
      sockname,
      options,
      algorithms,
-     channels
+     channels,
+     user_auth
     ].
 
 conn_info(client_version, #data{ssh_params=S}) -> {S#ssh.c_vsn, S#ssh.c_version};
@@ -1876,7 +1877,8 @@ conn_info(socket, D) ->   D#data.socket;
 conn_info(chan_ids, D) ->
     ssh_client_channel:cache_foldl(fun(#channel{local_id=Id}, Acc) ->
 				    [Id | Acc]
-			    end, [], cache(D)).
+                                   end, [], cache(D));
+conn_info(user_auth, #data{ssh_params=#ssh{last_userauth_tried=UserAuth}}) -> UserAuth.
 
 conn_info_chans(Chs) ->
     Fs = record_info(fields, channel),

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -68,6 +68,7 @@
          retrieve/2,
 	 info/1, info/2,
 	 connection_info/2,
+	 connection_info_server/1,
 	 channel_info/3,
 	 adjust_window/3, close/2,
 	 disconnect/4,
@@ -307,6 +308,17 @@ connection_info(ConnectionHandler, Key) when is_atom(Key) ->
     end;
 connection_info(ConnectionHandler, Options) ->
     call(ConnectionHandler, {connection_info, Options}).
+
+%%--------------------------------------------------------------------
+connection_info_server(D) when is_tuple(D) ->
+    Keys = [client_version,
+            server_version,
+            peer,
+            sockname,
+            options,
+            algorithms
+           ],
+    fold_keys(Keys, fun conn_info/2, D).
 
 %%--------------------------------------------------------------------
 -spec channel_info(connection_ref(),

--- a/lib/ssh/src/ssh_fsm_userauth_client.erl
+++ b/lib/ssh/src/ssh_fsm_userauth_client.erl
@@ -97,10 +97,12 @@ handle_event(internal, #ssh_msg_userauth_failure{authentications = Methods}, Sta
                                  io_lib:format("User auth failed for: ~p",[D0#data.auth_user]),
                                  StateName, D0#data{ssh_params = Ssh}),
 	    {stop, Shutdown, D};
-	{"keyboard-interactive", {Msg, Ssh}} ->
+	{"keyboard-interactive", {Msg, Ssh2}} ->
+            Ssh = Ssh2#ssh{last_userauth_tried = "keyboard-interactive"},
             D = ssh_connection_handler:send_msg(Msg, D0#data{ssh_params = Ssh}),
 	    {next_state, {userauth_keyboard_interactive,client}, D};
-	{_Method, {Msg, Ssh}} ->
+	{Method, {Msg, Ssh2}} ->
+            Ssh = Ssh2#ssh{last_userauth_tried = Method},
             D = ssh_connection_handler:send_msg(Msg, D0#data{ssh_params = Ssh}),
 	    {keep_state, D}
     end;

--- a/lib/ssh/src/ssh_fsm_userauth_server.erl
+++ b/lib/ssh/src/ssh_fsm_userauth_server.erl
@@ -184,8 +184,14 @@ set_max_initial_idle_timeout(#data{ssh_params = #ssh{opts=Opts}}) ->
     {{timeout,max_initial_idle_time}, ?GET_OPT(max_initial_idle_time,Opts), none}.
 
 connected_fun(User, Method, #data{ssh_params = #ssh{peer = {_,Peer}}} = D) ->
-    ?CALL_FUN(connectfun,D)(User, Peer, Method).
-
+    Fun = ?GET_OPT(connectfun, (D#data.ssh_params)#ssh.opts),
+    ConnInfo = ssh_connection_handler:connection_info_server(D),
+    case erlang:fun_info(Fun, arity) of
+        {arity, 3} ->
+            Fun(User, Peer, Method);
+        {arity, 4} ->
+            Fun(User, Peer, Method, ConnInfo)
+    end.
 
 retry_fun(_, undefined, _) ->
     ok;

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -584,7 +584,9 @@ default(server) ->
 
       connectfun =>
           #{default => fun(_,_,_) -> void end,
-            chk => fun(V) -> check_function3(V) end,
+            chk => fun(V) -> check_function3(V) orelse
+                                 check_function4(V) %% Adds ssh connection info
+                   end,
             class => user_option
            },
 

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -74,6 +74,7 @@
 	 user_dir_option/1,
 	 user_dir_fun_option/1,
 	 connectfun_disconnectfun_server/1,
+	 connectfun4_server/1,
 	 hostkey_fingerprint_check/1,
 	 hostkey_fingerprint_check_md5/1,
 	 hostkey_fingerprint_check_sha/1,
@@ -114,6 +115,7 @@ suite() ->
 
 all() -> 
     [connectfun_disconnectfun_server,
+     connectfun4_server,
      connectfun_disconnectfun_client,
      server_password_option,
      server_userpassword_option,
@@ -770,6 +772,44 @@ connectfun_disconnectfun_server(Config) ->
 		    end,
 		    {fail, "No disconnectfun action"}
 	    end
+    after 10000 ->
+	    receive
+		X -> ct:log("received ~p",[X])
+	    after 0 -> ok
+	    end,
+	    {fail, "No connectfun action"}
+    end.
+
+
+%%--------------------------------------------------------------------
+connectfun4_server(Config) ->
+    UserDir = proplists:get_value(user_dir, Config),
+    SysDir = proplists:get_value(data_dir, Config),
+
+    Parent = self(),
+    Ref = make_ref(),
+    ConnFun = fun(User,_,Method,ConnInfo) -> Parent ! {connect,Ref,User,Method,ConnInfo} end,
+    DiscFun = fun(R) -> Parent ! {disconnect,Ref,R} end,
+
+    {Pid, Host, Port} = ssh_test_lib:daemon([{system_dir, SysDir},
+					     {user_dir, UserDir},
+					     {password, "morot"},
+					     {failfun, fun ssh_test_lib:failfun/2},
+					     {connectfun, ConnFun}]),
+    ConnectionRef =
+	ssh_test_lib:connect(Host, Port, [{silently_accept_hosts, true},
+					  {user, "foo"},
+					  {password, "morot"},
+					  {user_dir, UserDir},
+					  {user_interaction, false}]),
+    receive
+	{connect,Ref,User,Method,ConnInfo} ->
+            "foo" = User,
+            "keyboard-interactive" = Method,
+            Keys = [client_version, server_version, peer, sockname, options, algorithms],
+            true = lists:all(fun({K, _}) -> lists:member(K, Keys) end, ConnInfo),
+	    ssh:close(ConnectionRef),
+            ssh:stop_daemon(Pid)
     after 10000 ->
 	    receive
 		X -> ct:log("received ~p",[X])

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -610,6 +610,8 @@ auth_none(Config) ->
 					  {password, "wrong-pwd"},
 					  {user_dir, UserDir},
 					  {user_interaction, false}]),
+    [{user_auth, "none"}] =
+        ssh:connection_info(ClientConnRef1, [user_auth]),
     "some-other-user" =
         proplists:get_value(user, ssh:connection_info(ClientConnRef1, [user])),
     ok = ssh:close(ClientConnRef1),
@@ -677,12 +679,14 @@ user_dir_fun_option(Config) ->
                                                                     UserDir
                                                             end},
 					     {failfun, fun ssh_test_lib:failfun/2}]),
-    _ConnectionRef =
+    ConnectionRef =
 	ssh_test_lib:connect(Host, Port, [{silently_accept_hosts, true},
 					  {user, "foo"},
 					  {user_dir, UserDir},
                                           {auth_methods,"publickey"},
 					  {user_interaction, false}]),
+    [{user_auth, "publickey"}] =
+        ssh:connection_info(ConnectionRef, [user_auth]),
     receive
         {user,Ref,"foo"} ->
             ssh:stop_daemon(Pid),
@@ -802,6 +806,9 @@ connectfun4_server(Config) ->
 					  {password, "morot"},
 					  {user_dir, UserDir},
 					  {user_interaction, false}]),
+    [{user_auth, "keyboard-interactive"}] =
+	ssh:connection_info(ConnectionRef, [user_auth]),
+
     receive
 	{connect,Ref,User,Method,ConnInfo} ->
             "foo" = User,


### PR DESCRIPTION
This PR expands the connectfun with the SSH connection information and expands the ssh:connection_info information with a new field which has the authentication method used. This last addition brings feature parity between the server and client role, since the authentication Method is available in the connectfun callback.

This PR brings part of the improvements needed to close #8718