### PR TITLE
Use -fvisibility=hidden on entire beam executable

### DIFF
--- a/erts/configure
+++ b/erts/configure
@@ -704,7 +704,6 @@ XCRUN
 LLVM_PROFDATA
 WFLAGS
 DEBUG_FLAGS
-VISIBILITY_HIDDEN
 ERTS_CONFIG_H_IDIR
 MIXED_MINGW
 MIXED_VC
@@ -8554,13 +8553,13 @@ esac
 fi
 
 
-  # Make -fvisibility=hidden usable if supported. Currently only used by
-  # our PCRE2 to avoid symbol clashes with real PCRE2 if dynamically loaded.
+  # Use -fvisibility=hidden to only export selected symbols
+  # such as NIF and driver APIs.
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fvisibility=hidden to VISIBILITY_HIDDEN (via CFLAGS)" >&5
-printf %s "checking if we can add -fvisibility=hidden to VISIBILITY_HIDDEN (via CFLAGS)... " >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can add -fvisibility=hidden to CFLAGS (via CFLAGS)" >&5
+printf %s "checking if we can add -fvisibility=hidden to CFLAGS (via CFLAGS)... " >&6; }
     saved_CFLAGS=$CFLAGS;
-    CFLAGS="-Werror -fvisibility=hidden $VISIBILITY_HIDDEN";
+    CFLAGS="-Werror -fvisibility=hidden $CFLAGS";
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -8584,7 +8583,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     if test "X$can_enable_flag" = "Xtrue"
 then :
 
-        VISIBILITY_HIDDEN="-fvisibility=hidden $VISIBILITY_HIDDEN"
+        CFLAGS="-fvisibility=hidden $CFLAGS"
         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
 
@@ -8596,16 +8595,17 @@ printf "%s\n" "no" >&6; }
 esac
 fi
 
+  if test "$can_enable_flag" = false; then
+    as_fn_error $? "Compiler option -fvisibility=hidden not supported" "$LINENO" 5
+  fi
 
 else case e in #(
   e)
   WFLAGS=""
   WERRORFLAGS=${WERRORFLAGS:-""}
-  VISIBILITY_HIDDEN=""
   ;;
 esac
 fi
-
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking C99 support" >&5
 printf %s "checking C99 support... " >&6; }

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -607,16 +607,17 @@ AS_IF([test "x$GCC" = xyes],
   # such dubious duplicates.
   LM_TRY_ENABLE_CFLAG([-fno-common], [CFLAGS])
 
-  # Make -fvisibility=hidden usable if supported. Currently only used by
-  # our PCRE2 to avoid symbol clashes with real PCRE2 if dynamically loaded.
-  LM_TRY_ENABLE_CFLAG([-fvisibility=hidden], [VISIBILITY_HIDDEN])
+  # Use -fvisibility=hidden to only export selected symbols
+  # such as NIF and driver APIs.
+  LM_TRY_ENABLE_CFLAG([-fvisibility=hidden], [CFLAGS])
+  if test "$can_enable_flag" = false; then
+    AC_MSG_ERROR([Compiler option -fvisibility=hidden not supported])
+  fi
  ],
  [
   WFLAGS=""
   WERRORFLAGS=${WERRORFLAGS:-""}
-  VISIBILITY_HIDDEN=""
  ])
-AC_SUBST(VISIBILITY_HIDDEN)
 
 AC_MSG_CHECKING([C99 support])
 

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -36,7 +36,6 @@ Z_LIB=@Z_LIB@
 CROSS_COMPILING = @CROSS_COMPILING@
 NO_INLINE_FUNCTIONS=false
 USING_VC=@MIXED_VC@
-VISIBILITY_HIDDEN=@VISIBILITY_HIDDEN@
 
 OPCODE_TABLES = \
     $(ERL_TOP)/lib/compiler/src/genop.tab \
@@ -550,6 +549,9 @@ include $(ERL_TOP)/make/otp_release_targets.mk
 RELSYSDIR = $(RELEASE_PATH)/erts-$(VSN)
 
 RELEASE_INCLUDES = beam/erl_driver.h sys/$(ERLANG_OSTYPE)/driver_int.h beam/erl_nif.h beam/erl_nif_api_funcs.h beam/erl_drv_nif.h
+
+INTERNAL_RELEASE_INCLUDES = beam/erl_internal_test.h
+
 ifeq ($(TARGET),win32)
 RELEASE_INCLUDES += sys/$(ERLANG_OSTYPE)/erl_win_dyn_driver.h
 endif
@@ -563,12 +565,14 @@ release_spec: all
 	$(INSTALL_DIR) "$(RELSYSDIR)"
 	$(INSTALL_DIR) "$(RELSYSDIR)/src"
 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
+	$(INSTALL_DIR) "$(RELSYSDIR)/include/internal"
 	$(INSTALL_DIR) "$(RELSYSDIR)/man"
 	$(INSTALL_DIR) "$(RELSYSDIR)/doc"
 	$(INSTALL_DIR) "$(RELSYSDIR)/bin"
 	$(INSTALL_DIR) "$(RELEASE_PATH)/usr/include"
 	$(INSTALL_DATA) $(RELEASE_INCLUDES) "$(RELEASE_PATH)/usr/include"
 	$(INSTALL_DATA) $(RELEASE_INCLUDES) "$(RELSYSDIR)/include"
+	$(INSTALL_DATA) $(INTERNAL_RELEASE_INCLUDES) "$(RELSYSDIR)/include/internal"
 	$(INSTALL_PROGRAM) $(BINDIR)/$(EMULATOR_EXECUTABLE) "$(RELSYSDIR)/bin"
 ifeq ($(TARGET),win32)
 	$(INSTALL_DATA) $(BINDIR)/$(EMULATOR_EXECUTABLE:.dll=.pdb) "$(RELSYSDIR)/bin"
@@ -1160,7 +1164,8 @@ RUN_OBJS += \
 	$(OBJDIR)/erl_term_hashing.o \
 	$(OBJDIR)/erl_bif_coverage.o \
 	$(OBJDIR)/erl_iolist.o \
-	$(OBJDIR)/erl_etp.o
+	$(OBJDIR)/erl_etp.o \
+	$(OBJDIR)/erl_internal_test.o
 
 LTTNG_OBJS = $(OBJDIR)/erlang_lttng.o
 

--- a/erts/emulator/beam/erl_alloc.h
+++ b/erts/emulator/beam/erl_alloc.h
@@ -118,6 +118,8 @@ void erts_alloc_late_init(void);
 
 #if defined(GET_ERTS_ALC_TEST) || defined(ERTS_ALC_INTERNAL__)
 /* Only for testing */
+#include "erl_drv_nif.h"
+ERL_NAPI_EXPORT
 UWord erts_alc_test(UWord,
 		    UWord,
 		    UWord,

--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -44,19 +44,18 @@
 #include <stdlib.h>
 
 #if defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_)
-#ifndef STATIC_ERLANG_DRIVER
-   /* Windows dynamic drivers, everything is different... */
-#define ERL_DRIVER_TYPES_ONLY
-#define WIN32_DYNAMIC_ERL_DRIVER
-#endif
+#  ifndef STATIC_ERLANG_DRIVER
+     /* Windows dynamic drivers, everything is different... */
+#    define ERL_DRIVER_TYPES_ONLY
+#    define WIN32_DYNAMIC_ERL_DRIVER
+#  endif
+#  define EXTERN extern
+#else
+#  define EXTERN ERL_NAPI_EXPORT extern
 #endif
 
-#ifndef EXTERN
-#  ifdef __cplusplus
-#    define EXTERN extern "C"
-#  else
-#    define EXTERN extern
-#  endif
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 #define ERL_DRV_READ  ((int)ERL_NIF_SELECT_READ)
@@ -550,7 +549,7 @@ EXTERN ErlDrvTermData driver_mk_atom(char*);
 EXTERN ErlDrvTermData driver_mk_port(ErlDrvPort);
 EXTERN ErlDrvTermData driver_connected(ErlDrvPort);
 EXTERN ErlDrvTermData driver_caller(ErlDrvPort);
-extern const ErlDrvTermData driver_term_nil;
+EXTERN const ErlDrvTermData driver_term_nil;
 EXTERN ErlDrvTermData driver_mk_term_nil(void);
 EXTERN ErlDrvPort driver_create_port(ErlDrvPort creator_port, 
 				     ErlDrvTermData connected, /* pid */
@@ -636,7 +635,11 @@ EXTERN void erl_drv_set_os_pid(ErlDrvPort ix, ErlDrvSInt pid);
 #  include "erl_win_dyn_driver.h"
 #endif
 
+#ifdef __cplusplus
+} //extern "C"
 #endif
+
+#endif //__ERL_DRIVER_H__
 
 /* also in global.h, but driver's can't include global.h */
 void dtrace_drvport_str(ErlDrvPort port, char *port_buf);

--- a/erts/emulator/beam/erl_drv_nif.h
+++ b/erts/emulator/beam/erl_drv_nif.h
@@ -224,4 +224,14 @@ typedef struct {
 #  endif
 #endif
 
+#if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))
+#  define ERL_NAPI_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) && __GNUC__ >= 4
+#  define ERL_NAPI_EXPORT __attribute__ ((visibility("default")))
+#elif defined (__SUNPRO_C) && (__SUNPRO_C >= 0x550)
+#  define ERL_NAPI_EXPORT __global
+#else
+#  define ERL_NAPI_EXPORT
+#endif
+
 #endif  /* __ERL_DRV_NIF_H__ */

--- a/erts/emulator/beam/erl_internal_test.c
+++ b/erts/emulator/beam/erl_internal_test.c
@@ -1,0 +1,47 @@
+/*
+ * %CopyrightBegin%
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright Ericsson AB 2010-2025. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+/*
+ *  A peephole to access selected internal symbols (functions) for testing
+ *  without having to pollute the name space of exported symbols.
+ */
+#include "erl_internal_test.h"
+#include "erl_misc_utils.h"
+
+const ErtsInternalTest erts_internal_test_instance = {
+    .erts_milli_sleep = &erts_milli_sleep,
+    .ethr_atomic_dec = &ethr_atomic_dec,
+    .ethr_atomic_inc = &ethr_atomic_inc,
+    .ethr_atomic_init = &ethr_atomic_init,
+    .ethr_atomic_read = &ethr_atomic_read,
+    .ethr_atomic_set = &ethr_atomic_set,
+    .ethr_rwmutex_destroy = &ethr_rwmutex_destroy,
+    .ethr_rwmutex_init_opt = &ethr_rwmutex_init_opt,
+    .ethr_rwmutex_rlock = &ethr_rwmutex_rlock,
+    .ethr_rwmutex_runlock = &ethr_rwmutex_runlock,
+    .ethr_rwmutex_rwlock = &ethr_rwmutex_rwlock,
+    .ethr_rwmutex_rwunlock = &ethr_rwmutex_rwunlock,
+    .ethr_rwmutex_tryrlock = &ethr_rwmutex_tryrlock,
+    .ethr_rwmutex_tryrwlock = &ethr_rwmutex_tryrwlock,
+    .ethr_thr_create = &ethr_thr_create,
+    .ethr_thr_join = &ethr_thr_join
+};

--- a/erts/emulator/beam/erl_internal_test.h
+++ b/erts/emulator/beam/erl_internal_test.h
@@ -1,0 +1,62 @@
+/*
+ * %CopyrightBegin%
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright Ericsson AB 2010-2025. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+/*
+ *  A peephole to access selected internal symbols (functions) for testing
+ *  without having to pollute the name space of exported symbols.
+ */
+#ifndef ERL_INTERNAL_TEST_H
+#define ERL_INTERNAL_TEST_H
+
+#include "erl_drv_nif.h"
+#include "ethread.h"
+
+typedef struct {
+    int (*erts_milli_sleep)(long);
+    void (*ethr_atomic_dec)(ethr_atomic_t *var);
+    void (*ethr_atomic_inc)(ethr_atomic_t *var);
+    void (*ethr_atomic_init)(ethr_atomic_t *var, ethr_sint_t val);
+    ethr_sint_t (*ethr_atomic_read)(ethr_atomic_t *var);
+    void (*ethr_atomic_set)(ethr_atomic_t *var, ethr_sint_t val);
+    int (*ethr_rwmutex_destroy)(ethr_rwmutex *);
+    int (*ethr_rwmutex_init_opt)(ethr_rwmutex *, ethr_rwmutex_opt *);
+    void (*ethr_rwmutex_rlock)(ethr_rwmutex *);
+    void (*ethr_rwmutex_runlock)(ethr_rwmutex *);
+    void (*ethr_rwmutex_rwlock)(ethr_rwmutex *);
+    void (*ethr_rwmutex_rwunlock)(ethr_rwmutex *);
+    int (*ethr_rwmutex_tryrlock)(ethr_rwmutex *);
+    int (*ethr_rwmutex_tryrwlock)(ethr_rwmutex *);
+    int (*ethr_thr_create)(ethr_tid *, void * (*)(void *), void *, ethr_thr_opts *);
+    int (*ethr_thr_join)(ethr_tid, void **);
+}ErtsInternalTest;
+
+#if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))
+extern const ErtsInternalTest erts_internal_test_instance;
+#  define erts_internal_test (*(const ErtsInternalTest*)(WinDynNifCallbacks.erts_internal_test_ptr))
+#else
+ERL_NAPI_EXPORT
+extern const ErtsInternalTest erts_internal_test_instance;
+#  define erts_internal_test erts_internal_test_instance
+#endif
+
+
+#endif // ERL_INTERNAL_TEST_H

--- a/erts/emulator/beam/erl_nif.h
+++ b/erts/emulator/beam/erl_nif.h
@@ -345,6 +345,7 @@ typedef enum {
 typedef struct {
 #  include "erl_nif_api_funcs.h"
    void* erts_alc_test;
+   const void* erts_internal_test_ptr;
 } TWinDynNifCallbacks;
 extern TWinDynNifCallbacks WinDynNifCallbacks;
 #  undef ERL_NIF_API_FUNC_DECL
@@ -371,7 +372,11 @@ extern void enif_rwlock_destroy(ErlNifRWLock *rwlck);
 extern void enif_thread_opts_destroy(ErlNifThreadOpts *opts);
 extern void enif_ioq_destroy(ErlNifIOQueue *q);
 
-#  define ERL_NIF_API_FUNC_DECL(RET_TYPE, NAME, ARGS) extern RET_TYPE NAME ARGS
+#  if (defined(__WIN32__) || defined(_WIN32) || defined(_WIN32_))
+#    define ERL_NIF_API_FUNC_DECL(RET_TYPE, NAME, ARGS) extern RET_TYPE NAME ARGS
+#  else
+#    define ERL_NIF_API_FUNC_DECL(RET_TYPE, NAME, ARGS) ERL_NAPI_EXPORT extern RET_TYPE NAME ARGS
+#  endif
 #  include "erl_nif_api_funcs.h"
 #  undef ERL_NIF_API_FUNC_DECL
 #endif
@@ -380,18 +385,10 @@ extern void enif_ioq_destroy(ErlNifIOQueue *q);
 #  define ERL_NIF_INIT_GLOB TWinDynNifCallbacks WinDynNifCallbacks;
 #  define ERL_NIF_INIT_ARGS TWinDynNifCallbacks* callbacks
 #  define ERL_NIF_INIT_BODY memcpy(&WinDynNifCallbacks,callbacks,sizeof(TWinDynNifCallbacks))
-#  define ERL_NIF_INIT_EXPORT __declspec(dllexport)
 #else 
 #  define ERL_NIF_INIT_GLOB
 #  define ERL_NIF_INIT_ARGS void
 #  define ERL_NIF_INIT_BODY
-#  if defined(__GNUC__) && __GNUC__ >= 4
-#    define ERL_NIF_INIT_EXPORT __attribute__ ((visibility("default")))
-#  elif defined (__SUNPRO_C) && (__SUNPRO_C >= 0x550)
-#    define ERL_NIF_INIT_EXPORT __global
-#  else
-#    define ERL_NIF_INIT_EXPORT
-#  endif
 #endif
 
 
@@ -407,7 +404,7 @@ extern void enif_ioq_destroy(ErlNifIOQueue *q);
           ErlNifEntry* ERL_NIF_INIT_NAME(MODNAME)(ERL_NIF_INIT_ARGS)
 #else
 #  define ERL_NIF_INIT_DECL(MODNAME) \
-          ERL_NIF_INIT_EXPORT ErlNifEntry* nif_init(ERL_NIF_INIT_ARGS)
+          ERL_NAPI_EXPORT ErlNifEntry* nif_init(ERL_NIF_INIT_ARGS)
 #endif
 
 

--- a/erts/emulator/pcre/pcre.mk
+++ b/erts/emulator/pcre/pcre.mk
@@ -54,7 +54,7 @@ PCRE_OBJDIR = $(ERL_TOP)/erts/emulator/pcre/obj/$(TARGET)/$(TYPE)
 
 PCRE_DIR =  $(ERL_TOP)/erts/emulator/pcre
 
-PCRE_CFLAGS = $(filter-out -Wimplicit-fallthrough,$(CFLAGS)) $(VISIBILITY_HIDDEN) -DERLANG_INTEGRATION
+PCRE_CFLAGS = $(filter-out -Wimplicit-fallthrough,$(CFLAGS)) -DERLANG_INTEGRATION
 
 ifeq ($(TARGET), win32)
 $(EPCRE_LIB): $(PCRE_OBJS)

--- a/erts/emulator/sys/win32/erl_win32_sys_ddll.c
+++ b/erts/emulator/sys/win32/erl_win32_sys_ddll.c
@@ -39,6 +39,7 @@
 #include "erl_win_dyn_driver.h"
 
 #include "erl_nif.h"
+#include "erl_internal_test.h"
 
 #define EXT_LEN          4
 #define FILE_EXT_WCHAR   L".dll"
@@ -63,6 +64,7 @@ void erl_sys_ddll_init(void) {
 #include "erl_nif_api_funcs.h"
 #undef ERL_NIF_API_FUNC_DECL
     nif_callbacks.erts_alc_test = erts_alc_test;
+    nif_callbacks.erts_internal_test_ptr = &erts_internal_test_instance;
  
     return;
 }

--- a/erts/emulator/sys/win32/erl_win_dyn_driver.h
+++ b/erts/emulator/sys/win32/erl_win_dyn_driver.h
@@ -89,10 +89,6 @@ WDD_TYPEDEF(void *, driver_dl_open, (char *));
 WDD_TYPEDEF(void *, driver_dl_sym, (void *, char *));
 WDD_TYPEDEF(int, driver_dl_close, (void *));
 WDD_TYPEDEF(char *, driver_dl_error, (void));
-WDD_TYPEDEF(ErlDrvUInt, erts_alc_test, (ErlDrvUInt,
-					ErlDrvUInt,
-					ErlDrvUInt,
-					ErlDrvUInt));
 WDD_TYPEDEF(ErlDrvSInt, driver_binary_get_refc, (ErlDrvBinary *dbp));
 WDD_TYPEDEF(ErlDrvSInt, driver_binary_inc_refc, (ErlDrvBinary *dbp));
 WDD_TYPEDEF(ErlDrvSInt, driver_binary_dec_refc, (ErlDrvBinary *dbp));
@@ -211,7 +207,7 @@ typedef struct {
     WDD_FTYPE(driver_dl_sym) *driver_dl_sym;
     WDD_FTYPE(driver_dl_close) *driver_dl_close;
     WDD_FTYPE(driver_dl_error) *driver_dl_error;
-    WDD_FTYPE(erts_alc_test) *erts_alc_test;
+    void* REMOVED_erts_alc_test;
     WDD_FTYPE(driver_binary_get_refc) *driver_binary_get_refc;
     WDD_FTYPE(driver_binary_inc_refc) *driver_binary_inc_refc;
     WDD_FTYPE(driver_binary_dec_refc) *driver_binary_dec_refc;
@@ -324,7 +320,6 @@ extern TWinDynDriverCallbacks WinDynDriverCallbacks;
 #define driver_dl_sym (WinDynDriverCallbacks.driver_dl_sym)
 #define driver_dl_close (WinDynDriverCallbacks.driver_dl_close)
 #define driver_dl_error (WinDynDriverCallbacks.driver_dl_error)
-#define erts_alc_test (WinDynDriverCallbacks.erts_alc_test)
 #define driver_binary_get_refc (WinDynDriverCallbacks.driver_binary_get_refc)
 #define driver_binary_inc_refc (WinDynDriverCallbacks.driver_binary_inc_refc)
 #define driver_binary_dec_refc (WinDynDriverCallbacks.driver_binary_dec_refc)
@@ -462,7 +457,7 @@ do {				                        \
 ((W).driver_dl_sym) =  driver_dl_sym;			\
 ((W).driver_dl_close) =  driver_dl_close;		\
 ((W).driver_dl_error) =  driver_dl_error;		\
-((W).erts_alc_test) = erts_alc_test;			\
+((W).REMOVED_erts_alc_test) = NULL;			\
 ((W).driver_binary_get_refc) = driver_binary_get_refc;	\
 ((W).driver_binary_inc_refc) = driver_binary_inc_refc;	\
 ((W).driver_binary_dec_refc) = driver_binary_dec_refc;	\

--- a/erts/emulator/test/mtx_SUITE.erl
+++ b/erts/emulator/test/mtx_SUITE.erl
@@ -82,12 +82,8 @@ all() ->
 init_per_suite(Config) when is_list(Config) ->
     DataDir = proplists:get_value(data_dir, Config),
     Lib = filename:join([DataDir, atom_to_list(?MODULE)]),
-    case {erlang:load_nif(Lib, none),erlang:system_info(threads)} of
-	{{error,_},false} ->
-	    {skip, "No thread support"};
-	_ ->
-	    Config
-    end.
+    ok = erlang:load_nif(Lib, none),
+    Config.
 
 end_per_suite(Config) when is_list(Config) ->
     catch erts_debug:set_internal_state(available_internal_state, false),

--- a/erts/emulator/test/mtx_SUITE_data/mtx_SUITE.c
+++ b/erts/emulator/test/mtx_SUITE_data/mtx_SUITE.c
@@ -27,6 +27,7 @@
  */
 
 #include <erl_nif.h>
+#include <erl_internal_test.h>
 
 #ifdef __WIN32__
 #  ifndef WIN32_LEAN_AND_MEAN
@@ -34,8 +35,6 @@
 #  endif
 #  include <windows.h>
 #else
-#  include "ethread.h"
-#  include "erl_misc_utils.h"
 #  include <unistd.h>
 #endif
 
@@ -48,33 +47,6 @@ fail(const char *file, int line, const char *function, const char *assertion);
 
 #undef ASSERT
 #define ASSERT(X) ((void) ((X) ? 1 : fail(__FILE__, __LINE__, __func__, #X)))
-
-#ifdef __WIN32__
-/*
- * We cannot access the ethread symbols directly; test
- * what we got in the nif api instead...
- */
-#define HAVE_FREQREAD_SUPPORT 0
-#define RWMUTEX_T ErlNifRWLock
-#define RWMUTEX_CREATE(FR) enif_rwlock_create("dummy")
-#define RWMUTEX_DESTROY enif_rwlock_destroy
-#define RWMUTEX_WLOCK enif_rwlock_rwlock
-#define RWMUTEX_TRYWLOCK enif_rwlock_tryrwlock
-#define RWMUTEX_WUNLOCK enif_rwlock_rwunlock
-#define RWMUTEX_TRYRLOCK enif_rwlock_tryrlock
-#define RWMUTEX_RLOCK enif_rwlock_rlock
-#define RWMUTEX_RUNLOCK enif_rwlock_runlock
-#define THR_ID ErlNifTid
-#define THR_CREATE(A, B, C, D) enif_thread_create("dummy", (A), (B), (C), (D))
-#define THR_JOIN enif_thread_join
-#define ATOMIC_T volatile LONG
-#define ATOMIC_INIT(VarP, Val) (*(VarP) = (Val))
-#define ATOMIC_SET(VarP, Val) (*(VarP) = (Val))
-#define ATOMIC_READ(VarP) (*(VarP))
-#define ATOMIC_INC InterlockedIncrement
-#define ATOMIC_DEC InterlockedDecrement
-
-#else
 
 #ifdef ETHR_USE_OWN_RWMTX_IMPL__
 #  define HAVE_FREQREAD_SUPPORT 1
@@ -91,32 +63,30 @@ RWMUTEX_CREATE(int freqread)
     if (freqread)
 	rwmtx_opt.type = ETHR_RWMUTEX_TYPE_FREQUENT_READ;
     ASSERT(rwmtx);
-    ASSERT(ethr_rwmutex_init_opt(rwmtx, &rwmtx_opt) == 0);
+    ASSERT(erts_internal_test.ethr_rwmutex_init_opt(rwmtx, &rwmtx_opt) == 0);
     return rwmtx;
 }
 static void
 RWMUTEX_DESTROY(ethr_rwmutex *rwmtx)
 {
-    ASSERT(ethr_rwmutex_destroy(rwmtx) == 0);
+    ASSERT(erts_internal_test.ethr_rwmutex_destroy(rwmtx) == 0);
     enif_free(rwmtx);
 }
-#define RWMUTEX_TRYWLOCK ethr_rwmutex_tryrwlock
-#define RWMUTEX_WLOCK ethr_rwmutex_rwlock
-#define RWMUTEX_WUNLOCK ethr_rwmutex_rwunlock
-#define RWMUTEX_TRYRLOCK ethr_rwmutex_tryrlock
-#define RWMUTEX_RLOCK ethr_rwmutex_rlock
-#define RWMUTEX_RUNLOCK ethr_rwmutex_runlock
-#define THR_ID ethr_tid
-#define THR_CREATE ethr_thr_create
-#define THR_JOIN ethr_thr_join
-#define ATOMIC_T ethr_atomic_t
-#define ATOMIC_INIT ethr_atomic_init
-#define ATOMIC_SET ethr_atomic_set
-#define ATOMIC_READ ethr_atomic_read
-#define ATOMIC_INC ethr_atomic_inc
-#define ATOMIC_DEC ethr_atomic_dec
-
-#endif
+#define RWMUTEX_TRYWLOCK erts_internal_test.ethr_rwmutex_tryrwlock
+#define RWMUTEX_WLOCK    erts_internal_test.ethr_rwmutex_rwlock
+#define RWMUTEX_WUNLOCK  erts_internal_test.ethr_rwmutex_rwunlock
+#define RWMUTEX_TRYRLOCK erts_internal_test.ethr_rwmutex_tryrlock
+#define RWMUTEX_RLOCK    erts_internal_test.ethr_rwmutex_rlock
+#define RWMUTEX_RUNLOCK  erts_internal_test.ethr_rwmutex_runlock
+#define THR_ID           ethr_tid
+#define THR_CREATE       erts_internal_test.ethr_thr_create
+#define THR_JOIN         erts_internal_test.ethr_thr_join
+#define ATOMIC_T         ethr_atomic_t
+#define ATOMIC_INIT      erts_internal_test.ethr_atomic_init
+#define ATOMIC_SET       erts_internal_test.ethr_atomic_set
+#define ATOMIC_READ      erts_internal_test.ethr_atomic_read
+#define ATOMIC_INC       erts_internal_test.ethr_atomic_inc
+#define ATOMIC_DEC       erts_internal_test.ethr_atomic_dec
 
 
 #if !defined(__func__)
@@ -687,7 +657,7 @@ milli_sleep(int ms)
 #ifdef __WIN32__
     Sleep(ms);
 #else
-    while (erts_milli_sleep(ms) != 0);
+    while (erts_internal_test.erts_milli_sleep(ms) != 0);
 #endif
 }
 

--- a/erts/emulator/zstd/zstd.mk
+++ b/erts/emulator/zstd/zstd.mk
@@ -62,7 +62,10 @@ endif # asan
 endif # debug
 endif # gcov
 
-ZSTD_CFLAGS+=-MMD -MP
+ZSTD_CFLAGS += -MMD -MP
+
+# Set VISIBLE's to empty to NOT export any symbols for dynamic linking
+ZSTD_CFLAGS += -DZSTDLIB_VISIBLE= -DZSTDERRORLIB_VISIBLE=
 
 ifeq ($(TARGET), win32)
 $(ZSTD_LIBRARY): $(ZSTD_OBJS)

--- a/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
+++ b/lib/jinterface/test/jinterface_SUITE_data/Makefile.src
@@ -62,6 +62,6 @@ clean:
 	-del /F /Q $(CLASS_FILES)
 
 $(CLASS_FILES) : $(JAVA_FILES)
-	$(JAVAC) -encoding UTF-8 -classpath $(CLASSPATH) $(JAVA_FILES)
+	$(JAVAC) -d . -encoding UTF-8 -classpath $(CLASSPATH) $(JAVA_FILES)
 
 #

--- a/lib/jinterface/test/nc_SUITE_data/Makefile.src
+++ b/lib/jinterface/test/nc_SUITE_data/Makefile.src
@@ -48,6 +48,6 @@ clean:
 	-del /F /Q $(CLASS_FILES)
 
 $(CLASS_FILES) : $(JAVA_FILES)
-	$(JAVAC) -encoding UTF-8 -classpath $(CLASSPATH) $(JAVA_FILES)
+	$(JAVAC) -d . -encoding UTF-8 -classpath $(CLASSPATH) $(JAVA_FILES)
 
 #


### PR DESCRIPTION
Keep the exported name space clean and only expose symbols of documented interfaces like NIF and driver APIs. This will avoid accidental name clashes with our statically linked variants of for example PCRE2 and ZSTD.