### PR TITLE
stdlib: Only check illegal_record_info for record_info/2

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -2903,7 +2903,7 @@ expr({ssa_check_when,_Anno,_WantedResult,_Args,_Tag,_Exprs}, _Vt, St) ->
 
 %% Check a call to function without a module name. This can be a call
 %% to a BIF or a local function.
-check_call(Anno, record_info, As, Aa, St0) ->
+check_call(Anno, record_info, [_,_]=As, Aa, St0) ->
     check_record_info_call(Anno, Aa, As, St0);
 check_call(Anno, F, As, _Aa, St0) ->
     A = length(As),

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -91,6 +91,7 @@
          update_literal/1,
          messages_with_jaro_suggestions/1,
          illegal_zip_generator/1,
+         record_info_0/1,
          coverage/1]).
 
 suite() ->
@@ -131,6 +132,7 @@ all() ->
      update_literal,
      messages_with_jaro_suggestions,
      illegal_zip_generator,
+     record_info_0,
      coverage].
 
 groups() -> 
@@ -5650,6 +5652,27 @@ illegal_zip_generator(Config) ->
                     []}}
            ],
     [] = run(Config,Ts),
+
+    ok.
+
+%% GH-9694. Only record_info/2 should be checked for illegal_record_info
+record_info_0(Config) ->
+    Ts = [{record_info_0,
+           <<"-export([f/0]).
+              record_info() -> ok.
+              f() -> record_info().
+            ">>,
+           [],
+           []},
+          {record_info_1,
+           <<"-export([g/0]).
+              record_info(X) -> X.
+              g() -> record_info(ok).
+            ">>,
+           [],
+           []}
+         ],
+    [] = run(Config, Ts),
 
     ok.
 


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/9694