### PR TITLE
diameter: Call message_cb 'ack' with updated callback

### DIFF
--- a/lib/diameter/src/transport/diameter_sctp.erl
+++ b/lib/diameter/src/transport/diameter_sctp.erl
@@ -1080,7 +1080,7 @@ actions([Dir | As], _, S)
 actions([Msg | As], send = Dir, S)
   when is_record(Msg, diameter_packet);
        is_binary(Msg) ->
-    actions(As, Dir, send(Msg, S));
+    send(Msg, actions(As, Dir, S));
 
 actions([Msg | As], recv = Dir, #transport{parent = Pid} = S)
   when is_record(Msg, diameter_packet);

--- a/lib/diameter/src/transport/diameter_tcp.erl
+++ b/lib/diameter/src/transport/diameter_tcp.erl
@@ -1128,7 +1128,7 @@ actions([Dir | As], _, S)
 actions([Msg | As], send = Dir, S)
   when is_binary(Msg);
        is_record(Msg, diameter_packet) ->
-    actions(As, Dir, send(Msg, S));
+    send(Msg, actions(As, Dir, S));
 
 actions([Msg | As], recv = Dir, #transport{parent = Pid} = S)
   when is_binary(Msg);


### PR DESCRIPTION
Diameter `message_cb` can return an updated callback that should be the one to be called for all subsequent events (`recv`, `send`, `ack`). When returning the new callback in response of a `send` event the subsequent `ack` event is notified with the old callback instead of the new one. This happens because the message is sent before parsing all the actions returned by the `send` callback.