### PR TITLE
Return the right type from ets:update_element/4 spec

### DIFF
--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -1796,7 +1796,7 @@ The function fails with reason `badarg` in the following situations:
 - The element to update is also the key.
 """.
 -doc(#{since => <<"OTP 27.0">>}).
--spec update_element(Table, Key, ElementSpec, Default) -> true when
+-spec update_element(Table, Key, ElementSpec, Default) -> boolean() when
       Table :: table(),
       Key :: term(),
       ElementSpec :: {Pos, Value} | [{Pos, Value}],


### PR DESCRIPTION
Note that the documentation already says that this function can return both boolean values, and it was the spec what was incomplete.