### PR TITLE
docs: Fix link vsn fixup to use .mk vsn values

### DIFF
--- a/make/ex_doc_wrapper.in
+++ b/make/ex_doc_wrapper.in
@@ -60,7 +60,6 @@ OUTPUT="$( { escript@EXEEXT@ "${EX_DOC}" "${ARGS[@]}"; } 2>&1 1>&3 | tee /dev/fd
 ## Close fd 3 and 4
 exec 3>&- 4>&-
 
-set -x
 ## If EX_DOC_WARNINGS_AS_ERRORS is not explicitly turned on
 ## and any .app file is missing, we turn off warnings as errors
 if [ "${EX_DOC_WARNINGS_AS_ERRORS}" != "true" ]; then

--- a/make/fixup_doc_links.sh
+++ b/make/fixup_doc_links.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # %CopyrightBegin%
 #
@@ -19,7 +19,24 @@
 # 
 # %CopyrightEnd%
 
-APP_VSNS=$(head -1 ${ERL_TOP}/otp_versions.table | awk -F: '{print $2}' | sed 's:#::g')
+set -eo pipefail
+
+APPS=$(head -1 ${ERL_TOP}/otp_versions.table | awk -F: '{print $2}' | sed 's:#::g' | sed 's: \+: :g' | tr ' ' '\n' | awk -F- '{print $1}')
+
+APP_VSNS=()
+
+for app in ${APPS}; do
+    dir="lib/${app}"
+    VSN_VAR="$(echo $app | tr [:lower:] [:upper:])_VSN"
+    if [ ${app} = "erts" ]; then
+        dir="erts/"
+        VSN_VAR="VSN"
+    elif [ ${app} = "erl_interface" ]; then
+        VSN_VAR="EI_VSN"
+    fi
+    VSN=$(grep "^${VSN_VAR}" "${ERL_TOP}/${dir}/vsn.mk" | grep "=" | awk -F= '{print $2}' | xargs)
+    APP_VSNS=("${app}-${VSN}" ${APP_VSNS[@]})
+done
 
 FIXUP="-e s:lib/\\.\\./::g"
 
@@ -30,7 +47,7 @@ fi
 
 FIXUP="${FIXUP} -e s:${ADJUST_PATH}system/doc/html:doc/system:g"
 
-for APP_VSN in ${APP_VSNS}; do
+for APP_VSN in ${APP_VSNS[@]}; do
     APP=$(echo ${APP_VSN} | awk -F- '{print $1}')
     if [ $APP = "erts" ]; then
         FIXUP="${FIXUP} -e s:${ADJUST_PATH}${APP}/doc/html/:${APP_VSN}/doc/html/:g"


### PR DESCRIPTION
Sometimes the otp_version.table version get out of sync with the version in lib/app/vsn.mk, so we use the vsn.mk values as they are the correct ones.