### PR TITLE
zstd: Fix copy of dict binary to environment

### DIFF
--- a/erts/emulator/zstd/zstd.mk
+++ b/erts/emulator/zstd/zstd.mk
@@ -45,12 +45,17 @@ endif
 
 ifeq ($(TYPE),gcov)
 ZSTD_CFLAGS = -O0 -fprofile-arcs -ftest-coverage $(DEBUG_CFLAGS) $(DEFS) $(THR_DEFS)
-else  # gcov
+else  # !gcov
 ifeq ($(TYPE),debug)
 ## DEBUGLEVEL=1 enables asserts, see common/debug.h for details
 ZSTD_CFLAGS = -DDEBUGLEVEL=1 $(DEBUG_CFLAGS) $(DEFS) $(THR_DEFS)
-else # debug
+else # !debug && !gcov
+
 ZSTD_CFLAGS = $(subst -O2, -O3, $(CONFIGURE_CFLAGS) $(DEFS) $(THR_DEFS))
+ifeq ($(TYPE), asan)
+ZSTD_CFLAGS += -DZSTD_ADDRESS_SANITIZER
+endif # asan
+
 endif # debug
 endif # gcov
 

--- a/lib/stdlib/test/zstd_SUITE.erl
+++ b/lib/stdlib/test/zstd_SUITE.erl
@@ -437,6 +437,9 @@ dict_api(Config) ->
     {ok, DCtx} = zstd:context(decompress, #{ dictionary => DDict }),
     {'EXIT', _} = catch zstd:set_parameter(DCtx, dictionary, CDict),
 
+    {'EXIT', _} = catch zstd:dict(compress, [1,2,3]),
+    {'EXIT', _} = catch zstd:dict(decompress, [1,2,3]),
+
     ok.
 
 


### PR DESCRIPTION
If we don't make a copy of the binary before referencing it in the dict and it is a heap binary, the binary will be released upon the next GC and the dict will segfault.