### PR TITLE
Polish documentation for the maps module

### DIFF
--- a/lib/stdlib/src/maps.erl
+++ b/lib/stdlib/src/maps.erl
@@ -73,7 +73,7 @@ Consumed by:
 -doc """
 Key-based iterator order option that can be one of `undefined` (default for
 [`maps:iterator/1`](`iterator/1`)), `ordered` (sorted in map-key order),
-`reversed`, or a custom sorting function.
+`reversed` (sorted in reverse map-key order), or a custom sorting function.
 
 Used by [`maps:iterator/2`](`iterator/2`).
 
@@ -100,22 +100,22 @@ Returns value `Value` associated with `Key` if `Map` contains `Key`.
 The call fails with a `{badmap,Map}` exception if `Map` is not a map, or with a
 `{badkey,Key}` exception if no value is associated with `Key`.
 
-_Example:_
+## Examples
 
 ```erlang
-> Key = 1337,
-  Map = #{42 => value_two,1337 => "value one","a" => 1},
-  maps:get(Key, Map).
+> Key = 1337.
+> Map = #{42 => value_two,1337 => "value one","a" => 1}.
+> maps:get(Key, Map).
 "value one"
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec get(Key,Map) -> Value when
+-spec get(Key, Map) -> Value when
     Key :: term(),
     Map :: map(),
     Value :: term().
 
-get(_,_) -> erlang:nif_error(undef).
+get(_, _) -> erlang:nif_error(undef).
 
 -doc """
 Returns a tuple `{ok, Value}`, where `Value` is the value associated with `Key`,
@@ -123,35 +123,33 @@ or `error` if no value is associated with `Key` in `Map`.
 
 The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map = #{"hi" => 42},
-  Key = "hi",
-  maps:find(Key,Map).
+> Map = #{"hi" => 42}.
+> Key = "hi".
+> maps:find(Key, Map).
 {ok,42}
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec find(Key,Map) -> {ok, Value} | error when
+-spec find(Key, Map) -> {ok, Value} | error when
     Map :: #{Key => Value, _ => _}.
 
-find(_,_) -> erlang:nif_error(undef).
+find(_, _) -> erlang:nif_error(undef).
 
 %% Shadowed by erl_bif_types: maps:from_list/1
 -doc """
-Takes a list of key-value tuples elements and builds a map. The associations can
-be in any order, and both keys and values in the association can be of any term.
+Takes a list of key-value tuples and builds a map.
 
+If the same key appears more than once, the last (rightmost) value is
+used, and previous values are ignored.
 
-If the same key appears more than once, the latter (right-most) value is used
-and the previous values are ignored.
-
-_Example:_
+## Examples
 
 ```erlang
-> List = [{"a",ignored},{1337,"value two"},{42,value_three},{"a",1}],
-  maps:from_list(List).
+> List = [{"a",ignored},{1337,"value two"},{42,value_three},{"a",1}].
+> maps:from_list(List).
 #{42 => value_three,1337 => "value two","a" => 1}
 ```
 """.
@@ -166,13 +164,14 @@ from_list(_) -> erlang:nif_error(undef).
 
 %% Shadowed by erl_bif_types: maps:from_keys/2
 -doc """
-Takes a list of keys and a value and builds a map where all keys point to the
-same value. The key can be in any order, and keys and value can be of any term.
+Takes a list of keys and a value and builds a map where all keys are
+associated with the same value.
 
-_Example:_
+## Examples
 
 ```erlang
-> Keys = ["a", "b", "c"], maps:from_keys(Keys, ok).
+> Keys = ["a", "b", "c"].
+> maps:from_keys(Keys, ok).
 #{"a" => ok,"b" => ok,"c" => ok}
 ```
 """.
@@ -185,22 +184,26 @@ _Example:_
 from_keys(_, _) -> erlang:nif_error(undef).
 
 -doc """
-Intersects two maps into a single map `Map3`. If a key exists in both maps, the
-value in `Map1` is superseded by the value in `Map2`.
+Computes the intersection of maps `Map1` and `Map2`, producing a
+single map `Map3`.
+
+If a key exists in both maps, the value in `Map1` is superseded by the
+value in `Map2`. Keys existing in only one of the maps are discarded
+along with their values.
 
 The call fails with a `{badmap,Map}` exception if `Map1` or `Map2` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map1 = #{a => "value_one", b => "value_two"},
-  Map2 = #{a => 1, c => 2},
-  maps:intersect(Map1,Map2).
+> Map1 = #{a => "one", b => "two"}.
+> Map2 = #{a => 1, c => 3}.
+> maps:intersect(Map1, Map2).
 #{a => 1}
 ```
 """.
 -doc(#{since => <<"OTP 24.0">>}).
--spec intersect(Map1,Map2) -> Map3 when
+-spec intersect(Map1, Map2) -> Map3 when
     Map1 :: #{Key => term()},
     Map2 :: #{term() => Value2},
     Map3 :: #{Key => Value2}.
@@ -219,24 +222,25 @@ intersect_combiner_v1(_K, V1, _V2) -> V1.
 intersect_combiner_v2(_K, _V1, V2) -> V2.
 
 -doc """
-Intersects two maps into a single map `Map3`. If a key exists in both maps, the
-value in `Map1` is combined with the value in `Map2` by the `Combiner` fun.
+Computes the intersection of maps `Map1` and `Map2`, producing a
+single map `Map3`, where values having the same key are combined using
+the `Combiner` fun.
 
-When `Combiner` is applied the key that exists in both maps is the first parameter,
-the value from `Map1` is the second parameter, and the value from `Map2` is the
-third parameter.
+When `Combiner` is applied, the key that exists in both maps is the
+first parameter, the value from `Map1` is the second parameter, and
+the value from `Map2` is the third parameter.
 
 The call fails with a `{badmap,Map}` exception if `Map1` or `Map2` is not a map.
 The call fails with a `badarg` exception if `Combiner` is not a fun that takes
 three arguments.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map1 = #{a => "value_one", b => "value_two"},
-  Map2 = #{a => 1, c => 2},
-  maps:intersect_with(fun(_Key, Value1, Value2) -> {Value1, Value2} end, Map1, Map2).
-#{a => {"value_one",1}}
+> Map1 = #{a => "one", b => "two"}.
+> Map2 = #{a => 1, c => 3}.
+> maps:intersect_with(fun(_Key, Val1, Val2) -> {Val1, Val2} end, Map1, Map2).
+#{a => {"one",1}}
 ```
 """.
 -doc(#{since => <<"OTP 24.0">>}).
@@ -249,7 +253,7 @@ _Example:_
 intersect_with(Combiner, Map1, Map2) when is_map(Map1),
                                           is_map(Map2),
                                           is_function(Combiner, 3) ->
-    %% Use =< because we want to avoid reversing the combiner if we can
+    %% Use =< because we want to avoid reversing the combiner if we can.
     case map_size(Map1) =< map_size(Map2) of
         true ->
             intersect_with_small_map_first(Combiner, Map1, Map2);
@@ -279,19 +283,18 @@ intersect_with_iterate(none, Keep, _BigMap2, _Combiner) ->
 
 %% Shadowed by erl_bif_types: maps:is_key/2
 -doc """
-Returns `true` if map `Map` contains `Key` and returns `false` if it does not
-contain the `Key`.
+Returns `true` if map `Map` contains `Key`; otherwise, returns `false`.
 
 The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
 > Map = #{"42" => value}.
 #{"42" => value}
-> maps:is_key("42",Map).
+> maps:is_key("42", Map).
 true
-> maps:is_key(value,Map).
+> maps:is_key(value, Map).
 false
 ```
 """.
@@ -300,19 +303,19 @@ false
     Key :: term(),
     Map :: map().
 
-is_key(_,_) -> erlang:nif_error(undef).
+is_key(_, _) -> erlang:nif_error(undef).
 
 
 -doc """
-Returns a complete list of keys, in any order, which resides within `Map`.
+Returns a complete list of keys contained in `Map`, in any order.
 
 The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1},
-  maps:keys(Map).
+> Map = #{42 => three,1337 => "two","a" => 1}.
+> maps:keys(Map).
 [42,1337,"a"]
 ```
 """.
@@ -326,47 +329,47 @@ keys(_) -> erlang:nif_error(undef).
 
 %% Shadowed by erl_bif_types: maps:merge/2
 -doc """
-Merges two maps into a single map `Map3`. If two keys exist in both maps, the
-value in `Map1` is superseded by the value in `Map2`.
+Merges maps `Map1` and `Map2` into a single map `Map3`, where values
+from `Map2` override those from `Map1` for duplicate keys.
 
 The call fails with a `{badmap,Map}` exception if `Map1` or `Map2` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map1 = #{a => "value_one", b => "value_two"},
-  Map2 = #{a => 1, c => 2},
-  maps:merge(Map1,Map2).
-#{a => 1,b => "value_two",c => 2}
+> Map1 = #{a => "one", b => "two"}.
+> Map2 = #{a => 1, c => 3}.
+> maps:merge(Map1, Map2).
+#{a => 1,b => "two",c => 3}
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec merge(Map1,Map2) -> Map3 when
+-spec merge(Map1, Map2) -> Map3 when
     Map1 :: map(),
     Map2 :: map(),
     Map3 :: map().
 
-merge(_,_) -> erlang:nif_error(undef).
+merge(_, _) -> erlang:nif_error(undef).
 
 -doc """
-Merges two maps into a single map `Map3`. If a key exists in both maps, the
-value in `Map1` is combined with the value in `Map2` by the `Combiner` fun.
+Merges maps `Map1` and `Map2` into a single map `Map3`, combining values for
+duplicate keys using the `Combiner` fun.
 
-When `Combiner` is applied the key that exists in both maps is the first parameter,
-the value from `Map1` is the second parameter, and the value from `Map2` is the
-third parameter.
+When `Combiner` is applied, the key that exists in both maps is the
+first parameter, the value from `Map1` is the second parameter, and
+the value from `Map2` is the third parameter.
 
 The call fails with a `{badmap,Map}` exception if `Map1` or `Map2` is not a map.
 The call fails with a `badarg` exception if `Combiner` is not a fun that takes
 three arguments.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map1 = #{a => "value_one", b => "value_two"},
-  Map2 = #{a => 1, c => 2},
-  maps:merge_with(fun(_Key, Value1, Value2) -> {Value1, Value2} end, Map1, Map2).
-#{a => {"value_one",1},b => "value_two",c => 2}
+> Map1 = #{a => 3, b => 5}.
+> Map2 = #{a => 4, c => 17}.
+> maps:merge_with(fun(_Key, Val1, Val2) -> Val1 + Val2 end, Map1, Map2).
+#{a => 7,b => 5,c => 17}
 ```
 """.
 -doc(#{since => <<"OTP 24.0">>}).
@@ -408,14 +411,13 @@ merge_with_1(none, Result, _) ->
 
 %% Shadowed by erl_bif_types: maps:put/3
 -doc """
-Associates `Key` with value `Value` and inserts the association into map `Map2`.
-If key `Key` already exists in map `Map1`, the old associated value is replaced
-by value `Value`. The function returns a new map `Map2` containing the new
-association and the old associations in `Map1`.
+Associates `Key` with `Value` in Map1, replacing any existing value, and
+returns a new map `Map2` with the updated association alongside the
+original entries from `Map1`.
 
 The call fails with a `{badmap,Map}` exception if `Map1` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
 > Map = #{"a" => 1}.
@@ -427,45 +429,45 @@ _Example:_
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec put(Key,Value,Map1) -> Map2 when
+-spec put(Key, Value, Map1) -> Map2 when
     Key :: term(),
     Value :: term(),
     Map1 :: map(),
     Map2 :: map().
 
-put(_,_,_) -> erlang:nif_error(undef).
+put(_, _, _) -> erlang:nif_error(undef).
 
 
 %% Shadowed by erl_bif_types: maps:remove/2
 -doc """
-Removes the `Key`, if it exists, and its associated value from `Map1` and
-returns a new map `Map2` without key `Key`.
+Removes `Key` and its associated value from `Map1`, if it exists, and
+returns a new map `Map2` without `Key`.
 
 The call fails with a `{badmap,Map}` exception if `Map1` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
 > Map = #{"a" => 1}.
 #{"a" => 1}
-> maps:remove("a",Map).
+> maps:remove("a", Map).
 #{}
-> maps:remove("b",Map).
+> maps:remove("b", Map).
 #{"a" => 1}
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec remove(Key,Map1) -> Map2 when
+-spec remove(Key, Map1) -> Map2 when
     Key :: term(),
     Map1 :: map(),
     Map2 :: map().
 
-remove(_,_) -> erlang:nif_error(undef).
+remove(_, _) -> erlang:nif_error(undef).
 
 -doc """
-The function removes the `Key`, if it exists, and its associated value from
-`Map1` and returns a tuple with the removed `Value` and the new map `Map2`
-without key `Key`. If the key does not exist `error` is returned.
+Removes `Key` and its associated value from `Map1`, if it exists,
+returning a tuple with the removed value `Value` and the new map
+`Map2`; otherwise, returns error.
 
 The call will fail with a `{badmap,Map}` exception if `Map1` is not a map.
 
@@ -474,14 +476,14 @@ Example:
 ```erlang
 > Map = #{"a" => "hello", "b" => "world"}.
 #{"a" => "hello", "b" => "world"}
-> maps:take("a",Map).
+> maps:take("a", Map).
 {"hello",#{"b" => "world"}}
-> maps:take("does not exist",Map).
+> maps:take("does not exist", Map).
 error
 ```
 """.
 -doc(#{since => <<"OTP 19.0">>}).
--spec take(Key,Map1) -> {Value,Map2} | error when
+-spec take(Key, Map1) -> {Value,Map2} | error when
     Map1 :: #{Key => Value, _ => _},
     Map2 :: #{_ => _}.
 
@@ -489,25 +491,27 @@ take(_,_) -> erlang:nif_error(undef).
 
 -doc """
 Returns a list of pairs representing the key-value associations of
-`MapOrIterator`, where the pairs `[{K1,V1}, ..., {Kn,Vn}]` are returned in
-arbitrary order.
+`MapOrIterator`.
+
+Unless `MapOrIter` is an ordered iterator returned by `iterator/2`,
+the order of the `{Key, Value}` tuples in the resulting list is not
+defined.
 
 The call fails with a `{badmap,Map}` exception if `MapOrIterator` is not a map
 or an iterator obtained by a call to `iterator/1` or `iterator/2`.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1},
-  maps:to_list(Map).
+> Map = #{42 => value_three,1337 => "value two","a" => 1}.
+> maps:to_list(Map).
 [{42,value_three},{1337,"value two"},{"a",1}]
 ```
 
-_Example (using _`iterator/2`_):_
+Using an ordered iterator to return an ordered list:
 
 ```erlang
-> Map = #{ z => 1, y => 2, x => 3 }.
-#{x => 3,y => 2,z => 1}
+> Map = #{z => 1, y => 2, x => 3}.
 > maps:to_list(maps:iterator(Map, ordered)).
 [{x,3},{y,2},{z,1}]
 ```
@@ -537,14 +541,13 @@ to_list_internal(Acc) ->
 
 %% Shadowed by erl_bif_types: maps:update/3
 -doc """
-If `Key` exists in `Map1`, the old associated value is replaced by value
-`Value`. The function returns a new map `Map2` containing the new associated
-value.
+If `Key` exists in `Map1`, its value is replaced with `Value`, and the
+function returns a new map `Map2` with the updated association.
 
 The call fails with a `{badmap,Map}` exception if `Map1` is not a map, or with a
 `{badkey,Key}` exception if no value is associated with `Key`.
 
-_Example:_
+## Examples
 
 ```erlang
 > Map = #{"a" => 1}.
@@ -554,23 +557,23 @@ _Example:_
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec update(Key,Value,Map1) -> Map2 when
+-spec update(Key, Value, Map1) -> Map2 when
     Map1 :: #{Key := _, _ => _},
     Map2 :: #{Key := Value, _ => _}.
 
-update(_,_,_) -> erlang:nif_error(undef).
+update(_, _, _) -> erlang:nif_error(undef).
 
 
 -doc """
-Returns a complete list of values, in arbitrary order, contained in map `Map`.
+Returns a complete list of values contained in map `Map`, in any order.
 
 The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1},
-  maps:values(Map).
+> Map = #{42 => value_three,1337 => "value two","a" => 1}.
+> maps:values(Map).
 [value_three,"value two",1]
 ```
 """.
@@ -586,7 +589,7 @@ values(_) -> erlang:nif_error(undef).
 -doc """
 Returns a new empty map.
 
-_Example:_
+## Examples
 
 ```text
 > maps:new().
@@ -600,73 +603,76 @@ _Example:_
 new() -> #{}.
 
 -doc """
-Update a value in a `Map1` associated with `Key` by calling `Fun` on the old
-value to get a new value. An exception `{badkey,Key}` is generated if `Key` is
-not present in the map.
+Updates a value in a `Map1` associated with `Key` by calling `Fun` on the old
+value to produce a new value.
 
-Example:
+The call fails with a `{badkey,Key}` exception if `Key` is not present
+in the map.
+
+## Examples
 
 ```erlang
-> Map = #{"counter" => 1},
-  Fun = fun(V) -> V + 1 end,
-  maps:update_with("counter",Fun,Map).
-#{"counter" => 2}
+> Map = #{counter => 1}.
+> Fun = fun(V) -> V + 1 end.
+> maps:update_with(counter, Fun, Map).
+#{counter => 2}
 ```
 """.
 -doc(#{since => <<"OTP 19.0">>}).
--spec update_with(Key,Fun,Map1) -> Map2 when
+-spec update_with(Key, Fun, Map1) -> Map2 when
       Map1 :: #{Key := Value1, _ => _},
       Map2 :: #{Key := Value2, _ => _},
       Fun :: fun((Value1) -> Value2).
 
-update_with(Key,Fun,Map) when is_function(Fun,1), is_map(Map) ->
+update_with(Key, Fun, Map) when is_function(Fun, 1), is_map(Map) ->
     case Map of
         #{Key := Value} -> Map#{Key := Fun(Value)};
-        #{} -> erlang:error({badkey,Key},[Key,Fun,Map])
+        #{} -> error({badkey,Key}, [Key,Fun,Map])
     end;
-update_with(Key,Fun,Map) ->
+update_with(Key, Fun, Map) ->
     error_with_info(error_type(Map), [Key,Fun,Map]).
 
 
 -doc """
-Update a value in a `Map1` associated with `Key` by calling `Fun` on the old
-value to get a new value. If `Key` is not present in `Map1` then `Init` will be
-associated with `Key`.
+Updates the value in `Map1` for `Key` by applying `Fun` to the old value or
+using `Init` if `Key` is not present in the map.
 
-Example:
+## Examples
 
 ```erlang
-> Map = #{"counter" => 1},
-  Fun = fun(V) -> V + 1 end,
-  maps:update_with("new counter",Fun,42,Map).
+> Map = #{"counter" => 1}.
+> Fun = fun(V) -> V + 1 end.
+> maps:update_with("counter", Fun, 42, Map).
+#{"counter" => 2}
+> maps:update_with("new counter", Fun, 42, Map).
 #{"counter" => 1,"new counter" => 42}
 ```
 """.
 -doc(#{since => <<"OTP 19.0">>}).
--spec update_with(Key,Fun,Init,Map1) -> Map2 when
+-spec update_with(Key, Fun, Init, Map1) -> Map2 when
       Map1 :: #{Key => Value1, _ => _},
       Map2 :: #{Key := Value2 | Init, _ => _},
       Fun :: fun((Value1) -> Value2).
 
-update_with(Key,Fun,Init,Map) when is_function(Fun,1), is_map(Map) ->
+update_with(Key, Fun, Init, Map) when is_function(Fun, 1), is_map(Map) ->
     case Map of
         #{Key := Value} -> Map#{Key := Fun(Value)};
         #{} -> Map#{Key => Init}
     end;
-update_with(Key,Fun,Init,Map) ->
+update_with(Key, Fun, Init, Map) ->
     error_with_info(error_type(Map), [Key,Fun,Init,Map]).
 
 
 -doc """
-Returns value `Value` associated with `Key` if `Map` contains `Key`. If no value
-is associated with `Key`, `Default` is returned.
+Returns the value associated with key `Key` in `Map`, or `Default` if
+`Key` is not present in the map.
 
 The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
-> Map = #{ key1 => val1, key2 => val2 }.
+> Map = #{key1 => val1, key2 => val2}.
 #{key1 => val1,key2 => val2}
 > maps:get(key1, Map, "Default value").
 val1
@@ -678,27 +684,31 @@ val1
 -spec get(Key, Map, Default) -> Value | Default when
       Map :: #{Key => Value, _ => _}.
 
-get(Key,Map,Default) when is_map(Map) ->
+get(Key, Map, Default) when is_map(Map) ->
     case Map of
         #{Key := Value} -> Value;
         #{} -> Default
     end;
-get(Key,Map,Default) ->
+get(Key, Map, Default) ->
     error_with_info({badmap,Map}, [Key,Map,Default]).
 
 -doc """
-Returns a map `Map` for which predicate `Pred` holds true in `MapOrIter`.
+Returns a map `Map` where each key-value pair from `MapOrIter` satisfies
+the predicate `Pred(Key, Value)`.
+
+Unless `MapOrIter` is an ordered iterator returned by `iterator/2`,
+the order of the `Pred(Key, Value)` calls is not defined.
 
 The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a map or
 valid iterator, or with `badarg` if `Pred` is not a function of arity 2.
 
-_Example:_
+## Examples
 
 ```erlang
-> M = #{a => 2, b => 3, c=> 4, "a" => 1, "b" => 2, "c" => 4},
-  Pred = fun(K,V) -> is_atom(K) andalso (V rem 2) =:= 0 end,
-  maps:filter(Pred,M).
-#{a => 2,c => 4}
+> M = #{a => 2, b => 3, "a" => 1, "b" => 2}.
+> Pred = fun(K, V) -> is_atom(K) andalso V rem 2 =:= 0 end.
+> maps:filter(Pred, M).
+#{a => 2}
 ```
 """.
 -doc(#{since => <<"OTP 18.0">>}).
@@ -732,23 +742,28 @@ filter_1(_Pred, none, _ErrorTag) ->
     [].
 
 -doc """
-Returns a map `Map` that is the result of calling `Fun(Key, Value1)` for every
-`Key` to value `Value1` association in `MapOrIter` in any order.
+Calls `Fun(Key, Value1)` on each key-value pair of `MapOrIter` to
+update or remove associations from `MapOrIter`.
 
 If `Fun(Key, Value1)` returns `true`, the association is copied to the result
 map. If it returns `false`, the association is not copied. If it returns
 `{true, NewValue}`, the value for `Key` is replaced with `NewValue` in the
 result map.
 
+Unless `MapOrIter` is an ordered iterator returned by `iterator/2`,
+the order of the `Fun(Key, Value1)` calls is not defined.
+
 The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a map or
 valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
 
-_Example:_
+## Examples
 
 ```erlang
-> Fun = fun(K,V) when is_atom(K) -> {true, V*2}; (_,V) -> (V rem 2) =:= 0 end,
-  Map = #{k1 => 1, "k2" => 2, "k3" => 3},
-  maps:filtermap(Fun,Map).
+> Fun = fun(K, V) when is_atom(K) -> {true, V*2};
+           (_, V) -> V rem 2 =:= 0
+  end.
+> Map = #{k1 => 1, "k2" => 2, "k3" => 3}.
+> maps:filtermap(Fun, Map).
 #{k1 => 2,"k2" => 2}
 ```
 """.
@@ -785,28 +800,28 @@ filtermap_1(_Fun, none, _ErrorTag) ->
     [].
 
 -doc """
-Calls `fun Fun(Key, Value)` for every `Key` to value `Value` association in
-`MapOrIter` in any order.
+Calls `Fun(Key, Value)` for every `Key` to `Value` association in
+`MapOrIter`.
+
+Unless `MapOrIter` is an ordered iterator returned by `iterator/2`,
+the order of the `Fun(Key, Value)` calls is not defined.
 
 The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a map or
 valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
 
-_Example:_
+## Examples
 
 ```erlang
-> Fun = fun(K,V) -> io:format("% ~p:~p~n",[K,V]) end.
-
-> Map = #{"x" => 10, "y" => 20, "z" => 30}.
-#{"x" => 10,"y" => 20,"z" => 30}
-> maps:foreach(Fun,Map).
-% "x":10
-% "y":20
-% "z":30
+> Fun = fun(K, V) -> self() ! {K,V} end.
+> Map = #{p => 1, q => 2,x => 10, y => 20, z => 30}.
+> maps:foreach(Fun, maps:iterator(Map, ordered)).
 ok
+> [receive X -> X end || _ <- [1,2,3,4,5]].
+[{p,1},{q,2},{x,10},{y,20},{z,30}]
 ```
 """.
 -doc(#{since => <<"OTP 24.0">>}).
--spec foreach(Fun,MapOrIter) -> ok when
+-spec foreach(Fun, MapOrIter) -> ok when
       Fun :: fun((Key, Value) -> term()),
       MapOrIter :: #{Key => Value} | iterator(Key, Value).
 
@@ -830,25 +845,31 @@ foreach_1(_Fun, none, _ErrorTag) ->
 
 -doc """
 Calls `Fun(Key, Value, AccIn)` for every `Key` to value `Value` association in
-`MapOrIter` in any order. Function `fun Fun/3` must return a new accumulator,
-which is passed to the next successive call. This function returns the final
-value of the accumulator. The initial accumulator value `Init` is returned if
-the map is empty.
+`MapOrIter`, starting with `AccIn` bound to `Acc0`.
 
-The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a map or
-valid iterator, or with `badarg` if `Fun` is not a function of arity 3.
+The `Fun/3` fun must return a new accumulator, which is passed to the
+next call. The function returns the final value of the
+accumulator. The initial accumulator value `Init` is returned if the
+map is empty.
 
-_Example:_
+Unless `MapOrIter` is an ordered iterator returned by `iterator/2`,
+the order of the `Fun(Key, Value, AccIn)` calls is not defined.
+
+The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a
+map or valid iterator, or with `badarg` if `Fun` is not a function of
+arity 3.
+
+## Examples
 
 ```erlang
-> Fun = fun(K,V,AccIn) when is_list(K) -> AccIn + V end,
-  Map = #{"k1" => 1, "k2" => 2, "k3" => 3},
-  maps:fold(Fun,0,Map).
+> Fun = fun(K, V, AccIn) -> AccIn + V end.
+> Map = #{k1 => 1, k2 => 2, k3 => 3}.
+> maps:fold(Fun, 0, Map).
 6
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec fold(Fun,Init,MapOrIter) -> Acc when
+-spec fold(Fun, Init, MapOrIter) -> Acc when
     Fun :: fun((Key, Value, AccIn) -> AccOut),
     Init :: term(),
     Acc :: AccOut,
@@ -873,25 +894,29 @@ fold_1(_Fun, Acc, none, _ErrorTag) ->
     Acc.
 
 -doc """
-Produces a new map `Map` by calling function `fun Fun(Key, Value1)` for every
-`Key` to value `Value1` association in `MapOrIter` in any order. Function
-`fun Fun/2` must return value `Value2` to be associated with key `Key` for the
-new map `Map`.
+Produces a new map `Map` by calling function `Fun(Key, Value1)` for every
+`Key` to value `Value1` association in `MapOrIter`.
+
+The `Fun/2` fun must return value `Value2` to be associated with key
+`Key` for the new map `Map`.
+
+Unless `MapOrIter` is an ordered iterator returned by `iterator/2`,
+the order of the `Fun(Key, Value1)` calls is not defined.
 
 The call fails with a `{badmap,Map}` exception if `MapOrIter` is not a map or
 valid iterator, or with `badarg` if `Fun` is not a function of arity 2.
 
-_Example:_
+## Examples
 
 ```erlang
-> Fun = fun(K,V1) when is_list(K) -> V1*2 end,
-  Map = #{"k1" => 1, "k2" => 2, "k3" => 3},
-  maps:map(Fun,Map).
+> Fun = fun(K,V1) when is_list(K) -> V1*2 end.
+> Map = #{"k1" => 1, "k2" => 2, "k3" => 3}.
+> maps:map(Fun, Map).
 #{"k1" => 2,"k2" => 4,"k3" => 6}
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec map(Fun,MapOrIter) -> Map when
+-spec map(Fun, MapOrIter) -> Map when
     Fun :: fun((Key, Value1) -> Value2),
     MapOrIter :: #{Key => Value1} | iterator(Key, Value1),
     Map :: #{Key => Value2}.
@@ -917,14 +942,15 @@ map_1(_Fun, none, _ErrorTag) ->
     [].
 
 -doc """
-Returns the number of key-value associations in `Map`. This operation occurs in
-constant time.
+Returns the number of key-value associations in `Map`.
 
-_Example:_
+This operation occurs in constant time.
+
+## Examples
 
 ```erlang
-> Map = #{42 => value_two,1337 => "value one","a" => 1},
-  maps:size(Map).
+> Map = #{42 => value_two,1337 => "value one","a" => 1}.
+> maps:size(Map).
 3
 ```
 """.
@@ -942,13 +968,15 @@ size(Map) ->
 
 -doc """
 Returns a map iterator `Iterator` that can be used by [`maps:next/1`](`next/1`)
-to traverse the key-value associations in a map. The order of iteration is
-undefined. When iterating over a map, the memory usage is guaranteed to be
-bounded no matter the size of the map.
+to traverse the key-value associations in a map.
+
+The order of iteration is undefined. When iterating over a map, the
+memory usage is guaranteed to be bounded no matter the size of the
+map.
 
 The call fails with a `{badmap,Map}` exception if `Map` is not a map.
 
-_Example:_
+## Examples
 
 ```erlang
 > M = #{ "foo" => 1, "bar" => 2 }.
@@ -975,14 +1003,15 @@ Returns a map iterator `Iterator` that can be used by [`maps:next/1`](`next/1`)
 to traverse the key-value associations in a map sorted by key using the given
 `Order`.
 
-The call fails with a `{badmap,Map}` exception if `Map` is not a map or if
-`Order` is invalid.
+The call fails with a `{badmap,Map}` exception if `Map` is not a map, or
+with a `badarg` exception if `Order` is invalid.
 
-_Example (when _`Order`_ is _`ordered`_):_
+## Examples
+
+Ordered iterator:
 
 ```erlang
-> M = #{ a => 1, b => 2 }.
-#{a => 1,b => 2}
+> M = #{a => 1, b => 2}.
 > OrdI = maps:iterator(M, ordered).
 > {K1, V1, OrdI2} = maps:next(OrdI), {K1, V1}.
 {a,1}
@@ -992,11 +1021,10 @@ _Example (when _`Order`_ is _`ordered`_):_
 none
 ```
 
-_Example (when _`Order`_ is _`reversed`_):_
+Iterator ordered in reverse:
 
 ```erlang
-> M = #{ a => 1, b => 2 }.
-#{a => 1,b => 2}
+> M = #{a => 1, b => 2}.
 > RevI = maps:iterator(M, reversed).
 > {K2, V2, RevI2} = maps:next(RevI), {K2, V2}.
 {b,2}
@@ -1004,19 +1032,21 @@ _Example (when _`Order`_ is _`reversed`_):_
 {a,1}
 > maps:next(RevI3).
 none
+> maps:to_list(RevI).
+[{b,2},{a,1}]
 ```
 
-_Example (when _`Order`_ is an arithmetic sorting function):_
+Using a custom ordering function that orders binaries by size:
 
 ```erlang
-> M = #{ -1 => a, -1.0 => b, 0 => c, 0.0 => d }.
-#{-1 => a,0 => c,-1.0 => b,0.0 => d}
-> ArithOrdI = maps:iterator(M, fun(A, B) -> A =< B end).
-> maps:to_list(ArithOrdI).
-[{-1,a},{-1.0,b},{0,c},{0.0,d}]
-> ArithRevI = maps:iterator(M, fun(A, B) -> B < A end).
-> maps:to_list(ArithRevI).
-[{0.0,d},{0,c},{-1.0,b},{-1,a}]
+> M = #{<<"abcde">> => d, <<"y">> => b, <<"x">> => a, <<"pqr">> => c}.
+> SizeI = fun(A, B) when byte_size(A) < byte_size(B) -> true;
+             (A, B) when byte_size(A) > byte_size(B) -> false;
+             (A, B) -> A =< B
+          end.
+> SizeOrdI = maps:iterator(M, SizeI).
+> maps:to_list(SizeOrdI).
+[{<<"x">>,a},{<<"y">>,b},{<<"pqr">>,c},{<<"abcde">>,d}]
 ```
 """.
 -doc(#{since => <<"OTP 26.0">>}).
@@ -1047,7 +1077,7 @@ remaining associations in the iterator.
 
 If there are no more associations in the iterator, `none` is returned.
 
-_Example:_
+## Examples
 
 ```erlang
 > Map = #{a => 1, b => 2, c => 3}.
@@ -1084,40 +1114,43 @@ next(Iter) ->
 
 -doc """
 Returns a new map `Map2` without keys `K1` through `Kn` and their associated
-values from map `Map1`. Any key in `Ks` that does not exist in `Map1` is ignored
+values from map `Map1`.
 
-_Example:_
+Any key in `Ks` that does not exist in `Map1` is ignored.
+
+## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1},
-  Ks = ["a",42,"other key"],
-  maps:without(Ks,Map).
+> Map = #{42 => value_three, 1337 => "value two", "a" => 1}.
+> Keys = ["a",42,"other key"].
+> maps:without(Keys, Map).
 #{1337 => "value two"}
 ```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
--spec without(Ks,Map1) -> Map2 when
+-spec without(Ks, Map1) -> Map2 when
     Ks :: [K],
     Map1 :: map(),
     Map2 :: map(),
     K :: term().
 
-without(Ks,M) when is_list(Ks), is_map(M) ->
+without(Ks, M) when is_list(Ks), is_map(M) ->
     lists:foldl(fun maps:remove/2, M, Ks);
-without(Ks,M) ->
+without(Ks, M) ->
     error_with_info(error_type(M), [Ks,M]).
 
 -doc """
 Returns a new map `Map2` with the keys `K1` through `Kn` and their associated
-values from map `Map1`. Any key in `Ks` that does not exist in `Map1` is
-ignored.
+values from map `Map1`.
 
-_Example:_
+Any key in `Ks` that does not exist in `Map1` is ignored.
+
+## Examples
 
 ```erlang
-> Map = #{42 => value_three,1337 => "value two","a" => 1},
-  Ks = ["a",42,"other key"],
-  maps:with(Ks,Map).
+> Map = #{42 => value_three,1337 => "value two","a" => 1}.
+> Keys = ["a",42,"other key"].
+> maps:with(Keys, Map).
 #{42 => value_three,"a" => 1}
 ```
 """.
@@ -1139,8 +1172,6 @@ with_1([K|Ks], Map) ->
     end;
 with_1([], _Map) -> [].
 
-%% groups_from_list/2 & groups_from_list/3
-
 -doc """
 Partitions the given `List` into a map of groups.
 
@@ -1150,13 +1181,15 @@ of elements from the given `List` for which `KeyFun` returned the same key.
 The order of elements within each group list is preserved from the original
 list.
 
-_Examples:_
+## Examples
 
 ```erlang
-> EvenOdd = fun(X) -> case X rem 2 of 0 -> even; 1 -> odd end end,
-  maps:groups_from_list(EvenOdd, [1, 2, 3]).
+> EvenOdd = fun(X) when X rem 2 =:= 0 -> even;
+               (_) -> odd
+            end.
+> maps:groups_from_list(EvenOdd, [1, 2, 3]).
 #{even => [2], odd => [1, 3]}
-> maps:groups_from_list(fun erlang:length/1, ["ant", "buffalo", "cat", "dingo"]).
+> maps:groups_from_list(fun length/1, ["ant", "buffalo", "cat", "dingo"]).
 #{3 => ["ant", "cat"], 5 => ["dingo"], 7 => ["buffalo"]}
 ```
 """.
@@ -1200,15 +1233,15 @@ returned the same key.
 The order of elements within each group list is preserved from the original
 list.
 
-_Examples:_
+## Examples
 
 ```erlang
-> EvenOdd = fun(X) -> case X rem 2 of 0 -> even; 1 -> odd end end,
-  Square = fun(X) -> X * X end,
-  maps:groups_from_list(EvenOdd, Square, [1, 2, 3]).
+> EvenOdd = fun(X) -> case X rem 2 of 0 -> even; 1 -> odd end end.
+> Square = fun(X) -> X * X end.
+> maps:groups_from_list(EvenOdd, Square, [1, 2, 3]).
 #{even => [4], odd => [1, 9]}
 > maps:groups_from_list(
-    fun erlang:length/1,
+    fun length/1,
     fun lists:reverse/1,
     ["ant", "buffalo", "cat", "dingo"]).
 #{3 => ["tna", "tac"],5 => ["ognid"],7 => ["olaffub"]}


### PR DESCRIPTION
Ensure that the first sentence describing each function makes sense by itself when shown in the Summary part of the documentation.

Don't say the the order is arbitrary for functions that accept an ordered iterator.

Consistently mark examples using `## Examples`.

While at it, also remove comments for documented functions, and remove out-commented code, and do some other minor clean ups.