### PR TITLE
Add missing wx dependencies

### DIFF
--- a/lib/debugger/src/Makefile
+++ b/lib/debugger/src/Makefile
@@ -87,7 +87,7 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -Werror
+ERL_COMPILE_FLAGS += -Werror -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
 
 
 # ----------------------------------------------------

--- a/lib/et/src/Makefile
+++ b/lib/et/src/Makefile
@@ -68,7 +68,11 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin -I../include -Werror
+ERL_COMPILE_FLAGS += -pa $(ERL_TOP)/lib/et/ebin \
+		     -pa $(ERL_TOP)/lib/wx/ebin \
+		     -I../include \
+		     -I $(ERL_TOP)/lib \
+		     -Werror
 
 # ----------------------------------------------------
 # Special Build Targets

--- a/lib/observer/src/Makefile
+++ b/lib/observer/src/Makefile
@@ -125,6 +125,8 @@ ERL_COMPILE_FLAGS += \
 	-I../include \
 	-I ../../et/include \
 	-I ../../../libraries/et/include \
+	-I $(ERL_TOP)/lib \
+	-pa $(ERL_TOP)/lib/wx/ebin \
 	-Werror
 
 # ----------------------------------------------------

--- a/lib/reltool/src/Makefile
+++ b/lib/reltool/src/Makefile
@@ -61,7 +61,8 @@ APPUP_TARGET = $(EBIN)/$(APPUP_FILE)
 
 ERL_COMPILE_FLAGS += +'{parse_transform,sys_pre_attributes}' \
                      +'{attribute,insert,app_vsn,$(APP_VSN)}' \
-		     -Werror
+		     -Werror \
+		     -I $(ERL_TOP)/lib
 
 # ----------------------------------------------------
 # Targets

--- a/lib/wx/examples/demo/Makefile
+++ b/lib/wx/examples/demo/Makefile
@@ -63,7 +63,8 @@ TESTMODS = \
 TESTTARGETS = $(TESTMODS:%=%.beam)
 TESTSRC = $(TESTMODS:%=%.erl)
 
-ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented
+ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented \
+		     -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
 
 # Targets
 $(TYPES):	$(TESTTARGETS)

--- a/lib/wx/examples/simple/Makefile
+++ b/lib/wx/examples/simple/Makefile
@@ -32,7 +32,8 @@ TESTMODS = hello hello2 minimal menu
 TESTTARGETS = $(TESTMODS:%=%.beam)
 TESTSRC = $(TESTMODS:%=%.erl)
 
-ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented
+ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented \
+		     -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
 
 # Targets
 $(TYPES):	$(TESTTARGETS)

--- a/lib/wx/examples/sudoku/Makefile
+++ b/lib/wx/examples/sudoku/Makefile
@@ -32,7 +32,8 @@ TESTMODS = sudoku sudoku_board sudoku_game sudoku_gui
 TESTTARGETS = $(TESTMODS:%=%.beam)
 TESTSRC = $(TESTMODS:%=%.erl)
 
-ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented
+ERL_COMPILE_FLAGS += +nowarn_missing_doc +nowarn_missing_spec_documented \
+		     -I $(ERL_TOP)/lib -pa $(ERL_TOP)/lib/wx/ebin
 
 # Targets
 $(TYPES):	$(TESTTARGETS)


### PR DESCRIPTION
The following applications:

 - et
 - observer
 - debugger
 - reltool

And also the wx/examples/[simple,demo,sudoku] depends on wx application in order to build properly.

When cross compiling Erlang/OTP [1], there are cases where the initial bootstrap system (which in most of the cases is just the same Erlang/OTP version but built for host) may not have Erlang wx application enabled. Thus when cross compiling the above applications will not able to found wx.hrl and wx behaviour files.

That is because the target build should look into ERL_TOP in order to see the missing dependencies.

Without the proper ERL_COMPILE_FLAGS the build will try to use from the host system, which in my case does not have wx enabled.

1: https://github.com/erlang/otp/blob/master/HOWTO/INSTALL-CROSS.md