### PR TITLE
gh: Only do initialization once when testing

### DIFF
--- a/.github/dockerfiles/.profile
+++ b/.github/dockerfiles/.profile
@@ -18,16 +18,20 @@
 ##
 ## %CopyrightEnd%
 
-sudo mkdir -p -m0755 /var/run/sshd
+## Only run this initialization once
+if [ ! -d /var/run/sshd ]; then
+    sudo mkdir -p -m0755 /var/run/sshd
 
-sudo /usr/sbin/sshd
+    sudo /usr/sbin/sshd
 
-sudo service postgresql start
+    sudo service postgresql start
 
-sudo -E bash -c "apt-get update && apt-get install -y linux-tools-common linux-tools-generic"
-sudo -E bash -c "apt-get install -y linux-tools-$(uname -r)" || true
+    sudo -E bash -c "apt-get update && apt-get install -y linux-tools-common linux-tools-generic"
+    sudo -E bash -c "apt-get install -y linux-tools-$(uname -r)" || true
 
-sudo bash -c "Xvfb :99 -ac -screen 0 1920x1080x24 -nolisten tcp" &
+    sudo bash -c "Xvfb :99 -ac -screen 0 1920x1080x24 -nolisten tcp" &
+fi
+
 export DISPLAY=:99
 
 PATH="$PATH:$(ls -1d /usr/local/lib/erlang-*/bin | tr '\n' ':')"


### PR DESCRIPTION
The ssh tests do a ssh to localhost for compatability testing and we don't want to start these services again when they are run.