### PR TITLE
Optimize json object encoding

### DIFF
--- a/lib/stdlib/src/json.erl
+++ b/lib/stdlib/src/json.erl
@@ -323,7 +323,7 @@ key(Key, _Encode) when is_integer(Key) -> [$", encode_integer(Key), $"];
 key(Key, _Encode) when is_float(Key) -> [$", encode_float(Key), $"].
 
 encode_object([]) -> <<"{}">>;
-encode_object([[_Comma | Entry] | Rest]) -> ["{", Entry, Rest, "}"].
+encode_object([[_Comma | Entry] | Rest]) -> [${, Entry, Rest, $}].
 
 -doc """
 Default encoder for binaries as JSON strings used by `json:encode/1`.
@@ -712,14 +712,14 @@ format_object([[_Comma,KeyIndent|Entry]], Indent) ->
     {_, Rest} = string:take(Value, [$\s,$\n]),
     [CP|_] = string:next_codepoint(Rest),
     if CP =:= ${ ->
-            ["{", KeyIndent, Entry, Indent, "}"];
+            [${, KeyIndent, Entry, Indent, $}];
        CP =:= $[ ->
-            ["{", KeyIndent, Entry, Indent, "}"];
+            [${, KeyIndent, Entry, Indent, $}];
        true ->
             ["{ ", Entry, " }"]
     end;
 format_object([[_Comma,KeyIndent|Entry] | Rest], Indent) ->
-    ["{", KeyIndent, Entry, Rest, Indent, "}"].
+    [${, KeyIndent, Entry, Rest, Indent, $}].
 
 indent(#{level := Level, indent := Indent}) ->
     Steps = Level * Indent,


### PR DESCRIPTION
Using characters rather than strings for curly brackets leads to faster downstream conversion of the generated iodata to binary.

```erlang
%% before
> json:encode(#{a => b}).
["{",[[34,<<"a">>,34],58,34,<<"b">>,34],[],"}"]

%% after
[123,[[34,<<"a">>,34],58,34,<<"b">>,34],[],125]
```

This quick benchmark encoding a couple of small objects consistently gives me ~10% speed improvements:
https://github.com/sabiwara/elixir_benches/commit/ccf6af580926a017f5b3cfb3686b9b62a08f9f47

I couldn't figure out if the use of strings here was intentional, but using characters seems more consistent with the rest of the module even disregarding performance consideration.

There might be other strings like [this one](https://github.com/erlang/otp/blob/0f854d92817eb0662fd04d6f6eda86694922d415/lib/stdlib/src/json.erl#L358) or [this one](https://github.com/erlang/otp/blob/0f854d92817eb0662fd04d6f6eda86694922d415/lib/stdlib/src/json.erl#L459) which might be replaceable by characters or binaries, but it seems to be less frequent use cases and I'm not sure what a good benchmark would be for these.

FYI @michalmuskala