### PR TITLE
gh: Remove erts-{vsn}/bin/erl.ini before creating otp*.zip

### DIFF
--- a/.github/workflows/upload-windows-zip.yaml
+++ b/.github/workflows/upload-windows-zip.yaml
@@ -72,6 +72,7 @@ jobs:
 
           cd ${{ env.basename }}
           rm bin\erl.ini
+          rm erts-*\erl.ini
           rm Install.exe
           rm Install.ini
           rm Uninstall.exe


### PR DESCRIPTION
Per https://github.com/erlang/otp/pull/8729#issuecomment-2298725210, erl.ini needs to be removed. However, there's another one, `erts-{vsn}\bin\erl.ini`:

```
$ curl -fsSLO https://github.com/erlang/otp/releases/download/OTP-27.2/otp_win64_27.2.zip
$ unzip -l otp_win64_27.2.zip | grep "erl.ini"
      117  12-11-2024 12:09   erts-15.2/bin/erl.ini
     3184  12-10-2024 21:23   lib/erts-15.2/ebin/erl_init.beam
     2028  12-10-2024 21:23   lib/erts-15.2/src/erl_init.erl
```

Calling `erts-{vsn}\bin\erl.exe` will fail while the file is there and succeed otherwise:

```
PS C:\Users\wojtek> C:\Users\wojtek\.elixir-install\installs\otp\27.1.2\erts-15.1.2\bin\erl.exe
Could not load module D:\a\otp\otp\otp_win64_27.1.2\erts-15.1.2\bin\erlexec.dll.
PS C:\Users\wojtek> rm C:\Users\wojtek\.elixir-install\installs\otp\27.1.2\erts-15.1.2\bin\erl.ini
PS C:\Users\wojtek> C:\Users\wojtek\.elixir-install\installs\otp\27.1.2\erts-15.1.2\bin\erl.exe
Erlang/OTP 27 [erts-15.1.2] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]

Eshell V15.1.2 (press Ctrl+G to abort, type help(). for help)
1>
```

One, admittedly niche but it sometimes comes up in tooling, stripped down example of this is:

```
PS C:\Users\wojtek> erl
1> os:cmd("erl -noshell -eval \"erlang:display(hi),halt().\"").
"Could not load module D:\\a\\otp\\otp\\otp_win64_27.1.2\\erts-15.1.2\\bin\\erlexec.dll.\r\n"
```

and the reason is when erl starts, it prepends `erts-{vsn}\bin` to `PATH`, so _that_ erl.exe will be used.

I don't know if we can/should change existing .zip files but hopefully this is fixed going forward.

cc @garazdawi 