### PR TITLE
inet: Rephrase setopts docs

### DIFF
--- a/lib/kernel/src/inet.erl
+++ b/lib/kernel/src/inet.erl
@@ -975,10 +975,10 @@ The following options are available:
 
   Use active mode only if your high-level protocol provides its own flow control
   (for example, acknowledging received messages) or the amount of data exchanged
-  is small. `{active, false}` mode, use of the `{active, once}` mode, or
-  `{active, N}` mode with values of `N` appropriate for the application
-  to provide flow control. The other side cannot send faster than
-  the receiver can read.
+  is small. Using `{active, false}` mode, `{active, once}` mode, or
+  `{active, N}` mode with values of `N` appropriate for the application to
+  provide flow control, ensures the other side cannot send faster than the
+  receiver can read.
 
 - **`{broadcast, Boolean}` (UDP sockets)** [](){: #option-broadcast } -
   Enables/disables permission to send broadcasts.


### PR DESCRIPTION
Small change to improve readability because I could not understand the current version.