### PR TITLE
ssl: Allow empty psk identity

### DIFF
--- a/lib/ssl/src/ssl_config.erl
+++ b/lib/ssl/src/ssl_config.erl
@@ -1303,7 +1303,7 @@ handle_psk(UserOpts, #{versions := Versions} = Opts) ->
             PSK1 = unicode:characters_to_binary(PSK0),
             PSKSize = byte_size(PSK1),
             assert_version_dep(psk_identity, Versions, ['tlsv1','tlsv1.1','tlsv1.2']),
-            option_error(not (0 < PSKSize andalso PSKSize < 65536),
+            option_error(not (0 =< PSKSize andalso PSKSize < 65536),
                          psk_identity, {psk_identity, PSK0}),
             PSK1;
         {_, PSK0} ->

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -3205,6 +3205,8 @@ options_identity(_Config) ->  %% psk_identity  srp_identity and user_lookup_fun
         [], client),
     ?OK(#{psk_identity := <<"foobar">>, srp_identity := undefined, user_lookup_fun := undefined},
         [{psk_identity, "foobar"}], server),
+    ?OK(#{psk_identity := <<"">>, srp_identity := undefined, user_lookup_fun := undefined},
+        [{psk_identity, ""}], server),
     ?OK(#{psk_identity := undefined, srp_identity := {<<"user">>, <<"pwd">>}, user_lookup_fun := undefined},
         [{srp_identity, {"user", "pwd"}}], client),
     ?OK(#{psk_identity := undefined, srp_identity := undefined, user_lookup_fun := {_, args}},


### PR DESCRIPTION
Relax the psk_identity validation to allow the client to provide an empty string.