### PR TITLE
erts: Disable unsafe optimization in bs_append

### DIFF
--- a/erts/emulator/beam/erl_bits.c
+++ b/erts/emulator/beam/erl_bits.c
@@ -1479,14 +1479,6 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
 	}
     }
 
-    if (build_size_in_bits == 0) {
-        if (HeapWordsLeft(c_p) < extra_words) {
-            (void) erts_garbage_collect(c_p, extra_words, reg, live+1);
-            bin = reg[live];
-        }
-	return bin;
-    }
-
     if((ERTS_UINT_MAX - build_size_in_bits) < erts_bin_offset) {
         c_p->fvalue = am_size;
         c_p->freason = SYSTEM_LIMIT;
@@ -1571,10 +1563,6 @@ erts_bs_append_checked(Process* c_p, Eterm* reg, Uint live,
                 c_p->fvalue = am_unit;
 		goto badarg;
 	    }
-	}
-
-	if (build_size_in_bits == 0) {
-            return bin;
 	}
 
         if((ERTS_UINT_MAX - build_size_in_bits) < erts_bin_offset) {

--- a/erts/emulator/test/bs_construct_SUITE.erl
+++ b/erts/emulator/test/bs_construct_SUITE.erl
@@ -553,9 +553,13 @@ do_something() ->
 
 append_empty_is_same(Config) when is_list(Config) ->
     NonWritableBin = <<"123">>,
-    true = erts_debug:same(NonWritableBin, append(NonWritableBin, <<>>)),
+
+    %% Should use erts_debug:same/2, but this was disabled in PR-9372
+    %% (ERIERL-1177) because the optimization was unsafe.
+    true = NonWritableBin =:= append(NonWritableBin, <<>>),
     WritableBin = <<(id(<<>>))/binary,0,1,2,3,4,5,6,7>>,
-    true = erts_debug:same(WritableBin, append(WritableBin, <<>>)),
+    true = WritableBin =:= append(WritableBin, <<>>),
+
     ok.
 
 append(A, B) ->


### PR DESCRIPTION
Imagine that we execute the following code, where `X` and `Y` are integers:

```
A = <<0, X>>,
B = <<A/bits, Y:X>>.
```

The first line sets up `erts_current_bin`, `erts_bin_offset`, etc because it obviously should.

However, the second line does not do so if `X` is zero, as `build_size_in_bits` being zero short-circuits the relevant logic.

This leaves a dangling pointer that, when we execute `erts_new_bs_put_integer` on the second line, we can land in a code path that ostensibly does not modify the buffer, but may nevertheless do a dummy read/write that is masked off, which can race with a write to the same address on another scheduler. For example, this can occur if there is a garbage collection between `A` and `B`, where the old heap that `A` lived on is picked up by another process _on another scheduler_ before `B` executes.

Note that there does not need to be an actual link between `A` and `B` here: all that is necessary is that an expression like `<<A/bits, Y:X>>` is executed where `X` is zero. This issue was mostly benign before 9256aad02f77bc4ca8c2ed5a4b41d5cad834fad1 that introduced an read-modify-write in certain cases that would be okay if `erts_current_bin` and `erts_bin_offset` had been set correctly.

While we could fix the read-modify-write issue separately, the invariant that `erts_current_bin` and `erts_bin_offset` are up to date has been broken, and it's difficult to tell whether other parts may suffer the same problem. Therefore, we will disable this optimization and reintroduce it again safely at a later time.