### PR TITLE
diameter: default port and transport for DiameterURI

### DIFF
--- a/lib/diameter/src/base/diameter_types.erl
+++ b/lib/diameter/src/base/diameter_types.erl
@@ -555,6 +555,8 @@ transport(<<>>, #{rfc := 6733}) ->
     tcp;
 transport(<<>>, #{rfc := 3588}) ->
     sctp;
+transport(<<>>, _) ->
+    tcp;
 transport(B, _) ->
     to_atom(B).
 

--- a/lib/diameter/src/base/diameter_types.erl
+++ b/lib/diameter/src/base/diameter_types.erl
@@ -546,7 +546,7 @@ portnr(<<>>, aaa, #{rfc := 6733}) ->
     3868;
 portnr(<<>>, aaas, #{rfc := 6733}) ->
     5868;
-portnr(<<>>, _, #{rfc := 3588}) ->
+portnr(<<>>, _, _) ->
     3868;
 portnr(B, _, _) ->
     binary_to_integer(B).

--- a/lib/diameter/test/diameter_codec_SUITE.erl
+++ b/lib/diameter/test/diameter_codec_SUITE.erl
@@ -164,7 +164,10 @@ run(gen) ->
                                       lists:prefix("diameter_gen_", ?L(M))
                               end,
                               Ms),
-    lists:foreach(fun diameter_codec_test:gen/1, Gs);
+    lists:foreach(fun(G) ->
+                          diameter_codec_test:gen(G, 6733),
+                          diameter_codec_test:gen(G, unknown)
+                  end, Gs);
 
 run(lib) ->
     diameter_codec_test:lib();

--- a/lib/diameter/test/diameter_codec_test.erl
+++ b/lib/diameter/test/diameter_codec_test.erl
@@ -21,7 +21,7 @@
 -module(diameter_codec_test).
 
 -export([base/0,
-         gen/1,
+         gen/2,
          lib/0]).
 
 %%
@@ -43,17 +43,17 @@
 base() ->
     [] = run([[fun base/1, T] || T <- [zero, decode]]).
 
-gen(Mod) ->
+gen(Mod, Rfc) ->
     Fs = [{Mod, F, []} || Mod /= diameter_gen_doic_rfc7683,
                           F <- [name, id, vendor_id, vendor_name]],
-    [] = run(Fs ++ [[fun gen/2, Mod, T] || T <- [messages,
-                                                 command_codes,
-                                                 avp_types,
-                                                 grouped,
-                                                 enum,
-                                                 import_avps,
-                                                 import_groups,
-                                                 import_enums]]).
+    [] = run(Fs ++ [[fun gen/3, Mod, T, Rfc] || T <- [messages,
+                                                      command_codes,
+                                                      avp_types,
+                                                      grouped,
+                                                      enum,
+                                                      import_avps,
+                                                      import_groups,
+                                                      import_enums]]).
 
 lib() ->
     Vs = {_,_,_} = values('Address'),
@@ -127,8 +127,8 @@ types() ->
 %% Test of generated encode/decode module.
 %% ------------------------------------------------------------------------
 
-gen(M, T) ->
-    [] = run(lists:map(fun(X) -> [fun gen/3, M, T, X] end,
+gen(M, T, Rfc) ->
+    [] = run(lists:map(fun(X) -> [fun gen/4, M, T, X, Rfc] end,
                        fetch(T, dict(M)))).
 
 fetch(T, Spec) ->
@@ -139,11 +139,11 @@ fetch(T, Spec) ->
             []
     end.
 
-gen(M, messages = T, {Name, Code, Flags, ApplId, Avps})
+gen(M, messages = T, {Name, Code, Flags, ApplId, Avps}, Rfc)
   when is_list(Name) ->
-    gen(M, T, {?A(Name), Code, Flags, ApplId, Avps});
+    gen(M, T, {?A(Name), Code, Flags, ApplId, Avps}, Rfc);
 
-gen(M, messages, {Name, Code, Flags, _, _}) ->
+gen(M, messages, {Name, Code, Flags, _, _}, _Rfc) ->
     Rname = M:msg2rec(Name),
     Name = M:rec2msg(Rname),
     {Code, F, _} = M:msg_header(Name),
@@ -157,16 +157,16 @@ gen(M, messages, {Name, Code, Flags, _, _}) ->
            end,
     [] = arity(M, Name, Rname);
 
-gen(M, command_codes, {Code, Req, Ans}) ->
+gen(M, command_codes, {Code, Req, Ans}, _Rfc) ->
     Msgs = orddict:fetch(messages, dict(M)),
     {_, Code, _, _, _} = lists:keyfind(Req, 1, Msgs),
     {_, Code, _, _, _} = lists:keyfind(Ans, 1, Msgs);
 
-gen(M, avp_types = T, {Name, Code, Type, Flags})
+gen(M, avp_types = T, {Name, Code, Type, Flags}, Rfc)
   when is_list(Name) ->
-    gen(M, T, {?A(Name), Code, ?A(Type), Flags});
+    gen(M, T, {?A(Name), Code, ?A(Type), Flags}, Rfc);
 
-gen(M, avp_types, {Name, Code, Type, _Flags}) ->
+gen(M, avp_types, {Name, Code, Type, _Flags}, Rfc) ->
     {Code, Flags, VendorId} = M:avp_header(Name),
     0 = Flags band 2#00011111,
     V = undefined /= VendorId,
@@ -174,57 +174,61 @@ gen(M, avp_types, {Name, Code, Type, _Flags}) ->
     {Name, Type} = M:avp_name(Code, VendorId),
     B = M:empty_value(Name, #{module => M}),
     B = z(B),
-    [] = avp_decode(M, Type, Name);
+    [] = avp_decode(M, Type, Name, Rfc);
 
-gen(M, grouped = T, {Name, Code, Vid, Avps})
+gen(M, grouped = T, {Name, Code, Vid, Avps}, Rfc)
   when is_list(Name) ->
-    gen(M, T, {?A(Name), Code, Vid, Avps});
+    gen(M, T, {?A(Name), Code, Vid, Avps}, Rfc);
 
-gen(M, grouped, {Name, _, _, _}) ->
+gen(M, grouped, {Name, _, _, _}, _Rfc) ->
     Rname = M:name2rec(Name),
     [] = arity(M, Name, Rname);
 
-gen(M, enum = T, {Name, ED})
+gen(M, enum = T, {Name, ED}, Rfc)
   when is_list(Name) ->
-    gen(M, T, {?A(Name), lists:map(fun({E,D}) -> {?A(E), D} end, ED)});
+    gen(M, T, {?A(Name), lists:map(fun({E,D}) -> {?A(E), D} end, ED)}, Rfc);
 
-gen(M, enum, {Name, ED}) ->
-    [] = run([[fun enum/3, M, Name, T] || T <- ED]);
+gen(M, enum, {Name, ED}, Rfc) ->
+    [] = run([[fun enum/4, M, Name, T, Rfc] || T <- ED]);
 
-gen(M, Tag, {_Mod, L}) ->
+gen(M, Tag, {_Mod, L}, Rfc) ->
     T = retag(Tag),
-    [] = run([[fun gen/3, M, T, I] || I <- L]).
+    [] = run([[fun gen/4, M, T, I, Rfc] || I <- L]).
 
 %% avp_decode/3
 
-avp_decode(Mod, Type, Name) ->
+avp_decode(Mod, Type, Name, Rfc) ->
     {Ts, Fs, _} = values(Type, Name, Mod),
-    [] = run([[fun avp_decode/5, Mod, Name, Type, true, V]
+    [] = run([[fun avp_decode/6, Mod, Name, Type, true, V, Rfc]
               || V <- v(Ts)]),
-    [] = run([[fun avp_decode/5, Mod, Name, Type, false, V]
+    [] = run([[fun avp_decode/6, Mod, Name, Type, false, V, Rfc]
               || V <- v(Fs)]).
 
-avp_decode(Mod, Name, Type, Eq, Value) ->
-    d(fun(X,V) -> avp(Mod, X, V, Name, Type) end, Eq, Value).
+avp_decode(Mod, Name, Type, Eq, Value, Rfc) ->
+    d(fun(X,V) -> avp(Mod, X, V, Name, Type, Rfc) end, Eq, Value).
 
-avp(Mod, decode = X, V, Name, 'Grouped') ->
-    {Rec, _} = Mod:avp(X, V, Name, opts(Mod)),
+avp(Mod, decode = X, V, Name, 'Grouped', Rfc) ->
+    {Rec, _} = Mod:avp(X, V, Name, opts(Mod, Rfc)),
     Rec;
-avp(Mod, decode = X, V, Name, _) ->
-    Mod:avp(X, V, Name, opts(Mod));
-avp(Mod, encode = X, V, Name, _) ->
-    iolist_to_binary(Mod:avp(X, V, Name, opts(Mod))).
-
-opts(Mod) ->
-    (opts())#{module => Mod,
-              app_dictionary => Mod}.
+avp(Mod, decode = X, V, Name, _, Rfc) ->
+    Mod:avp(X, V, Name, opts(Mod, Rfc));
+avp(Mod, encode = X, V, Name, _, Rfc) ->
+    iolist_to_binary(Mod:avp(X, V, Name, opts(Mod, Rfc))).
 
 opts() ->
+    opts(6733).
+
+opts(Mod, Rfc) ->
+    (opts(Rfc))#{module => Mod,
+                 app_dictionary => Mod}.
+
+opts(unknown) ->
     #{decode_format => record,
       string_decode => true,
       strict_mbit => true,
-      rfc => 6733,
-      failed_avp => false}.
+      failed_avp => false};
+opts(Rfc) ->
+    maps:put(rfc, Rfc, opts(unknown)).
 
 %% v/1
 
@@ -269,10 +273,10 @@ arity(M, Name, AvpName, Rec) ->
 
 %% enum/3
 
-enum(M, Name, {_,E}) ->
+enum(M, Name, {_,E}, Rfc) ->
     B = <<E:32>>,
-    B = M:avp(encode, E, Name, opts(M)),
-    E = M:avp(decode, B, Name, opts(M)).
+    B = M:avp(encode, E, Name, opts(M, Rfc)),
+    E = M:avp(decode, B, Name, opts(M, Rfc)).
 
 retag(import_avps)   -> avp_types;
 retag(import_groups) -> grouped;


### PR DESCRIPTION
This PR consists of two commits;

* [diameter: DiameterURI port defaults to 3868](https://github.com/erlang/otp/pull/9321/commits/50661d8bfe71cccddccfd466d4443a685b5a82e1)

This fixes the crash when decoding a DiameterURI without a port number. The crash always happens if an Diameter answer with an AVP of type DiameterURI without port number is decoded, since the `rfc` option cannot be specified when handling an answer.

* [diameter: DiameterURI transport defaults to tcp](https://github.com/erlang/otp/pull/9321/commits/d69f9353c7a28b78a465ee62e3417e5c0b007d6a)

When `rfc` is missing in the option, the transport part of the `diameter_uri` becomes an empty atom (''), which causes the diameter module to fail to re-encode the decoded AVP (because it won't match `diameter_types:'DiameterURI'/3` properly).

This sets `tcp` as the default transport as described in RFC6733 instead of leaving it empty.

## Some notes/thoughts;
* The first clause (`portnr(<<>>, aaa, #{rfc := 6733})`, `transport(<<>>, #{rfc := 6733})`) can be removed if it's preferable.
* This can be tested by removing `rfc => 6733` from `diameter_codec_test:opts`. I have no idea how to add a case for this.
* Perhaps adding `rfc => 6733` in the decode option by default is another way to solve this, but it may require wider consideration.

Please advise :slightly_smiling_face:

## Debug log w/ redbug:

```
% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:'DiameterURI'(decode, <<"aaa://ims.foo.com">>, #{app_dictionary => dia_3gpp_Cx,decode_format => map,failed_avp => false,
  incoming_maxlen => 16777215,module => dia_3gpp,
  restrict_connections => nodes,
  sequence => {0,28},
  share_peers => false,spawn_opt => [],strict_arities => false,
  strict_mbit => true,string_decode => false,traffic_counters => true,
  use_shared_peers => false})

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:scan_uri(<<"aaa://ims.foo.com">>, #{app_dictionary => dia_3gpp_Cx,decode_format => map,failed_avp => false,
  incoming_maxlen => 16777215,module => dia_3gpp,
  restrict_connections => nodes,
  sequence => {0,28},
  share_peers => false,spawn_opt => [],strict_arities => false,
  strict_mbit => true,string_decode => false,traffic_counters => true,
  use_shared_peers => false})

% 13:46:05.976 <0.32401.513>(dead)
% re:run(<<"aaa://ims.foo.com">>, "^(aaas?)://([-a-zA-Z0-9.]{1,255})(:0{0,5}([0-9]{1,5}))?(;transport=(tcp|sctp|udp))?(;protocol=(diameter|radius|tacacs\\+))?$", [{capture,[1,2,4,6,8],binary}])

% 13:46:05.976 <0.32401.513>(dead)
% re:run/3 -> {match,[<<"aaa">>,<<"ims.foo.com">>,<<>>,<<>>,<<>>]}

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:to_atom(<<"aaa">>)

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:to_atom/1 -> aaa

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:portnr(<<>>, aaa, #{app_dictionary => dia_3gpp_Cx,decode_format => map,failed_avp => false,
  incoming_maxlen => 16777215,module => dia_3gpp,
  restrict_connections => nodes,
  sequence => {0,28},
  share_peers => false,spawn_opt => [],strict_arities => false,
  strict_mbit => true,string_decode => false,traffic_counters => true,
  use_shared_peers => false})

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:portnr/3 -> {error,badarg}

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:scan_uri/2 -> {error,badarg}

% 13:46:05.976 <0.32401.513>(dead)
% diameter_types:'DiameterURI'/3 -> {error,badarg}
```
