### PR TITLE
eunit: Ensure failed setup is not silently ignored

### DIFF
--- a/lib/eunit/src/eunit_serial.erl
+++ b/lib/eunit/src/eunit_serial.erl
@@ -89,6 +89,17 @@ expect(Id, ParentId, GroupMinSize, St0) ->
 	    %% cast no cancel event (since the item might not exist)
 	    {true, St1};
 	{cancel, exact, Msg, St1} ->
+            %% We got a cancel before begin. If we're running in
+            %% parallel we might still have a begin message in the
+            %% message queue since the cancel message might have been
+            %% picked up by wait_1/5 for an different test case. So
+            %% flush the queue to avoid silently ignoring the cancel.
+            receive
+                {status, Id, {progress, 'begin', _}} = M ->
+                    cast(M, St1)
+            after 0 ->
+                ok
+            end,
 	    cast_cancel(Id, Msg, St1),
 	    {false, St1};
 	{ok, Msg, St1} ->

--- a/lib/eunit/test/eunit_SUITE.erl
+++ b/lib/eunit/test/eunit_SUITE.erl
@@ -24,7 +24,8 @@
 	 app_test/1, appup_test/1, eunit_test/1, eunit_exact_test/1,
          fixture_test/1, primitive_test/1, surefire_utf8_test/1,
          surefire_latin_test/1, surefire_c0_test/1, surefire_ensure_dir_test/1,
-         stacktrace_at_timeout_test/1, scale_timeouts_test/1]).
+         stacktrace_at_timeout_test/1, scale_timeouts_test/1,
+         report_failed_setup_inparallel_test/1]).
 
 %% Two eunit tests:
 -export([times_out_test_/0, times_out_default_test/0]).
@@ -41,7 +42,7 @@ all() ->
     [app_test, appup_test, eunit_test, eunit_exact_test, primitive_test,
      fixture_test, surefire_utf8_test, surefire_latin_test, surefire_c0_test,
      surefire_ensure_dir_test, stacktrace_at_timeout_test,
-     scale_timeouts_test].
+     scale_timeouts_test, report_failed_setup_inparallel_test].
 
 groups() ->
     [].
@@ -256,3 +257,18 @@ times_out_default_test() ->
     %% so this is long enough to cause a time out.
     timer:sleep(20_000).
 
+report_failed_setup_inparallel_test(_Config) ->
+    Test =
+        {
+         inparallel,
+         [
+          fun() -> test1 end,
+          {setup,
+           fun() -> exit(failing_setup) end,
+           fun(_) -> ok end,
+           [fun() -> test11 end]}
+         ]
+        },
+    eunit:test(Test,[verbose, {report, {eunit_test_listener, [self()]}}]),
+    check_test_results(Test, #{skip => 0,cancel => 1,fail => 0,pass => 1}),
+    ok.


### PR DESCRIPTION
When running tests in parallel 'cancel' messages are sometimes picked up before the 'begin' message for the same test case, causing the cancelled test to be siliently ignored. This commit checks the eunit_serial inbox for such 'begin' message and makes sure the cancelled test is reported.