### PR TITLE
Fix crash in initial_call

### DIFF
--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -902,6 +902,8 @@ raw_initial_call(ProcInfo) when is_list(ProcInfo) ->
     case lists:keyfind({dictionary, '$initial_call'}, 1, ProcInfo) of
         {{dictionary,_}, {_,_,_}=MFA} ->
             MFA;
+        {{dictionary,_}, _} ->
+            false;
         false ->
             case lists:keyfind(dictionary, 1, ProcInfo) of
                 {dictionary,Dict} ->

--- a/lib/stdlib/test/proc_lib_SUITE.erl
+++ b/lib/stdlib/test/proc_lib_SUITE.erl
@@ -383,6 +383,20 @@ spawn_opt(Config) when is_list(Config) ->
     FunMFArgs = proc_lib:initial_call(Pid1),
     FunMFArity = proc_lib:translate_initial_call(Pid1),
     Pid1 ! die,
+
+    %% Check modified initial_call
+
+    Pid2 = proc_lib:spawn_opt(fun() ->
+                                      put('$initial_call', undefined),
+                                      receive _ -> ok end
+                              end, [link]),
+    false = proc_lib:initial_call(Pid2),
+    {proc_lib, init_p, 5} = proc_lib:translate_initial_call(Pid2),
+    Dict2 = process_info(Pid2, [{dictionary, '$initial_call'}]),
+    false = proc_lib:initial_call(Dict2),
+    {proc_lib, init_p, 5} = proc_lib:translate_initial_call(Dict2),
+
+    Pid2 ! die,
     ok.
 
 


### PR DESCRIPTION
If user set the initial_call to undefined or something else, the shells process list function 'i()' crashed.