### PR TITLE
Use `tprof` `session` name in `trace:session_create`

### DIFF
--- a/lib/tools/src/tprof.erl
+++ b/lib/tools/src/tprof.erl
@@ -941,7 +941,7 @@ profile(Module, Function, Args, Options) when is_atom(Module), is_atom(Function)
 init(Config) ->
     Type = maps:get(type, Config, call_count),
     false = erlang:process_flag(trap_exit, true), %% need this for reliable terminate/2 call
-    Session = trace:session_create(maps:get(session_name, Config, ?MODULE), self(), []),
+    Session = trace:session_create(maps:get(session, Config, ?MODULE), self(), []),
     {ok, #tprof_state{session = Session, type = Type}}.
 
 -doc false.

--- a/lib/tools/test/tprof_SUITE.erl
+++ b/lib/tools/test/tprof_SUITE.erl
@@ -319,15 +319,15 @@ separate_sessions(Config) when is_list(Config) ->
     lists:reverse([1, 2, 3, 4, 5]),
     lists:map(fun(X) -> X * 2 end, [1, 2, 3, 4, 5]),
 
-    Profile1 = tprof:collect(Srv1),
-    Profile2 = tprof:collect(Srv2),
-    ProcInspected1 = tprof:inspect(Profile1),
-    ProcInspected2 = tprof:inspect(Profile2),
+    {call_memory, Profile1} = tprof:collect(Srv1),
+    {call_memory, Profile2} = tprof:collect(Srv2),
 
     tprof:stop(Srv1),
     tprof:stop(Srv2),
 
-    ?assertNotEqual(ProcInspected1, ProcInspected2).    
+    ?assertNotEqual(Profile1, Profile2),
+    ?assert(lists:all(fun({lists, reverse, 1, _}) -> true; (_) -> false end, Profile1)),
+    ?assert(lists:all(fun({lists, map, 2, _}) -> true; (_) -> false end, Profile2)).
 
 live_trace() ->
     [{doc, "Tests memory tracing for pre-existing processes"}].

--- a/lib/tools/test/tprof_SUITE.erl
+++ b/lib/tools/test/tprof_SUITE.erl
@@ -307,12 +307,12 @@ separate_sessions() ->
 
 separate_sessions(Config) when is_list(Config) ->
     %% Trace lists:reverse/1
-    {ok, Srv1} = tprof:start_link(#{session => tprof_SUEITE_separate_sessions_1, type => call_memory}),
+    {ok, Srv1} = tprof:start_link(#{session => tprof_SUITE_separate_sessions_1, type => call_memory}),
     tprof:set_pattern(Srv1, lists, reverse, 1),
     tprof:enable_trace(Srv1, self(), #{}),
 
     %% Trace lists:map/2
-    {ok, Srv2} = tprof:start_link(#{session => tprof_SUEITE_separate_sessions_2, type => call_memory}),
+    {ok, Srv2} = tprof:start_link(#{session => tprof_SUITE_separate_sessions_2, type => call_memory}),
     tprof:set_pattern(Srv2, lists, map, 2),
     tprof:enable_trace(Srv2, self(), #{}),
 

--- a/lib/tools/test/tprof_SUITE.erl
+++ b/lib/tools/test/tprof_SUITE.erl
@@ -307,12 +307,12 @@ separate_sessions() ->
 
 separate_sessions(Config) when is_list(Config) ->
     %% Trace lists:reverse/1
-    {ok, Srv1} = tprof:start_link(#{session => session1, type => call_memory}),
+    {ok, Srv1} = tprof:start_link(#{session => tprof_SUEITE_separate_sessions_1, type => call_memory}),
     tprof:set_pattern(Srv1, lists, reverse, 1),
     tprof:enable_trace(Srv1, self(), #{}),
 
     %% Trace lists:map/2
-    {ok, Srv2} = tprof:start_link(#{session => session2, type => call_memory}),
+    {ok, Srv2} = tprof:start_link(#{session => tprof_SUEITE_separate_sessions_2, type => call_memory}),
     tprof:set_pattern(Srv2, lists, map, 2),
     tprof:enable_trace(Srv2, self(), #{}),
 
@@ -324,7 +324,10 @@ separate_sessions(Config) when is_list(Config) ->
     ProcInspected1 = tprof:inspect(Profile1),
     ProcInspected2 = tprof:inspect(Profile2),
 
-    ?assertNotEqual(ProcInspected1, ProcInspected2).
+    tprof:stop(Srv1),
+    tprof:stop(Srv2),
+
+    ?assertNotEqual(ProcInspected1, ProcInspected2).    
 
 live_trace() ->
     [{doc, "Tests memory tracing for pre-existing processes"}].


### PR DESCRIPTION
👋 

`session_name` doesn't seem to be documented anywhere and without knowing about it it's not possible to create multiple trace sessions through `tprof`. Could it be that `session` was meant to be used?

---

(I haven't run tests, I'm still figuring out how to do it!)