### PR TITLE
Add .elp.toml file

### DIFF
--- a/.elp.toml
+++ b/.elp.toml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 Ericsson and the Erlang/OTP contributors
+
+[build_info]
+apps = [
+    "lib/*",
+    {"name" = "erts", "dir" = "erts/preloaded", "src_dirs" = ["src"]},
+    {"name" = "wx", "dir" = "lib/wx", "src_dirs" = ["src", "gen"]},
+    {"name" = "inets", "dir" = "lib/inets", "src_dirs" = ["src/http_client", "src/http_server", "src/http_lib", "src/inets_app"]},
+    {"name" = "common_test", "dir" = "lib/common_test", "src_dirs" = ["src", "test_server"]},
+    # Due to some Erlang/OTP bootstrapping issues, `stdlib` modules such as `gen_server` includes headers from the kernel application
+    # using a simple `-include` directive, causing ELP to fail resolving those inclusions.
+    # Include kernel as an `include_dir` for `stdlib` to solve the issue
+    {"name" = "stdlib", "dir" = "lib/stdlib", "include_dirs" = ["include", "../kernel/include"]},
+    ]
+deps = []


### PR DESCRIPTION
The `.elp.toml` file, documented [here](https://whatsapp.github.io/erlang-language-platform/docs/get-started/configure-project/elp-toml/), allows the [ELP language server](https://whatsapp.github.io/erlang-language-platform/) to correctly discover the project. This is equivalent to the [`erlang_ls.config`](https://github.com/erlang/otp/blob/master/erlang_ls.config) file which is already present (for the [Erlang LS language server](https://erlang-ls.github.io/)).
