### PR TITLE
[dbg] make simple tracer() remsh-friendly

### DIFF
--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -2382,8 +2382,10 @@ dhandler_default_out() ->
     %% When user (human) sets up dbg over remsh, group_leader is on other node.
     %% In this case, pass printed info to the remote group_leader
     %% so the user (human) can see what's happening
-    {_Key, Ancestors} = process_info(self(), {dictionary, '$ancestors'}),
-    IsShell = (shell:whereis() == hd(Ancestors)),
+    IsShell = case process_info(self(), {dictionary, '$ancestors'}) of
+        {_Key, [Shell | _]} -> (shell:whereis() == Shell);
+        _ -> false
+    end,
     case IsShell andalso (node(group_leader()) /= node()) of
         true ->
             % This is an interactive shell AND group_leader is remote

--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -1228,7 +1228,7 @@ To start a similar tracer on a remote node, use `n/1`.
 """.
 -spec tracer() -> {ok, pid()} | {error, already_started}.
 tracer() ->
-    tracer(process, {fun dhandler/2,user}).
+    tracer(process, {fun dhandler/2, dhandler_default_out()}).
 
 -doc """
 tracer(Type, Data)
@@ -1675,13 +1675,13 @@ The pids will vary.
       Filename :: file:name_all(),
       WrapFilesSpec :: trace_wrap_files_spec().
 trace_client(file, Filename) ->
-    trace_client(file, Filename, {fun dhandler/2,user});
+    trace_client(file, Filename, {fun dhandler/2, dhandler_default_out()});
 trace_client(follow_file, Filename) ->
-    trace_client(follow_file, Filename, {fun dhandler/2,user});
+    trace_client(follow_file, Filename, {fun dhandler/2, dhandler_default_out()});
 trace_client(ip, Portno) when is_integer(Portno) ->
-    trace_client1(ip, {"localhost", Portno}, {fun dhandler/2,user});
+    trace_client1(ip, {"localhost", Portno}, {fun dhandler/2, dhandler_default_out()});
 trace_client(ip, {Host, Portno}) when is_integer(Portno) ->
-    trace_client1(ip, {Host, Portno}, {fun dhandler/2,user}).
+    trace_client1(ip, {Host, Portno}, {fun dhandler/2, dhandler_default_out()}).
 
 -type handler_spec() :: {HandlerFun :: fun((Event :: term(), Data :: term()) -> NewData :: term()),
                          InitialData :: term()}.
@@ -2375,6 +2375,23 @@ do_relay_1(RelP, Session) ->
             Modifier = modifier(user),
 	    io:format(user,"** relay got garbage: ~"++Modifier++"p~n", [Other]),
 	    do_relay_1(RelP, Session)
+    end.
+
+-doc false.
+dhandler_default_out() ->
+    %% When user (human) sets up dbg over remsh, group_leader is on other node.
+    %% In this case, pass printed info to the remote group_leader
+    %% so the user (human) can see what's happening
+    {_Key, Ancestors} = process_info(self(), {dictionary, '$ancestors'}),
+    IsShell = (shell:whereis() == hd(Ancestors)),
+    case IsShell andalso (node(group_leader()) /= node()) of
+        true ->
+            % This is an interactive shell AND group_leader is remote
+            % Assume this is remsh and use the remote group_leader
+            group_leader();
+        false ->
+            % On the same node or when not a shell use 'user' (process) as default output
+            user
     end.
 
 -doc false.


### PR DESCRIPTION
### The problem
Consider following `dbg` getting started guide https://www.erlang.org/doc/apps/runtime_tools/dbg.html  
```erlang
1> dbg:tracer().  % Start the default trace message receiver
```

If performed over remsh (e.g. when debugging a production node), default tracer prints all its messages to `user` process on the main node. This leads to no data printed to the shell which started the tracer, making dbg unusable for novice remsh users.  

### Solution

In this PR I make default tracer aware of remsh, and when remsh is detected, the output is sent to remote group_leader.  
For local calls behaviour stays as before -- default output is `user` process.