### PR TITLE
Add command to remove dependencies from SPDX source SBOM

### DIFF
--- a/HOWTO/SBOM.md
+++ b/HOWTO/SBOM.md
@@ -205,3 +205,27 @@ in its own package.
 
 Delete the code and any remaining `vendor.info` files. 
 Re-run the source SBOM generation steps ([Erlang/OTP source SBOM]). 
+
+## Delete SPDX Package Dependencies
+
+Given an Erlang SPDX souce SBOM from `otp-compliance.es`, one can remove non-needed packages from it, together with its dependencies via `otp-compliance.es`.
+
+```
+.github/scripts/otp-compliance.es sbom remove-packages --sbom-file otp.spdx.json --input_file removed.json
+```
+
+
+### Example 1
+Assume,
+- the Erlang source SBOM was downloaded and is named `otp.spdx.json`.
+- the following package should be removed `SPDXRef-otp-erts-documentation` from the source SBOM.
+
+This implies removing the package, its dependencies, and all the files associated with this package in the SBOM.
+
+To facilitate this task, one should write a list of dependencies to be removed in a JSON file, named (e.g.) `removed.json`, which contains `["SPDXRef-otp-erts-documentation"]`.
+After this, run the following command to remove this package and its dependencies.
+
+```
+.github/scripts/otp-compliance.es sbom remove-packages --sbom-file otp.spdx.json --input_file removed.json
+```
+


### PR DESCRIPTION
Adds command to remove dependencies from SPDX source SBOM.

For example, removing the SPDX package `SPDXRef-otp-xmerl` implies
- Removing all files from the `files` section of the SPDX document
- Removing the SPDX package
- Removing depends on this package (reflexive and transitive closure of dependencies)

To facilitate removing dependents, we provide the following command, where the `removed.json` file contains a list of strings with the packages to be removed.

```
.github/scripts/otp-compliance.es sbom remove-packages --sbom-file otp.spdx.json --input_file removed.json
```