### PR TITLE
Remove -ftrivial-auto-var-init=zero as default OSSF compile option 

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -6702,46 +6702,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        CFLAGS="-ftrivial-auto-var-init=zero $CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -6502,46 +6502,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $DED_CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        DED_CFLAGS="-ftrivial-auto-var-init=zero $DED_CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -6096,46 +6096,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $DED_CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        DED_CFLAGS="-ftrivial-auto-var-init=zero $DED_CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;
@@ -11355,46 +11315,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 then :
 
         CFLAGS="-fno-strict-aliasing $CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        CFLAGS="-ftrivial-auto-var-init=zero $CFLAGS"
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -6556,46 +6556,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $DED_CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        DED_CFLAGS="-ftrivial-auto-var-init=zero $DED_CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -5013,46 +5013,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        CFLAGS="-ftrivial-auto-var-init=zero $CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -5817,46 +5817,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        CFLAGS="-ftrivial-auto-var-init=zero $CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -3182,7 +3182,6 @@ AC_DEFUN([ERL_OSSF_CFLAGS],
         LM_TRY_ENABLE_CFLAG([-fno-strict-overflow],[$1])
         LM_TRY_ENABLE_CFLAG([-fno-delete-null-pointer-checks],[$1])
         LM_TRY_ENABLE_CFLAG([-fno-strict-aliasing],[$1])
-        LM_TRY_ENABLE_CFLAG([-ftrivial-auto-var-init=zero],[$1])
         LM_TRY_ENABLE_CFLAG([-fstrict-flex-arrays=3],[$1])
         AS_IF([test "X$can_enable_flag" = "Xfalse"],
           [

--- a/make/configure
+++ b/make/configure
@@ -7806,46 +7806,6 @@ esac
 fi
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)" >&5
-printf %s "checking if we can add -ftrivial-auto-var-init=zero to DED_CFLAGS (via CFLAGS)... " >&6; }
-    saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -ftrivial-auto-var-init=zero $DED_CFLAGS";
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-return 0;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  can_enable_flag=true
-else case e in #(
-  e) can_enable_flag=false ;;
-esac
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    CFLAGS=$saved_CFLAGS;
-    if test "X$can_enable_flag" = "Xtrue"
-then :
-
-        DED_CFLAGS="-ftrivial-auto-var-init=zero $DED_CFLAGS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-else case e in #(
-  e)
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-       ;;
-esac
-fi
-
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)" >&5
 printf %s "checking if we can add -fstrict-flex-arrays=3 to DED_CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;


### PR DESCRIPTION
Seen to cause notable performance regressions due to large stack allocated variables (#9759). Skip `-ftrivial-auto-var-init=zero` until we have purged the code base from all such large stack frames.