### PR TITLE
Ets and Dets code should not be printing to stdout

### DIFF
--- a/lib/stdlib/src/dets.erl
+++ b/lib/stdlib/src/dets.erl
@@ -3188,7 +3188,7 @@ fopen2(Fname, Tab) ->
                  end,
             case Do of
 		{repair, Mess} ->
-                    io:format(user, "dets: file ~tp~s~n", [Fname, Mess]),
+                    error_logger:format("dets: file ~tp~s~n", [Fname, Mess]),
                     case fsck(Fd, Tab, Fname, FH, default, default) of
                         ok ->
                             fopen2(Fname, Tab);
@@ -3267,7 +3267,7 @@ fopen_existing_file(Tab, OpenArgs) ->
 	_ when FH#fileheader.keypos =/= Kp ->
 	    throw({error, {keypos_mismatch, Fname}});
 	{compact, SourceHead} ->
-	    io:format(user, "dets: file ~tp is now compacted ...~n", [Fname]),
+            error_logger:format("dets: file ~tp is now compacted ...~n", [Fname]),
 	    {ok, NewSourceHead} = open_final(SourceHead, Fname, read, false,
 					     ?DEFAULT_CACHE, Tab, Debug),
 	    case catch compact(NewSourceHead) of
@@ -3277,14 +3277,14 @@ fopen_existing_file(Tab, OpenArgs) ->
 		_Err ->
                     _ = file:close(Fd),
                     dets_utils:stop_disk_map(),
-		    io:format(user, "dets: compaction of file ~tp failed, "
-			      "now repairing ...~n", [Fname]),
+                    error_logger:format("dets: compaction of file ~tp failed, "
+                                        "now repairing ...~n", [Fname]),
                     {ok, Fd2, _FH} = read_file_header(Fname, Acc, Ram),
                     do_repair(Fd2, Tab, Fname, FH, MinSlots, MaxSlots, 
 			      OpenArgs)
 	    end;
 	{repair, Mess} ->
-	    io:format(user, "dets: file ~tp~s~n", [Fname, Mess]),
+            error_logger:format("dets: file ~tp~s~n", [Fname, Mess]),
             do_repair(Fd, Tab, Fname, FH, MinSlots, MaxSlots, 
 		      OpenArgs);
 	{final, H} ->

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -2025,9 +2025,7 @@ fun2ms(ShellFun) when is_function(ShellFun) ->
         {fun_data,ImportList,Clauses} ->
             case ms_transform:transform_from_shell(
                    ?MODULE,Clauses,ImportList) of
-                {error,[{_,[{_,_,Code}|_]}|_],_} ->
-                    io:format("Error: ~ts~n",
-                              [ms_transform:format_error(Code)]),
+                {error,[_|_],_} ->
                     {error,transform_error};
                 Else ->
                     Else


### PR DESCRIPTION
Some quite old code in Ets and Dets would print messages to stdout when repairing tables or when fun2ms failed.