### PR TITLE
Allow user-defined sigils via parse transforms

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -604,7 +604,8 @@ format_error_1({bad_dialyzer_option,Term}) ->
     {~"unknown dialyzer warning option: ~tw", [Term]};
 %% --- obsolete? unused? ---
 format_error_1({format_error, {Fmt, Args}}) ->
-    {Fmt, Args}.
+    {Fmt, Args};
+format_error_1(invalid_sigil) -> ~"invalid sigil".
 
 gen_type_paren(Arity) when is_integer(Arity), Arity >= 0 ->
     gen_type_paren_1(Arity, ")").
@@ -2899,7 +2900,9 @@ expr({remote,_Anno,M,_F}, _Vt, St) ->
 expr({executable_line,_,_}, _Vt, St) ->
     {[], St};
 expr({ssa_check_when,_Anno,_WantedResult,_Args,_Tag,_Exprs}, _Vt, St) ->
-    {[], St}.
+    {[], St};
+expr({sigil,Anno,_Type,_String,_Suffix}, _Vt, St) ->
+    {[], add_error(Anno, invalid_sigil, St)}.
 
 %% Check a call to function without a module name. This can be a call
 %% to a BIF or a local function.

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -1700,16 +1700,20 @@ build_sigil(SigilPrefix, String, SigilSuffix) ->
                       element(2, SigilSuffix),
                       "illegal sigil suffix")
             end;
-%%%         Type =:= 'r' -> % Regular expression
+        Type =:= 'r';
+        Type =:= 'R';
+        Type =:= 're' -> % Regular expression (make it reserved)
 %%%             %% Convert to {re,RE,Flags}
 %%%             {tuple, ?anno(SigilPrefix),
 %%%              [{atom,?anno(SigilPrefix),'re'},
 %%%               String,
 %%%               {string,?anno(SigilSuffix),Suffix}]};
-        true ->
             ret_err(
               element(2, SigilPrefix),
-              "illegal sigil prefix")
+              "illegal sigil prefix");
+        true ->
+            %% Custom sigils
+            {sigil, ?anno(SigilPrefix), Type, String, Suffix}
     end.
 
 -spec ret_err(_, _) -> no_return().

--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -660,6 +660,7 @@ type(Node) ->
 	{remote, _, _, _} -> module_qualifier;
 	{'try', _, _, _, _, _} -> try_expr;
 	{tuple, _, _} -> tuple;
+	{sigil, _, _, _, _} -> sigil;
 
         %% Type types
         {ann_type, _, _} -> annotated_type;
@@ -8014,7 +8015,9 @@ subtrees(T) ->
                     [[user_type_application_name(T)],
                      user_type_application_arguments(T)];
 		zip_generator ->
-		    [zip_generator_body(T)]
+		    [zip_generator_body(T)];
+                sigil ->
+                    []
 	    end
     end.
 


### PR DESCRIPTION
This is a POC of custom sigils implementation for Erlang/OTP.

It is based on [this comment](https://erlangforums.com/t/proposal-introduce-f-sigils-for-string-interpolation/4551/21?u=williamthome) on the Erlang Forums.

This is a minimal change and does not break any existing code.

## How it works

The developer can use the built-in sigils, like `s`, `S`, `b`, and `B`, but it can also use any sigil it wants. However, it is obligated to handle the custom sigil with parse transform, otherwise, an `invalid sigil` exception will be raised at the compile time.

### Why parse transform?

It was the first idea and seems to be the simplest one to implement this feature.

## Examples

> [!IMPORTANT]
>
> Please refer to the [example project](https://github.com/williamthome/custom_sigils) for the complete code.

```erlang
1> c(json_sigil), c(sql_sigil), c(example).
{ok,example}
2> example:json().
#{<<"key">> => <<"value">>}
3> example:sql(~"Bob", 18).
{sql,<<"SELECT *\n  FROM users\n WHERE name = $1\n   AND age >= $2">>,
     [<<"Bob">>,18]}
4> ~invalid"".
* 1:1: invalid sigil
```

## Notes

I have no idea what the core team has planned for sigils.
This PR is just to initiate a discussion about the future of sigils :)

> I'll continue the discussion on the same [thread of the Erlang Forums](https://erlangforums.com/t/proposal-introduce-f-sigils-for-string-interpolation/4551?u=williamthome) of the `f` sigil proposal (#9512).