### PR TITLE
kernel: Fix `code:get_doc/1,2` when cover_compiled

### DIFF
--- a/lib/compiler/test/beam_doc_SUITE_data/cover_compiled.erl
+++ b/lib/compiler/test/beam_doc_SUITE_data/cover_compiled.erl
@@ -1,0 +1,7 @@
+-module(cover_compiled).
+-moduledoc ~"""
+cover_compiled
+""".
+
+% SPDX-License-Identifier: Apache-2.0
+% SPDX-FileCopyrightText: 2025 Erlang/OTP and contributors

--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -1867,6 +1867,13 @@ get_doc(Mod, #{sources:=[Source|Sources]}=Options) ->
                 ErtsDir ->
                     GetDoc(filename:join([ErtsDir, "ebin", atom_to_list(Mod) ++ ".beam"]))
             end;
+        cover_compiled ->
+            case which(Mod, get_path()) of
+                non_existing ->
+                    {error, missing};
+                Fn when is_list(Fn) ->
+                    GetDoc(Fn)
+            end;
         Error when is_atom(Error) ->
             {error, Error};
         Fn ->


### PR DESCRIPTION
This PR fixes a bug getting docs when a module is compiled by the cover module. Also, the `cover_compiled` error was [missing in the spec](https://github.com/erlang/otp/blob/master/lib/kernel/src/code.erl#L1848).

To reproduce, first compile the module via `cover:compile` and run `code:get_doc`.

Find this bug via the new `doctest`, for example:

````erlang
% src/otp_doctest
-module(otp_doctest).

-export([foo/0]).

-doc ~"""
```
> otp_doctest:foo().
bar % must fail
```
""".
foo() ->
    foo.
````

```erlang
% rebar.config
{profiles, [
    {test, [
        {cover_enabled, true}
    ]}
]}.
```

```erlang
% test/otp_doctest_SUITE.erl
-module(otp_doctest_SUITE).
-behaviour(ct_suite).
-compile([export_all, nowarn_export_all]).

all() ->
    [doctests].

doctests(Config) when is_list(Config) ->
    shell_docs:test(otp_doctest, []).
```

The expected result is to fail, but the test passed:

```bash
$ rebar3 ct
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling otp_doctest
===> Running Common Test suites...
%%% otp_doctest_SUITE: .
All 1 tests passed.
```

After this PR the error is raised:

```bash
===> Verifying dependencies...
===> Analyzing applications...
===> Compiling otp_doctest
===> Running Common Test suites...
%%% otp_doctest_SUITE:
%%% otp_doctest_SUITE ==> doctests: FAILED
%%% otp_doctest_SUITE ==> {{badmatch,foo},
 [{erl_eval,expr,6,[{file,"erl_eval.erl"},{line,670}]},
  {shell_docs_test,run_tests,2,[{file,"shell_docs_test.erl"},{line,198}]},
  {lists,foldl,3,[{file,"lists.erl"},{line,2150}]},
  {shell_docs_test,test,2,[{file,"shell_docs_test.erl"},{line,153}]},
  {shell_docs_test,parse_and_run,3,[{file,"shell_docs_test.erl"},{line,137}]},
  {shell_docs_test,'-parse_and_run/3-lc$^0/1-0-',3,
                   [{file,"shell_docs_test.erl"},{line,133}]},
  {shell_docs_test,'-module/2-lc$^0/1-0-',3,
                   [{file,"shell_docs_test.erl"},{line,122}]},
  {shell_docs_test,module,2,[{file,"shell_docs_test.erl"},{line,123}]}]}
```

cc @garazdawi 