### PR TITLE
Fix Typespecs in zip module

### DIFF
--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -395,7 +395,7 @@ Options:
       Archive :: file:name() | binary(),
       Options :: [Option],
       Option  :: {file_list, FileList} | cooked
-               | keep_old_files | verbose | memory |
+               | keep_old_files | verbose | memory | skip_directories |
                  {file_filter, FileFilter} | {cwd, CWD} |
                  {extra, extra()},
       FileList :: [file:name()],
@@ -703,7 +703,7 @@ One option is available:
       RetValue :: {ok, CommentAndFiles} | {error, Reason :: term()},
       CommentAndFiles :: [zip_comment() | zip_file()],
       Options :: [Option],
-      Option :: cooked | {extra, extra()}).
+      Option :: cooked | skip_directories | {extra, extra()}).
 
 list_dir(F, Options) ->
     case ?CATCH(do_list_dir(F, Options)) of


### PR DESCRIPTION
The `zip` module has a typespec that is missing the `skip_directories` option in the `unzip/2` and `list_dir/2` functions.

This commit adds the missing option to the typespec, so dialyzer doesn't complain about it.