### PR TITLE
add purls to all vendor libraries

### DIFF
--- a/HOWTO/SBOM.md
+++ b/HOWTO/SBOM.md
@@ -163,7 +163,8 @@ This file may be a JSON object or a list of JSON objects. For simplicity, we doc
   "name": "asmjit",
   "versionInfo": "a465fe71ab3d0e224b2b4bd0fac69ae68ab9239d",
   "path": "./erts/emulator/asmjit",
-  "supplier": "Person: Petr Kobalicek"
+  "supplier": "Person: Petr Kobalicek",
+  "purl": "pkg:github/asmjit/asmjit"
 }
 ```
 
@@ -190,6 +191,7 @@ Fields summary:
   - `Person: <person name> (<email>)`, where `email` is optional.
   - `Organization: <Organization name> (email)`, where `email` is optional.
   - `NOASSERTION`, where the person adding this information (you) could not reach a reasonable conclusion, the person adding this information made no attempt to determine this field, or this field was left with no information and no meaning should be implied by doing so.
+- `purl`: if the vendor has a specific `purl`, we choose this format. Otherwise, we follow the guidelines from the [PURL Specification](https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst). 
 
 To update the package, perform any modifications in a `vendor.info` package
 and re-run the source SBOM generation steps ([Erlang/OTP source SBOM]).

--- a/erts/autoconf/vendor.info
+++ b/erts/autoconf/vendor.info
@@ -11,7 +11,8 @@
       "name": "Autoconf",
       "versionInfo": "2.71",
       "path": ["./erts/autoconf/config.guess", "./erts/autoconf/config.sub"],
-      "supplier": "Organization: Free Software Foundation"
+      "supplier": "Organization: Free Software Foundation",
+      "purl": "pkg:generic/autoconf"
     },
     {
       "ID": "erts-install-sh",
@@ -23,6 +24,7 @@
       "name": "Autoconf",
       "versionInfo": "2.71",
       "path": "./erts/autoconf/install-sh",
-      "supplier": "Organization: Free Software Foundation"
+      "supplier": "Organization: Free Software Foundation",
+      "purl": "pkg:generic/autoconf"
     }
 ]

--- a/erts/emulator/asmjit/vendor.info
+++ b/erts/emulator/asmjit/vendor.info
@@ -10,5 +10,6 @@
   "name": "asmjit",
   "versionInfo": "a465fe71ab3d0e224b2b4bd0fac69ae68ab9239d",
   "path": "./erts/emulator/asmjit",
-  "supplier": "Person: Petr Kobalicek"
+  "supplier": "Person: Petr Kobalicek",
+  "purl": "pkg:github/asmjit/asmjit"
 }

--- a/erts/emulator/beam/vendor.info
+++ b/erts/emulator/beam/vendor.info
@@ -3,7 +3,7 @@
 [
   {
   "ID": "erts-fp16",
-  "description": "fp16 vendor library",
+  "description": "fp16 library",
   "copyrightText": "Copyright (c) 2017 Facebook Inc./nCopyright (c) 2017 Georgia Institute of Technology/nCopyright 2019 Google LLC",
   "downloadLocation": "https://github.com/Maratyszcza/FP16",
   "homepage": "https://github.com/Maratyszcza/FP16",
@@ -11,7 +11,8 @@
   "name": "fp16",
   "versionInfo": "0a92994d729ff76a58f692d3028ca1b64b145d91",
   "path": "./erts/emulator/beam/erl_bits_f16.h",
-  "supplier": "Person:  Marat Dukhan"
+  "supplier": "Person:  Marat Dukhan",
+  "purl": "pkg:github/maratyszcza/fp16"
   },
   {
   "ID": "erts-tcl",
@@ -23,6 +24,7 @@
   "name": "tcl",
   "versionInfo": "7.6",
   "path": "./erts/emulator/beam/erl_posix_str.c",
-  "supplier": "Organization: Tcl Core Team"
+  "supplier": "Organization: Tcl Core Team",
+  "purl": "pkg:generic/tcl"
   }
 ]

--- a/erts/emulator/openssl/vendor.info
+++ b/erts/emulator/openssl/vendor.info
@@ -10,5 +10,6 @@
   "name": "openssl",
   "versionInfo": "3.1.4",
   "path": "./erts/emulator/openssl",
-  "supplier": "Organization: OpenSSL Mission"
+  "supplier": "Organization: OpenSSL Mission",
+  "purl": "pkg:generic/openssl"
 }

--- a/erts/emulator/pcre/vendor.info
+++ b/erts/emulator/pcre/vendor.info
@@ -2,7 +2,7 @@
 %% SPDX-FileCopyrightText: 2024 Erlang/OTP and its contributors
 {
   "ID": "erts-pcre",
-  "description": "PCRE vendor library",
+  "description": "PCRE2 library",
   "copyrightText": "NOASSERTION",
   "downloadLocation": "git+https://github.com/PCRE2Project/pcre2.git",
   "homepage": "https://pcre2project.github.io/pcre2/",
@@ -10,5 +10,6 @@
   "name": "pcre2",
   "versionInfo": "10.44",
   "path": "./erts/emulator/pcre",
-  "supplier": "Person: Philip Hazel"
+  "supplier": "Person: Philip Hazel",
+  "purl": "pkg:generic/pcre2"
 }

--- a/erts/emulator/ryu/vendor.info
+++ b/erts/emulator/ryu/vendor.info
@@ -10,5 +10,6 @@
   "name": "ryu",
   "versionInfo": "844864ac213bdbf1fb57e6f51c653b3d90af0937",
   "path": "./erts/emulator/ryu",
-  "supplier": "Person: Ulf Adams"
+  "supplier": "Person: Ulf Adams",
+  "purl": "pkg:github/ulfjack/ryu"
 }

--- a/erts/emulator/zlib/vendor.info
+++ b/erts/emulator/zlib/vendor.info
@@ -10,5 +10,6 @@
   "name": "zlib",
   "versionInfo": "1.3.1",
   "path": "./erts/emulator/zlib",
-  "supplier": "Person: Mark Adler (zlib@gzip.org)"
+  "supplier": "Person: Mark Adler (zlib@gzip.org)",
+  "purl": "pkg:generic/zlib"
 }

--- a/erts/emulator/zstd/vendor.info
+++ b/erts/emulator/zstd/vendor.info
@@ -11,5 +11,6 @@
   "name": "zstd",
   "versionInfo": "v1.5.6",
   "path": "./erts/emulator/zstd",
-  "supplier": "Organization: Meta"
+  "supplier": "Organization: Meta",
+  "purl": "pkg:generic/zstd"
 }

--- a/erts/emulator/zstd/vendor.info
+++ b/erts/emulator/zstd/vendor.info
@@ -12,5 +12,5 @@
   "versionInfo": "v1.5.7",
   "path": "./erts/emulator/zstd",
   "supplier": "Organization: Meta",
-  "purl": "pkg:generic/zstd"
+  "purl": "pkg:github/facebook/zstd"
 }

--- a/erts/emulator/zstd/vendor.info
+++ b/erts/emulator/zstd/vendor.info
@@ -9,7 +9,7 @@
   "license": "BSD-3-Clause OR GPL-2.0-only",
   "licenseDeclared": "BSD-3-Clause OR GPL-2.0-only",
   "name": "zstd",
-  "versionInfo": "v1.5.6",
+  "versionInfo": "v1.5.7",
   "path": "./erts/emulator/zstd",
   "supplier": "Organization: Meta",
   "purl": "pkg:generic/zstd"

--- a/lib/common_test/priv/vendor.info
+++ b/lib/common_test/priv/vendor.info
@@ -11,7 +11,8 @@
       "name": "jquery",
       "versionInfo": "3.7.1",
       "path": "./lib/common_test/priv/jquery-latest.js",
-      "supplier": "Organization: The jQuery Team"
+      "supplier": "Organization: The jQuery Team",
+      "purl": "pkg:github/jquery/jquery"
     },
     {
       "ID": "common_test-tablesorter",
@@ -23,6 +24,7 @@
       "name": "jquery-tablesorter",
       "versionInfo": "2.32",
       "path": "./lib/common_test/priv/jquery.tablesorter.min.js",
-      "supplier": "Person: Christian Bach"
+      "supplier": "Person: Christian Bach",
+      "purl": "pkg:github/mottie/tablesorter"
     }
 ]

--- a/lib/common_test/test_server/vendor.info
+++ b/lib/common_test/test_server/vendor.info
@@ -11,7 +11,8 @@
       "name": "Autoconf",
       "versionInfo": "2.71",
       "path": ["./lib/common_test/test_server/config.guess", "./lib/common_test/test_server/config.sub"],
-      "supplier": "Organization: Free Software Foundation"
+      "supplier": "Organization: Free Software Foundation",
+      "purl": "pkg:generic/autoconf"
     },
     {
       "ID": "common_test-install-sh",
@@ -23,6 +24,7 @@
       "name": "Autoconf",
       "versionInfo": "2.71",
       "path": "./lib/common_test/test_server/install-sh",
-      "supplier": "Organization: Free Software Foundation"
+      "supplier": "Organization: Free Software Foundation",
+      "purl": "pkg:generic/autoconf"
     }
 ]

--- a/lib/erl_interface/src/openssl/vendor.info
+++ b/lib/erl_interface/src/openssl/vendor.info
@@ -10,5 +10,6 @@
   "name": "openssl",
   "versionInfo": "3.1.4",
   "path": "./lib/erl_interface/src/openssl",
-  "supplier": "Organization: OpenSSL Mission"
+  "supplier": "Organization: OpenSSL Mission",
+  "purl": "pkg:generic/openssl"
 }

--- a/lib/stdlib/test/json_SUITE_data/vendor.info
+++ b/lib/stdlib/test/json_SUITE_data/vendor.info
@@ -10,5 +10,6 @@
   "name": "json-test-suite",
   "versionInfo": "984defc2deaa653cb73cd29f4144a720ec9efe7c",
   "path": "./lib/stdlib/test/json_SUITE_data",
-  "supplier": "Person: Nicolas Seriot"
+  "supplier": "Person: Nicolas Seriot",
+  "purl": "pkg:github/nst/JSONTestSuite"
 }

--- a/lib/wx/vendor.info
+++ b/lib/wx/vendor.info
@@ -11,5 +11,6 @@
   "versionInfo": "dc585039bbd426829e3433002023a93f9bedd0c2",
   "path": "./lib/wx",
   "comments": "This only applies to the source code of Erlang files in 'src', and specifically to the documentation embedded in them",
-  "supplier": "NOASSERTION"
+  "supplier": "NOASSERTION",
+  "purl": "pkg:github/wxwidgets/wxwidgets"
 }

--- a/make/autoconf/vendor.info
+++ b/make/autoconf/vendor.info
@@ -11,7 +11,8 @@
       "name": "Autoconf",
       "versionInfo": "2.71",
       "path": ["./make/autoconf/config.guess", "./make/autoconf/config.sub"],
-      "supplier": "Organization: Free Software Foundation"
+      "supplier": "Organization: Free Software Foundation",
+      "purl": "pkg:generic/autoconf"
     },
     {
       "ID": "make-install-sh",
@@ -23,6 +24,7 @@
       "name": "Autoconf",
       "versionInfo": "2.71",
       "path": "./make/autoconf/install-sh",
-      "supplier": "Organization: Free Software Foundation"
+      "supplier": "Organization: Free Software Foundation",
+      "purl": "pkg:generic/autoconf"
     }
 ]


### PR DESCRIPTION
We check if purls are added in their corresponding `vendor.info` files.
If so, we generate an `externalRefs` field with the purl of the vendor library.

Usually, if the vendor has a specific way of being referred to, we should follow that.
Otherwise, we follow the [PURL Specification](https://github.com/package-url/purl-spec/blob/main/PURL-TYPES.rst)