### PR TITLE
Use conventional FILE:LINE format for locations in stacktraces

### DIFF
--- a/lib/stdlib/src/erl_error.erl
+++ b/lib/stdlib/src/erl_error.erl
@@ -526,7 +526,7 @@ location(L) ->
     Line = proplists:get_value(line, L),
     if
 	File =/= undefined, Line =/= undefined ->
-	    io_lib:format("(~ts, line ~w)", [File, Line]);
+	    io_lib:format("(~ts:~w)", [File, Line]);
 	true ->
 	    ""
     end.

--- a/lib/stdlib/test/shell_SUITE.erl
+++ b/lib/stdlib/test/shell_SUITE.erl
@@ -2617,7 +2617,7 @@ otp_6554(Config) when is_list(Config) ->
         "lists:reverse(" ++ _ =
         comm_err(<<"F=fun() -> hello end, lists:reverse(F).">>),
     "exception error: no function clause matching "
-        "lists:reverse(34) (lists.erl, line " ++ _ =
+        "lists:reverse(34) (lists.erl:" ++ _ =
         comm_err(<<"lists:reverse(34).">>),
     "exception error: function_clause" =
         comm_err(<<"erlang:error(function_clause, 4).">>),


### PR DESCRIPTION
Today, when printing an Erlang stacktrace, we return location information in a custom `(PATH, line LINE)` format. E.g.:

```
** exception error: bad argument
     in function  lists:member/2
        called as lists:member(1,not_a_list)
        *** argument 2: not a list
     in call from test:main/0 (test.erl, line 8)
```

A more common notation would be `/path/to/filename:line_number`, which is used in many programming tools and languages to specify a location in a file. This would also be in line with what the Erlang compiler returns:

```
erlc test.erl
test.erl:8:16: syntax error before:
%    8|   lists:member(1
%     |                ^
```

While the `PATH:NUMBER` does not seem to be an official standard, it's a widely adopted and understood convention across various development communities.

Switching to the new format would simplify a number of tasks. For example, terminals such as `iTerm` would recognize this as a link and would allow developers to jump to the correct line number from terminal with a single click.

This change will most likely break some tests, but before fixing them I'm opening the PR to check how open would you be to the change.