### PR TITLE
Extending static NIF configure options

### DIFF
--- a/erts/doc/references/erl_nif.md
+++ b/erts/doc/references/erl_nif.md
@@ -513,6 +513,14 @@ calling NIF API functions. Functions exist for the following functionality:
   instead used, then the name of the archive file must match the name of the
   module.
 
+  Multiple static NIF libraries can be included in a single archive file by
+  specifying the respective `STATIC_ERLANG_NIF_LIBNAME` values in the configure
+  call separated by colons after the archive file name:
+
+  ```sh
+  ./confgure --enable-static-nifs=/path/to/archive.a:nif_lib1:nif_lib2
+  ```
+
 - __`int (*load)(ErlNifEnv* caller_env, void** priv_data, ERL_NIF_TERM load_info)`__ - 
   `load`{: #load } is called when the NIF library is loaded and no previously
   loaded library exists for this module.

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -209,6 +209,7 @@ LIBS += $(TYPE_LIBS)
 ORIG_LIBS:= $(LIBS)
 
 comma:=,
+colon:=:
 empty:=
 space:=$(empty) $(empty)
 
@@ -662,7 +663,7 @@ GENERATE += $(TARGET)/erl_version.h
 
 # driver table
 $(TTF_DIR)/driver_tab.c: Makefile.in utils/make_driver_tab
-	$(gen_verbose)LANG=C $(PERL) utils/make_driver_tab -o $@ -nifs $(NIF_OBJS) $(STATIC_NIF_LIBS) -drivers $(DRV_OBJS) $(STATIC_DRIVER_LIBS)
+	$(gen_verbose)LANG=C $(PERL) utils/make_driver_tab -o $@ -nifs $(NIF_OBJS) $(STATIC_NIF_SYMBOLS) -drivers $(DRV_OBJS) $(STATIC_DRIVER_LIBS)
 GENERATE += $(TTF_DIR)/driver_tab.c
 
 
@@ -1204,11 +1205,12 @@ DRV_OBJS = \
 endif
 
 ifneq ($(STATIC_NIFS),no)
-STATIC_NIF_LIBS = $(STATIC_NIFS)
+STATIC_NIF_LIBS = $(foreach n,$(STATIC_NIFS),$(word 1, $(subst $(colon),$(space),$(n))))
+STATIC_NIF_SYMBOLS = $(STATIC_NIFS)
 DEPLIBS += $(STATIC_NIF_LIBS)
 COMPILE_STATIC_LIBS = yes
 else
-STATIC_NIF_LIBS=
+STATIC_NIF_SYMBOLS=
 endif
 
 ifneq ($(STATIC_DRIVERS),no)

--- a/erts/emulator/utils/make_driver_tab
+++ b/erts/emulator/utils/make_driver_tab
@@ -49,7 +49,21 @@ while (@ARGV) {
 	$mode = 1;
 	next;
     }
-    if ( $d =~ /^.*\.a$/ ) {
+    if ( $d =~ /^(.*\.a)(:[A-Za-z_][A-Za-z0-9_]*)+$/ ) {
+        # Only implemented for NIFs
+        if ($mode != 2) {
+            next;
+        }
+
+        my @nifs = split(/:/, $2);
+        shift(@nifs);
+
+        foreach my $nif_symbol ( @nifs ) {
+            push(@static_nifs, $nif_symbol)
+        }
+        next;
+    }
+    elsif ( $d =~ /\.a$/ ) {
 	$d = basename $d;
 	$d =~ s/\.a$//;	# strip .a
 	$d =~ s/\.gprof$//;	# strip .gprof


### PR DESCRIPTION
Extend the `--enable-static-nifs` `configure` option to allow two things

- Use a single `.a` archive for multiple NIF modules
- Specify the `<name_of_module>_nif_init` prefix directly instead of relying on the filename

Both of these simplify or enable usage of Rustler libraries in static builds (e.g. for usage on iOS):

- `cargo` makes it difficult to ensure that a `module.a` file is created while at the same time `module` is known at compile-time to generate the `module_nif_init` function
- Linking Rust's standard library into two `.a` archives and then linking these together into a single resulting binary is not supported

With this PR, two Rust libaries can be linked into a single static library (side-stepping the issue with the standard libary) and the symbol names can be chosen explicitly at compile time. If, e.g., `rust_mod1` and `rust_mod2` are linked into an archive `rust_mods.a`, they can be linked as static NIFs like this:

    ./configure --enable-static-nifs=$(realpath rust_mods.a):rust_mod1:rust_mod2

The relevant discussion is here: https://github.com/rusterlium/rustler/discussions/687