### PR TITLE
Michal/mnesia/schema merge on ext backend/otp 19409

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -559,6 +559,10 @@ im_running(OldFriends, NewFriends) ->
     abcast(OldFriends, {im_running, node(), NewFriends}).
 
 schema_is_merged() ->
+    %% We might have merged a schema that contains external backends,
+    %% we must initialize them on current node if not already initialized.
+    mnesia_schema:init_backends(),
+
     MsgTag = schema_is_merged,
     SafeLoads = initial_safe_loads(),
 

--- a/lib/mnesia/src/mnesia_lib.erl
+++ b/lib/mnesia/src/mnesia_lib.erl
@@ -432,6 +432,7 @@ validate_record(Tab, Obj) ->
 %%
 %%   dir                                  -> directory path (**)
 %%   mnesia_status                        -> status | running | stopping (**)
+%%   ext_backends                         -> module list of initialized ext backends (**)
 %%   (**) ==   (Different on all nodes)
 %%
 
@@ -458,6 +459,7 @@ other_val_1(Var) ->
 	{_, where_to_read} -> nowhere;
 	{_, where_to_write} -> [];
 	{_, active_replicas} -> [];
+	ext_backends -> [];
 	_ -> error
     end.
 

--- a/lib/mnesia/test/ext_test.erl
+++ b/lib/mnesia/test/ext_test.erl
@@ -50,6 +50,9 @@
 	 select/1, select/3, select/4, repair_continuation/2
 	]).
 
+%% For testing purposes
+-export([is_backend_initialized/0]).
+
 semantics(ext_ram_copies, storage) -> ram_copies;
 semantics(ext_ram_copies, types  ) -> [set, ordered_set, bag];
 semantics(ext_ram_copies, index_types) -> [ordered];
@@ -74,13 +77,21 @@ init_backend() ->
 backend_init_marker() ->
     {test, ?MODULE, backend_init}.
 
-error_if_not_initialized() ->
+is_backend_initialized() ->
     case try ets:lookup_element(mnesia_gvar, backend_init_marker(), 2) catch _:_ -> error end of
         error ->
-            ?DBG({backend_not_initialized, {?MODULE, error}}),
-            error({backend_not_initialized, {?MODULE, error}});
+            false;
         _Other ->
-            ok
+            true
+    end.
+
+error_if_not_initialized() ->
+    case is_backend_initialized() of
+        true ->
+            ok;
+        false ->
+            ?DBG({backend_not_initialized, {?MODULE, error}}),
+            error({backend_not_initialized, {?MODULE, error}})
     end.
 
 add_aliases(_As) ->


### PR DESCRIPTION
Fixes problems when ram node joins a cluster, and must merge a schema with other node that has registered external backend, and has a table using this backend.

@uwiger, is it possible for you to look at this, you were the one who created this external backend system in mnesia. Thanks.