### PR TITLE
Fix race condition in mnesia_evil_coverage_test:table_info

### DIFF
--- a/lib/mnesia/test/mnesia_evil_coverage_test.erl
+++ b/lib/mnesia/test/mnesia_evil_coverage_test.erl
@@ -176,7 +176,7 @@ table_info(Config) when is_list(Config) ->
     Size = 10,
     Keys = lists:seq(1, Size),
     Records = [{Tab, A, 7} || A <- Keys],
-    lists:foreach(fun(Rec) -> ?match(ok, mnesia:dirty_write(Rec)) end, Records),
+    mnesia:sync_dirty(fun() -> lists:foreach(fun(Rec) -> ?match(ok, mnesia:write(Rec)) end, Records) end),
 
     case mnesia_test_lib:diskless(Config) of
 	true -> 


### PR DESCRIPTION
We're doing dirty writes with multiple nodes, and by default mnesia:dirty_write waits only for 1 node to complete. We must wait for all nodes to finish, and then check table size.