### PR TITLE
gh: Format all markdown release bodies

### DIFF
--- a/.github/workflows/sync-github-releases.yaml
+++ b/.github/workflows/sync-github-releases.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Sync releases
         env:
           ERLANG_ORG_TOKEN: ${{ secrets.TRIGGER_ERLANG_ORG_BUILD }}
-        run: >
-          .github/scripts/sync-github-releases.sh ${{ github.repository }}
-          "Bearer ${{ secrets.GITHUB_TOKEN }}" "^[2-9][1-9]\\..*" 25m
+        run: |
+          pip install mdformat mdformat-gfm
+          .github/scripts/sync-github-releases.sh ${{ github.repository }} \
+            "Bearer ${{ secrets.GITHUB_TOKEN }}" "^[2-9][1-9]\\..*" 25m


### PR DESCRIPTION
The github markdown rendered for releases render newlines as `<br/>` so the release notes tend to look a bit strange. This change updated the sync tool to format all the bodies of all releases to look correct.