### PR TITLE
Handle load_binary result in debugger int:load

### DIFF
--- a/lib/debugger/src/int.erl
+++ b/lib/debugger/src/int.erl
@@ -866,27 +866,56 @@ check(Mod) when is_atom(Mod) -> catch check_module(Mod);
 check(File) when is_list(File) -> catch check_file(File).
 
 load({Mod, Src, Beam, BeamBin, Exp, Abst}, Dist) ->
-    _ = everywhere(Dist,
-		   fun() ->
-		       code:purge(Mod),
-		       erts_debug:breakpoint({Mod,'_','_'}, false),
-		       {module,Mod} = code:load_binary(Mod, Beam, BeamBin)
-		   end),
-    case erl_prim_loader:read_file(filename:absname(Src)) of
-	{ok, SrcBin} ->
-	    MD5 = code:module_md5(BeamBin),
-            SrcBin1 = unicode:characters_to_binary(SrcBin, enc(SrcBin)),
-            true = is_binary(SrcBin1),
-	    Bin = term_to_binary({interpreter_module,Exp,Abst,SrcBin1,MD5}),
-	    {module, Mod} = dbg_iserver:safe_call({load, Mod, Src, Bin}),
-	    _ = everywhere(Dist,
-			   fun() ->
-			       true = erts_debug:breakpoint({Mod,'_','_'}, true) > 0
-			   end),
-	    {module, Mod};
-	error ->
-	    error
+    RawLoadResult = everywhere(Dist,
+        fun() ->
+            code:purge(Mod),
+            erts_debug:breakpoint({Mod, '_', '_'}, false),
+            code:load_binary(Mod, Beam, BeamBin)
+        end),
+    LoadResult = extract_result(RawLoadResult),
+    case LoadResult of
+        {module, Mod} ->
+            case erl_prim_loader:read_file(filename:absname(Src)) of
+                {ok, SrcBin} ->
+                    MD5 = code:module_md5(BeamBin),
+                    SrcBin1 = unicode:characters_to_binary(SrcBin, enc(SrcBin)),
+                    true = is_binary(SrcBin1),
+                    Bin = term_to_binary({interpreter_module, Exp, Abst, SrcBin1, MD5}),
+                    {module, Mod} = dbg_iserver:safe_call({load, Mod, Src, Bin}),
+                    _ = everywhere(Dist,
+                        fun() ->
+                            true = erts_debug:breakpoint({Mod, '_', '_'}, true) > 0
+                        end),
+                    {module, Mod};
+                error ->
+                    error
+            end;
+        {error, _} ->
+            error;
+        {badrpc, _} ->
+            error
     end.
+
+extract_result({Results, _BadNodes}) when is_list(Results) ->
+    %% In distributed mode, rpc:multicall returns {Results, BadNodes}.
+    %% Look for any successful result in the list.
+    case lists:filter(fun
+             ({module, _}) -> true;
+             (_) -> false
+         end, Results) of
+        [] ->
+            %% No node succeeded; return the first result from Results,
+            %% which should be an error tuple or badrpc tuple.
+            case Results of
+                [First | _] -> First;
+                [] -> error
+            end;
+        [Success | _] ->
+            Success
+    end;
+extract_result(Result) ->
+    %% For local (non-distributed) calls, the result is returned directly.
+    Result.
 
 check_module(Mod) ->
     case code:which(Mod) of


### PR DESCRIPTION
This PR changes the code used by `int:ni` to not crash when `load_binary` returns an error.
In case of local debugging the change is straightforward. The `extract_result` will get the result directly and the function will return `error`.
In case of distributed scenario the code will return success if any of the multicall results is a success. I'm not sure it is a best approach and if it will work 100% correct in distributed debugging scenario. Previous version would simply swallow all errors in distributed case.

Fixes https://github.com/erlang/otp/issues/7819