### PR TITLE
ssl: Improve error handling of sni_fun

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -1744,8 +1744,12 @@ Options specific to the server side, or with different semantics for the client 
   If the server receives a SNI (Server Name Indication) from the
   client, the given fun `SNIFun` will be called to retrieve
   [`server_option()`](`t:server_option/0`) for the indicated
-  hosts. These options will override previously specified options for
-  that host.
+  server. These options will override previously specified server options.
+  The sni_fun can indicate that it does not recognize the server name by
+  returning `unrecognized` in which case the connection will be closed with an
+  `unrecognized_name` alert. If the
+  sni_fun returns `undefined` the connection will be attempted with the default
+  options supplied to `listen/2` or  [`handshake/2,3`](`handshake/2`).
 
   > #### Note {: .info }
   The options `sni_fun` and `sni_hosts` are mutually exclusive.
@@ -1754,7 +1758,8 @@ Options specific to the server side, or with different semantics for the client 
 
   If the server receives a SNI (Server Name Indication) from the client matching a
   host listed in the `sni_hosts` option, the specific options for that host will
-  override previously specified options.
+  override previously specified options. If no match is found it behaves as
+  option sni_fun that returns `undefined`.
 
   > #### Note {: .info }
   The options `sni_fun` and `sni_hosts` are mutually exclusive.
@@ -1765,7 +1770,7 @@ Options specific to the server side, or with different semantics for the client 
         common_option_cert() |
         {alpn_preferred_protocols,  AppProtocols::[binary()]}|
         {sni_hosts, SNIHosts::[{inet:hostname(), [server_option() | common_option()]}]} |
-        {sni_fun, SNIFun:: fun((string()) -> [])} |
+        {sni_fun, SNIFun:: fun((string()) -> [server_option() | common_option()] | 'unrecognized' | 'undefined')} |
         server_option_pre_tls13() |
         common_option_pre_tls13() |
         server_option_tls13() |

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -520,9 +520,13 @@ handle_sni_extension(#sni{hostname = Hostname}, #state{static_env = #static_env{
                                                        ssl_options = #{protocol := Protocol}} = State0) ->
     case check_hostname(Hostname) of
         ok ->
-
-            proc_lib:set_label({Protocol, ?SERVER_ROLE, erlang:iolist_to_binary(Hostname), Port}),
-            {ok, handle_sni_hostname(Hostname, State0)};
+            case handle_sni_hostname(Hostname, State0) of
+                #alert{} = OptAlert ->
+                    {error, OptAlert};
+                State ->
+                    proc_lib:set_label({Protocol, ?SERVER_ROLE, erlang:iolist_to_binary(Hostname), Port}),
+                    {ok, State}
+            end;
         #alert{} = Alert ->
             {error, Alert}
     end.
@@ -1312,15 +1316,18 @@ handle_sni_hostname(Hostname,
                            handshake_env = HsEnv,
                            connection_env = CEnv,
                            ssl_options = Opts} = State0) ->
+    %% RFC6060:  "If the server understood the ClientHello extension but
+    %%  does not recognize the server name, the server SHOULD take one of two
+    %%  actions: either abort the handshake by sending a fatal-level
+    %%  unrecognized_name(112) alert or continue the handshake."
+    %% Realized as use_default_options |  #alert{description = ?UNRECOGNIZED_NAME}
     case update_ssl_options_from_sni(Opts, Hostname) of
-        undefined ->
-            %% RFC6060:  "If the server understood the ClientHello extension but
-            %%  does not recognize the server name, the server SHOULD take one of two
-            %%  actions: either abort the handshake by sending a fatal-level
-            %%  unrecognized_name(112) alert or continue the handshake."
+        use_original_options ->
             State0#state{handshake_env = HsEnv#handshake_env{sni_hostname = Hostname}};
+        #alert{} = Alert ->
+            Alert;
         NewOptions ->
-	    {ok, #{cert_db_ref := Ref,
+            {ok, #{cert_db_ref := Ref,
                    cert_db_handle := CertDbHandle,
                    fileref_db_handle := FileRefHandle,
                    session_cache := CacheHandle,
@@ -1345,13 +1352,36 @@ handle_sni_hostname(Hostname,
     end.
 
 update_ssl_options_from_sni(#{sni_fun := SNIFun} = OrigSSLOptions, SNIHostname) ->
-    case SNIFun(SNIHostname) of
+    try SNIFun(SNIHostname) of
         undefined ->
-            undefined;
+            use_original_options;
+        unrecognized ->
+            ?ALERT_REC(?FATAL, ?UNRECOGNIZED_NAME, {sni, SNIHostname});
         SSLOptions ->
-            VersionsOpt = proplists:get_value(versions, SSLOptions, []),
-            FallBackOptions = filter_for_versions(VersionsOpt, OrigSSLOptions),
-            ssl:update_options(SSLOptions, server, FallBackOptions)
+            try
+                FallBackOptions = fallback_options(SSLOptions, OrigSSLOptions),
+                ssl:update_options(SSLOptions, server, FallBackOptions)
+            catch
+                throw:#alert{} = Alert ->
+                    Alert;
+                throw:Reason ->
+                    ?LOG_ERROR("sni_fun provided erroneous options : ~p~n", [Reason]),
+                    ?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, sni_fun_provided_erroneous_options)
+            end
+    catch
+        Error:Reason:ST ->
+            ?LOG_ERROR("sni_fun crashed ~p ~p~n ~p~n", [Error, Reason, {stacktrace, ST}]),
+            ?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, sni_fun_crashed)
+    end.
+
+fallback_options(SSLOptions, OrigSSLOptions) ->
+    VersionsOpt = proplists:get_value(versions, SSLOptions, []),
+    try filter_for_versions(VersionsOpt, OrigSSLOptions) of
+        FallBackOptions ->
+            FallBackOptions
+    catch _:_:ST ->
+            ?LOG_ERROR("sni_fun provided erroneous options : ~p ~n ~p ~n", [VersionsOpt,  {stacktrace, ST}]),
+            throw(?ALERT_REC(?FATAL, ?HANDSHAKE_FAILURE, sni_fun_provided_erroneous_versions))
     end.
 
 filter_for_versions([], OrigSSLOptions) ->

--- a/lib/ssl/test/ssl_sni_SUITE.erl
+++ b/lib/ssl/test/ssl_sni_SUITE.erl
@@ -39,12 +39,14 @@
          end_per_testcase/2]).
 
 %% Testcases
--export([no_sni_header/1,
+-export([no_sni_ext/1,
          sni_match/1,
          sni_no_match/1,
-         no_sni_header_fun/1,
+         no_sni_ext_fun/1,
          sni_match_fun/1,
          sni_no_match_fun/1,
+         sni_fail_fun/1,
+         sni_crash_fun/1,
          dns_name/1,
          ip_fallback/1,
          no_ip_fallback/1,
@@ -88,12 +90,14 @@ groups() ->
     ].
 
 sni_tests() ->
-    [no_sni_header, 
+    [no_sni_ext, 
      sni_match, 
      sni_no_match,
-     no_sni_header_fun, 
+     no_sni_ext_fun, 
      sni_match_fun, 
      sni_no_match_fun,
+     sni_fail_fun,
+     sni_crash_fun,
      dns_name,
      ip_fallback,
      no_ip_fallback,
@@ -148,14 +152,14 @@ end_per_testcase(_TestCase, Config) ->
 %%--------------------------------------------------------------------
 %% Test Cases --------------------------------------------------------
 %%--------------------------------------------------------------------
-no_sni_header(Config) ->
+no_sni_ext(Config) ->
     {ClientNode, ServerNode, HostName} = ssl_test_lib:run_where(Config),
     ServerOptions = ssl_test_lib:ssl_options(proplists:get_value(sni_server_opts, Config), Config),
     ClientOptions = ssl_test_lib:ssl_options([{server_name_indication, disable} |
                                               proplists:get_value(client_local_opts, Config)], Config),
     basic_sni_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName, undefined).
 
-no_sni_header_fun(Config) ->
+no_sni_ext_fun(Config) ->
     {ClientNode, ServerNode, HostName} = ssl_test_lib:run_where(Config),
     [{sni_hosts, ServerSNIConf}| DefaultConf] = proplists:get_value(sni_server_opts, Config),
     SNIFun = fun(Domain) -> proplists:get_value(Domain, ServerSNIConf, []) end,
@@ -174,7 +178,7 @@ sni_match(Config) ->
 sni_match_fun(Config) ->
     {ClientNode, ServerNode, HostName} = ssl_test_lib:run_where(Config),
     [{sni_hosts, ServerSNIConf}| DefaultConf] = proplists:get_value(sni_server_opts, Config),
-    SNIFun = fun(Domain) -> proplists:get_value(Domain, ServerSNIConf, undefined) end,
+    SNIFun = fun(Domain) -> proplists:get_value(Domain, ServerSNIConf, unrecognized) end,
     ServerOptions =  ssl_test_lib:ssl_options(DefaultConf, Config) ++ [{sni_fun, SNIFun}],
     ClientOptions =  ssl_test_lib:ssl_options([{server_name_indication, HostName} |
                                                proplists:get_value(client_opts, Config)], Config),
@@ -186,15 +190,38 @@ sni_no_match(Config) ->
     ClientOptions =  ssl_test_lib:ssl_options([{server_name_indication, HostName} |
                                                proplists:get_value(client_opts, Config)], Config),
     ServerOptions =  ssl_test_lib:ssl_options(DefaultConf, Config),
-    basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName).
+    basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName, handshake_failure).
 
 sni_no_match_fun(Config) ->
     {ClientNode, ServerNode, HostName} = ssl_test_lib:run_where(Config),
-    [{sni_hosts, _}| DefaultConf] = proplists:get_value(sni_server_opts, Config),
-    ServerOptions =  ssl_test_lib:ssl_options(DefaultConf, Config),
-    ClientOptions =  ssl_test_lib:ssl_options([{server_name_indication, HostName} |
+    [{sni_hosts, ServerSNIConf}| DefaultConf] = proplists:get_value(sni_server_opts, Config),
+    SNIFun = fun(Domain) -> proplists:get_value(Domain, ServerSNIConf, unrecognized) end,
+    ServerOptions =  ssl_test_lib:ssl_options(DefaultConf, Config) ++ [{sni_fun, SNIFun}],
+    ClientOptions =  ssl_test_lib:ssl_options([{server_name_indication, "localhost"} |
                                                proplists:get_value(client_local_opts, Config)], Config),
-    basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName).
+    basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName, unrecognized_name).
+
+sni_fail_fun(Config) ->
+    {ClientNode, ServerNode, HostName} = ssl_test_lib:run_where(Config),
+    [_| DefaultConf] = proplists:get_value(sni_server_opts, Config),
+    ServerOptions =  ssl_test_lib:ssl_options(DefaultConf, Config) ,
+    ClientOptions =  ssl_test_lib:ssl_options([{server_name_indication, HostName} |
+                                               proplists:get_value(client_opts, Config)], Config),
+    basic_sni_alert_test(ServerNode, ServerOptions ++ [{sni_fun, fun(_Domain) -> [{versions, ['tlsv1.5']}] end}],
+                         ClientNode, ClientOptions, HostName, handshake_failure),
+    basic_sni_alert_test(ServerNode, ServerOptions ++  [{sni_fun, fun(_Domain) -> [{verify, foobar}] end}],
+                         ClientNode, ClientOptions, HostName, handshake_failure).
+
+sni_crash_fun(Config) ->
+    {ClientNode, ServerNode, HostName} = ssl_test_lib:run_where(Config),
+    [_| DefaultConf] = proplists:get_value(sni_server_opts, Config),
+    SNIFun = fun(Domain) -> Domain = nomatch end,
+    ServerOptions =  ssl_test_lib:ssl_options(DefaultConf, Config) ++ [{sni_fun, SNIFun}],
+    ClientOptions =  ssl_test_lib:ssl_options([{server_name_indication, HostName} |
+                                               proplists:get_value(client_opts, Config)], Config),
+    basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName, handshake_failure).
+
+
 
 dns_name(Config) ->
     Hostname = "OTP.test.server",
@@ -215,12 +242,12 @@ dns_name(Config) ->
     Version = ssl_test_lib:n_version(proplists:get_value(version, Config)),
     ServerConf = ssl_test_lib:sig_algs(rsa, Version) ++  ServerOpts0,
     ClientConf = ssl_test_lib:sig_algs(rsa, Version) ++ ClientOpts0,
-    unsuccessfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], undefined, Config),
-    successfull_connect(ServerConf, [{verify, verify_peer},
+    unsuccessful_connect(ServerConf, [{verify, verify_peer} | ClientConf], undefined, Config, handshake_failure),
+    successful_connect(ServerConf, [{verify, verify_peer},
                                      {server_name_indication, Hostname} | ClientConf], undefined, Config),
-    unsuccessfull_connect(ServerConf, [{verify, verify_peer}, {server_name_indication, "foo"} | ClientConf],
-                          undefined, Config),
-    successfull_connect(ServerConf, [{verify, verify_peer}, {server_name_indication, disable} | ClientConf],
+    unsuccessful_connect(ServerConf, [{verify, verify_peer}, {server_name_indication, "foo"} | ClientConf],
+                          undefined, Config, handshake_failure),
+    successful_connect(ServerConf, [{verify, verify_peer}, {server_name_indication, disable} | ClientConf],
                         undefined, Config).
 
 ip_fallback(Config) ->
@@ -246,10 +273,10 @@ ip_fallback(Config) ->
     Version = ssl_test_lib:n_version(proplists:get_value(version, Config)),
     ServerConf = ssl_test_lib:sig_algs(rsa, Version) ++  ServerOpts0,
     ClientConf = ssl_test_lib:sig_algs(rsa, Version) ++ ClientOpts0,
-    successfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], Hostname, Config),
-    successfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], IP, Config),
-    successfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], IPStr, Config),
-    successfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], list_to_atom(Hostname), Config).
+    successful_connect(ServerConf, [{verify, verify_peer} | ClientConf], Hostname, Config),
+    successful_connect(ServerConf, [{verify, verify_peer} | ClientConf], IP, Config),
+    successful_connect(ServerConf, [{verify, verify_peer} | ClientConf], IPStr, Config),
+    successful_connect(ServerConf, [{verify, verify_peer} | ClientConf], list_to_atom(Hostname), Config).
 
 no_ip_fallback(Config) ->
     Hostname = net_adm:localhost(),
@@ -274,9 +301,9 @@ no_ip_fallback(Config) ->
     Version = ssl_test_lib:n_version(proplists:get_value(version, Config)),
     ServerConf = ssl_test_lib:sig_algs(rsa, Version) ++  ServerOpts0,
     ClientConf = ssl_test_lib:sig_algs(rsa, Version) ++ ClientOpts0,
-    successfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], Hostname, Config),
-    unsuccessfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], IP, Config),
-    unsuccessfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], IPStr, Config).
+    successful_connect(ServerConf, [{verify, verify_peer} | ClientConf], Hostname, Config),
+    unsuccessful_connect(ServerConf, [{verify, verify_peer} | ClientConf], IP, Config, handshake_failure),
+    unsuccessful_connect(ServerConf, [{verify, verify_peer} | ClientConf], IPStr, Config, handshake_failure).
 
 dns_name_reuse(Config) ->
     SNIHostname = "OTP.test.server",
@@ -302,7 +329,7 @@ dns_name_reuse(Config) ->
 
     {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
 
-    unsuccessfull_connect(ServerConf, [{verify, verify_peer} | ClientConf], undefined, Config),
+    unsuccessful_connect(ServerConf, [{verify, verify_peer} | ClientConf], undefined, Config, handshake_failure),
 
     Server =
 	ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
@@ -475,7 +502,7 @@ basic_sni_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName, E
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
 
-basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName) ->
+basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostName, Alert) ->
     Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
                                         {from, self()}, {mfa, {ssl_test_lib, no_result, []}},
                                         {options, ServerOptions}]),
@@ -483,11 +510,11 @@ basic_sni_alert_test(ServerNode, ServerOptions, ClientNode, ClientOptions, HostN
     Client = ssl_test_lib:start_client_error([{node, ClientNode}, {port, Port},
                                               {host, HostName}, {from, self()},
                                               {options, [{verify, verify_peer} | ClientOptions]}]),
-    ssl_test_lib:check_client_alert(Client, handshake_failure),
+    ssl_test_lib:check_client_alert(Client, Alert),
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
 
-successfull_connect(ServerOptions, ClientOptions, Hostname0, Config) ->  
+successful_connect(ServerOptions, ClientOptions, Hostname0, Config) ->
     {ClientNode, ServerNode, Hostname1} = ssl_test_lib:run_where(Config),
     Hostname = host_name(Hostname0, Hostname1),
     Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
@@ -502,7 +529,7 @@ successfull_connect(ServerOptions, ClientOptions, Hostname0, Config) ->
     ssl_test_lib:close(Server),
     ssl_test_lib:close(Client).
 
-unsuccessfull_connect(ServerOptions, ClientOptions, Hostname0, Config) ->
+unsuccessful_connect(ServerOptions, ClientOptions, Hostname0, Config, Alert) ->
     {ClientNode, ServerNode, Hostname1} = ssl_test_lib:run_where(Config),
     Hostname = host_name(Hostname0, Hostname1),
     Server = ssl_test_lib:start_server_error([{node, ServerNode}, {port, 0},
@@ -514,7 +541,7 @@ unsuccessfull_connect(ServerOptions, ClientOptions, Hostname0, Config) ->
 					      {from, self()}, 
 					      {options, ClientOptions}]),
     
-    ssl_test_lib:check_server_alert(Server, Client, handshake_failure).
+    ssl_test_lib:check_server_alert(Server, Client, Alert).
 
 host_name(undefined, Hostname) ->
     Hostname;


### PR DESCRIPTION
If sni_fun returns undefined we will attempt connection with original option values, if it returns unrecognized we end the connection with UNRECOGNIZED_NAME alert and if provided options fail option verification we will end the connection with a HANDSHAKE_FAILURE and an error log.