### PR TITLE
Relax invariants checked by erts_add_taint before initialization

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -4375,7 +4375,8 @@ void erts_add_taint(Eterm mod_atom)
 #endif
     struct tainted_module_t *first, *t;
 
-    ERTS_LC_ASSERT(erts_lc_rwmtx_is_rwlocked(&erts_driver_list_lock)
+    ERTS_LC_ASSERT(!erts_initialized
+                   || erts_lc_rwmtx_is_rwlocked(&erts_driver_list_lock)
                    || erts_has_code_mod_permission());
 
     first = (struct tainted_module_t*) erts_atomic_read_nob(&first_taint);


### PR DESCRIPTION
Debug builds configured with static NIFs are currently not usable since they abort during startup.  The abort is caused by a check in erts_add_taint that makes sense once the runtime has started but might not be meaningful before the runtime has been started, notably during static NIF initialization.

This change adds an additional check that allows erts_add_taint to proceed when called during runtime initialization.  With this check, a debug with static NIFs can complete the startup process.

Resolves #9306