### PR TITLE
stdlib: Add warning for inlined nifs without loading

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -4600,19 +4600,20 @@ check_remote_function(Anno, M, F, As, St0) ->
 %%  been enabled.
 check_load_nif(Anno, erlang, load_nif, [_, _], St0) ->
     St = St0#lint{load_nif = true},
-    case is_warn_enabled(nif_inline, St) of
-        true -> check_nif_inline(Anno, St);
-        false -> St
-    end;
+    check_nif_inline(Anno, St);
+check_load_nif(Anno, erlang, nif_error, _, St) ->
+    check_nif_inline(Anno, St);
 check_load_nif(_Anno, _ModName, _FuncName, _Args, St) ->
     St.
 
 check_nif_inline(Anno, St) ->
-    case any(fun is_inline_opt/1, St#lint.compile) of
+    case is_warn_enabled(nif_inline, St) andalso
+        any(fun is_inline_opt/1, St#lint.compile) of
         true -> add_warning(Anno, nif_inline, St);
         false -> St
     end.
 
+is_inline_opt({inline, {_F,_A}}) -> true;
 is_inline_opt({inline, [_|_]=_FAs}) -> true;
 is_inline_opt(inline) -> true;
 is_inline_opt(_) -> false.

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -4950,7 +4950,32 @@ inline_nifs(Config) ->
               gurka() -> ok.
              ">>,
            [],
-           {warnings,[{{2,22},erl_lint,nif_inline}]}}],
+           {warnings,[{{2,22},erl_lint,nif_inline}]}},
+           {explicit_inline_unloaded_1,
+           <<"-compile({inline, [bar/0]}).
+              -nifs([bar/0]).
+              bar() -> erlang:nif_error(error).
+             ">>,
+           [],
+           {warnings,[{{2,16},erl_lint,no_load_nif},
+                      {{3,24},erl_lint,nif_inline}]}},
+           {explicit_inline_unloaded_2,
+           <<"-compile({inline, bar/0}).
+              -nifs([bar/0]).
+              bar() -> erlang:nif_error(error).
+             ">>,
+           [],
+           {warnings,[{{2,16},erl_lint,no_load_nif},
+                      {{3,24},erl_lint,nif_inline}]}},
+           {implicit_inline_unloaded,
+           <<"-compile(inline).
+              -nifs([bar/0]).
+              bar() -> erlang:nif_error(error).
+              gurka() -> ok.
+             ">>,
+           [],
+           {warnings,[{{2,16},erl_lint,no_load_nif},
+                      {{3,24},erl_lint,nif_inline}]}}],
     [] = run(Config, Ts).
 
 undefined_nifs(Config) when is_list(Config) ->


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/9227. 2 issues with the previous code: One is that if only 1 NIF is inlined, the linter did not omit warnings no matter if it is loaded. The other is the missing `nif_inline` warning for NIFs that were not loaded.