### PR TITLE
Bugfix: gethostbyname fails to respect ERL_INETRC on first call during initialization on linux

### DIFF
--- a/lib/kernel/src/inet_config.erl
+++ b/lib/kernel/src/inet_config.erl
@@ -58,36 +58,6 @@ init() ->
     OsType = os:type(),
     do_load_resolv(OsType, erl_dist_mode()),
 
-    case OsType of
-	{unix,Type} ->
-	    if Type =:= linux ->
-		    %% It may be the case that the domain name was not set
-		    %% because the hostname was short. But NOW we can look it
-		    %% up and get the long name and the domain name from it.
-		    
-		    %% FIXME: The second call to set_hostname will insert
-		    %% a duplicate entry in the search list.
-		    
-		    case inet_db:res_option(domain) of
-			"" ->
-			    case inet:gethostbyname(inet_db:gethostname()) of
-				{ok,#hostent{h_name = []}} ->
-				    ok;
-				{ok,#hostent{h_name = HostName}} ->
-				    set_hostname({ok,HostName});
-				_ ->
-				    ok
-			    end;
-			_ ->
-			    ok
-		    end;
-	       true -> ok
-	    end,    
-	    add_dns_lookup(inet_db:res_option(lookup));
-	_ ->
-	    ok
-    end,
-
     %% Read inetrc file, if it exists.
     {RcFile,CfgFiles,CfgList} = read_rc(),
 
@@ -133,6 +103,36 @@ init() ->
 		_ -> ok
 	    end;
 	_ -> ok
+    end, 
+
+    case OsType of
+	{unix,Type} ->
+	    if Type =:= linux ->
+		    %% It may be the case that the domain name was not set
+		    %% because the hostname was short. But NOW we can look it
+		    %% up and get the long name and the domain name from it.
+		    
+		    %% FIXME: The second call to set_hostname will insert
+		    %% a duplicate entry in the search list.
+		    
+		    case inet_db:res_option(domain) of
+			"" ->
+			    case inet:gethostbyname(inet_db:gethostname()) of
+				{ok,#hostent{h_name = []}} ->
+				    ok;
+				{ok,#hostent{h_name = HostName}} ->
+				    set_hostname({ok,HostName});
+				_ ->
+				    ok
+			    end;
+			_ ->
+			    ok
+		    end;
+	       true -> ok
+	    end,    
+	    add_dns_lookup(inet_db:res_option(lookup));
+	_ ->
+	    ok
     end.
 
 


### PR DESCRIPTION
When setting `ERL_INETRC` and using `{edns,0}` instead of `native` there is still an initial use of the `native`. As a result the binary `inet_gethost` is still being called for the initial lookup even if configured otherwise.

This is especially an issue when trying to deploy a minimal erlang distribution without the `inet_gethost`binary.

This issue only exists on linux at the moment - windows and macos are fine because the offending code block is not executed there.

To fix this issue, the offending code block is moved in the PR after the config from `ERL_INETRC` has been read.