### PR TITLE
Fix documented return value

### DIFF
--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -1482,9 +1482,11 @@ static int escape_and_quote(wchar_t *str, wchar_t *new, BOOL *quoted) {
  *	executable name.
  *
  * Results:
- *	The return value is FALSE if there was a problem creating the child process.  
- *      Otherwise, the return value is 0 and *phPid is
- *	filled with the process id of the child process.
+ *	The return value is FALSE if there was a problem creating the child process.
+ *
+ *      When successful, the return value is nonzero, *phPid is filled with the
+ *      process handle of the child process, and *pdwID is filled with its
+ *      process ID.
  * 
  * Side effects:
  *	A process is created.
@@ -1503,12 +1505,12 @@ create_child_process
  HANDLE hStdout, /* The standard output handle for child. */ 
  HANDLE hStderr, /* The standard error handle for child. */
  LPHANDLE phPid, /* Pointer to variable to received Process handle. */
- LPDWORD pdwID,   /* Pointer to variable to received Process ID */
+ LPDWORD pdwID,  /* Pointer to variable to received Process ID */
  BOOL hide,      /* Hide the window unconditionally. */
  LPVOID env,     /* Environment for the child */
- wchar_t *wd,      /* Working dir for the child */
+ wchar_t *wd,    /* Working dir for the child */
  unsigned st,    /* Flags for spawn, tells us how to interpret origcmd */
- wchar_t **argv,     /* Argument vector if given. */
+ wchar_t **argv, /* Argument vector if given. */
  int *errno_return /* Place to put an errno in case of failure */
  )
 {


### PR DESCRIPTION
On success, this function will return the result of CreateProcessW which upstream docs say will be "nonzero":
https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw#return-value