### PR TITLE
Fix local_to_universal time without dst + TZ on Windows

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -471,6 +471,10 @@
 /* Define to 1 if you have the <curses.h> header file. */
 #undef HAVE_CURSES_H
 
+/* Define to 1 if you have the declaration of 'daylight', and to 0 if you
+   don't. */
+#undef HAVE_DECL_DAYLIGHT
+
 /* Define to 1 if you have the declaration of 'getrlimit', and to 0 if you
    don't. */
 #undef HAVE_DECL_GETRLIMIT

--- a/erts/configure
+++ b/erts/configure
@@ -21120,6 +21120,17 @@ esac
 fi
 printf "%s\n" "#define HAVE_DECL_TIME2POSIX $ac_have_decl" >>confdefs.h
 
+ac_fn_check_decl "$LINENO" "daylight" "ac_cv_have_decl_daylight" "#include <time.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_daylight" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_DAYLIGHT $ac_have_decl" >>confdefs.h
+
 
 ac_func=
 for ac_item in $ac_func_c_list

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -2258,6 +2258,7 @@ case $host_os in
 esac
 
 AC_CHECK_DECLS([posix2time, time2posix],,,[#include <time.h>])
+AC_CHECK_DECLS([daylight],,,[#include <time.h>])
 
 AC_FUNC_VPRINTF
 

--- a/erts/emulator/sys/unix/erl_unix_sys.h
+++ b/erts/emulator/sys/unix/erl_unix_sys.h
@@ -148,6 +148,12 @@ typedef struct tms SysTimes;
 
 #define sys_times(Arg) times(Arg)
 
+#if !HAVE_DECL_DAYLIGHT
+extern int sys_daylight;
+#else
+#define sys_daylight daylight
+#endif
+
 #if SIZEOF_LONG == 8
 typedef long ErtsMonotonicTime;
 typedef long ErtsSysHrTime;

--- a/erts/emulator/sys/win32/erl_win_sys.h
+++ b/erts/emulator/sys/win32/erl_win_sys.h
@@ -132,6 +132,7 @@ time_t sys_mktime( struct tm *ptm);
 #define gmtime_r sys_gmtime_r
 #define HAVE_GMTIME_R
 #define mktime sys_mktime
+extern int sys_daylight;
 
 typedef struct {
     erts_time_t tv_sec;

--- a/erts/emulator/sys/win32/sys_time.c
+++ b/erts/emulator/sys/win32/sys_time.c
@@ -286,9 +286,65 @@ sys_hrtime_gtc64(void)
     return time;
 }
 
-/*
- * Init
- */
+/* Struct and algorithm taken from https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/ns-timezoneapi-time_zone_information */
+typedef struct _REG_TZI_FORMAT
+{
+    LONG Bias;
+    LONG StandardBias;
+    LONG DaylightBias;
+    SYSTEMTIME StandardDate;
+    SYSTEMTIME DaylightDate;
+} REG_TZI_FORMAT;
+
+static int sys_init_tzinfo(void) {
+    char *tz = getenv("TZ");
+    char regKey[255];
+    HKEY tzKey;
+    DWORD res, size;
+    REG_TZI_FORMAT tzi;
+
+
+    /* If TZ is not set we fallback to GetTimeZoneInformation, just like mktime and friends. */
+    if (!tz) {
+        return GetTimeZoneInformation(&static_tzi);
+    }
+
+    snprintf(regKey, sizeof(regKey), "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Time Zones\\%s", tz);
+
+    if ((res = RegOpenKey(HKEY_LOCAL_MACHINE, regKey, &tzKey)) != ERROR_SUCCESS) {
+        return 0;
+    }
+
+    size = sizeof(tzi);
+    if ((res = RegGetValueW(tzKey, NULL, L"TZI", RRF_RT_REG_BINARY, NULL,
+            &tzi, &size)) != ERROR_SUCCESS) {
+        RegCloseKey(tzKey);
+        return 0;
+    }
+
+    static_tzi.Bias = tzi.Bias;
+    static_tzi.StandardBias = tzi.StandardBias;
+    static_tzi.DaylightBias = tzi.DaylightBias;
+    static_tzi.StandardDate = tzi.StandardDate;
+    static_tzi.DaylightDate = tzi.DaylightDate;
+
+    size = sizeof(static_tzi.StandardName);
+    if ((res = RegGetValueW(tzKey, NULL, L"Std", RRF_RT_REG_SZ, NULL,
+            &static_tzi.StandardName, &size)) != ERROR_SUCCESS) {
+        RegCloseKey(tzKey);
+        return 0;
+    }
+
+    size = sizeof(static_tzi.DaylightName);
+    if ((res = RegGetValueW(tzKey, NULL, L"Dlt", RRF_RT_REG_SZ, NULL,
+            &static_tzi.DaylightName, &size)) != ERROR_SUCCESS) {
+        RegCloseKey(tzKey);
+        return 0;
+    }
+
+    RegCloseKey(tzKey);
+    return 1;
+}
 
 void
 sys_init_time(ErtsSysInitTimeResult *init_resp)
@@ -407,8 +463,9 @@ sys_init_time(ErtsSysInitTimeResult *init_resp)
     init_resp->os_system_time_info.resolution = 100;
     init_resp->os_system_time_info.locked_use = 0;
 
-    if(GetTimeZoneInformation(&static_tzi)) {
-	have_static_tzi = 1;
+    have_static_tzi = sys_init_tzinfo();
+
+    if (have_static_tzi) {
         sys_daylight = static_tzi.StandardDate.wMonth != 0 &&
                     static_tzi.DaylightDate.wMonth != 0;
     }

--- a/erts/emulator/sys/win32/sys_time.c
+++ b/erts/emulator/sys/win32/sys_time.c
@@ -76,6 +76,7 @@
 
 static TIME_ZONE_INFORMATION static_tzi;
 static int have_static_tzi = 0;
+int sys_daylight = 0;
 
 static int days_in_month[2][13] = {
     {0,31,28,31,30,31,30,31,31,30,31,30,31},
@@ -406,10 +407,10 @@ sys_init_time(ErtsSysInitTimeResult *init_resp)
     init_resp->os_system_time_info.resolution = 100;
     init_resp->os_system_time_info.locked_use = 0;
 
-    if(GetTimeZoneInformation(&static_tzi) && 
-       static_tzi.StandardDate.wMonth != 0 &&
-       static_tzi.DaylightDate.wMonth != 0) {
+    if(GetTimeZoneInformation(&static_tzi)) {
 	have_static_tzi = 1;
+        sys_daylight = static_tzi.StandardDate.wMonth != 0 &&
+                    static_tzi.DaylightDate.wMonth != 0;
     }
 }
 

--- a/erts/emulator/test/time_SUITE.erl
+++ b/erts/emulator/test/time_SUITE.erl
@@ -107,28 +107,22 @@ end_per_group(_GroupName, Config) ->
 
 %% Test that DST = true on timezones without DST is ignored
 local_to_univ_utc(Config) when is_list(Config) ->
-    case os:type() of
-	{unix,_} ->
-	    %% TZ variable has a meaning
-	    {ok, Peer, Node} = ?CT_PEER(["-env", "TZ", "UTC"]),
-	    {{2008,8,1},{0,0,0}} =
-		rpc:call(Node,
-			 erlang,localtime_to_universaltime,
-			 [{{2008, 8, 1}, {0, 0, 0}},
-			  false]),
-	    {{2008,8,1},{0,0,0}} =
-		rpc:call(Node,
-			 erlang,localtime_to_universaltime,
-			 [{{2008, 8, 1}, {0, 0, 0}},
-			  true]),
-	    [{{2008,8,1},{0,0,0}}] =
-		rpc:call(Node,
-			 calendar,local_time_to_universal_time_dst,
-			 [{{2008, 8, 1}, {0, 0, 0}}]),
-	    peer:stop(Peer);
-	_ ->
-	    {skip,"Only valid on Unix"}
-    end.
+    {ok, Peer, Node} = ?CT_PEER(["-env", "TZ", "UTC"]),
+    {{2008,8,1},{0,0,0}} =
+        rpc:call(Node,
+                 erlang,localtime_to_universaltime,
+                 [{{2008, 8, 1}, {0, 0, 0}},
+                  false]),
+    {{2008,8,1},{0,0,0}} =
+        rpc:call(Node,
+                 erlang,localtime_to_universaltime,
+                 [{{2008, 8, 1}, {0, 0, 0}},
+                  true]),
+    [{{2008,8,1},{0,0,0}}] =
+        rpc:call(Node,
+                 calendar,local_time_to_universal_time_dst,
+                 [{{2008, 8, 1}, {0, 0, 0}}]),
+    peer:stop(Peer).
 
 
 %% Tests conversion from universal to local time.

--- a/erts/etc/unix/cerl.src
+++ b/erts/etc/unix/cerl.src
@@ -423,6 +423,9 @@ if [ "x$GDB" = "x" ]; then
         fi
     elif [ $run_rr = yes ]; then
         if [ $1 = replay ] || [ $1 = eplay ]; then
+
+            install_gdb_tools
+
 	    rr_cmd=$1
             shift
             cmdfile="/tmp/.cerlgdb.$$"


### PR DESCRIPTION
With glibc 2.37, the behaviour of mktime was changed to no longer return an error if tm_isdst = 1 but the TZ actually does not have any dst data. For example if TZ=UTC.

Instead of trusting the timezone, and not assuming that dst is in effect, glibc decided to trust the caller and assume that dst is in effect. This means that Erlang and glibc now have different behaviours in this regard. So in order to keep backward compatability with how Erlang has always worked we instead check is the TZ has daylight handling at all, and if not we set isdst to 0.

The change was introduced by this commit: https://sourceware.org/git/?p=glibc.git;a=commit;h=83859e1115269cf56d21669361d4ddbe2687831c and a bug report was filed with glibc here: https://sourceware.org/bugzilla/show_bug.cgi?id=31144, but it seems like the new behaviour is desired.

While at it I also noticed that Windows does not respect the TZ environment variable, so I fixed that.