### PR TITLE
Build debug emulator with -Og instead of -O0

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -27000,7 +27000,7 @@ if test "X $CFLAGS" = "X$no_opt_CFLAGS"; then
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
-DEBUG_CFLAGS="-g -O0 $no_opt_CFLAGS"
+DEBUG_CFLAGS="-g -Og $no_opt_CFLAGS"
 
 
 no_opt_CXXFLAGS=$(echo " $CXXFLAGS" | sed 's/ -O[^ ]*/ /g')

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -3670,7 +3670,7 @@ if test "X $CFLAGS" = "X$no_opt_CFLAGS"; then
 	If you want to build ERTS without any optimization, pass -O0 to CFLAGS.])
 fi
 AC_MSG_RESULT([yes])
-DEBUG_CFLAGS="-g -O0 $no_opt_CFLAGS"
+DEBUG_CFLAGS="-g -Og $no_opt_CFLAGS"
 AC_SUBST(DEBUG_CFLAGS)
 
 no_opt_CXXFLAGS=$(echo " $CXXFLAGS" | sed 's/ -O[[^ ]]*/ /g')

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -2757,7 +2757,6 @@ BIF_RETTYPE make_tuple_3(BIF_ALIST_3)
 {
     Sint n;
     Uint limit;
-    Eterm* hp;
     Eterm res;
     Eterm list = BIF_ARG_3;
     Eterm* tup = NULL;
@@ -2770,13 +2769,13 @@ BIF_RETTYPE make_tuple_3(BIF_ALIST_3)
     if (n == 0) {
         res = ERTS_GLOBAL_LIT_EMPTY_TUPLE;
     } else {
-        hp = HAlloc(BIF_P, n+1);
+        Eterm* hp = HAlloc(BIF_P, n+1);
         res = make_tuple(hp);
         *hp++ = make_arityval(n);
         tup = hp;
-    }
-    while (n--) {
-	*hp++ = BIF_ARG_2;
+        while (n--) {
+            *hp++ = BIF_ARG_2;
+        }
     }
     while(is_list(list)) {
 	Eterm* cons;

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -3043,6 +3043,9 @@ static TreeDbTerm *slot_search(Process *p, TreeDbTerm *root,
     TreeDbTerm **pp;
     DbTreeStack* stack;
 
+#ifdef DEBUG
+    lastobj = (TreeDbTerm*)1;
+#endif
     if (iter) {
         /* Find first non-empty tree */
         while (!root) {
@@ -3134,6 +3137,7 @@ next_root:
         }
 
         ASSERT(slot > stack->slot);
+        ASSERT(lastobj != (TreeDbTerm*)1);
         if (lastobj) {
             lastkey = GETKEY(tb, lastobj->dbterm.tpl);
             lastobj = NULL;

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -5707,6 +5707,7 @@ static void dbg_assert_in_env(ErlNifEnv* env, Eterm term,
 {
     Uint saved_used_size;
     Eterm* real_htop;
+    ERTS_UNDEF(saved_used_size, 0);
 
     if (is_immed(term)
         || (is_non_value(term) && env->exception_thrown)

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -4292,6 +4292,7 @@ handle_exit_signal(Process *c_p, ErtsSigRecvTracing *tracing,
     Eterm reason;
     Eterm from;
 
+    ERTS_UNDEF(reason, THE_NON_VALUE);
     ASSERT(ERTS_PROC_SIG_TYPE(tag) == ERTS_SIG_Q_TYPE_GEN_EXIT);
     
     xsigd = get_exit_signal_data(sig);
@@ -4788,6 +4789,7 @@ handle_persistent_mon_msg(Process *c_p, ErtsSigRecvTracing *tracing,
             ErtsMessage *first = NULL, *prev, *last;
             Uint hsz = size_object(msg);
             Uint i;
+            ERTS_UNDEF(last,NULL);
 
             for (i = 0; i < n; i++) {
                 Eterm *hp;

--- a/erts/emulator/beam/erl_rbtree.h
+++ b/erts/emulator/beam/erl_rbtree.h
@@ -1387,6 +1387,7 @@ ERTS_RBT_FUNC__(foreach_unordered__)(ERTS_RBT_T **root,
 	while (1) {
 #ifdef ERTS_RBT_DEBUG
 	    int cdir;
+            ERTS_UNDEF(cdir,0);
 #endif
 	    if (yielding && reds <= 0) {
 		ystate->x = x;

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -1385,8 +1385,8 @@ trace_proc_spawn(Process *p, Eterm what, Eterm pid,
 {
     ErtsTracerRef *ref;
     ErtsTracerRef *next_ref;
-    Eterm mfa;
-    Eterm* hp = NULL;
+    Eterm mfa = THE_NON_VALUE;
+
     for (ref = p->common.tracee.first_ref; ref; ref = next_ref) {
         ErtsTracerNif *tnif = NULL;
         next_ref = ref->next;
@@ -1394,8 +1394,8 @@ trace_proc_spawn(Process *p, Eterm what, Eterm pid,
             && is_tracer_ref_enabled(NULL, 0, &p->common, ref, &tnif,
                                      TRACE_FUN_E_PROCS, what)) {
 
-            if(!hp){
-                hp = HAlloc(p, 4);
+            if(is_non_value(mfa)){
+                Eterm* hp = HAlloc(p, 4);
                 mfa = TUPLE3(hp, mod, func, args);
             }
             send_to_tracer_nif(NULL, &p->common, ref, p->common.id, tnif, TRACE_FUN_T_PROCS,


### PR DESCRIPTION
To improve performance of debug emulator with hopefully unreduced debuggability.