### PR TITLE
stdlib: create an init function for records with complex default values

### DIFF
--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -2846,10 +2846,8 @@ otp_5878(Config) when is_list(Config) ->
               t() -> #r2{}.
              ">>,
            [warn_unused_record],
-           {error,[{{1,44},erl_lint,{variable_in_record_def,'A'}},
-                   {{1,54},erl_lint,{unbound_var,'B'}},
-                   {{2,38},erl_lint,{variable_in_record_def,'A'}}],
-            [{{1,22},erl_lint,{unused_record,r1}}]}},
+           {errors,[{{1,54},erl_lint,{unbound_var,'B'}}],
+            []}},
 
           {otp_5878_30,
            <<"-record(r1, {t = case foo of _ -> 3 end}).
@@ -2859,9 +2857,7 @@ otp_5878(Config) when is_list(Config) ->
               t() -> {#r1{},#r2{},#r3{},#r4{}}.
              ">>,
            [warn_unused_record],
-           {errors,[{{2,44},erl_lint,{variable_in_record_def,'A'}},
-                    {{3,44},erl_lint,{variable_in_record_def,'A'}}],
-            []}},
+            []},
 
           {otp_5878_40,
            <<"-record(r1, {foo = A}). % A unbound
@@ -2898,9 +2894,7 @@ otp_5878(Config) when is_list(Config) ->
              ">>,
            [warn_unused_record],
            {error,[{{1,39},erl_lint,{unbound_var,'A'}},
-                   {{2,33},erl_lint,{unbound_var,'A'}},
-                   {{4,42},erl_lint,{variable_in_record_def,'A'}},
-                   {{17,44},erl_lint,{variable_in_record_def,'A'}}],
+                   {{2,33},erl_lint,{unbound_var,'A'}}],
             [{{8,36},erl_lint,{unused_var,'X'}}]}},
 
           {otp_5878_60,
@@ -2922,8 +2916,7 @@ otp_5878(Config) when is_list(Config) ->
               t() -> #r1{}.
              ">>,
            [warn_unused_record],
-           {errors,[{{3,40},erl_lint,{unbound_var,'Y'}},
-                    {{4,38},erl_lint,{variable_in_record_def,'Y'}}],
+           {errors,[{{3,40},erl_lint,{unbound_var,'Y'}}],
             []}},
 
           {otp_5878_80,
@@ -3042,8 +3035,7 @@ otp_5878(Config) when is_list(Config) ->
                 t() ->
                     {#u2{}}.
                ">>,
-    {warnings,[{{5,18},erl_lint,{unused_record,u3}},
-               {{6,18},erl_lint,{unused_record,u4}}]} = 
+    {warnings,[{{6,18},erl_lint,{unused_record,u4}}]} =
         run_test2(Config, Usage1, [warn_unused_record]),
 
     Usage2 = <<"-module(lint_test).

--- a/system/doc/reference_manual/ref_man_records.md
+++ b/system/doc/reference_manual/ref_man_records.md
@@ -39,8 +39,7 @@ used.
                FieldN [= ExprN]}).
 ```
 
-The default value for a field is an arbitrary expression, except that it must
-not use any variables.
+The default value for a field is an arbitrary expression.
 
 A record definition can be placed anywhere among the attributes and function
 declarations of a module, but the definition must come before any usage of the
@@ -54,6 +53,33 @@ definition is placed in an include file.
 > Starting from Erlang/OTP 26, records can be defined in the Erlang shell
 > using the syntax described in this section. In earlier releases, it was
 > necessary to use the `m:shell` built-in function `rd/2`.
+
+> #### Change {: .info }
+>
+> In Erlang/OTP 28, variables are allowed in the record definition.
+
+```erlang
+-record(r, {a = case my_f() of {X, _} -> X; _ -> ok end,
+            b = case my_g() of {Y, _} -> Y; _ -> ok end}).
+t(X) ->
+   #r{}. %% X will not have any effect on initialization of #r
+```
+
+Variables bound in a field are visible in subsequent fields,
+so use them with caution.
+
+```erlang
+-record(r, {a = case my_f() of {Res, _} -> Res; _ -> ok end,
+            b = case my_g() of {Res, _} -> Res; _ -> error end}).
+```
+
+Variables need to be bound, which is not the case in the following.
+
+```erlang
+-record(r, {a = X = 1, b = X}).
+
+my_mod.erl:4:17: variable 'X' is unbound
+```
 
 ## Creating Records
 


### PR DESCRIPTION
records that have field default values containing variables that are "free" was unsafe in functions that have variables with the same name. This commit creates init function for records to protect the variables in the default value.

e.g.
-record(r, {f = fun(X)->case X of {y, Y} -> Y; _ -> X end, g=..., h=abc}). foo(X)->\#r{}. --> foo(X)->(r_init()){}.

r_init() will only initialize fields that will not be updated e.g.
foo(X)->\#r{f=X} --> foo(X)->(r_init_f()){f=X}.
r_init_f will only initialize g and h with its default value, f will be initialized to undefined.

r_init() functions will not be generated if all fields of the record that contains "free variables" are initialized by the user.
e.g.
foo(X)->\#r{f=X,g=X}. --> foo(X)->{r,X,X,abc}.

closes #9317