### PR TITLE
otp: Only build and release debug emulator

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -364,6 +364,7 @@ jobs:
           ./otp_build boot -a
           ./otp_build release -a
           cp /mnt/c/opt/local64/pgm/wxWidgets-${{ env.WXWIDGETS_VERSION }}/3rdparty/webview2/runtimes/win-x64/native/WebView2Loader.dll $ERL_TOP/release/win32/erts-*/bin/
+          ./otp_build debuginfo_win32
           ./otp_build installer_win32
 
       - name: Upload installer

--- a/otp_build
+++ b/otp_build
@@ -1259,13 +1259,13 @@ do_update_ex_doc ()
 do_debuginfo_win32 ()
 {
     setup_make
-    ($MAKE MAKE="$MAKE" TARGET=$TARGET TYPE=debug) || exit 1
+    (cd erts/emulator && $MAKE MAKE="$MAKE" TARGET=$TARGET debug) || exit 1
     if [ -z "$1" ]; then
        RELDIR="$ERL_TOP/release/$TARGET"
     else
        RELDIR="$1"
     fi
-    ($MAKE release RELEASE_ROOT="$RELDIR" MAKE="$MAKE" TARGET=$TARGET TYPE=debug) || exit 1
+    (cd erts/emulator && $MAKE release RELEASE_ROOT="$RELDIR" MAKE="$MAKE" TARGET=$TARGET TYPE=debug) || exit 1
 }
 
 do_installer_win32 ()


### PR DESCRIPTION
If we build any other program, it will currently overwrite the optimized programs which is not what we want in a release as then they will all be debug instead of optimized.