### PR TITLE
ssl: Handle user initiated cancelation during handshake

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -887,7 +887,7 @@ handle_info({ErrorTag, Socket, econnaborted}, StateName,
     Pids = Connection:pids(State),
     alert_user(Pids, Transport, Trackers, Socket,
                StartFrom, ?ALERT_REC(?FATAL, ?CLOSE_NOTIFY), Role, StateName, Connection),
-    {stop, {shutdown, normal}, State};
+    {stop, {shutdown, transport_closed}, State};
 
 handle_info({ErrorTag, Socket, Reason}, StateName, #state{static_env = #static_env{
                                                                           role = Role,
@@ -897,28 +897,36 @@ handle_info({ErrorTag, Socket, Reason}, StateName, #state{static_env = #static_e
     ?SSL_LOG(info, "Socket error", [{error_tag, ErrorTag}, {description, Reason}]),
     Alert = ?ALERT_REC(?FATAL, ?CLOSE_NOTIFY, {transport_error, Reason}),
     handle_normal_shutdown(Alert#alert{role = Role}, StateName, State),
-    {stop, {shutdown,normal}, State};
-
+    {stop, {shutdown, transport_closed}, State};
 handle_info({'DOWN', MonitorRef, _, _, Reason}, _,
             #state{connection_env = #connection_env{user_application = {MonitorRef, _Pid}},
                    ssl_options = #{erl_dist := true}}) ->
     {stop, {shutdown, Reason}};
-handle_info({'DOWN', MonitorRef, _, _, _}, _,
+handle_info({'DOWN', MonitorRef, _, _, _}, connection,
             #state{connection_env = #connection_env{user_application = {MonitorRef, _Pid}}}) ->
     {stop, {shutdown, normal}};
+handle_info({'DOWN', MonitorRef, _, _, _}, _,
+            #state{recv = Recv,
+                   connection_env = #connection_env{user_application = {MonitorRef, _Pid}}} = State) ->
+    %% Receiver has died
+    {stop, {shutdown, cancel_hs}, State#state{recv = Recv#recv{from = undefined}}};
 handle_info({'EXIT', Pid, _Reason}, StateName,
             #state{connection_env = #connection_env{user_application = {_MonitorRef, Pid}}} = State) ->
     %% It seems the user application has linked to us
     %% - ignore that and let the monitor handle this
     {next_state, StateName, State};
 %%% So that terminate will be run when supervisor issues shutdown
-handle_info({'EXIT', _Sup, shutdown}, _StateName, State) ->
+handle_info({'EXIT', _Sup, shutdown}, connection, State) ->
     {stop, shutdown, State};
+handle_info({'EXIT', _Sup, shutdown}, _, #state{recv = #recv{from = StartFrom} = Recv} = State) ->
+    gen_statem:reply(StartFrom, {error, closed}),
+    {stop, {shutdown, cancel_hs},  State#state{recv = Recv#recv{from = undefined}}};
 handle_info({'EXIT', Socket, normal}, _StateName, #state{static_env = #static_env{socket = Socket}} = State) ->
     %% Handle as transport close"
     {stop,{shutdown, transport_closed}, State};
 handle_info({'EXIT', Socket, Reason}, _StateName, #state{static_env = #static_env{socket = Socket}} = State) ->
-    {stop,{shutdown, Reason}, State};
+    ?SSL_LOG(info, socket_error, [{error, Reason}]),
+    {stop,{shutdown, transport_closed}, State};
 handle_info(allow_renegotiate, StateName, #state{handshake_env = HsEnv} = State) -> %% PRE TLS-1.3
     {next_state, StateName, State#state{handshake_env = HsEnv#handshake_env{allow_renegotiate = true}}};
 handle_info(Msg, StateName, #state{static_env = #static_env{socket = Socket, error_tag = ErrorTag}} = State) ->
@@ -1247,19 +1255,29 @@ terminate(Reason, connection, #state{static_env = #static_env{
                                                      socket = Socket},
                                      connection_states = ConnectionStates
                                     } = State) ->
-
+    
     handle_trusted_certs_db(State),
     Alert = terminate_alert(Reason),
     %% Send the termination ALERT if possible
     catch Connection:send_alert_in_connection(Alert, State),
     Connection:close({close, ?DEFAULT_TIMEOUT}, Socket, Transport, ConnectionStates);
+terminate({shutdown, cancel_hs} = Reason , _StateName,
+          #state{static_env = #static_env{transport_cb = Transport,
+                                          protocol_cb = Connection,
+                                          socket = Socket}
+                } = State0) ->
+    handle_trusted_certs_db(State0),
+    CancelAlert = ?ALERT_REC(?WARNING, ?USER_CANCELED),
+    CloseAlert = ?ALERT_REC(?WARNING, ?CLOSE_NOTIFY),
+    State = Connection:send_alert(CancelAlert, State0),
+    Connection:send_alert(CloseAlert, State),
+    Connection:close(Reason, Socket, Transport, undefined);
 terminate(Reason, _StateName, #state{static_env = #static_env{transport_cb = Transport,
                                                               protocol_cb = Connection,
                                                               socket = Socket}
-				    } = State) ->
+                                    } = State) ->
     handle_trusted_certs_db(State),
     Connection:close(Reason, Socket, Transport, undefined).
-
 %%====================================================================
 %% Log handling
 %%====================================================================

--- a/lib/ssl/src/tls_client_connection_1_3.erl
+++ b/lib/ssl/src/tls_client_connection_1_3.erl
@@ -248,7 +248,7 @@ start(internal, #server_hello{}, State0) ->
     ssl_gen_statem:handle_own_alert(
       ?ALERT_REC(?FATAL, ?PROTOCOL_VERSION), ?STATE(start), State0);
 start(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(start), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(start), State);
 start(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(start), State).
 
@@ -300,7 +300,7 @@ wait_sh(internal, #server_hello{} = Hello,
                                           no_record, State1)
     end;
 wait_sh(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_sh), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_sh), State);
 wait_sh(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_sh), State).
 
@@ -319,7 +319,7 @@ hello_middlebox_assert(internal = Type, #encrypted_extensions{} = Msg,
                                      reason => [{missing, #change_cipher_spec{}}]}, ?LOCATION),
     ssl_gen_statem:handle_common_event(Type, Msg, hello_middlebox_assert, State);
 hello_middlebox_assert(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(hello_middlebox_assert), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(hello_middlebox_assert), State);
 hello_middlebox_assert(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(hello_middlebox_assert), State).
 
@@ -339,7 +339,7 @@ hello_retry_middlebox_assert(internal = Type, #server_hello{} = Msg,
                                      reason => [{missing, #change_cipher_spec{}}]}, ?LOCATION),
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(hello_retry_middlebox_assert), State);
 hello_retry_middlebox_assert(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(hello_retry_middlebox_assert), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(hello_retry_middlebox_assert), State);
 hello_retry_middlebox_assert(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(hello_retry_middlebox_assert), State).
 
@@ -363,7 +363,7 @@ wait_ee(internal, #encrypted_extensions{extensions = Extensions}, State0) ->
             tls_gen_connection:next_event(NextState, no_record, State)
     end;
 wait_ee(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_ee), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_ee), State);
 wait_ee(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_ee), State).
 
@@ -394,7 +394,7 @@ wait_cert_cr(internal, #certificate_request_1_3{} = CertificateRequest,
             tls_gen_connection:next_event(NextState, no_record, State1)
    end;
 wait_cert_cr(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_cert_cr), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_cert_cr), State);
 wait_cert_cr(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_cert_cr), State).
 
@@ -476,7 +476,7 @@ wait_finished(internal,
             ssl_gen_statem:handle_own_alert(Alert, wait_finished, State0)
     end;
 wait_finished(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_finished), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_finished), State);
 wait_finished(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_finished), State).
 %%--------------------------------------------------------------------

--- a/lib/ssl/src/tls_gen_connection_1_3.erl
+++ b/lib/ssl/src/tls_gen_connection_1_3.erl
@@ -126,7 +126,7 @@ wait_cert(internal,
             tls_gen_connection:next_event(NextState, no_record, State)
     end;
 wait_cert(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_cert), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_cert), State);
 wait_cert(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_cert), State).
 
@@ -138,7 +138,7 @@ wait_cv(internal = Type, #change_cipher_spec{} = Msg,
   when Id =/= ?EMPTY_ID ->
     handle_change_cipher_spec(Type, Msg, ?STATE(wait_cv), State);
 wait_cv(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_cv), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_cv), State);
 wait_cv(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_cv), State).
 

--- a/lib/ssl/src/tls_server_connection.erl
+++ b/lib/ssl/src/tls_server_connection.erl
@@ -223,7 +223,7 @@ hello(internal, #client_hello{client_version = ClientVersion} = Hello,
             ssl_gen_statem:handle_own_alert(Alert, ?STATE(hello), AlertState)
     end;
 hello(info, Event, State) ->
-    tls_gen_connection:handle_info(Event, ?STATE(hello), State);
+    tls_gen_connection:gen_info(Event, ?STATE(hello), State);
 hello(Type, Event, State) ->
     gen_state(?STATE(hello), Type, Event, State).
 

--- a/lib/ssl/src/tls_server_connection_1_3.erl
+++ b/lib/ssl/src/tls_server_connection_1_3.erl
@@ -236,7 +236,7 @@ start(internal, #client_hello{}, State0) -> %% Missing mandantory TLS-1.3 extens
     %% so it is a previous version hello.
     ssl_gen_statem:handle_own_alert(?ALERT_REC(?FATAL, ?PROTOCOL_VERSION), ?STATE(start), State0);
 start(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(start), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(start), State);
 start(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(start), State).
 
@@ -259,7 +259,7 @@ negotiated(internal, {start_handshake, _} = Message, State0) ->
             {next_state, NextState, State, []}
     end;
 negotiated(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(negotiated), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(negotiated), State);
 negotiated(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(negotiated), State).
 
@@ -326,7 +326,7 @@ wait_finished(internal,
             ssl_gen_statem:handle_own_alert(Alert, ?STATE(wait_finished), State0)
     end;
 wait_finished(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_finished), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_finished), State);
 wait_finished(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_finished), State).
 
@@ -352,7 +352,7 @@ wait_eoed(internal, #end_of_early_data{}, #state{handshake_env = HsEnv0} = State
                                             wait_eoed, State0)
     end;
 wait_eoed(info, Msg, State) ->
-    tls_gen_connection:handle_info(Msg, ?STATE(wait_eoed), State);
+    tls_gen_connection:gen_info(Msg, ?STATE(wait_eoed), State);
 wait_eoed(Type, Msg, State) ->
     ssl_gen_statem:handle_common_event(Type, Msg, ?STATE(wait_eoed), State).
 


### PR DESCRIPTION
An initiated handshake should always be closed with an alert, elminate controlled shutdown that does not send alert.