### PR TITLE
Fix updated runtime deps

### DIFF
--- a/lib/xmerl/src/xmerl.app.src
+++ b/lib/xmerl/src/xmerl.app.src
@@ -40,5 +40,5 @@
   {registered, []},
   {env, []},
   {applications, [kernel, stdlib]},
-  {runtime_dependencies, ["stdlib-2.5","kernel-3.0","erts-6.0"]}
+  {runtime_dependencies, ["stdlib-2.5","kernel-8.4","erts-6.0"]}
   ]}.


### PR DESCRIPTION
Was missing in the previous xmerl fix #9463