### PR TITLE
.elp.toml - configuring ELP to resolve all files and macros in OTP libs

### DIFF
--- a/.elp.toml
+++ b/.elp.toml
@@ -4,13 +4,20 @@
 [build_info]
 apps = [
     "lib/*",
-    {"name" = "erts", "dir" = "erts/preloaded", "src_dirs" = ["src"]},
-    {"name" = "wx", "dir" = "lib/wx", "src_dirs" = ["src", "gen"]},
-    {"name" = "inets", "dir" = "lib/inets", "src_dirs" = ["src/http_client", "src/http_server", "src/http_lib", "src/inets_app"]},
-    {"name" = "common_test", "dir" = "lib/common_test", "src_dirs" = ["src", "test_server"]},
+    {"name" = "erts", "dir" = "erts/preloaded", "src_dirs" = ["src"], "include_dirs" = ["../../lib/kernel/src", "../../lib/kernel/include"]},
+    {"name" = "wx", "dir" = "lib/wx", "src_dirs" = ["src", "gen"], "include_dirs" = ["include"]},
+    {"name" = "inets", "dir" = "lib/inets", "src_dirs" = ["src"], "include_dirs" = ["include", "src/inets_app", "src/http_lib"]},
+    {"name" = "common_test", "dir" = "lib/common_test", "src_dirs" = ["src", "test_server"], "include_dirs" = ["include", "../snmp/include", "../kernel/include"]},
     # Due to some Erlang/OTP bootstrapping issues, `stdlib` modules such as `gen_server` includes headers from the kernel application
     # using a simple `-include` directive, causing ELP to fail resolving those inclusions.
     # Include kernel as an `include_dir` for `stdlib` to solve the issue
-    {"name" = "stdlib", "dir" = "lib/stdlib", "include_dirs" = ["include", "../kernel/include"]},
+    {"name" = "stdlib", "dir" = "lib/stdlib", "src_dirs" = ["src"], "include_dirs" = ["include", "../kernel/include"]},
+    {"name" = "dialyzer", "dir" = "lib/dialyzer", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "macros" = {"VSN" = "DEFAULT_VSN"}},
+    {"name" = "snmp", "dir" = "lib/snmp", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "include_dirs" = ["include", "src/misc", "src/compile", "src/app"], "macros" = {"default_verbosity"="silence", "version"="version"}},
+    {"name" = "sasl", "dir" = "lib/sasl", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "include_dirs" = ["../stdlib/include"]},
+    {"name" = "compiler", "dir" = "lib/compiler", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "include_dirs" = [ "../stdlib/include"], "macros" = {"COMPILER_VSN"="COMPILER_VSN"}},
+    {"name" = "parsetools", "dir" = "lib/parsetools", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "include_dirs" = ["../stdlib/include"]},
+    {"name" = "eldap", "dir" = "lib/eldap", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "include_dirs" = ["include", "ebin"]},
+    {"name" = "observer", "dir" = "lib/observer", "src_dirs" = ["src"], "extra_src_dirs" = ["test"], "include_dirs" = ["include", "../et/include"]},
     ]
 deps = []


### PR DESCRIPTION
1. Some modules in sdtlib includes some headers from other directories and apps using a simple `-include` directive, causing ELP to fail resolving those inclusions. This diff provides corresponding customizations.
2. dialyzer uses VSN macro. Without a value ELP fails to correctly handle files using it, - specifying a dummy value `"DEFAULT_VSN"`.
3. The same is for `compiler` and `COMPILER_VSN`.

--- 

Testing.

There is a way to test whether ELP now understands the project - to run `eqwalizer` for all the modules.

I tested it in https://github.com/ilya-klyuchnikov/otp/tree/eqwalizer-main branch - which includes this plus 3 other small changes to make OTP repo eqwalizable. 

1. https://github.com/ilya-klyuchnikov/otp/commit/62769afa25e8ecf8cc538d00f6b3602300280012 - deleting `lib/snmp/src/agent/snmpa_mib_data_ttln.erl` which is just broken (it is not included in OTP builds and uses record fields which are not defined). - Probably, this module should be just deleted.
2. https://github.com/ilya-klyuchnikov/otp/commit/45708ed8479c52cfe9ab6967e11e4de308414e6d and https://github.com/ilya-klyuchnikov/otp/commit/d07fb8e0a1651fbfb67f44f17036361d271cded9 - removing shadowing or vars from `cerl_inline` and `edoc_layout` modules. Currently `ELP/eqwalizer` require that there are no warnings/errors "variable 'X' shadowed in ..." and fail hard if such a warning exists. - I would like to discuss it in separate PRs

(You have to build OTP first with `make` - as some headers are generated)

`elp eqwalize-all` works, - analyzes 1307 modules in 20sec (on my macbook) and produces more than 4K type errors.

