### PR TITLE
Makefile.in: Export `$MAKE` to be used by other scripts

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -39,6 +39,10 @@ ERTS = erts-@ERTS_VSN@
 # Include verbose output variables
 include $(ERL_TOP)/make/output.mk
 
+# Export the name of the actual make(1) command for executed scripts that
+# execute make again.
+export MAKE
+
 # ----------------------------------------------------------------------
 
 #

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -112,7 +112,7 @@ EOM
 
 release_erlang () {
     local RELEASE_ROOT="${1}"
-    if ! (cd $ERL_TOP && make release TYPE= release_docs DOC_TARGETS=chunks RELEASE_ROOT="${RELEASE_ROOT}"); then
+    if ! (cd $ERL_TOP && ${MAKE:-make} release TYPE= release_docs DOC_TARGETS=chunks RELEASE_ROOT="${RELEASE_ROOT}"); then
         return 1
     fi
     if ! (cd "$RELEASE_ROOT" && ./Install -minimal "`pwd`"); then
@@ -120,7 +120,7 @@ release_erlang () {
     fi
     ## Need to release both TYPE= and TYPE=$TYPE for tests to work
     if [ "$TYPE" != "" ]; then
-        if ! (cd $ERL_TOP && make release TYPE=$TYPE RELEASE_ROOT="${RELEASE_ROOT}"); then
+        if ! (cd $ERL_TOP && ${MAKE:-make} release TYPE=$TYPE RELEASE_ROOT="${RELEASE_ROOT}"); then
             return 1
         fi
     fi
@@ -214,7 +214,7 @@ EOF
     release_erlang "${RELEASE_ROOT}" > "${RELEASE_LOG}" 2>&1
     if [ $? != 0 ]
     then
-        print_highlighted_msg $RED "\"make release RELEASE_ROOT=${RELEASE_ROOT}\" failed.\nSee ${RELEASE_LOG} for full logs"
+        print_highlighted_msg $RED "\"${MAKE:-make} release RELEASE_ROOT=${RELEASE_ROOT}\" failed.\nSee ${RELEASE_LOG} for full logs"
         tail -30 "${RELEASE_LOG}"
         exit 1
     fi
@@ -231,12 +231,12 @@ then
     fi
 fi
 
-make RELEASE_PATH=$MAKE_TEST_DIR release_tests_spec > $RELEASE_TEST_SPEC_LOG 2>&1
+${MAKE:-make} RELEASE_PATH=$MAKE_TEST_DIR release_tests_spec > $RELEASE_TEST_SPEC_LOG 2>&1
 
 if [ $? != 0 ]
 then
     cat $RELEASE_TEST_SPEC_LOG
-    print_highlighted_msg $RED "\"make RELEASE_PATH="$MAKE_TEST_DIR" release_tests_spec\" failed."
+    print_highlighted_msg $RED "\"${MAKE:-make} RELEASE_PATH="$MAKE_TEST_DIR" release_tests_spec\" failed."
     exit 1
 fi
 if [ -z "${ARGS}" ]
@@ -271,11 +271,11 @@ fi
 # Compile test server and configure
 if [ ! -f "$ERL_TOP/lib/common_test/test_server/variables" ]; then
     cd "$ERL_TOP/lib/common_test/test_server"
-    ( make && erl -noshell -eval "ts:install()." -s init stop )  > "$INSTALL_TEST_LOG" 2>&1
+    ( ${MAKE:-make} && erl -noshell -eval "ts:install()." -s init stop )  > "$INSTALL_TEST_LOG" 2>&1
     if [ $? != 0 ]
     then
         cat "$INSTALL_TEST_LOG"
-        print_highlighted_msg $RED "\"make && erl -eval 'ts:install()'\" in common_test/test_server failed."
+        print_highlighted_msg $RED "\"${MAKE:-make} && erl -eval 'ts:install()'\" in common_test/test_server failed."
         exit 1
     fi
 fi


### PR DESCRIPTION
## Why

GNU make is sometimes installed as `gmake` and `make` points to another implementation that does not support GNU make extensions.

The name of the make command is stored in `$(MAKE)` and sub-make processes automatically inherit and use this variable. However other executed commands and scripts do not get this variable by default. Therefore if a script tries to call make(1) again, it will either not find this value or, more likely, will hard-code `make`.

## How

The top-level Makefile now exports the value of `$(MAKE)` into the environment of all executed sub-shells. This way, scripts can use the correct make command name if they need to run make(1) again.

An example fixed in this patch is `make/test_target_script.sh`. It used to hard-code `make` and now uses `$MAKE` passed from the parent make instance.