### PR TITLE
Augment `gen_server` timeout handling

### DIFF
--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -2278,6 +2278,12 @@ loop(ServerData, State, Time, Debug, Timer)
 	  end,
     decode_msg(ServerData, State, Msg, Debug, Timer, false).
 
+loop_continue(ServerData, State, Hib, Debug, Timer) ->
+    Action = case Hib of
+		 true -> hibernate;
+		 false -> infinity
+	     end,
+    loop(ServerData, State, Action, Debug, Timer).
 
 cancel_timer(undefined) ->
     ok;
@@ -2322,11 +2328,7 @@ decode_msg(#server_data{parent = Parent, tag = Tag} = ServerData, State, Msg, De
 	{timeout, TRef, Tag} when TRef =:= hd(Timer) ->
             decode_msg(ServerData, State, tl(Timer), Debug);
 	{timeout, _Stale, Tag} ->
-	    LoopAction = case Hib of
-			     true -> hibernate;
-			     false -> infinity
-			 end,
-	    loop(ServerData, State, LoopAction, Debug, Timer);
+	    loop_continue(ServerData, State, Hib, Debug, Timer);
         _ ->
 	    cancel_timer(Timer),
             decode_msg(ServerData, State, Msg, Debug)
@@ -2592,11 +2594,7 @@ handle_timer(#server_data{tag = Tag}, T, M, HibInf, Abs) ->
 %%-----------------------------------------------------------------
 -doc false.
 system_continue(Parent, Debug, [#server_data{parent=Parent} = ServerData, State, Timer, Hib]) ->
-    Action = case Hib of
-		 true -> hibernate;
-		 false -> infinity
-	     end,
-    loop(update_callback_cache(ServerData), State, Action, Debug, Timer).
+    loop_continue(update_callback_cache(ServerData), State, Hib, Debug, Timer).
 
 -doc false.
 -spec system_terminate(_, _, _, [_]) -> no_return().

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -2565,9 +2565,9 @@ handle_action(ServerData, Action) ->
         {hibernate, T, M} ->
             handle_timeout(ServerData, T, M, hibernate);
         {timeout, T, M, Opts} ->
-            handle_timeout(ServerData, T, M, infinity, Opts, false);
+            handle_timeout(ServerData, T, M, infinity, listify(Opts), false);
         {hibernate, T, M, Opts} ->
-            handle_timeout(ServerData, T, M, hibernate, Opts, false);
+            handle_timeout(ServerData, T, M, hibernate, listify(Opts), false);
         _ ->
             error
     end.
@@ -2580,13 +2580,10 @@ handle_timeout(ServerData, T, M, HibInf) ->
             error
     end.
 
-handle_timeout(ServerData, T, M, HibInf, {abs, Abs}, _Abs) when is_boolean(Abs),
-								?is_timeout(Abs, T) ->
+handle_timeout(ServerData, T, M, HibInf, [], Abs) when ?is_timeout(Abs, T) ->
     handle_timer(ServerData, T, M, HibInf, Abs);
 handle_timeout(ServerData, T, M, HibInf, [{abs, Abs} | Opts], _Abs) when is_boolean(Abs) ->
     handle_timeout(ServerData, T, M, HibInf, Opts, Abs);
-handle_timeout(ServerData, T, M, HibInf, [], Abs) when ?is_timeout(Abs, T) ->
-    handle_timer(ServerData, T, M, HibInf, Abs);
 handle_timeout(_ServerData, _T, _M, _HibInf, _Opts, _Abs) ->
     error.
 
@@ -2605,6 +2602,12 @@ handle_timer(#server_data{tag = Tag}, T, M, HibInf, Abs) ->
                 erlang:start_timer(T, self(), Tag)
         end,
     {timeout, [TRef | M], HibInf}.
+
+-compile({inline, [listify/1]}).
+listify(Opts) when is_list(Opts) ->
+    Opts;
+listify(Opt) ->
+    [Opt].
 
 %%-----------------------------------------------------------------
 %% Callback functions for system messages handling.

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -283,7 +283,7 @@ using exit signals.
 -type action() :: timeout() |
                   'hibernate' |
                   {'timeout', timeout(), term()} |
-                  {'timeout_and_hibernate', timeout(), term()}.
+                  {'hibernate', timeout(), term()}.
 
 -doc """
 Initialize the server.
@@ -2558,11 +2558,11 @@ handle_action(Action) ->
         Timeout when ?is_rel_timeout(Timeout)   -> Timeout;
         {timeout, T, M} ->
             handle_timeout(T, M, infinity);
-        {timeout_and_hibernate, T, M} ->
+        {hibernate, T, M} ->
             handle_timeout(T, M, hibernate);
         {timeout, T, M, Opts} ->
             handle_timeout(T, M, infinity, Opts, false);
-        {timeout_and_hibernate, T, M, Opts} ->
+        {hibernate, T, M, Opts} ->
             handle_timeout(T, M, hibernate, Opts, false);
         _ ->
             error

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -2271,7 +2271,13 @@ loop(ServerData, State, {timeout_and_hibernate, Time, TimeoutMsg, TimeoutOpts}, 
     loop(ServerData, State, hibernate, TRef, Debug);
 
 loop(ServerData, State, hibernate, TRef, Debug) ->
-    proc_lib:hibernate(?MODULE, wake_hib, [ServerData, State, TRef, Debug]);
+    receive
+	Msg ->
+	    _ = erlang:garbage_collect(),
+	    decode_msg(ServerData, State, Msg, TRef, Debug, false)
+    after 0 ->
+	proc_lib:hibernate(?MODULE, wake_hib, [ServerData, State, TRef, Debug])
+    end;
 
 loop(#server_data{hibernate_after = HibernateAfterTimeout} = ServerData, State, infinity, TRef, Debug) ->
     receive

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -2244,11 +2244,11 @@ loop(ServerData, State, {continue, Continue} = Msg, Debug) ->
 loop(ServerData, State, LoopAction, Debug) ->
     case LoopAction of
         {timeout_zero, TimeoutMsg} ->
-            decode_msg(ServerData, State, TimeoutMsg, Debug, undefined, false);
+            decode_msg(ServerData, State, TimeoutMsg, Debug, [], false);
         {timeout, Timer, HibInf} ->
             loop(ServerData, State, HibInf, Debug, Timer);
         HibT ->
-            loop(ServerData, State, HibT, Debug, undefined)
+            loop(ServerData, State, HibT, Debug, [])
     end.
 
 loop(ServerData, State, hibernate, Debug, Timer) ->
@@ -2295,7 +2295,7 @@ loop_continue(ServerData, State, Hib, Debug, Timer) ->
 	     end,
     loop(ServerData, State, Action, Debug, Timer).
 
-cancel_timer(undefined) ->
+cancel_timer([]) ->
     ok;
 cancel_timer([TRef | _]) ->
     ok = erlang:cancel_timer(TRef, [{async, true}, {info, false}]).

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -2,7 +2,7 @@
 %% 
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 1996-2024. All Rights Reserved.
+%% Copyright Ericsson AB 1996-2025. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -120,6 +120,6 @@
                dets]},
   {applications, [kernel]},
   {env, []},
-  {runtime_dependencies, ["sasl-3.0","kernel-10.0","erts-15.0","crypto-4.5",
+  {runtime_dependencies, ["sasl-3.0","kernel-10.0","erts-@OTP-19503@","crypto-4.5",
 			  "compiler-5.0", "syntax_tools-3.2.1"]}
 ]}.

--- a/lib/stdlib/test/gen_server_SUITE.erl
+++ b/lib/stdlib/test/gen_server_SUITE.erl
@@ -1446,35 +1446,35 @@ hibernate(Config) when is_list(Config) ->
     true = gen_server:call(my_test_name_hibernate, {hibernate_noreply,Pid2}),
 
     gen_server:cast(my_test_name_hibernate, hibernate_later),
-    true = ({current_function,{erlang,hibernate,3}} =/=
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/=
 		erlang:process_info(Pid, current_function)),
     is_in_erlang_hibernate(Pid),
     ok = gen_server:call(my_test_name_hibernate, started_p),
-    true = ({current_function,{erlang,hibernate,3}} =/=
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/=
 		erlang:process_info(Pid, current_function)),
 
     gen_server:cast(my_test_name_hibernate, hibernate_now),
     is_in_erlang_hibernate(Pid),
     ok = gen_server:call(my_test_name_hibernate, started_p),
-    true = ({current_function,{erlang,hibernate,3}} =/=
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/=
 		erlang:process_info(Pid, current_function)),
 
     Pid ! hibernate_later,
-    true = ({current_function,{erlang,hibernate,3}} =/=
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/=
 		erlang:process_info(Pid, current_function)),
     is_in_erlang_hibernate(Pid),
     ok = gen_server:call(my_test_name_hibernate, started_p),
-    true = ({current_function,{erlang,hibernate,3}} =/=
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/=
 		erlang:process_info(Pid, current_function)),
 
     Pid ! hibernate_now,
     is_in_erlang_hibernate(Pid),
     ok = gen_server:call(my_test_name_hibernate, started_p),
-    true = ({current_function,{erlang,hibernate,3}} =/=
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/=
 		erlang:process_info(Pid, current_function)),
     receive
 	{result,R} ->
-	    {current_function,{erlang,hibernate,3}} = R
+	    {current_function,{gen_server, loop_hibernate, 4}} = R
     end,
 
     true = gen_server:call(my_test_name_hibernate, hibernate),
@@ -1484,7 +1484,7 @@ hibernate(Config) when is_list(Config) ->
     sys:resume(my_test_name_hibernate),
     is_in_erlang_hibernate(Pid),
     ok = gen_server:call(my_test_name_hibernate, started_p),
-    true = ({current_function,{erlang,hibernate,3}} =/= erlang:process_info(Pid,current_function)),
+    true = ({current_function,{gen_server, loop_hibernate, 4}} =/= erlang:process_info(Pid,current_function)),
 
     ok = gen_server:call(my_test_name_hibernate, stop),
     receive 
@@ -1558,6 +1558,8 @@ is_in_erlang_hibernate_1(0, Pid) ->
 is_in_erlang_hibernate_1(N, Pid) ->
     {current_function,MFA} = erlang:process_info(Pid, current_function),
     case MFA of
+	{gen_server, loop_hibernate, 4} ->
+	    ok;
 	{erlang,hibernate,3} ->
 	    ok;
 	_ ->
@@ -1575,6 +1577,9 @@ is_not_in_erlang_hibernate_1(0, Pid) ->
 is_not_in_erlang_hibernate_1(N, Pid) ->
     {current_function,MFA} = erlang:process_info(Pid, current_function),
     case MFA of
+        {gen_server, loop_hibernate, 4} ->
+            receive after 10 -> ok end,
+            is_not_in_erlang_hibernate_1(N-1, Pid);
         {erlang,hibernate,3} ->
             receive after 10 -> ok end,
             is_not_in_erlang_hibernate_1(N-1, Pid);

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -716,7 +716,7 @@ child_adm(Config) when is_list(Config) ->
     {ok, Pid} = start_link({ok, {{one_for_one, 2, 3600}, [Child]}}),
 
     %% Test that supervisors of static nature are hibernated after start
-    {current_function, {erlang, hibernate, 3}} =
+    {current_function, {gen_server, loop_hibernate, 4}} =
 	process_info(Pid, current_function),
 
     [{child1, CPid, worker, []}] = supervisor:which_children(sup_test),


### PR DESCRIPTION
While working on something entirely different, it ocurred to me that timeouts in `gen_server` have some drawbacks and pitfalls.

When the return of `gen_server:init` or a `handle_*` callback contains a timeout, the next iteration will wait for a message for that time, and if no message arrives, instantly call `handle_info` with the message `timeout` (ie, not _sending_ itself a `timeout` message).

For one, this convolution of `handle_info` for message and timeout handling makes it impossible to distinguish an actual timeout from the message `timeout` having been received. This means that you either have to make sure that, if you are using timeouts, such a message will not be sent to your `gen_server` implementation, or live with possible premature "fake" timeouts.

For another, it is very inconvenient if one wants to enricht the timeout with some supplementary data. This is only possible by putting it somewhere in the state, and must likely be removed from the state again if a message arrives before the timeout occurs.

Another option is to manually maintain timers, which is also inconvenient and requires quite some boilerplate code.

The changes in this PR allow `init` and `handle_*` callbacks to return the tuple `{timeout, Time, TimeoutMessage}`. In case a timeout occurs, `handle_info` will instantly be called with the message `{timeout, TimeoutMessage}`.

There are no tests or documentation yet, I first want to see if there is any interest in this feature at all.