### PR TITLE
Fix `timer:sleep/1` spec

### DIFF
--- a/lib/stdlib/src/timer.erl
+++ b/lib/stdlib/src/timer.erl
@@ -539,7 +539,7 @@ Naturally, this function does _not_ return immediately.
 > values are accepted.
 """.
 -spec sleep(Time) -> 'ok'
-              when Time :: timeout().
+              when Time :: time() | 'infinity'.
 sleep(T)
   when is_integer(T),
        T > ?MAX_RECEIVE_AFTER ->


### PR DESCRIPTION
Since `timer:sleep/1` accepts timeouts greater than `16#ffffffff` since OTP 25, `timeout()` in the sense of "what is acceptable by `receive... after` is wrong.