### PR TITLE
Fix .github/workflows/upload-windows-zip.yaml

### DIFF
--- a/.github/workflows/upload-windows-zip.yaml
+++ b/.github/workflows/upload-windows-zip.yaml
@@ -71,11 +71,8 @@ jobs:
           $root = Get-Location
 
           cd ${{ env.basename }}
-          rm bin\erl.ini
-          rm erts-*\erl.ini
-          rm Install.exe
-          rm Install.ini
-          rm Uninstall.exe
+          Get-ChildItem -Recurse -Filter erl.ini | Remove-Item
+          rm Install.exe,Install.ini,Uninstall.exe
           $sha256 = Get-FileHash $root\otp.exe -Algorithm SHA256
           $sha256.Hash.ToLower() | Out-File -FilePath installer.sha256
           cp $root/vc_redist.exe .


### PR DESCRIPTION
In the previous patch, https://github.com/erlang/otp/pull/9326/files, this line was wrong:

```pwsh
rm erts-*\erl.ini
```

was wrong, it should have been:

```pwsh
rm erts-*\bin\erl.ini
```

however it seems because glob was used, pwsh did not report an error. This PR hopefully fixes this once and for all.

It was a rookie mistake and lack of testing and I suppose one way to avoid regressions is to move all of this logic into a .ps1 where this yaml just calls into it, and so people could more easily test the .ps1 script locally. In this particular case though locally testing the whole script is not ideal as it performs an actual install so there would be things written to the registry for example. I suppose at the end of the script we could run `Uninstall.exe /S` though. Anyway, if any of this resonates, I'm happy to improve this or send more PRs. I have manually tested it like this:

```
PS C:\Users\wojtek\tmp> curl.exe -fsSLo otp.exe https://github.com/erlang/otp/releases/download/OTP-27.2.1/otp_win64_27.2.1.exe
PS C:\Users\wojtek\tmp> Start-Process -FilePath ".\otp.exe" -ArgumentList "/S", "/D=$PWD\27.2.1" -Wait
PS C:\Users\wojtek\tmp> cd .\27.2.1\
PS C:\Users\wojtek\tmp\27.2.1> Get-ChildItem -Recurse -Filter erl.ini | Remove-Item
PS C:\Users\wojtek\tmp\27.2.1> rm Install.exe,Install.ini,Uninstall.exe
PS C:\Users\wojtek\tmp\27.2.1> .\bin\erl.exe
Erlang/OTP 27 [erts-15.2.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]

Eshell V15.2.1 (press Ctrl+G to abort, type help(). for help)
1> os:cmd("erl -noshell -eval \"erlang:display(hi),halt().\"").
"hi\r\n"
```

In any case, apologies for the noise.

cc @garazdawi 