### PR TITLE
gh: Update docker builds to use inline cache

### DIFF
--- a/.github/scripts/build-base-image.sh
+++ b/.github/scripts/build-base-image.sh
@@ -47,20 +47,23 @@ elif [ -f "otp_docker_base/otp_docker_base.tar" ]; then
     echo "BASE_BUILD=loaded" >> $GITHUB_OUTPUT
 else
     if [ "${BASE_USE_CACHE}" != "false" ]; then
-        docker pull "${BASE_TAG}:${BASE_BRANCH}"
-        docker tag "${BASE_TAG}:${BASE_BRANCH}" "${BASE_TAG}:latest"
-        BASE_CACHE="--cache-from ${BASE_TAG}"
+        if docker pull "${BASE_TAG}:${BASE_BRANCH}"; then
+            docker tag "${BASE_TAG}:${BASE_BRANCH}" "${BASE_TAG}:latest"
+        fi
+        BASE_CACHE="--cache-from type=registry,ref=${BASE_TAG}:${BASE_BRANCH}"
     fi
 
     BASE_IMAGE_ID=$(docker images -q "${BASE_TAG}:latest")
 
-    docker build --pull --tag "${BASE_TAG}:latest" \
+    DOCKER_BUILDKIT=1 docker build --pull --tag "${BASE_TAG}:latest" \
        ${BASE_CACHE} \
        --file ".github/dockerfiles/Dockerfile.${BASE_TYPE}" \
-       --build-arg MAKEFLAGS=-j$(($(nproc) + 2)) \
+       --build-arg MAKEFLAGS=-j6 \
        --build-arg USER=otptest --build-arg GROUP=uucp \
        --build-arg uid="$(id -u)" \
-       --build-arg BASE="${BASE}" .github/
+       --build-arg BASE="${BASE}" \
+       --build-arg BUILDKIT_INLINE_CACHE=1 \
+       .github/
 
     NEW_BASE_IMAGE_ID=$(docker images -q "${BASE_TAG}:latest")
     if [ "${BASE_IMAGE_ID}" = "${NEW_BASE_IMAGE_ID}" ]; then


### PR DESCRIPTION
For some reason the prebuilt images never were cached, by changing to inline cache it works again.