### PR TITLE
ssl: relax ssl_trace_SUITE

### DIFF
--- a/lib/ssl/test/ssl_trace_SUITE.erl
+++ b/lib/ssl/test/ssl_trace_SUITE.erl
@@ -219,7 +219,7 @@ tc_rle_profile(Config) ->
         #{
           call =>
               [],
-         return_from =>
+          return_from =>
               [{"    (client) <- ssl:connect/3 returned", ssl, connect},
                {"    (server) <- ssl:listen/2 returned", ssl, listen},
                {"    (client) <- tls_sender:init/3 returned", tls_sender, init},
@@ -381,9 +381,10 @@ check_trace_map(Ref, ExpectedTraces, ExpectedRemainders) ->
         true ->
             ok;
         _ ->
-            ?CT_FAIL("Expected trace remainders = ~w ~n"
-                 "Actual trace remainders = ~w",
-                 [ExpectedRemainders, ActualRemainders])
+            ?CT_PAL("~nExpected trace remainders = ~w ~n"
+                    "Actual trace remainders = ~w",
+                    [ExpectedRemainders, ActualRemainders]),
+            ok
     end.
 
 check_key(Type, ExpectedTraces, ReceivedPerType) ->
@@ -411,14 +412,16 @@ check_key(Type, ExpectedTraces, ReceivedPerType) ->
                                  _ -> false
                              end
                      end,
-                Result = lists:any(P2, ReceivedPerType),
-                case Result of
+                case lists:any(P2, ReceivedPerType) of
                     false ->
-                        F = "Trace not found: {~s, ~w, ~w}",
-                        ?CT_FAIL(F, [ExpectedString, Module, Function]);
-                    _ -> ok
-                end,
-                Result
+                        F = "Trace not found: {~s, ~w, ~w} (check trace profile)",
+                        %% don't fail, but become noisy instead
+                        ?CT_PAL(F, [ExpectedString, Module, Function]),
+                        ct:comment(F, [ExpectedString, Module, Function]),
+                        true;
+                    _ ->
+                        true
+                end
         end).
 
 -define(CHECK_PROCESSED_TRACE(PATTERN, Expected),
@@ -429,28 +432,30 @@ check_key(Type, ExpectedTraces, ReceivedPerType) ->
                                  string:str(lists:flatten(Txt), ExpectedString),
                              SearchResult > 0
                      end,
-                Result = lists:any(P2, ReceivedPerType),
-                case Result of
+                case lists:any(P2, ReceivedPerType) of
                     false ->
-                        F = "Processed trace not found: ~s",
-                        ?CT_FAIL(F, [ExpectedString]);
-                    _ -> ok
-                end,
-                Result
+                        F = "Processed trace not found: ~s (check trace profile)",
+                        %% don't fail, but become noisy instead
+                        ?CT_PAL(F, [ExpectedString]),
+                        ct:comment(F, [ExpectedString]),
+                        true;
+                    _ ->
+                        true
+                end
         end).
 
 check_trace(call, ExpectedPerType, ReceivedPerType) ->
     P1 = ?CHECK_TRACE([Txt, {call, {M, F, _Args}}, _], Expected),
-    true = lists:all(P1, ExpectedPerType);
+    lists:all(P1, ExpectedPerType);
 check_trace(return_from, ExpectedPerType, ReceivedPerType) ->
     P1 = ?CHECK_TRACE([Txt, {return_from, {M, F, _Args}, _Return}, _], Expected),
-    true = lists:all(P1, ExpectedPerType);
+    lists:all(P1, ExpectedPerType);
 check_trace(exception_from, ExpectedPerType, ReceivedPerType) ->
     P1 = ?CHECK_TRACE([Txt, {exception_from, {M, F, _Args}, _Return}, _], Expected),
-    true = lists:all(P1, ExpectedPerType);
+    lists:all(P1, ExpectedPerType);
 check_trace(processed, ExpectedPerType, ReceivedPerType) ->
     P1 = ?CHECK_PROCESSED_TRACE([_Timestamp, _Pid, Txt], Expected),
-    true = lists:all(P1, ExpectedPerType);
+    lists:all(P1, ExpectedPerType);
 check_trace(Type, _ExpectedPerType, _ReceivedPerType) ->
     ?CT_FAIL("Type = ~w not checked", [Type]),
     ok.


### PR DESCRIPTION
- reduce the strictness of code verifying trace profiles
- ct:pal and ct:comment instead of ct:fail
- I want that verification to be done
- but don't want it to stop someone from merging
- I can fix those myself later
- tc_check_profiles will still fail if one functions used in trace
- profile is not correct (non-existing function used in profile definition)