### PR TITLE
Make function application left associative so it can be chained

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -112,6 +112,7 @@ Left 400 add_op.
 Left 500 mult_op.
 Unary 600 prefix_op.
 Nonassoc 700 '#'.
+Left 750 '('.
 Nonassoc 800 ':'.
 Nonassoc 900 clause_body_exprs.
 
@@ -269,9 +270,9 @@ expr -> map_expr : '$1'.
 expr -> function_call : '$1'.
 expr -> record_expr : '$1'.
 expr -> expr_remote : '$1'.
+expr -> expr_max : '$1'.
 
-expr_remote -> expr_max ':' expr_max : {remote,?anno('$2'),'$1','$3'}.
-expr_remote -> expr_max : '$1'.
+expr_remote -> expr ':' expr : {remote,?anno('$2'),'$1','$3'}.
 
 expr_max -> var : '$1'.
 expr_max -> atomic : '$1'.
@@ -431,11 +432,8 @@ record_fields -> record_field ',' record_fields : ['$1' | '$3'].
 record_field -> var '=' expr : {record_field,?anno('$1'),'$1','$3'}.
 record_field -> atom '=' expr : {record_field,?anno('$1'),'$1','$3'}.
 
-%% N.B. This is called from expr.
-
-function_call -> expr_remote argument_list :
-	{call,first_anno('$1'),'$1',element(1, '$2')}.
-
+function_call -> expr argument_list :
+        {call,first_anno('$1'),'$1',element(1, '$2')}.
 
 if_expr -> 'if' if_clauses 'end' : {'if',?anno('$1'),'$2'}.
 
@@ -2033,7 +2031,8 @@ inop_prec('div') -> {500,500,600};
 inop_prec('rem') -> {500,500,600};
 inop_prec('band') -> {500,500,600};
 inop_prec('and') -> {500,500,600};
-inop_prec('#') -> {800,700,800};
+inop_prec('#') -> {750,700,750};
+inop_prec('(') -> {750,750,800};
 inop_prec(':') -> {900,800,900};
 inop_prec('.') -> {900,900,1000}.
 


### PR DESCRIPTION
A point where Erlang has always broken the Principle of Least Astonishment is in function application. You would typically expect (particularly in a functional language) that if a function call returns another function, you can apply it directly by appending another set of arguments within parentheses, but in Erlang, you are also forced to put the first function call within an extra parenthesis, like so: `(f(X))(Y)`, rather than the expected `f(X)(Y)`. For example, `(accessor(Path))(Thing)`. This can get tiresome when you're working with higher order functions, and sometimes actually obscures the fact that a function application is happening, due to the extra parentheses acting as camouflage.

The fix is easy, and since it has not been allowed before there is no existing code where this would change the meaning. It however required me to slightly refactor the `remote_expr` part of the grammar to fix conflicts. It turned out this could also easily be relaxed, so that you can write `get_callback_module(State):callbackFunc(...)` instead of the current `(get_callback_module(State)):callbackFunc(...)`.