### PR TITLE
Fix incompatible-pointer-type error in nif_SUITE.c

### DIFF
--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2861,7 +2861,7 @@ static void monitor_resource_down(ErlNifEnv* env, void* obj, ErlNifPid* pid,
      * without lock order violation. */
     {
         ErlNifPid pid;
-        ErlNifPid port;
+        ErlNifPort port;
         enif_whereis_pid(env, atom_null, &pid);
         enif_whereis_port(env, atom_null, &port);
     }


### PR DESCRIPTION
Starting with gcc-14, the emulator tests were failing to run due to gcc reporting an "incompatible pointer type" error in nif_SUITE.c. The fix is straighforward