### PR TITLE
compiler tests: Avoid running out of virtual address space

### DIFF
--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1148,14 +1148,7 @@ core_roundtrip(Config) ->
     TestBeams = get_unique_beam_files(),
 
     Test = fun(F) -> do_core_roundtrip(F, Outdir) end,
-    case erlang:system_info(wordsize) of
-        4 ->
-            %% This test case is very memory intensive. Only
-            %% use a single process.
-            test_lib:p_run(Test, TestBeams, 1);
-        8 ->
-            test_lib:p_run(Test, TestBeams)
-    end.
+    test_lib:p_run(Test, TestBeams).
 
 do_core_roundtrip(Beam, Outdir) ->
     try


### PR DESCRIPTION
On 32-bit Windows systems, there is typically only 2 GiB of available virtual adress space. Some of our memory-hungry test cases (especially `compile_SUITE:core_roundtrip/1`) occasionally crash when the virtual address is exhausted.

In an attempt to reduce fragmentation of the allocated memory, change `test_lib:p_run/2` to not spawn any new processes on 32-bit systems, but instead run all tasks sequentially in single process.