### PR TITLE
Simplify `monitor` option check in `proc_lib`

### DIFF
--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -112,18 +112,15 @@ is _not_ part of these options.
 %% in erlang:spawn_opt_options().
 %%
 -define(VERIFY_NO_MONITOR_OPT(M, F, A, T, Opts),
-        Monitor = monitor,
-        case lists:member(Monitor, Opts) of
-            true ->
+	case
+	    lists:member(monitor, Opts) orelse
+	    lists:keymember(monitor, 1, Opts)
+	of
+	    true ->
                 erlang:error(badarg, [M,F,A,T,Opts]);
-            false ->
-                case lists:keyfind(Monitor, 1, Opts) of
-                    false ->
-                        ok;
-                    {Monitor, _} ->
-                        erlang:error(badarg, [M,F,A,T,Opts])
-                end
-        end).
+	    false ->
+		ok
+	end).
 
 -doc """
 An exception passed to `init_fail/3`. See `erlang:raise/3` for a description


### PR DESCRIPTION
This way of checking for `monitor` or `{monitor, ...}` in the options lists seems to me much simpler than the current nested `case`.

There is a slight (but IMO inconsequential) change in behavior: if there is a `{monitor, ...}` tuple in the option list, the current code will result in a call `error(badarg, [M, F, A, T, Opts])` if it is a 2-tuple, but fail with a `function_clause` error if it is _not_ a 2-tuple; with my changes, _any_ `{monitor, ...}` tuple will result in a call `error(badarg, [M, F, A, T, Opts])`.