### PR TITLE
WiP: Add doctest exception testing

### DIFF
--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -33,6 +33,7 @@
 -export([default_multiline_prompt/1, inverted_space_prompt/1]).
 -export([prompt_width/1, prompt_width/2]).
 -export([help/0,whereis/0]).
+-export([report_exception/3, report_exception/4]).
 
 -define(LINEMAX, 30).
 -define(CHAR_MAX, 60).


### PR DESCRIPTION
Intent is to achieve possible future feature mentioned over in PR #9430 comment from [garazdawi](https://github.com/erlang/otp/pull/9430#issuecomment-2710238651), were we can test for expected error states;

> For `should_panic`, I think Elixir has gone the route of matching on an exception in the printout. That is:
>
> ```
> 1> 1 + a.
> ** exception error: an error occurred when evaluating an arithmetic expression
>      in operator  +/2
>         called as 1 + a
> ```

Near as I can tell this'll require _some_ rewrite of `shell:report_exception/4`, and current consumers, in order to make matching formatted errors in `doctest` against formatted errors that are expected.

If there is an easier way of going about this, then please do _@_ me as I'd like to add this feature with the least amount _opportunities_ for breaking to what already works well x-)