### PR TITLE
Don't include enabled_features tuple when there are none

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1905,6 +1905,8 @@ do_parse_module(DefEncoding, #compile{ifile=File,options=Opts,dir=Dir}=St) ->
 -define(META_USED_FEATURES, enabled_features).
 -define(META_CHUNK_NAME, <<"Meta">>).
 
+metadata_add_features([], St) ->
+    St;
 metadata_add_features(Ftrs, #compile{options = CompOpts,
                                      extra_chunks = Extra} = St) ->
     MetaData =


### PR DESCRIPTION
It's confusing/irritating that the MD5 of preloaded modules given by `m(Module).` doesn't match that given by `beam_lib:md5(Beam).`

The problem can be traced back to commit 435fce8 which introduces the enabled_features tuple in the Meta chunk - even if there are no enabled features.

Since `erts/emulator/utils/make_preload` doesn't include the Meta chunk the md5 sums don't match.

Assuming preloaded modules won't include features that aren't part of the standard Erlang release this PR fixes the problem by not including an empty enabled_features tuple in the Meta chunk.