### PR TITLE
ssh: refactor ssh_acceptor

### DIFF
--- a/lib/ssh/src/ssh_acceptor.erl
+++ b/lib/ssh/src/ssh_acceptor.erl
@@ -125,16 +125,10 @@ handle_connection(Address, Port, _Peer, Options, Socket,
     Pid ! {start,Ref},
     ok.
 
-handle_connection(Address, Port, Options0, Socket) ->
-    Options = ?PUT_INTERNAL_OPT([{user_pid, self()}
-                                ], Options0),
-    ssh_system_sup:start_connection(server,
-                                   #address{address = Address,
-                                            port = Port,
-                                            profile = ?GET_OPT(profile,Options)
-                                           },
-                                   Socket,
-                                   Options).
+handle_connection(Address, Port, Options, Socket) ->
+    AddressR = #address{address = Address, port = Port,
+                        profile = ?GET_OPT(profile,Options)},
+    ssh_system_sup:start_connection(server, AddressR, Socket, Options).
 
 %%%----------------------------------------------------------------
 handle_error(Reason, ToAddress, ToPort, {ok, {FromIP,FromPort}}) ->

--- a/lib/ssh/src/ssh_system_sup.erl
+++ b/lib/ssh/src/ssh_system_sup.erl
@@ -113,7 +113,7 @@ start_connection(Role = server, Address=#address{}, Socket, Options) ->
 
 do_start_connection(Role, SupPid, Significant, Socket, Options0) ->
     Id = make_ref(),
-    Options = ?PUT_INTERNAL_OPT([{user_pid, self()}], Options0),
+    Options = ?PUT_INTERNAL_OPT({user_pid, self()}, Options0),
     case supervisor:start_child(SupPid,
                                 #{id          => Id,
                                   start       => {ssh_connection_sup, start_link,


### PR DESCRIPTION
- user_pid always added in ssh_system_sup:do_start_connection
- same step in acceptor seems redundant