### PR TITLE
asn1: Suppress unmatched returns warnings from Dialyzer

### DIFF
--- a/lib/asn1/src/asn1ct_gen_ber_bin_v2.erl
+++ b/lib/asn1/src/asn1ct_gen_ber_bin_v2.erl
@@ -81,7 +81,7 @@ suppress({M,F,A}=MFA) ->
 	    ok;
 	true ->
 	    Args = [lists:concat(["element(",I,", Arg)"]) || I <- lists:seq(1, A)],
-	    emit(["    ",{call,M,F,Args},com,nl])
+	    emit(["    _ = ",{call,M,F,Args},com,nl])
     end.
 
 %%===============================================================================

--- a/lib/asn1/src/asn1ct_gen_jer.erl
+++ b/lib/asn1/src/asn1ct_gen_jer.erl
@@ -355,7 +355,7 @@ suppress({M,F,A}=MFA) ->
 	    ok;
 	true ->
 	    Args = [lists:concat(["element(",I,", Arg)"]) || I <- lists:seq(1, A)],
-	    emit(["    ",{call,M,F,Args},com,nl])
+	    emit(["    _ = ",{call,M,F,Args},com,nl])
     end.
 
 %%===============================================================================

--- a/lib/asn1/src/asn1ct_gen_per.erl
+++ b/lib/asn1/src/asn1ct_gen_per.erl
@@ -59,7 +59,7 @@ suppress({M,F,A}=MFA) ->
 	    Args =
                 [lists:concat(["element(",I,", Arg)"])
                  || I <- lists:seq(1, A)],
-	    emit(["    ",{call,M,F,Args},com,nl])
+	    emit(["    _ = ",{call,M,F,Args},com,nl])
     end.
 
 gen_encode(Erules,Type) when is_record(Type,typedef) ->


### PR DESCRIPTION
A function generated by the ASN.1 compiler meant to suppress potential Dialyzer warnings could itself produce warnings when Dialyzer was run with the `unmatched_return` option.

Resolves #9841