### PR TITLE
kernel: fixes socket.erl type spec

### DIFF
--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -3763,7 +3763,9 @@ an explanation of `TimeoutOrHandle`.
 """.
 
 -spec sendto(Socket :: socket(), Data :: iodata(),
-             Dest :: sockaddr(), Flags :: list()) -> Result when
+             Dest :: sockaddr(), Flags | TimeoutOrHandle) -> Result when
+      TimeoutOrHandle :: dynamic(),
+      Flags :: list(),
       Result :: 'ok'
               | {'ok', RestData :: binary()}
               | {'error', Reason}


### PR DESCRIPTION
The type specs for `socker.erl` were improved in PR-8986, but they introduced a bug by omitting one of the overloaded specs. this commit fixes that.

closes #9180 