### PR TITLE
erl_debugger: Add BIFs to list available line breakpoints and their status

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -172,6 +172,7 @@ atom caller_line
 atom capture
 atom case_clause
 atom caseless
+atom catch
 atom catchlevel
 atom cause
 atom cd

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -821,6 +821,8 @@ bif erl_debugger:register/1
 bif erl_debugger:unregister/2
 bif erl_debugger:whereis/0
 bif erl_debugger:breakpoint/3
+bif erl_debugger:breakpoints/1
+bif erl_debugger:breakpoints/3
 bif erts_internal:notify_breakpoint_hit/3
 bif erl_debugger:stack_frames/2
 bif erl_debugger:peek_stack_frame_slot/4

--- a/erts/emulator/beam/erl_debugger.c
+++ b/erts/emulator/beam/erl_debugger.c
@@ -402,7 +402,7 @@ erl_debugger_breakpoint_3(BIF_ALIST_3) {
 
         hp1 = HAlloc(BIF_P, 6);
         hp2 = hp1 + 3;
-        return TUPLE2(hp2, am_error, TUPLE2(hp1, error_type, error_source));
+        BIF_RET(TUPLE2(hp2, am_error, TUPLE2(hp1, error_type, error_source)));
     }
 }
 
@@ -448,6 +448,175 @@ erts_internal_notify_breakpoint_hit_3(BIF_ALIST_3) {
 
     BIF_RET(am_ok);
 }
+
+static Eterm build_breakpoints_info_for_fun(Process *c_p, const BeamCodeLineTab *lt, int fun_idx);
+
+BIF_RETTYPE
+erl_debugger_breakpoints_1(BIF_ALIST_1) {
+    Eterm module_name, result, *hp;
+    Module* modp;
+    ErtsCodeIndex code_ix = erts_active_code_ix();
+    const BeamCodeHeader* code_hdr;
+
+    BIF_UNDEF_IF_NO_DEBUGGER_SUPPORT();
+
+    module_name = BIF_ARG_1;
+    if (is_not_atom(module_name)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    modp = erts_get_module(module_name, code_ix);
+    if (modp == NULL) {
+        goto error;
+    }
+
+    code_hdr = modp->curr.code_hdr;
+    if (code_hdr == NULL) {
+        goto error;
+    }
+
+    hp = HAlloc(BIF_P, MAP0_SZ);
+    result = MAP0(hp);
+
+    for(int fun_idx = 0; fun_idx < code_hdr->num_functions; fun_idx++) {
+        Eterm fun_lines = build_breakpoints_info_for_fun(BIF_P,
+                                                         code_hdr->line_table,
+                                                         fun_idx);
+
+        const ErtsCodeInfo *fun_info = code_hdr->functions[fun_idx];
+        Eterm fun_term;
+        hp = HAlloc(BIF_P, 3);
+        fun_term = TUPLE2(hp,
+                          fun_info->mfa.function,
+                          make_small(fun_info->mfa.arity));
+
+        result = erts_maps_put(BIF_P, fun_term, fun_lines, result);
+    }
+
+    hp = HAlloc(BIF_P, 3);
+    BIF_RET(TUPLE2(hp, am_ok, result));
+
+    {
+    error:
+        hp = HAlloc(BIF_P, 3);
+        BIF_RET(TUPLE2(hp, am_error, am_badkey));
+    }
+}
+
+BIF_RETTYPE
+erl_debugger_breakpoints_3(BIF_ALIST_3) {
+    Eterm module_name, fun_name, arity, badkey_source, *hp;
+    Uint arity_val;
+    Module* modp;
+    ErtsCodeIndex code_ix = erts_active_code_ix();
+    const BeamCodeHeader* code_hdr;
+
+    BIF_UNDEF_IF_NO_DEBUGGER_SUPPORT();
+
+    module_name = BIF_ARG_1;
+    if (is_not_atom(module_name)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    fun_name = BIF_ARG_2;
+    if (is_not_atom(fun_name)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    arity = BIF_ARG_3;
+    if (is_not_small(BIF_ARG_3)) {
+        BIF_ERROR(BIF_P, BADARG);
+    }
+    arity_val = unsigned_val(BIF_ARG_3);
+
+    modp = erts_get_module(module_name, code_ix);
+    if (modp == NULL) {
+        badkey_source = module_name;
+        goto error;
+    }
+
+    code_hdr = modp->curr.code_hdr;
+    if (code_hdr == NULL) {
+        badkey_source = module_name;
+        goto error;
+    }
+
+    for(int fun_idx = 0; fun_idx < code_hdr->num_functions; fun_idx++) {
+        const ErtsCodeInfo *fun_info = code_hdr->functions[fun_idx];
+        const ErtsCodeMFA *mfa = &fun_info->mfa;
+        if (mfa->function == fun_name && mfa->arity == arity_val) {
+            const BeamCodeLineTab *lt = code_hdr->line_table;
+            Eterm result = build_breakpoints_info_for_fun(BIF_P, lt, fun_idx);
+            Eterm *hp = HAlloc(BIF_P, 3);
+            BIF_RET(TUPLE2(hp, am_ok, result));
+        }
+    }
+
+    hp = HAlloc(BIF_P, 3);
+    badkey_source = TUPLE2(hp, fun_name, arity);
+    goto error;
+
+    {
+        Eterm *hp1, *hp2;
+    error:
+
+        hp1 = HAlloc(BIF_P, 6);
+        hp2 = hp1 + 3;
+        BIF_RET(TUPLE2(hp2, am_error, TUPLE2(hp1, am_badkey, badkey_source)));
+    }
+}
+
+static Eterm build_breakpoints_info_for_fun(Process *c_p, const BeamCodeLineTab *lt, int fun_idx) {
+    Eterm *hp = HAlloc(c_p, MAP0_SZ);
+    Eterm fun_lines = MAP0(hp);
+
+    if (lt) {
+        const void **fun_line_starts = lt->func_tab[fun_idx];
+        const void *next_fun_start = lt->func_tab[fun_idx+1][0];
+        int loc_tab_idx = lt->func_tab[fun_idx] - lt->func_tab[0];
+
+        for(int fun_line=0; fun_line_starts[fun_line] < next_fun_start; fun_line++) {
+            Uint32 loc;
+            Eterm line, status;
+            const Eterm *prev_status;
+
+            if (lt->loc_size == 2) {
+                loc = lt->loc_tab.p2[loc_tab_idx + fun_line];
+            } else {
+                ASSERT(lt->loc_size == 4);
+                loc = lt->loc_tab.p4[loc_tab_idx + fun_line];
+            }
+            if (loc == LINE_INVALID_LOCATION) {
+                continue;
+            }
+
+            line = make_small(LOC_LINE(loc));
+
+            switch (erts_is_line_breakpoint_code(fun_line_starts[fun_line])) {
+            case IS_NOT_LINE_BP:
+                continue;
+            case IS_ENABLED_LINE_BP:
+                status = am_true;
+                break;
+            case IS_DISABLED_LINE_BP:
+                status = am_false;
+                break;
+            default:
+                ASSERT(0);
+                continue;
+            }
+            prev_status = erts_maps_get(line, fun_lines);
+            if (prev_status == NULL) {
+                fun_lines = erts_maps_put(c_p, line, status, fun_lines);
+            } else {
+                ASSERT(*prev_status == status);
+            }
+        }
+    }
+
+    return fun_lines;
+}
+
 
 /* Inspecting stack-frames and X registers */
 
@@ -654,7 +823,7 @@ erl_debugger_stack_frames_2(BIF_ALIST_2)
             this_frame = TUPLE3(hp,
                                 make_small(frame_no++),
                                 stack_frame_fun_info(BIF_P,
-                                                    code_ptr,
+                                                     code_ptr,
                                                      rp,
                                                      is_return_addr),
                                 frame_info_map);

--- a/erts/emulator/beam/erl_debugger.c
+++ b/erts/emulator/beam/erl_debugger.c
@@ -740,7 +740,7 @@ make_catch_tuple(Process *c_p, ErtsCodePtr catch_addr) {
 
     hp = HAlloc(c_p, tup2_sz);
     result = TUPLE2(hp,
-                    ERTS_MAKE_AM("catch"),
+                    am_catch,
                     stack_frame_fun_info(c_p, catch_addr, NULL, 0));
 
     return result;

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -516,6 +516,8 @@ _ET_DECLARE_CHECKED(Eterm*,tuple_val,Eterm)
   zero on heaps. One should instead use the literal that can be
   obtained by use the literal identified by ERTS_GLOBAL_LIT_EMPTY_TUPLE.
  */
+extern Eterm ERTS_GLOBAL_LIT_EMPTY_TUPLE;
+#define TUPLE0 ERTS_GLOBAL_LIT_EMPTY_TUPLE
 #define TUPLE1(t,e1) \
         ((t)[0] = make_arityval(1), \
         (t)[1] = (e1), \
@@ -1294,14 +1296,19 @@ _ET_DECLARE_CHECKED(struct erl_node_*,external_ref_node,Eterm)
      (hp)[1] = sz,                              \
      (hp)[2] = keys)
 
-#define MAP_SZ(sz) (MAP_HEADER_FLATMAP_SZ + 2*sz + 1)
+/* NB. When sz is 0, TUPLE0 is shared, so takes no space */
+#define MAP_SZ(sz) (MAP_HEADER_FLATMAP_SZ + 2*sz + !!sz)
 
+#define MAP0_SZ MAP_SZ(0)
 #define MAP1_SZ MAP_SZ(1)
 #define MAP2_SZ MAP_SZ(2)
 #define MAP3_SZ MAP_SZ(3)
 #define MAP4_SZ MAP_SZ(4)
 #define MAP5_SZ MAP_SZ(5)
 
+#define MAP0(hp)                                                        \
+    (MAP_HEADER(hp, 0, TUPLE0),                    \
+     make_flatmap(hp))
 #define MAP1(hp, k1, v1)                                                \
     (MAP_HEADER(hp, 1, TUPLE1(hp+1+MAP_HEADER_FLATMAP_SZ, k1)),         \
      (hp)[MAP_HEADER_FLATMAP_SZ+0] = v1,                                \

--- a/lib/kernel/src/erl_debugger.erl
+++ b/lib/kernel/src/erl_debugger.erl
@@ -44,7 +44,7 @@ or otherwise expect frequent incompatible changes.
 -export([supported/0]).
 -export([instrumentations/0, toggle_instrumentations/1]).
 -export([register/1, unregister/2, whereis/0]).
--export([breakpoint/3]).
+-export([breakpoint/3, breakpoints/1, breakpoints/3]).
 -export([stack_frames/2, peek_stack_frame_slot/4]).
 -export([xregs_count/1, peek_xreg/3]).
 
@@ -229,6 +229,40 @@ Returns `ok` on success. It can fail with the following reasons:
 breakpoint(_, _, _) ->
     erlang:nif_error(undef).
 
+-doc """
+Returns information on available breakpoints for a module.
+
+For each function in the module, returns a map `#{Line => boolean()}`,
+where the keys are lines where breakpoints can be set, and the value
+represents whether be breakpoint is enabled (`true`) or not (`false`).
+""".
+-spec breakpoints(Module) -> {ok, Result} | {error, Reason} when
+    Module :: module(),
+    Result :: #{Fun => #{Line => boolean()}},
+    Fun :: {atom(), arity()},
+    Line :: pos_integer(),
+    Reason :: badkey.
+breakpoints(_) ->
+    erlang:nif_error(undef).
+
+-doc """
+Returns information on available breakpoints for a given function. .
+
+The function need not be exported.
+
+Returns a map `#{Line => boolean()}`, where the keys are lines where
+breakpoints can be set, and the value represents whether be breakpoint
+is enabled (`true`) or not (`false`).
+""".
+-spec breakpoints(Module, FunName, Arity) -> {ok, Result} | {error, Reason} when
+    Module :: module(),
+    FunName :: atom(),
+    Arity ::  arity(),
+    Result :: #{Line => boolean()},
+    Line :: pos_integer(),
+    Reason :: {badkey, module() | {FunName, Arity}}.
+breakpoints(_, _, _) ->
+    erlang:nif_error(undef).
 
 %% Stack frames
 


### PR DESCRIPTION
The `erl_debugger` module currently exposes a BIF to toggle line-breakpoints, but there was no mechanism to query the status. We add BIFs that, for a give module or for a given MFA, will return all lines that allow breakpoints being set and what their status is.

The main motivation is to allow the edb debugger to implement stepping-over and stepping-out without requiring the module to be available on disk, and compiled with `debug_info`. 