### PR TITLE
Allow preads from non-owner processes

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -916,9 +916,6 @@
 /* Define to 1 if you have the 'ppoll' function. */
 #undef HAVE_PPOLL
 
-/* Define to 1 if you have the 'pread' function. */
-#undef HAVE_PREAD
-
 /* Define if you have processor_bind functionality */
 #undef HAVE_PROCESSOR_BIND
 
@@ -933,9 +930,6 @@
 
 /* Define if you have putc_unlocked */
 #undef HAVE_PUTC_UNLOCKED
-
-/* Define to 1 if you have the 'pwrite' function. */
-#undef HAVE_PWRITE
 
 /* Define to 1 if you have the 'res_gethostbyname' function. */
 #undef HAVE_RES_GETHOSTBYNAME

--- a/erts/configure
+++ b/erts/configure
@@ -20756,16 +20756,16 @@ then :
 
 fi
 ac_fn_c_check_func "$LINENO" "pread" "ac_cv_func_pread"
-if test "x$ac_cv_func_pread" = xyes
+if test "x$ac_cv_func_pread" != xyes
 then :
-  printf "%s\n" "#define HAVE_PREAD 1" >>confdefs.h
-
+  printf "%s\n" "$0: pread function not available"
+  exit 1
 fi
 ac_fn_c_check_func "$LINENO" "pwrite" "ac_cv_func_pwrite"
-if test "x$ac_cv_func_pwrite" = xyes
+if test "x$ac_cv_func_pwrite" != xyes
 then :
-  printf "%s\n" "#define HAVE_PWRITE 1" >>confdefs.h
-
+  printf "%s\n" "$0: pwrite function not available"
+  exit 1
 fi
 ac_fn_c_check_func "$LINENO" "memmove" "ac_cv_func_memmove"
 if test "x$ac_cv_func_memmove" = xyes

--- a/erts/preloaded/src/prim_file.erl
+++ b/erts/preloaded/src/prim_file.erl
@@ -325,7 +325,7 @@ position_1(Fd, Mark, Offset) ->
 
 pread(Fd, Offset, Size) ->
     try
-        #{ handle := FRef } = get_fd_data(Fd),
+        #{ handle := FRef } = Fd#file_descriptor.data,
         pread_nif(FRef, Offset, Size)
     catch
         error:badarg -> {error, badarg}
@@ -333,7 +333,7 @@ pread(Fd, Offset, Size) ->
 
 pread(Fd, LocNums) ->
     try
-        #{ handle := FRef } = get_fd_data(Fd),
+        #{ handle := FRef } = Fd#file_descriptor.data,
         pread_list(FRef, LocNums, [])
     catch
         error:badarg -> {error, badarg}


### PR DESCRIPTION
At the C API level pread [1] can be called from multiple threads. In Erlang, however, all the calls must be made from a single owner process.

In a busy concurrent environment that means all operations for a file descriptor must be serialized, and could pile up in the controller's mailbox having to wait for potentially slower operations to complete.

To fix it, add the ability to make raw concurrent pread calls from Erlang as well. File descriptor lifetime is still tied to the owner process, so it gets closed when owner dies. Other processes are only allowed to make pread calls, all others still require going through the owner.

Other file layers, like compression and delayed IO, still keep the previous behavior. They have their own `get_fd_data/1` functions per layer which check controller ownership. Concurrent preads are not allowed in those layers.

In unix_prim_file.c the seek+read fallback would have required exposing a flag in Erlang in order to keep the old behavior since another process could see the temporarily changed position. However, before adding a new flag looked where pread might not be supported, and it seems most Unix-like OSes since Sun0S 5(Solaris 2.5) and AT&T Sys V Rel4 (so all modern BSD) seem to have it. So perhaps, it's safe to remove the fallback altogether and simplify the code? As a precaution kept a configure check with an early failure and a clear message about it.

This necessitates updating preloaded beam files so an OTP team member would have to take over the PR, if the idea is acceptable to start with. I didn't commit the beam files so any CI tests might not run either?

Issue: https://github.com/erlang/otp/issues/9239

[1] https://www.man7.org/linux/man-pages/man2/pread.2.html