### PR TITLE
Is EngineID known

### DIFF
--- a/lib/snmp/src/manager/snmpm.erl
+++ b/lib/snmp/src/manager/snmpm.erl
@@ -1,7 +1,7 @@
 %% 
 %% %CopyrightBegin%
 %% 
-%% Copyright Ericsson AB 2004-2024. All Rights Reserved.
+%% Copyright Ericsson AB 2004-2025. All Rights Reserved.
 %% 
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ The module `snmpm` contains interface functions to the SNMP manager.
 
 	 register_agent/2, register_agent/3, register_agent/4, 
 	 unregister_agent/2, unregister_agent/3,
-	 which_agents/0, which_agents/1, 
+	 which_agents/0, which_agents/1, which_agents/2,
 	 agent_info/2, update_agent_info/3, update_agent_info/4, 
 	 
 	 register_usm_user/3, unregister_usm_user/2, 
@@ -947,6 +947,20 @@ Get a list of all registered agents or all agents registered by a specific user.
 
 which_agents(UserId) ->
     snmpm_config:which_agents(UserId).
+
+
+-doc false.
+-spec which_agents(Key, Id) -> Agents when
+      Key    :: user_id,
+      Id     :: user_id(),
+      Agents :: [target_name()];
+                  (Key, Id) -> Agents when
+      Key    :: engine_id,
+      Id     :: snmp:engine_id(),
+      Agents :: [target_name()].      
+      
+which_agents(Key, Id) ->
+    snmpm_config:which_agents(Key, Id).
 
 
 %% -- USM users --

--- a/lib/snmp/src/manager/snmpm_config.erl
+++ b/lib/snmp/src/manager/snmpm_config.erl
@@ -1,7 +1,7 @@
 %% 
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2004-2024. All Rights Reserved.
+%% Copyright Ericsson AB 2004-2025. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@
 	 register_agent/3, unregister_agent/2, 
 	 agent_info/0, agent_info/2, agent_info/3, 
 	 update_agent_info/3,
-	 which_agents/0, which_agents/1, 
+	 which_agents/0, which_agents/1, which_agents/2,
 
-	 is_known_engine_id/2, 
+	 is_known_engine_id/1, is_known_engine_id/2,
 	 get_agent_engine_id/1, 
 	 get_agent_engine_max_message_size/1, 
 	 get_agent_version/1, 
@@ -522,14 +522,31 @@ which_agents() ->
     which_agents('_').
 
 which_agents(UserId) ->
-    Pat = {{'$1', user_id}, UserId},
-    Agents = ets:match(snmpm_agent_table, Pat),
-    [TargetName || [TargetName] <- Agents].
+    which_agents(user_id, UserId).
 
+%% Choose agent(s) based on UserId or EngineID
+which_agents(Key = user_id, UserId) ->
+    do_which_agents(Key, UserId);
+which_agents(Key = engine_id, EngineID) ->
+    do_which_agents(Key, EngineID).
 
+do_which_agents(Key, Value) ->
+    Pat = {{'$1', Key}, Value},
+    [TargetName || [TargetName] <- ets:match(snmpm_agent_table, Pat)].
+    
 
 update_agent_info(UserId, TargetName, Info) ->
     call({update_agent_info, UserId, TargetName, Info}).
+
+is_known_engine_id(EngineID) ->
+    case which_agents(engine_id, EngineID) of
+        [] ->
+            false;
+        Targets ->
+            ?vdebug("~w -> Targets: "
+                    "~n   ~p", [?FUNCTION_NAME, Targets]),
+            true
+    end.
 
 is_known_engine_id(EngineID, TargetName) ->
     case agent_info(TargetName, engine_id) of

--- a/lib/snmp/src/manager/snmpm_mpd.erl
+++ b/lib/snmp/src/manager/snmpm_mpd.erl
@@ -1,7 +1,7 @@
 %% 
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2004-2024. All Rights Reserved.
+%% Copyright Ericsson AB 2004-2025. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -495,7 +495,8 @@ process_v3_msg(NoteStore, Msg, Hdr, Data, Address, Log) ->
 		    %% handle CtxEngineID to ourselves
 		    %% Check that we actually know of an agent with this
 		    %% CtxEngineID and Address
-		    case is_known_engine_id(CtxEngineID, Address) of
+		    %% case is_known_engine_id(CtxEngineID, Address) of
+                    case is_known_engine_id(CtxEngineID) of
 			true ->
 			    ?vtrace("and the agent EngineID (~p) "
 				    "is know to us", [CtxEngineID]),
@@ -1087,8 +1088,10 @@ get_engine_id() ->
 get_agent_engine_id(Name) ->
     snmpm_config:get_agent_engine_id(Name).
 
-is_known_engine_id(EngineID, {Addr, Port}) ->
-    snmpm_config:is_known_engine_id(EngineID, Addr, Port).
+%% is_known_engine_id(EngineID, {Addr, Port}) ->
+%%     snmpm_config:is_known_engine_id(EngineID, Addr, Port).
+is_known_engine_id(EngineID) ->
+    snmpm_config:is_known_engine_id(EngineID).
 
 
 %%-----------------------------------------------------------------

--- a/lib/snmp/test/snmp_manager_SUITE.erl
+++ b/lib/snmp/test/snmp_manager_SUITE.erl
@@ -1,7 +1,7 @@
 %% 
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2003-2024. All Rights Reserved.
+%% Copyright Ericsson AB 2003-2025. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -2257,31 +2257,64 @@ do_register_agent2([{_ManagerPeer, ManagerNode}], Config) ->
     ?IPRINT("manager info: ~p~n", [mgr_info(ManagerNode)]),
 
     ?IPRINT("register agent(s)"),
-    TargetName1 = "agent1", 
+    TargetName1 = "agent1",
+    EngineID1   = "agentEngineId-1",
     ok = mgr_register_agent(ManagerNode, user_alfa, TargetName1,
-				  [{address,   LocalHost},
-				   {port,      5001},
-				   {engine_id, "agentEngineId-1"}]),
+                            [{address,   LocalHost},
+                             {port,      5001},
+                             {engine_id, EngineID1}]),
     TargetName2 = "agent2", 
+    EngineID2   = "agentEngineId-2",
     ok = mgr_register_agent(ManagerNode, user_alfa, TargetName2,
-				  [{address,   LocalHost},
-				   {port,      5002},
-				   {engine_id, "agentEngineId-2"}]),
+                            [{address,   LocalHost},
+                             {port,      5002},
+                             {engine_id, EngineID2}]),
     TargetName3 = "agent3", 
+    EngineID3   = "agentEngineId-3",
     ok = mgr_register_agent(ManagerNode, user_beta, TargetName3,
-				  [{address,   LocalHost},
-				   {port,      5003},
-				   {engine_id, "agentEngineId-3"}]),
+                            [{address,   LocalHost},
+                             {port,      5003},
+                             {engine_id, EngineID3}]),
     TargetName4 = "agent4", 
+    EngineID4   = "agentEngineId-4",
     ok = mgr_register_agent(ManagerNode, user_beta, TargetName4,
-				  [{address,   LocalHost},
-				   {port,      5004},
-				   {engine_id, "agentEngineId-4"}]),
+                            [{address,   LocalHost},
+                             {port,      5004},
+                             {engine_id, EngineID4}]),
 
     ?IPRINT("verify all agent(s): expect 4"),
     case mgr_which_agents(ManagerNode) of
 	Agents1 when length(Agents1) =:= 4 ->
-	    ?IPRINT("all agents: ~p~n", [Agents1]),
+            UnknownEngineID = "agentEngineId-X",
+	    ?IPRINT("all agents: "
+                    "~n   ~p"
+                    "~nwhen"
+                    "~n   Which Agents (from EngineID 1; ~p):"
+                    "~n      ~p (~p)"
+                    "~n   Which Agents (from EngineID 2; ~p):"
+                    "~n      ~p (~p)"
+                    "~n   Which Agents (from EngineID 3; ~p):"
+                    "~n      ~p (~p)"
+                    "~n   Which Agents (from EngineID 4; ~p):"
+                    "~n      ~p (~p)"
+                    "~n   Which Agents (from unknown engine; ~p):"
+                    "~n      ~p (~p)"
+                    "~n", [Agents1,
+                           EngineID1,
+                           mgr_which_agents(ManagerNode, engine_id, EngineID1),
+                           mgr_is_known_engine_id(ManagerNode, EngineID1),
+                           EngineID2,
+                           mgr_which_agents(ManagerNode, engine_id, EngineID2),
+                           mgr_is_known_engine_id(ManagerNode, EngineID2),
+                           EngineID3,
+                           mgr_which_agents(ManagerNode, engine_id, EngineID3),
+                           mgr_is_known_engine_id(ManagerNode, EngineID3),
+                           EngineID4,
+                           mgr_which_agents(ManagerNode, engine_id, EngineID4),
+                           mgr_is_known_engine_id(ManagerNode, EngineID4),
+                           UnknownEngineID,
+                           mgr_which_agents(ManagerNode, engine_id, UnknownEngineID),
+                           mgr_is_known_engine_id(ManagerNode, UnknownEngineID)]),
 	    ok;
 	Agents1 ->
 	    ?FAIL({agent_registration_failure, Agents1})
@@ -5635,6 +5668,12 @@ mgr_which_agents(Node) ->
 
 mgr_which_agents(Node, Id) ->
     rcall(Node, snmpm, which_agents, [Id]).
+
+mgr_which_agents(Node, Key, Id) ->
+    rcall(Node, snmpm, which_agents, [Key, Id]).
+
+mgr_is_known_engine_id(Node, EngineId) ->
+    rcall(Node, snmpm_config, is_known_engine_id, [EngineId]).
 
 
 %% -- Misc crypto wrapper functions --


### PR DESCRIPTION
SNMP manager
When receiving an (v3) inform (request), use EngineID and (just) Address to check if Engine is known
(do not include the port number).
Some agents send notifications using ephemeral ports (random port), so including this (the used port number) in the
check (if the engine is known) does not work.