### PR TITLE
jit: Allow forcing Windows ABI to help find Windows bugs under Linux

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -399,6 +399,11 @@ jobs:
                 echo "::endgroup::"
               done
             done
+      - name: Build Erlang/OTP JIT Win32 ABI
+        run: >
+            docker run otp './configure CFLAGS="$CFLAGS -DERTS_JIT_ABI_WIN32=1" &&
+                 make && make TYPE=debug &&
+                 cerl -noshell -s init stop && cerl -debug -noshell -s init stop'
 
   build:
     name: Build Erlang/OTP

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -341,23 +341,24 @@ protected:
         a.blr(TMP1);
     }
 
-    void runtime_call(a64::Gp func, unsigned args) {
-        ASSERT(args < 5);
-        a.blr(func);
+    template<typename T, typename = void>
+    struct function_traits;
+
+    template<typename Range, typename... Domain>
+    struct function_traits<Range (*)(Domain...)> {
+        static constexpr size_t Arity = sizeof...(Domain);
+    };
+
+    template<typename T, T Func>
+    void runtime_call() {
+        a.mov(TMP1, Func);
+        a.blr(TMP1);
     }
 
-    template<typename T>
-    struct function_arity;
-    template<typename T, typename... Args>
-    struct function_arity<T(Args...)>
-            : std::integral_constant<int, sizeof...(Args)> {};
-
-    template<int expected_arity, typename T>
-    void runtime_call(T(*func)) {
-        static_assert(expected_arity == function_arity<T>());
-
-        a.mov(TMP1, func);
-        a.blr(TMP1);
+    template<int Arity>
+    void dynamic_runtime_call(a64::Gp func) {
+        ERTS_CT_ASSERT(Arity <= 4);
+        a.blr(func);
     }
 
     /* Explicitly position-independent absolute jump, for use in fragments that
@@ -1424,20 +1425,12 @@ protected:
         a.bind(next);
 #endif
 
-        a.bl(resolve_fragment((void (*)())target, disp128MB));
+        a.bl(resolve_fragment(reinterpret_cast<void (*)()>(target), disp128MB));
     }
 
-    template<typename T>
-    struct function_arity;
-    template<typename T, typename... Args>
-    struct function_arity<T(Args...)>
-            : std::integral_constant<int, sizeof...(Args)> {};
-
-    template<int expected_arity, typename T>
-    void runtime_call(T(*func)) {
-        static_assert(expected_arity == function_arity<T>());
-
-        a.bl(resolve_fragment((void (*)())func, disp128MB));
+    template<typename T, T Func>
+    void runtime_call() {
+        a.bl(resolve_fragment(reinterpret_cast<void (*)()>(Func), disp128MB));
     }
 
     bool isRegisterBacked(const ArgVal &arg) {

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -60,6 +60,9 @@ extern "C"
 
 using namespace asmjit;
 
+#define ERTS_CCONV_ERTS
+#define ERTS_CCONV_JIT
+
 struct BeamAssembler : public BeamAssemblerCommon {
     BeamAssembler() : BeamAssemblerCommon(a) {
         Error err = code.attach(&a);

--- a/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.hpp.pl
@@ -186,8 +186,8 @@ $decl_enums
 
 $decl_emit_funcs
 
-    template<typename T>
-    void emit_bitwise_fallback_body(T(*func_ptr), const ErtsCodeMFA *mfa);
+    template<typename T, T Func>
+    void emit_bitwise_fallback_body(const ErtsCodeMFA *mfa);
 
     void emit_i_length_common(Label fail, int state_size);
 

--- a/erts/emulator/beam/jit/arm/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_module.cpp
@@ -254,7 +254,7 @@ void BeamModuleAssembler::emit_i_breakpoint_trampoline() {
            BEAM_ASM_FUNC_PROLOGUE_SIZE);
 }
 
-static void i_emit_nyi(char *msg) {
+static void i_emit_nyi(const char *msg) {
     erts_exit(ERTS_ERROR_EXIT, "NYI: %s\n", msg);
 }
 
@@ -262,7 +262,7 @@ void BeamModuleAssembler::emit_nyi(const char *msg) {
     emit_enter_runtime(0);
 
     a.mov(ARG1, imm(msg));
-    runtime_call<1>(i_emit_nyi);
+    runtime_call<void (*)(const char *), i_emit_nyi>();
 
     /* Never returns */
 }

--- a/erts/emulator/beam/jit/arm/instr_call.cpp
+++ b/erts/emulator/beam/jit/arm/instr_call.cpp
@@ -127,7 +127,7 @@ void BeamGlobalAssembler::emit_dispatch_save_calls_export() {
 
     a.mov(ARG2, ARG1);
     a.mov(ARG1, c_p);
-    runtime_call<2>(save_calls);
+    runtime_call<void (*)(Process *, const Export *), save_calls>();
 
     emit_leave_runtime();
     emit_leave_runtime_frame();
@@ -223,7 +223,8 @@ arm::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
     mov_imm(ARG4, 0);
 
     comment("apply()");
-    runtime_call<4>(apply);
+    runtime_call<const Export *(*)(Process *, Eterm *, ErtsCodePtr, Uint),
+                 apply>();
 
     /* Any number of X registers can be live at this point. */
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc |
@@ -276,7 +277,8 @@ arm::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
 
     mov_imm(ARG5, 0);
 
-    runtime_call<5>(fixed_apply);
+    runtime_call<const Export *(*)(Process *, Eterm *, Uint, ErtsCodePtr, Uint),
+                 fixed_apply>();
 
     /* We will need to reload all X registers in case there has been
      * an error. */

--- a/erts/emulator/beam/jit/arm/instr_float.cpp
+++ b/erts/emulator/beam/jit/arm/instr_float.cpp
@@ -114,7 +114,7 @@ void BeamGlobalAssembler::emit_fconv_shared() {
 
     /* ARG1 already contains the source term. */
     lea(ARG2, TMP_MEM1q);
-    runtime_call<2>(big_to_double);
+    runtime_call<int (*)(Eterm, double *), big_to_double>();
 
     emit_leave_runtime();
     emit_leave_runtime_frame();

--- a/erts/emulator/beam/jit/arm/instr_fun.cpp
+++ b/erts/emulator/beam/jit/arm/instr_fun.cpp
@@ -42,7 +42,8 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
     load_x_reg_array(ARG2);
     a.lsr(ARG3, ARG3, imm(FUN_HEADER_ARITY_OFFS));
     /* ARG4 has already been set. */
-    runtime_call<4>(beam_jit_handle_unloaded_fun);
+    runtime_call<const Export *(*)(Process *, Eterm *, int, Eterm),
+                 beam_jit_handle_unloaded_fun>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions | Update::eCodeIndex>();
@@ -98,7 +99,8 @@ void BeamGlobalAssembler::emit_handle_call_fun_error() {
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
         a.lsr(ARG3, ARG3, imm(FUN_HEADER_ARITY_OFFS));
-        runtime_call<3>(beam_jit_build_argument_list);
+        runtime_call<Eterm (*)(Process *, const Eterm *, int),
+                     beam_jit_build_argument_list>();
 
         emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs>();
 

--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -76,7 +76,7 @@ void BeamGlobalAssembler::emit_bif_is_eq_exact_shared() {
     emit_enter_runtime_frame();
     emit_enter_runtime();
 
-    runtime_call<2>(eq);
+    runtime_call<int (*)(Eterm, Eterm), eq>();
 
     emit_leave_runtime();
     emit_leave_runtime_frame();
@@ -108,7 +108,7 @@ void BeamGlobalAssembler::emit_bif_is_ne_exact_shared() {
     emit_enter_runtime_frame();
     emit_enter_runtime();
 
-    runtime_call<2>(eq);
+    runtime_call<int (*)(Eterm, Eterm), eq>();
 
     emit_leave_runtime();
     emit_leave_runtime_frame();
@@ -821,7 +821,7 @@ void BeamModuleAssembler::emit_bif_is_map_key(const ArgWord &Bif,
         emit_cond_to_bool(arm::CondCode::kEQ, Dst);
     } else {
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         cmp(ARG1, THE_NON_VALUE);
@@ -914,7 +914,7 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
         }
     } else {
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         if (Fail.get() == 0) {

--- a/erts/emulator/beam/jit/arm/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/instr_map.cpp
@@ -64,7 +64,8 @@ void BeamGlobalAssembler::emit_internal_hash_helper() {
     a.str(ARG4, TMP_MEM3q);
 
     a.mov(ARG1, ARG3);
-    runtime_call<2>(erts_dbg_hashmap_collision_bonanza);
+    runtime_call<erts_ihash_t (*)(erts_ihash_t, Eterm),
+                 erts_dbg_hashmap_collision_bonanza>();
     a.mov(ARG3, ARG1);
 
     a.ldp(ARG1, ARG2, TMP_MEM1q);
@@ -229,7 +230,12 @@ void BeamGlobalAssembler::emit_new_map_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_new_map);
+    runtime_call<Eterm (*)(Process * p,
+                           Eterm * reg,
+                           Uint live,
+                           Uint n,
+                           const Eterm *ptr),
+                 erts_gc_new_map>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -332,7 +338,7 @@ void BeamGlobalAssembler::emit_i_get_map_element_shared() {
         emit_enter_runtime_frame();
 
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         a.cmp(ARG1, imm(THE_NON_VALUE));
@@ -368,7 +374,7 @@ void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
         a.b_ne(resolve_beam_label(Fail, disp1MB));
     } else {
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
@@ -468,7 +474,8 @@ void BeamModuleAssembler::emit_i_get_map_elements(const ArgLabel &Fail,
 
         mov_imm(ARG4, args.size() / 3);
         load_x_reg_array(ARG2);
-        runtime_call<5>(beam_jit_get_map_elements);
+        runtime_call<Eterm (*)(Eterm, Eterm *, Eterm *, Uint, Eterm *),
+                     beam_jit_get_map_elements>();
 
         emit_leave_runtime<Update::eXRegs>();
 
@@ -515,7 +522,8 @@ void BeamModuleAssembler::emit_i_get_map_element_hash(const ArgLabel &Fail,
         a.b_ne(resolve_beam_label(Fail, disp1MB));
     } else {
         emit_enter_runtime();
-        runtime_call<3>(get_map_element_hash);
+        runtime_call<Eterm (*)(Eterm, Eterm, erts_ihash_t),
+                     get_map_element_hash>();
         emit_leave_runtime();
 
         emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
@@ -538,7 +546,8 @@ void BeamGlobalAssembler::emit_update_map_assoc_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_update_map_assoc);
+    runtime_call<Eterm (*)(Process *, Eterm *, Uint, Uint, const Eterm *),
+                 erts_gc_update_map_assoc>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -556,7 +565,7 @@ void BeamGlobalAssembler::emit_update_map_single_assoc_shared() {
     emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
-    runtime_call<4>(erts_maps_put);
+    runtime_call<Eterm (*)(Process *, Eterm, Eterm, Eterm), erts_maps_put>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
     emit_leave_runtime_frame();
@@ -598,7 +607,8 @@ void BeamGlobalAssembler::emit_update_map_exact_guard_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_update_map_exact);
+    runtime_call<Eterm (*)(Process *, Eterm *, Uint, Uint, const Eterm *),
+                 erts_gc_update_map_exact>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -619,7 +629,8 @@ void BeamGlobalAssembler::emit_update_map_exact_body_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_update_map_exact);
+    runtime_call<Eterm (*)(Process *, Eterm *, Uint, Uint, const Eterm *),
+                 erts_gc_update_map_exact>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -650,7 +661,8 @@ void BeamGlobalAssembler::emit_update_map_single_exact_body_shared() {
 
     a.mov(ARG1, c_p);
     lea(ARG5, TMP_MEM1q);
-    runtime_call<5>(erts_maps_update);
+    runtime_call<int (*)(Process *, Eterm, Eterm, Eterm, Eterm *),
+                 erts_maps_update>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
     emit_leave_runtime_frame();

--- a/erts/emulator/beam/jit/arm/instr_msg.cpp
+++ b/erts/emulator/beam/jit/arm/instr_msg.cpp
@@ -34,7 +34,7 @@ void BeamModuleAssembler::emit_recv_marker_reserve(const ArgRegister &Dst) {
     emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
-    runtime_call<1>(erts_msgq_recv_marker_insert);
+    runtime_call<Eterm (*)(Process *), erts_msgq_recv_marker_insert>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
 
@@ -51,7 +51,8 @@ void BeamModuleAssembler::emit_recv_marker_bind(const ArgRegister &Marker,
     emit_enter_runtime();
 
     a.mov(ARG1, c_p);
-    runtime_call<3>(erts_msgq_recv_marker_bind);
+    runtime_call<void (*)(Process *, Eterm, Eterm),
+                 erts_msgq_recv_marker_bind>();
 
     emit_leave_runtime();
 }
@@ -62,7 +63,7 @@ void BeamModuleAssembler::emit_recv_marker_clear(const ArgRegister &Reference) {
     emit_enter_runtime();
 
     a.mov(ARG1, c_p);
-    runtime_call<2>(erts_msgq_recv_marker_clear);
+    runtime_call<void (*)(Process *, Eterm), erts_msgq_recv_marker_clear>();
 
     emit_leave_runtime();
 }
@@ -73,7 +74,7 @@ void BeamModuleAssembler::emit_recv_marker_use(const ArgRegister &Reference) {
     emit_enter_runtime();
 
     a.mov(ARG1, c_p);
-    runtime_call<2>(erts_msgq_recv_marker_set_save);
+    runtime_call<void (*)(Process *, Eterm), erts_msgq_recv_marker_set_save>();
 
     emit_leave_runtime();
 }
@@ -143,9 +144,11 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
         lea(ARG4, message_ptr);
         lea(ARG5, get_out);
 #ifdef ERTS_ENABLE_LOCK_CHECK
-        runtime_call<5>(erts_lc_proc_sig_receive_helper);
+        runtime_call<int (*)(Process *, int, int, ErtsMessage **, int *),
+                     erts_lc_proc_sig_receive_helper>();
 #else
-        runtime_call<5>(erts_proc_sig_receive_helper);
+        runtime_call<int (*)(Process *, int, int, ErtsMessage **, int *),
+                     erts_proc_sig_receive_helper>();
 #endif
 
         /* erts_proc_sig_receive_helper merely inspects FCALLS, so we don't
@@ -206,7 +209,8 @@ void BeamGlobalAssembler::emit_i_loop_rec_shared() {
 
         a.mov(ARG2, ARG1);
         a.mov(ARG1, c_p);
-        runtime_call<2>(beam_jit_decode_dist);
+        runtime_call<ErtsMessage *(*)(Process *, ErtsMessage *),
+                     beam_jit_decode_dist>();
 
         emit_leave_runtime(0);
 
@@ -242,7 +246,8 @@ void BeamModuleAssembler::emit_remove_message() {
     a.mov(ARG1, c_p);
     a.mov(ARG2.w(), FCALLS);
     a.mov(ARG5, active_code_ix);
-    runtime_call<5>(beam_jit_remove_message);
+    runtime_call<Sint32 (*)(Process *, Sint32, Eterm *, Eterm *, Uint32),
+                 beam_jit_remove_message>();
     a.mov(FCALLS, ARG1.w());
 
     emit_leave_runtime();
@@ -252,7 +257,7 @@ void BeamModuleAssembler::emit_loop_rec_end(const ArgLabel &Dest) {
     emit_enter_runtime(0);
 
     a.mov(ARG1, c_p);
-    runtime_call<1>(erts_msgq_set_save_next);
+    runtime_call<void (*)(Process *), erts_msgq_set_save_next>();
 
     emit_leave_runtime(0);
 
@@ -266,7 +271,7 @@ void BeamModuleAssembler::emit_wait_unlocked(const ArgLabel &Dest) {
 
     a.mov(ARG1, c_p);
     a.ldr(ARG2, embed_constant(Dest, disp32K));
-    runtime_call<2>(beam_jit_wait_unlocked);
+    runtime_call<void (*)(Process *, ErtsCodePtr), beam_jit_wait_unlocked>();
 
     emit_leave_runtime(0);
 
@@ -279,7 +284,7 @@ void BeamModuleAssembler::emit_wait_locked(const ArgLabel &Dest) {
 
     a.mov(ARG1, c_p);
     a.ldr(ARG2, embed_constant(Dest, disp32K));
-    runtime_call<2>(beam_jit_wait_locked);
+    runtime_call<void (*)(Process *, ErtsCodePtr), beam_jit_wait_locked>();
 
     emit_leave_runtime(0);
 
@@ -295,7 +300,7 @@ void BeamModuleAssembler::emit_wait_timeout_unlocked(const ArgSource &Src,
     emit_enter_runtime(0);
 
     a.mov(ARG1, c_p);
-    runtime_call<1>(beam_jit_take_receive_lock);
+    runtime_call<void (*)(Process *), beam_jit_take_receive_lock>();
 
     emit_leave_runtime(0);
 
@@ -312,7 +317,8 @@ void BeamModuleAssembler::emit_wait_timeout_locked(const ArgSource &Src,
 
     a.mov(ARG1, c_p);
     a.adr(ARG3, next);
-    runtime_call<3>(beam_jit_wait_timeout);
+    runtime_call<enum beam_jit_tmo_ret (*)(Process *, Eterm, ErtsCodePtr),
+                 beam_jit_wait_timeout>();
 
     emit_leave_runtime(0);
 
@@ -333,7 +339,7 @@ void BeamModuleAssembler::emit_timeout_locked() {
     emit_enter_runtime(0);
 
     a.mov(ARG1, c_p);
-    runtime_call<1>(beam_jit_timeout_locked);
+    runtime_call<void (*)(Process *), beam_jit_timeout_locked>();
 
     emit_leave_runtime(0);
 }
@@ -342,7 +348,7 @@ void BeamModuleAssembler::emit_timeout() {
     emit_enter_runtime(0);
 
     a.mov(ARG1, c_p);
-    runtime_call<1>(beam_jit_timeout);
+    runtime_call<void (*)(Process *), beam_jit_timeout>();
 
     emit_leave_runtime(0);
 }

--- a/erts/emulator/beam/jit/arm/instr_trace.cpp
+++ b/erts/emulator/beam/jit/arm/instr_trace.cpp
@@ -43,7 +43,8 @@ void BeamGlobalAssembler::emit_generic_bp_global() {
     a.mov(ARG1, c_p);
     /* ARG2 is already set above */
     load_x_reg_array(ARG3);
-    runtime_call<3>(erts_generic_breakpoint);
+    runtime_call<BeamInstr (*)(Process *, ErtsCodeInfo *, Eterm *),
+                 erts_generic_breakpoint>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -78,7 +79,8 @@ void BeamGlobalAssembler::emit_generic_bp_local() {
     a.mov(ARG1, c_p);
     /* ARG2 is already set above */
     load_x_reg_array(ARG3);
-    runtime_call<3>(erts_generic_breakpoint);
+    runtime_call<BeamInstr (*)(Process *, ErtsCodeInfo *, Eterm *),
+                 erts_generic_breakpoint>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -107,7 +109,9 @@ void BeamGlobalAssembler::emit_debug_bp() {
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG3);
     a.mov(ARG4, imm(am_breakpoint));
-    runtime_call<4>(call_error_handler);
+    runtime_call<
+            const Export *(*)(Process *, const ErtsCodeMFA *, Eterm *, Eterm),
+            call_error_handler>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>();
@@ -152,7 +156,8 @@ void BeamModuleAssembler::emit_return_trace() {
     emit_enter_runtime<Update::eHeapAlloc>(1);
 
     a.mov(ARG1, c_p);
-    runtime_call<5>(return_trace);
+    runtime_call<void (*)(Process *, ErtsCodeMFA *, Eterm, ErtsTracer, Eterm),
+                 return_trace>();
 
     emit_leave_runtime<Update::eHeapAlloc>(1);
 
@@ -175,7 +180,8 @@ void BeamModuleAssembler::emit_i_call_trace_return() {
     emit_enter_runtime<Update::eHeapAlloc>(1);
 
     a.mov(ARG1, c_p);
-    runtime_call<4>(erts_call_trace_return);
+    runtime_call<void (*)(Process *, const ErtsCodeInfo *, Eterm, Eterm),
+                 erts_call_trace_return>();
 
     emit_leave_runtime<Update::eHeapAlloc>(1);
 
@@ -192,7 +198,8 @@ void BeamModuleAssembler::emit_i_return_to_trace() {
     emit_enter_runtime<Update::eHeapAlloc>(1);
 
     a.mov(ARG1, c_p);
-    runtime_call<3>(beam_jit_return_to_trace);
+    runtime_call<void (*)(Process *, Eterm, Eterm *),
+                 beam_jit_return_to_trace>();
 
     emit_leave_runtime<Update::eHeapAlloc>(1);
 
@@ -208,7 +215,7 @@ void BeamModuleAssembler::emit_i_hibernate() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<2>(erts_hibernate);
+    runtime_call<int (*)(Process *, Eterm *), erts_hibernate>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eXRegs |
                        Update::eReductions>(3);

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -403,7 +403,7 @@ void init_emulator(void) {
 }
 
 void process_main(ErtsSchedulerData *esdp) {
-    typedef void (*pmain_type)(ErtsSchedulerData *);
+    typedef void(ERTS_CCONV_JIT * pmain_type)(ErtsSchedulerData *);
 
     pmain_type pmain = (pmain_type)bga->get_process_main();
     pmain(esdp);

--- a/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.hpp.pl
@@ -183,11 +183,11 @@ $decl_enums
 
 $decl_emit_funcs
 
-    template<typename T>
-    void emit_bitwise_fallback_body(T(*func_ptr), const ErtsCodeMFA *mfa);
+    template<typename T, T Func>
+    void emit_bitwise_fallback_body(const ErtsCodeMFA *mfa);
 
-    template<typename T>
-    void emit_bitwise_fallback_guard(T(*func_ptr));
+    template<typename T, T Func>
+    void emit_bitwise_fallback_guard();
 
     x86::Mem emit_i_length_common(Label fail, int state_size);
 

--- a/erts/emulator/beam/jit/x86/beam_asm_module.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_module.cpp
@@ -237,7 +237,7 @@ void BeamModuleAssembler::emit_nyi(const char *msg) {
     emit_enter_runtime();
 
     a.mov(ARG1, imm(msg));
-    runtime_call<1>(i_emit_nyi);
+    runtime_call<void (*)(char *), i_emit_nyi>();
 
     /* Never returns */
 }

--- a/erts/emulator/beam/jit/x86/instr_call.cpp
+++ b/erts/emulator/beam/jit/x86/instr_call.cpp
@@ -98,7 +98,7 @@ void BeamGlobalAssembler::emit_dispatch_save_calls_export() {
 
     a.mov(ARG1, c_p);
     a.mov(ARG2, RET);
-    runtime_call<2>(save_calls);
+    runtime_call<void (*)(Process *, const Export *), save_calls>();
 
     emit_leave_runtime();
 
@@ -157,7 +157,8 @@ x86::Mem BeamModuleAssembler::emit_variable_apply(bool includeI) {
 
     mov_imm(ARG4, 0);
 
-    runtime_call<4>(apply);
+    runtime_call<const Export *(*)(Process *, Eterm *, ErtsCodePtr, Uint),
+                 apply>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
@@ -208,8 +209,8 @@ x86::Mem BeamModuleAssembler::emit_fixed_apply(const ArgWord &Arity,
 
     mov_imm(ARG5, 0);
 
-    runtime_call<5>(fixed_apply);
-
+    runtime_call<const Export *(*)(Process *, Eterm *, Uint, ErtsCodePtr, Uint),
+                 fixed_apply>();
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.test(RET, RET);

--- a/erts/emulator/beam/jit/x86/instr_float.cpp
+++ b/erts/emulator/beam/jit/x86/instr_float.cpp
@@ -127,7 +127,7 @@ void BeamGlobalAssembler::emit_fconv_shared() {
 
     /* ARG1 already contains the source term. */
     a.lea(ARG2, TMP_MEM1q);
-    runtime_call<2>(big_to_double);
+    runtime_call<int (*)(Eterm, double *), big_to_double>();
 
     emit_leave_runtime();
     emit_leave_frame();

--- a/erts/emulator/beam/jit/x86/instr_fun.cpp
+++ b/erts/emulator/beam/jit/x86/instr_fun.cpp
@@ -38,7 +38,9 @@ void BeamGlobalAssembler::emit_unloaded_fun() {
     load_x_reg_array(ARG2);
     a.shr(ARG3, imm(FUN_HEADER_ARITY_OFFS));
     /* ARG4 has already been set. */
-    runtime_call<4>(beam_jit_handle_unloaded_fun);
+
+    runtime_call<const Export *(*)(Process *, Eterm *, int, Eterm),
+                 beam_jit_handle_unloaded_fun>();
 
     emit_leave_runtime<Update::eHeapAlloc | Update::eReductions |
                        Update::eCodeIndex>();
@@ -98,7 +100,8 @@ void BeamGlobalAssembler::emit_handle_call_fun_error() {
         a.mov(ARG1, c_p);
         load_x_reg_array(ARG2);
         a.shr(ARG3, imm(FUN_HEADER_ARITY_OFFS));
-        runtime_call<3>(beam_jit_build_argument_list);
+        runtime_call<Eterm (*)(Process *, const Eterm *, int),
+                     beam_jit_build_argument_list>();
 
         emit_leave_runtime<Update::eHeapAlloc>();
 

--- a/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
@@ -68,7 +68,7 @@ void BeamModuleAssembler::emit_bif_is_eq_ne_exact(const ArgSource &LHS,
         mov_arg(ARG2, RHS);
 
         emit_enter_runtime();
-        runtime_call<2>(eq);
+        runtime_call<int (*)(Eterm, Eterm), eq>();
         emit_leave_runtime();
 
         a.test(RET, RET);
@@ -576,7 +576,7 @@ void BeamModuleAssembler::emit_bif_is_map_key(const ArgWord &Bif,
         emit_cond_to_bool(x86::Inst::kIdCmovne, Dst);
     } else {
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         emit_test_the_non_value(RET);
@@ -668,7 +668,7 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
         }
     } else {
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         emit_test_the_non_value(RET);

--- a/erts/emulator/beam/jit/x86/instr_map.cpp
+++ b/erts/emulator/beam/jit/x86/instr_map.cpp
@@ -86,7 +86,8 @@ void BeamGlobalAssembler::emit_internal_hash_helper() {
 
     a.mov(ARG1, ARG3);
     emit_enter_runtime();
-    runtime_call<2>(erts_dbg_hashmap_collision_bonanza);
+    runtime_call<erts_ihash_t (*)(erts_ihash_t, Eterm),
+                 erts_dbg_hashmap_collision_bonanza>();
     emit_leave_runtime();
 
     a.mov(ARG3, RET);
@@ -240,7 +241,12 @@ void BeamGlobalAssembler::emit_new_map_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_new_map);
+    runtime_call<Eterm (*)(Process * p,
+                           Eterm * reg,
+                           Uint live,
+                           Uint n,
+                           const Eterm *ptr),
+                 erts_gc_new_map>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
@@ -367,7 +373,7 @@ void BeamGlobalAssembler::emit_i_get_map_element_shared() {
     {
         emit_enter_frame();
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
         emit_leave_frame();
 
@@ -402,7 +408,7 @@ void BeamModuleAssembler::emit_i_get_map_element(const ArgLabel &Fail,
         a.jne(resolve_beam_label(Fail));
     } else {
         emit_enter_runtime();
-        runtime_call<2>(get_map_element);
+        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
         emit_leave_runtime();
 
         emit_test_the_non_value(RET);
@@ -499,7 +505,8 @@ void BeamModuleAssembler::emit_i_get_map_elements(const ArgLabel &Fail,
         emit_enter_runtime();
 
         load_x_reg_array(ARG2);
-        runtime_call<5>(beam_jit_get_map_elements);
+        runtime_call<Eterm (*)(Eterm, Eterm *, Eterm *, Uint, Eterm *),
+                     beam_jit_get_map_elements>();
 
         emit_leave_runtime();
 
@@ -545,7 +552,8 @@ void BeamModuleAssembler::emit_i_get_map_element_hash(const ArgLabel &Fail,
         a.jne(resolve_beam_label(Fail));
     } else {
         emit_enter_runtime();
-        runtime_call<3>(get_map_element_hash);
+        runtime_call<Eterm (*)(Eterm, Eterm, erts_ihash_t),
+                     get_map_element_hash>();
         emit_leave_runtime();
 
         emit_test_the_non_value(RET);
@@ -566,7 +574,8 @@ void BeamGlobalAssembler::emit_update_map_assoc_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_update_map_assoc);
+    runtime_call<Eterm (*)(Process *, Eterm *, Uint, Uint, const Eterm *),
+                 erts_gc_update_map_assoc>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
@@ -583,7 +592,7 @@ void BeamGlobalAssembler::emit_update_map_single_assoc_shared() {
     emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
-    runtime_call<4>(erts_maps_put);
+    runtime_call<Eterm (*)(Process *, Eterm, Eterm, Eterm), erts_maps_put>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
     emit_leave_frame();
@@ -626,7 +635,8 @@ void BeamGlobalAssembler::emit_update_map_exact_guard_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_update_map_exact);
+    runtime_call<Eterm (*)(Process *, Eterm *, Uint, Uint, const Eterm *),
+                 erts_gc_update_map_exact>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
@@ -646,7 +656,8 @@ void BeamGlobalAssembler::emit_update_map_exact_body_shared() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<5>(erts_gc_update_map_exact);
+    runtime_call<Eterm (*)(Process *, Eterm *, Uint, Uint, const Eterm *),
+                 erts_gc_update_map_exact>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
@@ -678,7 +689,8 @@ void BeamGlobalAssembler::emit_update_map_single_exact_body_shared() {
 
     a.mov(ARG1, c_p);
     a.lea(ARG5, TMP_MEM1q);
-    runtime_call<5>(erts_maps_update);
+    runtime_call<int (*)(Process *, Eterm, Eterm, Eterm, Eterm *),
+                 erts_maps_update>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
     emit_leave_frame();

--- a/erts/emulator/beam/jit/x86/instr_trace.cpp
+++ b/erts/emulator/beam/jit/x86/instr_trace.cpp
@@ -37,7 +37,8 @@ void BeamGlobalAssembler::emit_generic_bp_global() {
     a.mov(ARG1, c_p);
     a.lea(ARG2, x86::qword_ptr(RET, offsetof(Export, info)));
     load_x_reg_array(ARG3);
-    runtime_call<3>(erts_generic_breakpoint);
+    runtime_call<BeamInstr (*)(Process *, ErtsCodeInfo *, Eterm *),
+                 erts_generic_breakpoint>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
@@ -98,7 +99,8 @@ void BeamGlobalAssembler::emit_generic_bp_local() {
     a.mov(ARG1, c_p);
     /* ARG2 is already set above */
     load_x_reg_array(ARG3);
-    runtime_call<3>(erts_generic_breakpoint);
+    runtime_call<BeamInstr (*)(Process *, ErtsCodeInfo *, Eterm *),
+                 erts_generic_breakpoint>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
@@ -146,7 +148,9 @@ void BeamGlobalAssembler::emit_debug_bp() {
     a.lea(ARG2, x86::qword_ptr(ARG2, -(int)sizeof(ErtsCodeMFA)));
     load_x_reg_array(ARG3);
     a.mov(ARG4, imm(am_breakpoint));
-    runtime_call<4>(call_error_handler);
+    runtime_call<
+            const Export *(*)(Process *, const ErtsCodeMFA *, Eterm *, Eterm),
+            call_error_handler>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
     emit_leave_frame();
@@ -182,7 +186,8 @@ void BeamModuleAssembler::emit_return_trace() {
     emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
-    runtime_call<5>(return_trace);
+    runtime_call<void (*)(Process *, ErtsCodeMFA *, Eterm, ErtsTracer, Eterm),
+                 return_trace>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
 
@@ -204,7 +209,8 @@ void BeamModuleAssembler::emit_i_call_trace_return() {
     emit_enter_runtime<Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
-    runtime_call<4>(erts_call_trace_return);
+    runtime_call<void (*)(Process *, const ErtsCodeInfo *, Eterm, Eterm),
+                 erts_call_trace_return>();
 
     emit_leave_runtime<Update::eHeapAlloc>();
 
@@ -225,7 +231,8 @@ void BeamModuleAssembler::emit_i_return_to_trace() {
     emit_enter_runtime<Update::eReductions | Update::eHeapAlloc>();
 
     a.mov(ARG1, c_p);
-    runtime_call<3>(beam_jit_return_to_trace);
+    runtime_call<void (*)(Process *, Eterm, Eterm *),
+                 beam_jit_return_to_trace>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 
@@ -240,7 +247,7 @@ void BeamModuleAssembler::emit_i_hibernate() {
 
     a.mov(ARG1, c_p);
     load_x_reg_array(ARG2);
-    runtime_call<2>(erts_hibernate);
+    runtime_call<int (*)(Process *, Eterm *), erts_hibernate>();
 
     emit_leave_runtime<Update::eReductions | Update::eHeapAlloc>();
 


### PR DESCRIPTION
Since I lack a decent Windows environment and felt too lazy to set one up while looking into #9222, I figured I'd dust off an old experiment of mine that used alternative ABIs in the JIT. The idea was that if the crash was caused by a Windows-specific JIT bug, we should be able to reproduce it on Linux by using the Windows ABI.

It turns out that I can't reproduce the bug with this, but since we've had other bugs of this sort we may as well add it now that I've put in the work. While we're at it, we'll also add improved function-signature checking to the ARM JIT. 