### PR TITLE
tools: Correct tprof session concurrency documentation

### DIFF
--- a/lib/tools/src/tprof.erl
+++ b/lib/tools/src/tprof.erl
@@ -287,15 +287,18 @@ the developer to take care of such processes.
 9> tprof:profile(timer, sleep, [100000], #{timeout => 1000}).
 ```
 
-By default, only one ad-hoc or server-aided profiling session is
-allowed at any point in time. It is possible to force multiple ad-hoc
-sessions concurrently, but it is the responsibility of the developer
-to ensure that trace patterns do not overlap:
+Each ad-hoc profile runs in an isolated trace session, so multiple ad-hoc
+profiles can run concurrently without changing one another's trace settings.
+Ad-hoc profiles can also run alongside server-aided profilers. To run multiple
+server-aided profilers, start them with the `session` option described in
+[`start/1`](`start/1`).
 
-```erlang
-1> tprof:profile(fun() -> lists:seq(1, 32) end,
-    #{registered => false, pattern => [{lists, '_', '_'}]}).
-```
+> #### Note {: .info }
+>
+> Trace patterns and `call_count` counters are isolated between sessions.
+> However, each counter includes matching calls from every process on the node.
+> Concurrent profiles with overlapping patterns can therefore count calls made
+> by each other's workloads.
 
 ## Server-aided profiling
 

--- a/lib/tools/test/tprof_SUITE.erl
+++ b/lib/tools/test/tprof_SUITE.erl
@@ -39,6 +39,7 @@
     rootset/0, rootset/1,
     set_on_spawn/0, set_on_spawn/1, seq/1,
     separate_sessions/0, separate_sessions/1,
+    concurrent_ad_hoc/0, concurrent_ad_hoc/1,
     live_trace/0, live_trace/1,
     patterns/0, patterns/1, pattern_fun/1, pattern_fun/2, pattern_fun/3,
     processes/0, processes/1,
@@ -67,7 +68,7 @@ groups() ->
     [{all, parallel(),
       [call_time_ad_hoc, call_memory_ad_hoc,
        call_memory_total, sort, rootset, set_on_spawn,
-       code_load, code_reload, separate_sessions,
+       code_load, code_reload, separate_sessions, concurrent_ad_hoc,
        {group, default_session},
        {group, custom_session}]},
      {default_session,[],session()},
@@ -383,6 +384,53 @@ separate_sessions(Config) when is_list(Config) ->
     ?assert(lists:all(fun({lists, reverse, 1, _}) -> true; (_) -> false end, Profile1)),
     ?assert(lists:all(fun({lists, map, 2, _}) -> true; (_) -> false end, Profile2)).
 
+concurrent_ad_hoc() ->
+    [{doc, "Tests overlapping ad-hoc profiles using the same trace pattern"}].
+
+concurrent_ad_hoc(Config) when is_list(Config) ->
+    Parent = self(),
+    Ref = make_ref(),
+    Start = fun(Tag) ->
+        spawn_link(fun() ->
+            Result = tprof:profile(
+                fun() ->
+                    %% Reaching this point means that this profile's pattern and
+                    %% process trace have both been enabled.
+                    Parent ! {Ref, ready, Tag, self()},
+                    receive
+                        {Ref, run} ->
+                            _ = lists:seq(1, 32),
+                            done
+                    end
+                end,
+                #{pattern => {lists, seq_loop, 3}, report => return,
+                    set_on_spawn => false, type => call_memory}),
+            Parent ! {Ref, result, Tag, Result}
+        end)
+    end,
+
+    _ = Start(first),
+    _ = Start(second),
+    Profiled1 = receive {Ref, ready, first, Pid1} -> Pid1 end,
+    Profiled2 = receive {Ref, ready, second, Pid2} -> Pid2 end,
+
+    %% Complete and tear down the first session while the second is active.
+    Profiled1 ! {Ref, run},
+    First = receive {Ref, result, first, Result1} -> Result1 end,
+    ?assertMatch(
+        {done, {call_memory,
+            [{lists, seq_loop, 3, [{Profiled1, 9, 64}]}]}},
+        First),
+    ?assert(is_process_alive(Profiled2)),
+
+    %% Destroying the first same-named trace session must not affect this one.
+    Profiled2 ! {Ref, run},
+    Second = receive {Ref, result, second, Result2} -> Result2 end,
+    ?assertMatch(
+        {done, {call_memory,
+            [{lists, seq_loop, 3, [{Profiled2, 9, 64}]}]}},
+        Second).
+
 live_trace() ->
     [{doc, "Tests memory tracing for pre-existing processes"}].
 
@@ -517,7 +565,7 @@ server(Config) when is_list(Config) ->
 
     %% test ad-hoc profiling can be done while running server-aided
     %% for that, profiler should have very specific pattern
-    {_, AdHoc} = tprof:profile(lists, seq, [1, 32], #{registered => false, pattern => {lists, '_', '_'},
+    {_, AdHoc} = tprof:profile(lists, seq, [1, 32], #{pattern => {lists, '_', '_'},
         report => return, type => call_memory}),
     %% check totals: must be 64 words allocated by a single lists:seq_loop
     ?assertMatch(#{all := {call_memory, 64, [{lists, _, _, 64, _, _}]}},


### PR DESCRIPTION
The `tprof` module documentation incorrectly states that only one ad-hoc or server-aided profiling session can run at a time and suggests the unsupported `registered => false` option.

Each ad-hoc profile already runs in an isolated trace session. This change documents that ad-hoc profiles can run concurrently and alongside server-aided profilers without changing trace settings in other sessions. It also points to the `session` option for running multiple server-aided profilers.

The documentation now also distinguishes session isolation from `call_count` measurement scope: counters belong to individual sessions but count matching calls from every process on the node, so concurrent workloads can contribute to multiple profiles when their patterns overlap.

The same unsupported `registered` option is removed from the server/ad-hoc coexistence test, where it was ignored and incorrectly implied that it enabled concurrent profiling.

A regression test now starts two ad-hoc `call_memory` profiles with the same trace pattern, waits until both are active, tears down the first session, and verifies that the second session continues collecting independently.