### PR TITLE
Michal/kernel/decreasing-disk-log-size-causes-crash/otp-19605

### DIFF
--- a/lib/kernel/src/disk_log_1.erl
+++ b/lib/kernel/src/disk_log_1.erl
@@ -1375,6 +1375,8 @@ inc_wrap(FName, CurF, MaxF) ->
 inc(N, {_NewMax, OldMax}) -> inc(N, OldMax, 1);
 inc(N, Max) -> inc(N, Max, 1).
 
+inc(N, {_NewMax, OldMax}, Step) ->
+    inc(N, OldMax, Step);
 inc(N, Max, Step) ->
     Nx = (N + Step) rem Max,
     if

--- a/lib/kernel/src/disk_log_1.erl
+++ b/lib/kernel/src/disk_log_1.erl
@@ -1372,7 +1372,6 @@ inc_wrap(FName, CurF, MaxF) ->
 	    {NewFt, MaxF}
     end.
 
-inc(N, {_NewMax, OldMax}) -> inc(N, OldMax, 1);
 inc(N, Max) -> inc(N, Max, 1).
 
 inc(N, {_NewMax, OldMax}, Step) ->


### PR DESCRIPTION
Fixes: #9720