### PR TITLE
fix warnings "variable X is shadowed in ..."

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -180,9 +180,6 @@ $(EGEN)/OPCODES-GENERATED: genop.tab
 $(EBIN)/beam_asm.beam: $(ESRC)/beam_asm.erl $(EGEN)/beam_opcodes.hrl
 	$(V_ERLC) $(ERL_COMPILE_FLAGS) -DCOMPILER_VSN='"$(VSN)"' -o$(EBIN) $<
 
-$(EBIN)/cerl_inline.beam: $(ESRC)/cerl_inline.erl
-	$(V_ERLC) $(ERL_COMPILE_FLAGS) +nowarn_shadow_vars -o$(EBIN) $<
-
 # Inlining core_parse is slow and has no benefit.
 $(EBIN)/core_parse.beam: $(EGEN)/core_parse.erl
 	$(V_ERLC) $(subst +inline,,$(ERL_COMPILE_FLAGS)) -o$(EBIN) $<

--- a/lib/edoc/src/Makefile
+++ b/lib/edoc/src/Makefile
@@ -23,7 +23,7 @@ RELSYSDIR = $(RELEASE_PATH)/lib/edoc-$(VSN)
 
 EBIN = ../ebin
 XMERL = ../../xmerl
-ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include +warn_unused_vars +nowarn_shadow_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented +warn_deprecated_catch -Werror
+ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include +warn_unused_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented +warn_deprecated_catch -Werror
 
 include files.mk
 

--- a/lib/edoc/src/edoc_layout.erl
+++ b/lib/edoc/src/edoc_layout.erl
@@ -201,9 +201,9 @@ layout_module(#xmlElement{name = module, content = Es}=E, Opts) ->
     Desc = get_content(description, Es),
     ShortDesc = get_content(briefDescription, Desc),
     FullDesc = get_content(fullDescription, Desc),
-    Functions = [{function_name(E, Opts), E} ||
-                    E <- get_content(functions, Es)],
-    Types = [{type_name(E, Opts), E} || E <- get_content(typedecls, Es)],
+    Functions = [{function_name(FunE, Opts), FunE} ||
+                    FunE <- get_content(functions, Es)],
+    Types = [{type_name(TypeE, Opts), TypeE} || TypeE <- get_content(typedecls, Es)],
     SortedFs = if Opts#opts.sort_functions -> lists:sort(Functions);
                   true -> Functions
                end,

--- a/lib/eunit/src/Makefile
+++ b/lib/eunit/src/Makefile
@@ -25,7 +25,7 @@ EBIN = ../ebin
 INCLUDE=../include
 
 ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ../../stdlib/ebin -I$(INCLUDE) \
-	 +warn_deprecated_catch +nowarn_shadow_vars +warn_unused_import -Werror
+	 +warn_deprecated_catch +warn_unused_import -Werror
 
 PARSE_TRANSFORM = eunit_autoexport.erl
 

--- a/lib/syntax_tools/src/Makefile
+++ b/lib/syntax_tools/src/Makefile
@@ -26,7 +26,7 @@ INCLUDE=../include
 
 ERL_COMPILE_FLAGS += -pa $(EBIN) -pa ./ -I$(INCLUDE)
 
-ERL_COMPILE_FLAGS += +warn_deprecated_catch +nowarn_shadow_vars +warn_unused_import -Werror # +warn_missing_spec +warn_untyped_record
+ERL_COMPILE_FLAGS += +warn_deprecated_catch +warn_unused_import -Werror # +warn_missing_spec +warn_untyped_record
 
 SOURCES=erl_syntax.erl erl_prettypr.erl erl_syntax_lib.erl	\
 	erl_comment_scan.erl erl_recomment.erl epp_dodger.erl	\


### PR DESCRIPTION
`doc_layout` and `cerl_inline` are only two modules in OTP that have warnings "variable X is shadowed in ...".
Renaming variables so that there is no shadowing anymore.

- the practical reason - https://github.com/erlang/otp/pull/9674 - to make code better for tooling (ELP/eqWAlizer)