### PR TITLE
dialyzer: remove license from expected result

### DIFF
--- a/lib/dialyzer/test/file_utils.erl
+++ b/lib/dialyzer/test/file_utils.erl
@@ -151,5 +151,13 @@ file_to_lines(File, Acc) ->
     case io:get_line(File, "") of
 	{error, _}=Error -> Error;
 	eof              -> Acc;
-	A                -> file_to_lines(File, [A|Acc])
+	A                ->
+            case A of
+                "%% SPDX-License-Identifier:"++_ ->
+                    file_to_lines(File, Acc);
+                "%% SPDX-FileCopyrightText:"++_ ->
+                    file_to_lines(File, Acc);
+                _ ->
+                    file_to_lines(File, [A|Acc])
+            end
     end.

--- a/lib/dialyzer/test/small_SUITE_data/results/abs
+++ b/lib/dialyzer/test/small_SUITE_data/results/abs
@@ -1,3 +1,5 @@
+%% SPDX-License-Identifier: Apache-2.0
+%% SPDX-FileCopyrightText: 2024 Erlang/OTP and its contributors
 
 abs.erl:12:1: Function i1/0 has no local return
 abs.erl:16:5: The pattern 'true' can never match the type 'false'

--- a/lib/dialyzer/test/small_SUITE_data/src/abs.erl
+++ b/lib/dialyzer/test/small_SUITE_data/src/abs.erl
@@ -76,3 +76,6 @@ int() ->
 
 float() ->
     math:sqrt(1.0).
+
+%% SPDX-License-Identifier: Apache-2.0
+%% SPDX-FileCopyrightText: 2024 Erlang/OTP and its contributors


### PR DESCRIPTION
We recently introduced license checking as best practices. New dialyzer tests are checked, and we need to be able to add the license and copyright to the expected results of a dialyzer test.

This commit removes the license and copyright comments in expected result file, so that it is not considered an expectation from the output of the test.

In case of existing programs, such as `abs`, one can add the license and copyright at the end of the test program file, and the license and copyright anywhere in the expected result (although it makes sense that it is the first lines).

This PR blocks #9295 (i.e., PR 9295 cannot be merged until this PR is merged).