### PR TITLE
xmerl: Fix exporting XML comments

### DIFF
--- a/lib/xmerl/src/xmerl.erl
+++ b/lib/xmerl/src/xmerl.erl
@@ -258,8 +258,8 @@ export_content([#xmlText{value = Text, type = cdata} | Es], Callbacks) ->
     [apply_cdata_cb(Callbacks, Text) | export_content(Es, Callbacks)];
 export_content([#xmlPI{} | Es], Callbacks) ->
     export_content(Es, Callbacks);
-export_content([#xmlComment{} | Es], Callbacks) ->
-    export_content(Es, Callbacks);
+export_content([#xmlComment{value = Text} | Es], Callbacks) ->
+    [apply_comment_cb(Callbacks, Text) | export_content(Es, Callbacks)];
 export_content([#xmlDecl{} | Es], Callbacks) ->
     export_content(Es, Callbacks);
 export_content([E | Es], Callbacks) ->
@@ -299,8 +299,8 @@ export_element(E = #xmlElement{name = Tag,
     tagdef(Tag,Pos,Parents,Args,CBs);
 export_element(#xmlPI{}, _CBs) ->
     [];
-export_element(#xmlComment{}, _CBs) ->
-    [];
+export_element(#xmlComment{value = Text}, CBs) ->
+    apply_comment_cb(CBs, Text);
 export_element(#xmlDecl{}, _CBs) ->
     [].
 
@@ -330,8 +330,8 @@ export_element(E=#xmlElement{name = Tag,
     tagdef(Tag,Pos,Parents,Args,Callbacks);
 export_element(#xmlPI{}, _CallbackModule, CallbackState) ->
     CallbackState;
-export_element(#xmlComment{},_CallbackModule, CallbackState) ->
-    CallbackState;
+export_element(#xmlComment{value = Text},CallbackModule,_CallbackState) ->
+    apply_comment_cb(CallbackModule,Text);
 export_element(#xmlDecl{},_CallbackModule, CallbackState) ->
     CallbackState.
 
@@ -382,6 +382,9 @@ apply_text_cb(Ms, Text) ->
 
 apply_cdata_cb(Ms, Text) ->
     apply_cb(Ms, '#cdata#', '#cdata#', [Text]).
+
+apply_comment_cb(Ms, Text) ->
+    apply_cb(Ms, '#comment#', '#comment#', [Text]).
 
 apply_tag_cb(Ms, F, Args) ->
     apply_cb(Ms, F, '#element#', Args).

--- a/lib/xmerl/src/xmerl_html.erl
+++ b/lib/xmerl/src/xmerl_html.erl
@@ -31,10 +31,11 @@
 	 '#element#'/5,
 	 '#text#'/1,
 	 '#cdata#'/1,
+	 '#comment#'/1,
 	 p/4]).
 
 -import(xmerl_lib, [start_tag/2, end_tag/1, is_empty_data/1,
-		    find_attribute/2, export_text/1]).
+		    find_attribute/2, export_text/1, export_comment/1]).
 
 -include("xmerl.hrl").
 
@@ -50,6 +51,10 @@
 %% Handled the same as text.
 '#cdata#'(Text) ->
     export_text(Text).
+
+%% The '#comment#' function is called for every comment element.
+'#comment#'(Text) ->
+    export_comment(Text).
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.

--- a/lib/xmerl/src/xmerl_lib.erl
+++ b/lib/xmerl/src/xmerl_lib.erl
@@ -28,6 +28,7 @@
 	 expand_content/3, normalize_element/1, normalize_element/3,
 	 expand_element/1, expand_element/3, expand_attributes/1,
 	 expand_attributes/3, export_text/1, flatten_text/1, export_cdata/1,
+	 export_comment/1,
 	 export_attribute/1, markup/2, markup/3, simplify_element/1,
 	 simplify_content/1, start_tag/1, start_tag/2, end_tag/1,
 	 empty_tag/1, empty_tag/2,is_empty_data/1, find_attribute/2,
@@ -101,6 +102,21 @@ export_cdata([], []) ->
     [];
 export_cdata(Bin, Cont) ->
     export_cdata(binary_to_list(Bin), Cont).
+
+%% Export comment
+export_comment(T) ->
+    R = "<!--" ++ export_comment(T, []),
+    R ++ "-->".
+export_comment([C | T], Cont) when is_integer(C) ->
+    [C | export_comment(T, Cont)];
+export_comment([T | T1], Cont) ->
+    export_comment(T, [T1 | Cont]);
+export_comment([], [T | Cont]) ->
+    export_comment(T, Cont);
+export_comment([], []) ->
+    [];
+export_comment(Bin, Cont) ->
+    export_comment(binary_to_list(Bin), Cont).
 
 %% Convert attribute value to a flat string, escaping characters `"',
 %% `<' and `&'. (Note that single-quote characters are not escaped; the

--- a/lib/xmerl/src/xmerl_text.erl
+++ b/lib/xmerl/src/xmerl_text.erl
@@ -29,7 +29,8 @@
 -export(['#root#'/4,
 	 '#element#'/5,
 	 '#text#'/1,
-	 '#cdata#'/1]).
+	 '#cdata#'/1,
+	 '#comment#'/1]).
 
 -include("xmerl.hrl").
 
@@ -43,6 +44,10 @@
 %% The '#cdata#' function is called for every text segment of type cdata.
 %% Handled the same as text.
 '#cdata#'(Text) -> Text.
+
+%% The '#comment#' function is called for every comment element.
+%% Comment value is not exported since there is no markup.
+'#comment#'(_Text) -> [].
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.

--- a/lib/xmerl/src/xmerl_xml.erl
+++ b/lib/xmerl/src/xmerl_xml.erl
@@ -29,9 +29,11 @@
 -export(['#root#'/4,
 	 '#element#'/5,
 	 '#text#'/1,
-	 '#cdata#'/1]).
+	 '#cdata#'/1,
+	 '#comment#'/1]).
 
--import(xmerl_lib, [markup/3, empty_tag/2, export_text/1, export_cdata/1]).
+-import(xmerl_lib, [markup/3, empty_tag/2, export_text/1, export_cdata/1,
+                    export_comment/1]).
 
 -include("xmerl.hrl").
 -include("xmerl_internal.hrl").
@@ -49,6 +51,10 @@
 '#cdata#'(Text) ->
 %?dbg("Cdata=~p~n",[Text]),
     export_cdata(Text).
+
+%% The '#comment#' function is called for every comment element.
+'#comment#'(Text) ->
+    export_comment(Text).
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.

--- a/lib/xmerl/src/xmerl_xml_indent.erl
+++ b/lib/xmerl/src/xmerl_xml_indent.erl
@@ -32,9 +32,10 @@
 
 -export(['#root#'/4,
 	 '#element#'/5,
-	 '#text#'/1]).
+	 '#text#'/1,
+	 '#comment#'/1]).
 
--import(xmerl_lib, [markup/3, empty_tag/2, export_text/1]).
+-import(xmerl_lib, [markup/3, empty_tag/2, export_text/1, export_comment/1]).
 
 -include("xmerl.hrl").
 -include("xmerl_internal.hrl").
@@ -48,6 +49,13 @@
 '#text#'(Text) ->
     export_text(Text).
 
+
+% The '#comment#' function is called for every comment element.
+
+'#comment#'(Text) ->
+    %% Returning a list allows is_char/1 to return true
+    %% when indenting the contents of an element.
+    [ export_comment(Text) ].
 
 %% The '#root#' tag is called when the entire structure has been
 %% exported. It does not appear in the structure itself.

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -55,7 +55,7 @@ groups() ->
      {misc, [],
       [latin1_alias, syntax_bug1, syntax_bug2, syntax_bug3,
        pe_ref1, copyright, testXSEIF, export_simple1, export,
-       export_cdata,
+       export_cdata, export_comments,
        default_attrs_bug, xml_ns, scan_splits_string_bug,
        allow_entities_test]},
      {eventp_tests, [], [sax_parse_and_export]},
@@ -319,6 +319,17 @@ export_cdata(Config) ->
 </doc>">>,
     Prolog = ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"],
     {E,_} = xmerl_scan:string(binary:bin_to_list(InData)),
+    Exported = xmerl:export([E],xmerl_xml,[{prolog,Prolog}]),
+    InData = list_to_binary(Exported),
+    ok.
+
+export_comments(Config) ->
+    InData = <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<doc>
+    <!-- top comment --><a>Test...</a>
+    <!-- bottom comment --></doc>">>,
+    Prolog = ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"],
+    {E, _} = xmerl_scan:string(binary:bin_to_list(InData)),
     Exported = xmerl:export([E],xmerl_xml,[{prolog,Prolog}]),
     InData = list_to_binary(Exported),
     ok.
@@ -782,6 +793,7 @@ xml_namespace_indented() ->
   "\n  <title>Cheaper by the Dozen</title>"
   "\n  <isbn:number>1568491379</isbn:number>"
   "\n  <notes>"
+  "\n    <!-- make HTML the default namespace for some comments -->"
   "\n    <p xmlns=\"urn:w3-org-ns:HTML\">This is a <i>funny</i> book!</p>"
   "\n  </notes>"
   "\n</book>".


### PR DESCRIPTION
Fix issue #5697 by exporting `#xmlComment` elements when calling `export/3` or `export_simple/3` and similar functions.

If we want to preserve the original document formatting, this will be impossible to solve only from the export side. The `xmerl_scan` functions strip white space after comments when creating the element records, and the original text elements are lost.

Top level comments like the example in #5697 will only be exported if we create and export as a document. There is no function to export an `#xmlDocument` directly, could be a possible enhancement.

The callback module `xmerl_xml_indented` doesn't indent properly if input data has text elements used for indentation. I allow for indentation of comments like the example in test 45 `formatter_pass` where there is no indentation in the input. I updated the test case to insert the newly exported comment.

I tried to implement an alternative PR that preserves formatting by changing `xmerl_scan` to not strip white space after comments. These would be read as extra text elements. Unfortunately this breaks more than 60 unit tests, mostly related to DTD validation. It would be a larger PR and introduce more risk of breaking something. I didn't have time to investigate a solution for this alternative to work.
