### PR TITLE
erts: fix incompatible pointer type

### DIFF
--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -2855,6 +2855,16 @@ static void monitor_resource_down(ErlNifEnv* env, void* obj, ErlNifPid* pid,
     enif_send(env, &rsrc->receiver, msg_env, msg);
     if (msg_env)
         enif_free_env(msg_env);
+
+    /* OTP-19330 GH-8983:
+     * Verify calling enif_whereis_pid/port in down callback
+     * without lock order violation. */
+    {
+        ErlNifPid pid;
+        ErlNifPort port;
+        enif_whereis_pid(env, atom_null, &pid);
+        enif_whereis_port(env, atom_null, &port);
+    }
 }
 
 static ERL_NIF_TERM alloc_monitor_resource_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])


### PR DESCRIPTION
Expected ErlNifPort instead ErlNifPid:

  nif_SUITE.c:2866:43: error: passing argument 3 of 'enif_whereis_port' from incompatible pointer type [-Wincompatible-pointer-types]