### PR TITLE
Fix PR Comment Workflow

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   pr-number:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'erlang/otp'
     permissions:
       issues: read
@@ -73,7 +73,7 @@ jobs:
                    pr_number: ${{ needs.pr-number.outputs.result }} });
 
   finished-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: pr-number
     ## Limit concurrency so that only one job deploys to erlang.github.io
     concurrency: erlang.github.io-deploy


### PR DESCRIPTION
The PR comment workflow had stopped running since it used Ubuntu 20.04 LTS for some jobs, which was retired by GitHub Actions on 15th April:

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

This PR replaces Ubuntu 20.04 with the latest Ubuntu version at the time of running the workflow.
