### PR TITLE
ssl: Fix function_clause error in tls_server_connection_1_3:select_server_cert_key_pair function

### DIFF
--- a/lib/ssl/src/tls_server_connection_1_3.erl
+++ b/lib/ssl/src/tls_server_connection_1_3.erl
@@ -702,7 +702,7 @@ select_server_cert_key_pair(_,[], _,_,_,_, undefined) ->
 select_server_cert_key_pair(Session, [#{private_key := Key, certs := [Cert| _] = Certs} | Rest],
                             ClientSignAlgs, ClientSignAlgsCert, CertAuths,
                             #state{static_env = #static_env{cert_db = CertDbHandle,
-                                                            cert_db_ref = CertDbRef} = State},
+                                                            cert_db_ref = CertDbRef}} = State,
                             Default0) ->
     {_, SignAlgo, SignHash, _, _} = tls_handshake_1_3:get_certificate_params(Cert),
     %% TODO: We do validate the signature algorithm and signature hash


### PR DESCRIPTION
The error occurs if more than one certificate is configured and the first certificate fails the check by the `tls_handshake_1_3:check_cert_sign_algo` function. The recursive call to the `select_server_cert_key_pair` function fails and as a result the TLS connection is not established.