### PR TITLE
compiler: Fix simultaneous binding of variables in zip generator

### DIFF
--- a/lib/stdlib/test/erl_eval_SUITE.erl
+++ b/lib/stdlib/test/erl_eval_SUITE.erl
@@ -337,6 +337,12 @@ zlc(Config) when is_list(Config) ->
     error_check("begin
         X = 32, Y = 32, [{X, Y} || X <- [1,2,3] && Y:=_V <- #{1=>1}] end.",
     {bad_generators,{[2,3],#{}}}),
+    error_check("[X || X <- [b] && X <:- [a]].",{bad_generators,{[b],[a]}}),
+    error_check("[X || X <:- [b] && X <- [a]].",{bad_generators,{[b],[a]}}),
+    error_check("[X || X <- [a,a] && X <:- [a,b]].",{bad_generators,{[a],[b]}}),
+    error_check("[{X,Y} || {X,Y} <- [{a,b}] && Y <:- [a] && X <- [a]].",
+    {bad_generators,{[{a,b}],[a],[a]}}),
+
     ok.
 
 zbc(Config) when is_list(Config) ->
@@ -438,6 +444,9 @@ zmc(Config) when is_list(Config) ->
     {bad_generators,{#{},#{c=>4}}}),
     error_check("begin #{X=>Y || X <- [1] && Y <- a && K1:=V1 <- #{b=>3}} end.",
         {bad_generators,{[1], a, #{b=>3}}}),
+
+    error_check("begin #{K => V || K := V <- #{1=>2} && K := _ <:- #{2=>3}} end.",
+        {bad_generators,{#{1 => 2},#{2 => 3}}}),
     ok.
 
 %% Simple cases, just to cover some code.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/9435

A failed simultaneous binding from a strict generator and a relaxed generator always crash the comprehension. All bindings within a generator happen "at the same time" for user. Switching the order of generators within a zip generator cannot change the result of the comprehension.