### PR TITLE
ssl: Remove unnecessary code generalization

### DIFF
--- a/lib/ssl/src/dtls_socket.erl
+++ b/lib/ssl/src/dtls_socket.erl
@@ -80,19 +80,19 @@ accept({Listener,_}, #config{}, _Timeout) ->
 	    {error, Reason}
     end.
 
-connect(Address, Port, #config{transport_info = {Transport, _, _, _, _} = CbInfo,
-                               connection_cb = ConnectionCb,
+connect(Host, Port, #config{transport_info = CbInfo,
                                ssl = SslOpts,
                                emulated = EmOpts,
                                inet_ssl = SocketOpts,
                                tab = _Tab
                               }, Timeout) ->
+    Transport = element(1, CbInfo),
     case Transport:open(0, SocketOpts ++ internal_inet_values()) of
 	{ok, Socket} ->
-	    ssl_gen_statem:connect(ConnectionCb, Address, Port, {{Address, Port},Socket},
-				   {SslOpts, 
-				    emulated_socket_options(EmOpts, #socket_options{}), undefined},
-				   self(), CbInfo, Timeout);
+	    dtls_gen_connection:start_fsm(client, Host, Port, {{Host, Port}, Socket},
+                                          {SslOpts,
+                                           emulated_socket_options(EmOpts, #socket_options{}), undefined},
+                                          self(), CbInfo, Timeout);
 	{error, _} = Error->	
 	    Error
     end.

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -42,8 +42,6 @@
 -export([opposite_role/1,
          init_ssl_config/3,
          ssl_config/3,
-         connect/8,
-         handshake/7,
          handshake/2,
          handshake/3,
          handshake_continue/3,
@@ -268,43 +266,6 @@ ssl_config(Opts, Role, #state{static_env = InitStatEnv0,
                      HsEnv#handshake_env{diffie_hellman_params = DHParams},
                  connection_env = CEnv#connection_env{cert_key_alts = CertKeyAlts},
                  ssl_options = Opts}.
-
-%%--------------------------------------------------------------------
--spec connect(tls_gen_connection | dtls_gen_connection,
-	      ssl:host(), inet:port_number(),
-	      port() | {tuple(), port()}, %% TLS | DTLS
-	      {ssl_options(), #socket_options{},
-	       %% Tracker only needed on server side
-	       undefined},
-	      pid(), tuple(), timeout()) ->
-		     {ok, #sslsocket{}} | {error, ssl:reason()}.
-%%
-%% Description: Connect to an ssl server.
-%%--------------------------------------------------------------------
-connect(Connection, Host, Port, Socket, Options, User, CbInfo, Timeout) ->
-    try Connection:start_fsm(client, Host, Port, Socket, Options, User, CbInfo,
-			     Timeout)
-    catch
-	exit:{noproc, _} ->
-	    {error, ssl_not_started}
-    end.
-%%--------------------------------------------------------------------
--spec handshake(tls_gen_connection | dtls_gen_connection,
-		 inet:port_number(), port(),
-		 {ssl_options(), #socket_options{}, list()},
-		 pid(), tuple(), timeout()) ->
-			{ok, #sslsocket{}} | {error, ssl:reason()}.
-%%
-%% Description: Performs accept on an ssl listen socket. e.i. performs
-%%              ssl handshake.
-%%--------------------------------------------------------------------
-handshake(Connection, Port, Socket, Opts, User, CbInfo, Timeout) ->
-    try Connection:start_fsm(server, "localhost", Port, Socket, Opts, User,
-		  CbInfo, Timeout)
-    catch
-	exit:{noproc, _} ->
-	    {error, ssl_not_started}
-    end.
 
 %%--------------------------------------------------------------------
 -spec handshake(#sslsocket{}, timeout()) ->  {ok, #sslsocket{}} |

--- a/lib/ssl/src/ssl_trace.erl
+++ b/lib/ssl/src/ssl_trace.erl
@@ -422,7 +422,7 @@ trace_profiles() ->
       [{ssl,
         [{listen,2}, {connect,3}, {handshake,2}, {close, 1}]},
        {ssl_gen_statem,
-        [{connect, 8}, {close, 2}, {terminate_alert, 1}]},
+        [{close, 2}, {terminate_alert, 1}]},
        {tls_client_connection,
         [{initial_hello, 3}]},
        {tls_server_connection,

--- a/lib/ssl/test/dtls_api_SUITE.erl
+++ b/lib/ssl/test/dtls_api_SUITE.erl
@@ -452,8 +452,8 @@ client_restarts(Config) ->
 
                 ct:sleep(250),
                 ?CT_LOG("Client second connect: ~p ~p~n", [Socket, CbInfo]),
-                {ok, NewSocket} = ssl_gen_statem:connect(ConnectionCb, Address, CPort, IntSocket,
-                                                         SslOpts, self(), CbInfo, infinity),
+                {ok, NewSocket} = dtls_gen_connection:start_fsm(client, Address, CPort, IntSocket,
+                                                                SslOpts, self(), CbInfo, infinity),
                 {replace, NewSocket}
         end,
 
@@ -535,8 +535,8 @@ client_restarts_multiple_acceptors(Config) ->
                 SslOpts = {SslOpts0, #socket_options{}, undefined},
                 ct:sleep(250),
                 ?CT_LOG("Client second connect: ~p ~p~n", [Socket, CbInfo]),
-                {ok, NewSocket} = ssl_gen_statem:connect(ConnectionCb, Address, CPort, IntSocket,
-                                                         SslOpts, self(), CbInfo, infinity),
+                {ok, NewSocket} = dtls_gen_connection:start_fsm(client, Address, CPort, IntSocket,
+                                                                SslOpts, self(), CbInfo, infinity),
                 {replace, NewSocket}
         end,
  

--- a/lib/ssl/test/ssl_trace_SUITE.erl
+++ b/lib/ssl/test/ssl_trace_SUITE.erl
@@ -149,8 +149,6 @@ tc_api_profile(Config) ->
                 tls_server_connection, initial_hello},
                {"    (client) <- tls_client_connection:initial_hello/3 returned",
                 tls_client_connection, initial_hello},
-               {"    (client) <- ssl_gen_statem:connect/8 returned",
-                ssl_gen_statem, connect},
                {"    (client) <- ssl:connect/3 returned", ssl, connect},
                {"    (server) <- ssl:handshake/2 returned", ssl, handshake},
                {"    (client) <- tls_sender:init/3 returned", tls_sender, init},
@@ -161,8 +159,7 @@ tc_api_profile(Config) ->
                "rle ('?') -> ssl:listen/2 (*server) Args",
                "rle ('?') -> ssl:connect/3 (*client) Args",
                "rle ('?') -> tls_sender:init/3 (*server)",
-               "rle ('?') -> tls_sender:init/3 (*client)",
-               "api (client) -> ssl_gen_statem:connect/8"]},
+               "rle ('?') -> tls_sender:init/3 (*client)"]},
     TracesAfterDisconnect =
         #{
           call =>


### PR DESCRIPTION
Removal of some code that is too generalizing making unnecessary module jumping so the code becomes harder to follow.  