### PR TITLE
Fix typo reasource → resource in otp/erts/preloaded/src/erlang.erl

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -8486,7 +8486,7 @@ The possible flags are:
   system have been busy. This value is normally a better indicator of how much
   load an Erlang node is under instead of looking at the CPU utilization provided
   by tools such as `top` or `sysstat`. This is because `scheduler_wall_time` also
-  includes time where the scheduler is waiting for some other reasource (such as
+  includes time where the scheduler is waiting for some other resource (such as
   an internal mutex) to be available but does not use the CPU. In order to better
   understand what a scheduler is busy doing you can use
   [microstate accounting](#statistics_microstate_accounting).


### PR DESCRIPTION
Fix typo reasource → resource in https://github.com/erlang/otp/blob/10e20b1dbe39b056fab430e50b08cb4f3696ae87/erts/preloaded/src/erlang.erl#L8489