### PR TITLE
help in Erlang shell raised exception

### DIFF
--- a/lib/stdlib/src/shell_docs.erl
+++ b/lib/stdlib/src/shell_docs.erl
@@ -591,7 +591,7 @@ render_type(Module, D) ->
 %% extract AST raw type specifications.
 extract_type_specs(Module) ->
     case find_path(Module) of
-        Path when is_list(Path); is_list(binary) ->
+        Path when is_list(Path); is_binary(Path) ->
             extract_type_specs1(Path);
         _ ->
             #{}


### PR DESCRIPTION
Invoking help about function in module in Erlang shell raised exception in shell_docs:render_function/3.

The exception was due to a missing pattern match on the return value of `beam_lib:chunks/2`.

Split the function in two, one handling errors from `find_path/1`; the other handling the return value of `beam_lib:chunks/2`.