### PR TITLE
Introduce scheduler pollset for nif select

### DIFF
--- a/erts/doc/Makefile
+++ b/erts/doc/Makefile
@@ -40,7 +40,9 @@ assets/erl_uds_dist.erl: ../../lib/kernel/examples/erl_uds_dist/src/erl_uds_dist
 assets/time_compat.erl: ../example/time_compat.erl
 	$(V_at)cp $< $@
 
-$(HTMLDIR)/index.html: $(patsubst ../emulator/internal_doc/assets/%,assets/%,$(wildcard ../emulator/internal_doc/assets/*.png) $(wildcard ../emulator/internal_doc/assets/*.svg)) assets/gen_tcp_dist.erl assets/erl_uds_dist.erl assets/time_compat.erl
+$(HTMLDIR)/index.html: $(wildcard ../emulator/internal_doc/*.md) \
+	$(patsubst ../emulator/internal_doc/assets/%,assets/%,$(wildcard ../emulator/internal_doc/assets/*.png) $(wildcard ../emulator/internal_doc/assets/*.svg)) \
+	assets/gen_tcp_dist.erl assets/erl_uds_dist.erl assets/time_compat.erl
 
 # ----------------------------------------------------
 # Release Target

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -810,20 +810,27 @@ error:
 /** @brief Create a message with the content of process independent \c msg_env.
  *  Invalidates \c msg_env.
  */
-ErtsMessage* erts_create_message_from_nif_env(ErlNifEnv* msg_env)
+ErtsMessage* erts_create_message_from_nif_env(ErlNifEnv* msg_env, Uint extra)
 {
     struct enif_msg_environment_t* menv = (struct enif_msg_environment_t*)msg_env;
     ErtsMessage* mp;
+    ErlHeapFragment *heap_frag;
 
     flush_env(msg_env);
-    mp = erts_alloc_message(0, NULL);
-    mp->data.heap_frag = menv->env.heap_frag;
-    ASSERT(mp->data.heap_frag == MBUF(&menv->phony_proc));
-    if (mp->data.heap_frag != NULL) {
+    mp = erts_alloc_message(extra, NULL);
+    if (extra) {
+        mp->hfrag.next = menv->env.heap_frag;
+        heap_frag = mp->hfrag.next;
+    } else {
+        mp->data.heap_frag = menv->env.heap_frag;
+        heap_frag = mp->data.heap_frag;
+    }
+    ASSERT(heap_frag == MBUF(&menv->phony_proc));
+    if (heap_frag != NULL) {
         /* Move all offheap's from phony proc to the first fragment.
            Quick and dirty... */
-        ASSERT(!is_offheap(&mp->data.heap_frag->off_heap));
-        mp->data.heap_frag->off_heap = MSO(&menv->phony_proc);
+        ASSERT(!is_offheap(&heap_frag->off_heap));
+        heap_frag->off_heap = MSO(&menv->phony_proc);
         clear_offheap(&MSO(&menv->phony_proc));
         menv->env.heap_frag = NULL;
         MBUF(&menv->phony_proc) = NULL;
@@ -944,7 +951,7 @@ int enif_send(ErlNifEnv* env, const ErlNifPid* to_pid,
             }
 #endif
         }
-        mp = erts_create_message_from_nif_env(msg_env);
+        mp = erts_create_message_from_nif_env(msg_env, 0);
         ERL_MESSAGE_TOKEN(mp) = token;
     } else {
         erts_literal_area_t litarea;

--- a/erts/emulator/beam/erl_port.h
+++ b/erts/emulator/beam/erl_port.h
@@ -334,7 +334,7 @@ Eterm erts_request_io_bytes(Process *c_p);
 #define ERTS_PORT_SFLG_INVALID		((Uint32) (1 << 11))
 /* Last port to terminate halts the emulator */
 #define ERTS_PORT_SFLG_HALT		((Uint32) (1 << 12))
-/* Check if the event in ready_input should be cleaned */
+/* Check if the event in ready_input should be cleaned. */
 #define ERTS_PORT_SFLG_CHECK_FD_CLEANUP ((Uint32) (1 << 13))
 #ifdef DEBUG
 /* Only debug: make sure all flags aren't cleared unintentionally */

--- a/erts/emulator/beam/erl_port_task.c
+++ b/erts/emulator/beam/erl_port_task.c
@@ -595,6 +595,11 @@ reset_executed_io_task_handle(Port *prt, ErtsPortTask *ptp)
                                                   reset_port_task_handle);
                 erts_atomic32_read_band_nob(&prt->state, ~ERTS_PORT_SFLG_CHECK_FD_CLEANUP);
             } else {
+                /* We don't have to call erts_io_notify_port_task_executed for scheduler events
+                   as we will keep the fd in the set. However, if driver_deselect was called in
+                   the ready_input callback, then we do need to call it in order to free the
+                   select structures from the fd state.
+                   */
                 reset_port_task_handle(ptp->u.alive.handle);
             }
         } else

--- a/erts/emulator/beam/erl_port_task.h
+++ b/erts/emulator/beam/erl_port_task.h
@@ -44,6 +44,7 @@ typedef erts_atomic_t ErtsPortTaskHandle;
 #if (defined(ERL_PROCESS_C__) \
      || defined(ERL_PORT_TASK_C__) \
      || defined(ERL_IO_C__) \
+     || defined(ERL_CHECK_IO_C__) \
      || (ERTS_GLB_INLINE_INCL_FUNC_DEF \
 	 && defined(ERTS_DO_INCL_GLB_INLINE_FUNC_DEF)))
 #define ERTS_INCLUDE_SCHEDULER_INTERNALS
@@ -138,6 +139,8 @@ ERTS_GLB_INLINE void erts_port_task_sched_enter_exiting_state(ErtsPortTaskSched 
 
 #if defined(ERTS_INCLUDE_SCHEDULER_INTERNALS) && ERTS_POLL_USE_SCHEDULER_POLLING
 ERTS_GLB_INLINE int erts_port_task_have_outstanding_io_tasks(void);
+ERTS_GLB_INLINE void erts_port_task_inc_outstanding_io_tasks(void);
+ERTS_GLB_INLINE void erts_port_task_dec_outstanding_io_tasks(void);
 /* NOTE: Do not access any of the exported variables directly */
 extern erts_atomic_t erts_port_task_outstanding_io_tasks;
 #endif
@@ -225,6 +228,18 @@ erts_port_task_have_outstanding_io_tasks(void)
 {
     return (erts_atomic_read_acqb(&erts_port_task_outstanding_io_tasks)
 	    != 0);
+}
+
+ERTS_GLB_INLINE void
+erts_port_task_inc_outstanding_io_tasks(void)
+{
+    erts_atomic_inc_nob(&erts_port_task_outstanding_io_tasks);
+}
+
+ERTS_GLB_INLINE void
+erts_port_task_dec_outstanding_io_tasks(void)
+{
+    erts_atomic_dec_nob(&erts_port_task_outstanding_io_tasks);
 }
 #endif
 

--- a/erts/emulator/beam/erl_proc_sig_queue.h
+++ b/erts/emulator/beam/erl_proc_sig_queue.h
@@ -169,7 +169,7 @@ typedef struct {
  * Note that not all signal are handled using this functionality!
  */
 
-#define ERTS_SIG_Q_OP_MAX 19
+#define ERTS_SIG_Q_OP_MAX 20
 
 #define ERTS_SIG_Q_OP_EXIT                      0  /* Exit signal due to bif call */
 #define ERTS_SIG_Q_OP_EXIT_LINKED               1  /* Exit signal due to link break*/
@@ -190,7 +190,8 @@ typedef struct {
 #define ERTS_SIG_Q_OP_RECV_MARK                 16
 #define ERTS_SIG_Q_OP_UNLINK_ACK                17
 #define ERTS_SIG_Q_OP_ADJ_MSGQ                  18
-#define ERTS_SIG_Q_OP_FLUSH			ERTS_SIG_Q_OP_MAX
+#define ERTS_SIG_Q_OP_FLUSH			19
+#define ERTS_SIG_Q_OP_NIF_SELECT		ERTS_SIG_Q_OP_MAX
 
 #define ERTS_SIG_Q_TYPE_MAX (ERTS_MON_LNK_TYPE_MAX + 10)
 
@@ -1177,6 +1178,9 @@ erts_proc_sig_send_cla_request(Process *c_p, Eterm to, Eterm req_id);
  */
 void
 erts_proc_sig_send_move_msgq_off_heap(Eterm to);
+
+int
+erts_proc_sig_send_nif_select(Eterm to, ErtsMessage *msg);
 
 /*
  * End of send operations of currently supported process signals.

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -3392,7 +3392,7 @@ try_set_sys_scheduling(void)
 
 
 static ERTS_INLINE int
-prepare_for_sys_schedule(void)
+prepare_for_sys_schedule(ErtsSchedulerData *esdp)
 {
     if (erts_sched_poll_enabled()) {
         while (!erts_port_task_have_outstanding_io_tasks()
@@ -3407,7 +3407,7 @@ prepare_for_sys_schedule(void)
 
 #else
 #define clear_sys_scheduling()
-#define prepare_for_sys_schedule() 0
+#define prepare_for_sys_schedule(esdp) 0
 #endif
 
 #ifdef HARDDEBUG
@@ -3542,13 +3542,18 @@ scheduler_wait(int *fcalls, ErtsSchedulerData *esdp, ErtsRunQueue *rq)
                 current_time = 0;
                 timeout_time = ERTS_MONOTONIC_TIME_MAX;
             }
+#if ERTS_POLL_USE_SCHEDULER_POLLING
+            if (!ERTS_SCHEDULER_IS_DIRTY(esdp) && erts_sched_poll_enabled()) {
+                erts_io_clear_nif_select_handles(esdp);
+            }
+#endif
             if (do_timeout) {
                 if (!thr_prgr_active) {
                     erts_thr_progress_active(erts_thr_prgr_data(esdp), thr_prgr_active = 1);
                     sched_wall_time_change(esdp, 1);
                 }
             }
-            else if (!ERTS_SCHEDULER_IS_DIRTY(esdp) && prepare_for_sys_schedule()) {
+            else if (!ERTS_SCHEDULER_IS_DIRTY(esdp) && prepare_for_sys_schedule(esdp)) {
                 /* We sleep in check_io, only for normal schedulers */
                 if (thr_prgr_active) {
                     erts_thr_progress_active(erts_thr_prgr_data(esdp), thr_prgr_active = 0);
@@ -5984,6 +5989,12 @@ init_scheduler_data(ErtsSchedulerData* esdp, int num,
 
     esdp->io.out = (Uint64) 0;
     esdp->io.in = (Uint64) 0;
+
+#if ERTS_POLL_USE_SCHEDULER_POLLING
+    for (int i = 0; i < sizeof(esdp->nif_select_fds) / sizeof(ErtsSysFdType); i++) {
+        esdp->nif_select_fds[i] = ERTS_SYS_FD_INVALID;
+    }
+#endif
 
     esdp->pending_signal.sig = NULL;
     esdp->pending_signal.to = THE_NON_VALUE;
@@ -9834,7 +9845,7 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 	    goto check_activities_to_run;
 	} else if (is_normal_sched &&
                    fcalls > (2 * context_reds) &&
-                   prepare_for_sys_schedule()) {
+                   prepare_for_sys_schedule(esdp)) {
             ErtsMonotonicTime current_time;
 	    /*
 	     * Schedule system-level activities.

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -71,6 +71,9 @@ typedef struct process Process;
 #include "erl_thr_progress.h"
 #undef ERL_THR_PROGRESS_TSD_TYPE_ONLY
 
+// Included for ERTS_POLL_USE_SCHEDULER_POLLING
+#include "erl_poll.h"
+
 #define ERTS_HAVE_SCHED_UTIL_BALANCING_SUPPORT_OPT	0
 #define ERTS_HAVE_SCHED_UTIL_BALANCING_SUPPORT		0
 
@@ -721,6 +724,9 @@ struct ErtsSchedulerData_ {
 	Uint64 out;
 	Uint64 in;
     } io;
+#if ERTS_POLL_USE_SCHEDULER_POLLING
+    ErtsSysFdType nif_select_fds[5]; /* Used by check io */
+#endif
     struct {
         ErtsSignal* sig;
         Eterm to;

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -142,7 +142,7 @@ extern Eterm erts_nif_call_function(Process *p, Process *tracee,
 
 int erts_call_dirty_nif(ErtsSchedulerData *esdp, Process *c_p,
                         ErtsCodePtr I, Eterm *reg);
-ErtsMessage* erts_create_message_from_nif_env(ErlNifEnv* msg_env);
+ErtsMessage* erts_create_message_from_nif_env(ErlNifEnv* msg_env, Uint extra);
 
 
 /* Driver handle (wrapper for old plain handle) */

--- a/erts/emulator/internal_doc/CheckIO.md
+++ b/erts/emulator/internal_doc/CheckIO.md
@@ -1,0 +1,162 @@
+<!--
+%CopyrightBegin%
+
+Copyright Ericsson AB 2025. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+%CopyrightEnd%
+-->
+
+# Checking for I/O events
+
+An I/O event in ERTS is any event triggered by a [file descriptor]
+on Unix or any OBJECT HANDLE that can be passed to [WaitForMultipleObjects] on Windows.
+The check I/O infrastructure is used by linked-in drivers through [driver_select](erl_driver.md#driver_select)
+and by NIFs through [enif_select](erl_nif.md#enif_select).
+
+The main user of the check I/O subsystem is network communication through
+`m:gen_tcp`, `m:gen_udp`, `m:gen_sctp` and `m:socket` on Unix (on Windows
+`m:socket` used its own internal check I/O implementation based on completion ports).
+It is also used by various other parts, such as when doing `os:cmd/1` or
+reading from the terminal.
+
+This document gives an overview of how the check I/O subsystem works.
+
+The check I/O subsystem consists of a platform specific ([erl_poll](#polling))
+and platform agnostic part ([check_io](#check-i-o)).
+
+[erl_poll] is the basic mechanisms for checking if any events have been signalled
+and allows waiting for a timeout if needed. The implementation of polling is very
+platform specific and lives in [erts/emulator/sys/common/erl_poll.c] for Unix and
+[erts/emulator/sys/win32/erl_poll.c] for Windows.
+
+[check_io](#check-i-o) is the cross-platform part of the check I/O subsystem
+that makes sure that [erl_poll] has the correct state and dispatches events to
+the correct entity. The implementation can be found in [erts/emulator/sys/common/erl_check_io.c].
+
+check_io is then used by ports and NIFs to listen to events. Ports are
+communicated to through [port signals](PortSignals.md) and are delivered through
+the [ready_input](driver_entry.md#ready_input) and [ready_output](driver_entry.md#ready_output) callbacks.
+[NIFs](erl_nif.md) get an Erlang message whenever an event is triggered.
+
+[file descriptor]: https://en.wikipedia.org/wiki/File_descriptor
+[erl_poll]: #polling
+[erts/emulator/sys/common/erl_poll.c]: https://github.com/erlang/otp/blob/master/erts/emulator/sys/common/erl_poll.c
+[erts/emulator/sys/win32/erl_poll.c]: https://github.com/erlang/otp/blob/master/erts/emulator/sys/win32/erl_poll.c
+[erts/emulator/sys/common/erl_check_io.c]: https://github.com/erlang/otp/blob/master/erts/emulator/sys/common/erl_check_io.c
+[erts/emulator/beam/erl_port_task.c]: https://github.com/erlang/otp/blob/master/erts/emulator/beam/erl_port_task.c
+[erl_check_io.c]: https://github.com/erlang/otp/blob/master/erts/emulator/sys/common/erl_check_io.c
+[erts/emulator/beam/erl_port_task.c]: https://github.com/erlang/otp/blob/master/erts/emulator/beam/erl_port_task.c
+[WaitForMultipleObjects]: https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitformultipleobjects
+
+## Polling
+
+The polling subsystem basically has two API functions; erts_poll_control and
+erts_poll_wait. erts_poll_control is used to update a ErtsPollSet and
+erts_poll_wait is used to wait for an event in the pollset to be triggered or a
+timeout to happen (the timeout can be 0 if just checking). Only a single thread
+usually calls erts_poll_wait at the same time, but multiple threads calls
+erts_poll_control at any time.
+
+The implementation of Unix and Windows are completely different as Windows does
+not really have a concept of "polling" for an event.
+
+### Polling on Unix
+
+The poll implemention on Unix support a variety of different polling mechanisms.
+At the writing of this document they are: [epoll] (Linux), [kqueue] (MacOS + *Bsd),
+[/dev/poll] (Solaris), [poll] and [select]. [epoll]+[kqueue]+[/dev/poll] are
+referred to as "kernel polling" methods, as the information about which FDs are currently monitored
+lives in the OS kernel, while [poll]+[select] are "user polling" methods as the
+caller needs to supply all FDs of interest to the kernel everything erts_poll_wait
+is called.
+
+By default all Unix'es use a "kernel polling" method, but has a fallback pollset that
+uses "user polling" for FDs that the "kernel polling" mechanism does not
+support (for example the stdin FD on Linux cannot be monitored by [epoll]).
+
+As the kernel polling methods have their monitoring information in the kernel
+it is possible to update these in parallel and without waking the thread that
+is currently waiting for events. For user polling a queue of needed updates
+is managed by each pollset and whenever an update is done to that queue the
+thread waiting on events is woken up to update the set of file descriptors it
+is waiting on.
+
+When using kernel polling it is possible to have multiple poll threads
+(using the [+IOt](erl_cmd.md#+IOt) flag) that read events from the same pollset.
+This can be useful for very busy systems with many many FDs that become active alot.
+If the kernel you are using is not very good at allowing multiple threads to
+check in the same pollset (this primarily applied to old versions of Linux),
+then it is also possible to configure erts to use separate
+pollsets for each pollthread ((using the [+IOp](erl_cmd.md#+IOp) flag)).
+
+When an event is triggered it is removed from the pollset and needs to be
+re-enabled before any new events are triggered. If [ONESHOT] or equivalent is
+available then kernel polling uses that flag, otherwise erl_poll will update
+the pollset as the event is triggered.
+
+[epoll]: https://man7.org/linux/man-pages/man7/epoll.7.html
+[kqueue]: https://man.freebsd.org/cgi/man.cgi?kqueue
+[/dev/poll]: https://docs.oracle.com/cd/E88353_01/html/E37851/poll-4d.html
+[poll]: https://man7.org/linux/man-pages/man2/poll.2.html
+[select]: https://man7.org/linux/man-pages/man2/select.2.html
+[ONESHOT]: https://man7.org/linux/man-pages/man2/epoll_ctl.2.html#:~:text=EPOLLONESHOT
+
+### Polling on Windows
+
+Polling on Windows uses similar mechanism to "user polling" on Unix, except
+that because WaitForMultipleObjects is limited to wait for 64 handles it
+also needs to manage a thread pool. New threads are created as needed, so
+if the system only ever listens for events on less then 64 handles only 1
+thread will be created, but as the number of concurrent handles grow more
+and more threads will be created.
+
+The thread pool is never shrunk, so if the system at any point uses 1000
+handles, there will forever be 16 threads in the thread pool.
+
+## Check I/O
+
+Checking for I/O is done by dedicated polling threads. By default, one
+thread will always be waiting for I/O events using default polling method
+and the "aux" thread will be waiting in the fallback pollset if such exists.
+
+When an event is triggered it is dispatched to the correct port or process
+depending on whether it is a driver or nif that has requested the event.
+As the pollsets use [ONESHOT], the event is disabled until the port/NIF
+registers a new interest in the event.
+
+When you do a driver_select in a linked-in driver, that select will
+be active until it is disabled. Because of this we need to insert the
+FD back into the pollset when a driver_select event has been handled.
+This is done by the port re-inserting the FD in the pollset after
+a ready_input/ready_output event is called. For NIFs you need to call
+enif_select for each event that you want, so no such mechanism needs
+to exist for NIFs.
+
+### Scheduler pollset
+
+For very active FDs the fact that we need to re-insert events each time
+they trigger can lead to quite a lot of overhead. Because of this there
+is an optimization that places FDs that are never deselected into a
+special pollset managed that is not checked by the poll threads, but
+instead checked by the normal schedulers. In this pollset, the FDs no
+longer use the [ONESHOT] mechanism, instead they trigger as soon as there
+is data. For this to work, and not re-trigger on FDs before the port/nif has
+handled the event, there is a global counter called erts_port_task_outstanding_io_tasks
+that is incremented for each FD that is dispatched from the scheduler pollset.
+That counter is then decremented as the FDs are handled by the ports/processes
+that have subscribed to the event. When it reaches 0, we know that it is
+safe to check for new events. This increases the latency for how quickly
+we check for new events by a bit, but drastically reduces the CPU usage
+for very active FDs.

--- a/erts/emulator/sys/common/erl_check_io.h
+++ b/erts/emulator/sys/common/erl_check_io.h
@@ -58,6 +58,23 @@ Eterm erts_check_io_info(void *proc);
 void erts_io_notify_port_task_executed(ErtsPortTaskType type,
                                        ErtsPortTaskHandle *handle,
                                        void (*reset)(ErtsPortTaskHandle *));
+
+#if ERTS_POLL_USE_SCHEDULER_POLLING
+/**
+ * Handles an nif select non-message signal. Returns the message Eterm.
+ * 
+ * @param sig The signal that has arrived
+ */
+Eterm erts_io_handle_nif_select(ErtsMessage *sig);
+
+/**
+ * Clears all nif select handles from scheduler queue.
+ * 
+ * @param sig The signal that has arrived
+ */
+void erts_io_clear_nif_select_handles(ErtsSchedulerData *esdp);
+#endif
+
 /**
  * Returns the maximum number of fds that the check io framework can handle.
  */

--- a/erts/emulator/test/driver_SUITE.erl
+++ b/erts/emulator/test/driver_SUITE.erl
@@ -89,6 +89,7 @@
 -export([bin_prefix/2]).
 
 -export([get_check_io_total/1]).   % for z_SUITE.erl
+-export([check_io_debug/0]). %% For nif_SUITE.erl
 
 -include_lib("common_test/include/ct.hrl").
 

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -62,6 +62,7 @@ document etp-help
 %   etp-heapdump, etp-offheapdump, etpf-offheapdump,
 %   etp-search-heaps, etp-search-alloc,
 %   etp-ets-tables, etp-ets-tabledump
+%   etp-fd-dump
 %
 % Complex commands that use the Erlang support module.
 %   etp-overlapped-heaps, etp-chart, etp-chart-start, etp-chart-end
@@ -4900,6 +4901,158 @@ document etp-ets-tabledump
 % Dump an ETS table with a specified slot index.
 %---------------------------------------------------------------------------
 end
+
+define _etp-fd-print-events
+    if $arg0 == 0 || $arg0 == etp_poll_ev_none
+        printf "NONE"
+    else
+    if $arg0 == etp_poll_ev_in
+        printf "IN"
+    else
+    if $arg0 == etp_poll_ev_out
+        printf "OUT"
+    else
+    if $arg0 == (etp_poll_ev_in|etp_poll_ev_out)
+        printf "IN|OUT"
+    else
+    if $arg0 == etp_poll_ev_err
+        printf "ERR"
+    else
+    if $arg0 == etp_poll_ev_nval
+        printf "NVAL"
+    else
+        printf "UNKNOWN(%d)", $arg0
+    end
+    end
+    end
+    end
+    end
+    end
+    printf "\n"
+end
+
+define etp-fd
+    set $etp_fd_state = &drv_ev_state.v[$arg0]
+    printf "fd: %d\n", $arg0
+    
+    printf "  type: "
+    if $etp_fd_state->type == 0
+        printf "NONE\n"
+    end
+    if $etp_fd_state->type == 1
+        printf "DRV_SEL\n"
+    end
+    if $etp_fd_state->type == 2
+        printf "STOP_USE\n"
+    end
+    if $etp_fd_state->type == 3
+        printf "NIF\n"
+    end
+    if $etp_fd_state->type == 4
+        printf "STOP_NIF\n"
+    end
+
+    printf "  events: "
+    _etp-fd-print-events $etp_fd_state->events
+    
+    printf "  active_events: "
+    _etp-fd-print-events $etp_fd_state->active_events
+    
+    printf "  flags: "
+    set $etp_fd_flags = $etp_fd_state->flags
+    if  $etp_fd_flags == 0x0
+        printf "NONE"
+    else
+        if  $etp_fd_flags & 0x1
+            printf "USED "
+            set $etp_fd_flags =  $etp_fd_flags & ~0x1
+        end
+        if  $etp_fd_flags & 0x2
+            printf "SCHEDULER "
+            set $etp_fd_flags =  $etp_fd_flags & ~0x2
+        end
+        if  $etp_fd_flags & 0x4
+            printf "IN_SCHEDULER "
+            set $etp_fd_flags =  $etp_fd_flags & ~0x4
+        end
+        if  $etp_fd_flags & 0x8
+            printf "NIF_SELECT "
+            set $etp_fd_flags =  $etp_fd_flags & ~0x8
+        end
+        if  $etp_fd_flags & 0x10
+            printf "FALLBACK "
+            set $etp_fd_flags =  $etp_fd_flags & ~0x10
+        end
+        if  $etp_fd_flags & 0x20
+            printf "WANT_ERROR "
+            set $etp_fd_flags =  $etp_fd_flags & ~0x20
+        end
+        if $etp_fd_flags
+            printf "ERROR(%d)", $etp_fd_flags
+        end
+    end
+    printf "\n"
+    if $etp_fd_state->driver.select
+        if $etp_fd_state->driver.select->inport != $etp_nil
+            printf "  IN PORT: "
+            etp $etp_fd_state->driver.select->inport
+        end
+        if $etp_fd_state->driver.select->outport != $etp_nil
+            printf "  OUT PORT: "
+            etp $etp_fd_state->driver.select->outport
+        end
+        if $etp_fd_state->driver.select->outiotask.task.counter != 0
+            printf "  OUT TASK: (ErtsPortTask*)%p\n", $etp_fd_state->driver.select->outiotask.task.counter
+        end
+        if $etp_fd_state->driver.select->iniotask.task.counter != 0
+            printf "  IN TASK: (ErtsPortTask*)%p\n", $etp_fd_state->driver.select->iniotask.task.counter
+        end
+    end
+    if $etp_fd_state->driver.nif
+        if $etp_fd_state->driver.nif->in.pid != $etp_nil
+            printf "  IN PID: "
+            etp $etp_fd_state->driver.nif->in.pid
+        end
+        if $etp_fd_state->driver.nif->out.pid != $etp_nil
+            printf "  OUT PID: "
+            etp $etp_fd_state->driver.nif->out.pid
+        end
+    end
+end
+
+document etp-fd
+%---------------------------------------------------------------------------
+% etp-fd FD
+%
+% Dump info about a specific FD
+%---------------------------------------------------------------------------
+end
+
+define etp-fd-dump
+    set $etp_fd_dump_i = 0
+    set $etp_fd_dump_len = drv_ev_state.len.counter
+    while $etp_fd_dump_i < $etp_fd_dump_len
+        set $etp_fd_dump_state = &drv_ev_state.v[$etp_fd_dump_i]
+        set $should_display = $etp_fd_dump_state->flags != 0
+        set $should_display |= $etp_fd_dump_state->events != etp_poll_ev_none && $etp_fd_dump_state->events != 0
+        set $should_display |= $etp_fd_dump_state->active_events != etp_poll_ev_none && $etp_fd_dump_state->active_events != 0
+        set $should_display |= $etp_fd_dump_state->driver.select != 0
+        set $should_display |= $etp_fd_dump_state->driver.nif != 0
+        if  $should_display
+            etp-fd $etp_fd_dump_i
+        end
+        set $etp_fd_dump_i++
+    end
+end
+
+document etp-fd-dump
+%---------------------------------------------------------------------------
+% etp-fd-dump
+%
+% Dump all FDs in the system
+%---------------------------------------------------------------------------
+end
+
 
 define etp-lc-dump
 # Non-reentrant

--- a/make/test_target_script.sh
+++ b/make/test_target_script.sh
@@ -269,14 +269,16 @@ if [ -n "${FLAVOR}" ]; then
 fi
 
 # Compile test server and configure
-if [ ! -f "$ERL_TOP/lib/common_test/test_server/variables" ]; then
+if [ ! -f "$ERL_TOP/lib/common_test/test_server/variables.${TYPE}.${FLAVOR}" ]; then
     cd "$ERL_TOP/lib/common_test/test_server"
-    ( make && erl -noshell -eval "ts:install()." -s init stop )  > "$INSTALL_TEST_LOG" 2>&1
+    ( ${MAKE:-make} && erl -noshell -eval "ts:install()." -s init stop )  > "$INSTALL_TEST_LOG" 2>&1
     if [ $? != 0 ]
     then
         cat "$INSTALL_TEST_LOG"
         print_highlighted_msg $RED "\"make && erl -eval 'ts:install()'\" in common_test/test_server failed."
         exit 1
+    else
+        cp "$ERL_TOP/lib/common_test/test_server/variables" "$ERL_TOP/lib/common_test/test_server/variables.${TYPE}.${FLAVOR}"
     fi
 fi
 
@@ -284,7 +286,7 @@ fi
 cd $MAKE_TEST_REL_DIR
 
 erl -sname test -noshell -pa "$ERL_TOP/lib/common_test/test_server" \
-    -eval "ts:compile_datadirs(\"$ERL_TOP/lib/common_test/test_server/variables\",\"*_SUITE_data\")."\
+    -eval "ts:compile_datadirs(\"$ERL_TOP/lib/common_test/test_server/variables.${TYPE}.${FLAVOR}\",\"*_SUITE_data\")."\
     -s init stop > "$COMPILE_TEST_LOG" 2>&1
 
 if [ $? != 0 ]


### PR DESCRIPTION
When FD polling on unix was migrated to a separate thread in OTP-21, polling on FDs that exhibit an "active true" behaviour for drivers were placed in a separate scheduler pollset in order to reduce the number of modifications of the pollset and thus reduce CPU cost. This PR introduces the same mechanism for FDs selected on by nifs.