### PR TITLE
Add support for debug information for a native debugger

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -111,6 +111,7 @@ atom asynchronous
 atom atom
 atom atom_used
 atom attributes
+atom auto
 atom auto_connect
 atom await_exit
 atom await_microstate_accounting_modifications
@@ -217,6 +218,7 @@ atom debug_flags
 atom decentralized_counters
 atom decimals
 atom default
+atom debug_hash_fixed_number_of_locks
 atom delay_trap
 atom demonitor
 atom deterministic
@@ -260,6 +262,7 @@ atom emulator
 atom enable_trace
 atom enabled
 atom endian
+atom entry
 atom env
 atom ensure_at_least ensure_exactly
 atom eof
@@ -486,6 +489,7 @@ atom new_processes
 atom new_ports
 atom new_uniq
 atom newline
+atom nifs
 atom no
 atom nomatch
 atom none
@@ -768,10 +772,9 @@ atom warning
 atom warning_msg
 atom wordsize
 atom write_concurrency
+atom x
 atom xor
 atom x86
+atom y
 atom yes
 atom yield
-atom nifs
-atom auto
-atom debug_hash_fixed_number_of_locks

--- a/erts/emulator/beam/beam_code.h
+++ b/erts/emulator/beam/beam_code.h
@@ -48,6 +48,7 @@
 #define MD5_SIZE MD5_DIGEST_LENGTH
 
 typedef struct BeamCodeLineTab_ BeamCodeLineTab;
+typedef struct BeamDebugTab_ BeamDebugTab;
 
 /*
  * Header of code chunks which contains additional information
@@ -99,6 +100,11 @@ typedef struct beam_code_header {
     Uint32 *loc_index_to_cover_id;
     Uint line_coverage_len;
 
+    /*
+     * Debug information. debug->items are indexed directly by
+     * the index in each `debug_line` instruction.
+     */
+    const BeamDebugTab *debug;
 #endif
 
     /*
@@ -135,6 +141,21 @@ struct BeamCodeLineTab_ {
         Uint32* p4;
     } loc_tab;
     const void** func_tab[1];
+};
+
+/*
+ * Layout of the debug information.
+ */
+typedef struct {
+    Uint32 location_index;
+    Sint16 frame_size;
+    Uint16 num_vars;
+    Eterm *first;
+} BeamDebugItem;
+
+struct BeamDebugTab_ {
+    Uint32 item_count;
+    BeamDebugItem *items;
 };
 
 /* Total code size in bytes */

--- a/erts/emulator/beam/beam_file.h
+++ b/erts/emulator/beam/beam_file.h
@@ -150,6 +150,24 @@ typedef struct {
     BeamType *entries;
 } BeamFile_TypeTable;
 
+#define BEAMFILE_FRAMESIZE_ENTRY (-2)
+#define BEAMFILE_FRAMESIZE_NONE (-1)
+
+typedef struct {
+    Uint32 location_index;
+    Sint32 frame_size;
+    Sint32 num_vars;
+    Eterm *first;
+} BeamFile_DebugItem;
+
+typedef struct {
+    Sint32 item_count;
+    Sint32 term_count;
+    BeamFile_DebugItem *items;
+    Eterm *terms;
+    byte *is_literal;
+} BeamFile_DebugTable;
+
 typedef struct {
     IFF_File iff;
 
@@ -166,6 +184,7 @@ typedef struct {
     BeamFile_LambdaTable lambdas;
     BeamFile_LineTable lines;
     BeamFile_TypeTable types;
+    BeamFile_DebugTable debug;
 
     /* Static literals are those defined in the file, and dynamic literals are
      * those created when loading. The former is positively indexed starting
@@ -206,7 +225,8 @@ enum beamfile_read_result {
     BEAMFILE_READ_CORRUPT_LAMBDA_TABLE,
     BEAMFILE_READ_CORRUPT_LINE_TABLE,
     BEAMFILE_READ_CORRUPT_LITERAL_TABLE,
-    BEAMFILE_READ_CORRUPT_TYPE_TABLE
+    BEAMFILE_READ_CORRUPT_TYPE_TABLE,
+    BEAMFILE_READ_CORRUPT_DEBUG_TABLE
 };
 
 typedef struct {

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -170,6 +170,8 @@ erts_prepare_loading(Binary* magic, Process *c_p, Eterm group_leader,
         BeamLoadError0(stp, "corrupt locals table");
     case BEAMFILE_READ_CORRUPT_TYPE_TABLE:
         BeamLoadError0(stp, "corrupt type table");
+    case BEAMFILE_READ_CORRUPT_DEBUG_TABLE:
+        BeamLoadError0(stp, "corrupt BEAM debug information table");
     case BEAMFILE_READ_SUCCESS:
         break;
     }

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -803,8 +803,10 @@ bif erts_trace_cleaner:check/0
 bif erts_trace_cleaner:send_trace_clean_signal/1
 
 #
-# New in 28
+# New in 28.
 #
 bif erts_internal:system_monitor/1
 bif erts_internal:system_monitor/3
 bif erts_internal:processes_next/1
+bif code:get_debug_info/1
+

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -97,6 +97,8 @@ line I
 
 executable_line _Id _Line => _
 
+debug_line u u u => _
+
 # For the JIT, the init_yregs/1 instruction allows generation of better code.
 # For the BEAM interpreter, though, it will probably be more efficient to
 # translate all uses of init_yregs/1 back to the instructions that the compiler

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -181,7 +181,7 @@ void BeamModuleAssembler::emit_validate(const ArgWord &Arity) {
 #    ifdef JIT_HARD_DEBUG
     emit_enter_runtime_frame();
 
-    for (unsigned i = 0; i < arity.get(); i++) {
+    for (unsigned i = 0; i < Arity.get(); i++) {
         mov_arg(ARG1, ArgVal(ArgVal::XReg, i));
 
         emit_enter_runtime();
@@ -3185,4 +3185,10 @@ void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
     } else {
         ASSERT(0);
     }
+}
+
+void BeamModuleAssembler::emit_debug_line(const ArgWord &Loc,
+                                          const ArgWord &Index,
+                                          const ArgWord &Live) {
+    emit_validate(Live);
 }

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -91,7 +91,7 @@ line I
 
 executable_line I I
 
-debug_line u u u => _
+debug_line I I t
 
 allocate t t
 allocate_heap t I t

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -91,6 +91,8 @@ line I
 
 executable_line I I
 
+debug_line u u u => _
+
 allocate t t
 allocate_heap t I t
 

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -706,6 +706,20 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
         }
         break;
     }
+    case op_debug_line_IIt: {
+        BeamFile_DebugItem *items = stp->beam.debug.items;
+        Uint location_index = tmp_op->a[0].val;
+        Sint index = tmp_op->a[1].val - 1;
+
+        if (add_line_entry(stp, location_index, 1)) {
+            goto load_error;
+        }
+
+        ASSERT(items[index].location_index == -1);
+        items[index].location_index = stp->current_li - 1;
+
+        break;
+    }
     case op_int_code_end:
         /* End of code found. */
         if (stp->function_number != stp->beam.code.function_count) {
@@ -859,6 +873,58 @@ static const BeamCodeLineTab *finish_line_table(LoaderState *stp,
     return line_tab_ro;
 }
 
+static const BeamDebugTab *finish_debug_table(LoaderState *stp,
+                                              char *module_base,
+                                              size_t module_size) {
+    BeamFile_DebugTable *debug = &stp->beam.debug;
+    const BeamDebugTab *debug_tab_ro;
+    byte *debug_tab_rw_base;
+    BeamDebugTab *debug_tab_top;
+    Eterm *debug_tab_terms;
+    BeamDebugItem *debug_tab_items;
+    Uint item_count = debug->item_count;
+    Uint term_count = debug->term_count;
+    Uint i;
+
+    if (item_count == 0) {
+        return NULL;
+    }
+
+    debug_tab_ro = (const BeamDebugTab *)beamasm_get_rodata(stp->ba, "debug");
+    debug_tab_rw_base = get_writable_ptr(stp->executable_region,
+                                         stp->writable_region,
+                                         debug_tab_ro);
+    debug_tab_top = (BeamDebugTab *)debug_tab_rw_base;
+    debug_tab_terms = (Eterm *)&debug_tab_top[1];
+    debug_tab_items = (BeamDebugItem *)&debug_tab_terms[term_count];
+
+    debug_tab_top->item_count = debug->item_count;
+    debug_tab_top->items = debug_tab_items;
+
+    for (i = 0; i < term_count; i++) {
+        if (debug->is_literal[i]) {
+            ASSERT(debug->is_literal[i] == 1);
+            debug_tab_terms[i] =
+                    beamfile_get_literal(&stp->beam, debug->terms[i]);
+        } else {
+            ASSERT(debug->is_literal[i] == 0);
+            debug_tab_terms[i] = debug->terms[i];
+        }
+    }
+
+    for (i = 0; i < item_count; i++) {
+        Uint num_vars = debug->items[i].num_vars;
+
+        debug_tab_items[i].location_index = debug->items[i].location_index;
+        debug_tab_items[i].frame_size = debug->items[i].frame_size;
+        debug_tab_items[i].num_vars = num_vars;
+        debug_tab_items[i].first = debug_tab_terms;
+        debug_tab_terms += 2 * num_vars;
+    }
+
+    return debug_tab_ro;
+}
+
 int beam_load_finish_emit(LoaderState *stp) {
     const BeamCodeHeader *code_hdr_ro = NULL;
     BeamCodeHeader *code_hdr_rw = NULL;
@@ -886,6 +952,17 @@ int beam_load_finish_emit(LoaderState *stp) {
         line_size += (stp->current_li + 1) * stp->beam.lines.location_size;
 
         beamasm_embed_bss(stp->ba, "line", line_size);
+    }
+
+    /* Calculate size of the load BEAM debug information. */
+    if (stp->beam.debug.item_count > 0) {
+        BeamFile_DebugTable *debug = &stp->beam.debug;
+        Uint debug_size;
+
+        debug_size = sizeof(BeamDebugTab);
+        debug_size += (Uint)debug->item_count * sizeof(BeamFile_DebugItem);
+        debug_size += (Uint)debug->term_count * sizeof(Eterm);
+        beamasm_embed_bss(stp->ba, "debug", debug_size);
     }
 
     /* Place the string table and, optionally, attributes here. */
@@ -977,6 +1054,10 @@ int beam_load_finish_emit(LoaderState *stp) {
     /* Line information must be added after moving literals, since source file
      * names are literal lists. */
     code_hdr_rw->line_table = finish_line_table(stp, module_base, module_size);
+
+    /* Debug information must be added after moving literals, since literals
+     * are used extensively. */
+    code_hdr_rw->debug = finish_debug_table(stp, module_base, module_size);
 
     if (stp->beam.attributes.size) {
         const byte *attr = beamasm_get_rodata(stp->ba, "attr");

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -3334,3 +3334,9 @@ void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
         ASSERT(0);
     }
 }
+
+void BeamModuleAssembler::emit_debug_line(const ArgWord &Loc,
+                                          const ArgWord &Index,
+                                          const ArgWord &Live) {
+    emit_validate(Live);
+}

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -91,7 +91,7 @@ line I
 
 executable_line I I
 
-debug_line u u u => _
+debug_line I I t
 
 allocate t t
 allocate_heap t I t

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -91,6 +91,8 @@ line I
 
 executable_line I I
 
+debug_line u u u => _
+
 allocate t t
 allocate_heap t I t
 

--- a/lib/compiler/src/beam_dict.erl
+++ b/lib/compiler/src/beam_dict.erl
@@ -23,11 +23,12 @@
 -moduledoc false.
 
 -export([new/0,opcode/2,highest_opcode/1,
-	 atom/2,local/4,export/4,import/4,
-	 string/2,lambda/3,literal/2,line/3,fname/2,type/2,
-	 atom_table/1,local_table/1,export_table/1,import_table/1,
-	 string_table/1,lambda_table/1,literal_table/1,
-	 line_table/1,type_table/1]).
+         atom/2,local/4,export/4,import/4,
+         string/2,lambda/3,literal/2,line/3,
+         fname/2,type/2,debug_info/3,
+         atom_table/1,local_table/1,export_table/1,import_table/1,
+         string_table/1,lambda_table/1,literal_table/1,
+         line_table/1,type_table/1,debug_table/1]).
 
 -include("beam_types.hrl").
 
@@ -35,13 +36,16 @@
 
 -type index() :: non_neg_integer().
 
+-type frame_size() :: 'none' | non_neg_integer().
+-type debug_info() :: {frame_size(), list()}.
+
 -type atom_tab()   :: #{atom() => index()}.
 -type import_tab() :: gb_trees:tree(mfa(), index()).
 -type fname_tab()  :: #{Name :: term() => index()}.
 -type line_tab()   :: #{{Fname :: index(), Line :: term()} => index()}.
 -type literal_tab() :: #{Literal :: term() => index()}.
--type type_tab() :: #{ Type :: binary() => index()}.
-
+-type type_tab()   :: #{Type :: binary() => index()}.
+-type debug_tab() :: #{index() => debug_info()}.
 -type lambda_info() :: {label(),{index(),label(),non_neg_integer()}}.
 -type lambda_tab() :: {non_neg_integer(),[lambda_info()]}.
 -type wrapper() :: #{label() => index()}.
@@ -58,6 +62,7 @@
          literals = #{}	            :: literal_tab(),
          fnames = #{}               :: fname_tab(),
          lines = #{}                :: line_tab(),
+         debug = #{}                :: debug_tab(),
          num_lines = 0              :: non_neg_integer(), %Number of line instructions
          exec_line = false          :: boolean(),
          next_import = 0            :: non_neg_integer(),
@@ -203,7 +208,7 @@ literal1(Key, #asm{literals=Tab0,next_literal=NextIndex}=Dict) ->
 
 %% Returns the index for a line instruction (adding information
 %% to the location information table).
--spec line(list(), bdict(), 'line' | 'executable_line') ->
+-spec line(list(), bdict(), 'line' | 'executable_line' | 'debug_line') ->
           {non_neg_integer(), bdict()}.
 
 line([], #asm{num_lines=N}=Dict, Instr) when is_atom(Instr) ->
@@ -250,6 +255,14 @@ type(Type, #asm{types=Types0}=Dict) ->
             Types = Types0#{ ExtType => Index },
             {Index, Dict#asm{types=Types}}
     end.
+
+-spec debug_info(index(), debug_info(), bdict()) -> bdict().
+
+debug_info(Index, DebugInfo, #asm{debug=DebugTab0}=Dict)
+  when is_integer(Index) ->
+    false = is_map_key(Index, DebugTab0),       %Assertion.
+    DebugTab = DebugTab0#{Index => DebugInfo},
+    Dict#asm{debug=DebugTab}.
 
 %% Returns the atom table.
 %%    atom_table(Dict, Encoding) -> {LastIndex,[Length,AtomString...]}
@@ -357,6 +370,12 @@ line_table(#asm{fnames=Fnames0,lines=Lines0,
     Lines1 = lists:keysort(2, maps:to_list(Lines0)),
     Lines = [L || {L,_} <:- Lines1],
     {NumLineInstrs,NumFnames,Fnames,NumLines,Lines,ExecLine}.
+
+
+-spec debug_table(bdict()) -> debug_tab().
+
+debug_table(#asm{debug=Debug}) ->
+    Debug.
 
 %% Search for binary string Str in the binary string pool Pool.
 %%    old_string(Str, Pool) -> none | Index

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1300,6 +1300,13 @@ resolve_inst({executable_line,[Location,Index]},_,_,_) ->
     {executable_line,resolve_arg(Location),resolve_arg(Index)};
 
 %%
+%% OTP 28.
+%%
+
+resolve_inst({debug_line,[Location,Index,Live]},_,_,_) ->
+    {debug_line,resolve_arg(Location),resolve_arg(Index),resolve_arg(Live)};
+
+%%
 %% Catches instructions that are not yet handled.
 %%
 resolve_inst(X,_,_,_) -> ?exit({resolve_inst,X}).

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -65,6 +65,7 @@ norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],{line,_}=Line}) -> Line;
 norm({set,[],[],{executable_line,_,_}=Line}) -> Line;
+norm({set,[],_,{debug_line,_,_,_,_}=Line}) -> Line;
 norm({set,[D1,D2],[D1,D2],swap})   -> {swap,D1,D2}.
 
 norm_allocate({_Zero,nostack,Nh,[]}, Regs) ->

--- a/lib/compiler/src/beam_ssa.erl
+++ b/lib/compiler/src/beam_ssa.erl
@@ -42,7 +42,7 @@
          predecessors/1,
          rename_vars/3,
          rpo/1,rpo/2,
-         split_blocks/4,
+         split_blocks_before/4,split_blocks_after/4,
          successors/1,successors/2,
          trim_unreachable/1,
          used/1,uses/2]).
@@ -140,7 +140,7 @@
                       'set_tuple_element' | 'succeeded' |
                       'update_record'.
 
--import(lists, [foldl/3,mapfoldl/3,member/2,reverse/1,sort/1]).
+-import(lists, [foldl/3,mapfoldl/3,member/2,reverse/1,reverse/2,sort/1]).
 
 -spec add_anno(Key, Value, Construct0) -> Construct when
       Key :: atom(),
@@ -717,7 +717,7 @@ rename_vars(Rename, Labels, Blocks) when is_map(Rename), is_map(Blocks) ->
 %%  block if the predicate returns true for the first instruction in a
 %%  block.
 
--spec split_blocks(Labels, Pred, Blocks0, Count0) -> {Blocks,Count} when
+-spec split_blocks_before(Labels, Pred, Blocks0, Count0) -> {Blocks,Count} when
       Labels :: [label()],
       Pred :: fun((b_set()) -> boolean()),
       Blocks :: block_map(),
@@ -726,8 +726,25 @@ rename_vars(Rename, Labels, Blocks) when is_map(Rename), is_map(Blocks) ->
       Blocks :: block_map(),
       Count :: label().
 
-split_blocks(Ls, P, Blocks, Count) when is_map(Blocks) ->
-    split_blocks_1(Ls, P, Blocks, Count).
+split_blocks_before(Ls, P, Blocks, Count) when is_map(Blocks) ->
+    split_blocks_1(Ls, P, fun split_blocks_before_is/3, Blocks, Count).
+
+%% split_blocks_after(Labels, Predicate, Blocks0, Count0) -> {Blocks,Count}.
+%%  Call Predicate(Instruction) for each instruction in the given
+%%  blocks. If Predicate/1 returns true, split the block after this
+%%  instruction.
+
+-spec split_blocks_after(Labels, Pred, Blocks0, Count0) -> {Blocks,Count} when
+      Labels :: [label()],
+      Pred :: fun((b_set()) -> boolean()),
+      Blocks :: block_map(),
+      Count0 :: label(),
+      Blocks0 :: block_map(),
+      Blocks :: block_map(),
+      Count :: label().
+
+split_blocks_after(Ls, P, Blocks, Count) when is_map(Blocks) ->
+    split_blocks_1(Ls, P, fun split_blocks_after_is/3, Blocks, Count).
 
 -spec trim_unreachable(SSA0) -> SSA when
       SSA0 :: block_map() | [{label(),b_blk()}],
@@ -1080,9 +1097,9 @@ flatmapfoldl(F, Accu0, [Hd|Tail]) ->
     {R++Rs,Accu2};
 flatmapfoldl(_, Accu, []) -> {[],Accu}.
 
-split_blocks_1([L|Ls], P, Blocks0, Count0) ->
+split_blocks_1([L|Ls], P, Split, Blocks0, Count0) ->
     #b_blk{is=Is0} = Blk = map_get(L, Blocks0),
-    case split_blocks_is(Is0, P, []) of
+    case Split(Is0, P, []) of
         {yes,Bef,Aft} ->
             NewLbl = Count0,
             Count = Count0 + 1,
@@ -1092,23 +1109,32 @@ split_blocks_1([L|Ls], P, Blocks0, Count0) ->
             Blocks1 = Blocks0#{L:=BefBlk,NewLbl=>NewBlk},
             Successors = successors(NewBlk),
             Blocks = update_phi_labels(Successors, L, NewLbl, Blocks1),
-            split_blocks_1([NewLbl|Ls], P, Blocks, Count);
+            split_blocks_1([NewLbl|Ls], P, Split, Blocks, Count);
         no ->
-            split_blocks_1(Ls, P, Blocks0, Count0)
+            split_blocks_1(Ls, P, Split, Blocks0, Count0)
     end;
-split_blocks_1([], _, Blocks, Count) ->
+split_blocks_1([], _, _, Blocks, Count) ->
     {Blocks,Count}.
 
-split_blocks_is([I|Is], P, []) ->
-    split_blocks_is(Is, P, [I]);
-split_blocks_is([I|Is], P, Acc) ->
+split_blocks_before_is([I|Is], P, []) ->
+    split_blocks_before_is(Is, P, [I]);
+split_blocks_before_is([I|Is], P, Acc) ->
     case P(I) of
         true ->
             {yes,reverse(Acc),[I|Is]};
         false ->
-            split_blocks_is(Is, P, [I|Acc])
+            split_blocks_before_is(Is, P, [I|Acc])
     end;
-split_blocks_is([], _, _) -> no.
+split_blocks_before_is([], _, _) -> no.
+
+split_blocks_after_is([I|Is], P, Acc) ->
+    case P(I) of
+        true ->
+            {yes,reverse(Acc, [I]),Is};
+        false ->
+            split_blocks_after_is(Is, P, [I|Acc])
+    end;
+split_blocks_after_is([], _, _) -> no.
 
 update_phi_labels_is([#b_set{op=phi,args=Args0}=I0|Is], Old, New) ->
     Args = [{Arg,rename_label(Lbl, Old, New)} || {Arg,Lbl} <:- Args0],

--- a/lib/compiler/src/beam_ssa_alias.erl
+++ b/lib/compiler/src/beam_ssa_alias.erl
@@ -610,6 +610,8 @@ aa_is([_I=#b_set{dst=Dst,op=Op,args=Args,anno=Anno0}|Is], SS0,
                 {SS0, AAS0};
             bs_test_tail ->
                 {SS0, AAS0};
+            debug_line ->
+                {SS0, AAS0};
             executable_line ->
                 {SS0, AAS0};
             has_map_field ->

--- a/lib/compiler/src/beam_ssa_codegen.erl
+++ b/lib/compiler/src/beam_ssa_codegen.erl
@@ -23,6 +23,7 @@
 -moduledoc false.
 
 -export([module/2]).
+-export([is_original_variable/1]).  %Called from beam_core_to_ssa.
 -export([classify_heap_need/2]).    %Called from beam_ssa_pre_codegen.
 
 -export_type([ssa_register/0]).
@@ -41,14 +42,16 @@
              regs=#{} :: #{beam_ssa:b_var() => ssa_register()},
              ultimate_fail=1 :: beam_label(),
              catches=gb_sets:empty() :: gb_sets:set(ssa_label()),
-             fc_label=1 :: beam_label()
+             fc_label=1 :: beam_label(),
+             debug_info=false :: boolean()
             }).
 
 -spec module(beam_ssa:b_module(), [compile:option()]) ->
-                    {'ok',beam_asm:module_code()}.
+          {'ok',beam_asm:module_code()}.
 
-module(#b_module{name=Mod,exports=Es,attributes=Attrs,body=Fs}, _Opts) ->
-    {Asm,St} = functions(Fs, {atom,Mod}),
+module(#b_module{name=Mod,exports=Es,attributes=Attrs,body=Fs}, Opts) ->
+    DebugInfo = member(beam_debug_info, Opts),
+    {Asm,St} = functions(Fs, {atom,Mod}, DebugInfo),
     {ok,{Mod,Es,Attrs,Asm,St#cg.lcount}}.
 
 -record(need, {h=0 :: non_neg_integer(),   % heap words
@@ -109,12 +112,12 @@ module(#b_module{name=Mod,exports=Es,attributes=Attrs,body=Fs}, _Opts) ->
 
 -type ssa_register() :: xreg() | yreg() | freg() | zreg().
 
-functions(Forms, AtomMod) ->
+functions(Forms, AtomMod, DebugInfo) ->
     mapfoldl(fun (F, St) -> function(F, AtomMod, St) end,
-             #cg{lcount=1}, Forms).
+             #cg{lcount=1,debug_info=DebugInfo}, Forms).
 
-function(#b_function{anno=Anno,bs=Blocks}, AtomMod, St0) ->
-    #{func_info:={_,Name,Arity}} = Anno,
+function(#b_function{anno=Anno,bs=Blocks,args=Args}, AtomMod, St0) ->
+    #{func_info := {_,Name,Arity}} = Anno,
     NoBsMatch = not maps:get(bs_ensure_opt, Anno, false),
     try
         assert_exception_block(Blocks),            %Assertion.
@@ -127,11 +130,12 @@ function(#b_function{anno=Anno,bs=Blocks}, AtomMod, St0) ->
         Labels = (St4#cg.labels)#{0=>Entry,?EXCEPTION_BLOCK=>0},
         St5 = St4#cg{labels=Labels,used_labels=gb_sets:singleton(Entry),
                      ultimate_fail=Ult},
-        {Body,St} = cg_fun(Blocks, NoBsMatch, St5#cg{fc_label=Fi}),
-        Asm = [{label,Fi},line(Anno),
-               {func_info,AtomMod,{atom,Name},Arity}] ++
+        {Body,St} = cg_fun(Blocks, Args, NoBsMatch, St5#cg{fc_label=Fi}),
+        Asm0 = [{label,Fi},line(Anno),
+                {func_info,AtomMod,{atom,Name},Arity}] ++
                add_parameter_annos(Body, Anno) ++
                [{label,Ult},if_end],
+        Asm = fix_debug_line(Asm0, Arity, St),
         Func = {function,Name,Arity,Entry,Asm},
         {Func,St}
     catch
@@ -139,6 +143,24 @@ function(#b_function{anno=Anno,bs=Blocks}, AtomMod, St0) ->
             io:fwrite("Function: ~w/~w\n", [Name,Arity]),
             erlang:raise(Class, Error, Stack)
     end.
+
+fix_debug_line(Is0, Live, #cg{debug_info=true}) ->
+    case Is0 of
+        [{label,_}=FiLbl,
+         {line,_}=Li,
+         {func_info,_,_,_}=Fi,
+         {label,_}=Entry,
+         {debug_line,Location,Index,Live,{none,[]}}|Is] ->
+            %% Mark this debug_line instruction as being the
+            %% very first instruction in the function.
+            Args = [{{integer,I}, [{x,I-1}]} || I <- lists:seq(1, Live)],
+            DbgLine = {debug_line,Location,Index,Live,{entry,Args}},
+            [FiLbl,Li,Fi,Entry,DbgLine|Is];
+        _ ->
+            Is0
+    end;
+fix_debug_line(Is, _Arity, #cg{debug_info=false}) ->
+    Is.
 
 assert_exception_block(Blocks) ->
     %% Assertion: ?EXCEPTION_BLOCK must be a call erlang:error(badarg).
@@ -166,7 +188,7 @@ add_parameter_annos([{label, _}=Entry | Body], Anno) ->
 
     [Entry | sort(Annos)] ++ Body.
 
-cg_fun(Blocks, NoBsMatch, St0) ->
+cg_fun(Blocks, Args, NoBsMatch, St0) ->
     Linear0 = linearize(Blocks),
     St1 = collect_catch_labels(Linear0, St0),
     Linear1 = need_heap(Linear0),
@@ -174,7 +196,8 @@ cg_fun(Blocks, NoBsMatch, St0) ->
     Linear3 = liveness(Linear2, St1),
     Linear4 = defined(Linear3, St1),
     Linear5 = opt_allocate(Linear4, St1),
-    Linear = fix_wait_timeout(Linear5),
+    Linear6 = fix_wait_timeout(Linear5),
+    Linear = add_debug_info(Linear6, Args, St1),
     {Asm,St} = cg_linear(Linear, St1),
     case NoBsMatch of
         true -> {Asm,St};
@@ -245,11 +268,16 @@ need_heap_never(_) ->
 need_heap_blks([{L,#cg_blk{is=Is0}=Blk0}|Bs], H0, Acc) ->
     {Is1,H1} = need_heap_is(reverse(Is0), H0, []),
     {Ns,H} = need_heap_terminator(Bs, L, H1),
-    Is = Ns ++ Is1,
+    Is = delay_alloc(Ns ++ Is1),
     Blk = Blk0#cg_blk{is=Is},
     need_heap_blks(Bs, H, [{L,Blk}|Acc]);
 need_heap_blks([], H, Acc) ->
     {Acc,H}.
+
+delay_alloc([#cg_alloc{}=AI,
+             #cg_set{op=debug_line}=ELI|Is2]) ->
+    [ELI|delay_alloc([AI|Is2])];
+delay_alloc(Is) -> Is.
 
 need_heap_is([#cg_alloc{words=Words}=Alloc0|Is], N, Acc) ->
     Alloc = Alloc0#cg_alloc{words=add_heap_words(N, Words)},
@@ -390,6 +418,7 @@ classify_heap_need(build_stacktrace) -> gc;
 classify_heap_need(call) -> gc;
 classify_heap_need(catch_end) -> gc;
 classify_heap_need(copy) -> neutral;
+classify_heap_need(debug_line) -> gc;
 classify_heap_need(executable_line) -> neutral;
 classify_heap_need(extract) -> gc;
 classify_heap_need(get_hd) -> neutral;
@@ -689,6 +718,7 @@ need_live_anno(Op) ->
         bs_start_match -> true;
         bs_skip -> true;
         call -> true;
+        debug_line -> true;
         put_map -> true;
         update_record -> true;
         _ -> false
@@ -816,6 +846,7 @@ need_y_init(#cg_set{op=bs_skip,args=[#b_literal{val=Type}|_]}) ->
         _ -> false
     end;
 need_y_init(#cg_set{op=bs_start_match}) -> true;
+need_y_init(#cg_set{op=debug_line}) -> true;
 need_y_init(#cg_set{op=put_map}) -> true;
 need_y_init(#cg_set{op=update_record}) -> true;
 need_y_init(#cg_set{}) -> false.
@@ -954,6 +985,246 @@ fix_wait_timeout_is([#cg_set{op=wait_timeout,dst=WaitBool}=WT,
 fix_wait_timeout_is([I|Is], Acc) ->
     fix_wait_timeout_is(Is, [I|Acc]);
 fix_wait_timeout_is([], _Acc) -> no.
+
+%%%
+%%% Gather debug information and add as annotations to `debug_line`
+%%% instructions.
+%%%
+%%% This pass is run when collection of BEAM debug information has
+%%% been requested.
+%%%
+
+add_debug_info(Linear0, Args, #cg{regs=Regs,debug_info=true}) ->
+    Def0 = ordsets:from_list(Args),
+    Linear = anno_defined_regs(Linear0, Def0, Regs),
+    FrameSzMap = #{0 => none},
+    VarMap = #{},
+    add_debug_info_blk(Linear, Regs, FrameSzMap, VarMap);
+add_debug_info(Linear, _Args, #cg{debug_info=false}) ->
+    Linear.
+
+add_debug_info_blk([{L,#cg_blk{is=Is0,last=Last}=Blk0}|Bs],
+                   Regs, FrameSzMap0, VarMap0) ->
+    FrameSize0 = map_get(L, FrameSzMap0),
+    {Is,VarMap,FrameSize} =
+        add_debug_info_is(Is0, Regs, FrameSize0, VarMap0, []),
+    Successors = successors(Last),
+    FrameSzMap = foldl(fun(Succ, Acc) ->
+                               Acc#{Succ => FrameSize}
+                       end, FrameSzMap0, Successors),
+    Blk = Blk0#cg_blk{is=Is},
+    [{L,Blk}|add_debug_info_blk(Bs, Regs, FrameSzMap, VarMap)];
+add_debug_info_blk([], _Regs, _FrameSzMap, _VarMap) ->
+    [].
+
+add_debug_info_is([#cg_alloc{stack=FrameSize}=I|Is],
+                  Regs, FrameSize0, VarMap, Acc) ->
+    if
+        is_integer(FrameSize) ->
+            add_debug_info_is(Is, Regs, FrameSize, VarMap, [I|Acc]);
+        true ->
+            add_debug_info_is(Is, Regs, FrameSize0, VarMap, [I|Acc])
+    end;
+add_debug_info_is([#cg_set{anno=#{was_phi := true},op=copy}=I|Is],
+                  Regs, FrameSize, VarMap, Acc) ->
+    %% This copy operation originates from a phi node. The source and
+    %% destination are not equivalent and must not be added to VarMap.
+    add_debug_info_is(Is, Regs, FrameSize, VarMap, [I|Acc]);
+add_debug_info_is([#cg_set{anno=Anno,op=copy,dst=#b_var{name=Dst},
+                           args=[#b_var{name=Src}]}=I|Is],
+                  Regs, FrameSize, VarMap0, Acc) ->
+    VarMap = case Anno of
+                 #{delayed_yreg_copy := true} ->
+                     VarMap0#{Src => [Dst]};
+                 #{} ->
+                     VarMap0#{Dst => [Src]}
+             end,
+    add_debug_info_is(Is, Regs, FrameSize, VarMap, [I|Acc]);
+add_debug_info_is([#cg_set{anno=Anno0,op=debug_line,args=[Index]}=I0|Is],
+                  Regs, FrameSize, VarMap, Acc) ->
+    #{def_regs := DefRegs,
+      alias := Alias,
+      literals := Literals0,
+      live := NumLive0} = Anno0,
+    AliasMap = maps:merge_with(fun(_, L1, L2) -> L1 ++ L2 end,
+                               VarMap, Alias),
+    Literals1 = [{get_original_names(#b_var{name=Var}, AliasMap),Val} ||
+                    {Val,Var} <:- Literals0],
+    Literals = [{hd(Vars),[{literal,Val}]} ||
+                   {Vars,Val} <:- Literals1, Vars =/= []],
+    RegVarMap = [{map_get(V, Regs),get_original_names(V, AliasMap)} ||
+                    V <- DefRegs,
+                    not is_beam_register(V)],
+    S0 = sofs:family(RegVarMap, [{reg,[variable]}]),
+    S1 = sofs:family_to_relation(S0),
+    S2 = sofs:converse(S1),
+    S3 = sofs:relation_to_family(S2),
+    S = sort(Literals ++ sofs:to_external(S3)),
+    Live = max(NumLive0, num_live(DefRegs, Regs)),
+    Info = {FrameSize,S},
+    I = I0#cg_set{args=[Index,#b_literal{val=Live},#b_literal{val=Info}]},
+    add_debug_info_is(Is, Regs, FrameSize, VarMap, [I|Acc]);
+add_debug_info_is([#cg_set{}=I|Is], Regs, FrameSize, VarMap, Acc) ->
+    add_debug_info_is(Is, Regs, FrameSize, VarMap, [I|Acc]);
+add_debug_info_is([], _Regs, FrameSize, VarMap, Info) ->
+    {reverse(Info),VarMap,FrameSize}.
+
+get_original_names(#b_var{name=Name}, AliasMap) ->
+    get_original_names_1([Name], AliasMap, sets:new()).
+
+get_original_names_1([Name|Names0], AliasMap, Seen0) ->
+    case sets:is_element(Name, Seen0) of
+        true ->
+            get_original_names_1(Names0, AliasMap, Seen0);
+        false ->
+            Seen = sets:add_element(Name, Seen0),
+            Names = case AliasMap of
+                        #{Name := Vars0} ->
+                            Vars = Vars0 ++ Names0,
+                            get_original_names_1(Vars, AliasMap, Seen);
+                        #{} ->
+                            Names0
+                    end,
+            case is_original_variable(Name) of
+                true ->
+                    [Name|get_original_names_1(Names, AliasMap, Seen)];
+                false ->
+                    get_original_names_1(Names, AliasMap, Seen)
+            end
+    end;
+get_original_names_1([], _, _) ->
+    [].
+
+-spec is_original_variable(Name) -> boolean() when
+      Name :: non_neg_integer() | atom().
+
+%% Test whether the variable name originates from the Erlang source
+%% code, meaning that it was not invented by the compiler. It is
+%% sufficient to check that the first character can legally start an
+%% Erlang variable name, because all new variables inserted by the
+%% compiler always start with an invalid character such as "@" or a
+%% lower-case letter.
+is_original_variable(Name) when is_atom(Name) ->
+    <<C/utf8,_/binary>> = atom_to_binary(Name),
+    if
+        %% A variable name must start with "_" or an upper-case letter
+        %% included in ISO Latin-1.
+        C =:= $_ -> true;
+        $A =< C, C =< $Z -> true;
+        $À =< C, C =< $Þ, C =/= $× -> true;
+        true -> false
+    end;
+is_original_variable(Name) when is_integer(Name) ->
+    false.
+
+%%%
+%%% Annotate `debug_line` instructions with all variables that have
+%%% been defined and are still available in a BEAM register.
+%%%
+
+anno_defined_regs(Linear, Def, Regs) ->
+    def_regs(Linear, #{0 => Def}, Regs).
+
+def_regs([{L,#cg_blk{is=Is0,last=Last}=Blk0}|Bs], DefMap0, Regs) ->
+    Def0 = map_get(L, DefMap0),
+    {Is,Def,MaybeDef} = def_regs_is(Is0, Regs, Def0, []),
+    DefMap = def_successors(Last, Def, MaybeDef, DefMap0),
+    Blk = Blk0#cg_blk{is=Is},
+    [{L,Blk}|def_regs(Bs, DefMap, Regs)];
+def_regs([], _, _) -> [].
+
+def_regs_is([#cg_alloc{live=Live}=I|Is], Regs, Def0, Acc) when is_integer(Live) ->
+    Def = trim_xregs(Def0, Live, Regs),
+    def_regs_is(Is, Regs, Def, [I|Acc]);
+def_regs_is([#cg_set{op=succeeded,args=[Var]}=I], _Regs, Def, Acc) ->
+    %% Var will only be defined on the success branch of the `br`
+    %% for this block.
+    MaybeDef = [Var],
+    {reverse(Acc, [I]),Def,MaybeDef};
+def_regs_is([#cg_set{op=kill_try_tag,args=[#b_var{}=Tag]}=I|Is], Regs, Def0, Acc) ->
+    Def = ordsets:del_element(Tag, Def0),
+    def_regs_is(Is, Regs, Def, [I|Acc]);
+def_regs_is([#cg_set{op=catch_end,dst=Dst,args=[#b_var{}=Tag|_]}=I|Is], Regs, Def0, Acc) ->
+    Def1 = trim_xregs(Def0, 0, Regs),
+    Def2 = kill_regs(Def1, [Dst,Tag], Regs),
+    Def = ordsets:add_element(Dst, Def2),
+    def_regs_is(Is, Regs, Def, [I|Acc]);
+def_regs_is([#cg_set{anno=Anno0,op=debug_line}=I0|Is], Regs, Def, Acc) ->
+    Anno = Anno0#{def_regs => Def},
+    I = I0#cg_set{anno=Anno},
+    def_regs_is(Is, Regs, Def, [I|Acc]);
+def_regs_is([#cg_set{anno=Anno,dst=Dst,op={bif,Bif},args=Args}=I|Is], Regs, Def0, Acc) ->
+    Def1 = case is_gc_bif(Bif, Args) of
+               true ->
+                   #{live := Live} = Anno,
+                   trim_xregs(Def0, Live, Regs);
+               false ->
+                   Def0
+           end,
+    case Regs of
+        #{Dst := {Tag,_}=R} when Tag =:= x; Tag =:= y ->
+            Def2 = kill_reg(Def1, R, Regs),
+            Def = ordsets:add_element(Dst, Def2),
+            def_regs_is(Is, Regs, Def, [I|Acc]);
+        #{} ->
+            def_regs_is(Is, Regs, Def1, [I|Acc])
+    end;
+def_regs_is([#cg_set{anno=Anno,dst=Dst}=I|Is], Regs, Def0, Acc) ->
+    Def1 = case Anno of
+               #{live := Live} -> trim_xregs(Def0, Live, Regs);
+               #{} -> Def0
+           end,
+    Def2 = case Anno of
+               #{kill_yregs := KillYregs} ->
+                   kill_regs(Def1, KillYregs, Regs);
+               #{} ->
+                   Def1
+           end,
+    case Anno of
+        #{clobbers := true} ->
+            Def3 = trim_xregs(Def2, 0, Regs),
+            Def = case Regs of
+                      #{Dst := {Tag,_}=R} when Tag =:= x; Tag =:= y ->
+                          Def4 = kill_reg(Def3, R, Regs),
+                          ordsets:add_element(Dst, Def4);
+                      #{} ->
+                          Def3
+                  end,
+            def_regs_is(Is, Regs, Def, [I|Acc]);
+        #{} ->
+            case Regs of
+                #{Dst := {Tag,_}=R} when Tag =:= x; Tag =:= y ->
+                    Def3 = kill_reg(Def2, R, Regs),
+                    Def = ordsets:add_element(Dst, Def3),
+                    def_regs_is(Is, Regs, Def, [I|Acc]);
+                #{} ->
+                    def_regs_is(Is, Regs, Def1, [I|Acc])
+            end
+    end;
+def_regs_is([], _Regs, Def, Acc) ->
+    {reverse(Acc),Def,[]}.
+
+trim_xregs([V|Vs], Live, Regs) ->
+    case Regs of
+        #{V := {x,R}} when R < Live ->
+            [V|trim_xregs(Vs, Live, Regs)];
+        #{V := {y,_}}->
+            [V|trim_xregs(Vs, Live, Regs)];
+        #{} ->
+            trim_xregs(Vs, Live, Regs)
+    end;
+trim_xregs([], _, _) -> [].
+
+kill_reg([V|Vs], R, Regs) ->
+    case Regs of
+        #{V := R} -> Vs;
+        #{} -> [V|kill_reg(Vs, R, Regs)]
+    end;
+kill_reg([], _, _) -> [].
+
+kill_regs(Defs, KillRegs0, Regs) ->
+    KillRegs = #{map_get(V, Regs) => [] || V <- KillRegs0},
+    [D || D <- Defs, not is_map_key(map_get(D, Regs), KillRegs)].
 
 %%%
 %%% Here follows the main code generation functions.
@@ -1822,6 +2093,14 @@ cg_instr(bs_get_position, [Ctx], Dst, Set) ->
 cg_instr(executable_line, [{integer,Index}], _Dst, #cg_set{anno=Anno}) ->
     {line,Location} = line(Anno),
     [{executable_line,Location,Index}];
+cg_instr(debug_line, [{integer,Index},{integer,Live},{literal,Info}],
+         _Dst, #cg_set{anno=Anno}) ->
+    case line(Anno) of
+        {line,[]} ->
+            [];
+        {line,Location} ->
+            [{debug_line,Location,Index,Live,Info}]
+    end;
 cg_instr(put_map, [{atom,assoc},SrcMap|Ss], Dst, Set) ->
     Live = get_live(Set),
     [{put_map_assoc,{f,0},SrcMap,Dst,Live,{list,Ss}}];
@@ -2133,9 +2412,10 @@ translate_phis(L, #cg_br{succ=Target,fail=Target}, Blocks) ->
     end;
 translate_phis(_, _, _) -> [].
 
-phi_copies([#b_set{dst=Dst,args=PhiArgs}|Sets], L) ->
-    CopyArgs = [V || {V,Target} <:- PhiArgs, Target =:= L],
-    [#cg_set{op=copy,dst=Dst,args=CopyArgs}|phi_copies(Sets, L)];
+phi_copies([#b_set{anno=Anno0,dst=Dst,args=PhiArgs}|Sets], L) ->
+    CopyArgs = [V || {V,Target} <- PhiArgs, Target =:= L],
+    Anno = Anno0#{was_phi => true},
+    [#cg_set{anno=Anno,op=copy,dst=Dst,args=CopyArgs}|phi_copies(Sets, L)];
 phi_copies([], _) -> [].
 
 %% opt_move_to_x0([Instruction]) -> [Instruction].

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -555,7 +555,7 @@ ssa_opt_split_blocks({#opt_st{ssa=Blocks0,cnt=Count0}=St, FuncDb}) ->
            (_) -> false
         end,
     RPO = beam_ssa:rpo(Blocks0),
-    {Blocks,Count} = beam_ssa:split_blocks(RPO, P, Blocks0, Count0),
+    {Blocks,Count} = beam_ssa:split_blocks_before(RPO, P, Blocks0, Count0),
     {St#opt_st{ssa=Blocks,cnt=Count}, FuncDb}.
 
 %%%

--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -1453,7 +1453,8 @@ split_rm_blocks([L|Ls], Blocks0, Count0, Acc) ->
                         Op =:= remove_message
                 end,
             Next = Count0,
-            {Blocks,Count} = beam_ssa:split_blocks([L], P, Blocks0, Count0),
+            {Blocks,Count} = beam_ssa:split_blocks_before([L], P,
+                                                          Blocks0, Count0),
             true = Count0 =/= Count,            %Assertion.
             split_rm_blocks(Ls, Blocks, Count, [Next|Acc])
     end;

--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -114,6 +114,8 @@ functions([], _Ps) -> [].
 
 passes(Opts) ->
     AddPrecgAnnos = proplists:get_bool(dprecg, Opts),
+    BeamDebugInfo = proplists:get_bool(beam_debug_info, Opts),
+
     Ps = [?PASS(assert_no_critical_edges),
 
           %% Preliminaries.
@@ -121,6 +123,12 @@ passes(Opts) ->
           ?PASS(sanitize),
           ?PASS(expand_match_fail),
           ?PASS(expand_update_tuple),
+
+          case BeamDebugInfo of
+              false -> ignore;
+              true -> ?PASS(break_out_debug_line)
+          end,
+
           ?PASS(place_frames),
           ?PASS(fix_receives),
 
@@ -820,6 +828,21 @@ sanitize_is([], Last, _InBlocks, _Blocks, Count, Values, Changed, Acc) ->
             no_change
     end.
 
+do_sanitize_is(#b_set{anno=Anno0,op=debug_line,args=Args0}=I0,
+               Is, Last, InBlocks, Blocks, Count, Values, _Changed0, Acc) ->
+    Args = sanitize_args(Args0, Values),
+    #{alias := Alias0, literals := Literals0} = Anno0,
+    Alias = sanitize_alias(Alias0, Values),
+    Anno1 = Anno0#{alias := Alias},
+    Anno = case [{Val,From} || #b_var{name=From} := #b_literal{val=Val} <- Values] of
+               [] ->
+                   Anno1;
+               [_|_]=Literals ->
+                   Anno1#{literals => Literals ++ Literals0}
+           end,
+    I = I0#b_set{anno=Anno,args=Args},
+    Changed = true,
+    sanitize_is(Is, Last, InBlocks, Blocks, Count, Values, Changed, [I|Acc]);
 do_sanitize_is(#b_set{op=Op,dst=Dst,args=Args0}=I0,
                Is, Last, InBlocks, Blocks, Count, Values, Changed0, Acc) ->
     Args = sanitize_args(Args0, Values),
@@ -852,6 +875,19 @@ sanitize_last(#b_blk{last=Last0}=Blk, Values) ->
         true ->
             Blk
     end.
+
+sanitize_alias(Alias, Values) ->
+    sanitize_alias_1(maps:keys(Alias), Values, Alias).
+
+sanitize_alias_1([Old|Vs], Values, Alias0) ->
+    Alias = case Values of
+                #{#b_var{name=Old} := #b_var{name=New}} ->
+                    Alias0#{New => map_get(Old, Alias0)};
+                #{} ->
+                    Alias0
+            end,
+    sanitize_alias_1(Vs, Values, Alias);
+sanitize_alias_1([], _Values, Alias) -> Alias.
 
 sanitize_args(Args, Values) ->
     [sanitize_arg(Arg, Values) || Arg <- Args].
@@ -1190,6 +1226,91 @@ sort_update_tuple([#b_literal{}=Index, Value | Updates], Acc) ->
     sort_update_tuple(Updates, [{Index, Value} | Acc]);
 sort_update_tuple([], Acc) ->
     append([[Index, Value] || {Index, Value} <:- sort(fun erlang:'>='/2, Acc)]).
+
+
+%%%
+%%% Avoid placing stack frame allocation instructions before an
+%%% `debug_line` instruction to potentially provide information for
+%%% more variables.
+%%%
+%%% This sub pass is only run when the `beam_debug_info` option has been given.
+%%%
+%%% As an example, consider this function:
+%%%
+%%%     foo(A, B, C) ->
+%%%         {ok,bar(A),B}.
+%%%
+%%% When compiled with the `beam_debug_info` option the first part of the SSA code
+%%% will look like this:
+%%%
+%%%     0:
+%%%       _7 = debug_line `1`
+%%%       _3 = call (`bar`/1), _0
+%%%
+%%% The beam_ssa_pre_codegen pass will place a stack frame before the block:
+%%%
+%%%     %% #{frame_size => 1,yregs => #{{b_var,1} => []}}
+%%%     0:
+%%%       [1] y0/_12 = copy x1/_1
+%%%       [3] z0/_7 = debug_line `1`
+%%%
+%%% In the resulting BEAM code there will not be any information for
+%%% variable `C`, because the allocate instruction will kill it before
+%%% reaching the `debug_line` instruction:
+%%%
+%%%     {allocate,1,2}.
+%%%     {move,{x,1},{y,0}}.
+%%%     {debug_line,[{location,...}],1,
+%%%                  {1,[{'A',[{x,0}]},{'B',[{x,1},{y,0}]}]},
+%%%                  2}.
+%%%
+%%% If we split the block after the `debug_line` instruction, the
+%%% allocation of the stack frame will be placed after the
+%%% `debug_line` instruction:
+%%%
+%%%     0:
+%%%       [1] z0/_7 = debug_line `1`
+%%%       [3] br ^12
+%%%
+%%%     %% #{frame_size => 1,yregs => #{{b_var,1} => []}}
+%%%     12:
+%%%       [5] y0/_13 = copy x1/_1
+%%%       [7] x0/_3 = call (`bar`/1), x0/_0
+%%%
+%%% In the resulting BEAM code, there will now be information for variable `C`:
+%%%
+%%%     {debug_line,[{location,"t.erl",5}],
+%%%                 1,
+%%%                 {none,[{'A',[{x,0}]},{'B',[{x,1}]},{'C',[{x,2}]}]},
+%%%                 2}.
+%%%     {allocate,1,2}.
+%%%
+
+break_out_debug_line(#st{ssa=Blocks0,cnt=Count0}=St) ->
+    RPO = beam_ssa:rpo(Blocks0),
+
+    %% Calculate the set of all indices for `debug_line` instructions
+    %% that occur as the first instruction in a block. Splitting after
+    %% every `debug_line` instruction is not always beneficial, and
+    %% can even result in worse information about variables.
+    F = fun(_, #b_blk{is=[#b_set{op=debug_line,
+                                 args=[#b_literal{val=Index}]}|_]}, Acc) ->
+                sets:add_element(Index, Acc);
+           (_, _, Acc) ->
+                Acc
+        end,
+    ToBeSplit = beam_ssa:fold_blocks(F, RPO, sets:new(), Blocks0),
+
+    %% Now split blocks after the found `debug_line` instructions that
+    %% are known to start blocks.
+    P = fun(#b_set{op=debug_line,args=[#b_literal{val=Index}]}) ->
+                sets:is_element(Index, ToBeSplit);
+           (_) ->
+                false
+        end,
+    {Blocks,Count} = beam_ssa:split_blocks_after(RPO, P, Blocks0, Count0),
+
+    St#st{ssa=Blocks,cnt=Count}.
 
 %%%
 %%% Find out where frames should be placed.
@@ -1985,7 +2106,8 @@ copy_retval_is([#b_set{op=call,dst=#b_var{}=Dst}=I0|Is], RC, Yregs,
     case sets:is_element(Dst, Yregs) of
         true ->
             {NewVar,Count} = new_var(Count1),
-            Copy = #b_set{op=copy,dst=Dst,args=[NewVar]},
+            Copy = #b_set{anno=#{delayed_yreg_copy => true},
+                          op=copy,dst=Dst,args=[NewVar]},
             I = I1#b_set{dst=NewVar},
             copy_retval_is(Is, RC, Yregs, Copy, Count, [I|Acc]);
         false ->
@@ -2615,6 +2737,7 @@ use_zreg(bs_checked_skip) -> yes;
 use_zreg(bs_ensure) -> yes;
 use_zreg(bs_match_string) -> yes;
 use_zreg(bs_set_position) -> yes;
+use_zreg(debug_line) -> yes;
 use_zreg(executable_line) -> yes;
 use_zreg(kill_try_tag) -> yes;
 use_zreg(landingpad) -> yes;

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -375,8 +375,11 @@ vi({'%',_}, Vst) ->
     Vst;
 vi({line,_}, Vst) ->
     Vst;
-vi({executable_line,_,_}, Vst) ->
+vi({executable_line,_,Index}, Vst) when is_integer(Index) ->
     Vst;
+vi({debug_line,_,Index,Live,Info}, Vst) when is_integer(Index),
+                                             is_integer(Live) ->
+    validate_debug_line(Info, Live, Vst);
 vi(nif_start, Vst) ->
     Vst;
 %%
@@ -2156,6 +2159,44 @@ validate_select_tuple_arity(Fail, [], _, #vst{}=Vst) ->
                    %% The next instruction is never executed.
                    kill_state(SuccVst)
            end).
+
+%%
+%% Validate debug information in `debug_line` instructions.
+%%
+
+validate_debug_line({entry,Args}, Live, Vst) ->
+    do_validate_debug_line(none, Live, Vst),
+    _ = [get_term_type(Reg, Vst) || {_Name,[Reg]} <:- Args],
+    prune_x_regs(Live, Vst);
+validate_debug_line({Stk,Vars}, Live, Vst0) ->
+    do_validate_debug_line(Stk, Live, Vst0),
+    Vst = prune_x_regs(Live, Vst0),
+    _ = [validate_dbg_vars(Regs, Name, Vst) || {Name,Regs} <:- Vars],
+    Vst.
+
+do_validate_debug_line(ExpectedStk, Live, #vst{current=St}=Vst) ->
+    case St of
+        #st{numy=ExpectedStk} ->
+            ok;
+        #st{numy=ActualStk} ->
+            error({beam_debug_info,frame_size,ExpectedStk,actual,ActualStk})
+    end,
+    verify_live(Live, Vst),
+    verify_y_init(Vst).
+
+validate_dbg_vars([R|Rs], Name, Vst) ->
+    Type = get_term_type(R, Vst),
+    validate_dbg_vars(Rs, Type, Name, Vst).
+
+validate_dbg_vars([R|Rs], Type, Name, Vst) ->
+    case get_term_type(R, Vst) of
+        Type ->
+            validate_dbg_vars(Rs, Type, Name, Vst);
+        OtherType ->
+            error({type_mismatch,Name,OtherType,Type})
+    end;
+validate_dbg_vars([], _Type, _Name, _Vst) ->
+    ok.
 
 %%
 %% Infers types from comparisons, looking at the expressions that produced the

--- a/lib/compiler/src/beam_z.erl
+++ b/lib/compiler/src/beam_z.erl
@@ -123,6 +123,8 @@ undo_rename(I) -> I.
 remove_redundant_lines(Is) ->
     remove_redundant_lines_1(Is, none).
 
+remove_redundant_lines_1([{debug_line,_,_,_,_}=I|Is], _PrevLoc) ->
+    [I|remove_redundant_lines_1(Is, none)];
 remove_redundant_lines_1([{executable_line,_,_}=I|Is], _PrevLoc) ->
     [I|remove_redundant_lines_1(Is, none)];
 remove_redundant_lines_1([{line,Loc}=I|Is], PrevLoc) ->

--- a/lib/compiler/src/core_pp.erl
+++ b/lib/compiler/src/core_pp.erl
@@ -62,7 +62,11 @@ maybe_anno(Node, Fun, #ctxt{clean=true}=Ctxt) ->
 	    maybe_anno(Node, Fun, Ctxt, As0);
   	Line ->
 	    As = strip_line(As0),
-	    if Line > Ctxt#ctxt.line ->
+            NeedsAnno = needs_line_anno(Node),
+	    if
+                NeedsAnno ->
+                    maybe_anno(Node, Fun, Ctxt, As0);
+                Line > Ctxt#ctxt.line ->
 		    [io_lib:format("%% Line ~w",[Line]),
 		     nl_indent(Ctxt),
 		     maybe_anno(Node, Fun, Ctxt#ctxt{line = Line}, As)
@@ -70,6 +74,14 @@ maybe_anno(Node, Fun, #ctxt{clean=true}=Ctxt) ->
 		true ->
 		    maybe_anno(Node, Fun, Ctxt, As)
 	    end
+    end.
+
+needs_line_anno(Node) ->
+    case (cerl:is_c_primop(Node) andalso
+          cerl:concrete(cerl:primop_name(Node))) of
+        debug_line -> true;
+        executable_line -> true;
+        _ -> false
     end.
 
 maybe_anno(Node, Fun, Ctxt, []) ->

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -695,3 +695,9 @@ BEAM_FORMAT_NUMBER=0
 ## @spec executable_line Location Index
 ## @doc  Provide location for an executable line.
 183: executable_line/2
+
+# OTP 28
+
+## @spec debug_line Location Index Live
+## @doc  Provide location for a place where a break point can be placed.
+184: debug_line/3

--- a/lib/compiler/src/sys_coverage.erl
+++ b/lib/compiler/src/sys_coverage.erl
@@ -193,7 +193,7 @@ bool_switch(E, T, F, AllVars, AuxVarN) ->
          [{tuple,Anno,[{atom,Anno,badarg},AuxVar]}]}]}]}.
 
 aux_var(Vars, N) ->
-    Name = list_to_atom(lists:concat(['_', N])),
+    Name = list_to_atom(lists:concat(["cov", N])),
     case sets:is_element(Name, Vars) of
         true -> aux_var(Vars, N + 1);
         false -> Name

--- a/lib/compiler/src/sys_coverage.erl
+++ b/lib/compiler/src/sys_coverage.erl
@@ -21,8 +21,8 @@
 
 -module(sys_coverage).
 -moduledoc false.
--export([module/2,cover_transform/2]).
--import(lists, [member/2,reverse/1,reverse/2]).
+-export([module/2,cover_transform/2,beam_debug_info/1]).
+-import(lists, [duplicate/2,member/2,reverse/1,reverse/2]).
 
 -type attribute() :: atom().
 -type form()      :: {function, integer(), atom(), arity(), _}
@@ -34,16 +34,8 @@
 -spec module([form()], [compile:option()]) ->
         {'ok',[form()]}.
 
-module(Forms0, _Opts) when is_list(Forms0) ->
-    put(executable_line_index, 1),
-    GetIndex = fun(_, _, _, _, _) ->
-                       Index = get(executable_line_index),
-                       put(executable_line_index, Index + 1),
-                       Index
-               end,
-    Forms = transform(Forms0, GetIndex),
-    erase(executable_line_index),
-    Forms.
+module(Forms, _Opts) when is_list(Forms) ->
+    transform(Forms, executable_line).
 
 %% Undocumented helper function for the `cover` module.
 -spec cover_transform([form()], index_fun()) ->
@@ -51,7 +43,14 @@ module(Forms0, _Opts) when is_list(Forms0) ->
 
 cover_transform(Forms, IndexFun) when is_list(Forms),
                                       is_function(IndexFun, 5) ->
-    transform(Forms, IndexFun).
+    transform(Forms, IndexFun, executable_line).
+
+%% Undocumented helper function for inserting `debug_line` instructions.
+
+-spec beam_debug_info([form()]) -> {'ok',[form()]}.
+
+beam_debug_info(Forms) when is_list(Forms) ->
+    transform(Forms, debug_line).
 
 %%%
 %%% Local functions.
@@ -66,7 +65,8 @@ cover_transform(Forms, IndexFun) when is_list(Forms),
             true ->
                 ?BLOCK(Expr)
         end).
--define(EXECUTABLE_LINE, executable_line).
+
+-type bump_instruction() :: 'executable_line' | 'debug_line'.
 
 -record(vars,
         {module=[]      :: module() | [],
@@ -76,11 +76,23 @@ cover_transform(Forms, IndexFun) when is_list(Forms),
          lines=[]       :: [non_neg_integer()],
          bump_lines=[]  :: [non_neg_integer()],
          in_guard=false :: boolean(),
-         index_fun      :: index_fun()
+         index_fun      :: index_fun(),
+         bump_instr     :: bump_instruction()
         }).
 
-transform(Code, IndexFun) ->
-    Vars = #vars{index_fun=IndexFun},
+transform(Forms, BumpInstr) ->
+    put(bump_index, 1),
+    GetIndex = fun(_, _, _, _, _) ->
+                       Index = get(bump_index),
+                       put(bump_index, Index + 1),
+                       Index
+               end,
+    Result = transform(Forms, GetIndex, BumpInstr),
+    erase(bump_index),
+    Result.
+
+transform(Code, IndexFun, BumpInstr) ->
+    Vars = #vars{index_fun=IndexFun,bump_instr=BumpInstr},
     transform(Code, [], Vars, none, on).
 
 transform([Form0|Forms], MungedForms, Vars0, MainFile0, Switch0) ->
@@ -208,6 +220,26 @@ munge({attribute,_,file,{File,_}}=Form, Vars, none, _) ->
     {Form,Vars,File,on};
 munge({attribute,_,module,Mod}=Form, Vars, MainFile, Switch) when is_atom(Mod) ->
     {Form,Vars#vars{module=Mod},MainFile,Switch};
+munge({function,Anno,Function,Arity,Clauses0},
+      #vars{bump_instr=debug_line}=Vars0, _MainFile, on) ->
+    %% We want to insert a `debug_line` instruction at the beginning
+    %% of the function before all clauses, but there is not really a
+    %% way to express that. So we insert an extra clause before all
+    %% other clauses. The v3_core pass will pick up the annotation and
+    %% index from the `debug_line` instruction in the body of the
+    %% clause and will then discard it.
+    Vars = Vars0#vars{function=Function,
+                      arity=Arity,
+                      clause=1,
+                      lines=[],
+                      bump_lines=[]},
+    Args = duplicate(Arity, {var,Anno,'_'}),
+    FakeBif = {remote,Anno,{atom,Anno,fake},{atom,Anno,is_beam_bif_info}},
+    Gs = [[{call,Anno,FakeBif,[]}]],
+    Body = [{atom,Anno,ignore}],
+    Clauses = [{clause,Anno,Args,Gs,Body}|Clauses0],
+    MungedClauses = munge_fun_clauses(Clauses, Vars),
+    {{function,Anno,Function,Arity,MungedClauses},Vars,on};
 munge({function,Anno,Function,Arity,Clauses}, Vars0, _MainFile, on) ->
     Vars = Vars0#vars{function=Function,
                       arity=Arity,
@@ -367,7 +399,7 @@ fix_expr(E, _Line, _Bump) ->
 fix_clauses([], _Line, _Bump) ->
     [];
 fix_clauses(Cs, Line, Bump) ->
-    case bumps_line(lists:last(Cs), Line) of
+    case bumps_line(lists:last(Cs), Line, Bump) of
         true ->
             fix_cls(Cs, Line, Bump);
         false ->
@@ -377,7 +409,7 @@ fix_clauses(Cs, Line, Bump) ->
 fix_cls([], _Line, _Bump) ->
     [];
 fix_cls([Cl | Cls], Line, Bump) ->
-    case bumps_line(Cl, Line) of
+    case bumps_line(Cl, Line, Bump) of
         true ->
             [fix_expr(C, Line, Bump) || C <- [Cl | Cls]];
         false ->
@@ -390,24 +422,30 @@ fix_cls([Cl | Cls], Line, Bump) ->
             [{clause,CA,P,G,Body1} | fix_cls(Cls, Line, Bump)]
     end.
 
-bumps_line(E, L) ->
-    try bumps_line1(E, L) catch true -> true end.
+bumps_line(E, L, Bump) ->
+    try
+        bumps_line1(E, L, Bump)
+    catch
+        throw:true ->
+            true
+    end.
 
-bumps_line1({?EXECUTABLE_LINE,Line,_}, Line) ->
+bumps_line1({BumpInstr,Line,_}, Line, {BumpInstr,_,_}) ->
     throw(true);
-bumps_line1([E | Es], Line) ->
-    bumps_line1(E, Line),
-    bumps_line1(Es, Line);
-bumps_line1(T, Line) when is_tuple(T) ->
-    bumps_line1(tuple_to_list(T), Line);
-bumps_line1(_, _) ->
+bumps_line1([E | Es], Line, Bump) ->
+    bumps_line1(E, Line, Bump),
+    bumps_line1(Es, Line, Bump);
+bumps_line1(T, Line, Bump) when is_tuple(T) ->
+    bumps_line1(tuple_to_list(T), Line, Bump);
+bumps_line1(_, _, _Bump) ->
     false.
 
 %% Insert an executable_line instruction in the abstract code.
 bump_call(Vars, Line) ->
-    #vars{module=M,function=F,arity=A,clause=C,index_fun=GetIndex} = Vars,
+    #vars{module=M,function=F,arity=A,clause=C,index_fun=GetIndex,
+          bump_instr=BumpInstr} = Vars,
     Index = GetIndex(M, F, A, C, Line),
-    {?EXECUTABLE_LINE,Line,Index}.
+    {BumpInstr,Line,Index}.
 
 %%% End of fix of last expression.
 
@@ -464,11 +502,11 @@ munge_expr({'catch',Anno,Expr}, Vars0) ->
 munge_expr({call,Anno1,{remote,Anno2,ExprM,ExprF},Exprs}, Vars0) ->
     {MungedExprM, Vars1} = munge_expr(ExprM, Vars0),
     {MungedExprF, Vars2} = munge_expr(ExprF, Vars1),
-    {MungedExprs, Vars3} = munge_exprs(Exprs, Vars2),
+    {MungedExprs, Vars3} = munge_args(Exprs, Vars2),
     {{call,Anno1,{remote,Anno2,MungedExprM,MungedExprF},MungedExprs}, Vars3};
 munge_expr({call,Anno,Expr,Exprs}, Vars0) ->
     {MungedExpr, Vars1} = munge_expr(Expr, Vars0),
-    {MungedExprs, Vars2} = munge_exprs(Exprs, Vars1),
+    {MungedExprs, Vars2} = munge_args(Exprs, Vars1),
     {{call,Anno,MungedExpr,MungedExprs}, Vars2};
 munge_expr({lc,Anno,Expr,Qs}, Vars0) ->
     {MungedExpr, Vars1} = munge_expr(?BLOCK1(Expr), Vars0),
@@ -531,6 +569,28 @@ munge_expr({bin_element,Anno,Value,Size,TypeSpecifierList}, Vars0) ->
     {{bin_element,Anno,MungedValue,MungedSize,TypeSpecifierList},Vars2};
 munge_expr(Form, Vars0) ->
     {Form, Vars0}.
+
+munge_args(Args0, #vars{in_guard=false,bump_instr=debug_line}=Vars) ->
+    %% We want to have `debug_line` instructions inserted before each line in
+    %% this example:
+    %%
+    %% bar:f(
+    %%     bar:g(X),
+    %%     bar:h(X)).
+    Args = [case is_atomic(Arg) of
+                true -> Arg;
+                false -> ?BLOCK(Arg)
+            end || Arg <- Args0],
+    munge_exprs(Args, Vars);
+munge_args(Args, Vars) ->
+    munge_exprs(Args, Vars).
+
+is_atomic({atom,_,_}) -> true;
+is_atomic({float,_,_}) -> true;
+is_atomic({integer,_,_}) -> true;
+is_atomic({nil,_}) -> true;
+is_atomic({var,_,_}) -> true;
+is_atomic(_) -> false.
 
 munge_exprs(Exprs, Vars) ->
     munge_exprs(Exprs, Vars, []).

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -11,6 +11,7 @@ MODULES= \
 	beam_block_SUITE \
 	beam_bounds_SUITE \
 	beam_validator_SUITE \
+	beam_debug_info_SUITE \
 	beam_disasm_SUITE \
 	beam_doc_SUITE \
 	beam_except_SUITE \
@@ -167,6 +168,8 @@ ERL_FILES= $(MODULES:%=%.erl)
 CORE_FILES= $(CORE_MODULES:%=%.core)
 ERL_DUMMY_FILES= $(CORE_MODULES:%=%.erl)
 
+BEAM_OPCODES_HRL=$(ERL_TOP)/lib/compiler/src/beam_opcodes.hrl
+
 ##TARGET_FILES= $(MODULES:%=$(EBIN)/%.$(EMULATOR))
 ##INSTALL_PROGS= $(TARGET_FILES)
 
@@ -309,6 +312,7 @@ release_tests_spec: make_emakefile
         done
 	$(INSTALL_DATA) $(ERL_DUMMY_FILES) "$(RELSYSDIR)"
 	rm $(ERL_DUMMY_FILES)
+	$(INSTALL_DATA) $(BEAM_OPCODES_HRL) "$(RELSYSDIR)"
 	chmod -R u+w "$(RELSYSDIR)"
 	@tar cf - *_SUITE_data property_test | (cd "$(RELSYSDIR)"; tar xf -)
 

--- a/lib/compiler/test/beam_debug_info_SUITE.erl
+++ b/lib/compiler/test/beam_debug_info_SUITE.erl
@@ -1,0 +1,706 @@
+%%
+%% %CopyrightBegin%
+%%
+%% Copyright Ericsson AB 2024. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(beam_debug_info_SUITE).
+
+%% Make sure that we test running code compiled using the
+%% `beam_debug_info` option. This will ensure that we test
+%% `beam_disasm` on a module with debug information.
+-compile([beam_debug_info]).
+
+-include("beam_opcodes.hrl").
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
+         init_per_group/2,end_per_group/2,
+         smoke/1,
+         fixed_bugs/1,
+         empty_module/1,
+         call_in_call_args/1,
+         missing_vars/1]).
+
+suite() -> [{ct_hooks,[ts_install_cth]}].
+
+all() ->
+    [smoke,
+     {group,p}].
+
+groups() ->
+    [{p,test_lib:parallel(),
+      [fixed_bugs,
+       empty_module,
+       call_in_call_args,
+       missing_vars]}].
+
+init_per_suite(Config) ->
+    id(Config),
+    test_lib:recompile(?MODULE),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_GroupName, Config) ->
+    Config.
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+smoke(_Config) ->
+    TestBeams0 = get_unique_beam_files(),
+    TestBeams = compiler_beams() ++ TestBeams0,
+
+    S = ~"""
+         Below, for each module, there is a list of functions with
+         variables missing in the BEAM debug info. Note that there
+         will probably never be possible to have all variables
+         present in the debug info, because some variables die before
+         a `debug_line` instruction is reached.
+
+         ** means that at least one of the missing variables is
+            significant (does not start with an underscore).
+
+         """,
+    io:put_chars(S),
+
+    test_lib:p_run(fun do_smoke/1, TestBeams).
+
+compiler_beams() ->
+    filelib:wildcard(filename:join([code:lib_dir(compiler), "ebin", "*.beam"])).
+
+do_smoke(Beam) ->
+    try
+	{ok,{Mod,[{abstract_code,{raw_abstract_v1,Abstr0}}]}} =
+	    beam_lib:chunks(Beam, [abstract_code]),
+
+        %% beam_validator will check for each `debug_line` instruction
+        %% that the frame size is correct and that all referenced BEAM
+        %% registers are valid.
+        {ok,Mod,Code} = compile:forms(Abstr0,
+                                      [beam_debug_info,binary,report_errors]),
+        {ok,_,Abstr} = compile:forms(Abstr0,
+                                     [beam_debug_info,dexp,binary,report_errors]),
+        SrcVars = source_variables(Abstr),
+        IndexToFunctionMap = abstr_debug_lines(Abstr),
+        DebugInfo = get_debug_info(Mod, Code),
+
+        {DbgVars,DbgLiterals} = debug_info_vars(DebugInfo, IndexToFunctionMap),
+
+        %% The debug information must only contain variables that are
+        %% present in the source code. If the sanity check below
+        %% fails, it could be for one of the following reasons:
+        %%
+        %%   * A compiler pass has introduced a new temporary variable
+        %%     whose name is a legal Erlang variable name. (Such
+        %%     temporary variables are supposed to have invalid names,
+        %%     such as `rec1`.)
+        %%
+        %%   * Something is wrong in the mapping from `debug_line`
+        %%     instruction to function names, causing a variable to be
+        %%     collected into the wrong function. (See
+        %%     abstr_debug_lines/1.)
+        %%
+        %%   * A heuristic in source_variables/1 is wrong, causing variables
+        %%     that actually are present in the debug information to be
+        %%     removed from the list of variables from the source code.
+
+        [] = family_difference(DbgVars, SrcVars),
+
+        %% Now figure out which variables are missing from the debug info
+        %% and print them.
+        AllDbg = family_union(DbgVars, DbgLiterals),
+        Diff0 = family_difference(SrcVars, AllDbg),
+        Diff = [begin
+                    {Vars,B} = format_vars(Vars0),
+                    S = io_lib:format("~p/~p: ~ts", [F,A,Vars]),
+                    ["  ",case B of
+                              true -> "   " ++ S;
+                              false -> "** " ++ S
+                          end,"\n"]
+                end || {{F,A},Vars0} <:- Diff0],
+        io:format("~p:\n~ts", [Mod,Diff])
+    catch
+	throw:{error,Error} ->
+	    io:format("*** compilation failure '~p' for file ~s\n",
+		      [Error,Beam]),
+	    error;
+	Class:Error:Stk ->
+	    io:format("~p: ~p ~p\n~p\n", [Beam,Class,Error,Stk]),
+	    error
+    end.
+
+format_vars(Vs) ->
+    Str = lists:join(", ", [io_lib:format("~ts", [V]) || V <- Vs]),
+    B = lists:all(fun(V) ->
+                          case atom_to_binary(V) of
+                              <<"_",_/binary>> -> true;
+                              _ -> false
+                          end
+                  end, Vs),
+    {Str,B}.
+
+debug_info_vars(DebugInfo, IndexToFunctionMap) ->
+    {Vars0,Literals0} = debug_info_vars_1(DebugInfo, IndexToFunctionMap, [], []),
+    Vars = family_union(Vars0),
+    Literals = family_union(Literals0),
+    {Vars,Literals}.
+
+debug_info_vars_1([{I,{_FrameSize,List}}|T], IndexToFunctionMap, VarAcc, LitAcc) ->
+    case debug_info_vars_2(List, [], []) of
+        {[],[]} ->
+            debug_info_vars_1(T, IndexToFunctionMap, VarAcc, LitAcc);
+        {Vars,Literals} ->
+            F = map_get(I, IndexToFunctionMap),
+            debug_info_vars_1(T, IndexToFunctionMap,
+                              [{F,Vars}|VarAcc], [{F,Literals}|LitAcc])
+    end;
+debug_info_vars_1([], _, VarAcc, LitAcc) ->
+    {VarAcc,LitAcc}.
+
+debug_info_vars_2([{Name,_Value}|T], VarAcc, LitAcc) when is_integer(Name) ->
+    debug_info_vars_2(T, VarAcc, LitAcc);
+debug_info_vars_2([{Name0,Value}|T], VarAcc, LitAcc) when is_binary(Name0) ->
+    Name = binary_to_atom(Name0),
+    case Value of
+        {x,_} -> debug_info_vars_2(T, [Name|VarAcc], LitAcc);
+        {y,_} -> debug_info_vars_2(T, [Name|VarAcc], LitAcc);
+        {value,_} -> debug_info_vars_2(T, VarAcc, [Name|LitAcc])
+    end;
+debug_info_vars_2([], VarAcc, LitAcc) ->
+    {VarAcc,LitAcc}.
+
+family_union(S0) ->
+    S1 = sofs:relation(S0, [{function,[variable]}]),
+    S2 = sofs:relation_to_family(S1),
+    S3 = sofs:family_union(S2),
+    sofs:to_external(S3).
+
+family_union(F0, F1) ->
+    S0 = sofs:relation(F0, [{function,[variable]}]),
+    S1 = sofs:relation(F1, [{function,[variable]}]),
+    S2 = sofs:family_union(S0, S1),
+    sofs:to_external(S2).
+
+family_difference(F0, F1) ->
+    S0 = sofs:family(F0, [{function,[variable]}]),
+    S1 = sofs:family(F1, [{function,[variable]}]),
+    S2 = sofs:family_difference(S0, S1),
+    SpecFun = fun(S) -> sofs:no_elements(S) =/= 0 end,
+    S3 = sofs:family_specification(SpecFun, S2),
+    sofs:to_external(S3).
+
+%%
+%% Extract variables mentioned in the source code. Try to remove
+%% variables that will never show up in the debug information; for
+%% examples, definitions of variables that are not followed by any
+%% `debug_line` instructions can be ignored.
+%%
+source_variables(Abstr) ->
+    [{{Name,Arity},extract_src_vars(F)} ||
+        {function,_,Name,Arity,_}=F <- Abstr].
+
+extract_src_vars(F) ->
+    L1 = extract_src_vars(F, true, #{}),
+    L2 = [V || V := true <- L1],
+    lists:sort(L2).
+
+extract_src_vars({var,_,'_'}, _Lc, Acc) ->
+    Acc;
+extract_src_vars({var,_,Name}, _Lc, Acc0) ->
+    case atom_to_binary(Name) of
+        <<"cov",_/binary>> ->
+            %% Ignore variable added by the sys_coverage pass.
+            Acc0;
+        <<"rec",_/binary>> ->
+            %% Ignore variable added by the erl_expand_pass.
+            Acc0;
+        _ ->
+            true = beam_ssa_codegen:is_original_variable(Name),
+            Acc0#{Name => true}
+    end;
+extract_src_vars({atom,_,_}, _Lc, Acc) -> Acc;
+extract_src_vars({bin,_,Es}, _Lc, Acc) ->
+    extract_args(Es, Acc);
+extract_src_vars({bin_element,_,Val,Size,_}, _Lc, Acc0) ->
+    Acc1 = extract_src_vars(Val, false, Acc0),
+    case Size of
+        default -> Acc1;
+        _ -> extract_src_vars(Size, false, Acc1)
+    end;
+extract_src_vars({char,_,_}, _Lc, Acc) -> Acc;
+extract_src_vars({float,_,_}, _Lc, Acc) -> Acc;
+extract_src_vars({integer,_,_}, _Lc, Acc) -> Acc;
+extract_src_vars({nil,_}, _Lc, Acc) -> Acc;
+extract_src_vars({string,_,_}, _Lc, Acc) -> Acc;
+extract_src_vars({cons,_,Hd,Tl}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(Hd, Lc, Acc0),
+    extract_src_vars(Tl, Lc, Acc1);
+extract_src_vars({map,_,Fs}, _Lc, Acc0) ->
+    extract_args(Fs, Acc0);
+extract_src_vars({map,_,M,Fs}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(M, Lc, Acc0),
+    extract_args(Fs, Acc1);
+extract_src_vars({map_field_assoc,_,K,V}, _Lc, Acc0) ->
+    Acc1 = extract_src_vars(K, false, Acc0),
+    extract_src_vars(V, false, Acc1);
+extract_src_vars({map_field_exact,_,K,V}, _Lc, Acc0) ->
+    Acc1 = extract_src_vars(K, false, Acc0),
+    extract_src_vars(V, false, Acc1);
+extract_src_vars({tuple,_,Es}, _Lc, Acc) ->
+    extract_args(Es, Acc);
+extract_src_vars({call,_,F,As}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(F, Lc, Acc0),
+    extract_args(As, Acc1);
+extract_src_vars({remote,_,Mod,Name}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(Mod, Lc, Acc0),
+    extract_src_vars(Name, Lc, Acc1);
+extract_src_vars({match,_,P,E}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(P, false, Acc0),
+    extract_src_vars(E, Lc, Acc1);
+extract_src_vars({op,_,_Name,Arg}, Lc, Acc0) ->
+    extract_src_vars(Arg, Lc, Acc0);
+extract_src_vars({op,_,_Name,Lhs,Rhs}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(Lhs, false, Acc0),
+    extract_src_vars(Rhs, Lc, Acc1);
+extract_src_vars({debug_line,_,_}, _Lc, Acc) ->
+    Acc;
+extract_src_vars({executable_line,_,_}, _Lc, Acc) ->
+    Acc;
+extract_src_vars({named_fun,_,Name,Cs}, Lc, Acc0) ->
+    case any_debug_line_instrs(Cs) of
+        false ->
+            %% Since there are no `debug_line` instructions within this fun,
+            %% none of the variables defined in the fun should ever
+            %% show up in the debug info.
+            Acc0;
+        true when Name =/= '_' ->
+            Acc = case Name of
+                      '_' -> Acc0;
+                      _ -> extract_src_vars({var,anno,Name}, Lc, Acc0)
+                  end,
+            extract_cs(Cs, true, Acc)
+    end;
+extract_src_vars({function,_Anno,_,_,Cs}, _Lc, Acc0) ->
+    case any_debug_line_instrs(Cs) of
+        true ->
+            extract_cs(Cs, true, Acc0);
+        false ->
+            %% There are no `debug_line` instructions in this
+            %% function. This happens if code has been placed in a
+            %% header filer, or if the `-file()` attribute has been
+            %% used to change the name of the source file.
+            Acc0
+    end;
+extract_src_vars({'fun',_Anno,{clauses,Cs}}, _Lc, Acc0) ->
+    case any_debug_line_instrs(Cs) of
+        true ->
+            extract_cs(Cs, true, Acc0);
+        false ->
+            Acc0
+    end;
+extract_src_vars({'fun',_Anno,_}, _Lc, Acc0) -> Acc0;
+extract_src_vars({block,_Anno,Es}, Lc, Acc0) ->
+    extract_body(Es, Lc, Acc0);
+extract_src_vars({'receive',_Anno,Cs}, Lc, Acc0) ->
+    extract_cs(Cs, Lc, Acc0);
+extract_src_vars({'receive',_Anno,Cs,_To,ToE}, Lc, Acc0) ->
+    Acc1 = extract_cs(Cs, Lc, Acc0),
+    extract_body(ToE, Lc, Acc1);
+extract_src_vars({'maybe',_Anno,Body}, Lc, Acc0) ->
+    extract_body(Body, Lc, Acc0);
+extract_src_vars({'maybe',_Anno,Body,{'else',_,ElseClauses}}, Lc, Acc0) ->
+    Acc1 = extract_body(Body, Lc, Acc0),
+    extract_cs(ElseClauses, Lc, Acc1);
+extract_src_vars({'maybe_match',_Anno,P,E}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(P, false, Acc0),
+    extract_src_vars(E, Lc, Acc1);
+extract_src_vars({'case',_Anno,E,Cs}, Lc, Acc0) ->
+    Acc1 = extract_src_vars(E, false, Acc0),
+    extract_cs(Cs, Lc, Acc1);
+extract_src_vars({'if',_Anno,Cs}, Lc, Acc0) ->
+    extract_cs(Cs, Lc, Acc0);
+extract_src_vars({'try',_Anno,Es,Scs,Ccs,As}, Lc, Acc0) ->
+    Acc1 = extract_body(Es, false, Acc0),
+    Acc2 = extract_cs(Scs, Lc, Acc1),
+    Acc3 = extract_cs(Ccs, Lc, Acc2),
+    extract_body(As, Lc, Acc3);
+extract_src_vars({'catch',_Anno,E}, Lc, Acc0) ->
+    extract_src_vars(E, Lc, Acc0);
+extract_src_vars({zip,_,Qs0}, _Lc, Acc0) ->
+    Qs = extract_sv_qs(Qs0),
+    extract_args(Qs, Acc0);
+extract_src_vars({C,_,Build,Qs0}, Lc, Acc0)
+  when C =:= lc; C =:= bc; C =:= mc ->
+    case any_debug_line_instrs(Build) of
+        false ->
+            Qs = extract_sv_qs(Qs0),
+            case any_debug_line_instrs(Qs) of
+                false ->
+                    Acc0;
+                true ->
+                    extract_args(Qs, Acc0)
+            end;
+        true ->
+            Acc1 = extract_src_vars(Build, Lc, Acc0),
+            extract_args(Qs0, Acc1)
+    end;
+extract_src_vars({G,_,P,E}, _Lc, Acc0) ->
+    true = is_generator(G),                     %Assertion.
+    Acc1 = extract_src_vars(P, false, Acc0),
+    extract_src_vars(E, false, Acc1).
+
+is_generator(generate) -> true;
+is_generator(b_generate) -> true;
+is_generator(m_generate) -> true;
+is_generator(generate_strict) -> true;
+is_generator(b_generate_strict) -> true;
+is_generator(m_generate_strict) -> true;
+is_generator(_) -> false.
+
+extract_cs([{clause,_,Pats,Gs,Body}|Cs], Lc, Acc0) ->
+    case Lc andalso not any_debug_line_instrs(Body)  of
+        true ->
+            extract_cs(Cs, Lc, Acc0);
+        false ->
+            Acc1 = extract_args(Pats, Acc0),
+            Acc2 = extract_guards(Gs, Acc1),
+            Acc3 = extract_body(Body, Lc, Acc2),
+            extract_cs(Cs, Lc, Acc3)
+    end;
+extract_cs([], _, Acc) ->
+    Acc.
+
+extract_body([I], Lc, Acc) ->
+    case Lc andalso not any_debug_line_instrs(I) of
+        true ->
+            Acc;
+        false ->
+            extract_src_vars(I, Lc, Acc)
+    end;
+extract_body([I|Is], Lc, Acc0) ->
+    Acc = extract_src_vars(I, false, Acc0),
+    extract_body(Is, Lc, Acc);
+extract_body([], _Lc, Acc) -> Acc.
+
+extract_args([A|As], Acc) ->
+    extract_args(As, extract_src_vars(A, false, Acc));
+extract_args([], Acc) -> Acc.
+
+extract_guards([A|As], Acc) ->
+    extract_guards(As, extract_args(A, Acc));
+extract_guards([], Acc) -> Acc.
+
+extract_sv_qs([{block,BlkL,[{executable_line,_,_}|Bs]}|Qs1]) ->
+    %% Note: `debug_line` instructions are `executable_line`
+    %% instructions in the abstract code.
+    [{block,BlkL,Bs}|extract_sv_qs_1(Qs1)];
+extract_sv_qs(Qs) -> Qs.
+
+extract_sv_qs_1([Q|Qs]) ->
+    case abstr_extract_debug_lines(Qs, []) of
+        [] ->
+            [Q];
+        [_|_] ->
+            [Q|extract_sv_qs_1(Qs)]
+    end;
+extract_sv_qs_1([]) -> [].
+
+any_debug_line_instrs(Abstr) ->
+    abstr_extract_debug_lines(Abstr, []) =/= [].
+
+%%
+%% Return a mapping from `debug_line` instruction index to function.
+%%
+abstr_debug_lines(Abstr) ->
+    S0 = [{{Name,Arity},abstr_extract_debug_lines(Body)} ||
+             {function,_,Name,Arity,Body} <- Abstr],
+    S1 = sofs:family(S0, [{function,[line]}]),
+    S2 = sofs:family_to_relation(S1),
+    S3 = sofs:converse(S2),
+    S4 = sofs:to_external(S3),
+    maps:from_list(S4).
+
+abstr_extract_debug_lines(Abstr) ->
+    abstr_extract_debug_lines(Abstr, []).
+
+abstr_extract_debug_lines({debug_line,_,Index}, Acc) ->
+    [Index|Acc];
+abstr_extract_debug_lines([H|T], Acc0) ->
+    Acc1 = abstr_extract_debug_lines(H, Acc0),
+    abstr_extract_debug_lines(T, Acc1);
+abstr_extract_debug_lines(Tuple, Acc0) when is_tuple(Tuple) ->
+    abstr_extract_debug_lines(tuple_to_list(Tuple), Acc0);
+abstr_extract_debug_lines(_, Acc) -> Acc.
+
+%%%
+%%% Read and disassemble the BEAM debug information from the "DbgB"
+%%% chunk of a BEAM file.
+%%%
+get_debug_info(Mod, Beam) ->
+    {ok,{Mod,[{"DbgB",DebugInfo0},
+              {atoms,Atoms0}]}} = beam_lib:chunks(Beam, ["DbgB",atoms]),
+    Atoms = maps:from_list(Atoms0),
+    Literals = case beam_lib:chunks(Beam, ["LitT"]) of
+                   {ok,{Mod,[{"LitT",Literals0}]}} ->
+                       decode_literal_table(Literals0);
+                   {error,_,_} ->
+                       []
+               end,
+    Op = beam_opcodes:opcode(call, 2),
+    <<Version:32,
+      _NumItems:32,
+      _NumVars:32,
+      DebugInfo1/binary>> = DebugInfo0,
+    0 = Version,
+    DebugInfo = decode_debug_info(DebugInfo1, Literals, Atoms, Op),
+    lists:zip(lists:seq(1, length(DebugInfo)), DebugInfo).
+
+decode_literal_table(<<0:32,N:32,Tab/binary>>) ->
+    #{Index => binary_to_term(Literal) ||
+        Index <- lists:seq(0, N - 1) &&
+            <<Size:32,Literal:Size/binary>> <:= Tab}.
+
+decode_debug_info(Code0, Literals, Atoms, Op) ->
+    case Code0 of
+        <<Op,Code1/binary>> ->
+            {FrameSize0,Code2} = decode_arg(Code1, Literals, Atoms),
+            FrameSize = case FrameSize0 of
+                            nil -> none;
+                            {atom,entry} -> entry;
+                            _ -> FrameSize0
+                        end,
+            {{list,List0},Code3} = decode_arg(Code2, Literals, Atoms),
+            List = decode_list(List0),
+            [{FrameSize,List}|decode_debug_info(Code3, Literals, Atoms, Op)];
+        <<>> ->
+            []
+    end.
+
+decode_list([{integer,Var}|T]) when is_integer(Var) ->
+    decode_list([{literal,Var}|T]);
+decode_list([{literal,Var},Where0|T]) ->
+    Where = case Where0 of
+                {literal,Lit} -> {value,Lit};
+                {atom,A} -> {value,A};
+                {integer,I} -> {value,I};
+                nil -> {value,[]};
+                {x,_} -> Where0;
+                {y,_} -> Where0
+            end,
+    [{Var,Where}|decode_list(T)];
+decode_list([]) -> [].
+
+decode_args(0, Code, _Literals, _Atoms) ->
+    {[],Code};
+decode_args(N, Code0, Literals, Atoms) when is_integer(N), N > 0 ->
+    {Arg,Code1} = decode_arg(Code0, Literals, Atoms),
+    {Args,Code2} = decode_args(N - 1, Code1, Literals, Atoms),
+    {[Arg|Args],Code2}.
+
+decode_arg(Code0, Literals, Atoms) ->
+    case decode_raw_arg(Code0) of
+        {nil,_}=Res -> Res;
+        {{u,N},Code1} ->
+            {N,Code1};
+        {{atom,Index},Code1} ->
+            {{atom,map_get(Index, Atoms)},Code1};
+        {{integer,_},_}=Res -> Res;
+        {{x,_},_}=Res -> Res;
+        {{y,_},_}=Res -> Res;
+        {{z,1},Code1} ->
+            {{u,N},Code2} = decode_raw_arg(Code1),
+            {List,Code3} = decode_args(N, Code2, Literals, Atoms),
+            {{list,List},Code3};
+        {{z,4},Code1} ->
+            {{u,N},Code2} = decode_raw_arg(Code1),
+            {{literal,map_get(N, Literals)},Code2}
+    end.
+
+decode_raw_arg(<<0:4,0:1,?tag_a:3,Code/binary>>) ->
+    {nil,Code};
+decode_raw_arg(<<N:4,0:1,Tag:3,Code/binary>>) ->
+    {{decode_tag(Tag),N},Code};
+decode_raw_arg(<<2#111:3,1:1,1:1,Tag:3,Code0/binary>>) ->
+    {{u,W0},Code1} = decode_raw_arg(Code0),
+    W = W0 + 9,
+    <<N:W/signed-unit:8,Code2/binary>> = Code1,
+    {{decode_tag(Tag),N},Code2};
+decode_raw_arg(<<W0:3,1:1,1:1,Tag:3,Code0/binary>>) ->
+    W = W0 + 2,
+    <<N:W/signed-unit:8,Code1/binary>> = Code0,
+    {{decode_tag(Tag),N},Code1};
+decode_raw_arg(<<High:3,0:1,1:1,Tag:3,Low,Code0/binary>>) ->
+    N = (High bsl 8) bor Low,
+    {{decode_tag(Tag),N},Code0}.
+
+decode_tag(?tag_u) -> u;
+decode_tag(?tag_i) -> integer;
+decode_tag(?tag_a) -> atom;
+decode_tag(?tag_x) -> x;
+decode_tag(?tag_y) -> y;
+decode_tag(?tag_z) -> z.
+
+%%%
+%%% Other test cases.
+%%%
+
+fixed_bugs(_Config) ->
+    ok = unassigned_yreg(ok),
+    {'EXIT',_} = catch unassigned_yreg(not_ok),
+
+    ~"xyz" = wrong_frame_size(id(~"xyz")),
+    boom = catch wrong_frame_size(id(42)),
+
+    {ok,error} = no_function(ok),
+
+    ok.
+
+unassigned_yreg(V) ->
+    case id(V) of
+        _ ->
+            case V of ok -> ok end,
+            case catch id(whatever) of
+                Y ->
+                    case id(true) of
+                        true ->
+                            id(Y),
+                            ok;
+                        false ->
+                            ok
+                    end
+            end
+    end.
+
+wrong_frame_size(X) ->
+    id(X),
+    case id(X) of
+        Y when is_binary(Y) -> Y;
+        _Err -> throw(boom)
+    end.
+
+no_function(X) ->
+    case catch id(X) of
+        ok ->
+            case catch id(error) of
+                Err ->
+                    id(0),
+                    id({X, Err})
+            end;
+        Err ->
+            id(0),
+            id({X, Err})
+    end.
+
+
+empty_module(_Config) ->
+    Mod = list_to_atom(?MODULE_STRING ++ "_" ++
+                           atom_to_list(?FUNCTION_NAME)),
+    Empty = [{attribute,{1,1},file,{atom_to_list(Mod),1}},
+             {attribute,{1,2},module,Mod},
+             {eof,{3,1}}],
+    {ok,Mod,_Code} = compile:forms(Empty, [beam_debug_info,report]),
+
+    ok.
+
+call_in_call_args(Config) ->
+    M = ?FUNCTION_NAME,
+    PrivDir = proplists:get_value(priv_dir, Config),
+    SrcName = filename:join(PrivDir, atom_to_list(M) ++ ".erl"),
+
+    S = ~"""
+         -module(call_in_call_args).
+         -export([f/1]).
+
+         f(X) ->
+             bar:g(
+               bar:h(X),
+               id(X)
+              ).
+         id(I) -> I.
+         """,
+
+    ok = file:write_file(SrcName, S),
+    {ok,M,Asm} = compile:file(SrcName, [report,beam_debug_info,binary,to_asm]),
+    {M,_,_,[{function,f,1,_,Is}|_],_} = Asm,
+    DebugLines = [I || I <- Is, element(1, I) =:= debug_line],
+    io:format("~p\n", [DebugLines]),
+    4 = length(DebugLines),
+
+    ok.
+
+missing_vars(Config) ->
+    M = ?FUNCTION_NAME,
+    PrivDir = proplists:get_value(priv_dir, Config),
+    SrcName = filename:join(PrivDir, atom_to_list(M) ++ ".erl"),
+
+    S = ~"""
+         -module(missing_vars).              %%L01
+         -export([f/3]).                     %%L02
+         f(X, Y, Z0) ->                      %%L03
+             case X of                       %%L04
+                 false ->                    %%L05
+                     Z1 = Z0#{k := Y},       %%L06
+                     foo:go(X),              %%L07
+                     Z1;                     %%L08
+                 _ ->                        %%L09
+                     Z1 = Z0#{k := X},       %%L10
+                     Z1                      %%L11
+             end.                            %%L12
+         """,
+
+    ok = file:write_file(SrcName, S),
+    {ok,M,Asm} = compile:file(SrcName, [report,beam_debug_info,binary,to_asm]),
+    {M,_,_,[{function,f,3,_,Is}|_],_} = Asm,
+    DebugLines0 = [begin
+                       {location,_File,Line} = lists:keyfind(location, 1, Anno),
+                       {Line,FrameSz,[Name || {Name,_} <- Vars]}
+                   end || {debug_line,Anno,_,_,{FrameSz,Vars}} <- Is],
+    DebugLines = lists:sort(DebugLines0),
+    io:format("~p\n", [DebugLines]),
+    Expected = [{3,entry,[{integer,1},{integer,2},{integer,3}]},
+                {4,none,['X','Y','Z0']},
+                {6,none,['X','Y','Z0']},
+                {7,none,['X','Z0','Z1']},
+                {8,1,['Z1']},
+                {10,none,['X','Y','Z0']},
+                {11,none,['Y','Z0','Z1']}],
+
+    ?assertEqual(Expected, DebugLines),
+
+    ok.
+
+
+%%%
+%%% Common utility functions.
+%%%
+
+get_unique_beam_files() ->
+    F = fun IsCloned(ModString) ->
+                case ModString of
+                    "_dialyzer_SUITE" -> true;
+                    "_r25_SUITE" -> true;
+                    [_|T] -> IsCloned(T);
+                    _ -> false
+                end
+        end,
+    test_lib:get_unique_files(".beam", F).
+
+id(I) -> I.

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1476,7 +1476,7 @@ beam_ssa_pp_1(Mod, Abstr, Outdir) ->
 
 %% Test that warnings contain filenames and line numbers.
 warnings(_Config) ->
-    Files = get_unique_files(".erl"),
+    Files = test_lib:get_unique_files(".erl"),
     test_lib:p_run(fun do_warnings/1, Files).
 
 do_warnings(F) ->
@@ -1749,7 +1749,10 @@ bc_options(Config) ->
          {182, small, [r26]},
          {182, small, []},
 
-         {183, small, [line_coverage]}
+         {183, small, [line_coverage]},
+
+         {184, small, [beam_debug_info]},
+         {184, big, [beam_debug_info]}
         ],
 
     Test = fun({Expected,Mod,Options}) ->
@@ -2371,22 +2374,7 @@ compile_and_verify(Name, Target, Opts) ->
     Opts = BeamOpts.
 
 get_unique_beam_files() ->
-    get_unique_files(".beam").
-
-get_unique_files(Ext) ->
-    Wc = filename:join(filename:dirname(code:which(?MODULE)), "*"++Ext),
-    [F || F <- filelib:wildcard(Wc),
-	  not is_cloned(F, Ext), not is_lfe_module(F, Ext)].
-
-is_cloned(File, Ext) ->
-    Mod = list_to_atom(filename:basename(File, Ext)),
-    test_lib:is_cloned_mod(Mod).
-
-is_lfe_module(File, Ext) ->
-    case filename:basename(File, Ext) of
-	"lfe_" ++ _ -> true;
-	_ -> false
-    end.
+    test_lib:get_unique_files(".beam").
 
 %% Compiles a test module and returns the list of errors and warnings.
 

--- a/lib/compiler/test/compile_SUITE_data/small.erl
+++ b/lib/compiler/test/compile_SUITE_data/small.erl
@@ -1,6 +1,6 @@
 -module(small).
 
--export([go/0,go/2]).
+-export([go/0,go/2,latin1_var/1]).
 
 
 -small_attribute({value,3}).
@@ -43,6 +43,8 @@ recv() ->
     tmo = F(),
     ok.
 
+latin1_var(Överskott) ->
+    Överskott + 1.
 
 id(I) -> I.
 

--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -947,6 +947,8 @@ handle_primop(Tree, Map, State) ->
       {State, Map, t_any()};
     nif_start ->
       {State, Map, t_any()};
+    debug_line ->
+      {State, Map, t_any()};
     executable_line ->
       {State, Map, t_any()};
     Other ->

--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -438,6 +438,8 @@ traverse(Tree, DefinedVars, State) ->
           {State, t_any()};
         nif_start ->
           {State, t_any()};
+        debug_line ->
+          {State, t_any()};
         executable_line ->
           {State, t_any()};
 	Other -> erlang:error({'Unsupported primop', Other})

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -403,7 +403,8 @@ common reasons.
          module_status/0,
          module_status/1,
          modified_modules/0,
-         get_mode/0]).
+         get_mode/0,
+         get_debug_info/1]).
 
 -removed({rehash,0,"the code path cache feature has been removed"}).
 -removed({is_module_native,1,"HiPE has been removed"}).
@@ -418,6 +419,18 @@ common reasons.
 -export_type([coverage_mode/0]).
 -type coverage_mode() :: 'none' | 'function' | 'function_counters' |
                          'line_coverage' | 'line_counters'.
+
+-export_type([debug_line/0, debug_frame/0, debug_name/0, debug_source/0,
+              debug_value/0, debug_info/0]).
+
+-nominal debug_line() :: pos_integer().
+-nominal debug_frame() :: non_neg_integer() | 'entry' | 'none'.
+-nominal debug_name() :: binary() | 1..255.
+-nominal debug_source() :: {'x',non_neg_integer()}
+                         | {'y',non_neg_integer()}
+                         | {value, _}.
+-nominal debug_value() :: {debug_name(), debug_source()}.
+-nominal debug_info() :: [{debug_line(), {debug_frame(), [debug_value()]}}].
 
 -export([coverage_support/0,
          get_coverage/2,
@@ -2325,4 +2338,11 @@ _See also:_ [Native Coverage Support](#module-native-coverage-support)
 -spec coverage_support() -> Supported when
       Supported :: boolean().
 coverage_support() ->
+    erlang:nif_error(undefined).
+
+-doc(#{since => <<"OTP 28.0">>}).
+-spec get_debug_info(Module) -> DebugInfo when
+      Module :: module(),
+      DebugInfo :: debug_info().
+get_debug_info(_Module) ->
     erlang:nif_error(undefined).

--- a/lib/kernel/src/erl_kernel_errors.erl
+++ b/lib/kernel/src/erl_kernel_errors.erl
@@ -81,6 +81,18 @@ format_code_error(get_coverage_mode, [Module]) ->
                        end
                end]
       end);
+format_code_error(get_debug_info, [Module]) ->
+    [if
+         not is_atom(Module) ->
+             not_atom;
+         true ->
+             case erlang:module_loaded(Module) of
+                 false ->
+                     module_not_loaded;
+                 true ->
+                     ~"this runtime system does not support the native debug API"
+             end
+     end];
 format_code_error(reset_coverage, [Module]) ->
     coverage(
       fun () ->

--- a/lib/kernel/test/code_coverage_SUITE.erl
+++ b/lib/kernel/test/code_coverage_SUITE.erl
@@ -273,6 +273,9 @@ error_info(_Config) ->
          {get_coverage, [cover_line_id,NotLoaded]},
          {get_coverage, [whatever,?MODULE]},
 
+         {get_debug_info, [42]},
+         {get_debug_info, [NotLoaded]},
+
          {reset_coverage, [42]},
          {reset_coverage, [NotLoaded]},
          {reset_coverage, [?MODULE]},

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -498,6 +498,8 @@ expr({op,Anno,Op,L0,R0}, St0) ->
     {{op,Anno,Op,L,R},St2};
 expr({executable_line,_,_}=E, St) ->
     {E, St};
+expr({debug_line,_,_}=E, St) ->
+    {E, St};
 expr({ssa_check_when,_,_,_,_,_}=E, St) ->
     {E, St}.
 

--- a/lib/stdlib/src/erl_pp.erl
+++ b/lib/stdlib/src/erl_pp.erl
@@ -845,6 +845,8 @@ lexpr({remote,_,M,F}, Prec, Opts) ->
 %% BIT SYNTAX:
 lexpr({bin,_,Fs}, _, Opts) ->
     bit_grp(Fs, Opts);
+lexpr({debug_line,Line,Index}, _Prec, _Opts) ->
+    leaf(format("beam_instruction:debug_line(~p, ~p)", [Line,Index]));
 lexpr({executable_line,Line,Index}, _Prec, _Opts) ->
     leaf(format("beam_instruction:executable_line(~p, ~p)", [Line,Index]));
 %% Special case for straight values.


### PR DESCRIPTION
This pull request introduces support for adding debug information to BEAM files for a native debugger and for the BEAM loader to load that information. For more information, see the individual commit messages.

This is one of the components needed for the [new debugger being developed by WhatsApp](https://github.com/WhatsApp/edb).
