### PR TITLE
ssl: Postpone verifying of server options when {handshake, hello} is used

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -2414,7 +2414,7 @@ owning the [`sslsocket()`](`t:sslsocket/0`) will receive messages of type
           {error, Reason} when
       Socket :: socket() | sslsocket(),
       SslSocket :: sslsocket(),
-      Options :: [server_option()],
+      Options :: [server_option() | common_option()],
       Timeout :: timeout(),
       Ext :: protocol_extensions(),
       Reason :: closed | timeout | {options, any()} | error_alert().
@@ -2468,7 +2468,7 @@ handshake(Socket, SslOptions, Timeout)
 -spec handshake_continue(HsSocket, Options) ->
           {ok, SslSocket} | {error, Reason} when
       HsSocket :: sslsocket(),
-      Options :: [tls_client_option() | tls_server_option()],
+      Options :: [client_option() | server_option() | common_option()],
       SslSocket :: sslsocket(),
       Reason :: closed | timeout | error_alert().
 %%--------------------------------------------------------------------
@@ -2482,7 +2482,7 @@ handshake_continue(Socket, SSLOptions) ->
 -spec handshake_continue(HsSocket, Options, Timeout) ->
           {ok, SslSocket} | {error, Reason} when
       HsSocket :: sslsocket(),
-      Options :: [tls_client_option() | tls_server_option()],
+      Options :: [client_option() | server_option() | common_option()],
       Timeout :: timeout(),
       SslSocket :: sslsocket(),
       Reason :: closed | timeout | error_alert().

--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -4873,6 +4873,10 @@ validate_filename(FN, Option) ->
 
 validate_server_cert_opts(_Opts, #{validate_certs_or_anon_ciphers := false}) ->
     ok;
+validate_server_cert_opts(#{handshake := hello}, _) ->
+    %% This verification should be done only when handshake := full, as options
+    %% to fulfill the requirement can be supplied at that time.
+    ok;
 validate_server_cert_opts(#{certs_keys := [_|_]=CertsKeys, ciphers := CPHS, versions := Versions}, _) ->
     validate_certs_or_anon_ciphers(CertsKeys, CPHS, Versions);
 validate_server_cert_opts(#{ciphers := CPHS, versions := Versions}, _) ->

--- a/lib/ssl/src/tls_server_connection_1_3.erl
+++ b/lib/ssl/src/tls_server_connection_1_3.erl
@@ -212,7 +212,7 @@ start(internal = Type, #change_cipher_spec{} = Msg, State) ->
 start(internal, #client_hello{extensions = #{client_hello_versions :=
                                                  #client_hello_versions{versions = ClientVersions}
                                             }} = Hello,
-      #state{ssl_options = #{handshake := full}} = State) ->
+      #state{handshake_env = #handshake_env{continue_status = full}} = State) ->
     case tls_record:is_acceptable_version(?TLS_1_3, ClientVersions) of
         true ->
             handle_client_hello(Hello, State);


### PR DESCRIPTION
Also correct handshake environment handling so that {hanshake, hello} can be used in ssl:handshake as well as in ssl:listen

closes #9177