### PR TITLE
Supervisor/gen spawn options

### DIFF
--- a/lib/ssl/src/tls_dyn_connection_sup.erl
+++ b/lib/ssl/src/tls_dyn_connection_sup.erl
@@ -32,7 +32,7 @@
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/1]).
 -export([start_child/3]).
 
 %% Supervisor callback
@@ -41,8 +41,9 @@
 %%%=========================================================================
 %%%  API
 %%%=========================================================================
-start_link() ->
-    supervisor:start_link(?MODULE, []).
+-spec start_link(Options :: [gen_server:start_opt()]) -> supervisor:startlink_ret().
+start_link(Options) ->
+    supervisor:start_link(?MODULE, [], Options).
 
 start_child(Sup, sender, Args) ->
     supervisor:start_child(Sup, sender(Args));

--- a/lib/ssl/src/tls_socket.erl
+++ b/lib/ssl/src/tls_socket.erl
@@ -421,7 +421,8 @@ call(Pid, Msg) ->
 
 start_tls_server_connection(SslOpts, Port, Socket, EmOpts, Trackers, CbInfo) ->
     try
-        {ok, DynSup} = tls_connection_sup:start_child([]),
+        SupOpts = maps:to_list(maps:with([timeout, debug, hibernate_after, spawn_opt], SslOpts)),
+        {ok, DynSup} = tls_connection_sup:start_child([SupOpts]),
         SenderOpts = maps:get(sender_spawn_opts, SslOpts, []),
         {ok, Sender} = tls_dyn_connection_sup:start_child(DynSup, sender, [[{spawn_opt, SenderOpts}]]),
         ConnArgs = [server, Sender, "localhost", Port, Socket,

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -280,7 +280,7 @@ but the map is preferred.
 -behaviour(gen_server).
 
 %% External exports
--export([start_link/2, start_link/3,
+-export([start_link/2, start_link/3, start_link/4,
 	 start_child/2, restart_child/2,
 	 delete_child/2, terminate_child/2,
 	 which_children/1, which_child/2,
@@ -530,12 +530,28 @@ start_link(Mod, Args) ->
 -doc """
 Creates a supervisor process as part of a supervision tree.
 
+The supervisor can be nameless or registered,
+and it can receive options or none at all.
+""".
+-spec start_link(SupNameOrModule, ModuleOrArgs, ArgsOrOptions) -> Return when
+      SupNameOrModule :: sup_name() | module(),
+      ModuleOrArgs :: module() | term(),
+      ArgsOrOptions :: term() | [gen_server:start_opt()],
+      Return :: startlink_ret().
+start_link(Mod, Args, Options) when is_atom(Mod), is_list(Options) ->
+    gen_server:start_link(supervisor, {self, Mod, Args}, Options);
+start_link(SupName, Mod, Args) when is_tuple(SupName), is_atom(Mod) ->
+    gen_server:start_link(SupName, supervisor, {SupName, Mod, Args}, []).
+
+-doc """
+Creates a supervisor process as part of a supervision tree.
+
 For example, the function ensures that the supervisor is linked to the calling
 process (its supervisor).
 
 The created supervisor process calls [`Module:init/1`](`c:init/1`) to find out
 about restart strategy, maximum restart intensity, and child processes. To
-ensure a synchronized startup procedure, `start_link/2,3` does not return until
+ensure a synchronized startup procedure, `start_link/2,3,4` does not return until
 [`Module:init/1`](`c:init/1`) has returned and all child processes have been
 started.
 
@@ -571,13 +587,14 @@ started.
   processes with reason `shutdown` and then terminate itself and returns
   `{error, {shutdown, Reason}}`.
 """.
--spec start_link(SupName, Module, Args) -> startlink_ret() when
+-spec start_link(SupName, Module, Args, Options) -> startlink_ret() when
       SupName :: sup_name(),
       Module :: module(),
-      Args :: term().
-start_link(SupName, Mod, Args) ->
-    gen_server:start_link(SupName, supervisor, {SupName, Mod, Args}, []).
- 
+      Args :: term(),
+      Options :: [gen_server:start_opt()].
+start_link(SupName, Mod, Args, Options) ->
+    gen_server:start_link(SupName, supervisor, {SupName, Mod, Args}, Options).
+
 %%% ---------------------------------------------------
 %%% Interface functions.
 %%% ---------------------------------------------------

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -33,7 +33,7 @@
          middle9212/0, gen_server9212/0, handle_info/2, start_registered_name/1, log/2]).
 
 %% API tests
--export([ sup_start_normal/1, sup_start_ignore_init/1, 
+-export([ sup_start_normal/1, sup_start_ignore_init/1, sup_start_gen_flags/1,
 	  sup_start_ignore_child/1, sup_start_ignore_temporary_child/1,
 	  sup_start_ignore_temporary_child_start_child/1,
 	  sup_start_ignore_temporary_child_start_child_simple/1,
@@ -125,7 +125,7 @@ all() ->
 
 groups() -> 
     [{sup_start, [],
-      [sup_start_normal, sup_start_ignore_init,
+      [sup_start_normal, sup_start_ignore_init, sup_start_gen_flags,
        sup_start_ignore_child, sup_start_ignore_temporary_child,
        sup_start_ignore_temporary_child_start_child,
        sup_start_ignore_temporary_child_start_child_simple,
@@ -230,6 +230,15 @@ sup_start_ignore_init(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     ignore = start_link(ignore),
     check_no_exit(100).
+
+%%-------------------------------------------------------------------------
+%% Tests what happens if init-callback returns ignore.
+sup_start_gen_flags(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    Ret = {ok, {{one_for_one, 2, 3600}, []}},
+    {ok, Pid} = supervisor:start_link(?MODULE, Ret, [{hibernate_after, 0}]),
+    check_no_exit(100),
+    terminate(Pid, shutdown).
 
 %%-------------------------------------------------------------------------
 %% Tests what happens if init-callback returns ignore.


### PR DESCRIPTION
This comes from my thoughts on https://erlangforums.com/t/passing-gen-servers-start-opts-to-supervisors/4325.

Supervisors are too `gen` behaviours, and we can also plan for them to for example go into hibernation when appropriate, but currently they don't expose passing start options. One example is for SSL connections, where I can set to hibernate the two SSL connection workers if I know they'll be long-lived but not specially active, but the dynamic supervisor doesn't hibernate and therefore will likely never GC until it dies.