### PR TITLE
Add option to discard whitespace before xml tag

### DIFF
--- a/lib/xmerl/src/xmerl_sax_parser.erl
+++ b/lib/xmerl/src/xmerl_sax_parser.erl
@@ -92,6 +92,9 @@ Possible options are:
 - **`{fail_undeclared_ref, Boolean}`** - Decides how the parser should behave
   when an undeclared reference is found. Can be useful if one has turned of
   external entities so that an external DTD is not parsed. Default is `true`.
+
+- **`{discard_ws_before_xml_document, Boolean}`** - Discard whitespace before
+  `xml` tag instead of returning a fatal error. Default is `false`.
 """.
 -type options() :: [{continuation_fun, continuation_fun()} |
                     {continuation_state, continuation_state()} |
@@ -102,7 +105,8 @@ Possible options are:
                     skip_external_dtd | disallow_entities |
                     {entity_recurse_limit, non_neg_integer()} |
                     {external_entities, all | file | none} |
-                    {fail_undeclared_ref, boolean()}].
+                    {fail_undeclared_ref, boolean()} |
+                    {discard_ws_before_xml_document, boolean()}].
 
 -type continuation_state() :: term().
 
@@ -472,6 +476,8 @@ parse_options([{external_entities, Type} |Options], State) when Type =:= all;
     parse_options(Options, State#xmerl_sax_parser_state{external_entities = Type});
 parse_options([{fail_undeclared_ref, Bool} |Options], State) when is_boolean(Bool) ->
     parse_options(Options, State#xmerl_sax_parser_state{fail_undeclared_ref = Bool});
+parse_options([{discard_ws_before_xml_document, Bool} |Options], State) when is_boolean(Bool) ->
+    parse_options(Options, State#xmerl_sax_parser_state{discard_ws_before_xml_document = Bool});
 parse_options([O |_], _State) ->
      {error, lists:flatten(io_lib:format("Option: ~p not supported", [O]))}.
 

--- a/lib/xmerl/src/xmerl_sax_parser.hrl
+++ b/lib/xmerl/src/xmerl_sax_parser.hrl
@@ -93,9 +93,7 @@
          attribute_values = [],     % default attribute values
          allow_entities = true,     % If true entities are allowed in the document
          entity_recurse_limit = 3,  % How many levels of recursion is allowed for entities
-         external_entities = none,   % Which types of external entities are allowed: all, file or none(default)
-         fail_undeclared_ref = true % If false the reference will be left unresolved in the document, true is default
+         external_entities = none,  % Which types of external entities are allowed: all, file or none(default)
+         fail_undeclared_ref = true, % If false the reference will be left unresolved in the document, true is default
+         discard_ws_before_xml_document = false % If true allow whitespace fefore the xml tag
         }).
-
-
-

--- a/lib/xmerl/src/xmerl_sax_parser_base.erlsrc
+++ b/lib/xmerl/src/xmerl_sax_parser_base.erlsrc
@@ -187,6 +187,11 @@ handle_end_document({other, Error, State}) ->
 %% Description: Parsing an XML document
 %%              [1] document ::= prolog element Misc*
 %%----------------------------------------------------------------------
+parse_document(Rest, #xmerl_sax_parser_state{discard_ws_before_xml_document = true} = State) ->
+    {_WS, Rest1, State1} = whitespace(Rest, State, []),
+    {Rest2, State2} = parse_byte_order_mark(Rest1, State1),
+    {Rest3, State3} = parse_misc(Rest2, State2, true),
+    {ok, Rest3, State3};
 parse_document(Rest, State) when is_record(State, xmerl_sax_parser_state) ->
     {Rest1, State1} = parse_byte_order_mark(Rest, State),
     {Rest2, State2} = parse_misc(Rest1, State1, true),
@@ -336,8 +341,9 @@ parse_prolog(?STRING_REST("<?", Rest), State) ->
     case parse_pi(Rest, State) of
 	{Rest1, State1} ->
 	    parse_prolog(Rest1, State1);
-	{endDocument, Rest1, State1} ->
-	    parse_prolog(Rest1, State1)  
+	{endDocument, _Rest1, State1} ->
+            ?fatal_error(State1, "<?xml  ...?> not first in document")
+	    %% parse_prolog(Rest1, State1)  
     end;
 parse_prolog(?STRING_REST("<!", Rest), State) ->
     parse_prolog_1(Rest, State);

--- a/lib/xmerl/test/xmerl_sax_SUITE.erl
+++ b/lib/xmerl/test/xmerl_sax_SUITE.erl
@@ -38,10 +38,11 @@
 %%----------------------------------------------------------------------
 
 all() ->
-    [{group, bugs}].
+    [{group, basic}, {group, bugs}].
 
 groups() ->
-    [{bugs, [], [ticket_8213, ticket_8214, ticket_11551, 
+    [{basic, [], [discard_ws_before_xml_tag_test]},
+     {bugs, [], [ticket_8213, ticket_8214, ticket_11551, 
                  fragmented_xml_directive,
                  old_dom_event_fun_endDocument_bug, 
                  event_fun_endDocument_error_test,
@@ -210,6 +211,23 @@ fail_undeclared_ref_test(Config) ->
     {fatal_error, _, _, _, _} = xmerl_sax_parser:file(File, [{external_entities, none}]),
     %% fail_undeclared_ref == false
     {ok, undefined, <<>>} = xmerl_sax_parser:file(File, [{external_entities, none}, {fail_undeclared_ref, false}]),
+    ok.
+
+%%----------------------------------------------------------------------
+%% Test Case 
+%% ID: Test option that allows whitespace before xml tag
+discard_ws_before_xml_tag_test(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "two_messages_with_ws_between.xml"),
+    {ok, Bin} = file:read_file(File),
+    %% Use Bin as stream
+    %% Parse first
+    {ok, undefined, RestBin} = xmerl_sax_parser:stream(Bin, []),
+    %% Parse second that has a number of whitespaces first
+    %% Whithout option
+    {fatal_error, _, _, _, _} = xmerl_sax_parser:stream(RestBin, []),
+    %% Whit option
+    {ok, undefined, _} = xmerl_sax_parser:stream(RestBin, [{discard_ws_before_xml_document, true}]),
     ok.
 
 %%======================================================================

--- a/lib/xmerl/test/xmerl_sax_SUITE_data/two_messages_with_ws_between.xml
+++ b/lib/xmerl/test/xmerl_sax_SUITE_data/two_messages_with_ws_between.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--
+%CopyrightBegin%
+
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Ericsson AB 2025. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+%CopyrightEnd%
+-->
+<document>
+  <batch>
+    <group>
+      <rec>
+        <aaaaaa>123456</aaaaaa>
+        <bbbbbb>hej hopp</bbbbbb>
+        <cccccc>
+          This is a test string
+        </cccccc>
+      </rec>
+      <rec>
+        <aaaaaa>123456</aaaaaa>
+        <bbbbbb>hej hopp</bbbbbb>
+        <cccccc>
+          This is a test string
+        </cccccc>
+      </rec>
+    </group>
+  </batch>
+</document>
+ 
+    
+
+<?xml version="1.0"?>
+<document>
+  <batch>
+    <group>
+      <rec>
+        <aaaaaa>123456</aaaaaa>
+        <bbbbbb>hej hopp</bbbbbb>
+        <cccccc>
+          This is a test string
+        </cccccc>
+      </rec>
+    </group>
+  </batch>
+</document>


### PR DESCRIPTION
Add an option to discard whitespace before the xml tag when reading from a stream.

Also updated a bad error message.