### PR TITLE
Improve json decode error messages

### DIFF
--- a/lib/stdlib/src/json.erl
+++ b/lib/stdlib/src/json.erl
@@ -541,7 +541,8 @@ invalid_byte(Bin, Skip) ->
     error({invalid_byte, Byte}, none, error_info(Skip)).
 
 error_info(Skip) ->
-    [{error_info, #{cause => #{position => Skip}}}].
+    [{error_info, #{cause => #{position => Skip},
+                    module => erl_stdlib_errors}}].
 
 %%
 %% Format implementation

--- a/lib/stdlib/test/json_SUITE.erl
+++ b/lib/stdlib/test/json_SUITE.erl
@@ -56,7 +56,8 @@
     property_integer_roundtrip/1,
     property_float_roundtrip/1,
     property_object_roundtrip/1,
-    property_escape_all/1
+    property_escape_all/1,
+    error_info/1
 ]).
 
 
@@ -75,7 +76,8 @@ all() ->
         {group, format},
         test_json_test_suite,
         {group, properties},
-        counterexamples
+        counterexamples,
+        error_info
     ].
 
 groups() ->
@@ -1041,6 +1043,11 @@ test_file(yes, File, Data) ->
     ?assertEqual(Parsed, decode(iolist_to_binary(json:format(Parsed))), File);
 test_file(no, File, Data) ->
     ?assertError(_, decode(Data), File).
+
+error_info(_) ->
+    L = [{decode, [~'["valid string", not_valid'], [allow_rename, unexplained]}],
+    error_info_lib:test_error_info(json, L,  [allow_nyi]).
+
 
 %%
 %% Property tests


### PR DESCRIPTION
When printing errors include the position that the error occured at if included in the error.