### PR TITLE
Revert "Don't steal task when there is a single one"

### DIFF
--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -4521,6 +4521,8 @@ try_steal_task_from_victim(ErtsRunQueue *rq, ErtsRunQueue *vrq, Uint32 flags, Pr
             continue;
         }
         rpq = &vrq->procs.prio[prio_q];
+        /* Steal at least one task, even if there is a single one */
+        max_processes_to_steal++;
         /* Only steal half the tasks (to balance the load between the victim runqueue and this one) */
         max_processes_to_steal /= 2;
         /* Don't steal too many tasks at once, to keep the critical section from getting too long */


### PR DESCRIPTION
This reverts commit d86d313ee6f62423208ac696986f45bad3350f6b.

The reverted commit frequently leaves one or more schedulers out of work when there actually is work to do.

The simplest example: We have two schedulers and two processes executing full time currently located on the same scheduler. Both processes will be left on the scheduler where they are currently located, instead of one of them being stolen by the scheduler that is out of work. This since the scheduler performing work will always be executing one process while the other process exist in the run queue, i.e, the run-queue length is always 1. The work stealing functionality will leave the system in this state until something else changes the state of the system.