### PR TITLE
inets: Document asynchronous httpc request body format

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -332,7 +332,7 @@ Options details:
 - **`body_format`** - Defines if the body is to be delivered as a string or
   binary. This option is only valid for the synchronous request.
 
-  Default is `string`.
+  Default is `string`. Asynchronous requests always use `binary`.
 
 - **`full_result`** - Defines if a "full result" is to be returned to the caller
   (that is, the body, the headers, and the entire status line) or not (the body


### PR DESCRIPTION
The default `string` option converts messages from the client from binary to string. `binary` is the default, e.g. `test/httpc_SUITE.erl`, `receive_streamed_body`.