### PR TITLE
add missing verify_fun mfa translation

### DIFF
--- a/lib/ssl/src/inet_tls_dist.erl
+++ b/lib/ssl/src/inet_tls_dist.erl
@@ -425,6 +425,8 @@ get_ssl_server_options(PeerIP) when PeerIP =/= undefined ->
 %%
 setup_verify_client([Opt | Opts], PeerIP) ->
     case Opt of
+        {verify_fun,{Mod,Fun,Init}} ->
+            [{verify_fun, {fun Mod:Fun/3, Init}} | setup_verify_client(Opts, PeerIP)];
         {verify_fun,{VerifyFun, _}} ->
             case fun inet_tls_dist:verify_client/3 of
                 VerifyFun ->
@@ -445,6 +447,16 @@ setup_verify_client([Opt | Opts], PeerIP) ->
       end;
 setup_verify_client([], _PeerIP) ->
     [].
+
+setup_verify_server([]) ->
+    [];
+setup_verify_server([Opt|Opts]) ->
+    case Opt of
+        {verify_fun,{Mod,Fun,Init}} ->
+            [{verify_fun, {fun Mod:Fun/3, Init}} | setup_verify_server(Opts)];
+        _ ->
+            [Opt | setup_verify_server(Opts)]
+    end.
 
 allowed_hosts(Allowed) ->
     lists:usort(allowed_node_hosts(Allowed)).
@@ -639,7 +651,7 @@ do_setup(
         inet_tcp_dist:merge_options(
           inet_tcp_dist:merge_options(
             ConnectOptions,
-            get_ssl_options(client)),
+            setup_verify_server(get_ssl_options(client))),
           [Family, binary, {active, false}, {packet, 4},
            {read_ahead, false}, {nodelay, true}],
           [{server_name_indication, Host}]),


### PR DESCRIPTION
inet_tls_dist is missing a configuration translation for verify_fun from an mfa tuple to a closure that can be called during ssl_handshake.

@IngelaAndin This is the missing verify_fun translation I spoke of, applied to master