### PR TITLE
Polish documentation for the lists module

### DIFF
--- a/lib/stdlib/src/lists.erl
+++ b/lib/stdlib/src/lists.erl
@@ -97,7 +97,18 @@ An example of a typical ordering function is less than or equal to: `=</2`.
 %% Shadowed by erl_bif_types: lists:keyfind/3
 -doc """
 Searches the list of tuples `TupleList` for a tuple whose `N`th element compares
-equal to `Key`. Returns `Tuple` if such a tuple is found, otherwise `false`.
+equal to `Key`.
+
+Returns `Tuple` if such a tuple is found; otherwise, returns `false`.
+
+## Examples
+
+```erlang
+> lists:keyfind(b, 1, [{a,10}, {b,20}, {c,30}]).
+{b,20}
+> lists:keyfind(unknown, 1, [{a,10}, {b,20}, {c,30}]).
+false
+```
 """.
 -spec keyfind(Key, N, TupleList) -> Tuple | false when
       Key :: term(),
@@ -110,8 +121,17 @@ keyfind(_, _, _) ->
 
 %% Shadowed by erl_bif_types: lists:keymember/3
 -doc """
-Returns `true` if there is a tuple in `TupleList` whose `N`th element compares
-equal to `Key`, otherwise `false`.
+Returns `true` if `TupleList` contains a tuple whose `N`th element compares
+equal to `Key`; otherwise, returns `false`.
+
+## Examples
+
+```erlang
+> lists:keymember(b, 1, [{a,10}, {b,20}, {c,30}]).
+true
+> lists:keymember(unknown, 1, [{a,10}, {b,20}, {c,30}]).
+false
+```
 """.
 -spec keymember(Key, N, TupleList) -> boolean() when
       Key :: term(),
@@ -125,13 +145,15 @@ keymember(_, _, _) ->
 %% Shadowed by erl_bif_types: lists:keysearch/3
 -doc """
 Searches the list of tuples `TupleList` for a tuple whose `N`th element compares
-equal to `Key`. Returns `{value, Tuple}` if such a tuple is found, otherwise
+equal to `Key`.
+
+Returns `{value, Tuple}` if such a tuple is found; otherwise, returns
 `false`.
 
 > #### Note {: .info }
 >
 > This function is retained for backward compatibility. Function `keyfind/3` is
-> usually more convenient.
+> easier to use and more efficient.
 """.
 -spec keysearch(Key, N, TupleList) -> {value, Tuple} | false when
       Key :: term(),
@@ -143,7 +165,18 @@ keysearch(_, _, _) ->
     erlang:nif_error(undef).
 
 %% Shadowed by erl_bif_types: lists:member/2
--doc "Returns `true` if `Elem` matches some element of `List`, otherwise `false`.".
+-doc """
+Returns `true` if `Elem` matches some element of `List`; otherwise, returns `false`.
+
+## Examples
+
+```erlang
+> lists:member(2, [1,2,3]).
+true
+> lists:member(nope, [1,2,3]).
+false
+```
+""".
 -spec member(Elem, List) -> boolean() when
       Elem :: T,
       List :: [T],
@@ -154,10 +187,10 @@ member(_, _) ->
 
 %% Shadowed by erl_bif_types: lists:reverse/2
 -doc """
-Returns a list with the elements in `List1` in reverse order, with tail `Tail`
-appended.
+Returns a list containing the elements of `List1` in reverse order,
+with tail `Tail` appended.
 
-_Example:_
+## Examples
 
 ```erlang
 > lists:reverse([1, 2, 3, 4], [a, b, c]).
@@ -175,22 +208,11 @@ reverse(_, _) ->
 
 %%% End of BIFs
 
-%% member(X, L) -> (true | false)
-%%  test if X is a member of the list L
-%%  Now a BIF!
-
-%member(X, [X|_]) -> true;
-%member(X, [_|Y]) ->
-%	member(X, Y);
-%member(X, []) -> false.
-
-%% append(X, Y) appends lists X and Y
-
 -doc """
-Returns a new list `List3`, which is made from the elements of `List1` followed
-by the elements of `List2`.
+Returns a new list, `List3`, consisting of the elements of
+`List1`, followed by the elements of `List2`.
 
-_Example:_
+## Examples
 
 ```erlang
 > lists:append("abc", "def").
@@ -207,12 +229,10 @@ _Example:_
 
 append(L1, L2) -> L1 ++ L2.
 
-%% append(L) appends the list of lists L
-
 -doc """
-Returns a list in which all the sublists of `ListOfLists` have been appended.
+Returns a list in which all sublists of `ListOfLists` have been concatenated.
 
-_Example:_
+## Examples
 
 ```erlang
 > lists:append([[1, 2, 3], [a, b], [4, 5, 6]]).
@@ -229,14 +249,12 @@ append([E]) -> E;
 append([H|T]) -> H ++ append(T);
 append([]) -> [].
 
-%% subtract(List1, List2) subtract elements in List2 form List1.
-
 -doc """
-Returns a new list `List3` that is a copy of `List1`, subjected to the following
-procedure: for each element in `List2`, its first occurrence in `List1` is
-deleted.
+Returns a new list, `List3`, which is a copy of `List1` with the
+following modification: for each element in `List2`, its first
+occurrence in `List1` is removed.
 
-_Example:_
+## Examples
 
 ```erlang
 > lists:subtract("123212", "212").
@@ -253,9 +271,16 @@ _Example:_
 
 subtract(L1, L2) -> L1 -- L2.
 
-%% reverse(L) reverse all elements in the list L. reverse/2 is now a BIF!
+-doc """
+Returns a list containing the elements in `List1` in reverse order.
 
--doc "Returns a list with the elements in `List1` in reverse order.".
+## Examples
+
+```erlang
+> lists:reverse([1,2,3]).
+[3,2,1]
+```
+""".
 -spec reverse(List1) -> List2 when
       List1 :: [T],
       List2 :: [T],
@@ -270,18 +295,11 @@ reverse([A, B]) ->
 reverse([A, B | L]) ->
     lists:reverse(L, [B, A]).
 
-%reverse([H|T], Y) ->
-%    reverse(T, [H|Y]);
-%reverse([], X) -> X.
-
-
-%% nth(N, L) returns the N`th element of the list L
-%% nthtail(N, L) returns the N`th tail of the list L
 
 -doc """
 Returns the `N`th element of `List`.
 
-_Example:_
+## Examples
 
 ```erlang
 > lists:nth(3, [a, b, c, d, e]).
@@ -303,10 +321,10 @@ nth_1(N, [_|T]) ->
     nth_1(N - 1, T).
 
 -doc """
-Returns the `N`th tail of `List`, that is, the sublist of `List` starting at
-`N+1` and continuing up to the end of the list.
+Returns the `N`th tail of `List`, meaning the sublist of `List`
+starting at `N+1` and continuing to the end of the list.
 
-_Example_
+## Examples
 
 ```erlang
 > lists:nthtail(3, [a, b, c, d, e]).
@@ -335,9 +353,25 @@ nthtail_1(1, [_|T]) -> T;
 nthtail_1(N, [_|T]) ->
     nthtail_1(N - 1, T).
 
-%% prefix(Prefix, List) -> (true | false)
+-doc """
+Returns `true` if `List1` is a prefix of `List2`; otherwise, returns `false`.
 
--doc "Returns `true` if `List1` is a prefix of `List2`, otherwise `false`.".
+A prefix of a list is the first part of the list, starting from the
+beginning and stopping at any point.
+
+## Examples
+
+```erlang
+> lists:prefix("abc", "abcdef").
+true
+> lists:prefix("def", "abcdef").
+false
+> lists:prefix([], "any list").
+true
+> lists:prefix("abc", "abc").
+true
+```
+""".
 -spec prefix(List1, List2) -> boolean() when
       List1 :: [T],
       List2 :: [T],
@@ -348,9 +382,25 @@ prefix([X|PreTail], [X|Tail]) ->
 prefix([], List) when is_list(List) -> true;
 prefix([_|_], List) when is_list(List) -> false.
 
-%% suffix(Suffix, List) -> (true | false)
+-doc """
+Returns `true` if `List1` is a suffix of `List2`; otherwise, returns `false`.
 
--doc "Returns `true` if `List1` is a suffix of `List2`, otherwise `false`.".
+A suffix of a list is the last part of the list, starting from any position
+and going all the way to the end.
+
+## Examples
+
+```erlang
+> lists:suffix("abc", "abcdef").
+false
+> lists:suffix("def", "abcdef").
+true
+> lists:suffix([], "any list").
+true
+> lists:suffix("abc", "abc").
+true
+```
+""".
 -spec suffix(List1, List2) -> boolean() when
       List1 :: [T],
       List2 :: [T],
@@ -360,11 +410,20 @@ suffix(Suffix, List) ->
     Delta = length(List) - length(Suffix),
     Delta >= 0 andalso nthtail(Delta, List) =:= Suffix.
 
-%% droplast(List) returns the list dropping its last element
-
 -doc """
-Drops the last element of a `List`. The list is to be non-empty, otherwise the
-function crashes with a `function_clause`.
+Drops the last element of a `List`.
+
+The list must be non-empty; otherwise, the function raises a
+`function_clause` exception.
+
+## Examples
+
+```erlang
+> lists:droplast([1]).
+[]
+> lists:droplast([1,2,3]).
+[1,2]
+```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
 -spec droplast(List) -> InitList when
@@ -372,15 +431,24 @@ function crashes with a `function_clause`.
       InitList :: [T],
       T :: term().
 
-%% This is the simple recursive implementation
+%% This is the simple recursive implementation.
 %% reverse(tl(reverse(L))) is faster on average,
 %% but creates more garbage.
 droplast([_T])  -> [];
 droplast([H|T]) -> [H|droplast(T)].
 
-%% last(List) returns the last element in a list.
+-doc """
+Returns the last element in `List`.
 
--doc "Returns the last element in `List`.".
+## Examples
+
+```erlang
+> lists:last([1]).
+1
+> lists:last([1,2,3]).
+3
+```
+""".
 -spec last(List) -> Last when
       List :: [T,...],
       Last :: T,
@@ -391,11 +459,6 @@ last([E|Es]) -> last(E, Es).
 last(_, [E|Es]) -> last(E, Es);
 last(E, []) -> E.
 
-%% seq(Min, Max) -> [Min,Min+1, ..., Max]
-%% seq(Min, Max, Incr) -> [Min,Min+Incr, ..., Max]
-%%  returns the sequence Min..Max
-%%  Min <= Max and Min and Max must be integers
-
 -doc(#{equiv => seq(From, To, 1)}).
 -spec seq(From, To) -> Seq when
       From :: integer(),
@@ -403,15 +466,15 @@ last(E, []) -> E.
       Seq :: [integer()].
 
 seq(First, Last)
-    when is_integer(First), is_integer(Last), First-1 =< Last -> 
+  when is_integer(First), is_integer(Last), First-1 =< Last ->
     seq_loop(Last-First+1, Last, []).
 
 seq_loop(N, X, L) when N >= 4 ->
-     seq_loop(N-4, X-4, [X-3,X-2,X-1,X|L]);
+    seq_loop(N-4, X-4, [X-3,X-2,X-1,X|L]);
 seq_loop(N, X, L) when N >= 2 ->
-     seq_loop(N-2, X-2, [X-1,X|L]);
+    seq_loop(N-2, X-2, [X-1,X|L]);
 seq_loop(1, X, L) ->
-     [X|L];
+    [X|L];
 seq_loop(0, _, L) ->
      L.
 
@@ -419,6 +482,7 @@ seq_loop(0, _, L) ->
 Returns a sequence of integers that starts with `From` and contains the
 successive results of adding `Incr` to the previous element, until `To` is
 reached or passed (in the latter case, `To` is not an element of the sequence).
+
 `Incr` defaults to 1.
 
 Failures:
@@ -434,7 +498,7 @@ length(lists:seq(From, To)) =:= To - From + 1
 length(lists:seq(From, To, Incr)) =:= (To - From + Incr) div Incr
 ```
 
-_Examples:_
+## Examples
 
 ```erlang
 > lists:seq(1, 10).
@@ -464,7 +528,8 @@ seq(First, Last, Inc)
 seq(Same, Same, 0) when is_integer(Same) ->
     [Same];
 seq(First, Last, Inc) ->
-    erlang:error(badarg, [First, Last, Inc], [{error_info, #{module => erl_stdlib_errors}}]).
+    error(badarg, [First, Last, Inc],
+          [{error_info, #{module => erl_stdlib_errors}}]).
 
 seq_loop(N, X, D, L) when N >= 4 ->
      Y = X-D, Z = Y-D, W = Z-D,
@@ -477,9 +542,18 @@ seq_loop(1, X, _, L) ->
 seq_loop(0, _, _, L) ->
      L.
 
-%% sum(L) returns the sum of the elements in L
+-doc """
+Returns the sum of the elements in `List`.
 
--doc "Returns the sum of the elements in `List`.".
+## Examples
+
+```erlang
+> lists:sum([]).
+0
+> lists:sum([1,2,3]).
+6
+```
+""".
 -spec sum(List) -> number() when
       List :: [number()].
 
@@ -488,13 +562,10 @@ sum(L)          -> sum(L, 0).
 sum([H|T], Sum) -> sum(T, Sum + H);
 sum([], Sum)    -> Sum.
 
-%% duplicate(N, X) -> [X,X,X,.....,X]  (N times)
-%%   return N copies of X
-
 -doc """
 Returns a list containing `N` copies of term `Elem`.
 
-_Example:_
+## Examples
 
 ```erlang
 > lists:duplicate(5, xx).
@@ -512,11 +583,16 @@ duplicate(N, X) when is_integer(N), N >= 0 -> duplicate(N, X, []).
 duplicate(0, _, L) -> L;
 duplicate(N, X, L) -> duplicate(N-1, X, [X|L]).
 
-%% min(L) -> returns the minimum element of the list L
-
 -doc """
 Returns the first element of `List` that compares less than or equal to all
 other elements of `List`.
+
+## Examples
+
+```erlang
+> lists:min([17,19,7,55]).
+7
+```
 """.
 -spec min(List) -> Min when
       List :: [T,...],
@@ -529,11 +605,16 @@ min([H|T], Min) when H < Min -> min(T, H);
 min([_|T], Min)              -> min(T, Min);
 min([],    Min)              -> Min. 
 
-%% max(L) -> returns the maximum element of the list L
-
 -doc """
 Returns the first element of `List` that compares greater than or equal to all
 other elements of `List`.
+
+## Examples
+
+```erlang
+> lists:max([17,19,7,55]).
+55
+```
 """.
 -spec max(List) -> Max when
       List :: [T,...],
@@ -546,14 +627,13 @@ max([H|T], Max) when H > Max -> max(T, H);
 max([_|T], Max)              -> max(T, Max);
 max([],    Max)              -> Max.
 
-%% sublist(List, Start, Length)
-%%  Returns the sub-list starting at Start of length Length.
-
 -doc """
-Returns the sublist of `List1` starting at `Start` and with (maximum) `Len`
-elements. It is not an error for `Start+Len` to exceed the length of the list.
+Returns the sublist of `List1` starting at `Start` and with no more than `Len`
+elements.
 
-_Examples:_
+It is not an error for `Start+Len` to exceed the length of the list.
+
+## Examples
 
 ```erlang
 > lists:sublist([1,2,3,4], 2, 2).
@@ -579,9 +659,20 @@ sublist([_H|T], S, L) when is_integer(S), S >= 2 ->
     sublist(T, S-1, L).
 
 -doc """
-Returns the sublist of `List1` starting at position 1 and with (maximum) `Len`
-elements. It is not an error for `Len` to exceed the length of the list, in that
+Returns the sublist of `List1` starting at position 1 and with no more than `Len`
+elements.
+
+It is not an error for `Len` to exceed the length of the list, in which
 case the whole list is returned.
+
+## Examples
+
+```erlang
+> lists:sublist([1,2,3,4,5], 2)
+[1,2]
+> lists:sublist([1,2,3,4,5], 99)
+[1,2,3,4,5]
+```
 """.
 -spec sublist(List1, Len) -> List2 when
       List1 :: [T],
@@ -599,12 +690,18 @@ sublist_2(_, 0) ->
 sublist_2(List, L) when is_list(List), L > 0 ->
     [].
 
-%% delete(Item, List) -> List'
-%%  Delete the first occurrence of Item from the list L.
-
 -doc """
-Returns a copy of `List1` where the first element matching `Elem` is deleted, if
+Returns a copy of `List1` where the first element matching `Elem` is removed, if
 there is such an element.
+
+## Examples
+
+```erlang
+> lists:delete(b, [a,b,c]).
+[a,c]
+> lists:delete(x, [a,b,c]).
+[a,b,c]
+```
 """.
 -spec delete(Elem, List1) -> List2 when
       Elem :: T,
@@ -616,9 +713,6 @@ delete(Item, [Item|Rest]) -> Rest;
 delete(Item, [H|Rest]) -> 
     [H|delete(Item, Rest)];
 delete(_, []) -> [].
-
-%% Return [{X0, Y0}, {X1, Y1}, ..., {Xn, Yn}] for lists [X0, X1, ...,
-%% Xn] and [Y0, Y1, ..., Yn].
 
 -doc(#{equiv => zip(List1, List2, fail)}).
 -spec zip(List1, List2) -> List3 when
@@ -643,7 +737,7 @@ lengths.
 
 - **`trim`** - Surplus elements from the longer list will be ignored.
 
-  _Examples:_
+  ## Examples
 
   ```erlang
   > lists:zip([a, b], [1, 2, 3], trim).
@@ -655,7 +749,7 @@ lengths.
 - **`{pad, Defaults}`** - The shorter list will be padded to the length of the
   longer list, using the respective elements from the given `Defaults` tuple.
 
-  _Examples:_
+  ## Examples
 
   ```erlang
   > lists:zip([a, b], [1, 2, 3], {pad, {x, 0}}).
@@ -693,13 +787,17 @@ zip([_ | _]=Xs, [], {pad, {_, Y}}) ->
     [{X, Y} || X <- Xs].
 
 
-%% Return {[X0, X1, ..., Xn], [Y0, Y1, ..., Yn]}, for a list [{X0, Y0},
-%% {X1, Y1}, ..., {Xn, Yn}].
-
 -doc """
 "Unzips" a list of two-tuples into two lists, where the first list contains the
 first element of each tuple, and the second list contains the second element of
 each tuple.
+
+## Examples
+
+```erlang
+> lists:unzip([{1, a}, {2, b}]).
+{[1,2],[a,b]}
+```
 """.
 -spec unzip(List1) -> {List2, List3} when
       List1 :: [{A, B}],
@@ -712,9 +810,6 @@ unzip(Ts) -> unzip(Ts, [], []).
 
 unzip([{X, Y} | Ts], Xs, Ys) -> unzip(Ts, [X | Xs], [Y | Ys]);
 unzip([], Xs, Ys) -> {reverse(Xs), reverse(Ys)}.
-
-%% Return [{X0, Y0, Z0}, {X1, Y1, Z1}, ..., {Xn, Yn, Zn}] for lists [X0,
-%% X1, ..., Xn], [Y0, Y1, ..., Yn] and [Z0, Z1, ..., Zn].
 
 -doc(#{equiv => zip3(List1, List2, List3, fail)}).
 -spec zip3(List1, List2, List3) -> List4 when
@@ -735,6 +830,15 @@ corresponding element in the second list, and the third element is taken from
 the corresponding element in the third list.
 
 For a description of the `How` parameter, see `zip/3`.
+
+## Examples
+
+```erlang
+> lists:zip3([a], [1, 2, 3], [17, 19], trim).
+[{a,1,17}]
+> lists:zip3([a], [1, 2, 3], [17, 19], {pad, {z, 0, 0}}).
+[{a,1,17}, {z,2,19}, {z,3,0}]
+```
 """.
 -doc(#{since => <<"OTP 26.0">>}).
 -spec zip3(List1, List2, List3, How) -> List4 when
@@ -773,13 +877,17 @@ zip3([X | Xs], [], [Z | Zs], {pad, {_, Y, _}} = How) ->
 zip3([X | Xs], [Y | Ys], [], {pad, {_, _, Z}} = How) ->
     [{X, Y, Z} | zip3(Xs, Ys, [], How)].
 
-%% Return {[X0, X1, ..., Xn], [Y0, Y1, ..., Yn], [Z0, Z1, ..., Zn]}, for
-%% a list [{X0, Y0, Z0}, {X1, Y1, Z1}, ..., {Xn, Yn, Zn}].
-
 -doc """
 "Unzips" a list of three-tuples into three lists, where the first list contains
 the first element of each tuple, the second list contains the second element of
 each tuple, and the third list contains the third element of each tuple.
+
+## Examples
+
+```erlang
+> lists:unzip3([{a, 1, 2}, {b, 777, 999}]).
+{[a,b],[1,777],[2,999]}
+```
 """.
 -spec unzip3(List1) -> {List2, List3, List4} when
       List1 :: [{A, B, C}],
@@ -797,9 +905,6 @@ unzip3([{X, Y, Z} | Ts], Xs, Ys, Zs) ->
 unzip3([], Xs, Ys, Zs) ->
     {reverse(Xs), reverse(Ys), reverse(Zs)}.
 
-%% Return [F(X0, Y0), F(X1, Y1), ..., F(Xn, Yn)] for lists [X0, X1, ...,
-%% Xn] and [Y0, Y1, ..., Yn].
-
 -doc(#{equiv => zipwith(Combine, List1, List2, fail)}).
 -spec zipwith(Combine, List1, List2) -> List3 when
       Combine :: fun((X, Y) -> T),
@@ -813,18 +918,20 @@ unzip3([], Xs, Ys, Zs) ->
 zipwith(F, Xs, Ys) -> zipwith(F, Xs, Ys, fail).
 
 -doc """
-Combines the elements of two lists into one list. For each pair `X, Y` of list
-elements from the two lists, the element in the result list is `Combine(X, Y)`.
+Combines the elements of two lists into a single list using the `Combine` fun.
+
+For each pair `X, Y` of list elements from the two lists, the element
+in the result list is `Combine(X, Y)`.
 
 For a description of the `How` parameter, see `zip/3`.
 
 [`zipwith(fun(X, Y) -> {X,Y} end, List1, List2)`](`zipwith/3`) is equivalent to
 [`zip(List1, List2)`](`zip/2`).
 
-_Example:_
+## Examples
 
 ```erlang
-> lists:zipwith(fun(X, Y) -> X+Y end, [1,2,3], [4,5,6]).
+> lists:zipwith(fun(X, Y) -> X+Y end, [1,2,3], [4,5,6], fail).
 [5,7,9]
 ```
 """.
@@ -858,9 +965,6 @@ zipwith(F, [], [_ | _]=Ys, {pad, {X, _}}) ->
 zipwith(F, [_ | _]=Xs, [], {pad, {_, Y}}) ->
     [F(X, Y) || X <- Xs].
 
-%% Return [F(X0, Y0, Z0), F(X1, Y1, Z1), ..., F(Xn, Yn, Zn)] for lists
-%% [X0, X1, ..., Xn], [Y0, Y1, ..., Yn] and [Z0, Z1, ..., Zn].
-
 -doc(#{equiv => zipwith3(Combine, List1, List2, List3, fail)}).
 -spec zipwith3(Combine, List1, List2, List3) -> List4 when
       Combine :: fun((X, Y, Z) -> T),
@@ -876,21 +980,23 @@ zipwith(F, [_ | _]=Xs, [], {pad, {_, Y}}) ->
 zipwith3(F, Xs, Ys, Zs) -> zipwith3(F, Xs, Ys, Zs, fail).
 
 -doc """
-Combines the elements of three lists into one list. For each triple `X, Y, Z` of
-list elements from the three lists, the element in the result list is
-`Combine(X, Y, Z)`.
+Combines the elements of three lists into a single list using the
+`Combine` fun.
+
+For each triple `X, Y, Z` of list elements from the three lists, the
+element in the result list is `Combine(X, Y, Z)`.
 
 For a description of the `How` parameter, see `zip/3`.
 
 [`zipwith3(fun(X, Y, Z) -> {X,Y,Z} end, List1, List2, List3)`](`zipwith3/4`) is
 equivalent to [`zip3(List1, List2, List3)`](`zip3/3`).
 
-_Examples:_
+## Examples
 
 ```erlang
-> lists:zipwith3(fun(X, Y, Z) -> X+Y+Z end, [1,2,3], [4,5,6], [7,8,9]).
+> lists:zipwith3(fun(X, Y, Z) -> X+Y+Z end, [1,2,3], [4,5,6], [7,8,9], fail).
 [12,15,18]
-> lists:zipwith3(fun(X, Y, Z) -> [X,Y,Z] end, [a,b,c], [x,y,z], [1,2,3]).
+> lists:zipwith3(fun(X, Y, Z) -> [X,Y,Z] end, [a,b,c], [x,y,z], [1,2,3], fail).
 [[a,x,1],[b,y,2],[c,z,3]]
 ```
 """.
@@ -933,10 +1039,29 @@ zipwith3(F, [X | Xs], [], [Z | Zs], {pad, {_, Y, _}} = How) ->
 zipwith3(F, [X | Xs], [Y | Ys], [], {pad, {_, _, Z}} = How) ->
     [F(X, Y, Z) | zipwith3(F, Xs, Ys, [], How)].
 
-%% sort(List) -> L
-%%  sorts the list L
+-doc """
+Returns a list containing the sorted elements of `List1`.
 
--doc "Returns a list containing the sorted elements of `List1`.".
+The sort is stable.
+
+## Examples
+
+```erlang
+> lists:sort([4,1,3,2]).
+[1,2,3,4]
+> lists:sort([a,4,3,b,9]).
+[3,4,9,a,b]
+```
+Since the sort is stable, the relative order of elements that compare
+equal is not changed:
+
+```erlang
+> lists:sort([1.0,1]).
+[1.0,1]
+> lists:sort([1,1.0]).
+[1,1.0]
+```
+""".
 -spec sort(List1) -> List2 when
       List1 :: [T],
       List2 :: [T],
@@ -984,15 +1109,20 @@ sort_1(X, [Y | L], R) ->
 sort_1(X, [], R) ->
     lists:reverse(R, [X]).
 
-%% merge(List) -> L
-%%  merges a list of sorted lists
-
 -doc """
-Returns the sorted list formed by merging all the sublists of `ListOfLists`. All
-sublists must be sorted before evaluating this function.
+Returns the sorted list formed by merging all sublists of `ListOfLists`.
+
+All sublists must be sorted before evaluating this function.
 
 When two elements compare equal, the element from the sublist with the lowest
 position in `ListOfLists` is picked before the other element.
+
+## Examples
+
+```erlang
+> lists:merge([[b,l,l], [g,k,q]]).
+[b,g,k,l,l,q]
+```
 """.
 -spec merge(ListOfLists) -> List1 when
       ListOfLists :: [List],
@@ -1003,16 +1133,22 @@ position in `ListOfLists` is picked before the other element.
 merge(L) ->
     mergel(L, []).
 
-%% merge3(X, Y, Z) -> L
-%%  merges three sorted lists X, Y and Z
-
 -doc """
-Returns the sorted list formed by merging `List1`, `List2`, and `List3`. All of
-`List1`, `List2`, and `List3` must be sorted before evaluating this function.
+Returns the sorted list formed by merging `List1`, `List2`, and `List3`.
+
+All of `List1`, `List2`, and `List3` must be sorted before evaluating
+this function.
 
 When two elements compare equal, the element from `List1`, if there is such an
 element, is picked before the other element, otherwise the element from `List2`
 is picked before the element from `List3`.
+
+## Examples
+
+```erlang
+> lists:merge3([a,o], [g,q], [j]).
+[a,g,j,o,q]
+```
 """.
 -spec merge3(List1, List2, List3) -> List4 when
       List1 :: [X],
@@ -1063,15 +1199,20 @@ rmerge3([], [], [_|_]=L3) ->
 rmerge3([], [], []) ->
     [].
 
-%% merge(X, Y) -> L
-%%  merges two sorted lists X and Y
-
 -doc """
-Returns the sorted list formed by merging `List1` and `List2`. Both `List1` and
-`List2` must be sorted before evaluating this function.
+Returns the sorted list formed by merging `List1` and `List2`.
+
+Both `List1` and `List2` must be sorted before evaluating this function.
 
 When two elements compare equal, the element from `List1` is picked before the
 element from `List2`.
+
+## Examples
+
+```erlang
+> lists:merge([a,o], [b,x]).
+[a,b,o,x]
+```
 """.
 -spec merge(List1, List2) -> List3 when
       List1 :: [X],
@@ -1106,15 +1247,12 @@ rmerge([], [_|_]=L2) ->
 rmerge([], []) ->
     [].
 
-%% concat(L) concatenate the list representation of the elements
-%%  in L - the elements in L can be atoms, numbers of strings.
-%%  Returns a list of characters.
-
 -doc """
-Concatenates the text representation of the elements of `Things`. The elements
-of `Things` can be atoms, integers, floats, or strings.
+Concatenates the text representation of the elements of `Things`.
 
-_Example:_
+The elements of `Things` can be atoms, integers, floats, or strings.
+
+## Examples
 
 ```erlang
 > lists:concat([doc, '/', file, '.', 3]).
@@ -1133,11 +1271,16 @@ thing_to_list(X) when is_float(X)   -> float_to_list(X);
 thing_to_list(X) when is_atom(X)    -> atom_to_list(X);
 thing_to_list(X) when is_list(X)    -> X.	%Assumed to be a string
 
-%% flatten(List)
-%% flatten(List, Tail)
-%%  Flatten a list, adding optional tail.
+-doc """
+Returns a flattened version of `DeepList`.
 
--doc "Returns a flattened version of `DeepList`.".
+## Examples
+
+```erlang
+> lists:flatten([a,[b,c,[d,e]],f]).
+[a,b,c,d,e,f]
+```
+""".
 -spec flatten(DeepList) -> List when
       DeepList :: [term() | DeepList],
       List :: [term()].
@@ -1145,7 +1288,16 @@ thing_to_list(X) when is_list(X)    -> X.	%Assumed to be a string
 flatten(List) when is_list(List) ->
     do_flatten(List, []).
 
--doc "Returns a flattened version of `DeepList` with tail `Tail` appended.".
+-doc """
+Returns a flattened version of `DeepList` with tail `Tail` appended.
+
+## Examples
+
+```erlang
+> lists:flatten([a,[b,c,[d,e]],f], [g,h,i]).
+[a,b,c,d,e,f,g,h,i]
+```
+""".
 -spec flatten(DeepList, Tail) -> List when
       DeepList :: [term() | DeepList],
       Tail :: [term()],
@@ -1164,7 +1316,19 @@ do_flatten([], Tail) ->
 %% flatlength(List)
 %%  Calculate the length of a list of lists.
 
--doc "Equivalent to [`length(flatten(DeepList))`](`length/1`), but more efficient.".
+-doc """
+Equivalent to [`length(flatten(DeepList))`](`length/1`), but more efficient.
+
+## Examples
+
+```erlang
+> lists:flatlength([a,[b,c,[d,e]],f,[[g,h,i]]]).
+9
+> lists:flatlength([[[]]]).
+0
+```
+
+""".
 -spec flatlength(DeepList) -> non_neg_integer() when
       DeepList :: [term() | DeepList].
 
@@ -1191,26 +1355,19 @@ flatlength([], L) -> L.
 %% keymap(Function, Index, [Tuple])
 %% keymap(Function, ExtraArgs, Index, [Tuple])
 
-%keymember(K,N,L) when is_integer(N), N > 0 ->
-%    keymember3(K,N,L).
-
-%keymember3(Key, N, [T|Ts]) when element(N, T) == Key -> true;
-%keymember3(Key, N, [T|Ts]) ->
-%    keymember3(Key, N, Ts);
-%keymember3(Key, N, []) -> false.
-
-%keysearch(K, N, L) when is_integer(N), N > 0 ->
-%    keysearch3(K, N, L).
-
-%keysearch3(Key, N, [H|T]) when element(N, H) == Key ->
-%    {value, H};
-%keysearch3(Key, N, [H|T]) ->
-%    keysearch3(Key, N, T);
-%keysearch3(Key, N, []) -> false.
-
 -doc """
-Returns a copy of `TupleList1` where the first occurrence of a tuple whose `N`th
-element compares equal to `Key` is deleted, if there is such a tuple.
+Returns a copy of `TupleList1`, where the first occurrence of a tuple
+whose `N`th element compares equal to `Key` is removed, if there is
+such a tuple.
+
+## Examples
+
+```erlang
+> lists:keydelete(c, 1, [{b,1}, {c,55}, {d,75}]).
+[{b,1},{d,75}]
+> lists:keydelete(unknown, 1, [{b,1}, {c,55}, {d,75}]).
+[{b,1},{c,55},{d,75}]
+```
 """.
 -spec keydelete(Key, N, TupleList1) -> TupleList2 when
       Key :: term(),
@@ -1228,9 +1385,18 @@ keydelete3(Key, N, [H|T]) ->
 keydelete3(_, _, []) -> [].
 
 -doc """
-Returns a copy of `TupleList1` where the first occurrence of a `T` tuple whose
+Returns a copy of `TupleList1` where the first occurrence of a tuple `T` whose
 `N`th element compares equal to `Key` is replaced with `NewTuple`, if there is
 such a tuple `T`.
+
+## Examples
+
+```erlang
+> lists:keyreplace(c, 1, [{b,1}, {c,55}, {d,75}], {new,tuple}).
+[{b,1},{new,tuple},{d,75}]
+> lists:keyreplace(unknown, 1, [{b,1}, {c,55}, {d,75}], {new,tuple}).
+[{b,1},{c,55},{d,75}]
+```
 """.
 -spec keyreplace(Key, N, TupleList1, NewTuple) -> TupleList2 when
       Key :: term(),
@@ -1250,10 +1416,21 @@ keyreplace3(Key, Pos, [H|T], New) ->
 keyreplace3(_, _, [], _) -> [].
 
 -doc """
-Searches the list of tuples `TupleList1` for a tuple whose `N`th element
-compares equal to `Key`. Returns `{value, Tuple, TupleList2}` if such a tuple is
-found, otherwise `false`. `TupleList2` is a copy of `TupleList1` where the first
-occurrence of `Tuple` has been removed.
+Searches the list of tuples `TupleList1` for a tuple whose `N`th
+element compares equal to `Key`, returning `{value, Tuple,
+TupleList2}` if found, where `TupleList2` is a copy of `TupleList1`
+with the first occurrence of `Tuple` removed.
+
+Otherwise, returns `false` if no such tuple is found.
+
+## Examples
+
+```erlang
+> lists:keytake(b, 1, [{a, 10}, {b, 23}, {c, 99}]).
+{value,{b,23},[{a, 10},{c, 99}]}
+> lists:keytake(z, 1, [{a, 10}, {b, 23}, {c, 99}]).
+false
+```
 """.
 -spec keytake(Key, N, TupleList1) -> {value, Tuple, TupleList2} | false when
       Key :: term(),
@@ -1272,10 +1449,18 @@ keytake(Key, N, [H|T], L) ->
 keytake(_K, _N, [], _L) -> false.
 
 -doc """
-Returns a copy of `TupleList1` where the first occurrence of a tuple `T` whose
-`N`th element compares equal to `Key` is replaced with `NewTuple`, if there is
-such a tuple `T`. If there is no such tuple `T`, a copy of `TupleList1` where
-[`NewTuple`] has been appended to the end is returned.
+Returns a copy of `TupleList1` with the first tuple whose `N`th
+element compares equal to `Key` replaced by `NewTuple`, or with
+`[NewTuple]` appended if no such tuple exists.
+
+## Examples
+
+```erlang
+> lists:keystore(b, 1, [{a, 10}, {b, 23}, {c, 99}], {bb, 1}).
+[{a, 10}, {bb, 1}, {c, 99}]
+> lists:keystore(z, 1, [{a, 10}, {b, 23}, {c, 99}], {z, 2}).
+[{a, 10}, {b, 23}, {c, 99}, {z, 2}]
+```
 """.
 -spec keystore(Key, N, TupleList1, NewTuple) -> TupleList2 when
       Key :: term(),
@@ -1296,8 +1481,18 @@ keystore2(_Key, _N, [], New) ->
     [New].
 
 -doc """
-Returns a list containing the sorted elements of list `TupleList1`. Sorting is
-performed on the `N`th element of the tuples. The sort is stable.
+
+Returns a list of the elements in `TupleList1`, sorted by the `N`th
+element of each tuple.
+
+The sort is stable.
+
+## Examples
+
+```erlang
+> lists:keysort(2, [{a, 99}, {b, 17}, {c, 50}, {d, 50}]).
+[{b,17},{c,50},{d,50},{a,99}]
+```
 """.
 -spec keysort(N, TupleList1) -> TupleList2 when
       N :: pos_integer(),
@@ -1363,10 +1558,18 @@ keysort_1(_I, X, _EX, [], R) ->
 -doc """
 Returns the sorted list formed by merging `TupleList1` and `TupleList2`.
 
-The merge is performed on the `N`th element of each tuple. Both `TupleList1` and
-`TupleList2` must be key-sorted before evaluating this function. When two tuples
-compare equal, the tuple from `TupleList1` is picked before the tuple from
+The merge is performed on the `N`th element of each tuple. Both
+`TupleList1` and `TupleList2` must be key-sorted before evaluating
+this function. When the key elements of the two tuples compare equal,
+the tuple from `TupleList1` is picked before the tuple from
 `TupleList2`.
+
+## Examples
+
+```erlang
+> lists:keymerge(2, [{b, 50}], [{c, 20}, {a, 50}]).
+[{c,20},{b,50},{a,50}]
+```
 """.
 -spec keymerge(N, TupleList1, TupleList2) -> TupleList3 when
       N :: pos_integer(),
@@ -1412,9 +1615,17 @@ rkeymerge_1(_Index, [], []) ->
     [].
 
 -doc """
-Returns a list containing the sorted elements of list `TupleList1` where all
-except the first tuple of the tuples comparing equal have been deleted. Sorting
-is performed on the `N`th element of the tuples.
+Returns a sorted list of the elements in `TupleList1`, keeping only the
+first occurrence of tuples whose `N`th elements compare equal.
+
+Sorting is performed on the `N`th element of the tuples.
+
+## Examples
+
+```erlang
+> lists:ukeysort(2, [{a, 27}, {d, 23}, {e, 23}]).
+[{d,23}, {a, 27}]
+```
 """.
 -spec ukeysort(N, TupleList1) -> TupleList2 when
       N :: pos_integer(),
@@ -1486,13 +1697,21 @@ ukeysort_1(_I, X, _EX, []) ->
     [X].
 
 -doc """
-Returns the sorted list formed by merging `TupleList1` and `TupleList2`. The
-merge is performed on the `N`th element of each tuple. Both `TupleList1` and
-`TupleList2` must be key-sorted without duplicates before evaluating this
-function.
+Returns the sorted list formed by merging `TupleList1` and `TupleList2`
+based on the `N`th element of each tuple.
 
-When two tuples compare equal, the tuple from `TupleList1` is picked
-and the one from `TupleList2` is deleted.
+Both `TupleList1` and `TupleList2` must be key-sorted without
+duplicates before evaluating this function.
+
+When the `N`th elements of two tuples compare equal, the tuple
+from `TupleList1` is picked and the one from `TupleList2` is removed.
+
+## Examples
+
+```erlang
+> lists:ukeymerge(1, [{a, 33}, {c, 15}], [{a, 59}, {d, 39}]).
+[{a,33},{c,15},{d,39}]
+```
 """.
 -spec ukeymerge(N, TupleList1, TupleList2) -> TupleList3 when
       N :: pos_integer(),
@@ -1542,7 +1761,7 @@ Returns a list of tuples where, for each tuple in `TupleList1`, the `N`th
 element `Term1` of the tuple has been replaced with the result of calling
 `Fun(Term1)`.
 
-_Examples:_
+## Examples
 
 ```erlang
 > Fun = fun(Atom) -> atom_to_list(Atom) end.
@@ -1583,11 +1802,13 @@ enumerate(Index, List1) ->
     enumerate(Index, 1, List1).
 
 -doc """
-Returns `List1` with each element `H` replaced by a tuple of form `{I, H}` where
-`I` is the position of `H` in `List1`. The enumeration starts with `Index` and
-increases by `Step` in each step.
+Returns `List1` with each element `H` replaced by a tuple of form `{I, H}`, where
+`I` is the position of `H` in `List1`.
 
-That is, [`enumerate/3`](`enumerate/3`) behaves as if it had been defined as
+The enumeration starts with `Index` and increases by `Step` in each
+step.
+
+That is, [`enumerate/3`](`enumerate/3`) behaves as if it were defined as
 follows:
 
 ```erlang
@@ -1598,19 +1819,13 @@ enumerate(I, S, List) ->
 
 The default values for `Index` and `Step` are both `1`.
 
-_Examples:_
+## Examples
 
 ```erlang
 > lists:enumerate([a,b,c]).
 [{1,a},{2,b},{3,c}]
-```
-
-```erlang
 > lists:enumerate(10, [a,b,c]).
 [{10,a},{11,b},{12,c}]
-```
-
-```erlang
 > lists:enumerate(0, -2, [a,b,c]).
 [{0,a},{-2,b},{-4,c}]
 ```
@@ -1630,13 +1845,19 @@ enumerate_1(Index, Step, [H|T]) ->
 enumerate_1(_Index, _Step, []) ->
     [].
 
-%%% Suggestion from OTP-2948: sort and merge with Fun.
-
 -doc """
-Returns a list containing the sorted elements of `List1`, according to the
-[ordering function](`m:lists#ordering_function`) `Fun`. `Fun(A, B)` is to return
-`true` if `A` compares less than or equal to `B` in the ordering, otherwise
-`false`.
+Returns a list of the elements in `List1`, sorted according to the
+[ordering function](`m:lists#ordering_function`) `Fun`, where `Fun(A,
+B)` returns `true` if `A` compares less than or equal to `B` in the
+ordering; otherwise, it returns `false`.
+
+## Examples
+
+```erlang
+> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+> lists:sort(F, [{a, b, c}, {x, y}, {q, w}]).
+[{x,y},{q,w},{a,b,c}]
+```
 """.
 -spec sort(Fun, List1) -> List2 when
       Fun :: fun((A :: T, B :: T) -> boolean()),
@@ -1657,14 +1878,23 @@ sort(Fun, [X, Y | T]) ->
     end.
 
 -doc """
-Returns the sorted list formed by merging `List1` and `List2`. Both `List1` and
-`List2` must be sorted according to the
+Returns a sorted list formed by merging `List1` and `List2` based on `Fun`.
+
+Both `List1` and`List2` must be sorted according to the
 [ordering function](`m:lists#ordering_function`) `Fun` before evaluating this
 function.
 
 `Fun(A, B)` is to return `true` if `A` compares less than or equal to
 `B` in the ordering, otherwise `false`. When two elements compare equal, the
 element from `List1` is picked before the element from `List2`.
+
+## Examples
+
+```erlang
+> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+> lists:merge(F, [{x, y}, {a, b, c}], [{q, w}]).
+[{x,y},{q,w},{a,b,c}]
+```
 """.
 -spec merge(Fun, List1, List2) -> List3 when
       Fun :: fun((A, B) -> boolean()),
@@ -1706,9 +1936,18 @@ rmerge_1(_Fun, [], []) ->
 -doc """
 Returns a list containing the sorted elements of `List1` where all except the
 first element of the elements comparing equal according to the
-[ordering function](`m:lists#ordering_function`) `Fun` have been deleted.
+[ordering function](`m:lists#ordering_function`) `Fun` have been removed.
+
 `Fun(A, B)` is to return `true` if `A` compares less than or equal to `B` in the
 ordering, otherwise `false`.
+
+## Examples
+
+```erlang
+> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+> lists:usort(F, [{a, b, c}, {x, y}, {q, w}]).
+[{x,y},{a,b,c}]
+```
 """.
 -spec usort(Fun, List1) -> List2 when
       Fun :: fun((T, T) -> boolean()),
@@ -1740,17 +1979,25 @@ usort_1(Fun, X, [Y | L]) ->
         false  ->
 	    ufsplit_2(Y, L, Fun, [X])
     end.
-                    
--doc """
-Returns the sorted list formed by merging `List1` and `List2`. Both `List1` and
-`List2` must be sorted according to the
-[ordering function](`m:lists#ordering_function`) `Fun` and contain no duplicates
-before evaluating this function.
 
-`Fun(A, B)` is to return `true` if `A` compares
-less than or equal to `B` in the ordering, otherwise `false`. When two elements
-compare equal, the element from `List1` is picked and the one from `List2` is
-deleted.
+-doc """
+
+Returns a sorted list by merging `List1` and `List2` using [ordering
+function](`m:lists#ordering_function`) `Fun`, assuming both lists are
+pre-sorted according to `Fun` and contain no duplicates.
+
+`Fun(A, B)` is to return `true` if `A` compares less than or equal to
+`B` in the ordering; otherwise, it should return `false`. When two
+elements compare equal, the element from `List1` is picked and the one
+from `List2` is removed.
+
+## Examples
+
+```erlang
+> F = fun(A, B) -> tuple_size(A) =< tuple_size(B) end.
+> lists:umerge(F, [{x, y}, {a, b, c}], [{q, w}, {x, y, z, w}]).
+[{x,y},{a,b,c},{x,y,z,w}]
+```
 """.
 -spec umerge(Fun, List1, List2) -> List3 when
       Fun :: fun((A, B) -> boolean()),
@@ -1789,12 +2036,22 @@ rumerge_1(_Fun, [], [_|_]=L2) ->
 rumerge_1(_Fun, [], []) ->
     [].
 
-%% usort(List) -> L
-%%  sorts the list L, removes duplicates
-
 -doc """
-Returns a list containing the sorted elements of `List1` where all except the
-first element of the elements comparing equal have been deleted.
+Returns a sorted list of the elements of `List1`, keeping only the
+first occurrence of elements that compare equal.
+
+## Examples
+
+```erlang
+> lists:usort([a,x,y,b,c,x,a]).
+[a,b,c,x,y]
+> lists:usort([3,2,a,3,2,a,1,3,b,2,2,1]).
+[1,2,3,a,b]
+> lists:usort([1.0,1]).
+[1.0]
+> lists:usort([1,1.0]).
+[1]
+```
 """.
 -spec usort(List1) -> List2 when
       List1 :: [T],
@@ -1851,16 +2108,22 @@ usort_1(X, [Y | L]) ->
 usort_1(X, []) ->
     [X].
 
-%% umerge(List) -> L
-%%  merges a list of sorted lists without duplicates, removes duplicates
-
 -doc """
-Returns the sorted list formed by merging all the sublists of `ListOfLists`. All
-sublists must be sorted and contain no duplicates before evaluating this
-function.
+Returns a sorted list formed by merging all sublists in `ListOfLists`,
+while removing duplicates.
+
+All sublists must be sorted and contain no duplicates before
+evaluating this function.
 
 When two elements compare equal, the element from the sublist with the
-lowest position in `ListOfLists` is picked and the other is deleted.
+lowest position in `ListOfLists` is picked and the other is removed.
+
+## Examples
+
+```erlang
+> lists:umerge([[a,b], [a,d,e]]).
+[a,b,d,e]
+```
 """.
 -spec umerge(ListOfLists) -> List1 when
       ListOfLists :: [List],
@@ -1871,18 +2134,23 @@ lowest position in `ListOfLists` is picked and the other is deleted.
 umerge(L) ->
     umergel(L).
 
-%% umerge3(X, Y, Z) -> L
-%%  merges three sorted lists X, Y and Z without duplicates, 
-%%  removes duplicates
-
 -doc """
-Returns the sorted list formed by merging `List1`, `List2`, and `List3`. All of
-`List1`, `List2`, and `List3` must be sorted and contain no duplicates before
-evaluating this function.
+Returns the sorted list formed by merging `List1`, `List2`, and `List3`,
+while removing duplicates.
+
+All of `List1`, `List2`, and `List3` must be sorted and contain no
+duplicates before evaluating this function.
 
 When two elements compare equal, the element from
 `List1` is picked if there is such an element, otherwise the element from
-`List2` is picked, and the other is deleted.
+`List2` is picked, and the other is removed.
+
+## Examples
+
+```erlang
+> lists:umerge3([a,b], [a,d,e], [b,f]).
+[a,b,d,e,f]
+```
 """.
 -spec umerge3(List1, List2, List3) -> List4 when
       List1 :: [X],
@@ -1934,16 +2202,22 @@ rumerge3([], [], [_|_]=L3) ->
 rumerge3([], [], []) ->
     [].
 
-%% umerge(X, Y) -> L
-%%  merges two sorted lists X and Y without duplicates, removes duplicates
-
 -doc """
-Returns the sorted list formed by merging `List1` and `List2`. Both `List1` and
-`List2` must be sorted and contain no duplicates before evaluating this
-function.
+Returns the sorted list formed by merging `List1` and `List2`,
+while removing duplicates.
+
+Both `List1` and `List2` must be sorted and contain no duplicates
+before evaluating this function.
 
 When two elements compare equal, the element from `List1` is picked
-and the one from `List2` is deleted.
+and the one from `List2` is removed.
+
+## Examples
+
+```erlang
+> lists:umerge([a,b], [a,d,e]).
+[a,b,d,e]
+```
 """.
 -spec umerge(List1, List2) -> List3 when
       List1 :: [X],
@@ -2000,13 +2274,20 @@ rumerge([], []) ->
 %%  N.B. Unless where the functions actually needs it only foreach/2/3,
 %%  which is meant to be used for its side effects, has a defined order
 %%  of evaluation.
-%%
-%%  There are also versions with an extra argument, ExtraArgs, which is a
-%%  list of extra arguments to each call.
 
 -doc """
-Returns `true` if `Pred(Elem)` returns `true` for all elements `Elem` in `List`,
-otherwise `false`. The `Pred` function must return a boolean.
+Returns `true` if `Pred(Elem)` returns `true` for all elements `Elem` in `List`;
+otherwise, returns `false`.
+
+## Examples
+
+```erlang
+> IsEven = fun(N) -> N rem 2 =:= 0 end.
+> lists:all(IsEven, [2,4,5]).
+false
+> lists:all(IsEven, [2,4,6]).
+true
+```
 """.
 -spec all(Pred, List) -> boolean() when
       Pred :: fun((Elem :: T) -> boolean()),
@@ -2033,7 +2314,17 @@ all_1(_Pred, []) ->
 
 -doc """
 Returns `true` if `Pred(Elem)` returns `true` for at least one element `Elem` in
-`List`. The `Pred` function must return a boolean.
+`List`; otherwise, returns `false`.
+
+## Examples
+
+```erlang
+> IsEven = fun(N) -> N rem 2 =:= 0 end.
+> lists:any(IsEven, [3,5,7]).
+false
+> lists:any(IsEven, [2,3,5,7]).
+true
+```
 """.
 -spec any(Pred, List) -> boolean() when
       Pred :: fun((Elem :: T) -> boolean()),
@@ -2059,10 +2350,15 @@ any_1(_Pred, []) ->
     false.
 
 -doc """
-Takes a function from `A`s to `B`s, and a list of `A`s and produces a list of
-`B`s by applying the function to every element in the list. This function is
-used to obtain the return values. The evaluation order depends on the
-implementation.
+Takes a function from `A`s to `B`s and a list of `A`s, producing a list of
+`B`s by applying the function to each element in the list.
+
+## Examples
+
+```erlang
+> lists:map(fun(N) -> N + 1 end, [1,2,3]).
+[2,3,4]
+```
 """.
 -spec map(Fun, List1) -> List2 when
       Fun :: fun((A) -> B),
@@ -2083,22 +2379,27 @@ map_1(_F, []) ->
     [].
 
 -doc """
-Takes a function from `A`s to lists of `B`s, and a list of `A`s (`List1`) and
-produces a list of `B`s by applying the function to every element in `List1` and
+Takes a function from `A`s to lists of `B`s, and a list of `A`s (`List1`),
+producing a list of `B`s by applying the function to each element in `List1` and
 appending the resulting lists.
 
-That is, `flatmap` behaves as if it had been defined as follows:
+That is, `flatmap` behaves as if it were defined as follows:
 
 ```erlang
 flatmap(Fun, List1) ->
-    append(map(Fun, List1)).
+    lists:append(lists:map(Fun, List1)).
 ```
 
-_Example:_
+## Examples
 
 ```erlang
-> lists:flatmap(fun(X)->[X,X] end, [a,b,c]).
+> lists:flatmap(fun(X)-> [X,X] end, [a,b,c]).
 [a,a,b,b,c,c]
+> F = fun(N) when is_integer(N) -> [10 * N];
+         (_) -> []
+      end, ok.
+> lists:flatmap(F, [1,2,a,b,c,3]).
+[10,20,30]
 ```
 """.
 -spec flatmap(Fun, List1) -> List2 when
@@ -2123,11 +2424,13 @@ flatmap_1(_F, []) ->
 
 -doc """
 Calls `Fun(Elem, AccIn)` on successive elements `A` of `List`, starting with
-`AccIn == Acc0`. `Fun/2` must return a new accumulator, which is passed to the
-next call. The function returns the final value of the accumulator. `Acc0` is
-returned if the list is empty.
+`AccIn` bound to `Acc0`.
 
-_Example:_
+`Fun/2` must return a new accumulator, which is passed to the next
+call. The function returns the final value of the accumulator. `Acc0`
+is returned if the list is empty.
+
+## Examples
 
 ```erlang
 > lists:foldl(fun(X, Sum) -> X + Sum end, 0, [1,2,3,4,5]).
@@ -2159,7 +2462,7 @@ foldl_1(_F, Accu, []) ->
 -doc """
 Like `foldl/3`, but the list is traversed from right to left.
 
-_Example:_
+## Examples
 
 ```erlang
 > P = fun(A, AccIn) -> [A|AccIn] end.
@@ -2169,7 +2472,7 @@ _Example:_
 [1,2,3]
 ```
 
-[`foldl/3`](`foldl/3`) is tail recursive and is usually preferred to
+[`foldl/3`](`foldl/3`) is tail-recursive and is usually preferred to
 [`foldr/3`](`foldr/3`).
 """.
 -spec foldr(Fun, Acc0, List) -> Acc1 when
@@ -2190,8 +2493,17 @@ foldr_1(_F, Accu, []) ->
     Accu.
 
 -doc """
-`List2` is a list of all elements `Elem` in `List1` for which `Pred(Elem)`
-returns `true`. The `Pred` function must return a boolean.
+Returns a list of elements `Elem` in `List1` for which `Pred(Elem)`
+returns `true`.
+
+## Examples
+
+```erlang
+> IsEven = fun(N) -> N rem 2 =:= 0 end.
+> lists:filter(IsEven, [1,2,3,4,5]).
+[2,4]
+```
+
 """.
 -spec filter(Pred, List1) -> List2 when
       Pred :: fun((Elem :: T) -> boolean()),
@@ -2202,18 +2514,15 @@ returns `true`. The `Pred` function must return a boolean.
 filter(Pred, List) when is_function(Pred, 1) ->
     [ E || E <- List, Pred(E) ].
 
-%% Equivalent to {filter(F, L), filter(NotF, L)}, if NotF = 'fun(X) ->
-%% not F(X) end'.
-
 -doc """
-Partitions `List` into two lists, where the first list contains all elements for
-which `Pred(Elem)` returns `true`, and the second list contains all elements for
-which `Pred(Elem)` returns `false`.
+Partitions `List` into two lists: the first containing elements for
+which `Pred(Elem)` returns `true`, and the second containing elements
+for which `Pred(Elem)` returns `false`.
 
-_Examples:_
+## Examples
 
 ```erlang
-> lists:partition(fun(A) -> A rem 2 == 1 end, [1,2,3,4,5,6,7]).
+> lists:partition(fun(A) -> A rem 2 =:= 1 end, [1,2,3,4,5,6,7]).
 {[1,3,5,7],[2,4,6]}
 > lists:partition(fun(A) -> is_atom(A) end, [a,b,1,c,d,2,3,4,e]).
 {[a,b,c,d,e],[1,2,3,4]}
@@ -2240,30 +2549,35 @@ partition_1(_Pred, [], As, Bs) ->
     {reverse(As), reverse(Bs)}.
 
 -doc """
-Calls `Fun(Elem)` on successive elements `Elem` of `List1` in order to update or
+Calls `Fun(Elem)` on successive elements `Elem` of `List1` to update or
 remove elements from `List1`.
 
-`Fun/1` must return either a Boolean or a tuple `{true, Value}`. The function
-returns the list of elements for which `Fun` returns a new value, where a value
-of `true` is synonymous with `{true, Elem}`.
+`Fun/1` must return either a Boolean or a tuple `{true, Value}`. The
+function returns the list of elements for which `Fun` returns a new
+value, with `true` being equivalent to `{true, Elem}`.
 
-That is, `filtermap` behaves as if it had been defined as follows:
+That is, `filtermap` behaves as if it were defined as follows:
 
 ```erlang
 filtermap(Fun, List1) ->
-    lists:foldr(fun(Elem, Acc) ->
-                       case Fun(Elem) of
-                           false -> Acc;
-                           true -> [Elem|Acc];
-                           {true,Value} -> [Value|Acc]
-                       end
-                end, [], List1).
+    lists:flatmap(fun(Elem) ->
+                          case Fun(Elem) of
+                              false -> [];
+                              true -> [Elem];
+                              {true,Value} -> [Value]
+                          end
+                  end, List1).
 ```
 
-_Example:_
+## Examples
 
 ```erlang
-> lists:filtermap(fun(X) -> case X rem 2 of 0 -> {true, X div 2}; _ -> false end end, [1,2,3,4,5]).
+> lists:filtermap(fun(X) ->
+                          case X rem 2 of
+                              0 -> {true, X div 2};
+                              1 -> false
+                          end
+                  end, [1,2,3,4,5]).
 [1,2]
 ```
 """.
@@ -2297,9 +2611,10 @@ zf(F, L) ->
     filtermap(F, L).
 
 -doc """
-Calls `Fun(Elem)` for each element `Elem` in `List`. This function is used for
-its side effects and the evaluation order is defined to be the same as the order
-of the elements in the list.
+Calls `Fun(Elem)` for each element `Elem` in `List`, ignoring the return value.
+
+This function is used for its side effects and the evaluation order is
+defined to be the same as the order of the elements in the list.
 """.
 -spec foreach(Fun, List) -> ok when
       Fun :: fun((Elem :: T) -> term()),
@@ -2318,13 +2633,12 @@ foreach_1(_F, []) ->
 -doc """
 Combines the operations of `map/2` and `foldl/3` into one pass.
 
-_Example:_
+## Examples
 
 Summing the elements in a list and double them at the same time:
 
 ```erlang
-> lists:mapfoldl(fun(X, Sum) -> {2*X, X+Sum} end,
-  0, [1,2,3,4,5]).
+> lists:mapfoldl(fun(X, Sum) -> {2*X, X+Sum} end, 0, [1,2,3,4,5]).
 {[2,4,6,8,10],15}
 ```
 """.
@@ -2349,7 +2663,24 @@ mapfoldl_1(F, Accu0, [Hd | Tail]) ->
 mapfoldl_1(_F, Accu, []) ->
     {[], Accu}.
 
--doc "Combines the operations of `map/2` and `foldr/3` into one pass.".
+-doc """
+Combines the operations of `map/2` and `foldr/3` into one pass.
+
+> #### Note {: .info }
+>
+> Unless the order in which the elements are accumulated is important,
+> prefer [`mapfoldl/3`](`mapfoldl/3`) as it is slighly more efficient.
+
+## Examples
+
+Doubling the elements in list and producing a list of squares at the
+same time:
+
+```erlang
+> lists:mapfoldr(fun(X, Acc) -> {2*X, [X*X|Acc]} end, [], [1,2,3,4,5]).
+{[2,4,6,8,10],[1,4,9,16,25]}
+```
+""".
 -spec mapfoldr(Fun, Acc0, List1) -> {List2, Acc1} when
       Fun :: fun((A, AccIn) -> {B, AccOut}),
       Acc0 :: term(),
@@ -2372,9 +2703,17 @@ mapfoldr_1(_F, Accu, []) ->
     {[], Accu}.
 
 -doc """
-Takes elements `Elem` from `List1` while `Pred(Elem)` returns `true`, that is,
-the function returns the longest prefix of the list for which all elements
-satisfy the predicate. The `Pred` function must return a boolean.
+Takes elements `Elem` from `List1` while `Pred(Elem)` returns `true`,
+returning the longest prefix in which all elements satisfy the predicate.
+
+## Examples
+
+```erlang
+> lists:takewhile(fun is_atom/1, [a,b,c,1,2,3,x,y,z]).
+[a,b,c]
+> lists:takewhile(fun is_integer/1, [a,b,c,1,2,3,x,y,z]).
+[]
+```
 """.
 -spec takewhile(Pred, List1) -> List2 when
       Pred :: fun((Elem :: T) -> boolean()),
@@ -2394,8 +2733,17 @@ takewhile_1(_Pred, []) ->
     [].
 
 -doc """
-Drops elements `Elem` from `List1` while `Pred(Elem)` returns `true` and returns
-the remaining list. The `Pred` function must return a boolean.
+Drops elements `Elem` from `List1` while `Pred(Elem)` returns `true`,
+and then returns the remaining list.
+
+## Examples
+
+```erlang
+> lists:dropwhile(fun is_atom/1, [a,b,c,1,2,3,x,y,z]).
+[1,2,3,x,y,z]
+> lists:dropwhile(fun is_integer/1, [a,b,c,1,2,3,x,y,z]).
+[a,b,c,1,2,3,x,y,z]
+```
 """.
 -spec dropwhile(Pred, List1) -> List2 when
       Pred :: fun((Elem :: T) -> boolean()),
@@ -2416,8 +2764,17 @@ dropwhile_1(_Pred, []) ->
 
 -doc """
 If there is a `Value` in `List` such that `Pred(Value)` returns `true`, returns
-`{value, Value}` for the first such `Value`, otherwise returns `false`. The
-`Pred` function must return a boolean.
+`{value, Value}` for the first such `Value`; otherwise, returns `false`.
+
+## Examples
+
+```erlang
+> lists:search(fun is_atom/1, [1,2,3,a,b,c]).
+{value,a}
+> lists:search(fun(#{a := V}) -> V =:= 42 end,
+    [#{a => 1}, #{a => 42}, #{a => 100}]).
+{value,#{a => 42}}
+```
 """.
 -doc(#{since => <<"OTP 21.0">>}).
 -spec search(Pred, List) -> {value, Value} | false when
@@ -2438,24 +2795,24 @@ search_1(_Pred, []) ->
 
 -doc """
 Partitions `List` into two lists according to `Pred`.
-[`splitwith/2`](`splitwith/2`) behaves as if it is defined as follows:
+
+[`splitwith/2`](`splitwith/2`) behaves as if it were defined as follows:
 
 ```erlang
 splitwith(Pred, List) ->
     {takewhile(Pred, List), dropwhile(Pred, List)}.
 ```
 
-_Examples:_
+## Examples
 
 ```erlang
-> lists:splitwith(fun(A) -> A rem 2 == 1 end, [1,2,3,4,5,6,7]).
+> lists:splitwith(fun(A) -> A rem 2 =:= 1 end, [1,2,3,4,5,6,7]).
 {[1],[2,3,4,5,6,7]}
 > lists:splitwith(fun(A) -> is_atom(A) end, [a,b,1,c,d,2,3,4,e]).
 {[a,b],[1,c,d,2,3,4,e]}
 ```
 
-The `Pred` function must return a boolean. For a different way to partition a
-list, see `partition/2`.
+For a different way to partition a list, see `partition/2`.
 """.
 -spec splitwith(Pred, List) -> {List1, List2} when
       Pred :: fun((T) -> boolean()),
@@ -2476,8 +2833,15 @@ splitwith_1(_Pred, [], Taken) ->
     {reverse(Taken),[]}.
 
 -doc """
-Splits `List1` into `List2` and `List3`. `List2` contains the first `N` elements
-and `List3` the remaining elements (the `N`th tail).
+Splits `List1` into `List2`, containing the first `N` elements, and
+`List3`, containing the rest.
+
+## Examples
+
+```erlang
+> lists:split(3, [1,2,3,4,5,6,7]).
+{[1,2,3],[4,5,6,7]}
+```
 """.
 -spec split(N, List1) -> {List2, List3} when
       N :: non_neg_integer(),
@@ -2490,10 +2854,10 @@ split(N, List) when is_integer(N), N >= 0, is_list(List) ->
     case split(N, List, []) of
 	{_, _} = Result -> Result;
 	Fault when is_atom(Fault) ->
-	    erlang:error(Fault, [N,List])
+	    error(Fault, [N,List])
     end;
 split(N, List) ->
-    erlang:error(badarg, [N,List]).
+    error(badarg, [N,List]).
 
 split(0, L, R) ->
     {lists:reverse(R, []), L};
@@ -2503,8 +2867,11 @@ split(_, [], _) ->
     badarg.
 
 -doc """
-Inserts `Sep` between each element in `List1`. Has no effect on the empty list
-and on a singleton list. For example:
+Inserts `Sep` between each element in `List1`.
+
+Has no effect on an empty list or a singleton list.
+
+## Examples
 
 ```erlang
 > lists:join(x, [a,b,c]).
@@ -2527,6 +2894,75 @@ join(Sep, [H|T]) -> [H|join_prepend(Sep, T)].
 
 join_prepend(_Sep, []) -> [];
 join_prepend(Sep, [H|T]) -> [Sep,H|join_prepend(Sep,T)].
+
+
+-doc """
+Returns a list containing the elements of `List1` with duplicated elements
+removed (preserving the order of the elements).
+
+The first occurrence of each element is kept.
+
+## Examples
+
+```erlang
+> lists:uniq([3, 3, 1, 2, 1, 2, 3]).
+[3,1,2]
+> lists:uniq([a, a, 1, b, 2, a, 3]).
+[a, 1, b, 2, 3]
+```
+""".
+-doc(#{since => <<"OTP 25.0">>}).
+-spec uniq(List1) -> List2 when
+      List1 :: [T],
+      List2 :: [T],
+      T :: term().
+
+uniq(L) ->
+    uniq_1(L, #{}).
+
+uniq_1([X | Xs], M) ->
+    case is_map_key(X, M) of
+        true ->
+            uniq_1(Xs, M);
+        false ->
+            [X | uniq_1(Xs, M#{X => true})]
+    end;
+uniq_1([], _) ->
+    [].
+
+-doc """
+Returns a list containing the elements of `List1` without the elements for which
+`Fun` returned duplicate values (preserving the order of the elements).
+
+The first occurrence of each element is kept.
+
+## Examples
+
+```erlang
+> lists:uniq(fun({X, _}) -> X end, [{b, 2}, {a, 1}, {c, 3}, {a, 2}]).
+[{b, 2}, {a, 1}, {c, 3}]
+```
+""".
+-doc(#{since => <<"OTP 25.0">>}).
+-spec uniq(Fun, List1) -> List2 when
+      Fun :: fun((T) -> any()),
+      List1 :: [T],
+      List2 :: [T],
+      T :: term().
+
+uniq(F, L) when is_function(F, 1) ->
+    uniq_2(L, F, #{}).
+
+uniq_2([X | Xs], F, M) ->
+    Key = F(X),
+    case is_map_key(Key, M) of
+        true ->
+            uniq_2(Xs, F, M);
+        false ->
+            [X | uniq_2(Xs, F, M#{Key => true})]
+    end;
+uniq_2([], _, _) ->
+    [].
 
 %%% =================================================================
 %%% Here follows the implementation of the sort functions.
@@ -3914,72 +4350,7 @@ rufmerge2_2(H1, T1, Fun, [], M, H2M) ->
             lists:reverse(T1, [H1, H2M | M])
     end.
 
-%% uniq/1: return a new list with the unique elements of the given list
-
--doc """
-Returns a list containing the elements of `List1` with duplicated elements
-removed (preserving the order of the elements). The first occurrence of each
-element is kept.
-
-_Examples:_
-
-```erlang
-> lists:uniq([3,3,1,2,1,2,3]).
-[3,1,2]
-> lists:uniq([a, a, 1, b, 2, a, 3]).
-[a, 1, b, 2, 3]
-```
-""".
--doc(#{since => <<"OTP 25.0">>}).
--spec uniq(List1) -> List2 when
-      List1 :: [T],
-      List2 :: [T],
-      T :: term().
-
-uniq(L) ->
-    uniq_1(L, #{}).
-
-uniq_1([X | Xs], M) ->
-    case is_map_key(X, M) of
-        true ->
-            uniq_1(Xs, M);
-        false ->
-            [X | uniq_1(Xs, M#{X => true})]
-    end;
-uniq_1([], _) ->
-    [].
-
-%% uniq/2: return a new list with the unique elements of the given list using a function key
-
--doc """
-Returns a list containing the elements of `List1` without the elements for which
-`Fun` returned duplicate values (preserving the order of the elements). The
-first occurrence of each element is kept.
-
-_Examples:_
-
-```erlang
-> lists:uniq(fun({X, _}) -> X end, [{b, 2}, {a, 1}, {c, 3}, {a, 2}]).
-[{b, 2}, {a, 1}, {c, 3}]
-```
-""".
--doc(#{since => <<"OTP 25.0">>}).
--spec uniq(Fun, List1) -> List2 when
-      Fun :: fun((T) -> any()),
-      List1 :: [T],
-      List2 :: [T],
-      T :: term().
-
-uniq(F, L) when is_function(F, 1) ->
-    uniq_2(L, F, #{}).
-
-uniq_2([X | Xs], F, M) ->
-    Key = F(X),
-    case is_map_key(Key, M) of
-        true ->
-            uniq_2(Xs, F, M);
-        false ->
-            [X | uniq_2(Xs, F, M#{Key => true})]
-    end;
-uniq_2([], _, _) ->
-    [].
+%%%
+%%% Don't place new functions here; place them before the
+%%% implementation of sort functions.
+%%%


### PR DESCRIPTION
Ensure that the first paragraph describing each function makes sense by itself when shown in the Summary part of the documentation.

Add examples to functions lacking examples.

While at it, also remove comments for documented functions, and remove out-commented code, and do some other minor clean ups.