### PR TITLE
compiler alias analysis: Fix repeated argument bug

### DIFF
--- a/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/alias.erl
@@ -107,7 +107,9 @@
          fuzz0/0, fuzz0/1,
          alias_after_phi/0,
          check_identifier_type/0,
-         gh9014_main/0]).
+         gh9014_main/0,
+
+         duplicated_args/1]).
 
 %% Trivial smoke test
 transformable0(L) ->
@@ -1180,3 +1182,14 @@ gh9014_wibble(State) ->
 
 gh9014_main() ->
     {counter, 1} = gh9014_wibble({state, {counter, 0}}).
+
+duplicated_args(V) ->
+    %% The constructed list was considered unique, which made
+    %% duplicated_args/2 think that both arguments were unique
+    %% (which is wrong).
+    duplicated_args([V], [V]).
+
+duplicated_args(A, B) ->
+%ssa% (A, B) when post_ssa_opt ->
+%ssa% _ = put_tuple(A, B) {aliased => [A, B]}.
+    {A, B}.


### PR DESCRIPTION
When the same variable occurs multiple times in the argument list to a call, that variable should become aliased.

This patch corrects the above described omission by renaming the current aa_alias_surviving_args/4 to aa_alias_surviving_phi_args/4 which we use for Phi-instructions and creating a new aa_alias_surviving_args/4 (for calls) which makes use of aa_alias_surviving_phi_args/4 but also does a second pass through the argument list to find repeated variables.

This patch is made against OTP-27.2.1 (the bug first appeared in OTP-27), the same functional change should also be pulled into master, where it doesn't apply cleanly. [This branch contains the same change](https://github.com/frej/otp/tree/frej/aa-bugfix), but rebased to the [current](https://github.com/erlang/otp/commit/a0a606be02d33fd91c0cc8749268b6c7701cda74) master. 