### PR TITLE
adds dependabot alerts for vendor packages

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -847,6 +847,40 @@ jobs:
             fail-on: ${{ github.ref_type == 'tag' && '' || '' }} # 'violations,issues' }}
             sw-version: ${{ env.OTP_SBOM_VERSION }}
 
+  vendor-analysis:
+    name: Vendor Dependency Analysis
+    runs-on: ubuntu-latest
+    needs:
+        - sbom
+        - pack
+    ## Needed to use Github Dependency API
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
+      - uses: ./.github/actions/build-base-image
+        with:
+            BASE_BRANCH: ${{ env.BASE_BRANCH }}
+
+      - name: Download SBoM
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # ratchet:actions/download-artifact@v4.2.1
+        with:
+            name: ort-results-otp-${{ env.OTP_SBOM_VERSION }}
+
+      - name: Generate Vendor SBOM
+        run: |
+          docker run -v $PWD/:/github -v $HOME:$HOME otp \
+            "/github/.github/scripts/otp-compliance.es sbom vendor \
+              --sbom-file /github/bom.spdx.json"
+
+      # allows Dependabot to give us alert of the vendor libraries that use semantic versioning
+      - name: Upload SBOM to Github Dependency API
+        uses: advanced-security/spdx-dependency-submission-action@5530bab9ee4bbe66420ce8280624036c77f89746 # ratchet:advanced-security/spdx-dependency-submission-action@v0.1.1
+
+
+
   ## If this is an "OTP-*" tag that has been pushed we do some release work
   release:
     name: Release Erlang/OTP

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -850,6 +850,7 @@ jobs:
   vendor-analysis:
     name: Vendor Dependency Analysis
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs:
         - sbom
         - pack
@@ -878,8 +879,6 @@ jobs:
       # allows Dependabot to give us alert of the vendor libraries that use semantic versioning
       - name: Upload SBOM to Github Dependency API
         uses: advanced-security/spdx-dependency-submission-action@5530bab9ee4bbe66420ce8280624036c77f89746 # ratchet:advanced-security/spdx-dependency-submission-action@v0.1.1
-
-
 
   ## If this is an "OTP-*" tag that has been pushed we do some release work
   release:


### PR DESCRIPTION
Uploads SBoM in SPDX 2.2 format to Github's dependency submission API. 

This lets Erlang/OTP receive Dependabot alerts for SPDX packages. In Erlang's case, this will allow us to track vulnerabilities in vendor dependencies. 

For this to work with Dependabot, we should include packages with semantic versioning, not commit hashes. Not all vendor libraries in the SBoM will be tracked, but most of them will (e.g., `asmjit` and `fp16` will not be tracked; `zlib`, `pcre`, `tcl`, `zstd`, `autoconf`, and `openssl` should be tracked, in theory, based on their `purl`).