### PR TITLE
stdlib: Fix jaro_similarity for matching strings of length 1

### DIFF
--- a/lib/stdlib/src/string.erl
+++ b/lib/stdlib/src/string.erl
@@ -1061,7 +1061,7 @@ The Jaro distance between two strings can be calculated with
 jaro_similarity(A0, B0) ->
     {A, ALen} = str_to_gcl_and_length(A0),
     {B, BLen} = str_to_indexmap(B0),
-    Dist = max(ALen, BLen) div 2,
+    Dist = max(1, max(ALen, BLen) div 2),
     {AM, BM} = jaro_match(A, B, -Dist, Dist, [], []),
     if
         ALen =:= 0 andalso BLen =:= 0 ->

--- a/lib/stdlib/test/string_SUITE.erl
+++ b/lib/stdlib/test/string_SUITE.erl
@@ -808,6 +808,9 @@ jaro_similarity(_Config) ->
     ?TEST("Sunday", ["Saturday"], 0.71944444),
 
     %% Short strings (no translations counted)
+    ?TEST("a", ["a"], 1.0),
+    ?TEST("c", ["a"], 0.0),
+    ?TEST("ca", ["ac"], 0.0),
     ?TEST("ca", ["abc"], 0.0),
     ?TEST("ca", ["cb"],  ((1/2+1/2+1)/3)),
     ?TEST("ca", ["cab"], ((2/2+2/3+1)/3)),


### PR DESCRIPTION
Fixes #9369 