### PR TITLE
[scheduler] Various optimizations to task stealing

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -6818,8 +6818,7 @@ schedule_out_process(ErtsRunQueue *c_rq, erts_aint32_t *statep, Process *p,
 
 static ERTS_INLINE void
 add2runq(int enqueue, erts_aint32_t prio,
-	 Process *proc, erts_aint32_t state,
-	 Process **proxy)
+	 Process *proc, erts_aint32_t state)
 {
     ErtsRunQueue *runq;
 
@@ -6831,12 +6830,7 @@ add2runq(int enqueue, erts_aint32_t prio,
 	if (enqueue < 0) { /* use proxy */
 	    Process *pxy;
 
-	    if (!proxy)
-		pxy = NULL;
-	    else {
-		pxy = *proxy;
-		*proxy = NULL;
-	    }
+	    pxy = NULL;
 	    sched_p = make_proxy_proc(pxy, proc, prio);
 	}
 
@@ -6971,7 +6965,7 @@ schedule_process(Process *p, erts_aint32_t in_state, ErtsProcLocks locks)
 					     &state,
 					     &enq_prio,
 					     locks);
-    add2runq(enqueue, enq_prio, p, state, NULL);
+    add2runq(enqueue, enq_prio, p, state);
 }
 
 void
@@ -7104,7 +7098,7 @@ active_sys_enqueue(Process *p, ErtsProcSysTask *sys_task,
     }
 
     if (!already_scheduled) {
-        add2runq(enqueue, enq_prio, p, n, NULL);
+        add2runq(enqueue, enq_prio, p, n);
     }
 
 cleanup:
@@ -7280,7 +7274,7 @@ resume_process(Process *p, ErtsProcLocks locks)
 					 &state,
 					 &enq_prio,
 					 locks);
-    add2runq(enqueue, enq_prio, p, state, NULL);
+    add2runq(enqueue, enq_prio, p, state);
 }
 
 
@@ -13497,7 +13491,7 @@ erts_set_self_exiting(Process *c_p, Eterm reason)
 
     erts_proc_unlock(c_p, ERTS_PROC_LOCKS_ALL_MINOR);
     if (enqueue)
-        add2runq(enqueue, enq_prio, c_p, state, NULL);
+        add2runq(enqueue, enq_prio, c_p, state);
 }
 
 static int

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -163,16 +163,14 @@ extern int erts_dio_sched_thread_suggested_stack_size;
   (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 4))
 #define ERTS_RUNQ_FLG_NONEMPTY \
   (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 5))
-#define ERTS_RUNQ_FLG_PROTECTED \
-  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 6))
 #define ERTS_RUNQ_FLG_EXEC \
-  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 7))
+  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 6))
 #define ERTS_RUNQ_FLG_MSB_EXEC \
-  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 8))
+  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 7))
 #define ERTS_RUNQ_FLG_MISC_OP \
-  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 9))
+  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 8))
 #define ERTS_RUNQ_FLG_HALTING \
-  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 10))
+  (((Uint32) 1) << (ERTS_RUNQ_FLG_BASE2 + 9))
 
 #define ERTS_RUNQ_FLG_MAX (ERTS_RUNQ_FLG_BASE2 + 12)
 


### PR DESCRIPTION
Profiling some services on many-core machines showed very high lock contention in the scheduler, specifically in the task-stealing mechanism.
This PR has a bunch of commits that both shrink the related critical sections, and reduce contention on these locks.

Testing:
- make emulator_test ARGS="-suite process_SUITE"
- tested in production on a many-core server, it showed very large improvements at low to medium load (on the order of 30% vs 40% cpu utilization), and tiny but measurable improvements at high load (about 1-2% cpu utilization). Lock-counting confirmed a fall in the contention of the runqueue locks.