### PR TITLE
erts: Remove erl.ini from Windows release

### DIFF
--- a/erts/etc/win32/Install.c
+++ b/erts/etc/win32/Install.c
@@ -231,30 +231,6 @@ int wmain(int argc, wchar_t **argv)
 	exit(1);
     }
 
-    /* OBS!!! If the format of the init file is changed, do not forget
-       to update release_handler:write_ini_file(...) */
-    ini_file = create_init_file();
-    ini_section = create_init_section("erlang");
-    add_init_section(ini_file,ini_section);
-    WideCharToMultiByte(CP_UTF8,0,erts_dir,-1,tmp_utf8,MAX_PATH*4,NULL,NULL);
-    add_init_entry(ini_section,"Bindir",tmp_utf8);
-    add_init_entry(ini_section,"Progname","erl");
-    WideCharToMultiByte(CP_UTF8,0,root,-1,tmp_utf8,MAX_PATH*4,NULL,NULL);
-    add_init_entry(ini_section,"Rootdir",tmp_utf8);
-    swprintf(fromname,MAX_PATH,L"%s\\erl.ini",erts_dir);
-    swprintf(toname,MAX_PATH,L"%s\\erl.ini",bin_dir);
-    if (store_init_file(ini_file,fromname) != 0) {
-	fprintf(stderr,"Could not create file %S\n",
-		fromname);
-	fprintf(stderr,"Cannot continue installation, bailing out.\n");
-	exit(1);
-    }
-    if (!CopyFileW(fromname,toname,FALSE)) {
-	fprintf(stderr,"Could not copy file %S to %S\n",
-		 fromname,toname);
-	fprintf(stderr,"Cannot continue installation, bailing out.\n");
-	exit(1);
-    }
     if (!silent) {
 	printf("Erlang %s installed successfully\n", erts_version);
     }

--- a/lib/sasl/test/systools_SUITE.erl
+++ b/lib/sasl/test/systools_SUITE.erl
@@ -1138,7 +1138,7 @@ erts_tar(Config) ->
                            "typer.exe",
                            "yielding_c_fun.exe"],
                 PdbIgnored = [filename:rootname(F) ++ ".pdb" || F <- IgnoredFiles],
-                {["erl.ini"] ++ Files ++ PdbFiles, IgnoredFiles ++ PdbIgnored}
+                {Files ++ PdbFiles, IgnoredFiles ++ PdbIgnored}
         end,
 
     ErtsTarContent =


### PR DESCRIPTION
The erl.ini file is no longer needed as Windows can figure out everything it needs by using the C API.

We keep support for it as they are convinient when running erlang in the source/bootstrap tree.

/cc @wojtekmach 