### PR TITLE
Fix bug in call_memory tracing when calling BIFs that delay GC

### DIFF
--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -543,11 +543,6 @@ delay_garbage_collection(Process *p, int need, int fcalls)
 
     p->hend = hend;
 
-    /* Keep the high water mark pointing into the current heap to ensure
-     * that the test for the safe range in the update_record_in_place (JIT)
-     * stays honest. */
-    p->high_water = p->heap;
-
     if (p->abandoned_heap) {
 	/*
          * Active heap already in a fragment; adjust it and
@@ -576,6 +571,11 @@ delay_garbage_collection(Process *p, int need, int fcalls)
 	p->abandoned_heap = orig_heap;
         erts_adjust_memory_break(p, orig_htop - p->high_water);
     }
+
+    /* Keep the high water mark pointing into the current heap to ensure
+     * that the test for the safe range in the update_record_in_place (JIT)
+     * stays honest. */
+    p->high_water = p->heap;
 
 #ifdef CHECK_FOR_HOLES
     p->last_htop = p->htop;

--- a/erts/emulator/test/trace_call_memory_SUITE.erl
+++ b/erts/emulator/test/trace_call_memory_SUITE.erl
@@ -41,7 +41,7 @@
     spawn_memory/0, spawn_memory/1, spawn_memory_internal/1,
     spawn_memory_lambda/1,
     conflict_traces/0, conflict_traces/1,
-    big_words/0, big_words/1
+    big_words/0, big_words/1, delayed_gc/1
 ]).
 
 suite() ->
@@ -55,7 +55,7 @@ groups() ->
 
 testcases() ->
     [basic, on_load, late_trace, skip, message, parallel_map, trace_all, spawn_memory,
-    spawn_memory_lambda, conflict_traces, big_words].
+     spawn_memory_lambda, conflict_traces, big_words, delayed_gc].
 
 init_per_suite(Config) ->
     trace_sessions:init_per_suite(Config, ?MODULE).
@@ -115,6 +115,10 @@ end_per_testcase(conflict_traces, Config) ->
     trace_sessions:end_per_testcase(Config);
 end_per_testcase(big_words, Config) ->
     erlang_trace_pattern({?MODULE,alloc_tuples,2}, false, [call_memory]),
+    erlang_trace(self(), false, [call]),
+    trace_sessions:end_per_testcase(Config);
+end_per_testcase(delayed_gc, Config) ->
+    erlang_trace_pattern({?MODULE, build_on_heap, 1}, false, [call_memory]),
     erlang_trace(self(), false, [call]),
     trace_sessions:end_per_testcase(Config).
 
@@ -451,3 +455,47 @@ alloc_tuples(0, _) ->
 alloc_tuples(N, TupleSz) ->
     erlang:make_tuple(TupleSz, []),
     alloc_tuples(N-1, TupleSz).
+
+
+%% OTP-19581
+%% Verify that reported memory is correct after getting disabled GC with "need".
+delayed_gc(Config) when is_list(Config) ->
+    AIS = erts_debug:set_internal_state(available_internal_state, true),
+    try
+        Self = self(),
+        Traced = {?MODULE, build_on_heap, 1},
+        1 = erlang_trace_pattern(Traced, true, [call_memory]),
+        1 = erlang_trace(Self, true, [call]),
+
+        {heap_size, HeapSize} = process_info(self(), heap_size),
+        [begin
+             %% Disable GC and fill up heap to trigger GC with need != 0
+             %% which will provoke the abandoned heap scenario.
+             true = erts_debug:set_internal_state(gc_state, false),
+             Term = build_on_heap(Words),
+             false = erts_debug:set_internal_state(gc_state, true),
+
+             ?assertEqual(Words, erts_debug:flat_size(Term)),
+             ?assertEqual({call_memory, [{Self, 1, Words}]},
+                          erlang_trace_info(Traced, call_memory)),
+             1 = erlang_trace_pattern(Traced, restart, [call_memory])
+         end
+         || Words <- lists:seq(HeapSize, HeapSize*10, HeapSize)],
+
+        1 = erlang_trace(Self, false, [call]),
+        1 = erlang_trace_pattern(Traced, false, [call_memory])
+    after
+        erts_debug:set_internal_state(available_internal_state, AIS)
+    end,
+    ok.
+
+
+build_on_heap(Words) ->
+    build_on_heap(Words, []).
+
+build_on_heap(0, Acc) ->
+    Acc;
+build_on_heap(3, Acc) ->
+    {3, Acc};
+build_on_heap(Words, Acc) when Words > 1 ->
+    build_on_heap(Words-2, [Words | Acc]).

--- a/lib/kernel/src/trace.erl
+++ b/lib/kernel/src/trace.erl
@@ -208,8 +208,10 @@ being destroyed when the last strong handle is garbage collected.
        {meta, module(), term() } |
        {meta_match_spec, trace_match_spec() | false | undefined} |
        {call_count, non_neg_integer() | boolean() | undefined} |
-       {call_time | call_memory, [{pid(), non_neg_integer(),
-		     non_neg_integer(), non_neg_integer()}] | boolean() | undefined}.
+       {call_time, [{pid(), non_neg_integer(), non_neg_integer(), non_neg_integer()}]
+                   | boolean() | undefined} |
+       {call_memory, [{pid(), non_neg_integer(), non_neg_integer()}]
+                   | boolean() | undefined}.
 
 -type trace_info_return() ::
       undefined |
@@ -870,6 +872,9 @@ Argument **`FlagList`** is a list of options. The following are the valid option
 
 - **`call_memory`**{: #call_memory } - Start (`MatchSpec == true`) or stop
   (`MatchSpec == false`) call memory tracing for all types of function calls.
+  For every function, a counter is incremented when the function is called and
+  the memory consumed by the function is measured and accumulated in another
+  counter. Separate counters are stored for each call traced process.
 
   If call memory tracing is started while already running, counters and
   allocations restart from zero. To pause running counters, use


### PR DESCRIPTION
Tracing functions with `call_memory` could report arbitrarily incorrect values for consumed memory. Even negative values. This could happen if the traced process called BIFs that yielded while delaying garbage collection, like `binary_to_list/1`.