### PR TITLE
kernel: fix broken spec for `socket:recv/3`

### DIFF
--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -4913,7 +4913,7 @@ With arguments `Flags` and `TimeoutOrHandle`; equivalent to
       TimeoutOrHandle :: nowait | select_handle() | completion_handle();
           (Socket :: socket(), Length :: non_neg_integer(), Flags :: list())
           -> dynamic();
-          (Socket :: socket(), Length :: non_neg_integer(), TimeoutOrHandle :: select_handle() | completion_handle())
+          (Socket :: socket(), Length :: non_neg_integer(), TimeoutOrHandle :: nowait | select_handle() | completion_handle())
           -> dynamic().
 
 recv(Socket, Flags, TimeoutOrHandle) when is_list(Flags) ->


### PR DESCRIPTION

Like reported in #9180, the spec is also broken for `socket:recv/3` and dialyzer currently complains by mistake. This PR fixes the spec.

**To Reproduce**

Run dialyzer on the following code:
```erl
socket:recv(Sock, 0, nowait)
```

**Expected behavior**
Call is not reported as violating the function specification.

**Affected versions**

27.2.1