### PR TITLE
stdlib: update broken link in docs for sys:get_status/2

### DIFF
--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -315,7 +315,7 @@ The value of `Misc` varies for different types of processes, for example:
 - A `m:gen_event` process returns information about each of its registered
   handlers.
 - A bare `m:sys` process returns the value passed as `Misc` to
-  `handle_system_message/6`.
+  `handle_system_msg/6`.
 
 Callback modules for `m:gen_server`, `m:gen_statem`, and `m:gen_event` can also change
 the value of `Misc` by exporting a function `format_status/1`, which contributes


### PR DESCRIPTION
Link was `handle_system_message/6` and should be `handle_system_msg/6`