### PR TITLE
Updated doc for maps:foreach/2. Added example for maps:foreach/2.

### DIFF
--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -785,11 +785,25 @@ filtermap_1(_Fun, none, _ErrorTag) ->
     [].
 
 -doc """
-Calls `fun F(Key, Value)` for every `Key` to value `Value` association in
+Calls `fun Fun(Key, Value)` for every `Key` to value `Value` association in
 `MapOrIter` in any order.
 
 The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a map or
 valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
+
+_Example:_
+
+```erlang
+> Fun = fun(K,V) -> io:format("~p:~p~n",[K,V]) end.
+#Fun<erl_eval.41.18682967>
+> Map = #{"x" => 10, "y" => 20, "z" => 30}.
+#{"x" => 10,"y" => 20,"z" => 30}
+> maps:foreach(Fun,Map).
+"x":10
+"y":20
+"z":30
+ok
+```
 """.
 -doc(#{since => <<"OTP 24.0">>}).
 -spec foreach(Fun,MapOrIter) -> ok when

--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -829,8 +829,8 @@ foreach_1(_Fun, none, _ErrorTag) ->
     ok.
 
 -doc """
-Calls `F(Key, Value, AccIn)` for every `Key` to value `Value` association in
-`MapOrIter` in any order. Function `fun F/3` must return a new accumulator,
+Calls `Fun(Key, Value, AccIn)` for every `Key` to value `Value` association in
+`MapOrIter` in any order. Function `fun Fun/3` must return a new accumulator,
 which is passed to the next successive call. This function returns the final
 value of the accumulator. The initial accumulator value `Init` is returned if
 the map is empty.
@@ -873,7 +873,7 @@ fold_1(_Fun, Acc, none, _ErrorTag) ->
     Acc.
 
 -doc """
-Produces a new map `Map` by calling function `fun F(Key, Value1)` for every
+Produces a new map `Map` by calling function `fun Fun(Key, Value1)` for every
 `Key` to value `Value1` association in `MapOrIter` in any order. Function
 `fun Fun/2` must return value `Value2` to be associated with key `Key` for the
 new map `Map`.


### PR DESCRIPTION
(Code not changed)
- Updated doc for maps:foreach/2 (renamed F to Fun, so docs text corresponds with -spec for foreach/2)
- Added example for maps:foreach/2
