### PR TITLE
Fix debug emulator bugs for AArch64

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_bs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bs.cpp
@@ -261,7 +261,6 @@ void BeamModuleAssembler::emit_bs_get_small(const Label &fail,
         auto ctx_reg = load_source(Ctx, TMP1);
 
         comment("simplified helper call because the result is a known small");
-        emit_enter_runtime(Live.get());
 
         /* We KNOW that the process argument is never actually used. */
 #ifdef DEBUG
@@ -269,6 +268,8 @@ void BeamModuleAssembler::emit_bs_get_small(const Label &fail,
 #endif
         mov_imm(ARG3, flags);
         emit_untag_ptr(ARG4, ctx_reg.reg);
+
+        emit_enter_runtime(Live.get());
         runtime_call<Eterm (*)(Process *, Uint, unsigned, ErlSubBits *),
                      erts_bs_get_integer_2>();
 

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -726,7 +726,7 @@ void BeamModuleAssembler::emit_put_list_deallocate(const ArgSource &Hd,
     a64::Gp hd_reg, tl_reg;
     auto dst = init_destination(Dst, TMP3);
 
-    ASSERT(dealloc <= 1023);
+    ASSERT(dealloc < MAX_REG * sizeof(Eterm));
 
     if (Hd.isYRegister() && !Tl.isYRegister() && dealloc > 0) {
         auto hd_index = Hd.as<ArgYRegister>().get();


### PR DESCRIPTION
This PR eliminates two crashes in the debug emulator for AArch64/ARM64.