### PR TITLE
Shrink ErtsAtomTranslationTable to correct max size

### DIFF
--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -116,9 +116,11 @@ typedef struct {
     } cache[ERTS_ATOM_CACHE_SIZE];
 } ErtsAtomCacheMap;
 
+#define ERTS_MAX_INTERNAL_ATOM_CACHE_ENTRIES 255
+
 typedef struct {
     Uint32 size;
-    Eterm atom[ERTS_ATOM_CACHE_SIZE];
+    Eterm atom[ERTS_MAX_INTERNAL_ATOM_CACHE_ENTRIES];
 } ErtsAtomTranslationTable;
 
 /*


### PR DESCRIPTION
Shrink `ErtsAtomTranslationTable` from 2048 to 255 slots. Only 255 slots can be used (0-254) as only one byte is used in distribution header for `NumberOfAtomCacheRefs` and in `ATOM_CACHE_REF` for `AtomCacheReferenceIndex`.

This will probably not be a significant performance gain as it will only affect the native stack frame size of `erts_net_message()`.