### PR TITLE
doctest allow int/line-number prefix

### DIFF
--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -99,7 +99,7 @@ Converts `Subject` to a list of `t:byte/0`s, each representing the value of one 
 _Example:_
 
 ```erlang
-> binary:bin_to_list(<<"erlang">>).
+1> binary:bin_to_list(<<"erlang">>).
 "erlang"
 %% or [101,114,108,97,110,103] in list notation.
 ```
@@ -142,7 +142,7 @@ converted.
 _Example:_
 
 ```erlang
-> binary:bin_to_list(<<"erlang">>, {1,3}).
+1> binary:bin_to_list(<<"erlang">>, {1,3}).
 "rla"
 %% or [114,108,97] in list notation.
 ```
@@ -259,11 +259,11 @@ positive integer in `Subject` to an Erlang `t:integer/0`.
 _Example:_
 
 ```erlang
-> binary:decode_unsigned(<<169,138,199>>).
+1> binary:decode_unsigned(<<169,138,199>>).
 11111111
-> binary:decode_unsigned(<<169,138,199>>, big).
+2> binary:decode_unsigned(<<169,138,199>>, big).
 11111111
-> binary:decode_unsigned(<<169,138,199>>, little).
+3> binary:decode_unsigned(<<169,138,199>>, little).
 13077161
 ```
 """.
@@ -291,11 +291,11 @@ digit representation, either big endian or little endian.
 _Example:_
 
 ```erlang
-> binary:encode_unsigned(11111111).
+1> binary:encode_unsigned(11111111).
 <<169,138,199>>
-> binary:encode_unsigned(11111111, big).
+2> binary:encode_unsigned(11111111, big).
 <<169,138,199>>
-> binary:encode_unsigned(11111111, little).
+3> binary:encode_unsigned(11111111, little).
 <<199,138,169>>
 ```
 """.
@@ -344,9 +344,9 @@ Returns the length of the longest common prefix of the binaries in list
 _Example:_
 
 ```erlang
-> binary:longest_common_prefix([<<"erlang">>, <<"ergonomy">>]).
+1> binary:longest_common_prefix([<<"erlang">>, <<"ergonomy">>]).
 2
-> binary:longest_common_prefix([<<"erlang">>, <<"perl">>]).
+2> binary:longest_common_prefix([<<"erlang">>, <<"perl">>]).
 0
 ```
 
@@ -367,9 +367,9 @@ Returns the length of the longest common suffix of the binaries in list
 _Example:_
 
 ```erlang
-> binary:longest_common_suffix([<<"erlang">>, <<"fang">>]).
+1> binary:longest_common_suffix([<<"erlang">>, <<"fang">>]).
 3
-> binary:longest_common_suffix([<<"erlang">>, <<"perl">>]).
+2> binary:longest_common_suffix([<<"erlang">>, <<"perl">>]).
 0
 ```
 
@@ -404,7 +404,7 @@ the lowest position in `Subject`.
 _Example:_
 
 ```erlang
-> binary:match(<<"abcde">>, [<<"bcde">>, <<"cd">>],[]).
+1> binary:match(<<"abcde">>, [<<"bcde">>, <<"cd">>],[]).
 {1,4}
 ```
 
@@ -457,7 +457,7 @@ The first and longest match is preferred to a shorter, which is illustrated by
 the following example:
 
 ```erlang
-> binary:matches(<<"abcde">>,
+1> binary:matches(<<"abcde">>,
                   [<<"bcde">>,<<"bc">>,<<"de">>],[]).
 [{1,4}]
 ```
@@ -504,8 +504,8 @@ Extracts the part of binary `Subject` described by `PosLen`.
 A negative length can be used to extract bytes at the end of a binary:
 
 ```erlang
-> Bin = <<1,2,3,4,5,6,7,8,9,10>>.
-> binary:part(Bin, {byte_size(Bin), -5}).
+1> Bin = <<1,2,3,4,5,6,7,8,9,10>>.
+2> binary:part(Bin, {byte_size(Bin), -5}).
 <<6,7,8,9,10>>
 ```
 
@@ -564,17 +564,17 @@ for memory use.
 Example of binary sharing:
 
 ```erlang
-> A = binary:copy(<<1>>, 1000).
+1> A = binary:copy(<<1>>, 1000).
 <<1,1,1,1,1,_/binary>>
-> byte_size(A).
+2> byte_size(A).
 1000
-> binary:referenced_byte_size(A).
+3> binary:referenced_byte_size(A).
 1000
-> <<B:10/binary, C/binary>> = A.
+4> <<B:10/binary, C/binary>> = A.
 _
-> {byte_size(B), binary:referenced_byte_size(B)}.
+5> {byte_size(B), binary:referenced_byte_size(B)}.
 {10,10}
-> {byte_size(C), binary:referenced_byte_size(C)}.
+6> {byte_size(C), binary:referenced_byte_size(C)}.
 {990,1000}
 ```
 
@@ -618,9 +618,9 @@ The parts of `Pattern` found in `Subject` are not included in the result.
 _Example:_
 
 ```erlang
-> binary:split(<<1,255,4,0,0,0,2,3>>, [<<0,0,0>>,<<2>>],[]).
+1> binary:split(<<1,255,4,0,0,0,2,3>>, [<<0,0,0>>,<<2>>],[]).
 [<<1,255,4>>, <<2,3>>]
-> binary:split(<<0,1,0,0,4,255,255,9>>, [<<0,0>>, <<255,255>>],[global]).
+2> binary:split(<<0,1,0,0,4,255,255,9>>, [<<0,0>>, <<255,255>>],[global]).
 [<<0,1>>,<<4>>,<<9>>]
 ```
 
@@ -644,9 +644,9 @@ Example of the difference between a scope and taking the binary apart before
 splitting:
 
 ```erlang
-> binary:split(<<"banana">>, [<<"a">>],[{scope,{2,3}}]).
+1> binary:split(<<"banana">>, [<<"a">>],[{scope,{2,3}}]).
 [<<"ban">>,<<"na">>]
-> binary:split(binary:part(<<"banana">>,{2,3}), [<<"a">>],[]).
+2> binary:split(binary:part(<<"banana">>,{2,3}), [<<"a">>],[]).
 [<<"n">>,<<"n">>]
 ```
 
@@ -714,28 +714,28 @@ For a description of `Pattern`, see `compile_pattern/1`.
 _Examples:_
 
 ```erlang
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"X">>, []).
+1> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"X">>, []).
 <<"aXcde">>
 
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"X">>, [global]).
+2> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"X">>, [global]).
 <<"aXcXe">>
 
-> binary:replace(<<"abcde">>, <<"b">>, <<"[]">>, [{insert_replaced, 1}]).
+3> binary:replace(<<"abcde">>, <<"b">>, <<"[]">>, [{insert_replaced, 1}]).
 <<"a[b]cde">>
 
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"[]">>, [global, {insert_replaced, 1}]).
+4> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"[]">>, [global, {insert_replaced, 1}]).
 <<"a[b]c[d]e">>
 
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"[]">>, [global, {insert_replaced, [1, 1]}]).
+5> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"[]">>, [global, {insert_replaced, [1, 1]}]).
 <<"a[bb]c[dd]e">>
 
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"[-]">>, [global, {insert_replaced, [1, 2]}]).
+6> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], <<"[-]">>, [global, {insert_replaced, [1, 2]}]).
 <<"a[b-b]c[d-d]e">>
 
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], fun(M) -> <<$[, M/binary, $]>> end, []).
+7> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], fun(M) -> <<$[, M/binary, $]>> end, []).
 <<"a[b]cde">>
 
-> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], fun(M) -> <<$[, M/binary, $]>> end, [global]).
+8> binary:replace(<<"abcde">>, [<<"b">>, <<"d">>], fun(M) -> <<$[, M/binary, $]>> end, [global]).
 <<"a[b]c[d]e">>
 ```
 """.
@@ -839,13 +839,13 @@ The default case is `uppercase`.
 _Example:_
 
 ```erlang
-> binary:encode_hex(<<"f">>).
+1> binary:encode_hex(<<"f">>).
 <<"66">>
-> binary:encode_hex(<<"/">>).
+2> binary:encode_hex(<<"/">>).
 <<"2F">>
-> binary:encode_hex(<<"/">>, lowercase).
+3> binary:encode_hex(<<"/">>, lowercase).
 <<"2f">>
-> binary:encode_hex(<<"/">>, uppercase).
+4> binary:encode_hex(<<"/">>, uppercase).
 <<"2F">>
 ```
 """.
@@ -918,7 +918,7 @@ Decodes a hex encoded binary into a binary.
 _Example_
 
 ```erlang
-> binary:decode_hex(<<"66">>).
+1> binary:decode_hex(<<"66">>).
 <<"f">>
 ```
 """.
@@ -967,7 +967,7 @@ Equivalent to `iolist_to_binary(lists:join(Separator, Binaries))`, but faster.
 _Example:_
 
 ```erlang
-> binary:join([<<"a">>, <<"b">>, <<"c">>], <<", ">>).
+1> binary:join([<<"a">>, <<"b">>, <<"c">>], <<", ">>).
 <<"a, b, c">>
 ```
 """.

--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -104,9 +104,9 @@ Returns `Tuple` if such a tuple is found; otherwise, returns `false`.
 ## Examples
 
 ```erlang
-> lists:keyfind(b, 1, [{a,10}, {b,20}, {c,30}]).
+1> lists:keyfind(b, 1, [{a,10}, {b,20}, {c,30}]).
 {b,20}
-> lists:keyfind(unknown, 1, [{a,10}, {b,20}, {c,30}]).
+2> lists:keyfind(unknown, 1, [{a,10}, {b,20}, {c,30}]).
 false
 ```
 """.
@@ -127,9 +127,9 @@ equal to `Key`; otherwise, returns `false`.
 ## Examples
 
 ```erlang
-> lists:keymember(b, 1, [{a,10}, {b,20}, {c,30}]).
+1> lists:keymember(b, 1, [{a,10}, {b,20}, {c,30}]).
 true
-> lists:keymember(unknown, 1, [{a,10}, {b,20}, {c,30}]).
+2> lists:keymember(unknown, 1, [{a,10}, {b,20}, {c,30}]).
 false
 ```
 """.
@@ -171,9 +171,9 @@ Returns `true` if `Elem` matches some element of `List`; otherwise, returns `fal
 ## Examples
 
 ```erlang
-> lists:member(2, [1,2,3]).
+1> lists:member(2, [1,2,3]).
 true
-> lists:member(nope, [1,2,3]).
+2> lists:member(nope, [1,2,3]).
 false
 ```
 """.
@@ -193,7 +193,7 @@ with tail `Tail` appended.
 ## Examples
 
 ```erlang
-> lists:reverse([1, 2, 3, 4], [a, b, c]).
+1> lists:reverse([1, 2, 3, 4], [a, b, c]).
 [4,3,2,1,a,b,c]
 ```
 """.
@@ -215,7 +215,7 @@ Returns a new list, `List3`, consisting of the elements of
 ## Examples
 
 ```erlang
-> lists:append("abc", "def").
+1> lists:append("abc", "def").
 "abcdef"
 ```
 
@@ -235,7 +235,7 @@ Returns a list in which all sublists of `ListOfLists` have been concatenated.
 ## Examples
 
 ```erlang
-> lists:append([[1, 2, 3], [a, b], [4, 5, 6]]).
+1> lists:append([[1, 2, 3], [a, b], [4, 5, 6]]).
 [1,2,3,a,b,4,5,6]
 ```
 """.
@@ -257,7 +257,7 @@ occurrence in `List1` is removed.
 ## Examples
 
 ```erlang
-> lists:subtract("123212", "212").
+1> lists:subtract("123212", "212").
 "312"
 ```
 
@@ -277,7 +277,7 @@ Returns a list containing the elements in `List1` in reverse order.
 ## Examples
 
 ```erlang
-> lists:reverse([1,2,3]).
+1> lists:reverse([1,2,3]).
 [3,2,1]
 ```
 """.
@@ -302,7 +302,7 @@ Returns the `N`th element of `List`.
 ## Examples
 
 ```erlang
-> lists:nth(3, [a, b, c, d, e]).
+1> lists:nth(3, [a, b, c, d, e]).
 c
 ```
 """.
@@ -327,13 +327,13 @@ starting at `N+1` and continuing to the end of the list.
 ## Examples
 
 ```erlang
-> lists:nthtail(3, [a, b, c, d, e]).
+1> lists:nthtail(3, [a, b, c, d, e]).
 [d,e]
-> tl(tl(tl([a, b, c, d, e]))).
+2> tl(tl(tl([a, b, c, d, e]))).
 [d,e]
-> lists:nthtail(0, [a, b, c, d, e]).
+3> lists:nthtail(0, [a, b, c, d, e]).
 [a,b,c,d,e]
-> lists:nthtail(5, [a, b, c, d, e]).
+4> lists:nthtail(5, [a, b, c, d, e]).
 []
 ```
 """.
@@ -362,13 +362,13 @@ beginning and stopping at any point.
 ## Examples
 
 ```erlang
-> lists:prefix("abc", "abcdef").
+1> lists:prefix("abc", "abcdef").
 true
-> lists:prefix("def", "abcdef").
+2> lists:prefix("def", "abcdef").
 false
-> lists:prefix([], "any list").
+3> lists:prefix([], "any list").
 true
-> lists:prefix("abc", "abc").
+4> lists:prefix("abc", "abc").
 true
 ```
 """.
@@ -391,13 +391,13 @@ and going all the way to the end.
 ## Examples
 
 ```erlang
-> lists:suffix("abc", "abcdef").
+1> lists:suffix("abc", "abcdef").
 false
-> lists:suffix("def", "abcdef").
+2> lists:suffix("def", "abcdef").
 true
-> lists:suffix([], "any list").
+3> lists:suffix([], "any list").
 true
-> lists:suffix("abc", "abc").
+4> lists:suffix("abc", "abc").
 true
 ```
 """.
@@ -419,9 +419,9 @@ The list must be non-empty; otherwise, the function raises a
 ## Examples
 
 ```erlang
-> lists:droplast([1]).
+1> lists:droplast([1]).
 []
-> lists:droplast([1,2,3]).
+2> lists:droplast([1,2,3]).
 [1,2]
 ```
 """.
@@ -443,9 +443,9 @@ Returns the last element in `List`.
 ## Examples
 
 ```erlang
-> lists:last([1]).
+1> lists:last([1]).
 1
-> lists:last([1,2,3]).
+2> lists:last([1,2,3]).
 3
 ```
 """.
@@ -501,15 +501,15 @@ length(lists:seq(From, To, Incr)) =:= (To - From + Incr) div Incr
 ## Examples
 
 ```erlang
-> lists:seq(1, 10).
+1> lists:seq(1, 10).
 [1,2,3,4,5,6,7,8,9,10]
-> lists:seq(1, 20, 3).
+2> lists:seq(1, 20, 3).
 [1,4,7,10,13,16,19]
-> lists:seq(1, 0, 1).
+3> lists:seq(1, 0, 1).
 []
-> lists:seq(10, 6, 4).
+4> lists:seq(10, 6, 4).
 []
-> lists:seq(1, 1, 0).
+5> lists:seq(1, 1, 0).
 [1]
 ```
 """.
@@ -548,9 +548,9 @@ Returns the sum of the elements in `List`.
 ## Examples
 
 ```erlang
-> lists:sum([]).
+1> lists:sum([]).
 0
-> lists:sum([1,2,3]).
+2> lists:sum([1,2,3]).
 6
 ```
 """.
@@ -568,7 +568,7 @@ Returns a list containing `N` copies of term `Elem`.
 ## Examples
 
 ```erlang
-> lists:duplicate(5, xx).
+1> lists:duplicate(5, xx).
 [xx,xx,xx,xx,xx]
 ```
 """.
@@ -590,7 +590,7 @@ other elements of `List`.
 ## Examples
 
 ```erlang
-> lists:min([17,19,7,55]).
+1> lists:min([17,19,7,55]).
 7
 ```
 """.
@@ -612,7 +612,7 @@ other elements of `List`.
 ## Examples
 
 ```erlang
-> lists:max([17,19,7,55]).
+1> lists:max([17,19,7,55]).
 55
 ```
 """.
@@ -636,11 +636,11 @@ It is not an error for `Start+Len` to exceed the length of the list.
 ## Examples
 
 ```erlang
-> lists:sublist([1,2,3,4], 2, 2).
+1> lists:sublist([1,2,3,4], 2, 2).
 [2,3]
-> lists:sublist([1,2,3,4], 2, 5).
+2> lists:sublist([1,2,3,4], 2, 5).
 [2,3,4]
-> lists:sublist([1,2,3,4], 5, 2).
+3> lists:sublist([1,2,3,4], 5, 2).
 []
 ```
 """.
@@ -668,9 +668,9 @@ case the whole list is returned.
 ## Examples
 
 ```erlang
-> lists:sublist([1,2,3,4,5], 2)
+1> lists:sublist([1,2,3,4,5], 2)
 [1,2]
-> lists:sublist([1,2,3,4,5], 99)
+2> lists:sublist([1,2,3,4,5], 99)
 [1,2,3,4,5]
 ```
 """.
@@ -697,9 +697,9 @@ there is such an element.
 ## Examples
 
 ```erlang
-> lists:delete(b, [a,b,c]).
+1> lists:delete(b, [a,b,c]).
 [a,c]
-> lists:delete(x, [a,b,c]).
+2> lists:delete(x, [a,b,c]).
 [a,b,c]
 ```
 """.
@@ -795,7 +795,7 @@ each tuple.
 ## Examples
 
 ```erlang
-> lists:unzip([{1, a}, {2, b}]).
+1> lists:unzip([{1, a}, {2, b}]).
 {[1,2],[a,b]}
 ```
 """.
@@ -834,9 +834,9 @@ For a description of the `How` parameter, see `zip/3`.
 ## Examples
 
 ```erlang
-> lists:zip3([a], [1, 2, 3], [17, 19], trim).
+1> lists:zip3([a], [1, 2, 3], [17, 19], trim).
 [{a,1,17}]
-> lists:zip3([a], [1, 2, 3], [17, 19], {pad, {z, 0, 0}}).
+2> lists:zip3([a], [1, 2, 3], [17, 19], {pad, {z, 0, 0}}).
 [{a,1,17}, {z,2,19}, {z,3,0}]
 ```
 """.
@@ -885,7 +885,7 @@ each tuple, and the third list contains the third element of each tuple.
 ## Examples
 
 ```erlang
-> lists:unzip3([{a, 1, 2}, {b, 777, 999}]).
+1> lists:unzip3([{a, 1, 2}, {b, 777, 999}]).
 {[a,b],[1,777],[2,999]}
 ```
 """.
@@ -931,7 +931,7 @@ For a description of the `How` parameter, see `zip/3`.
 ## Examples
 
 ```erlang
-> lists:zipwith(fun(X, Y) -> X+Y end, [1,2,3], [4,5,6], fail).
+1> lists:zipwith(fun(X, Y) -> X+Y end, [1,2,3], [4,5,6], fail).
 [5,7,9]
 ```
 """.
@@ -994,9 +994,9 @@ equivalent to [`zip3(List1, List2, List3)`](`zip3/3`).
 ## Examples
 
 ```erlang
-> lists:zipwith3(fun(X, Y, Z) -> X+Y+Z end, [1,2,3], [4,5,6], [7,8,9], fail).
+1> lists:zipwith3(fun(X, Y, Z) -> X+Y+Z end, [1,2,3], [4,5,6], [7,8,9], fail).
 [12,15,18]
-> lists:zipwith3(fun(X, Y, Z) -> [X,Y,Z] end, [a,b,c], [x,y,z], [1,2,3], fail).
+2> lists:zipwith3(fun(X, Y, Z) -> [X,Y,Z] end, [a,b,c], [x,y,z], [1,2,3], fail).
 [[a,x,1],[b,y,2],[c,z,3]]
 ```
 """.
@@ -1047,18 +1047,18 @@ The sort is stable.
 ## Examples
 
 ```erlang
-> lists:sort([4,1,3,2]).
+1> lists:sort([4,1,3,2]).
 [1,2,3,4]
-> lists:sort([a,4,3,b,9]).
+2> lists:sort([a,4,3,b,9]).
 [3,4,9,a,b]
 ```
 Since the sort is stable, the relative order of elements that compare
 equal is not changed:
 
 ```erlang
-> lists:sort([1.0,1]).
+1> lists:sort([1.0,1]).
 [1.0,1]
-> lists:sort([1,1.0]).
+2> lists:sort([1,1.0]).
 [1,1.0]
 ```
 """.
@@ -1120,7 +1120,7 @@ position in `ListOfLists` is picked before the other element.
 ## Examples
 
 ```erlang
-> lists:merge([[b,l,l], [g,k,q]]).
+1> lists:merge([[b,l,l], [g,k,q]]).
 [b,g,k,l,l,q]
 ```
 """.
@@ -1146,7 +1146,7 @@ is picked before the element from `List3`.
 ## Examples
 
 ```erlang
-> lists:merge3([a,o], [g,q], [j]).
+1> lists:merge3([a,o], [g,q], [j]).
 [a,g,j,o,q]
 ```
 """.
@@ -1210,7 +1210,7 @@ element from `List2`.
 ## Examples
 
 ```erlang
-> lists:merge([a,o], [b,x]).
+1> lists:merge([a,o], [b,x]).
 [a,b,o,x]
 ```
 """.
@@ -1255,7 +1255,7 @@ The elements of `Things` can be atoms, integers, floats, or strings.
 ## Examples
 
 ```erlang
-> lists:concat([doc, '/', file, '.', 3]).
+1> lists:concat([doc, '/', file, '.', 3]).
 "doc/file.3"
 ```
 """.
@@ -1277,7 +1277,7 @@ Returns a flattened version of `DeepList`.
 ## Examples
 
 ```erlang
-> lists:flatten([a,[b,c,[d,e]],f]).
+1> lists:flatten([a,[b,c,[d,e]],f]).
 [a,b,c,d,e,f]
 ```
 """.
@@ -1294,7 +1294,7 @@ Returns a flattened version of `DeepList` with tail `Tail` appended.
 ## Examples
 
 ```erlang
-> lists:flatten([a,[b,c,[d,e]],f], [g,h,i]).
+1> lists:flatten([a,[b,c,[d,e]],f], [g,h,i]).
 [a,b,c,d,e,f,g,h,i]
 ```
 """.
@@ -1322,9 +1322,9 @@ Equivalent to [`length(flatten(DeepList))`](`length/1`), but more efficient.
 ## Examples
 
 ```erlang
-> lists:flatlength([a,[b,c,[d,e]],f,[[g,h,i]]]).
+1> lists:flatlength([a,[b,c,[d,e]],f,[[g,h,i]]]).
 9
-> lists:flatlength([[[]]]).
+2> lists:flatlength([[[]]]).
 0
 ```
 
@@ -1363,9 +1363,9 @@ such a tuple.
 ## Examples
 
 ```erlang
-> lists:keydelete(c, 1, [{b,1}, {c,55}, {d,75}]).
+1> lists:keydelete(c, 1, [{b,1}, {c,55}, {d,75}]).
 [{b,1},{d,75}]
-> lists:keydelete(unknown, 1, [{b,1}, {c,55}, {d,75}]).
+2> lists:keydelete(unknown, 1, [{b,1}, {c,55}, {d,75}]).
 [{b,1},{c,55},{d,75}]
 ```
 """.
@@ -1392,9 +1392,9 @@ such a tuple `T`.
 ## Examples
 
 ```erlang
-> lists:keyreplace(c, 1, [{b,1}, {c,55}, {d,75}], {new,tuple}).
+1> lists:keyreplace(c, 1, [{b,1}, {c,55}, {d,75}], {new,tuple}).
 [{b,1},{new,tuple},{d,75}]
-> lists:keyreplace(unknown, 1, [{b,1}, {c,55}, {d,75}], {new,tuple}).
+2> lists:keyreplace(unknown, 1, [{b,1}, {c,55}, {d,75}], {new,tuple}).
 [{b,1},{c,55},{d,75}]
 ```
 """.
@@ -1426,9 +1426,9 @@ Otherwise, returns `false` if no such tuple is found.
 ## Examples
 
 ```erlang
-> lists:keytake(b, 1, [{a, 10}, {b, 23}, {c, 99}]).
+1> lists:keytake(b, 1, [{a, 10}, {b, 23}, {c, 99}]).
 {value,{b,23},[{a, 10},{c, 99}]}
-> lists:keytake(z, 1, [{a, 10}, {b, 23}, {c, 99}]).
+2> lists:keytake(z, 1, [{a, 10}, {b, 23}, {c, 99}]).
 false
 ```
 """.
@@ -1456,9 +1456,9 @@ element compares equal to `Key` replaced by `NewTuple`, or with
 ## Examples
 
 ```erlang
-> lists:keystore(b, 1, [{a, 10}, {b, 23}, {c, 99}], {bb, 1}).
+1> lists:keystore(b, 1, [{a, 10}, {b, 23}, {c, 99}], {bb, 1}).
 [{a, 10}, {bb, 1}, {c, 99}]
-> lists:keystore(z, 1, [{a, 10}, {b, 23}, {c, 99}], {z, 2}).
+2> lists:keystore(z, 1, [{a, 10}, {b, 23}, {c, 99}], {z, 2}).
 [{a, 10}, {b, 23}, {c, 99}, {z, 2}]
 ```
 """.
@@ -1490,7 +1490,7 @@ The sort is stable.
 ## Examples
 
 ```erlang
-> lists:keysort(2, [{a, 99}, {b, 17}, {c, 50}, {d, 50}]).
+1> lists:keysort(2, [{a, 99}, {b, 17}, {c, 50}, {d, 50}]).
 [{b,17},{c,50},{d,50},{a,99}]
 ```
 """.
@@ -1567,7 +1567,7 @@ the tuple from `TupleList1` is picked before the tuple from
 ## Examples
 
 ```erlang
-> lists:keymerge(2, [{b, 50}], [{c, 20}, {a, 50}]).
+1> lists:keymerge(2, [{b, 50}], [{c, 20}, {a, 50}]).
 [{c,20},{b,50},{a,50}]
 ```
 """.
@@ -1623,7 +1623,7 @@ Sorting is performed on the `N`th element of the tuples.
 ## Examples
 
 ```erlang
-> lists:ukeysort(2, [{a, 27}, {d, 23}, {e, 23}]).
+1> lists:ukeysort(2, [{a, 27}, {d, 23}, {e, 23}]).
 [{d,23}, {a, 27}]
 ```
 """.
@@ -1709,7 +1709,7 @@ from `TupleList1` is picked and the one from `TupleList2` is removed.
 ## Examples
 
 ```erlang
-> lists:ukeymerge(1, [{a, 33}, {c, 15}], [{a, 59}, {d, 39}]).
+1> lists:ukeymerge(1, [{a, 33}, {c, 15}], [{a, 59}, {d, 39}]).
 [{a,33},{c,15},{d,39}]
 ```
 """.
@@ -1764,8 +1764,8 @@ element `Term1` of the tuple has been replaced with the result of calling
 ## Examples
 
 ```erlang
-> Fun = fun(Atom) -> atom_to_list(Atom) end.
-> lists:keymap(Fun, 2, [{name,jane,22},{name,lizzie,20},{name,lydia,15}]).
+1> Fun = fun(Atom) -> atom_to_list(Atom) end.
+2> lists:keymap(Fun, 2, [{name,jane,22},{name,lizzie,20},{name,lydia,15}]).
 [{name,"jane",22},{name,"lizzie",20},{name,"lydia",15}]
 ```
 """.
@@ -1822,11 +1822,11 @@ The default values for `Index` and `Step` are both `1`.
 ## Examples
 
 ```erlang
-> lists:enumerate([a,b,c]).
+1> lists:enumerate([a,b,c]).
 [{1,a},{2,b},{3,c}]
-> lists:enumerate(10, [a,b,c]).
+2> lists:enumerate(10, [a,b,c]).
 [{10,a},{11,b},{12,c}]
-> lists:enumerate(0, -2, [a,b,c]).
+3> lists:enumerate(0, -2, [a,b,c]).
 [{0,a},{-2,b},{-4,c}]
 ```
 """.
@@ -1854,8 +1854,8 @@ ordering; otherwise, it returns `false`.
 ## Examples
 
 ```erlang
-> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
-> lists:sort(F, [{a, b, c}, {x, y}, {q, w}]).
+1> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+2> lists:sort(F, [{a, b, c}, {x, y}, {q, w}]).
 [{x,y},{q,w},{a,b,c}]
 ```
 """.
@@ -1891,8 +1891,8 @@ element from `List1` is picked before the element from `List2`.
 ## Examples
 
 ```erlang
-> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
-> lists:merge(F, [{x, y}, {a, b, c}], [{q, w}]).
+1> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+2> lists:merge(F, [{x, y}, {a, b, c}], [{q, w}]).
 [{x,y},{q,w},{a,b,c}]
 ```
 """.
@@ -1944,8 +1944,8 @@ ordering, otherwise `false`.
 ## Examples
 
 ```erlang
-> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
-> lists:usort(F, [{a, b, c}, {x, y}, {q, w}]).
+1> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+2> lists:usort(F, [{a, b, c}, {x, y}, {q, w}]).
 [{x,y},{a,b,c}]
 ```
 """.
@@ -1994,8 +1994,8 @@ from `List2` is removed.
 ## Examples
 
 ```erlang
-> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
-> lists:umerge(F, [{x, y}, {a, b, c}], [{q, w}, {x, y, z, w}]).
+1> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+2> lists:umerge(F, [{x, y}, {a, b, c}], [{q, w}, {x, y, z, w}]).
 [{x,y},{a,b,c},{x,y,z,w}]
 ```
 """.
@@ -2043,13 +2043,13 @@ first occurrence of elements that compare equal.
 ## Examples
 
 ```erlang
-> lists:usort([a,x,y,b,c,x,a]).
+1> lists:usort([a,x,y,b,c,x,a]).
 [a,b,c,x,y]
-> lists:usort([3,2,a,3,2,a,1,3,b,2,2,1]).
+2> lists:usort([3,2,a,3,2,a,1,3,b,2,2,1]).
 [1,2,3,a,b]
-> lists:usort([1.0,1]).
+3> lists:usort([1.0,1]).
 [1.0]
-> lists:usort([1,1.0]).
+4> lists:usort([1,1.0]).
 [1]
 ```
 """.
@@ -2121,7 +2121,7 @@ lowest position in `ListOfLists` is picked and the other is removed.
 ## Examples
 
 ```erlang
-> lists:umerge([[a,b], [a,d,e]]).
+1> lists:umerge([[a,b], [a,d,e]]).
 [a,b,d,e]
 ```
 """.
@@ -2148,7 +2148,7 @@ When two elements compare equal, the element from
 ## Examples
 
 ```erlang
-> lists:umerge3([a,b], [a,d,e], [b,f]).
+1> lists:umerge3([a,b], [a,d,e], [b,f]).
 [a,b,d,e,f]
 ```
 """.
@@ -2215,7 +2215,7 @@ and the one from `List2` is removed.
 ## Examples
 
 ```erlang
-> lists:umerge([a,b], [a,d,e]).
+1> lists:umerge([a,b], [a,d,e]).
 [a,b,d,e]
 ```
 """.
@@ -2282,10 +2282,10 @@ otherwise, returns `false`.
 ## Examples
 
 ```erlang
-> IsEven = fun(N) -> N rem 2 =:= 0 end.
-> lists:all(IsEven, [2,4,5]).
+1> IsEven = fun(N) -> N rem 2 =:= 0 end.
+2> lists:all(IsEven, [2,4,5]).
 false
-> lists:all(IsEven, [2,4,6]).
+3> lists:all(IsEven, [2,4,6]).
 true
 ```
 """.
@@ -2319,10 +2319,10 @@ Returns `true` if `Pred(Elem)` returns `true` for at least one element `Elem` in
 ## Examples
 
 ```erlang
-> IsEven = fun(N) -> N rem 2 =:= 0 end.
-> lists:any(IsEven, [3,5,7]).
+1> IsEven = fun(N) -> N rem 2 =:= 0 end.
+2> lists:any(IsEven, [3,5,7]).
 false
-> lists:any(IsEven, [2,3,5,7]).
+3> lists:any(IsEven, [2,3,5,7]).
 true
 ```
 """.
@@ -2356,7 +2356,7 @@ Takes a function from `A`s to `B`s and a list of `A`s, producing a list of
 ## Examples
 
 ```erlang
-> lists:map(fun(N) -> N + 1 end, [1,2,3]).
+1> lists:map(fun(N) -> N + 1 end, [1,2,3]).
 [2,3,4]
 ```
 """.
@@ -2393,12 +2393,12 @@ flatmap(Fun, List1) ->
 ## Examples
 
 ```erlang
-> lists:flatmap(fun(X)-> [X,X] end, [a,b,c]).
+1> lists:flatmap(fun(X)-> [X,X] end, [a,b,c]).
 [a,a,b,b,c,c]
-> F = fun(N) when is_integer(N) -> [10 * N];
-         (_) -> []
-      end, ok.
-> lists:flatmap(F, [1,2,a,b,c,3]).
+2> F = fun(N) when is_integer(N) -> [10 * N];
+          (_) -> []
+       end, ok.
+3> lists:flatmap(F, [1,2,a,b,c,3]).
 [10,20,30]
 ```
 """.
@@ -2433,9 +2433,9 @@ is returned if the list is empty.
 ## Examples
 
 ```erlang
-> lists:foldl(fun(X, Sum) -> X + Sum end, 0, [1,2,3,4,5]).
+1> lists:foldl(fun(X, Sum) -> X + Sum end, 0, [1,2,3,4,5]).
 15
-> lists:foldl(fun(X, Prod) -> X * Prod end, 1, [1,2,3,4,5]).
+2> lists:foldl(fun(X, Prod) -> X * Prod end, 1, [1,2,3,4,5]).
 120
 ```
 """.
@@ -2465,10 +2465,10 @@ Like `foldl/3`, but the list is traversed from right to left.
 ## Examples
 
 ```erlang
-> P = fun(A, AccIn) -> [A|AccIn] end.
-> lists:foldl(P, [], [1,2,3]).
+1> P = fun(A, AccIn) -> [A|AccIn] end.
+2> lists:foldl(P, [], [1,2,3]).
 [3,2,1]
-> lists:foldr(P, [], [1,2,3]).
+3> lists:foldr(P, [], [1,2,3]).
 [1,2,3]
 ```
 
@@ -2499,8 +2499,8 @@ returns `true`.
 ## Examples
 
 ```erlang
-> IsEven = fun(N) -> N rem 2 =:= 0 end.
-> lists:filter(IsEven, [1,2,3,4,5]).
+1> IsEven = fun(N) -> N rem 2 =:= 0 end.
+2> lists:filter(IsEven, [1,2,3,4,5]).
 [2,4]
 ```
 
@@ -2522,9 +2522,9 @@ for which `Pred(Elem)` returns `false`.
 ## Examples
 
 ```erlang
-> lists:partition(fun(A) -> A rem 2 =:= 1 end, [1,2,3,4,5,6,7]).
+1> lists:partition(fun(A) -> A rem 2 =:= 1 end, [1,2,3,4,5,6,7]).
 {[1,3,5,7],[2,4,6]}
-> lists:partition(fun(A) -> is_atom(A) end, [a,b,1,c,d,2,3,4,e]).
+2> lists:partition(fun(A) -> is_atom(A) end, [a,b,1,c,d,2,3,4,e]).
 {[a,b,c,d,e],[1,2,3,4]}
 ```
 
@@ -2572,12 +2572,12 @@ filtermap(Fun, List1) ->
 ## Examples
 
 ```erlang
-> lists:filtermap(fun(X) ->
-                          case X rem 2 of
-                              0 -> {true, X div 2};
-                              1 -> false
-                          end
-                  end, [1,2,3,4,5]).
+1> lists:filtermap(fun(X) ->
+                           case X rem 2 of
+                               0 -> {true, X div 2};
+                               1 -> false
+                           end
+                   end, [1,2,3,4,5]).
 [1,2]
 ```
 """.
@@ -2638,7 +2638,7 @@ Combines the operations of `map/2` and `foldl/3` into one pass.
 Summing the elements in a list and double them at the same time:
 
 ```erlang
-> lists:mapfoldl(fun(X, Sum) -> {2*X, X+Sum} end, 0, [1,2,3,4,5]).
+1> lists:mapfoldl(fun(X, Sum) -> {2*X, X+Sum} end, 0, [1,2,3,4,5]).
 {[2,4,6,8,10],15}
 ```
 """.
@@ -2677,7 +2677,7 @@ Doubling the elements in list and producing a list of squares at the
 same time:
 
 ```erlang
-> lists:mapfoldr(fun(X, Acc) -> {2*X, [X*X|Acc]} end, [], [1,2,3,4,5]).
+1> lists:mapfoldr(fun(X, Acc) -> {2*X, [X*X|Acc]} end, [], [1,2,3,4,5]).
 {[2,4,6,8,10],[1,4,9,16,25]}
 ```
 """.
@@ -2709,9 +2709,9 @@ returning the longest prefix in which all elements satisfy the predicate.
 ## Examples
 
 ```erlang
-> lists:takewhile(fun is_atom/1, [a,b,c,1,2,3,x,y,z]).
+1> lists:takewhile(fun is_atom/1, [a,b,c,1,2,3,x,y,z]).
 [a,b,c]
-> lists:takewhile(fun is_integer/1, [a,b,c,1,2,3,x,y,z]).
+2> lists:takewhile(fun is_integer/1, [a,b,c,1,2,3,x,y,z]).
 []
 ```
 """.
@@ -2739,9 +2739,9 @@ and then returns the remaining list.
 ## Examples
 
 ```erlang
-> lists:dropwhile(fun is_atom/1, [a,b,c,1,2,3,x,y,z]).
+1> lists:dropwhile(fun is_atom/1, [a,b,c,1,2,3,x,y,z]).
 [1,2,3,x,y,z]
-> lists:dropwhile(fun is_integer/1, [a,b,c,1,2,3,x,y,z]).
+2> lists:dropwhile(fun is_integer/1, [a,b,c,1,2,3,x,y,z]).
 [a,b,c,1,2,3,x,y,z]
 ```
 """.
@@ -2769,10 +2769,10 @@ If there is a `Value` in `List` such that `Pred(Value)` returns `true`, returns
 ## Examples
 
 ```erlang
-> lists:search(fun is_atom/1, [1,2,3,a,b,c]).
+1> lists:search(fun is_atom/1, [1,2,3,a,b,c]).
 {value,a}
-> lists:search(fun(#{a := V}) -> V =:= 42 end,
-    [#{a => 1}, #{a => 42}, #{a => 100}]).
+2> lists:search(fun(#{a := V}) -> V =:= 42 end,
+     [#{a => 1}, #{a => 42}, #{a => 100}]).
 {value,#{a => 42}}
 ```
 """.
@@ -2806,9 +2806,9 @@ splitwith(Pred, List) ->
 ## Examples
 
 ```erlang
-> lists:splitwith(fun(A) -> A rem 2 =:= 1 end, [1,2,3,4,5,6,7]).
+1> lists:splitwith(fun(A) -> A rem 2 =:= 1 end, [1,2,3,4,5,6,7]).
 {[1],[2,3,4,5,6,7]}
-> lists:splitwith(fun(A) -> is_atom(A) end, [a,b,1,c,d,2,3,4,e]).
+2> lists:splitwith(fun(A) -> is_atom(A) end, [a,b,1,c,d,2,3,4,e]).
 {[a,b],[1,c,d,2,3,4,e]}
 ```
 
@@ -2839,7 +2839,7 @@ Splits `List1` into `List2`, containing the first `N` elements, and
 ## Examples
 
 ```erlang
-> lists:split(3, [1,2,3,4,5,6,7]).
+1> lists:split(3, [1,2,3,4,5,6,7]).
 {[1,2,3],[4,5,6,7]}
 ```
 """.
@@ -2874,11 +2874,11 @@ Has no effect on an empty list or a singleton list.
 ## Examples
 
 ```erlang
-> lists:join(x, [a,b,c]).
+1> lists:join(x, [a,b,c]).
 [a,x,b,x,c]
-> lists:join(x, [a]).
+2> lists:join(x, [a]).
 [a]
-> lists:join(x, []).
+3> lists:join(x, []).
 []
 ```
 """.
@@ -2905,9 +2905,9 @@ The first occurrence of each element is kept.
 ## Examples
 
 ```erlang
-> lists:uniq([3, 3, 1, 2, 1, 2, 3]).
+1> lists:uniq([3, 3, 1, 2, 1, 2, 3]).
 [3,1,2]
-> lists:uniq([a, a, 1, b, 2, a, 3]).
+2> lists:uniq([a, a, 1, b, 2, a, 3]).
 [a, 1, b, 2, 3]
 ```
 """.
@@ -2939,7 +2939,7 @@ The first occurrence of each element is kept.
 ## Examples
 
 ```erlang
-> lists:uniq(fun({X, _}) -> X end, [{b, 2}, {a, 1}, {c, 3}, {a, 2}]).
+1> lists:uniq(fun({X, _}) -> X end, [{b, 2}, {a, 1}, {c, 3}, {a, 2}]).
 [{b, 2}, {a, 1}, {c, 3}]
 ```
 """.

--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -103,9 +103,9 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map, or with a
 ## Examples
 
 ```erlang
-> Key = 1337.
-> Map = #{42 => value_two,1337 => "value one","a" => 1}.
-> maps:get(Key, Map).
+1> Key = 1337.
+2> Map = #{42 => value_two,1337 => "value one","a" => 1}.
+3> maps:get(Key, Map).
 "value one"
 ```
 """.
@@ -126,9 +126,9 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{"hi" => 42}.
-> Key = "hi".
-> maps:find(Key, Map).
+1> Map = #{"hi" => 42}.
+2> Key = "hi".
+3> maps:find(Key, Map).
 {ok,42}
 ```
 """.
@@ -148,8 +148,8 @@ used, and previous values are ignored.
 ## Examples
 
 ```erlang
-> List = [{"a",ignored},{1337,"value two"},{42,value_three},{"a",1}].
-> maps:from_list(List).
+1> List = [{"a",ignored},{1337,"value two"},{42,value_three},{"a",1}].
+2> maps:from_list(List).
 #{42 => value_three,1337 => "value two","a" => 1}
 ```
 """.
@@ -170,8 +170,8 @@ associated with the same value.
 ## Examples
 
 ```erlang
-> Keys = ["a", "b", "c"].
-> maps:from_keys(Keys, ok).
+1> Keys = ["a", "b", "c"].
+2> maps:from_keys(Keys, ok).
 #{"a" => ok,"b" => ok,"c" => ok}
 ```
 """.
@@ -196,9 +196,9 @@ The call fails with a `{badmap,Map}` exception if `Map1` or `Map2` is not a map.
 ## Examples
 
 ```erlang
-> Map1 = #{a => "one", b => "two"}.
-> Map2 = #{a => 1, c => 3}.
-> maps:intersect(Map1, Map2).
+1> Map1 = #{a => "one", b => "two"}.
+2> Map2 = #{a => 1, c => 3}.
+3> maps:intersect(Map1, Map2).
 #{a => 1}
 ```
 """.
@@ -237,9 +237,9 @@ three arguments.
 ## Examples
 
 ```erlang
-> Map1 = #{a => "one", b => "two"}.
-> Map2 = #{a => 1, c => 3}.
-> maps:intersect_with(fun(_Key, Val1, Val2) -> {Val1, Val2} end, Map1, Map2).
+1> Map1 = #{a => "one", b => "two"}.
+2> Map2 = #{a => 1, c => 3}.
+3> maps:intersect_with(fun(_Key, Val1, Val2) -> {Val1, Val2} end, Map1, Map2).
 #{a => {"one",1}}
 ```
 """.
@@ -290,11 +290,11 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{"42" => value}.
+1> Map = #{"42" => value}.
 #{"42" => value}
-> maps:is_key("42", Map).
+2> maps:is_key("42", Map).
 true
-> maps:is_key(value, Map).
+3> maps:is_key(value, Map).
 false
 ```
 """.
@@ -314,8 +314,8 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{42 => three,1337 => "two","a" => 1}.
-> maps:keys(Map).
+1> Map = #{42 => three,1337 => "two","a" => 1}.
+2> maps:keys(Map).
 [42,1337,"a"]
 ```
 """.
@@ -337,9 +337,9 @@ The call fails with a `{badmap,Map}` exception if `Map1` or `Map2` is not a map.
 ## Examples
 
 ```erlang
-> Map1 = #{a => "one", b => "two"}.
-> Map2 = #{a => 1, c => 3}.
-> maps:merge(Map1, Map2).
+1> Map1 = #{a => "one", b => "two"}.
+2> Map2 = #{a => 1, c => 3}.
+3> maps:merge(Map1, Map2).
 #{a => 1,b => "two",c => 3}
 ```
 """.
@@ -366,9 +366,9 @@ three arguments.
 ## Examples
 
 ```erlang
-> Map1 = #{a => 3, b => 5}.
-> Map2 = #{a => 4, c => 17}.
-> maps:merge_with(fun(_Key, Val1, Val2) -> Val1 + Val2 end, Map1, Map2).
+1> Map1 = #{a => 3, b => 5}.
+2> Map2 = #{a => 4, c => 17}.
+3> maps:merge_with(fun(_Key, Val1, Val2) -> Val1 + Val2 end, Map1, Map2).
 #{a => 7,b => 5,c => 17}
 ```
 """.
@@ -420,11 +420,11 @@ The call fails with a `{badmap,Map}` exception if `Map1` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{"a" => 1}.
+1> Map = #{"a" => 1}.
 #{"a" => 1}
-> maps:put("a", 42, Map).
+2> maps:put("a", 42, Map).
 #{"a" => 42}
-> maps:put("b", 1337, Map).
+3> maps:put("b", 1337, Map).
 #{"a" => 1,"b" => 1337}
 ```
 """.
@@ -448,11 +448,11 @@ The call fails with a `{badmap,Map}` exception if `Map1` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{"a" => 1}.
+1> Map = #{"a" => 1}.
 #{"a" => 1}
-> maps:remove("a", Map).
+2> maps:remove("a", Map).
 #{}
-> maps:remove("b", Map).
+3> maps:remove("b", Map).
 #{"a" => 1}
 ```
 """.
@@ -474,11 +474,11 @@ The call will fail with a `{badmap,Map}` exception if `Map1` is not a map.
 Example:
 
 ```erlang
-> Map = #{"a" => "hello", "b" => "world"}.
+1> Map = #{"a" => "hello", "b" => "world"}.
 #{"a" => "hello", "b" => "world"}
-> maps:take("a", Map).
+2> maps:take("a", Map).
 {"hello",#{"b" => "world"}}
-> maps:take("does not exist", Map).
+3> maps:take("does not exist", Map).
 error
 ```
 """.
@@ -503,16 +503,16 @@ or an iterator obtained by a call to `iterator/1` or `iterator/2`.
 ## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1}.
-> maps:to_list(Map).
+1> Map = #{42 => value_three,1337 => "value two","a" => 1}.
+2> maps:to_list(Map).
 [{42,value_three},{1337,"value two"},{"a",1}]
 ```
 
 Using an ordered iterator to return an ordered list:
 
 ```erlang
-> Map = #{z => 1, y => 2, x => 3}.
-> maps:to_list(maps:iterator(Map, ordered)).
+1> Map = #{z => 1, y => 2, x => 3}.
+2> maps:to_list(maps:iterator(Map, ordered)).
 [{x,3},{y,2},{z,1}]
 ```
 """.
@@ -550,9 +550,9 @@ The call fails with a `{badmap,Map}` exception if `Map1` is not a map, or with a
 ## Examples
 
 ```erlang
-> Map = #{"a" => 1}.
+1> Map = #{"a" => 1}.
 #{"a" => 1}
-> maps:update("a", 42, Map).
+2> maps:update("a", 42, Map).
 #{"a" => 42}
 ```
 """.
@@ -572,8 +572,8 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1}.
-> maps:values(Map).
+1> Map = #{42 => value_three,1337 => "value two","a" => 1}.
+2> maps:values(Map).
 [value_three,"value two",1]
 ```
 """.
@@ -592,7 +592,7 @@ Returns a new empty map.
 ## Examples
 
 ```text
-> maps:new().
+1> maps:new().
 #{}
 ```
 """.
@@ -612,9 +612,9 @@ in the map.
 ## Examples
 
 ```erlang
-> Map = #{counter => 1}.
-> Fun = fun(V) -> V + 1 end.
-> maps:update_with(counter, Fun, Map).
+1> Map = #{counter => 1}.
+2> Fun = fun(V) -> V + 1 end.
+3> maps:update_with(counter, Fun, Map).
 #{counter => 2}
 ```
 """.
@@ -640,11 +640,11 @@ using `Init` if `Key` is not present in the map.
 ## Examples
 
 ```erlang
-> Map = #{"counter" => 1}.
-> Fun = fun(V) -> V + 1 end.
-> maps:update_with("counter", Fun, 42, Map).
+1> Map = #{"counter" => 1}.
+2> Fun = fun(V) -> V + 1 end.
+3> maps:update_with("counter", Fun, 42, Map).
 #{"counter" => 2}
-> maps:update_with("new counter", Fun, 42, Map).
+4> maps:update_with("new counter", Fun, 42, Map).
 #{"counter" => 1,"new counter" => 42}
 ```
 """.
@@ -672,11 +672,11 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 ## Examples
 
 ```erlang
-> Map = #{key1 => val1, key2 => val2}.
+1> Map = #{key1 => val1, key2 => val2}.
 #{key1 => val1,key2 => val2}
-> maps:get(key1, Map, "Default value").
+2> maps:get(key1, Map, "Default value").
 val1
-> maps:get(key3, Map, "Default value").
+3> maps:get(key3, Map, "Default value").
 "Default value"
 ```
 """.
@@ -705,9 +705,9 @@ valid iterator, or with `badarg` if `Pred` is not a function of arity 2.
 ## Examples
 
 ```erlang
-> M = #{a => 2, b => 3, "a" => 1, "b" => 2}.
-> Pred = fun(K, V) -> is_atom(K) andalso V rem 2 =:= 0 end.
-> maps:filter(Pred, M).
+1> M = #{a => 2, b => 3, "a" => 1, "b" => 2}.
+2> Pred = fun(K, V) -> is_atom(K) andalso V rem 2 =:= 0 end.
+3> maps:filter(Pred, M).
 #{a => 2}
 ```
 """.
@@ -759,11 +759,11 @@ valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
 ## Examples
 
 ```erlang
-> Fun = fun(K, V) when is_atom(K) -> {true, V*2};
-           (_, V) -> V rem 2 =:= 0
-  end.
-> Map = #{k1 => 1, "k2" => 2, "k3" => 3}.
-> maps:filtermap(Fun, Map).
+1> Fun = fun(K, V) when is_atom(K) -> {true, V*2};
+            (_, V) -> V rem 2 =:= 0
+   end.
+2> Map = #{k1 => 1, "k2" => 2, "k3" => 3}.
+3> maps:filtermap(Fun, Map).
 #{k1 => 2,"k2" => 2}
 ```
 """.
@@ -812,11 +812,11 @@ valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
 ## Examples
 
 ```erlang
-> Fun = fun(K, V) -> self() ! {K,V} end.
-> Map = #{p => 1, q => 2,x => 10, y => 20, z => 30}.
-> maps:foreach(Fun, maps:iterator(Map, ordered)).
+1> Fun = fun(K, V) -> self() ! {K,V} end.
+2> Map = #{p => 1, q => 2,x => 10, y => 20, z => 30}.
+3> maps:foreach(Fun, maps:iterator(Map, ordered)).
 ok
-> [receive X -> X end || _ <- [1,2,3,4,5]].
+4> [receive X -> X end || _ <- [1,2,3,4,5]].
 [{p,1},{q,2},{x,10},{y,20},{z,30}]
 ```
 """.
@@ -862,9 +862,9 @@ arity 3.
 ## Examples
 
 ```erlang
-> Fun = fun(K, V, AccIn) -> AccIn + V end.
-> Map = #{k1 => 1, k2 => 2, k3 => 3}.
-> maps:fold(Fun, 0, Map).
+1> Fun = fun(K, V, AccIn) -> AccIn + V end.
+2> Map = #{k1 => 1, k2 => 2, k3 => 3}.
+3> maps:fold(Fun, 0, Map).
 6
 ```
 """.
@@ -909,9 +909,9 @@ valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
 ## Examples
 
 ```erlang
-> Fun = fun(K,V1) when is_list(K) -> V1*2 end.
-> Map = #{"k1" => 1, "k2" => 2, "k3" => 3}.
-> maps:map(Fun, Map).
+1> Fun = fun(K,V1) when is_list(K) -> V1*2 end.
+2> Map = #{"k1" => 1, "k2" => 2, "k3" => 3}.
+3> maps:map(Fun, Map).
 #{"k1" => 2,"k2" => 4,"k3" => 6}
 ```
 """.
@@ -949,8 +949,8 @@ This operation occurs in constant time.
 ## Examples
 
 ```erlang
-> Map = #{42 => value_two,1337 => "value one","a" => 1}.
-> maps:size(Map).
+1> Map = #{42 => value_two,1337 => "value one","a" => 1}.
+2> maps:size(Map).
 3
 ```
 """.
@@ -979,14 +979,14 @@ The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 ## Examples
 
 ```erlang
-> M = #{ "foo" => 1, "bar" => 2 }.
+1> M = #{ "foo" => 1, "bar" => 2 }.
 #{"foo" => 1,"bar" => 2}
-> I = maps:iterator(M).
-> {K1, V1, I2} = maps:next(I), {K1, V1}.
+2> I = maps:iterator(M).
+3> {K1, V1, I2} = maps:next(I), {K1, V1}.
 {"bar",2}
-> {K2, V2, I3} = maps:next(I2),{K2, V2}.
+4> {K2, V2, I3} = maps:next(I2),{K2, V2}.
 {"foo",1}
-> maps:next(I3).
+5> maps:next(I3).
 none
 ```
 """.
@@ -1011,41 +1011,41 @@ with a `badarg` exception if `Order` is invalid.
 Ordered iterator:
 
 ```erlang
-> M = #{a => 1, b => 2}.
-> OrdI = maps:iterator(M, ordered).
-> {K1, V1, OrdI2} = maps:next(OrdI), {K1, V1}.
+1> M = #{a => 1, b => 2}.
+2> OrdI = maps:iterator(M, ordered).
+3> {K1, V1, OrdI2} = maps:next(OrdI), {K1, V1}.
 {a,1}
-> {K2, V2, OrdI3} = maps:next(OrdI2),{K2, V2}.
+4> {K2, V2, OrdI3} = maps:next(OrdI2),{K2, V2}.
 {b,2}
-> maps:next(OrdI3).
+5> maps:next(OrdI3).
 none
 ```
 
 Iterator ordered in reverse:
 
 ```erlang
-> M = #{a => 1, b => 2}.
-> RevI = maps:iterator(M, reversed).
-> {K2, V2, RevI2} = maps:next(RevI), {K2, V2}.
+1> M = #{a => 1, b => 2}.
+2> RevI = maps:iterator(M, reversed).
+3> {K2, V2, RevI2} = maps:next(RevI), {K2, V2}.
 {b,2}
-> {K1, V1, RevI3} = maps:next(RevI2),{K1, V1}.
+4> {K1, V1, RevI3} = maps:next(RevI2),{K1, V1}.
 {a,1}
-> maps:next(RevI3).
+5> maps:next(RevI3).
 none
-> maps:to_list(RevI).
+6> maps:to_list(RevI).
 [{b,2},{a,1}]
 ```
 
 Using a custom ordering function that orders binaries by size:
 
 ```erlang
-> M = #{<<"abcde">> => d, <<"y">> => b, <<"x">> => a, <<"pqr">> => c}.
-> SizeI = fun(A, B) when byte_size(A) < byte_size(B) -> true;
-             (A, B) when byte_size(A) > byte_size(B) -> false;
-             (A, B) -> A =< B
-          end.
-> SizeOrdI = maps:iterator(M, SizeI).
-> maps:to_list(SizeOrdI).
+1> M = #{<<"abcde">> => d, <<"y">> => b, <<"x">> => a, <<"pqr">> => c}.
+2> SizeI = fun(A, B) when byte_size(A) < byte_size(B) -> true;
+              (A, B) when byte_size(A) > byte_size(B) -> false;
+              (A, B) -> A =< B
+           end.
+3> SizeOrdI = maps:iterator(M, SizeI).
+4> maps:to_list(SizeOrdI).
 [{<<"x">>,a},{<<"y">>,b},{<<"pqr">>,c},{<<"abcde">>,d}]
 ```
 """.
@@ -1080,16 +1080,16 @@ If there are no more associations in the iterator, `none` is returned.
 ## Examples
 
 ```erlang
-> Map = #{a => 1, b => 2, c => 3}.
+1> Map = #{a => 1, b => 2, c => 3}.
 #{a => 1,b => 2,c => 3}
-> I = maps:iterator(Map, ordered).
-> {K1, V1, I1} = maps:next(I), {K1, V1}.
+2> I = maps:iterator(Map, ordered).
+3> {K1, V1, I1} = maps:next(I), {K1, V1}.
 {a,1}
-> {K2, V2, I2} = maps:next(I1), {K2, V2}.
+4> {K2, V2, I2} = maps:next(I1), {K2, V2}.
 {b,2}
-> {K3, V3, I3} = maps:next(I2), {K3, V3}.
+5> {K3, V3, I3} = maps:next(I2), {K3, V3}.
 {c,3}
-> maps:next(I3).
+6> maps:next(I3).
 none
 ```
 """.
@@ -1121,9 +1121,9 @@ Any key in `Ks` that does not exist in `Map1` is ignored.
 ## Examples
 
 ```erlang
-> Map = #{42 => value_three, 1337 => "value two", "a" => 1}.
-> Keys = ["a",42,"other key"].
-> maps:without(Keys, Map).
+1> Map = #{42 => value_three, 1337 => "value two", "a" => 1}.
+2> Keys = ["a",42,"other key"].
+3> maps:without(Keys, Map).
 #{1337 => "value two"}
 ```
 """.
@@ -1148,9 +1148,9 @@ Any key in `Ks` that does not exist in `Map1` is ignored.
 ## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1}.
-> Keys = ["a",42,"other key"].
-> maps:with(Keys, Map).
+1> Map = #{42 => value_three,1337 => "value two","a" => 1}.
+2> Keys = ["a",42,"other key"].
+3> maps:with(Keys, Map).
 #{42 => value_three,"a" => 1}
 ```
 """.
@@ -1184,12 +1184,12 @@ list.
 ## Examples
 
 ```erlang
-> EvenOdd = fun(X) when X rem 2 =:= 0 -> even;
-               (_) -> odd
-            end.
-> maps:groups_from_list(EvenOdd, [1, 2, 3]).
+1> EvenOdd = fun(X) when X rem 2 =:= 0 -> even;
+                (_) -> odd
+             end.
+2> maps:groups_from_list(EvenOdd, [1, 2, 3]).
 #{even => [2], odd => [1, 3]}
-> maps:groups_from_list(fun length/1, ["ant", "buffalo", "cat", "dingo"]).
+3> maps:groups_from_list(fun length/1, ["ant", "buffalo", "cat", "dingo"]).
 #{3 => ["ant", "cat"], 5 => ["dingo"], 7 => ["buffalo"]}
 ```
 """.
@@ -1236,11 +1236,11 @@ list.
 ## Examples
 
 ```erlang
-> EvenOdd = fun(X) -> case X rem 2 of 0 -> even; 1 -> odd end end.
-> Square = fun(X) -> X * X end.
-> maps:groups_from_list(EvenOdd, Square, [1, 2, 3]).
+1> EvenOdd = fun(X) -> case X rem 2 of 0 -> even; 1 -> odd end end.
+2> Square = fun(X) -> X * X end.
+3> maps:groups_from_list(EvenOdd, Square, [1, 2, 3]).
 #{even => [4], odd => [1, 9]}
-> maps:groups_from_list(
+4> maps:groups_from_list(
     fun length/1,
     fun lists:reverse/1,
     ["ant", "buffalo", "cat", "dingo"]).

--- a/lib/stdlib/src/zstd.erl
+++ b/lib/stdlib/src/zstd.erl
@@ -29,9 +29,9 @@ and offers the same compression ratio as `m:zlib` but at a lower CPU cost.
 Example:
 
 ```
-> Data = ~"my data to be compressed".
-> Compressed = zstd:compress(Data).
-> zstd:decompress(Compressed).
+1> Data = ~"my data to be compressed".
+2> Compressed = zstd:compress(Data).
+3> zstd:decompress(Compressed).
 [~"my data to be compressed"]
 ```
 
@@ -41,21 +41,21 @@ it is also possible to do streamed compression/decompression.
 Example:
 
 ```erlang
-> Compress = fun F(Ctx, D) ->
-                     case file:read(D, 5) of
-                         {ok, Data} ->
-                             {continue, C} = zstd:stream(Ctx, Data),
-                             [C|F(Ctx, D)];
-                         eof ->
-                             {done, C} = zstd:finish(Ctx, ""),
-                             C
-                     end
-             end.
-> {ok, Ctx} = zstd:context(compress).
-> {ok, D} = file:open(File,[read,binary]).
-> Compressed = iolist_to_binary(Compress(Ctx, D)).
+1> Compress = fun F(Ctx, D) ->
+                      case file:read(D, 5) of
+                          {ok, Data} ->
+                              {continue, C} = zstd:stream(Ctx, Data),
+                              [C|F(Ctx, D)];
+                          eof ->
+                              {done, C} = zstd:finish(Ctx, ""),
+                              C
+                      end
+              end.
+2> {ok, Ctx} = zstd:context(compress).
+3> {ok, D} = file:open(File,[read,binary]).
+4> Compressed = iolist_to_binary(Compress(Ctx, D)).
 <<40,181,47,253,0,88,89,0,0,108,111,114,101,109,32,105,112,115,117,109>>
-> zstd:decompress(Compressed).
+5> zstd:decompress(Compressed).
 [~"lorem ipsum"]
 ```
 
@@ -252,13 +252,13 @@ Returns `ok` on success, raises an error on failure.
 Example:
 
 ```
-> {ok, CCtx} = zstd:context(compress).
+1> {ok, CCtx} = zstd:context(compress).
 {ok, _}
-> ok = zstd:set_parameter(CCtx, compressionLevel, 15).
+2> ok = zstd:set_parameter(CCtx, compressionLevel, 15).
 ok
-> zstd:stream(CCtx, "abc").
+3> zstd:stream(CCtx, "abc").
 {continue, _}
-> catch zstd:set_parameter(CCtx, dictionary, "abc").
+4> catch zstd:set_parameter(CCtx, dictionary, "abc").
 {'EXIT', {{zstd_error, <<"Operation not authorized at current processing stage">>}, _}}
 ```
 """.
@@ -297,13 +297,13 @@ Returns `ok` on success, raises an error on failure.
 Example:
 
 ```
-> {ok, CCtx} = zstd:context(compress).
+1> {ok, CCtx} = zstd:context(compress).
 {ok, _}
-> zstd:get_parameter(CCtx, compressionLevel).
+2> zstd:get_parameter(CCtx, compressionLevel).
 3
-> zstd:set_parameter(CCtx, compressionLevel, 15).
+3> zstd:set_parameter(CCtx, compressionLevel, 15).
 ok
-> zstd:get_parameter(CCtx, compressionLevel).
+4> zstd:get_parameter(CCtx, compressionLevel).
 15
 ```
 """.
@@ -341,12 +341,12 @@ set in the `t:context/0`.
 Example:
 
 ```
-> {ok, CDict} = zstd:dict(compress, Dict).
-> Data = lists:duplicate(100, 1).
+1> {ok, CDict} = zstd:dict(compress, Dict).
+2> Data = lists:duplicate(100, 1).
 [1, 1, 1 | _]
-> iolist_size(zstd:compress(Data)).
+3> iolist_size(zstd:compress(Data)).
 17
-> iolist_size(zstd:compress(Data, #{ dictionary => CDict, dictIDFlag => false })).
+4> iolist_size(zstd:compress(Data, #{ dictionary => CDict, dictIDFlag => false })).
 16
 ```
 
@@ -371,10 +371,10 @@ The dictionary ID 0 represents no dictionary.
 Example:
 
 ```
-> {ok, CDict} = zstd:dict(compress, Dict).
-> zstd:get_dict_id(CDict).
+1> {ok, CDict} = zstd:dict(compress, Dict).
+2> zstd:get_dict_id(CDict).
 1850243626
-> zstd:get_dict_id(zstd:compress("abc")).
+3> zstd:get_dict_id(zstd:compress("abc")).
 0
 ```
 """.
@@ -402,8 +402,8 @@ can be useful when debugging corrupted Zstandard streams.
 Example:
 
 ```
-> Compressed = zstd:compress(~"abc").
-> zstd:get_frame_header(Compressed).
+1> Compressed = zstd:compress(~"abc").
+2> zstd:get_frame_header(Compressed).
 {ok,#{frameContentSize => 3,windowSize => 3,blockSizeMax => 3,
       frameType => 'ZSTD_frame',headerSize => 6,
       dictID => 0, checksumFlag => false}}
@@ -459,12 +459,12 @@ with `finish/2` to complete the compression/decompression.
 Example:
 
 ```
-> {ok, CCtx} = zstd:context(compress).
-> {continue, C1} = zstd:stream(CCtx, ~"a").
-> {done, C2} = zstd:finish(CCtx, ~"b").
-> Compressed = iolist_to_binary([C1, C2]).
+1> {ok, CCtx} = zstd:context(compress).
+2> {continue, C1} = zstd:stream(CCtx, ~"a").
+3> {done, C2} = zstd:finish(CCtx, ~"b").
+4> Compressed = iolist_to_binary([C1, C2]).
 <<40,181,47,253,0,88,17,0,0,97,98>>
-> zstd:decompress(Compressed).
+5> zstd:decompress(Compressed).
 [<<"ab">>]
 ```
 """.
@@ -504,10 +504,10 @@ that it can be used for compressing/decompressing again.
 Example:
 
 ```
-> {ok, DCtx} = zstd:context(decompress).
-> {continue, D1} = zstd:stream(DCtx, <<40,181,47,253,32>>).
-> {done, D2} = zstd:finish(DCtx, <<2,17,0,0,97,98>>).
-> iolist_to_binary([D1,D2]).
+1> {ok, DCtx} = zstd:context(decompress).
+2> {continue, D1} = zstd:stream(DCtx, <<40,181,47,253,32>>).
+3> {done, D2} = zstd:finish(DCtx, <<2,17,0,0,97,98>>).
+4> iolist_to_binary([D1,D2]).
 <<"ab">>
 ```
 """.
@@ -566,13 +566,13 @@ if it is in the middle of a (de)compression stream.
 Example:
 
 ```
-> {ok, CCtx} = zstd:context(compress).
-> zstd:stream(CCtx, "a").
+1> {ok, CCtx} = zstd:context(compress).
+2> zstd:stream(CCtx, "a").
 {continue, _}
-> zstd:reset(CCtx).
+3> zstd:reset(CCtx).
 ok
-> {done, Compressed} = zstd:finish(CCtx, "b").
-> zstd:decompress(Compressed).
+4> {done, Compressed} = zstd:finish(CCtx, "b").
+5> zstd:decompress(Compressed).
 [~"b"]
 ```
 """.
@@ -612,8 +612,8 @@ Compress `Data` using the given `t:compress_parameters/0` or the `t:context/0`.
 Example:
 
 ```
-> zstd:compress("abc").
-> zstd:compress("abc", #{ compressionLevel => 20 }).
+1> zstd:compress("abc").
+2> zstd:compress("abc", #{ compressionLevel => 20 }).
 ```
 """.
 -doc #{ since => "OTP @OTP-19477@" }.
@@ -647,8 +647,8 @@ Decompress `Data` using the given `t:compress_parameters/0` or the `t:context/0`
 Example:
 
 ```
-> Compressed = zstd:compress("abc").
-> zstd:decompress(Compressed).
+1> Compressed = zstd:compress("abc").
+2> zstd:decompress(Compressed).
 [~"abc"]
 ```
 """.


### PR DESCRIPTION
:warning: nested `case` does not spark joy and RegExp might be a better choice for this feature request!

This patch aims to formally begin the discussion here about feature parity between Erlang OTP doctest, and the library of the same name maintained by [williamthome](https://github.com/williamthome/doctest/)

Specifically this patch targets `>` vs `1>` syntax for declaring the start of a testable code line or set of lines, ex;

**Erlang OTP doctest**

````erlang
-doc """
This test is how we do with `erlang/otp` doctests

```
> true.
true
> totallyOkay.
totallyOkay
```
"""
woot() -> ok.
````

**williamthome doctest**

````erlang
-doc """
This test is how we do with `williamthome/doctest` (prior to version `0.10.0`)

```erlang
1> false.
false
2> thisIsFine.
thisIsFine
```
"""
muchJoy() -> ok.
````