### PR TITLE
Optimize binary_to_term

### DIFF
--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -117,6 +117,11 @@ static void store_in_vec(TTBEncodeContext *ctx, byte *ep, Binary *ohbin, Eterm o
 static Uint32 calc_iovec_fun_size(SysIOVec* iov, Uint32 fun_high_ix, byte* size_p);
 
 void erts_init_external(void) {
+    ERTS_CT_ASSERT(offsetof(ErtsDistExternalFake,data) ==
+                   offsetof(ErtsDistExternal,data));
+    ERTS_CT_ASSERT(offsetof(ErtsDistExternalFake,flags) ==
+                   offsetof(ErtsDistExternal,flags));
+
     erts_init_trap_export(&term_to_binary_trap_export,
 			  am_erts_internal, am_term_to_binary_trap, 1,
 			  &term_to_binary_trap_1);
@@ -1302,7 +1307,8 @@ erts_decode_dist_ext(ErtsHeapFactory* factory,
 
 Eterm erts_decode_ext(ErtsHeapFactory* factory, const byte **ext, Uint32 flags)
 {
-    ErtsDistExternal ede, *edep;
+    ErtsDistExternalFake ede;
+    ErtsDistExternal *edep;
     Eterm obj;
     const byte *ep = *ext;
     if (*ep++ != VERSION_MAGIC) {
@@ -1313,7 +1319,7 @@ Eterm erts_decode_ext(ErtsHeapFactory* factory, const byte **ext, Uint32 flags)
         ASSERT(flags == ERTS_DIST_EXT_BTT_SAFE);
         ede.flags = flags; /* a dummy struct just for the flags */
         ede.data = NULL;
-        edep = &ede;
+        edep = (ErtsDistExternal*) &ede;
     } else {
         edep = NULL;
     }
@@ -2045,10 +2051,10 @@ static BIF_RETTYPE binary_to_term_int(Process* p, Eterm bin, B2TContext *ctx)
         case B2TDecodeTuple:
         case B2TDecodeString:
         case B2TDecodeBinary: {
-	    ErtsDistExternal fakedep;
+	    ErtsDistExternalFake fakedep;
             fakedep.flags = ctx->flags;
             fakedep.data = NULL;
-            dec_term(&fakedep, NULL, NULL, NULL, ctx, 0);
+            dec_term((ErtsDistExternal*)&fakedep, NULL, NULL, NULL, ctx, 0);
             break;
 	}
         case B2TDecodeFail:

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -142,14 +142,23 @@ struct erl_dist_external_data {
 };
 
 typedef struct erl_dist_external {
+    ErtsDistExternalData *data;
+    Uint32 flags;
+
+    Uint32 connection_id;
     Sint heap_size;
     DistEntry *dep;
-    Uint32 flags;
-    Uint32 connection_id;
-    ErtsDistExternalData *data;
     struct ErtsMonLnkDist__ *mld;   /* copied from DistEntry.mld */
     ErtsAtomTranslationTable attab;
 } ErtsDistExternal;
+
+/* This fake one is used to impersonate ErtsDistExternal for dec_term()
+ * just for the flags without a large unused ErtsAtomTranslationTable.
+ */
+typedef struct {
+    ErtsDistExternalData *data;
+    Uint32 flags;
+} ErtsDistExternalFake;
 
 typedef struct {
     byte *extp;


### PR DESCRIPTION
Remove use of struct `ErtsDistExternal` which contains a large atom cache table (64kb). The atom cache is not even used by `binary_to_term` and just consumes native stack space. With compiler option `-ftrivial-auto-var-init=zero` it gets really bad as it zeroes all those 64kb for each call.
