### PR TITLE
Extend the `debug_line_entry` instruction

### DIFF
--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -97,7 +97,7 @@ line I
 
 executable_line _Id _Line => _
 
-debug_line u u u => _
+debug_line a u u u => _
 
 # For the JIT, the init_yregs/1 instruction allows generation of better code.
 # For the BEAM interpreter, though, it will probably be more efficient to

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -3187,7 +3187,8 @@ void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
     }
 }
 
-void BeamModuleAssembler::emit_debug_line(const ArgWord &Loc,
+void BeamModuleAssembler::emit_debug_line(const ArgAtom &Kind,
+                                          const ArgWord &Loc,
                                           const ArgWord &Index,
                                           const ArgWord &Live) {
     emit_validate(Live);

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -91,7 +91,8 @@ line I
 
 executable_line I I
 
-debug_line I I t
+debug_line a==am_entry u u u => _
+debug_line a I I t
 
 allocate t t
 allocate_heap t I t

--- a/erts/emulator/beam/jit/asm_load.c
+++ b/erts/emulator/beam/jit/asm_load.c
@@ -706,10 +706,10 @@ int beam_load_emit_op(LoaderState *stp, BeamOp *tmp_op) {
         }
         break;
     }
-    case op_debug_line_IIt: {
+    case op_debug_line_aIIt: {
         BeamFile_DebugItem *items = stp->beam.debug.items;
-        Uint location_index = tmp_op->a[0].val;
-        Sint index = tmp_op->a[1].val - 1;
+        Uint location_index = tmp_op->a[1].val;
+        Sint index = tmp_op->a[2].val - 1;
 
         if (add_line_entry(stp, location_index, 1)) {
             goto load_error;

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -3335,7 +3335,8 @@ void BeamModuleAssembler::emit_coverage(void *coverage, Uint index, Uint size) {
     }
 }
 
-void BeamModuleAssembler::emit_debug_line(const ArgWord &Loc,
+void BeamModuleAssembler::emit_debug_line(const ArgAtom &Kind,
+                                          const ArgWord &Loc,
                                           const ArgWord &Index,
                                           const ArgWord &Live) {
     emit_validate(Live);

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -91,7 +91,8 @@ line I
 
 executable_line I I
 
-debug_line I I t
+debug_line a==am_entry u u u => _
+debug_line a I I t
 
 allocate t t
 allocate_heap t I t

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -516,10 +516,10 @@ make_op({line=Op,Location}, Dict0) ->
 make_op({executable_line=Op,Location,Index}, Dict0) ->
     {LocationIndex,Dict} = beam_dict:line(Location, Dict0, Op),
     encode_op(executable_line, [LocationIndex,Index], Dict);
-make_op({debug_line=Op,Location,Index,Live,DebugInfo}, Dict0) ->
+make_op({debug_line=Op,Kind,Location,Index,Live,DebugInfo}, Dict0) ->
     {LocationIndex,Dict1} = beam_dict:line(Location, Dict0, Op),
     Dict = beam_dict:debug_info(Index, DebugInfo, Dict1),
-    encode_op(debug_line, [LocationIndex,Index,Live], Dict);
+    encode_op(debug_line, [Kind,LocationIndex,Index,Live], Dict);
 make_op({bif, Bif, {f,_}, [], Dest}, Dict) ->
     %% BIFs without arguments cannot fail.
     encode_op(bif0, [{extfunc, erlang, Bif, 0}, Dest], Dict);

--- a/lib/compiler/src/beam_dict.erl
+++ b/lib/compiler/src/beam_dict.erl
@@ -36,7 +36,7 @@
 
 -type index() :: non_neg_integer().
 
--type frame_size() :: 'none' | non_neg_integer().
+-type frame_size() :: 'none' | 'entry' | non_neg_integer().
 -type debug_info() :: {frame_size(), list()}.
 
 -type atom_tab()   :: #{atom() => index()}.

--- a/lib/compiler/src/beam_disasm.erl
+++ b/lib/compiler/src/beam_disasm.erl
@@ -1303,8 +1303,9 @@ resolve_inst({executable_line,[Location,Index]},_,_,_) ->
 %% OTP 28.
 %%
 
-resolve_inst({debug_line,[Location,Index,Live]},_,_,_) ->
-    {debug_line,resolve_arg(Location),resolve_arg(Index),resolve_arg(Live)};
+resolve_inst({debug_line,[Kind,Location,Index,Live]},_,_,_) ->
+    {debug_line,resolve_arg(Kind),resolve_arg(Location),
+     resolve_arg(Index),resolve_arg(Live)};
 
 %%
 %% Catches instructions that are not yet handled.

--- a/lib/compiler/src/beam_flatten.erl
+++ b/lib/compiler/src/beam_flatten.erl
@@ -65,7 +65,7 @@ norm({set,[D],[S|Puts],{alloc,R,{put_map,Op,F}}}) ->
 norm({set,[],[],remove_message})   -> remove_message;
 norm({set,[],[],{line,_}=Line}) -> Line;
 norm({set,[],[],{executable_line,_,_}=Line}) -> Line;
-norm({set,[],_,{debug_line,_,_,_,_}=Line}) -> Line;
+norm({set,[],_,{debug_line,_,_,_,_}=Line}) -> norm_debug_line(Line);
 norm({set,[D1,D2],[D1,D2],swap})   -> {swap,D1,D2}.
 
 norm_allocate({_Zero,nostack,Nh,[]}, Regs) ->
@@ -74,3 +74,11 @@ norm_allocate({nozero,Ns,0,Inits}, Regs) ->
     [{allocate,Ns,Regs}|Inits];
 norm_allocate({nozero,Ns,Nh,Inits}, Regs) ->
     [{allocate_heap,Ns,Nh,Regs}|Inits].
+
+norm_debug_line({debug_line,Location,Index,Live,Info}) ->
+    Kind = case Info of
+               {entry,_} -> entry;
+               {_,_} -> line
+           end,
+    {debug_line,{atom,Kind},Location,Index,Live,Info}.
+

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -380,6 +380,9 @@ vi({executable_line,_,Index}, Vst) when is_integer(Index) ->
 vi({debug_line,_,Index,Live,Info}, Vst) when is_integer(Index),
                                              is_integer(Live) ->
     validate_debug_line(Info, Live, Vst);
+vi({debug_line,_,_,Index,Live,Info}, Vst) when is_integer(Index),
+                                               is_integer(Live) ->
+    validate_debug_line(Info, Live, Vst);
 vi(nif_start, Vst) ->
     Vst;
 %%

--- a/lib/compiler/src/genop.tab
+++ b/lib/compiler/src/genop.tab
@@ -698,6 +698,10 @@ BEAM_FORMAT_NUMBER=0
 
 # OTP 28
 
-## @spec debug_line Location Index Live
+## @spec debug_line Kind Location Index Live
 ## @doc  Provide location for a place where a break point can be placed.
-184: debug_line/3
+##       Kind can be one of:
+##
+##       * {atom,entry}       - Function entry.
+##       * {atom,line}        - Any other line in the function.
+184: debug_line/4


### PR DESCRIPTION
The `entry` form of the debug line was troublesome to handle in the loader. Include an atom in the instruction to indicate whether it is an entry or plain debug_line.