### PR TITLE
Purge `supervisor` restarts

### DIFF
--- a/lib/sasl/test/release_handler_SUITE.erl
+++ b/lib/sasl/test/release_handler_SUITE.erl
@@ -1663,7 +1663,7 @@ upgrade_supervisor(Conf) when is_list(Conf) ->
     %% Check that the restart strategy and child spec is updated
     {status, _, {module, _}, [_, _, _, _, [_,_,{data,[{"State",State}]}|_]]} =
 	rpc:call(Node,sys,get_status,[a_sup]),
-    {state,_,RestartStrategy,{[a],Db},_,_,_,_,_,_,_,_,_,_,_} = State,
+    {state,_,RestartStrategy,{[a],Db},_,_,_,_,_,_,_,_,_,_,_,_} = State,
     one_for_all = RestartStrategy, % changed from one_for_one
     {child,_,_,_,_,_,brutal_kill,_,_} = maps:get(a,Db), % changed from timeout 2000
 


### PR DESCRIPTION
This PR intends to reduce the memory footprint of supervisors by purging the list of restarts if possible, before and after going into/coming out of scheduled hibernation (`hibernate_after`). Therefore, it checks if the latest restart is already outside of the period, and if so, discards the entire restarts list, as any other restart in it will be even older. I refrained from performing a "proper" cleanup, in the sense of keeping in-period and discarding out-of-period restarts, as this would involve a list traversal which could be expensive.

The reason for doing a purge before going into hibernation is in order to not carry unneeded data over into hibernation.

The reason for doing a purge when waking up from hibernation is that it is likely that enough time has passed and all previous restarts have fallen out of period.