### PR TITLE
Extend error to match the fuction type spec

### DIFF
--- a/lib/tools/src/eprof.erl
+++ b/lib/tools/src/eprof.erl
@@ -444,9 +444,9 @@ handle_call({profile_start, Rootset, Pattern, {M,F,A}, Opts}, From, #state{fd = 
 		    trace_opts = Topts,
 		    pattern    = Pattern
 		}};
-	false ->
+	{false, FailedPid} ->
 	    exit(Pid, eprof_kill),
-	    {reply, error, #state{ fd = Fd}}
+	    {reply, {error, {set_process_trace_failed, FailedPid}}, #state{ fd = Fd}}
     end;
 
 handle_call({profile_start, Rootset, Pattern, undefined, Opts}, From, #state{ fd = Fd } = S) ->
@@ -468,8 +468,8 @@ handle_call({profile_start, Rootset, Pattern, undefined, Opts}, From, #state{ fd
 		    trace_opts = Topts,
 		    pattern    = Pattern
 		}};
-	false ->
-	    {reply, error, #state{ fd = Fd }}
+	{false, FailedPid} ->
+	    {reply, {error, {set_process_trace_failed, FailedPid}}, #state{ fd = Fd }}
     end;
 
 handle_call(profile_stop, _From, #state{ profiling = false } = S) ->
@@ -635,7 +635,7 @@ set_process_trace(Flag, [Pid|Pids], Options) when is_pid(Pid) ->
 	set_process_trace(Flag, Pids, Options)
     catch
 	_:_ ->
-	    false
+	    {false, Pid}
     end;
 set_process_trace(Flag, [Name|Pids], Options) when is_atom(Name) ->
     case whereis(Name) of


### PR DESCRIPTION
I was trying to use `eprof` but came across strange behaviour:

```erlang
(my_program@my_machine)1> f().
ok
% here I am just making sure no eprof process is running
(my_program@my_machine)2> TracerPid = case eprof:start() of
(my_program@my_machine)2>     {error, {already_started, TracerPid}} -> TracerPid;
(my_program@my_machine)2>     {ok, TracerPid} -> TracerPid
(my_program@my_machine)2> end,
(my_program@my_machine)2> exit(TracerPid, kill).
true
% I start eprof to rack all processes in the beam
(my_program@my_machine)3>
(my_program@my_machine)3> eprof:start_profiling(erlang:processes(), {'_', '_', '_'}, []).
% it return atom error
error
% here I just point out the OTP version
(my_program@my_machine)4> erlang:system_info(otp_release).
"24"
(my_program@my_machine)5>
```

but spec for `fun eprof:start_profiling/3` says it returns atom `profiling` or a tuple `{error, Sth}` but never just atom `error`. In PR, I extended respective handle_call returned value to return that certain process cannot be traced and it's pid. 

```erlang
-spec start_profiling(Rootset, Pattern, Options) ->
                             'profiling' | {'error', Reason} when
      Rootset :: [atom() | pid()],
      Pattern :: trace_pattern_mfa(),
      Options :: ['set_on_spawn' | {'set_on_spawn', boolean()}],
      Reason :: term().
```

says that 
https://github.com/erlang/otp/blob/1042ae2445ad003fc32e608b91478c184d5d72d6/lib/tools/src/eprof.erl#L367

I assume the issue is because it is forbidden to trace the tracer, unless I made up this rule, then I do not know why I observed the issue.