### PR TITLE
argparse: Accept the progname in the command path

### DIFF
--- a/lib/stdlib/src/argparse.erl
+++ b/lib/stdlib/src/argparse.erl
@@ -1592,7 +1592,21 @@ is_valid_command_help(_) ->
 
 format_help({ProgName, Root}, Format) ->
     Prefix = hd(maps:get(prefixes, Format, [$-])),
-    Nested = maps:get(command, Format, []),
+    Nested0 = maps:get(command, Format, [ProgName]),
+    %% The command path should always start with the progname, that's why it is
+    %% dropped here to keep the command and sub-commands only.
+    %%
+    %% However, earlier versions of this function did not drop that progname.
+    %% The function thus used to crash with a badkey excception if the caller
+    %% passed the `CmdPath' returned by `parse/2' to this function's `command'.
+    %% Therefore, to keep backward compatibility, if the command path does not
+    %% start with the progname, it uses the entire list untouched.
+    Nested = case Nested0 of
+                 [ProgName | Tail] ->
+                     Tail;
+                 _ ->
+                     Nested0
+             end,
     %% descent into commands collecting all options on the way
     {_CmdName, Cmd, AllArgs} = collect_options(ProgName, Root, Nested, []),
     %% split arguments into Flags, Options, Positional, and create help lines

--- a/lib/stdlib/test/argparse_SUITE.erl
+++ b/lib/stdlib/test/argparse_SUITE.erl
@@ -783,6 +783,9 @@ usage(Config) when is_list(Config) ->
         "  --safe       safe atom (existing atom)\n"
         "  -foobar      foobaring option\n",
     ?assertEqual(Usage, unicode:characters_to_list(argparse:help(Cmd,
+        #{progname => "erl", command => ["erl", "start"]}))),
+    %% Same assertion for the backward-compatible way of calling `argparse:help/2'.
+    ?assertEqual(Usage, unicode:characters_to_list(argparse:help(Cmd,
         #{progname => "erl", command => ["start"]}))),
     FullCmd = "Usage:\n  erl"
         " <command> [-rfv] [--force] [-i <interval>] [--req <weird>] [--float <float>]\n\n"
@@ -812,7 +815,7 @@ usage(Config) when is_list(Config) ->
         "  --float     floating-point long form argument (float), default: 3.14\n"
         "  ---extra    extra option very deep\n",
     ?assertEqual(CrawlerStatus, unicode:characters_to_list(argparse:help(Cmd,
-        #{progname => "erl", command => ["status", "crawler"]}))),
+        #{progname => "erl", command => ["erl", "status", "crawler"]}))),
     ok.
 
 usage_required_args() ->
@@ -821,7 +824,7 @@ usage_required_args() ->
 usage_required_args(Config) when is_list(Config) ->
     Cmd = #{commands => #{"test" => #{arguments => [#{name => required, required => true, long => "-req"}]}}},
     Expected = "Usage:\n  " ++ prog() ++ " test --req <required>\n\nOptional arguments:\n  --req required\n",
-    ?assertEqual(Expected, unicode:characters_to_list(argparse:help(Cmd, #{command => ["test"]}))).
+    ?assertEqual(Expected, unicode:characters_to_list(argparse:help(Cmd, #{command => ["erl", "test"]}))).
 
 usage_template() ->
     [{doc, "Tests templates in help/usage"}].
@@ -888,7 +891,7 @@ usage_args_ordering(Config) when is_list(Config) ->
         "  second second\n"
         "  third  third\n"
         "  fourth fourth\n",
-        unicode:characters_to_list(argparse:help(Cmd, #{command => ["cmd"]}))),
+        unicode:characters_to_list(argparse:help(Cmd, #{command => ["erl", "cmd"]}))),
     ok.
 
 parser_error_usage() ->


### PR DESCRIPTION
## Why

The documentation of `cmd_path()` states that it always starts with the progname. Indeed, `argparse:parse/{1,2}` returns a command path with the progname at the beginning.

However, if `argparse:help/2` is called with `#{command => CmdPath}` in the parser options with `CmdPath` starting with the progname, it crashes with a `badkey` exception because it expects the command path to only contain commands and sub-commands.

## How

The patch drops the first element of the command path if it matches the progname.

This adds support for the correct values of `CmdPath` while retaining backward compatibility with callers that dropped the progname themselves to work around the issue.