### PR TITLE
Deprecate old catches in edoc, eunit, and syntax_tools

### DIFF
--- a/lib/edoc/src/Makefile
+++ b/lib/edoc/src/Makefile
@@ -23,7 +23,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/edoc-$(VSN)
 
 EBIN = ../ebin
 XMERL = ../../xmerl
-ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include +warn_unused_vars +nowarn_shadow_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented
+ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include +warn_unused_vars +nowarn_shadow_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented +warn_deprecated_catch -Werror
 
 include files.mk
 

--- a/lib/edoc/src/edoc_data.erl
+++ b/lib/edoc/src/edoc_data.erl
@@ -31,6 +31,8 @@
 
 -module(edoc_data).
 
+-compile(nowarn_deprecated_catch).
+
 -export([module/4, overview/4, type/3]).
 
 -export([hidden_filter/2, get_all_tags/1, get_entry/2, get_tags/2]).

--- a/lib/edoc/src/edoc_doclet.erl
+++ b/lib/edoc/src/edoc_doclet.erl
@@ -36,6 +36,8 @@
 
 -module(edoc_doclet).
 
+-compile(nowarn_deprecated_catch).
+
 -export([run/2]).
 
 -import(edoc_report, [report/2, warning/2]).

--- a/lib/edoc/src/edoc_extract.erl
+++ b/lib/edoc/src/edoc_extract.erl
@@ -29,6 +29,8 @@
 
 -module(edoc_extract).
 
+-compile(nowarn_deprecated_catch).
+
 -export([source/3, source/4, source/5,
 	 header/3, header/4, header/5,
 	 file/4,

--- a/lib/edoc/src/edoc_html_to_markdown.erl
+++ b/lib/edoc/src/edoc_html_to_markdown.erl
@@ -27,6 +27,8 @@
 
 -include_lib("kernel/include/eep48.hrl").
 
+-compile(nowarn_deprecated_catch).
+
 -export([convert_html/2, convert_xml/2, convert_html/3, convert_xml/3]).
 
 %% @doc

--- a/lib/edoc/src/edoc_layout_chunks.erl
+++ b/lib/edoc/src/edoc_layout_chunks.erl
@@ -40,6 +40,8 @@
 %% @end
 -module(edoc_layout_chunks).
 
+-compile(nowarn_deprecated_catch).
+
 % -behaviour(edoc_layout).
 -export([module/2, overview/2]).
 

--- a/lib/edoc/src/edoc_lib.erl
+++ b/lib/edoc/src/edoc_lib.erl
@@ -29,6 +29,8 @@
 
 -module(edoc_lib).
 
+-compile(nowarn_deprecated_catch).
+
 -export([count/2, lines/1, split_at/2, split_at_stop/1,
 	 split_at_space/1, filename/1, transpose/1, segment/2,
 	 get_first_sentence/1, is_space/1, strip_space/1, parse_expr/2,

--- a/lib/edoc/src/edoc_macros.erl
+++ b/lib/edoc/src/edoc_macros.erl
@@ -30,6 +30,8 @@
 
 -module(edoc_macros).
 
+-compile(nowarn_deprecated_catch).
+
 -export([expand_tags/3, std_macros/1, check_defs/1]).
 
 -include("edoc.hrl").

--- a/lib/edoc/src/edoc_run.erl
+++ b/lib/edoc/src/edoc_run.erl
@@ -45,6 +45,8 @@
 
 -module(edoc_run).
 
+-compile(nowarn_deprecated_catch).
+
 -export([file/1, application/1, files/1, toc/1]).
 
 -compile({no_auto_import,[error/1]}).

--- a/lib/edoc/src/edoc_scanner.erl
+++ b/lib/edoc/src/edoc_scanner.erl
@@ -34,6 +34,8 @@
 %% `tokens' function *always* returns `{more, Continuation}' unless an
 %% error occurs.
 
+-compile(nowarn_deprecated_catch).
+
 -export([string/1,string/2,format_error/1]).
 
 -import(lists, [reverse/1]).

--- a/lib/edoc/src/edoc_tags.erl
+++ b/lib/edoc/src/edoc_tags.erl
@@ -33,6 +33,8 @@
 
 -module(edoc_tags).
 
+-compile(nowarn_deprecated_catch).
+
 -export([tags/0, tags/1, tag_names/0, tag_parsers/0, scan_lines/2,
 	 filter_tags/2, filter_tags/3, check_tags/4, parse_tags/4,
 	 check_types/3]).

--- a/lib/edoc/src/edoc_wiki.erl
+++ b/lib/edoc/src/edoc_wiki.erl
@@ -70,6 +70,8 @@
 
 -module(edoc_wiki).
 
+-compile(nowarn_deprecated_catch).
+
 -export([parse_xml/2, expand_text/2]).
 
 -include("edoc.hrl").

--- a/lib/eunit/src/Makefile
+++ b/lib/eunit/src/Makefile
@@ -25,7 +25,7 @@ EBIN = ../ebin
 INCLUDE=../include
 
 ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ../../stdlib/ebin -I$(INCLUDE) \
-	+nowarn_shadow_vars +warn_unused_import -Werror
+	 +warn_deprecated_catch +nowarn_shadow_vars +warn_unused_import -Werror
 
 PARSE_TRANSFORM = eunit_autoexport.erl
 

--- a/lib/eunit/src/eunit_server.erl
+++ b/lib/eunit/src/eunit_server.erl
@@ -202,7 +202,10 @@ server_command(From, {start, Job}, St) ->
 server_command(From, stop, St) ->
     %% unregister the server name and let remaining jobs finish
     server_command_reply(From, {error, stopped}),
-    catch unregister(St#state.name),
+    try unregister(St#state.name)
+    catch
+        error:badarg -> ok
+    end,
     server(St#state{stopped = true});
 server_command(From, {watch, Target, _Opts}, St) ->
     %% the code watcher is only started on demand

--- a/lib/syntax_tools/src/Makefile
+++ b/lib/syntax_tools/src/Makefile
@@ -26,7 +26,7 @@ INCLUDE=../include
 
 ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ./ -I$(INCLUDE)
 
-ERL_COMPILE_FLAGS += +nowarn_shadow_vars +warn_unused_import #-Werror # +warn_missing_spec +warn_untyped_record
+ERL_COMPILE_FLAGS += +warn_deprecated_catch +nowarn_shadow_vars +warn_unused_import -Werror # +warn_missing_spec +warn_untyped_record
 
 SOURCES=erl_syntax.erl erl_prettypr.erl erl_syntax_lib.erl	\
 	erl_comment_scan.erl erl_recomment.erl epp_dodger.erl	\

--- a/lib/syntax_tools/src/epp_dodger.erl
+++ b/lib/syntax_tools/src/epp_dodger.erl
@@ -69,6 +69,8 @@ preprocessor [`//stdlib/epp`](`m:epp`) before the parser sees them), an extended
 syntax tree is created, using the `m:erl_syntax` module.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([parse_file/1, quick_parse_file/1, parse_file/2,
 	 quick_parse_file/2, parse/1, quick_parse/1, parse/2,
 	 quick_parse/2, parse/3, quick_parse/3, parse_form/2,

--- a/lib/syntax_tools/src/erl_comment_scan.erl
+++ b/lib/syntax_tools/src/erl_comment_scan.erl
@@ -28,6 +28,8 @@
 -module(erl_comment_scan).
 -moduledoc "Functions for reading comment lines from Erlang source code.".
 
+-compile(nowarn_deprecated_catch).
+
 -export([file/1, join_lines/1, scan_lines/1, string/1]).
 
 -export_type([comment/0]).

--- a/lib/syntax_tools/src/erl_prettypr.erl
+++ b/lib/syntax_tools/src/erl_prettypr.erl
@@ -32,6 +32,8 @@ This module is a front end to the pretty-printing library module `prettypr`, for
 text formatting of abstract syntax trees defined by the module `erl_syntax`.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([format/1, format/2, best/1, best/2, layout/1, layout/2,
 	 get_ctxt_precedence/1, set_ctxt_precedence/2,
 	 get_ctxt_paperwidth/1, set_ctxt_paperwidth/2,

--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -60,6 +60,8 @@ list `[]`. This can be relied on when writing functions that operate on syntax
 trees.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([type/1,
 	 is_leaf/1,
 	 is_form/1,

--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -32,6 +32,8 @@ This module contains utility functions for working with the abstract data type
 defined in the module `m:erl_syntax`.
 """.
 
+-compile(nowarn_deprecated_catch).
+
 -export([analyze_application/1, analyze_attribute/1,
          analyze_export_attribute/1, analyze_file_attribute/1,
          analyze_form/1, analyze_forms/1, analyze_function/1,


### PR DESCRIPTION
This deprecates uses of old catch expressions in "my" applications.