### PR TITLE
Fix whitespace in NIF tutorial for syntax highlighting

### DIFF
--- a/system/doc/tutorial/nif.md
+++ b/system/doc/tutorial/nif.md
@@ -102,7 +102,7 @@ static ERL_NIF_TERM foo_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     int x, ret;
     if (!enif_get_int(env, argv[0], &x)) {
-	return enif_make_badarg(env);
+        return enif_make_badarg(env);
     }
     ret = foo(x);
     return enif_make_int(env, ret);
@@ -112,7 +112,7 @@ static ERL_NIF_TERM bar_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     int y, ret;
     if (!enif_get_int(env, argv[0], &y)) {
-	return enif_make_badarg(env);
+        return enif_make_badarg(env);
     }
     ret = bar(y);
     return enif_make_int(env, ret);


### PR DESCRIPTION
Previously, a tab character was used, which doesn't syntax highlight correctly in hexdocs. This has been changed to use spaces instead.

Before:
![nif-before](https://github.com/user-attachments/assets/b97dcee5-4499-4f20-a773-17dddc653b93)

After:
![nif-after](https://github.com/user-attachments/assets/73953877-f5e6-4fe7-8a26-c5dcd2258522)
