### PR TITLE
Add write_concurrency auto to `ets:info/1` return spec

### DIFF
--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -496,7 +496,7 @@ table, `undefined` is returned. If `Table` is not of the correct type, a
                  | {protection, table_access()}
                  | {size, non_neg_integer()}
                  | {type, table_type()}
-		 | {write_concurrency, boolean()}
+		 | {write_concurrency, boolean() | auto}
 		 | {read_concurrency, boolean()}.
 
 info(_) ->


### PR DESCRIPTION
👋 

This PR adds the missing `{write_concurrency, auto}` tuple to `ets:info/1` return spec.

```erl
1> ets:info(ets:new(tab, [{write_concurrency, auto}])).
%> [{id,#Ref<0.1217228914.4266262529.13740>},
%> {decentralized_counters,true},
%> {read_concurrency,false},
%> {write_concurrency,auto}, % <--
%> {compressed,false},
%> {memory,1497},
%> {owner,<0.88.0>},
%> {heir,none},
%> {name,tab},
%> {size,0},
%> {node,nonode@nohost},
%> {named_table,false},
%> {type,set},
%> {keypos,1},
%> {protection,protected}]
```