### PR TITLE
eldap: fix typespec

### DIFF
--- a/lib/eldap/src/eldap.erl
+++ b/lib/eldap/src/eldap.erl
@@ -803,7 +803,7 @@ Create a filter where at least one of the `Filter` must be true.
 Negate a filter.
 """.
 -doc(#{since => <<"OTP R15B01">>}).
--spec 'not'(Filter) -> filter() when Filter :: {filter()}.
+-spec 'not'(Filter) -> filter() when Filter :: filter().
 'not'(Filter)        when is_tuple(Filter)       -> {'not',Filter}.
 
 %%%


### PR DESCRIPTION
Hello! That is probably a typo. There is no actual need to wrap a filter into a tuple before negating.