### PR TITLE
Fix typo in erts/erlang:system_flag/2 documentation comment

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -8777,7 +8777,7 @@ Sets a system flag to the given value.
 The possible flags to set are:
 
 - ```erlang
-  system_flag(backtrace_depths, non_neg_integer()) -> non_neg_integer()
+  system_flag(backtrace_depth, non_neg_integer()) -> non_neg_integer()
   ```
 
    Sets the maximum depth of call stack back-traces in the exit reason element of


### PR DESCRIPTION
Corrected `backtrace_depths` to `backtrace_depth` in `system_flag/2` fn of `erts/preloaded/src/erlang.erl` and corresponding test data file `unknown_erlang_system_flag_2_func.txt`.