### PR TITLE
erts: Remove faulty assert checking for DELAYED_DEL_PROC flag

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -9499,9 +9499,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
     erts_aint32_t state = 0; /* Suppress warning... */
     int is_normal_sched;
     ErtsSchedType sched_type;
-#ifdef DEBUG
-    int aborted_execution = 0;
-#endif
 
     ERTS_MSACC_DECLARE_CACHE();
 
@@ -9659,11 +9656,7 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
             ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_OTHER);
 
             if (state & ERTS_PSFLG_FREE) {
-                if (!is_normal_sched) {
-                    ASSERT((p->flags & F_DELAYED_DEL_PROC)
-                           || aborted_execution);
-                }
-                else {
+                if (is_normal_sched) {
                     ASSERT(esdp->free_process == p);
                     esdp->free_process = NULL;
                 }
@@ -9687,10 +9680,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
  check_activities_to_run: {
 	ErtsMigrationPaths *mps;
 	ErtsMigrationPath *mp;
-
-#ifdef DEBUG
-        aborted_execution = 0;
-#endif
 
 	if (is_normal_sched) {
 
@@ -10127,9 +10116,6 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 		erts_proc_unlock(p, ERTS_PROC_LOCK_STATUS);
                 if (ERTS_IS_P_TRACED(p))
                     trace_schedule_in(p, state);
-#ifdef DEBUG
-                aborted_execution = !0;
-#endif
 		goto sched_out_proc;
 	    }
             break;


### PR DESCRIPTION
In Erlang/OTP 22 functionality was added to yield after process "death" in order to send large error reasons for down/exit signals. This change meant that we not can be in state FREE, but the DELAYED_DEL_PROC is first set later, so the assert checking for it is incorrecy.