### PR TITLE
ssh: Fix badmatch in ssh:daemon_replace_options/2

### DIFF
--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -682,9 +682,13 @@ chapters [Configuration in SSH](configurations.md) and
       NewUserOptions :: daemon_options().
 
 daemon_replace_options(DaemonRef, NewUserOptions) ->
-    {ok,Os0} = ssh_system_sup:get_acceptor_options(DaemonRef),
-    Os1 = ssh_options:merge_options(server, NewUserOptions, Os0),
-    ssh_system_sup:replace_acceptor_options(DaemonRef, Os1).
+    case ssh_system_sup:get_acceptor_options(DaemonRef) of
+        {ok, Os0} ->
+            Os1 = ssh_options:merge_options(server, NewUserOptions, Os0),
+            ssh_system_sup:replace_acceptor_options(DaemonRef, Os1);
+        {error, _Reason} = Error ->
+            Error
+    end.
 
 %%--------------------------------------------------------------------
 -doc """

--- a/lib/ssh/src/ssh_system_sup.erl
+++ b/lib/ssh/src/ssh_system_sup.erl
@@ -160,8 +160,8 @@ get_acceptor_options(SysPid) ->
     case get_daemon_listen_address(SysPid) of
         {ok,Address} ->
             get_options(SysPid, Address);
-        {error,Error} ->
-            {error,Error}
+        {error,not_found} ->
+            {error,bad_daemon_ref}
     end.
 
 replace_acceptor_options(SysPid, NewOpts) ->

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -88,7 +88,8 @@
          daemon_replace_options_simple/1,
          daemon_replace_options_algs/1,
          daemon_replace_options_algs_connect/1,
-         daemon_replace_options_algs_conf_file/1
+         daemon_replace_options_algs_conf_file/1,
+         daemon_replace_options_not_found/1
 	]).
 
 %%% Common test callbacks
@@ -159,6 +160,7 @@ all() ->
      daemon_replace_options_algs,
      daemon_replace_options_algs_connect,
      daemon_replace_options_algs_conf_file,
+     daemon_replace_options_not_found,
      {group, hardening_tests}
     ].
 
@@ -2031,6 +2033,14 @@ daemon_replace_options_algs_conf_file(Config) ->
         [] ->
             {skip, "No non-default kex"}
     end.
+
+%%--------------------------------------------------------------------
+daemon_replace_options_not_found(_Config) ->
+    %% when the daemon doesn't exist the error should be the same
+    %% in daemon_info and daemon_replace_options
+    %% which is {error, bad_daemon_ref}
+    Error = ssh:daemon_info(self()),
+    Error = ssh:daemon_replace_options(self(), []).
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------


### PR DESCRIPTION
Return error instead of having a badmatch inside the function implementation.

Fixes #9544