### PR TITLE
Add group metadata to EEP48

### DIFF
--- a/lib/kernel/doc/guides/eep48_chapter.md
+++ b/lib/kernel/doc/guides/eep48_chapter.md
@@ -145,14 +145,19 @@ information to each entry. This EEP documents the following metadata keys:
   deprecated with a binary that represents the reason for deprecation and a
   recommendation to replace the deprecated code.
 
+- **`group := binary()`** - when present, it allows tooling, such as shell
+  autocompletion and documentation generators, to list all entries within the
+  same group together, often using the group name as an indicator. It currently
+  only applies to doc entries, not for module metadata.
+
 - **`since := binary()`** - a binary representing the version such entry was
   added, such as `<<"1.3.0">>` or `<<"20.0">>`.
 
-- **`source_path := binary()`** - the absolute location of the source file for
-  this module. Applies only to the module metadata.
-
 - **`source_annos := [erl_anno:anno()]`** - a list of source code locations.
   You may either store one for each clause or only for the first clause.
+
+- **`source_path := binary()`** - the absolute location of the source file for
+  this module. Applies only to the module metadata.
 
 Any key may be added to Metadata at any time. Keys that are frequently used by
 the community can be standardized in future versions.

--- a/system/doc/reference_manual/documentation.md
+++ b/system/doc/reference_manual/documentation.md
@@ -206,6 +206,9 @@ There are four reserved metadata keys for `-doc`:
   explaining that it is deprecated and what to use instead. The compiler will
   automatically insert this key if there is a `-deprecated` attribute marking a
   function as deprecated.
+- `group => unicode:chardata()` - A group that the function, type or callback belongs to.
+  It allows tooling, such as shell autocompletion and documentation generators, to list all
+  entries within the same group together, often using the group name as an indicator.
 - `equiv => unicode:chardata() | F/A | F(...)` - Notes that this function is equivalent to
   another function in this module. The equivalence can be described using either
   `Func/Arity`, `Func(Args)` or a [unicode string](`t:unicode:chardata/0`). For example:


### PR DESCRIPTION
Also changed one item to keep order alphabetical.

For ExDoc, I propose that, if the group is used, it will still be prefixed by its type, such as "Functions" or "Types". For example, in Nx, you can imagine the functions below were tagged as: `group: "Aggregates"`, `group: "Backend"`, etc.

<img width="499" alt="Screenshot 2024-12-12 at 11 57 17" src="https://github.com/user-attachments/assets/dbdb3f53-ad6c-403c-a9ca-7a814260f618" />

However, if you really want to override it, you can use the `groups_for_docs` configuration. Like done above, where "Guards" are getting its own group.

@garazdawi would these conventions suit Erlang?