### PR TITLE
Make `poll()` test work with `gcc` 14

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -21677,6 +21677,7 @@ else case e in #(
 /* end confdefs.h.  */
 
 #include <stdlib.h>
+#include <unistd.h>
 #ifdef HAVE_MALLOC_H
 #  include <malloc.h>
 #endif
@@ -25866,8 +25867,10 @@ else case e in #(
   e) cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
+#include <fcntl.h>
 #include <poll.h>
-main()
+#include <stdlib.h>
+int main()
 {
 #ifdef _POLL_EMUL_H_
   exit(1); /* Implemented using select() -- fail */

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -2439,6 +2439,7 @@ AC_CACHE_CHECK([if __after_morecore_hook can track malloc()s core memory use],
 		erts_cv___after_morecore_hook_can_track_malloc,
 		[AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
+#include <unistd.h>
 #ifdef HAVE_MALLOC_H
 #  include <malloc.h>
 #endif
@@ -3133,8 +3134,10 @@ poll_works=no
 [
 
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <fcntl.h>
 #include <poll.h>
-main()
+#include <stdlib.h>
+int main()
 {
 #ifdef _POLL_EMUL_H_
   exit(1); /* Implemented using select() -- fail */


### PR DESCRIPTION
Fixes erlang/otp#9211

* Add headers (`stdlib.h`, `fcntl.h`) for `poll`
* Add `unistd.h` for `sbrk`

(cherry picked from commit e2604aa7a92b3bb7c1293afd12705c7ce9c952a4)