### PR TITLE
Add support to `erl` for `+JPperfdirectory <directory>`

### DIFF
--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -772,6 +772,10 @@ behavior of earlier flags.
   [perf support](BeamAsm.md#linux-perf-support) section in the BeamAsm internal
   documentation.
 
+- **`+JPperfdirectory <directory>`{: #+JPperfdirectory }** - Set the directory
+  used to store `perf` dump and map files when running with the JIT on Linux.
+  Defaults to `/tmp`.
+
 - **`+JMsingle true|false`{: #+JMsingle }** - Enables or disables the use of
   single-mapped RWX memory for JIT code.
 

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -594,6 +594,7 @@ __decl_noreturn void __noreturn  erts_usage(void)
     erts_fprintf(stderr, "-JDdump bool   enable or disable dumping of generated assembly code for each module loaded\n");
     erts_fprintf(stderr, "-JPcover true|false|line|line_counters|function|function_counters  enable or disable instrumentation for coverage\n");
     erts_fprintf(stderr, "-JPperf true|false|dump|map|fp|no_fp   enable or disable support for perf on Linux\n");
+    erts_fprintf(stderr, "-JPperfdirectory <directory>    set the directory perf files are stored. Default: /tmp\n");
     erts_fprintf(stderr, "-JMsingle bool enable the use of single-mapped RWX memory for JIT:ed code\n");
     erts_fprintf(stderr, "\n");
 #endif
@@ -1686,7 +1687,17 @@ erl_start(int argc, char **argv)
             case 'P':
                 sub_param++;
 
-                if (has_prefix("perf", sub_param)) {
+                if (has_prefix("perfdirectory", sub_param)){
+                    arg = get_arg(sub_param+13, argv[i + 1], &i);
+#ifdef HAVE_LINUX_PERF_SUPPORT
+                    sys_strncpy(etrs_jit_perf_directory, arg, sizeof(etrs_jit_perf_directory));
+                    etrs_jit_perf_directory[sizeof(etrs_jit_perf_directory) -1 ] = '\0';
+#else
+                    erts_fprintf(stderr, "+JPperfdirectory is not supported on this platform\n");
+                    erts_usage();
+#endif
+                }
+                else if (has_prefix("perf", sub_param)) {
                     arg = get_arg(sub_param+4, argv[i + 1], &i);
 
 #ifdef HAVE_LINUX_PERF_SUPPORT

--- a/erts/emulator/beam/jit/beam_asm.h
+++ b/erts/emulator/beam/jit/beam_asm.h
@@ -47,6 +47,7 @@ enum beamasm_perf_flags {
     BEAMASM_PERF_DISABLED = 0,
 };
 extern enum beamasm_perf_flags erts_jit_perf_support;
+extern char etrs_jit_perf_directory[MAXPATHLEN];
 #    endif
 extern int erts_jit_single_map;
 

--- a/erts/emulator/beam/jit/beam_jit_main.cpp
+++ b/erts/emulator/beam/jit/beam_jit_main.cpp
@@ -44,6 +44,7 @@ ErtsFrameLayout ERTS_WRITE_UNLIKELY(erts_frame_layout);
 /* Global configuration variables (under the `+J` prefix) */
 #ifdef HAVE_LINUX_PERF_SUPPORT
 enum beamasm_perf_flags erts_jit_perf_support;
+char etrs_jit_perf_directory[MAXPATHLEN] = "/tmp";
 #endif
 /* Force use of single-mapped RWX memory for JIT code */
 int erts_jit_single_map = 0;

--- a/erts/emulator/beam/jit/beam_jit_metadata.cpp
+++ b/erts/emulator/beam/jit/beam_jit_metadata.cpp
@@ -332,7 +332,11 @@ public:
 
         /* LLVM places this file in ~/.debug/jit/ maybe we should do that to? */
 
-        erts_snprintf(name, sizeof(name), "/tmp/jit-%d.dump", getpid());
+        erts_snprintf(name,
+                      sizeof(name),
+                      "%s/jit-%d.dump",
+                      etrs_jit_perf_directory,
+                      getpid());
 
         file = fopen(name, "w+");
 
@@ -473,7 +477,11 @@ public:
 
         if (erts_sys_explicit_host_getenv("ERL_SYM_MAP_FILE", name, &namesz) !=
             1) {
-            snprintf(name, sizeof(name), "/tmp/perf-%i.map", getpid());
+            erts_snprintf(name,
+                          sizeof(name),
+                          "%s/perf-%i.map",
+                          etrs_jit_perf_directory,
+                          getpid());
         }
         file = fopen(name, "w");
         if (!file) {


### PR DESCRIPTION
This adds support for a `+JPperfdirectory <directory>` cli arg which allows changing the location used for the `jit<pid>.dump` and `perf<pid>.map` files which prior to this always went into `/tmp`.

The motivation is so that a different mount from `/tmp` can be used.

Example usage:
```console
[ ~/otp/bin @issue/9500 ] $ mkdir /testdir
[ ~/otp/bin @issue/9500 ] $ ./erl -noinput -eval 'io:format("I am ~s~n", [os:getpid()]).' -s init stop +JPperf true +JPperfdirectory /testdir
I am 149279
[ ~/otp/bin @issue/9500 ] $ ls /testdir/
jit-149279.dump  perf-149279.map
```

Without it, they still go to `/tmp/`:
```console
[ ~/otp/bin @issue/9500 ] $ ./erl -noinput -eval 'io:format("I am ~s~n", [os:getpid()]).' -s init stop +JPperf true
I am 209905
[ ~/otp/bin @issue/9500 ] $ ls /tmp/*209905*
/tmp/jit-209905.dump  /tmp/perf-209905.map
```

`FILENAME_MAX` / `FILENAME_BUFSIZ` are used in a few places as 250 so matched those with `ETRS_JIT_PERF_DIR_SIZE`, although chose a more specific variable name since it leaks in the header.

Closes #9500.