### PR TITLE
Handle TLS 1.3 closure alerts consistently

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -1927,6 +1927,12 @@ log_alert(Level, Role, ProtocolName, StateName, #alert{role = Role} = Alert) ->
                                     statename => StateName,
                                     alert => Alert,
                                     alerter => own}, Alert#alert.where);
+log_alert(Level, Role, ProtocolName, StateName, #alert{description = ?USER_CANCELED} = Alert) ->
+    ssl_logger:log(info, Level, #{protocol => ProtocolName,
+                                  role => Role,
+                                  statename => StateName,
+                                  alert => Alert,
+                                  alerter => peer}, Alert#alert.where);
 log_alert(Level, Role, ProtocolName, StateName,  Alert) ->
     ssl_logger:log(notice, Level, #{protocol => ProtocolName,
                                     role => Role,

--- a/lib/ssl/src/tls_record_1_3.erl
+++ b/lib/ssl/src/tls_record_1_3.erl
@@ -157,15 +157,17 @@ decode_cipher_text(#ssl_tls{type = ?ALERT,
     {#ssl_tls{type = ?ALERT,
               version = ?TLS_1_3, %% Internally use real version
               fragment = <<?FATAL,?ILLEGAL_PARAMETER>>}, ConnectionStates0};
-%% TLS 1.3 server can receive a User Cancelled Alert when handshake is
-%% paused and then cancelled on the client side.
+%% TLS 1.3 server can receive Closure Alerts before the handshake is completed
 decode_cipher_text(#ssl_tls{type = ?ALERT,
                             version = ?LEGACY_VERSION,
-                            fragment = <<?FATAL,?USER_CANCELED>>},
-		   ConnectionStates0) ->
+                            fragment = <<_Level,ClosureAlert>>},
+                   #{current_read :=
+                         #{security_parameters :=
+                               #security_parameters{application_traffic_secret = undefined}}} = ConnectionStates0)
+  when (ClosureAlert == ?USER_CANCELED orelse ClosureAlert == ?CLOSE_NOTIFY) ->
     {#ssl_tls{type = ?ALERT,
               version = ?TLS_1_3, %% Internally use real version
-              fragment = <<?FATAL,?USER_CANCELED>>}, ConnectionStates0};
+              fragment = <<?FATAL,ClosureAlert>>}, ConnectionStates0};
 %% RFC8446 - TLS 1.3
 %% D.4.  Middlebox Compatibility Mode
 %%    -  If not offering early data, the client sends a dummy


### PR DESCRIPTION
RFC 8446 section 6.2 states a pre-connection user_canceled alert should be followed by a close_notify alert. In these states, these alerts may be sent in the clear.

This PR fixes the handling of both alerts by:

1. Ignoring the alert level which is unused in TLS 1.3
2. Returning close_notify alert as well as user_canceled

This PR also lowers the logging level of the user_canceled alert since this is a perfectly valid client action which should not spam the server log.