### PR TITLE
bmk/erts/20250226/inet_buffer_size

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -1242,6 +1242,15 @@
 /* define if h_errno is declared (in some way) in a system header file */
 #undef H_ERRNO_DECLARED
 
+/* Default size of the buffer for an SCTP socket (in bytes) */
+#undef INET_BUFFER_SCTP_DEFAULT
+
+/* Default size of the buffer for an TCP socket (in bytes) */
+#undef INET_BUFFER_TCP_DEFAULT
+
+/* Default size of the buffer for an UDP socket (in bytes) */
+#undef INET_BUFFER_UDP_DEFAULT
+
 /* Define to monotonic clock id to use */
 #undef MONOTONIC_CLOCK_ID
 

--- a/erts/configure
+++ b/erts/configure
@@ -851,6 +851,9 @@ with_with_sparc_memory_order
 enable_ppc_lwsync_instruction
 with_threadnames
 enable_builtin_zlib
+with_inet_buffer_tcp_default
+with_inet_buffer_udp_default
+with_inet_buffer_sctp_default
 enable_esock
 enable_esock_use_rcvsndtimeo
 enable_esock_extended_error_info
@@ -1665,6 +1668,15 @@ Optional Packages:
   --with-threadnames      use pthread_setname to set the thread names
                           (default)
   --without-threadnames   do not set any thread names
+  --with-inet-buffer-tcp-default=SZ
+                          Default size of the internal buffer (for a tcp
+                          socket) in bytes (default value is 8192)
+  --with-inet-buffer-udp-default=SZ
+                          Default size of the internal buffer (for a udp
+                          socket) in bytes (default value is 8192)
+  --with-inet-buffer-sctp-default=SZ
+                          Default size of the internal buffer (for a sctp
+                          socket) in bytes (default value is 8192)
   --with-esock-counter-size=SZ
                           Size of the esock counters, in number of bits: 16 |
                           24 | 32 | 48 | 64; default is 64
@@ -16451,6 +16463,199 @@ esac
 fi
 
 
+
+
+
+
+
+# Check whether --with-inet-buffer-tcp-default was given.
+if test ${with_inet_buffer_tcp_default+y}
+then :
+  withval=$with_inet_buffer_tcp_default;
+else case e in #(
+  e) with_inet_buffer_tcp_default=8192 ;;
+esac
+fi
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking Validate (tcp) buffer size" >&5
+printf %s "checking Validate (tcp) buffer size... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int main(void)
+{
+   unsigned int sz = $with_inet_buffer_tcp_default;
+   return (int) sz;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  inet_tcp_buf_sz=yes
+else case e in #(
+  e) inet_tcp_buf_sz=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+if test "$inet_tcp_buf_sz" = yes
+then :
+
+       case $with_inet_buffer_tcp_default in #(
+  1*|2*|3*|4*|5*|6*|7*|8*|9*) :
+
+
+printf "%s\n" "#define INET_BUFFER_TCP_DEFAULT $with_inet_buffer_tcp_default" >>confdefs.h
+
+                ;; #(
+  *) :
+
+                                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --with-inet-buffer-tcp-default - Invalid buffer size - using default" >&5
+printf "%s\n" "$as_me: WARNING: --with-inet-buffer-tcp-default - Invalid buffer size - using default" >&2;}
+
+printf "%s\n" "#define INET_BUFFER_TCP_DEFAULT 8192" >>confdefs.h
+
+                ;;
+esac
+
+else case e in #(
+  e)
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --with-inet-buffer-tcp-default - Invalid buffer size - using default" >&5
+printf "%s\n" "$as_me: WARNING: --with-inet-buffer-tcp-default - Invalid buffer size - using default" >&2;}
+
+printf "%s\n" "#define INET_BUFFER_TCP_DEFAULT 8192" >>confdefs.h
+
+       ;;
+esac
+fi
+
+
+
+
+# Check whether --with-inet-buffer-udp-default was given.
+if test ${with_inet_buffer_udp_default+y}
+then :
+  withval=$with_inet_buffer_udp_default;
+else case e in #(
+  e) with_inet_buffer_udp_default=8192 ;;
+esac
+fi
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking Validate (udp) buffer size" >&5
+printf %s "checking Validate (udp) buffer size... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int main(void)
+{
+   unsigned int sz = $with_inet_buffer_udp_default;
+   return (int) sz;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  inet_udp_buf_sz=yes
+else case e in #(
+  e) inet_udp_buf_sz=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+if test "$inet_udp_buf_sz" = yes
+then :
+
+       case $with_inet_buffer_udp_default in #(
+  1*|2*|3*|4*|5*|6*|7*|8*|9*) :
+
+
+printf "%s\n" "#define INET_BUFFER_UDP_DEFAULT $with_inet_buffer_udp_default" >>confdefs.h
+
+                ;; #(
+  *) :
+
+                                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --with-inet-buffer-udp-default - Invalid buffer size - using default" >&5
+printf "%s\n" "$as_me: WARNING: --with-inet-buffer-udp-default - Invalid buffer size - using default" >&2;}
+
+printf "%s\n" "#define INET_BUFFER_UDP_DEFAULT 8192" >>confdefs.h
+
+                ;;
+esac
+
+else case e in #(
+  e)
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --with-inet-buffer-udp-default - Invalid buffer size - using default" >&5
+printf "%s\n" "$as_me: WARNING: --with-inet-buffer-udp-default - Invalid buffer size - using default" >&2;}
+
+printf "%s\n" "#define INET_BUFFER_UDP_DEFAULT 8192" >>confdefs.h
+
+       ;;
+esac
+fi
+
+
+
+
+# Check whether --with-inet-buffer-sctp-default was given.
+if test ${with_inet_buffer_sctp_default+y}
+then :
+  withval=$with_inet_buffer_sctp_default;
+else case e in #(
+  e) with_inet_buffer_sctp_default=8192 ;;
+esac
+fi
+
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking Validate (sctp) buffer size" >&5
+printf %s "checking Validate (sctp) buffer size... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int main(void)
+{
+   unsigned int sz = $with_inet_buffer_sctp_default;
+   return (int) sz;
+}
+
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  inet_sctp_buf_sz=yes
+else case e in #(
+  e) inet_sctp_buf_sz=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+if test "$inet_sctp_buf_sz" = yes
+then :
+
+       case $with_inet_buffer_sctp_default in #(
+  1*|2*|3*|4*|5*|6*|7*|8*|9*) :
+
+
+printf "%s\n" "#define INET_BUFFER_SCTP_DEFAULT $with_inet_buffer_sctp_default" >>confdefs.h
+
+                ;; #(
+  *) :
+
+                                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --with-inet-buffer-sctp-default - Invalid buffer size - using default" >&5
+printf "%s\n" "$as_me: WARNING: --with-inet-buffer-sctp-default - Invalid buffer size - using default" >&2;}
+
+printf "%s\n" "#define INET_BUFFER_SCTP_DEFAULT 8192" >>confdefs.h
+
+                ;;
+esac
+
+else case e in #(
+  e)
+                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --with-inet-buffer-sctp-default - Invalid buffer size - using default" >&5
+printf "%s\n" "$as_me: WARNING: --with-inet-buffer-sctp-default - Invalid buffer size - using default" >&2;}
+
+printf "%s\n" "#define INET_BUFFER_SCTP_DEFAULT 8192" >>confdefs.h
+
+       ;;
+esac
+fi
 
 
 

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -1303,6 +1303,145 @@ AC_SUBST(Z_LIB)
 
 
 dnl -------------
+dnl inet (driver)
+dnl -------------
+
+dnl *** INET_BUFFER_TCP_DEFAULT
+
+AC_ARG_WITH(inet-buffer-tcp-default, 
+AS_HELP_STRING([--with-inet-buffer-tcp-default=SZ], 
+               [Default size of the internal buffer (for a tcp socket) in bytes (default value is 8192)]), 
+[], 
+[with_inet_buffer_tcp_default=8192])
+
+AC_MSG_CHECKING([Validate (tcp) buffer size])
+dnl This takes care of the case when its not even a number ("foobar")
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+int main(void)
+{
+   unsigned int sz = $with_inet_buffer_tcp_default;
+   return (int) sz;
+}
+]])],[inet_tcp_buf_sz=yes],[inet_tcp_buf_sz=no])
+dnl This takes care of the case when its an "invalid" number (-10)
+AS_IF([test "$inet_tcp_buf_sz" = yes],
+      [
+       AS_CASE([$with_inet_buffer_tcp_default],
+               [1*|2*|3*|4*|5*|6*|7*|8*|9*],
+               [
+                AC_DEFINE_UNQUOTED(INET_BUFFER_TCP_DEFAULT,
+                                   $with_inet_buffer_tcp_default,
+                                   [Default size of the buffer for an TCP socket (in bytes)])
+               ],
+               [
+                dnl Its a number but not a "valid" one... 01000?
+                dnl Shall we fail instead?
+                AC_MSG_WARN([--with-inet-buffer-tcp-default - Invalid buffer size - using default])
+                AC_DEFINE_UNQUOTED(INET_BUFFER_TCP_DEFAULT,
+                                   8192,
+                                   [Default size of the buffer for an TCP socket (in bytes)])
+               ])
+      ],
+      [
+        dnl Shall we fail instead?
+        AC_MSG_WARN([--with-inet-buffer-tcp-default - Invalid buffer size - using default])
+        AC_DEFINE_UNQUOTED(INET_BUFFER_TCP_DEFAULT,
+                           8192,
+                           [Default size of the buffer for an TCP socket (in bytes)])
+      ])
+
+
+dnl *** INET_BUFFER_UDP_DEFAULT
+
+AC_ARG_WITH(inet-buffer-udp-default, 
+AS_HELP_STRING([--with-inet-buffer-udp-default=SZ], 
+               [Default size of the internal buffer (for a udp socket) in bytes (default value is 8192)]), 
+[], 
+[with_inet_buffer_udp_default=8192])
+
+AC_MSG_CHECKING([Validate (udp) buffer size])
+dnl This takes care of the case when its not even a number ("foobar")
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+int main(void)
+{
+   unsigned int sz = $with_inet_buffer_udp_default;
+   return (int) sz;
+}
+]])],[inet_udp_buf_sz=yes],[inet_udp_buf_sz=no])
+dnl This takes care of the case when its an "invalid" number (-10)
+AS_IF([test "$inet_udp_buf_sz" = yes],
+      [
+       AS_CASE([$with_inet_buffer_udp_default],
+               [1*|2*|3*|4*|5*|6*|7*|8*|9*],
+               [
+                AC_DEFINE_UNQUOTED(INET_BUFFER_UDP_DEFAULT,
+                                   $with_inet_buffer_udp_default,
+                                   [Default size of the buffer for an UDP socket (in bytes)])
+               ],
+               [
+                dnl Its a number but not a "valid" one... 01000?
+                dnl Shall we fail instead?
+                AC_MSG_WARN([--with-inet-buffer-udp-default - Invalid buffer size - using default])
+                AC_DEFINE_UNQUOTED(INET_BUFFER_UDP_DEFAULT,
+                                   8192,
+                                   [Default size of the buffer for an UDP socket (in bytes)])
+               ])
+      ],
+      [
+        dnl Shall we fail instead?
+        AC_MSG_WARN([--with-inet-buffer-udp-default - Invalid buffer size - using default])
+        AC_DEFINE_UNQUOTED(INET_BUFFER_UDP_DEFAULT,
+                           8192,
+                           [Default size of the buffer for an UDP socket (in bytes)])
+      ])
+
+
+dnl *** INET_BUFFER_SCTP_DEFAULT
+
+AC_ARG_WITH(inet-buffer-sctp-default, 
+AS_HELP_STRING([--with-inet-buffer-sctp-default=SZ], 
+               [Default size of the internal buffer (for a sctp socket) in bytes (default value is 8192)]), 
+[], 
+[with_inet_buffer_sctp_default=8192])
+
+AC_MSG_CHECKING([Validate (sctp) buffer size])
+dnl This takes care of the case when its not even a number ("foobar")
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+int main(void)
+{
+   unsigned int sz = $with_inet_buffer_sctp_default;
+   return (int) sz;
+}
+]])],[inet_sctp_buf_sz=yes],[inet_sctp_buf_sz=no])
+dnl This takes care of the case when its an "invalid" number (-10)
+AS_IF([test "$inet_sctp_buf_sz" = yes],
+      [
+       AS_CASE([$with_inet_buffer_sctp_default],
+               [1*|2*|3*|4*|5*|6*|7*|8*|9*],
+               [
+                AC_DEFINE_UNQUOTED(INET_BUFFER_SCTP_DEFAULT,
+                                   $with_inet_buffer_sctp_default,
+                                   [Default size of the buffer for an SCTP socket (in bytes)])
+               ],
+               [
+                dnl Its a number but not a "valid" one... 01000?
+                dnl Shall we fail instead?
+                AC_MSG_WARN([--with-inet-buffer-sctp-default - Invalid buffer size - using default])
+                AC_DEFINE_UNQUOTED(INET_BUFFER_SCTP_DEFAULT,
+                                   8192,
+                                   [Default size of the buffer for an SCTP socket (in bytes)])
+               ])
+      ],
+      [
+        dnl Shall we fail instead?
+        AC_MSG_WARN([--with-inet-buffer-sctp-default - Invalid buffer size - using default])
+        AC_DEFINE_UNQUOTED(INET_BUFFER_SCTP_DEFAULT,
+                           8192,
+                           [Default size of the buffer for an SCTP socket (in bytes)])
+      ])
+
+
+dnl -------------
 dnl esock
 dnl -------------
 

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -1,7 +1,7 @@
 /*
  * %CopyrightBegin%
  *
- * Copyright Ericsson AB 1997-2024. All Rights Reserved.
+ * Copyright Ericsson AB 1997-2025. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1032,8 +1032,17 @@ static size_t my_strnlen(const char *s, size_t maxlen)
 
 #define INET_MAX_OPT_BUFFER (64*1024)
 
-#define INET_DEF_BUFFER     1460        /* default buffer size */
-#define INET_MIN_BUFFER     1           /* internal min buffer */
+#if !defined(INET_BUFFER_TCP_DEFAULT)
+#define INET_BUFFER_TCP_DEFAULT  8192
+#endif
+#if !defined(INET_BUFFER_UDP_DEFAULT)
+#define INET_BUFFER_UDP_DEFAULT  8192
+#endif
+#if !defined(INET_BUFFER_SCTP_DEFAULT)
+#define INET_BUFFER_SCTP_DEFAULT 8192
+#endif
+#define INET_BUFFER_MIN          1
+#define INET_UDP_THEORETICAL_MAX_MTU (1 << 16)
 
 #define INET_HIGH_WATERMARK (1024*8) /* 8k pending high => busy  */
 #define INET_LOW_WATERMARK  (1024*4) /* 4k pending => allow more */
@@ -1877,7 +1886,11 @@ static void end_caller_ref(CallerRef *cref_p) {
 #else
 #   define IS_SCTP(desc) 0
 #endif
-#   define ANC_BUFF_SIZE   INET_DEF_BUFFER/2 /* XXX: not very good... */
+/*
+ * Can we "calculate" this dynamically?
+ * On linux: sysctl net.core.optmem_max
+ */
+#   define ANC_BUFF_SIZE        1024
 
 
 #ifdef HAVE_UDP
@@ -6904,7 +6917,7 @@ static int inet_set_opts(inet_descriptor* desc, char* ptr, int len)
                  ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
                   "inet_set_opts(buffer) -> %d\r\n",
                   __LINE__, desc->s, driver_caller(desc->port), ival) );
-	    if (ival < INET_MIN_BUFFER) ival = INET_MIN_BUFFER;
+	    if (ival < INET_BUFFER_MIN) ival = INET_BUFFER_MIN;
 	    desc->bufsz = ival;
             desc->flags |= INET_FLG_BUFFER_SET;
 	    continue;
@@ -7268,14 +7281,39 @@ static int inet_set_opts(inet_descriptor* desc, char* ptr, int len)
                   "inet_set_opts(rcvbuf) -> %d\r\n",
                   __LINE__, desc->s, driver_caller(desc->port), ival) );
             if (!(desc->flags & INET_FLG_BUFFER_SET)) {
-                /* make sure we have desc->bufsz >= SO_RCVBUF */
-                if (ival > (1 << 16) && desc->stype == SOCK_DGRAM && !IS_SCTP(desc))
+
+                /* BUFFER has not previously been explicitly set.
+                 * Make sure we have desc->bufsz >= SO_RCVBUF,
+                 * except if rcvbuf is larger than max when type = DGRAM.
+                 */
+
+                if ((ival > INET_UDP_THEORETICAL_MAX_MTU) &&
+                    (desc->stype == SOCK_DGRAM) &&
+                    !IS_SCTP(desc)) {
+
                     /* For UDP we don't want to automatically
-                       set the buffer size to be larger than
-                       the theoretical max MTU */
-                    desc->bufsz = 1 << 16;
-                else if (ival > desc->bufsz)
+                     * set the buffer size to be larger than
+                     * the theoretical max MTU. */
+
+                    DDBG(desc,
+                         ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+                          "inet_set_opts(rcvbuf) -> "
+                          "force update of 'buffer' to max-mtu (%d)\r\n",
+                          __LINE__, desc->s, driver_caller(desc->port),
+                          INET_UDP_THEORETICAL_MAX_MTU) );
+
+                    desc->bufsz = INET_UDP_THEORETICAL_MAX_MTU;
+
+                } else if (ival > desc->bufsz) {
+
+                    DDBG(desc,
+                         ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+                          "inet_set_opts(rcvbuf) -> "
+                          "force update of 'buffer'\r\n",
+                          __LINE__, desc->s, driver_caller(desc->port)) );
+
                     desc->bufsz = ival;
+                }
             }
 	    break;
 
@@ -7999,8 +8037,8 @@ static int sctp_set_opts(inet_descriptor* desc, char* ptr, int len)
 
                 desc->bufsz  = ival;
 
-                if (desc->bufsz < INET_MIN_BUFFER)
-                    desc->bufsz = INET_MIN_BUFFER;
+                if (desc->bufsz < INET_BUFFER_MIN)
+                    desc->bufsz = INET_BUFFER_MIN;
                 desc->flags |= INET_FLG_BUFFER_SET;
                 res = 0;   /* This does not affect the kernel buffer size */
             }
@@ -9024,6 +9062,10 @@ static ErlDrvSSizeT inet_fill_opts(inet_descriptor* desc,
 
 	switch(opt) {
 	case INET_LOPT_BUFFER:
+            DDBG(desc,
+                 ("INET-DRV-DBG[%d][" SOCKET_FSTR ",%T] "
+                  "inet_fill_opts -> buffer: %d\r\n",
+                  __LINE__, desc->s, driver_caller(desc->port), desc->bufsz) );
 	    *ptr++ = opt;
 	    put_int32(desc->bufsz, ptr);
 	    continue;
@@ -10749,7 +10791,18 @@ static ErlDrvData inet_start(ErlDrvPort port, int size, int protocol)
     desc->dport = driver_mk_port(port);
     desc->state = INET_STATE_CLOSED;
     desc->prebound = 0;
-    desc->bufsz = INET_DEF_BUFFER; 
+
+    if (protocol == IPPROTO_TCP)
+        desc->bufsz = INET_BUFFER_TCP_DEFAULT;
+    else if (protocol == IPPROTO_UDP)
+        desc->bufsz = INET_BUFFER_UDP_DEFAULT;
+#if defined(HAVE_SCTP)
+    else if (protocol == IPPROTO_SCTP)
+        desc->bufsz = INET_BUFFER_SCTP_DEFAULT;
+#endif
+    else /* We only support tcp, udp and SCTP so this "should not" happen... */
+        desc->bufsz = 9999;
+
     desc->hsz = 0;                     /* list header size */
     desc->htype = TCP_PB_RAW;          /* default packet type */
     desc->psize = 0;                   /* no size check */

--- a/lib/kernel/src/inet_udp.erl
+++ b/lib/kernel/src/inet_udp.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %% 
-%% Copyright Ericsson AB 1997-2024. All Rights Reserved.
+%% Copyright Ericsson AB 1997-2025. All Rights Reserved.
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
 -define(FAMILY, inet).
 -define(PROTO,  udp).
 -define(TYPE,   dgram).
--define(RECBUF, (8*1024)).
+-define(RECBUF, (8*1024)). % No longer needed when opening a *new* socket
 
 
 %% inet_udp port lookup
@@ -52,7 +52,7 @@ open(Port) -> open(Port, []).
 -spec open(_, _) -> {ok, port()} | {error, atom()}.
 open(Port, Opts) ->
     case inet:udp_options(
-	   [{port,Port}, {recbuf, ?RECBUF} | Opts], 
+	   [{port,Port} | Opts], 
 	   ?MODULE) of
 	{error, Reason} -> exit(Reason);
 	{ok,


### PR DESCRIPTION
Update tha default values for the inet driver 'buffer' sizes (tcp, udp and sctp, all now has 8192 as default value).
Also make it possible to change these when performing configure.