### PR TITLE
tprof added to tools.app.src

### DIFF
--- a/lib/tools/src/tools.app.src
+++ b/lib/tools/src/tools.app.src
@@ -24,6 +24,7 @@
 	     cprof,
 	     eprof,
 	     fprof,
+	     tprof,
 	     lcnt,
 	     make,
 	     tags,


### PR DESCRIPTION
The tprof profiler is not present in the .app.src file. This causes that tprof is not part of the release and, as a result, possibly not available in an installed system. This PR just adds tprof to tools.app.src.