### PR TITLE
Correct faulty type spec

### DIFF
--- a/lib/xmerl/src/xmerl_xpath.erl
+++ b/lib/xmerl/src/xmerl_xpath.erl
@@ -106,17 +106,21 @@ Possible options are:
 
 
 -doc(#{ equiv => string(String, Doc, [], Doc, []) }).
--spec string(String, Doc) -> _ when
+-spec string(String, Doc) ->  
+          [nodeEntity()] | Scalar when
       String  :: xPathString(),
-      Doc     :: nodeEntity().
+      Doc     :: nodeEntity(),
+      Scalar  :: #xmlObj{}.
 string(Str, Doc) ->
     string(Str, Doc, []).
 
 -doc(#{ equiv => string(String, Doc, [], Doc, Options) }).
--spec string(String, Doc, Options) -> _ when
+-spec string(String, Doc, Options) -> 
+          [nodeEntity()] | Scalar when
       String  :: xPathString(),
       Doc     :: nodeEntity(),
-      Options :: option_list().
+      Options :: option_list(),
+      Scalar  :: #xmlObj{}.
 string(Str, Doc, Options) ->
     string(Str, Doc, [], Doc, Options).
 

--- a/lib/xmerl/src/xmerl_xs.erl
+++ b/lib/xmerl/src/xmerl_xs.erl
@@ -132,7 +132,8 @@ becomes:
 
 ```
 """.
--spec value_of(E :: xmerl:element()) -> io_lib:chars().
+-spec value_of(E) -> io_lib:chars() when
+      E :: xmerl:element() | [xmerl:element()].
 value_of(E)->
     lists:reverse(xmerl_lib:foldxml(fun value_of1/2, [], E)).
 
@@ -148,7 +149,18 @@ Equivalent to [`xmerl_xpath:string(Str, E)`](`xmerl_xpath:string/2`).
 
 _See also:_ `value_of/1`.
 """.
--spec select(String :: term(), E :: xmerl:element()) -> _.
+-spec select(String, E) -> Result when
+      String  :: term(),
+      E :: xmerl:element(),
+      Result :: [xmerl:xmlElement()
+                | xmerl:xmlAttribute()
+                | xmerl:xmlText()
+                | xmerl:xmlPI()
+                | xmerl:xmlComment()
+                | xmerl:xmlNsNode()
+                | xmerl:xmlDocument()] |
+                Scalar,
+      Scalar  :: #xmlObj{}.
 select(Str,E)->
     xmerl_xpath:string(Str,E).
 


### PR DESCRIPTION
- Corrected spec of xmerl_xs:value_of/1
- Also replaced '_' in the type specs of xmerl_xs:select/2 and xmerl_xpath:string/2/3 with a specified return value to improve documentation.