### PR TITLE
stdlib: Fix preorder and postorder traversals in `digraph_utils`

### DIFF
--- a/lib/stdlib/test/digraph_utils_SUITE.erl
+++ b/lib/stdlib/test/digraph_utils_SUITE.erl
@@ -30,7 +30,7 @@
 	 init_per_group/2,end_per_group/2]).
 
 -export([simple/1, loop/1, isolated/1, topsort/1, subgraph/1, 
-         condensation/1, tree/1]).
+         condensation/1, tree/1, traversals/1]).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -39,7 +39,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     [simple, loop, isolated, topsort, subgraph,
-     condensation, tree].
+     condensation, tree, traversals].
 
 groups() -> 
     [].
@@ -246,6 +246,22 @@ tree(Config) when is_list(Config) ->
     %% Parallel edges.
     false = is_arborescence([{a,b},{a,b}]),
 
+    ok.
+
+%% OTP-9040
+traversals(Config) when is_list(Config) ->
+    G = digraph:new([]),
+    [] = digraph_utils:preorder(G),
+    [] = digraph_utils:postorder(G),
+    add_edges(G, [{a,b},{b,c},{c,d},{d,e}]),
+    [a,b,c,d,e] = digraph_utils:preorder(G),
+    [e,d,c,b,a] = digraph_utils:postorder(G),
+    add_edges(G, [{0,1},{1,2},{2,0}]),
+    [a,b,c,d,e,0,1,2] = digraph_utils:preorder(G),
+    [e,d,c,b,a,2,1,0] = digraph_utils:postorder(G),
+    add_edges(G, [{x,0},{y,1},{z,2}]),
+    [z,2,0,1,y,x,a,b,c,d,e] = digraph_utils:preorder(G),
+    [1,0,2,z,y,x,e,d,c,b,a] = digraph_utils:postorder(G),
     ok.
 
 is_tree(Es) ->


### PR DESCRIPTION
The previous `digraph_utils:preorder/1` and `digraph_utils:postorder/1` did not start the traversal from root nodes. This fix makes both traversals only start or restart from a root node in one of the components, or an arbitrary node if no root node can be visited. Since in the previous version, the search can start and restart from arbitrary nodes, this fix should not break backwards compatibility.

It is worth noting that the digraph does not have a notion of a left or right subtree. The result of both traversals may not be the same after relabelling vertices.