### PR TITLE
Document `throw/1` the same way it's documented in `expressions.html#catch-and-throw`

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -6503,7 +6503,7 @@ catch
 end
 ```
 
-Failure: `nocatch` if not caught by an exception handler.
+If `throw/1` is not evaluated within a catch, a `nocatch` run-time error occurs.
 
 See the guide about [errors and error handling](`e:system:errors.md`) for
 additional information.


### PR DESCRIPTION
Minor tweak to the docs; open to suggestions for change.

Closes #9845.