### PR TITLE
Introduce `supervisor:stop/1,3`

### DIFF
--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -1562,6 +1562,13 @@ If the process does not exist,
 the call exits the calling process with reason `noproc`,
 and with reason `{nodedown, Node}` if the connection fails
 to the remote `Node` where the server runs.
+
+> #### Note {: .info }
+>
+> If the event manager `EventMgrRef` is a permanent child of a
+> supervisor, it will be restarted. If it is a transient child, it will
+> be restarted if the given `Reason` is not `normal`, `shutdown` or
+> `{shutdown, Term}`.
 """.
 -doc(#{since => <<"OTP 18.0">>}).
 -spec stop(EventMgrRef :: emgr_ref(), Reason :: term(), Timeout :: timeout()) -> 'ok'.

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -1108,6 +1108,13 @@ the call exits the calling process with reason `timeout`.
 If the process does not exist, the call exits the calling process
 with reason `noproc`, or with reason `{nodedown,Node}`
 if the connection fails to the remote `Node` where the server runs.
+
+> #### Note {: .info }
+>
+> If the `gen_server` `ServerRef` is a permanent child of a
+> supervisor, it will be restarted. If it is a transient child, it will
+> be restarted if the given `Reason` is not `normal`, `shutdown` or
+> `{shutdown, Term}`.
 """.
 -doc(#{since => <<"OTP 18.0">>}).
 -spec stop(

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -2474,6 +2474,13 @@ the call exits the calling process with reason `timeout`.
 If the process does not exist, the call exits the calling process
 with reason `noproc`, or with reason `{nodedown, Node}`
 if the connection fails to the remote `Node` where the server runs.
+
+> #### Note {: .info }
+>
+> If the `gen_statem` `ServerRef` is a permanent child of a
+> supervisor, it will be restarted. If it is a transient child, it will
+> be restarted if the given `Reason` is not `normal`, `shutdown` or
+> `{shutdown, Term}`.
 """.
 -doc #{ since => <<"OTP 19.0">> }.
 -spec stop(

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -285,7 +285,8 @@ but the map is preferred.
 	 delete_child/2, terminate_child/2,
 	 which_children/1, which_child/2,
 	 count_children/1, check_childspecs/1,
-	 check_childspecs/2, get_childspec/2]).
+	 check_childspecs/2, get_childspec/2,
+	 stop/1, stop/3]).
 
 %% Internal exports
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
@@ -807,6 +808,45 @@ processes:
              | {workers, ChildWorkerCount :: non_neg_integer()}.
 count_children(Supervisor) ->
     call(Supervisor, count_children).
+
+-doc(#{equiv => stop(SupRef, normal, infinity)}).
+-doc(#{since => <<"OTP 28.0">>}).
+-spec stop(SupRef :: sup_ref()) -> ok.
+stop(Supervisor) ->
+    gen_server:stop(Supervisor).
+
+-doc """
+Stop a supervisor.
+
+Orders the supervisor specified by `SupRef` to exit
+with the specified `Reason` and waits for it to terminate.
+The supervisor will terminate all its children
+before exiting.
+
+The function returns `ok` if the supervisor terminates
+with the expected reason. Any other reason than `normal`, `shutdown`,
+or `{shutdown,Term}` causes an error report to be issued using `m:logger`.
+An exit signal with the same reason is sent to linked processes and ports.
+
+`Timeout` is an integer that specifies how many milliseconds to wait
+for the supervisor to terminate, or the atom `infinity` to wait indefinitely.
+If the supervisor has not terminated within the specified time,
+the call exits the calling process with reason `timeout`.
+
+If the process does not exist, the call exits the calling process
+with reason `noproc`, or with reason `{nodedown,Node}`
+if the connection fails to the remote `Node` where the supervisor runs.
+
+> #### Warning {: .warning }
+>
+> Calling this function from a (sub-)child process of the given supervisor
+> will result in a deadlock which will last until either the shutdown timeout
+> of the child or the timeout given to `stop/3` has expired.
+""".
+-doc(#{since => <<"OTP 28.0">>}).
+-spec stop(SupRef :: sup_ref(), Reason :: term(), Timeout :: timeout()) -> ok.
+stop(Supervisor, Reason, Timeout) ->
+    gen_server:stop(Supervisor, Reason, Timeout).
 
 call(Supervisor, Req) ->
     gen_server:call(Supervisor, Req, infinity).

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -842,6 +842,13 @@ if the connection fails to the remote `Node` where the supervisor runs.
 > Calling this function from a (sub-)child process of the given supervisor
 > will result in a deadlock which will last until either the shutdown timeout
 > of the child or the timeout given to `stop/3` has expired.
+
+> #### Note {: .info }
+>
+> If the `supervisor` `SupRef` is a permanent child of another
+> supervisor, it will be restarted. If it is a transient child, it will
+> be restarted if the given `Reason` is not `normal`, `shutdown` or
+> `{shutdown, Term}`.
 """.
 -doc(#{since => <<"OTP 28.0">>}).
 -spec stop(SupRef :: sup_ref(), Reason :: term(), Timeout :: timeout()) -> ok.

--- a/lib/stdlib/test/supervisor_1.erl
+++ b/lib/stdlib/test/supervisor_1.erl
@@ -72,10 +72,8 @@ handle_info({'EXIT',_,{shutdown,Term}}, State) ->
     {stop, {shutdown,Term}, State};
 
 handle_info({sleep, Time}, State) ->
-    io:format("FOO: ~p~n", [Time]),
     timer:sleep(Time),
-    io:format("FOO: sleept~n", []),
-    handle_info({sleep, Time}, State);
+    {noreply, State};
 
 handle_info(_, State) ->
     {noreply, State}.

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -47,6 +47,7 @@
 	  sup_stop_infinity/1, sup_stop_timeout/1, sup_stop_timeout_dynamic/1,
 	  sup_stop_brutal_kill/1, sup_stop_brutal_kill_dynamic/1,
           sup_stop_race/1, sup_stop_non_shutdown_exit_dynamic/1,
+	  sup_stop_manual/1, sup_stop_manual_timeout/1,
 	  child_adm/1, child_adm_simple/1, child_specs/1, child_specs_map/1,
 	  extra_return/1, sup_flags/1]).
 
@@ -139,7 +140,8 @@ groups() ->
      {sup_stop, [],
       [sup_stop_infinity, sup_stop_timeout, sup_stop_timeout_dynamic,
        sup_stop_brutal_kill, sup_stop_brutal_kill_dynamic,
-       sup_stop_race, sup_stop_non_shutdown_exit_dynamic]},
+       sup_stop_race, sup_stop_non_shutdown_exit_dynamic,
+       sup_stop_manual, sup_stop_manual_timeout]},
      {normal_termination, [],
       [external_start_no_progress_log, permanent_normal, transient_normal, temporary_normal]},
      {shutdown_termination, [],
@@ -651,6 +653,72 @@ sup_stop_non_shutdown_exit_dynamic(Config) when is_list(Config) ->
         end,
         [temporary, transient, permanent]
     ).
+
+%%-------------------------------------------------------------------------
+%% Tests that children are shut down when a supervisor is stopped via
+%% supervisor:stop/1
+%% Since supervisors are gen_servers and the basic functionality of the
+%% stop functions is already tested in gen_server_SUITE, we only make
+%% sure that children are terminated correctly when applied to a
+%% supervisor.
+sup_stop_manual(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, Pid} = start_link({ok, {{one_for_one, 2, 3600}, []}}),
+    Child1 = {child1, {supervisor_1, start_child, []}, 
+	      permanent, brutal_kill, worker, []},
+    Child2 = {child2, {supervisor_1, start_child, []}, 
+	      permanent, 1000, worker, []},
+    Child3 = {child3, {supervisor_1, start_child, []},
+	      permanent, 1000, worker, []},
+    {ok, CPid1} = supervisor:start_child(sup_test, Child1),
+    link(CPid1),
+    {ok, CPid2} = supervisor:start_child(sup_test, Child2),
+    link(CPid2),
+    {ok, CPid3} = supervisor:start_child(sup_test, Child3),
+    link(CPid3),
+
+    CPid3 ! {sleep, 100000},
+
+    supervisor:stop(Pid),
+
+    check_exit_reason(Pid, normal),
+    check_exit_reason(CPid1, killed),
+    check_exit_reason(CPid2, shutdown),
+    check_exit_reason(CPid3, killed).
+
+%%-------------------------------------------------------------------------
+%% Tests that children are shut down when a supervisor is stopped via
+%% supervisor:stop/3, even if the stop call times out.
+%% Since supervisors are gen_servers and the basic functionality of the
+%% stop functions is already tested in gen_server_SUITE, we only make
+%% sure that children are terminated correctly when applied to a
+%% supervisor.
+sup_stop_manual_timeout(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, Pid} = start_link({ok, {{one_for_one, 2, 3600}, []}}),
+    Child1 = {child1, {supervisor_1, start_child, []}, 
+	      permanent, 5000, worker, []},
+    Child2 = {child2, {supervisor_1, start_child, []},
+	      permanent, 1000, worker, []},
+    {ok, CPid1} = supervisor:start_child(sup_test, Child1),
+    link(CPid1),
+    {ok, CPid2} = supervisor:start_child(sup_test, Child2),
+    link(CPid2),
+
+    CPid1 ! {sleep, 1000},
+
+    try
+	supervisor:stop(Pid, normal, 100)
+    of
+	ok -> ct:fail(expected_timeout)
+    catch
+	exit:timeout ->
+	    ok
+    end,
+
+    check_exit_reason(Pid, normal),
+    check_exit_reason(CPid1, shutdown),
+    check_exit_reason(CPid2, shutdown).
 
 %%-------------------------------------------------------------------------
 %% The start function provided to start a child may return {ok, Pid}


### PR DESCRIPTION
Adding `supervisor:stop` has been suggested by @IngelaAndin a while ago.

Since `supervisor`s are `gen_server`s, implementing this functionality amounts to delegating to `gen_server:stop`.

The base functionality of `gen_server:stop` is tested extensively in `gen_server_SUITE` and not re-tested in `supervisor_SUITE`, I only added tests to ensure that children are terminated.
I also found and fixed a bug in one of the supervisor test helper modules, `supervisor_1`.

Most work has gone into documentation, to highlight that calling `supervisor:stop` from a child or sub-child will result in a deadlock (the child will wait for `supervisor:stop` to return, and the supervisor to be stopped waits for the child that waits for the supervisor etc etc). I also added a note (also to `gen_server`, `gen_statem` and `gen_event`) to highlight that children in a supervision tree stopped via `...:stop` may be restarted by a parent supervisor, depending on the child restart strategy and stop reason.