### PR TITLE
ssl: Add callbacks to retrieve keylog 

### DIFF
--- a/lib/ssl/src/ssl_logger.erl
+++ b/lib/ssl/src/ssl_logger.erl
@@ -26,6 +26,12 @@
          format/2,
          format/1]).
 
+-export([keylog/3,
+         keylog_early_data/3,
+         keylog_hs/4,
+         keylog_traffic_pre_1_3/2,
+         keylog_traffic_1_3/5]).
+
 -define(DEC2HEX(X),
         if ((X) >= 0) andalso ((X) =< 9) -> (X) + $0;
            ((X) >= 10) andalso ((X) =< 15) -> (X) + $a - 10
@@ -130,9 +136,70 @@ format(#{msg:= {report, Msg}}, _Config0) ->
             []
     end.
 
+
+%%-------------------------------------------------------------------------
+%%  Keylog functions (not erlang logger related)
+%%-------------------------------------------------------------------------
+
+keylog(KeyLog, Random, Fun) ->
+    try
+        Fun(#{items => KeyLog, client_random => Random})
+    catch
+        _:function_clause:FunclauseST ->
+            [_| RestST] = FunclauseST,
+            %% Do not log arguments, our app should not cause any information leak.
+            %% What user fun does with the arguments is the users responsibility.
+            ?LOG_WARNING("user keylogging fun failed with function_clause: ~p ~n", [RestST]);
+        _:Reason:ST ->
+            ?LOG_WARNING("user keylogging fun failed : ~p ~p ~n", [Reason, ST])
+    end.
+
+keylog_early_data(ClientRand, Prf, EarlySecret) ->
+    ClientRandom = binary:decode_unsigned(ClientRand),
+    ClientEarlySecret = keylog_secret(EarlySecret, Prf),
+    [io_lib:format("CLIENT_EARLY_TRAFFIC_SECRET ~64.16.0B ",
+                   [ClientRandom]) ++ ClientEarlySecret].
+
+keylog_hs(ClientRand, Prf, ClientHSSecretBin, ServerHSSecretBin) ->
+    ClientRandom = binary:decode_unsigned(ClientRand),
+    ClientHSecret = keylog_secret(ClientHSSecretBin, Prf),
+    ServerHSecret = keylog_secret(ServerHSSecretBin, Prf),
+    [io_lib:format("CLIENT_HANDSHAKE_TRAFFIC_SECRET ~64.16.0B ",
+                   [ClientRandom]) ++ ClientHSecret,
+     io_lib:format("SERVER_HANDSHAKE_TRAFFIC_SECRET ~64.16.0B ",
+                   [ClientRandom]) ++ ServerHSecret].
+
+keylog_traffic_1_3(Role, ClientRandom, Prf, TrafficSecretBin, N) ->
+    ClientRandBin = binary:decode_unsigned(ClientRandom),
+    TrafficSecret = keylog_secret(TrafficSecretBin, Prf),
+    ClientRand = io_lib:format("~64.16.0B", [ClientRandBin]),
+    case Role of
+        client ->
+            ["CLIENT_TRAFFIC_SECRET_" ++ integer_to_list(N),
+             ClientRand,
+             TrafficSecret];
+        server ->
+            ["SERVER_TRAFFIC_SECRET_" ++ integer_to_list(N),
+             ClientRand,
+             TrafficSecret]
+    end.
+
+keylog_traffic_pre_1_3(ClientRandom, MasterSecret) ->
+    ClientRandBin = binary:decode_unsigned(ClientRandom),
+    MasterSecretBin = binary:decode_unsigned(MasterSecret),
+    [io_lib:format("CLIENT_RANDOM ~64.16.0B ~96.16.0B", [ClientRandBin, MasterSecretBin])].
+
+
 %%-------------------------------------------------------------------------
 %%  Internal functions
 %%-------------------------------------------------------------------------
+
+keylog_secret(SecretBin, sha256) ->
+    io_lib:format("~64.16.0B", [binary:decode_unsigned(SecretBin)]);
+keylog_secret(SecretBin, sha384) ->
+    io_lib:format("~96.16.0B", [binary:decode_unsigned(SecretBin)]);
+keylog_secret(SecretBin, sha512) ->
+    io_lib:format("~128.16.0B", [binary:decode_unsigned(SecretBin)]).
 
 %%-------------------------------------------------------------------------
 %% Handshake Protocol

--- a/lib/ssl/src/tls_client_connection_1_3.erl
+++ b/lib/ssl/src/tls_client_connection_1_3.erl
@@ -439,7 +439,9 @@ wait_finished(internal = Type, #change_cipher_spec{} = Msg, State) ->
                                                      ?STATE(wait_finished), State);
 wait_finished(internal,
               #finished{verify_data = VerifyData},
-              #state{static_env = #static_env{protocol_cb = Connection}}
+              #state{static_env = #static_env{protocol_cb = Connection,
+                                              role = Role},
+                     ssl_options = SSLOpts}
               = State0) ->
     {Ref,Maybe} = tls_gen_connection_1_3:do_maybe(),
     try
@@ -456,20 +458,15 @@ wait_finished(internal,
         State4 = Connection:queue_handshake(Finished, State3),
         %% Send first flight
         {State5, _} = Connection:send_handshake_flight(State4),
-        State6 = tls_handshake_1_3:calculate_traffic_secrets(State5),
-        State7 =
-            tls_handshake_1_3:maybe_calculate_resumption_master_secret(State6),
-        ExporterMasterSecret = tls_handshake_1_3:calculate_exporter_master_secret(State7),
-        State8 = tls_handshake_1_3:forget_master_secret(State7),
+        State6 = tls_handshake_1_3:handle_secrets(State5),
         %% Configure traffic keys
-        State9 = ssl_record:step_encryption_state(State8),
-        {Record, #state{protocol_specific = PS} = State} =
-            ssl_gen_statem:prepare_connection(State9, tls_gen_connection),
-
-        tls_gen_connection:next_event(connection, Record,
-                                      State#state{protocol_specific =
-                                                      PS#{exporter_master_secret =>
-                                                              ExporterMasterSecret}},
+        State7 = ssl_record:step_encryption_state(State6),
+        {Record, State} =
+            ssl_gen_statem:prepare_connection(State7, tls_gen_connection),
+        KeepSecrets = maps:get(keep_secrets, SSLOpts, false),
+        tls_gen_connection_1_3:maybe_traffic_keylog_1_3(KeepSecrets, Role,
+                                                        State#state.connection_states, 0),
+        tls_gen_connection:next_event(connection, Record, State,
                                       [{{timeout, handshake}, cancel}])
     catch
         {Ref, #alert{} = Alert} ->

--- a/lib/ssl/src/tls_dtls_gen_connection.erl
+++ b/lib/ssl/src/tls_dtls_gen_connection.erl
@@ -196,15 +196,17 @@ negotiated_hashsign(HashSign = {_, _}, _, _, _) ->
     HashSign.
 
 finalize_handshake(State0, StateName, Connection) ->
-    #state{connection_states = ConnectionStates0} =
+    #state{connection_states = ConnectionStates0,
+           ssl_options = SslOpts} =
 	State1 = cipher_protocol(State0, Connection),
 
     ConnectionStates =
         ssl_record:activate_pending_connection_state(ConnectionStates0,
                                                      write, Connection),
-
     State2 = State1#state{connection_states = ConnectionStates},
     State = next_protocol(State2, Connection),
+    KeepSecrets = maps:get(keep_secrets, SslOpts, false),
+    maybe_keylog_pre_1_3(KeepSecrets, ConnectionStates),
     finished(State, StateName, Connection).
 
 calculate_master_secret(PremasterSecret,
@@ -459,3 +461,12 @@ master_secret(PremasterSecret, #state{static_env = #static_env{role = Role},
 	#alert{} = Alert ->
 	    throw(Alert)
     end.
+
+maybe_keylog_pre_1_3({keylog, Fun}, ConnectionStates) ->
+    #{security_parameters := #security_parameters{client_random = ClientRandom,
+                                                   master_secret = MasterSecret}}
+        = ssl_record:current_connection_state(ConnectionStates, write),
+    KeyLog = ssl_logger:keylog_traffic_pre_1_3(ClientRandom, MasterSecret),
+    ssl_logger:keylog(KeyLog, ClientRandom, Fun);
+maybe_keylog_pre_1_3(_,_) ->
+    ok.

--- a/lib/ssl/src/tls_gen_connection.erl
+++ b/lib/ssl/src/tls_gen_connection.erl
@@ -164,6 +164,12 @@ initialize_tls_sender(#state{static_env = #static_env{
                              connection_states = #{current_write := ConnectionWriteState} = CS,
                              protocol_specific = #{sender := Sender}}) ->
     HibernateAfter = maps:get(hibernate_after, SSLOpts, infinity),
+    KeyLogFun = case maps:get(keep_secrets, SSLOpts, false) of
+                    {keylog, Fun} ->
+                        Fun;
+                    _ ->
+                        undefined
+                end,
     Init = #{current_write => ConnectionWriteState,
              beast_mitigation => maps:get(beast_mitigation, CS, disabled),
              role => Role,
@@ -176,7 +182,8 @@ initialize_tls_sender(#state{static_env = #static_env{
              renegotiate_at => RenegotiateAt,
              key_update_at => KeyUpdateAt,
              log_level => LogLevel,
-             hibernate_after => HibernateAfter},
+             hibernate_after => HibernateAfter,
+             keylog_fun => KeyLogFun},
     tls_sender:initialize(Sender, Init).
 
 %%====================================================================
@@ -910,10 +917,12 @@ handle_alerts([#alert{level = ?WARNING, description = ?CLOSE_NOTIFY} | _Alerts],
                                                           recv =  #recv{from = From}} = State}) when From == undefined ->
     %% Linger to allow recv and setopts to possibly fetch data not yet delivered to user to be fetched
     {next_state, StateName, State#state{connection_env = CEnv#connection_env{socket_tls_closed = true}}};
-handle_alerts([#alert{level = ?FATAL} = Alert | _Alerts], 
+handle_alerts([#alert{level = ?FATAL} = Alert0 | _Alerts],
               {next_state, connection = StateName, #state{connection_env = CEnv, 
+                                                          static_env = #static_env{role = Role},
                                                           socket_options = #socket_options{active = false},
                                                           recv = #recv{from = From}} = State}) when From == undefined ->
+    Alert = Alert0#alert{role = ssl_gen_statem:opposite_role(Role)},
     %% Linger to allow recv and setopts to retrieve alert reason 
     {next_state, StateName, State#state{connection_env = CEnv#connection_env{socket_tls_closed = Alert}}};
 handle_alerts([Alert | Alerts], {next_state, StateName, State}) ->

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -58,7 +58,7 @@
 %% Tracing
 -export([handle_trace/3]).
 
--record(static,
+-record(env,
         {connection_pid,
          role,
          socket,
@@ -71,12 +71,14 @@
          key_update_at,  %% TLS 1.3
          dist_handle,
          log_level,
-         hibernate_after
+         hibernate_after,
+         keylog_fun,
+         num_key_updates = 0
         }).
 
 -record(data,
         {
-         static = #static{},
+         env = #env{},
          connection_states = #{},
          bytes_sent     %% TLS 1.3
         }).
@@ -237,8 +239,9 @@ init({call, From}, {Pid, #{current_write := WriteState,
                            renegotiate_at := RenegotiateAt,
                            key_update_at := KeyUpdateAt,
                            log_level := LogLevel,
-                           hibernate_after := HibernateAfter}},
-     #data{connection_states = ConnectionStates0, static = Static0} = StateData0) ->
+                           hibernate_after := HibernateAfter,
+                           keylog_fun := Fun}},
+     #data{connection_states = ConnectionStates0, env = Env0} = StateData0) ->
     ConnectionStates = case BeastMitigation of
                            disabled ->
                                ConnectionStates0#{current_write => WriteState};
@@ -249,7 +252,7 @@ init({call, From}, {Pid, #{current_write := WriteState,
     StateData =
         StateData0#data{connection_states = ConnectionStates,
                         bytes_sent = 0,
-                        static = Static0#static{connection_pid = Pid,
+                        env = Env0#env{connection_pid = Pid,
                                                 role = Role,
                                                 socket = Socket,
                                                 socket_options = SockOpts,
@@ -260,7 +263,8 @@ init({call, From}, {Pid, #{current_write := WriteState,
                                                 renegotiate_at = RenegotiateAt,
                                                 key_update_at = KeyUpdateAt,
                                                 log_level = LogLevel,
-                                                hibernate_after = HibernateAfter}},
+                                                hibernate_after = HibernateAfter,
+                                                keylog_fun = Fun}},
     proc_lib:set_label({tls_sender, Role, {connection, Pid}}),
     {next_state, handshake, StateData, [{reply, From, ok}]};
 init(info = Type, Msg, StateData) ->
@@ -276,7 +280,7 @@ init(_, _, _) ->
                   gen_statem:event_handler_result(atom()).
 %%--------------------------------------------------------------------
 connection({call, From}, {application_data, AppData}, 
-           #data{static = #static{socket_options = #socket_options{packet = Packet}}} =
+           #data{env = #env{socket_options = #socket_options{packet = Packet}}} =
                StateData) ->
     case encode_packet(Packet, AppData) of
         {error, _} = Error ->
@@ -299,14 +303,14 @@ connection({call, From}, downgrade, #data{connection_states =
 connection({call, From}, {set_opts, Opts}, StateData) ->
     handle_set_opts(connection, From, Opts, StateData);
 connection({call, From}, dist_get_tls_socket, 
-           #data{static = #static{transport_cb = Transport,
+           #data{env = #env{transport_cb = Transport,
                                   socket = Socket,
                                   connection_pid = Pid,
                                   trackers = Trackers}} = StateData) ->
     TLSSocket = tls_gen_connection:socket([Pid, self()], Transport, Socket, Trackers),
     hibernate_after(connection, StateData, [{reply, From, {ok, TLSSocket}}]);
 connection({call, From}, {dist_handshake_complete, _Node, DHandle},
-           #data{static = #static{connection_pid = Pid} = Static} = StateData) ->
+           #data{env = #env{connection_pid = Pid} = Env} = StateData) ->
     false = erlang:dist_ctrl_set_opt(DHandle, get_size, true),
     ok = erlang:dist_ctrl_input_handler(DHandle, Pid),
     ok = ssl_gen_statem:dist_handshake_complete(Pid, DHandle),
@@ -317,22 +321,22 @@ connection({call, From}, {dist_handshake_complete, _Node, DHandle},
         [] ->
             hibernate_after(connection,
                             StateData#data{
-                              static = Static#static{dist_handle = DHandle}},
+                              env = Env#env{dist_handle = DHandle}},
                             [{reply,From,ok}]);
         Data ->
             {keep_state,
-             StateData#data{static = Static#static{dist_handle = DHandle}},
+             StateData#data{env = Env#env{dist_handle = DHandle}},
              [{reply,From,ok},
               {next_event, internal,
                {application_packets, {self(),undefined}, Data}}]}
     end;
-connection({call, From}, get_application_traffic_secret, State) ->
-    CurrentWrite = maps:get(current_write, State#data.connection_states),
+connection({call, From}, get_application_traffic_secret, #data{env = #env{num_key_updates = N}} = Data) ->
+    CurrentWrite = maps:get(current_write, Data#data.connection_states),
     SecurityParams = maps:get(security_parameters, CurrentWrite),
     ApplicationTrafficSecret =
         SecurityParams#security_parameters.application_traffic_secret,
-    hibernate_after(connection, State,
-                    [{reply, From, {ok, ApplicationTrafficSecret}}]);
+    hibernate_after(connection, Data,
+                    [{reply, From, {ok, ApplicationTrafficSecret, N}}]);
 connection(internal, {application_packets, From, Data}, StateData) ->
     send_application_data(Data, From, connection, StateData);
 connection(internal, {post_handshake_data, From, HSData}, StateData) ->
@@ -341,15 +345,15 @@ connection(cast, #alert{} = Alert, StateData0) ->
     StateData = send_tls_alert(Alert, StateData0),
     {next_state, connection, StateData};
 connection(cast, {new_write, WritesState, Version}, 
-           #data{connection_states = ConnectionStates, static = Static} = StateData) ->
+           #data{connection_states = ConnectionStates, env = Env} = StateData) ->
     hibernate_after(connection,
                     StateData#data{connection_states =
                                        ConnectionStates#{current_write => WritesState},
-                                   static =
-                                       Static#static{negotiated_version = Version}}, []);
+                                   env =
+                                       Env#env{negotiated_version = Version}}, []);
 %%
 connection(info, dist_data,
-           #data{static = #static{dist_handle = DHandle}} = StateData) ->
+           #data{env = #env{dist_handle = DHandle}} = StateData) ->
       case dist_data(DHandle) of
           [] ->
               hibernate_after(connection, StateData, []);
@@ -391,12 +395,22 @@ handshake({call, _}, _, _) ->
 handshake(internal, {application_packets,_,_}, _) ->
     {keep_state_and_data, [postpone]};
 handshake(cast, {new_write, WriteState, Version},
-          #data{connection_states = ConnectionStates,
-                static = #static{key_update_at = KeyUpdateAt0} = Static} = StateData) ->
+          #data{connection_states = ConnectionStates0,
+                env = #env{key_update_at = KeyUpdateAt0,
+                                 role = Role,
+                                 num_key_updates = N,
+                                 keylog_fun = Fun} = Env} = StateData) ->
+    ConnectionStates = ConnectionStates0#{current_write => WriteState},
     KeyUpdateAt = key_update_at(Version, WriteState, KeyUpdateAt0),
+     case Version of
+         ?TLS_1_3 ->
+             maybe_traffic_keylog_1_3(Fun, Role, ConnectionStates, N);
+          _ ->
+             ok
+     end,
     {next_state, connection, 
-     StateData#data{connection_states = ConnectionStates#{current_write => WriteState},
-                    static = Static#static{negotiated_version = Version,
+     StateData#data{connection_states = ConnectionStates,
+                    env = Env#env{negotiated_version = Version,
                                            key_update_at = KeyUpdateAt}}};
 handshake(info, dist_data, _) ->
     {keep_state_and_data, [postpone]};
@@ -450,25 +464,25 @@ code_change(_OldVsn, State, Data, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 handle_set_opts(StateName, From, Opts,
-                #data{static = #static{socket_options = SockOpts} = Static}
+                #data{env = #env{socket_options = SockOpts} = Env}
                 = StateData) ->
     hibernate_after(StateName,
                     StateData#data{
-                      static =
-                          Static#static{
+                      env =
+                          Env#env{
                             socket_options = set_opts(SockOpts, Opts)}},
                     [{reply, From, ok}]).
 
 handle_common(StateName, {call, From}, {set_opts, Opts},
-  #data{static = #static{socket_options = SockOpts} = Static} = StateData) ->
+  #data{env = #env{socket_options = SockOpts} = Env} = StateData) ->
     hibernate_after(StateName,
                     StateData#data{
-                      static =
-                          Static#static{
+                      env =
+                          Env#env{
                             socket_options = set_opts(SockOpts, Opts)}},
      [{reply, From, ok}]);
 handle_common(_StateName, info, {'EXIT', _Sup, shutdown = Reason},
-              #data{static = #static{erl_dist = true}} = StateData) ->
+              #data{env = #env{erl_dist = true}} = StateData) ->
     %% When the connection is on its way down operations
     %% begin to fail. We wait to receive possible exit signals
     %% for one of our links to the other involved distribution parties,
@@ -476,23 +490,23 @@ handle_common(_StateName, info, {'EXIT', _Sup, shutdown = Reason},
     %% for the connection teardown.
     death_row_shutdown(Reason, StateData);
 handle_common(_StateName, info, {'EXIT', _Dist, Reason},
-              #data{static = #static{erl_dist = true}} = StateData) ->
+              #data{env = #env{erl_dist = true}} = StateData) ->
     {stop, {shutdown, Reason}, StateData};
 handle_common(_StateName, info, {'EXIT', _Sup, shutdown}, StateData) ->
     {stop, shutdown, StateData};
 handle_common(StateName, info, Msg,
-              #data{static = #static{log_level = Level}} = StateData) ->
+              #data{env = #env{log_level = Level}} = StateData) ->
     ssl_logger:log(info, Level, #{event => "TLS sender received unexpected info",
                                   reason => [{message, Msg}]}, ?LOCATION),
     hibernate_after(StateName, StateData, []);
 handle_common(StateName, Type, Msg,
-              #data{static = #static{log_level = Level}} = StateData) ->
+              #data{env = #env{log_level = Level}} = StateData) ->
     ssl_logger:log(error, Level, #{event => "TLS sender received unexpected event",
                                    reason => [{type, Type}, {message, Msg}]}, ?LOCATION),
     hibernate_after(StateName, StateData, []).
 
 send_tls_alert(#alert{} = Alert,
-               #data{static = #static{negotiated_version = Version,
+               #data{env = #env{negotiated_version = Version,
                                       socket = Socket,
                                       transport_cb = Transport,
                                       log_level = LogLevel},
@@ -504,7 +518,7 @@ send_tls_alert(#alert{} = Alert,
     StateData0#data{connection_states = ConnectionStates}.
 
 send_application_data(Data, From, StateName,
-                      #data{static = #static{connection_pid = Pid,
+                      #data{env = #env{connection_pid = Pid,
                                              socket = Socket,
                                              dist_handle = DistHandle,
                                              negotiated_version = Version,
@@ -555,7 +569,7 @@ send_application_data(Data, From, StateName,
 
 %% TLS 1.3 Post Handshake Data
 send_post_handshake_data(Handshake, From, StateName,
-                         #data{static = #static{socket = Socket,
+                         #data{env = #env{socket = Socket,
                                                 dist_handle = DistHandle,
                                                 negotiated_version = Version,
                                                 transport_cb = Transport,
@@ -581,17 +595,33 @@ send_post_handshake_data(Handshake, From, StateName,
             {next_state, StateName, StateData1,  [{reply, From, Result}]}
     end.
 
-maybe_update_cipher_key(#data{connection_states = ConnectionStates0}= StateData, #key_update{}) ->
+maybe_update_cipher_key(#data{connection_states = ConnectionStates0,
+                              env = #env{role = Role,
+                                         num_key_updates = N,
+                                         keylog_fun = Fun} = Env
+                             } = StateData, #key_update{}) ->
     ConnectionStates = tls_gen_connection_1_3:update_cipher_key(current_write, ConnectionStates0),
+    maybe_traffic_keylog_1_3(Fun, Role, ConnectionStates, N + 1),
     StateData#data{connection_states = ConnectionStates,
+                   env = Env#env{num_key_updates = N + 1},
                    bytes_sent = 0};
 maybe_update_cipher_key(StateData, _) ->
     StateData.
 
+maybe_traffic_keylog_1_3(Fun, Role, ConnectionStates, N) when is_function(Fun) ->
+    #{security_parameters := #security_parameters{client_random = ClientRandom,
+                                                  prf_algorithm = Prf,
+                                                  application_traffic_secret = TrafficSecret}}
+        = ssl_record:current_connection_state(ConnectionStates, write),
+    KeyLog =  ssl_logger:keylog_traffic_1_3(Role, ClientRandom, Prf, TrafficSecret, N),
+    ssl_logger:keylog(KeyLog, ClientRandom, Fun);
+maybe_traffic_keylog_1_3(_,_,_,_) ->
+    ok.
+
 update_bytes_sent(Version, CS, StateData, _) when ?TLS_LT(Version, ?TLS_1_3) ->
     StateData#data{connection_states = CS};
 %% Count bytes sent in TLS 1.3 for AES-GCM
-update_bytes_sent(_, CS, #data{static = #static{key_update_at = seq_num_wrap}} = StateData, _) ->
+update_bytes_sent(_, CS, #data{env = #env{key_update_at = seq_num_wrap}} = StateData, _) ->
     StateData#data{connection_states = CS};  %% Chacha20-Poly1305
 update_bytes_sent(_, CS, #data{bytes_sent = Sent} = StateData, DataSz) ->
     StateData#data{connection_states = CS,
@@ -717,7 +747,7 @@ consume_ticks() ->
     end.
 
 hibernate_after(connection = StateName,
-		#data{static=#static{hibernate_after = HibernateAfter}} = State,
+		#data{env=#env{hibernate_after = HibernateAfter}} = State,
 		Actions) when HibernateAfter =/= infinity ->
     {next_state, StateName, State, [{timeout, HibernateAfter, hibernate} | Actions]};
 hibernate_after(StateName, State, []) ->
@@ -753,7 +783,7 @@ handle_trace(hbn,
                  {call, {?MODULE, hibernate_after,
                          [_StateName = connection, State, Actions]}},
              Stack) ->
-    #data{static=#static{hibernate_after = HibernateAfter}} = State,
+    #data{env=#env{hibernate_after = HibernateAfter}} = State,
     {io_lib:format("* * * maybe hibernating in ~w ms * * * Actions = ~W ",
                    [HibernateAfter, Actions, 10]), Stack};
 handle_trace(hbn,

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -3095,8 +3095,13 @@ options_debug(_Config) -> %% debug  log_level keep_secrets
     ?OK(#{log_level := notice}, [], server, [keep_secrets]),
     ?OK(#{log_level := debug, keep_secrets := true},
         [{log_level, debug}, {keep_secrets, true}], server),
+    Fun = fun(_KeyLogItems) -> _KeyLogItems end,
+    ?OK(#{log_level := debug, keep_secrets := {keylog_hs, Fun}},
+        [{log_level, debug}, {keep_secrets, {keylog_hs, Fun}}], server),
+    ?OK(#{log_level := debug, keep_secrets := {keylog, Fun}},
+        [{log_level, debug}, {keep_secrets, {keylog, Fun}}], server),
     ?OK(#{log_level := info},
-        [{log_level, info}, {keep_secrets, false}], server, [keep_secrets]),
+        [{log_level, info}, {keep_secrets, false}], server, []),
 
     %% Errors
     ?ERR({log_level, foo}, [{log_level, foo}], server),
@@ -4056,9 +4061,9 @@ keylog_connection_info_result(Socket, KeepSecrets) ->
 
 check_keylog_info('tlsv1.3', [{keylog, ["CLIENT_HANDSHAKE_TRAFFIC_SECRET"++_,_|_]=Keylog}], true) ->
     {ok, Keylog};
-check_keylog_info('tlsv1.3', []=Keylog, false) ->
+check_keylog_info(_, []=Keylog, false) ->
     {ok, Keylog};
-check_keylog_info(_, [{keylog, ["CLIENT_RANDOM"++_]=Keylog}], _) ->
+check_keylog_info(_, [{keylog, ["CLIENT_RANDOM"++_]=Keylog}], true) ->
     {ok, Keylog};
 check_keylog_info(_, Unexpected, Keep) ->
     {unexpected, Keep, Unexpected}.

--- a/lib/ssl/test/ssl_key_update_SUITE.erl
+++ b/lib/ssl/test/ssl_key_update_SUITE.erl
@@ -37,7 +37,12 @@
          key_update_at_server/0,
          key_update_at_server/1,
          explicit_key_update/0,
-         explicit_key_update/1]).
+         explicit_key_update/1,
+         keylog_client_cb/0,
+         keylog_client_cb/1,
+         keylog_server_cb/0,
+         keylog_server_cb/1
+        ]).
 
 -include("ssl_test_lib.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -52,11 +57,12 @@ groups() ->
 tls_1_3_tests() ->
     [key_update_at_client,
      key_update_at_server,
-     explicit_key_update].
+     explicit_key_update,
+     keylog_client_cb,
+     keylog_server_cb].
 
 init_per_suite(Config0) ->
-    catch crypto:stop(),
-    try crypto:start() of
+    case application:ensure_started(crypto) of
         ok ->
             ssl_test_lib:clean_start(),
             case proplists:get_bool(ecdh, proplists:get_value(public_keys, crypto:supports())) of
@@ -64,8 +70,8 @@ init_per_suite(Config0) ->
                     ssl_test_lib:make_ecdsa_cert(Config0);
                 false ->
                     {skip, "Missing EC crypto support"}
-            end
-    catch _:_ ->
+            end;
+        _ ->
             {skip, "Crypto did not start"}
     end.
 
@@ -78,7 +84,7 @@ init_per_group(GroupName, Config) ->
     ssl_test_lib:init_per_group(GroupName, Config).
 
 end_per_group(GroupName, Config) ->
-  ssl_test_lib:end_per_group(GroupName, Config).
+    ssl_test_lib:end_per_group(GroupName, Config).
 
 init_per_testcase(_TestCase, Config) ->
     ssl_test_lib:ct_log_supported_protocol_versions(Config),
@@ -103,6 +109,102 @@ key_update_at_server() ->
       "Server initiating the update."}].
 key_update_at_server(Config) ->
     key_update_at(Config, server).
+
+explicit_key_update() ->
+    [{doc,"Test ssl:update_key/2 between erlang client and erlang server."}].
+
+explicit_key_update(Config) ->
+    Data = "123456789012345",  %% 15 bytes
+
+    Server = ssl_test_lib:start_server(erlang, [], Config),
+    Port = ssl_test_lib:inet_port(Server),
+
+    Client = ssl_test_lib:start_client(erlang, [{port, Port}], Config),
+    ssl_test_lib:send_recv_result_active(Client, Server, Data),
+
+    ssl_test_lib:update_keys(Client, write),
+    ssl_test_lib:update_keys(Client, read_write),
+    ssl_test_lib:send_recv_result_active(Client, Server, Data),
+
+    ssl_test_lib:update_keys(Server, write),
+    ssl_test_lib:update_keys(Server, read_write),
+    ssl_test_lib:send_recv_result_active(Client, Server, Data),
+    %% TODO check if key has been updated (needs debug logging of secrets)
+
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
+
+keylog_client_cb() ->
+    [{doc,"Test option {keep_secrets, {keylog, fun()}}"}].
+keylog_client_cb(Config) ->
+    Data = "123456789012345",  %% 15 bytes
+    TestCase = self(),
+    Fun = fun(KeyLogInfo) ->
+                  TestCase ! {keylog, KeyLogInfo}
+          end,
+    Server = ssl_test_lib:start_server(erlang,[], Config),
+    Port = ssl_test_lib:inet_port(Server),
+    {_Client, ClientSocket} =
+        ssl_test_lib:start_client(erlang, [return_socket,{port, Port},
+                                          {options, [{keep_secrets, {keylog, Fun}},
+                                                     {key_update_at, 9}]}],Config),
+    ssl:send(ClientSocket, Data),
+    receive
+        {keylog, #{items := HSKeylog}} ->
+            ["CLIENT_HANDSHAKE_TRAFFIC_SECRET" ++ _| _] = HSKeylog
+    end,
+    receive
+        {keylog, #{items := RConKeylog}} ->
+            ["SERVER_TRAFFIC_SECRET_0" ++ _| _] = RConKeylog
+    end,
+    receive
+     {keylog, #{items := SConKeylog}} ->
+            ["CLIENT_TRAFFIC_SECRET_0" ++ _| _] = SConKeylog
+    end,
+    receive
+        {keylog, #{items := UpdateKeylog}} ->
+            ["CLIENT_TRAFFIC_SECRET_1" ++ _| _] = UpdateKeylog
+    end.
+
+keylog_server_cb() ->
+    [{doc,"Test option {keep_secrets, {keylog, fun()}}"}].
+keylog_server_cb(Config) ->
+    Data = "123456789012345",  %% 15 bytes
+    TestCase = self(),
+    Fun = fun(KeyLogInfo) ->
+                  TestCase ! {keylog, KeyLogInfo}
+          end,
+    Server = ssl_test_lib:start_server(erlang,[{options, [{keep_secrets, {keylog, Fun}},
+                                                          {key_update_at, 9}]}], Config),
+    Port = ssl_test_lib:inet_port(Server),
+    
+    _ = ssl_test_lib:start_client(erlang, [{port, Port}], Config),
+
+    Server ! get_socket,
+    ServerSocket = receive
+                       {Server, {socket, S}} -> S
+                   end,
+    ssl:send(ServerSocket, Data),
+    receive
+        {keylog, #{items := HSKeylog}} ->
+             ["CLIENT_HANDSHAKE_TRAFFIC_SECRET" ++ _| _] = HSKeylog
+    end,
+    receive
+        {keylog, #{items := RConKeylog}} ->
+            ["CLIENT_TRAFFIC_SECRET_0" ++ _| _] = RConKeylog
+    end,
+    receive
+     {keylog, #{items := SConKeylog}} ->
+            ["SERVER_TRAFFIC_SECRET_0" ++ _| _] = SConKeylog
+    end,
+    receive
+        {keylog, #{items := UpdateKeylog}} ->
+            ["SERVER_TRAFFIC_SECRET_1" ++ _| _] = UpdateKeylog
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions  -----------------------------------------------
+%%--------------------------------------------------------------------
 
 key_update_at(Config, Role) ->
     Data = "123456789012345",  %% 15 bytes
@@ -142,78 +244,28 @@ key_update_at(Config, Role) ->
     ?CT_LOG("sent and waited 2", []),
     Keys2 = get_traffic_secrets(ClientSocket, ServerSocket),
     verify_key_update(Keys1, Keys2),
+    %% Verify prevention 
+    {["CLIENT_TRAFFIC_SECRET_10"| _], ["CLIENT_TRAFFIC_SECRET_10"| _]} = Keys2,
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
 
 get_traffic_secrets(ClientSocket, ServerSocket) ->
-    ProcessSocket =
-        fun(Socket, Role) ->
-                {ok, [{keylog, KeyLog}]} = ssl:connection_information(Socket, [keylog]),
-                Interesting =
-                    fun(S) ->
-                            Patterns = ["CLIENT_TRAFFIC_SECRET", "SERVER_TRAFFIC_SECRET"],
-                            SearchResults = [string:find(S, P) || P <- Patterns],
-                            lists:any(fun(I) -> I /= nomatch end, SearchResults)
-                    end,
-                TrafficSecrets = lists:filter(Interesting, KeyLog),
-                Print = fun(Secret) ->
-                                [Name, _A, B] = string:lexemes(Secret, " "),
-                                [Key] = io_lib:format("~s", [B]),
-                                {Name, {Role, Key}}
-                        end,
-                [Print(Scr) || Scr <- TrafficSecrets]
-        end,
-    Secrets = lists:flatten(
-                [ProcessSocket(S, R) ||
-                    {S, R} <-
-                        [{ClientSocket, client}, {ServerSocket, server}]]),
-    P = fun(Direction) ->
-                Vals = proplists:get_all_values(Direction, Secrets),
-                ?CT_LOG("~30s ~10s(c) ~10s(s)",
-                     [Direction, proplists:get_value(client, Vals),
-                      proplists:get_value(server, Vals)]),
-                {Direction, [proplists:get_value(client, Vals),
-                             proplists:get_value(server, Vals)]}
-        end,
-    [P(Direction) ||
-        Direction <-
-            ["CLIENT_TRAFFIC_SECRET_0", "SERVER_TRAFFIC_SECRET_0"]].
+    {ok, [{keylog, KeyLog1}]} = ssl:connection_information(ClientSocket, [keylog]),
+    {ok, [{keylog, KeyLog2}]} = ssl:connection_information(ServerSocket, [keylog]),
+    {KeyLog1, KeyLog2}.
 
-verify_key_update(Keys0, Keys1) ->
-    CTS0 = proplists:get_value("CLIENT_TRAFFIC_SECRET_0", Keys0),
-    CTS1 = proplists:get_value("CLIENT_TRAFFIC_SECRET_0", Keys1),
-    STS0 = proplists:get_value("SERVER_TRAFFIC_SECRET_0", Keys0),
-    STS1 = proplists:get_value("SERVER_TRAFFIC_SECRET_0", Keys1),
-    CTS = lists:zip(CTS0, CTS1),
-    STS = lists:zip(STS0, STS1),
-    Pred = fun({A, B}) when A == B ->
-                   ct:fail(no_key_update),
-                   false;
-              (_) ->
-                   true
-           end,
-    [true = lists:all(Pred, X) || X <- [CTS, STS]].
 
-explicit_key_update() ->
-    [{doc,"Test ssl:update_key/2 between erlang client and erlang server."}].
+%% Only traffic secrets
+verify_key_update({[TS1, TS2, TS3, TS4, TS5, TS6],
+                   [TS1, TS2, TS3, TS4, TS5, TS6]} = TSC,
+                  {[TS7, TS8, TS9, TS10, TS11, TS12],
+                   [TS7, TS8, TS9, TS10, TS11, TS12]}= TSS
+                 ) ->
+    TSC =/= TSS;
+%% Handshake + traffic secrets
+verify_key_update({[CH1, SH1 | T1], [CH1, SH1 | T1]},
+                  {[CH2, SH2 | T2], [CH2, SH2 | T2]}) ->
+    CH1 =/= CH2 andalso
+        SH1 =/= SH2 andalso
+        T1 =/= T2.
 
-explicit_key_update(Config) ->
-    Data = "123456789012345",  %% 15 bytes
-
-    Server = ssl_test_lib:start_server(erlang, [], Config),
-    Port = ssl_test_lib:inet_port(Server),
-
-    Client = ssl_test_lib:start_client(erlang, [{port, Port}], Config),
-    ssl_test_lib:send_recv_result_active(Client, Server, Data),
-
-    ssl_test_lib:update_keys(Client, write),
-    ssl_test_lib:update_keys(Client, read_write),
-    ssl_test_lib:send_recv_result_active(Client, Server, Data),
-
-    ssl_test_lib:update_keys(Server, write),
-    ssl_test_lib:update_keys(Server, read_write),
-    ssl_test_lib:send_recv_result_active(Client, Server, Data),
-    %% TODO check if key has been updated (needs debug logging of secrets)
-
-    ssl_test_lib:close(Server),
-    ssl_test_lib:close(Client).

--- a/lib/ssl/test/ssl_session_ticket_SUITE.erl
+++ b/lib/ssl/test/ssl_session_ticket_SUITE.erl
@@ -1180,7 +1180,8 @@ early_data_enabled_small_limit(Config) when is_list(Config) ->
     ssl_test_lib:close(Client1).
 
 early_data_basic() ->
-    [{doc,"Test early data when client is not authenticated (erlang client - erlang server)"}].
+    [{doc,"Test early data when client is not authenticated (erlang client - erlang server)"
+      "Also test that early data keylog happens"}].
 early_data_basic(Config) when is_list(Config) ->
     ClientOpts0 = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
     ServerOpts0 = ssl_test_lib:ssl_options(server_rsa_verify_opts, Config),
@@ -1199,13 +1200,19 @@ early_data_basic(Config) when is_list(Config) ->
     ServerOpts = [{session_tickets, ServerTicketMode}, {early_data, enabled},
                   {versions, ['tlsv1.2','tlsv1.3']}|ServerOpts0],
 
+    %%% Test keylog
+    TestCase = self(),
+    Fun = fun(KeyLogInfo) ->
+                  TestCase ! {keylog, KeyLogInfo}
+          end,
+
     Server0 =
 	ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
 				   {from, self()},
 				   {mfa, {ssl_test_lib,
                                           verify_active_session_resumption,
                                           [false]}},
-				   {options, ServerOpts}]),
+				   {options, [{keep_secrets, {keylog, Fun}} | ServerOpts]}]),
     Port0 = ssl_test_lib:inet_port(Server0),
 
     %% Store ticket from first connection
@@ -1215,6 +1222,8 @@ early_data_basic(Config) when is_list(Config) ->
                                                 verify_active_session_resumption,
                                                 [false]}},
                                          {from, self()}, {options, ClientOpts1}]),
+    skip_keylogs(3), %% HS and two traffic secrets
+
     ssl_test_lib:check_result(Server0, ok, Client0, ok),
 
     Server0 ! {listen, {mfa, {ssl_test_lib,
@@ -1233,11 +1242,27 @@ early_data_basic(Config) when is_list(Config) ->
                                                 verify_active_session_resumption,
                                                 [true]}},
                                          {from, self()}, {options, ClientOpts2}]),
+    %% Check that we get the EARLY DATA keylog event
+    receive
+        {keylog, #{items := EarlyKeylog}} ->
+            ["CLIENT_EARLY_TRAFFIC_SECRET" ++ _| _] = EarlyKeylog
+    end,
+    skip_keylogs(3), %% HS and two traffic secrets so they do not end up
+                     %% in check_result
+
     ssl_test_lib:check_result(Server0, ok, Client1, ok),
 
     process_flag(trap_exit, false),
     ssl_test_lib:close(Server0),
     ssl_test_lib:close(Client1).
+
+skip_keylogs(0) ->
+    ok;
+skip_keylogs(N) ->
+    receive
+        {keylog, _} ->
+            skip_keylogs(N-1)
+    end.
 
 early_data_basic_auth() ->
     [{doc,"Test early data when client is authenticated (erlang client - erlang server)"}].

--- a/lib/ssl/test/tls_1_3_version_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_version_SUITE.erl
@@ -79,7 +79,9 @@
          client_cert_fail_alert_active/0,
          client_cert_fail_alert_active/1,
          client_cert_fail_alert_passive/0,
-         client_cert_fail_alert_passive/1
+         client_cert_fail_alert_passive/1,
+         keylog_on_alert/0,
+         keylog_on_alert/1
         ]).
 
 
@@ -117,7 +119,8 @@ tls_1_3_1_2_tests() ->
      middle_box_client_tls_v2_session_reused,
      renegotiate_error,
      client_cert_fail_alert_active,
-     client_cert_fail_alert_passive   
+     client_cert_fail_alert_passive,
+     keylog_on_alert
     ].
 legacy_tests() ->
     [tls_client_tls10_server,
@@ -134,8 +137,7 @@ legacy_tests() ->
     ].
 
 init_per_suite(Config) ->
-    catch crypto:stop(),
-    try crypto:start() of
+    case application:ensure_started(crypto) of
 	ok ->
             case ssl_test_lib:sufficient_crypto_support('tlsv1.3') of                
                 true ->
@@ -144,8 +146,8 @@ init_per_suite(Config) ->
                      Config];
                 false ->
                     {skip, "Insufficient crypto support for TLS-1.3"}
-            end
-    catch _:_ ->
+            end;
+        _ ->
 	    {skip, "Crypto did not start"}
     end.
 
@@ -533,7 +535,7 @@ client_cert_fail_alert_active(Config) when is_list(Config) ->
     ServerOpts0 = ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config),
     PrivDir = proplists:get_value(priv_dir, Config),
 
-    NewClientCertFile = filename:join(PrivDir, "clinet_invalid_cert.pem"),
+    NewClientCertFile = filename:join(PrivDir, "client_invalid_cert.pem"),
     create_bad_client_certfile(NewClientCertFile, ClientOpts0),
 
     ClientOpts = [{active, true},
@@ -584,6 +586,51 @@ tls13_client_tls11_server(Config) when is_list(Config) ->
     ServerOpts =  [{versions, ['tlsv1']} | ssl_test_lib:ssl_options(server_cert_opts, Config)],
     ssl_test_lib:basic_alert(ClientOpts, ServerOpts, Config, insufficient_security).
 
+keylog_on_alert() ->
+    [{doc,"Test that keep_secrets keylog_hs callback, if specified, "
+      "is called with keylog info when handshake alert is raised"}].
+
+keylog_on_alert(Config) when is_list(Config) ->
+    ssl:clear_pem_cache(),
+    {_, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    ClientOpts0 = ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config),
+    ServerOpts0 = ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
+    NewClientCertFile = filename:join(PrivDir, "client_invalid_cert.pem"),
+    create_bad_client_certfile(NewClientCertFile, ClientOpts0),
+    ClientOpts = [{versions, ['tlsv1.3']}, {active, false}, {certfile, NewClientCertFile}|
+                  proplists:delete(certfile, ClientOpts0)],
+    ServerOpts =  [{versions, ['tlsv1.3']},
+                   {verify, verify_peer}, {fail_if_no_peer_cert, true}
+                  | ServerOpts0],
+
+    Me = self(),
+    Fun = fun(AlertInfo) ->
+                  Me ! {alert_info, AlertInfo}
+          end,
+    alert_passive([{keep_secrets, {keylog_hs, Fun}} | ServerOpts], ClientOpts, recv,
+                  ServerNode, Hostname),
+    receive
+        {alert_info, #{items := SKeyLog}} ->
+            case SKeyLog of
+                ["CLIENT_HANDSHAKE_TRAFFIC_SECRET"++_,_|_] ->
+                    ok;
+                SOther ->
+                    ct:fail({server_received, SOther})
+            end
+    end,
+
+    alert_passive(ServerOpts, [{keep_secrets, {keylog_hs, Fun}} | ClientOpts], recv,
+                  ServerNode, Hostname),
+    receive
+        {alert_info, #{items := CKeyLog}} ->
+            case CKeyLog of
+                ["CLIENT_HANDSHAKE_TRAFFIC_SECRET"++_,_,_|_] ->
+                    ok;
+            COther ->
+                    ct:fail({client_received, COther})
+            end
+    end.
 
 %%--------------------------------------------------------------------
 %% Internal functions and callbacks -----------------------------------
@@ -645,14 +692,14 @@ create_bad_client_certfile(NewClientCertFile, ClientOpts) ->
 
 test_rsa_pcks1_cert(SHA, COpts, SOpts, Config) ->
     #{client_config := ClientOpts,
-      server_config := ServerOpts} = public_key:pkix_test_data(#{server_chain => #{root => root_key(SHA),
-                                                                                   intermediates => intermediates(SHA, 1),
-                                                                                   peer => peer_key(SHA)},
-                                                                 client_chain => #{root => root_key(SHA),
-                                                                                   intermediates => intermediates(SHA, 1),
-                                                                                   peer => peer_key(SHA)}}),
+      server_config := ServerOpts} =
+        public_key:pkix_test_data(#{server_chain => #{root => root_key(SHA),
+                                                      intermediates => intermediates(SHA, 1),
+                                                      peer => peer_key(SHA)},
+                                    client_chain => #{root => root_key(SHA),
+                                                      intermediates => intermediates(SHA, 1),
+                                                      peer => peer_key(SHA)}}),
     ssl_test_lib:basic_test(COpts ++ ClientOpts, SOpts ++ ServerOpts, Config).
-
 
 root_key(SHA) ->
     root_key(SHA, undefined).


### PR DESCRIPTION
Keylogging debug functionality should be useable also for failed connections, this
is especially interesting for TLS-1.3.