### PR TITLE
Add the `debug_line_entry` instruction

### DIFF
--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -97,6 +97,7 @@ line I
 
 executable_line _Id _Line => _
 
+debug_line_entry u u u => _
 debug_line u u u => _
 
 # For the JIT, the init_yregs/1 instruction allows generation of better code.

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -3187,6 +3187,12 @@ void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
     }
 }
 
+void BeamModuleAssembler::emit_debug_line_entry(const ArgWord &Loc,
+                                                const ArgWord &Index,
+                                                const ArgWord &Live) {
+    emit_validate(Live);
+}
+
 void BeamModuleAssembler::emit_debug_line(const ArgWord &Loc,
                                           const ArgWord &Index,
                                           const ArgWord &Live) {

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -91,6 +91,7 @@ line I
 
 executable_line I I
 
+debug_line_entry I I t
 debug_line I I t
 
 allocate t t

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -706,6 +706,20 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
         }
         break;
     }
+    case op_debug_line_entry_IIt: {
+        BeamFile_DebugItem *items = stp->beam.debug.items;
+        Uint location_index = tmp_op->a[0].val;
+        Sint index = tmp_op->a[1].val - 1;
+
+        if (add_line_entry(stp, location_index, 1)) {
+            goto load_error;
+        }
+
+        ASSERT(items[index].location_index == -1);
+        items[index].location_index = stp->current_li - 1;
+
+        break;
+    }
     case op_debug_line_IIt: {
         BeamFile_DebugItem *items = stp->beam.debug.items;
         Uint location_index = tmp_op->a[0].val;

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -3335,6 +3335,12 @@ void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
     }
 }
 
+void BeamModuleAssembler::emit_debug_line_entry(const ArgWord &Loc,
+                                                const ArgWord &Index,
+                                                const ArgWord &Live) {
+    emit_validate(Live);
+}
+
 void BeamModuleAssembler::emit_debug_line(const ArgWord &Loc,
                                           const ArgWord &Index,
                                           const ArgWord &Live) {

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -91,6 +91,7 @@ line I
 
 executable_line I I
 
+debug_line_entry I I t
 debug_line I I t
 
 allocate t t

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -516,6 +516,10 @@ make_op({line=Op,Location}, Dict0) ->
 make_op({executable_line=Op,Location,Index}, Dict0) ->
     {LocationIndex,Dict} = beam_dict:line(Location, Dict0, Op),
     encode_op(executable_line, [LocationIndex,Index], Dict);
+make_op({debug_line_entry,Location,Index,Live,DebugInfo}, Dict0) ->
+    {LocationIndex,Dict1} = beam_dict:line(Location, Dict0, debug_line),
+    Dict = beam_dict:debug_info(Index, {entry,DebugInfo}, Dict1),
+    encode_op(debug_line_entry, [LocationIndex,Index,Live], Dict);
 make_op({debug_line=Op,Location,Index,Live,DebugInfo}, Dict0) ->
     {LocationIndex,Dict1} = beam_dict:line(Location, Dict0, Op),
     Dict = beam_dict:debug_info(Index, DebugInfo, Dict1),

--- a/lib/compiler/src/beam_dict.erl
+++ b/lib/compiler/src/beam_dict.erl
@@ -36,7 +36,7 @@
 
 -type index() :: non_neg_integer().
 
--type frame_size() :: 'none' | non_neg_integer().
+-type frame_size() :: 'none' | 'entry' | non_neg_integer().
 -type debug_info() :: {frame_size(), list()}.
 
 -type atom_tab()   :: #{atom() => index()}.

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1305,6 +1305,9 @@ resolve_inst({executable_line,[Location,Index]},_,_,_) ->
 
 resolve_inst({debug_line,[Location,Index,Live]},_,_,_) ->
     {debug_line,resolve_arg(Location),resolve_arg(Index),resolve_arg(Live)};
+resolve_inst({debug_line_entry,[Location,Index,Live]},_,_,_) ->
+    {debug_line_entry,resolve_arg(Location),resolve_arg(Index),
+     resolve_arg(Live)};
 
 %%
 %% Catches instructions that are not yet handled.

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -65,7 +65,7 @@ norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],{line,_}=Line}) -> Line;
 norm({set,[],[],{executable_line,_,_}=Line}) -> Line;
-norm({set,[],_,{debug_line,_,_,_,_}=Line}) -> Line;
+norm({set,[],_,{debug_line,_,_,_,_}=Line}) -> norm_debug_line(Line);
 norm({set,[D1,D2],[D1,D2],swap})   -> {swap,D1,D2}.
 
 norm_allocate({_Zero,nostack,Nh,[]}, Regs) ->
@@ -74,3 +74,8 @@ norm_allocate({nozero,Ns,0,Inits}, Regs) ->
     [{allocate,Ns,Regs}|Inits];
 norm_allocate({nozero,Ns,Nh,Inits}, Regs) ->
     [{allocate_heap,Ns,Nh,Regs}|Inits].
+
+norm_debug_line({debug_line,Loc,Index,Live,{entry,Args}}) ->
+    {debug_line_entry,Loc,Index,Live,Args};
+norm_debug_line({debug_line,_Loc,_Index,_Live,{_,_}}=Line) ->
+    Line.

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -377,6 +377,9 @@ vi({line,_}, Vst) ->
     Vst;
 vi({executable_line,_,Index}, Vst) when is_integer(Index) ->
     Vst;
+vi({debug_line_entry,_,Index,Live,Info}, Vst) when is_integer(Index),
+                                                   is_integer(Live) ->
+    validate_debug_line({entry,Info}, Live, Vst);
 vi({debug_line,_,Index,Live,Info}, Vst) when is_integer(Index),
                                              is_integer(Live) ->
     validate_debug_line(Info, Live, Vst);

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -701,3 +701,9 @@ BEAM_FORMAT_NUMBER=0
 ## @spec debug_line Location Index Live
 ## @doc  Provide location for a place where a break point can be placed.
 184: debug_line/3
+
+## @spec debug_line_entry Location Index Live
+## @doc  Provide location for a place where a break point can be placed.
+##       This instruction can optionally be used as the very first
+##       instruction in a function.
+185: debug_line_entry/3

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1744,8 +1744,8 @@ bc_options(Config) ->
 
          {183, small, [line_coverage]},
 
-         {184, small, [beam_debug_info]},
-         {184, big, [beam_debug_info]}
+         {185, small, [beam_debug_info]},
+         {185, big, [beam_debug_info]}
         ],
 
     Test = fun({Expected,Mod,Options}) ->


### PR DESCRIPTION
The `entry` form of the debug line was troublesome to handle in the loader. Make it into a special instruction.