### PR TITLE
fix: erts +t, +P, +Q arg overflow

### DIFF
--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -1820,14 +1820,16 @@ erl_start(int argc, char **argv)
 	    if (sys_strcmp(arg, "legacy") == 0)
 		legacy_proc_tab = 1;
 	    else {
+                long val;
 		errno = 0;
-		proc_tab_sz = strtol(arg, NULL, 10);
+		val = strtol(arg, NULL, 10);
 		if (errno != 0
-		    || proc_tab_sz < ERTS_MIN_PROCESSES
-		    || ERTS_MAX_PROCESSES < proc_tab_sz) {
+		    || val < ERTS_MIN_PROCESSES
+		    || ERTS_MAX_PROCESSES < val) {
 		    erts_fprintf(stderr, "bad number of processes %s\n", arg);
 		    erts_usage();
 		}
+                proc_tab_sz=val;
 	    }
 	    break;
 
@@ -1836,14 +1838,16 @@ erl_start(int argc, char **argv)
 	    if (sys_strcmp(arg, "legacy") == 0)
 		legacy_port_tab = 1;
 	    else {
+                long val;
 		errno = 0;
-		port_tab_sz = strtol(arg, NULL, 10);
+		val = strtol(arg, NULL, 10);
 		if (errno != 0
-		    || port_tab_sz < ERTS_MIN_PORTS
-		    || ERTS_MAX_PORTS < port_tab_sz) {
+		    || val < ERTS_MIN_PORTS
+		    || ERTS_MAX_PORTS < val) {
 		    erts_fprintf(stderr, "bad number of ports %s\n", arg);
 		    erts_usage();
 		}
+                port_tab_sz = val;
 		port_tab_sz_ignore_files = 1;
 	    }
 	    break;
@@ -2160,15 +2164,17 @@ erl_start(int argc, char **argv)
 	}
 	case 't':
 	    /* set atom table size */
-	    arg = get_arg(argv[i]+2, argv[i+1], &i);
+            long val;
+            arg = get_arg(argv[i]+2, argv[i+1], &i);
 	    errno = 0;
-	    erts_atom_table_size = strtol(arg, NULL, 10);
+	    val = strtol(arg, NULL, 10);
 	    if (errno != 0 ||
-		erts_atom_table_size < MIN_ATOM_TABLE_SIZE ||
-		erts_atom_table_size > MAX_ATOM_TABLE_SIZE) {
+		val < MIN_ATOM_TABLE_SIZE ||
+		val > MAX_ATOM_TABLE_SIZE) {
 		erts_fprintf(stderr, "bad atom table size %s\n", arg);
 		erts_usage();
 	    }
+            erts_atom_table_size=val;
 	    VERBOSE(DEBUG_SYSTEM,
                     ("setting maximum number of atoms to %d\n",
 		     erts_atom_table_size));

--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -2162,7 +2162,7 @@ erl_start(int argc, char **argv)
 	    }
 	    break;
 	}
-	case 't':
+	case 't': {
 	    /* set atom table size */
             long val;
             arg = get_arg(argv[i]+2, argv[i+1], &i);
@@ -2179,6 +2179,7 @@ erl_start(int argc, char **argv)
                     ("setting maximum number of atoms to %d\n",
 		     erts_atom_table_size));
 	    break;
+        }
 
 	case 'T' :
 	    arg = get_arg(argv[i]+2, argv[i+1], &i);

--- a/erts/test/erlexec_SUITE.erl
+++ b/erts/test/erlexec_SUITE.erl
@@ -32,7 +32,8 @@
 
 -export([args_file/1, evil_args_file/1, missing_args_file/1, env/1, args_file_env/1,
          otp_7461/1, otp_7461_remote/1, argument_separation/1, argument_with_option/1,
-         zdbbl_dist_buf_busy_limit/1, long_path_env/1, long_path_env_when_rootdir_not_present/1]).
+         zdbbl_dist_buf_busy_limit/1, long_path_env/1, long_path_env_when_rootdir_not_present/1,
+         argument_too_large/1]).
 
 -include_lib("stdlib/include/assert.hrl").
 
@@ -43,7 +44,7 @@ suite() ->
 all() ->
     [args_file, evil_args_file, missing_args_file, env, args_file_env,
      otp_7461, argument_separation, argument_with_option, zdbbl_dist_buf_busy_limit,
-     long_path_env, long_path_env_when_rootdir_not_present].
+     long_path_env, long_path_env_when_rootdir_not_present, argument_too_large].
 
 init_per_suite(Config) ->
     [{suite_erl_flags, save_env()} | Config].
@@ -491,6 +492,19 @@ long_path_env_when_rootdir_not_present(Config) when is_list(Config) ->
 
     ?assertEqual(string:length(string:find(Output, LongPath ++ pathsep() ++ LongPath)), (LongPathLength * 2) + string:length(pathsep())),
     ok.
+
+%% https://github.com/erlang/otp/issues/9668
+argument_too_large(_Config) ->
+    {ok,[[PName]]} = init:get_argument(progname),
+    GtInt32 = "4294975488",
+    BadArg = fun(Flag, Arg) ->
+                Cmd = os:cmd(PName ++ " "++Flag++" "++GtInt32++" -s init stop"),
+                ?assertMatch({match,_}, re:run(Cmd, "bad "++Arg++" "++GtInt32))
+             end,
+    Args = [{"+t", "atom table size"},
+            {"+P", "number of processes"},
+            {"+Q", "number of ports"}],
+    [BadArg(Flag, Arg) || {Flag, Arg} <- Args].
 
 compare_erl_path(Cmd, BinPath, Path) ->
     os:putenv("PATH", Path),


### PR DESCRIPTION
Code pattern and naming is copied from similar cases from this file.

Should we add some testcases for it? If yes, where exactly? (my first contribution to ERTS...)

Props to issue author for clues.

Fixes #9668 