### PR TITLE
kernel: Fix CNAME loop detection

### DIFF
--- a/lib/kernel/src/inet_db.erl
+++ b/lib/kernel/src/inet_db.erl
@@ -761,7 +761,7 @@ resolve_cnames(Domain, Type, LookupFun, LcDomain, Aliases, LcAliases) ->
                             %% Repeat with the (more) canonical domain name
                             resolve_cnames(
                               CName, Type, LookupFun, LcCname,
-                              [Domain | Aliases], [LcDomain, LcAliases])
+                              [Domain | Aliases], [LcDomain | LcAliases])
                     end;
                 [_ | _] = _CNames ->
                     ?dbg("resolve_cnames duplicate cnames=~p~n", [_CNames]),

--- a/lib/kernel/test/inet_SUITE.erl
+++ b/lib/kernel/test/inet_SUITE.erl
@@ -1214,6 +1214,14 @@ cname_loop(Config) when is_list(Config) ->
     ok = inet_db:add_rr("mydomain.com", in, ?S_CNAME, ttl, "mydomain.com"),
     {error,nxdomain} = inet_db:getbyname("mydomain.com", ?S_A),
     ok = inet_db:del_rr("mydomain.com", in, ?S_CNAME, "mydomain.com"),
+    %% deep loop
+    ok = inet_db:add_rr("rtest1.example.com", in, ?S_CNAME, ttl, "rtest2.example.com"),
+    ok = inet_db:add_rr("rtest2.example.com", in, ?S_CNAME, ttl, "rtest3.example.com"),
+    ok = inet_db:add_rr("rtest3.example.com", in, ?S_CNAME, ttl, "rtest1.example.com"),
+    {error,nxdomain} = inet_db:getbyname("rtest1.example.com", ?S_A),
+    ok = inet_db:del_rr("rtest1.example.com", in, ?S_CNAME, "rtest2.example.com"),
+    ok = inet_db:del_rr("rtest2.example.com", in, ?S_CNAME, "rtest3.example.com"),
+    ok = inet_db:del_rr("rtest3.example.com", in, ?S_CNAME, "rtest1.example.com"),
     %% res_hostent_by_domain
     RR = #dns_rr{domain = "mydomain.com",
 		 class = in,
@@ -2709,4 +2717,3 @@ pi(Item) ->
     {Item, Val} = process_info(self(), Item),
     Val.
     
-


### PR DESCRIPTION
Fixes a bug in CNAME loop detection. This bug can be exploited and leads to OOM.