### PR TITLE
SNMP: Use ASN.1 for encode/decode of basic types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -312,6 +312,8 @@ JAVADOC-GENERATED
 /lib/snmp/priv/mibs/[A-Z]*.bin
 /lib/snmp/test/snmp_test_data/[A-Z]*.bin
 /lib/snmp/test/snmp_test_data/[A-Z]*.hrl
+/lib/snmp/test/snmp_to_snmpnet_SUITE_data/[A-Z]*.bin
+/lib/snmp/test/snmp_to_snmpnet_SUITE_data/[A-Z]*.hrl
 /lib/snmp/doc/intex.html
 
 # system

--- a/lib/snmp/.gitignore
+++ b/lib/snmp/.gitignore
@@ -7,6 +7,10 @@
 doc/index.html
 mibs/.index
 
+# Generated src and stuff...
+/src/misc/snmp_pdus_basic.erl
+/src/misc/snmp_pdus_basic.asn1db
+
 # Agent
 src/agent/Makefile
 

--- a/lib/snmp/src/app/snmp.app.src
+++ b/lib/snmp/src/app/snmp.app.src
@@ -119,6 +119,7 @@
              snmp_mini_mib,
              snmp_misc,
              snmp_note_store,
+             snmp_pdus_basic, % Generated from ASN.1 spec
              snmp_pdus,
              snmp_usm,
 	     snmp_verbosity

--- a/lib/snmp/src/misc/Makefile
+++ b/lib/snmp/src/misc/Makefile
@@ -110,13 +110,23 @@ opt: $(TARGET_FILES)
 
 
 clean:
-	rm -f $(TARGET_FILES) 
+	rm -f $(TARGET_FILES)
+	rm -f snmp_pdus_basic.erl
+	rm -f snmp_pdus_basic.asn1db
 	rm -f core *~
 
 docs:
 
 info:
-	@echo "TARGET_FILES: $(TARGET_FILES)"
+	@echo ""
+	@echo "MODULES:           $(MODULES)"
+	@echo "HRLS:              $(HRLS)"
+	@echo ""
+	@echo "ASN1_SPECS:        $(ASN1_SPECS)"
+	@echo ""
+	@echo "TARGET_FILES:      $(TARGET_FILES)"
+	@echo ""
+	@echo "ERL_COMPILE_FLAGS: $(ERL_COMPILE_FLAGS)"
 	@echo ""
 
 
@@ -131,8 +141,6 @@ release_spec: opt
 	$(INSTALL_DATA) $(ERL_FILES) $(HRL_FILES) "$(RELSYSDIR)/src/misc"
 	$(INSTALL_DIR) "$(RELSYSDIR)/ebin"
 	$(INSTALL_DATA) $(TARGET_FILES) "$(RELSYSDIR)/ebin"
-# 	$(INSTALL_DIR) "$(RELSYSDIR)/include"
-# 	$(INSTALL_DATA) $(EXT_HRL_FILES) "$(RELSYSDIR)/include"
 
 release_docs_spec:
 

--- a/lib/snmp/src/misc/depend.mk
+++ b/lib/snmp/src/misc/depend.mk
@@ -60,4 +60,15 @@ $(EBIN)/snmp_usm.$(EMULATOR): \
 $(EBIN)/snmp_verbosity.$(EMULATOR): \
 	snmp_verbosity.erl
 
+# Rules for generated "stuff"
+
+$(EBIN)/snmp_pdus_basic.$(EMULATOR): \
+	snmp_pdus_basic.erl
+
+# ASN1_OPTS += +abs
+snmp_pdus_basic.erl: \
+	snmp_pdus_basic.set.asn \
+	snmp_pdus_basic.asn
+	$(V_colon)@echo "snmp_pdus_basec:"
+	$(asn_verbose)$(ERLC) -bber +noobj $(ASN1_OPTS) snmp_pdus_basic.set.asn
 

--- a/lib/snmp/src/misc/snmp_pdus_basic.asn
+++ b/lib/snmp/src/misc/snmp_pdus_basic.asn
@@ -1,0 +1,47 @@
+-- 
+-- %CopyrightBegin%
+-- 
+-- Copyright Ericsson AB 2025-2025. All Rights Reserved.
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- 
+-- %CopyrightEnd%
+
+-- This file is intended for 'basic types' in general, but currently only
+-- contains (integer) types from the SNMPv2-SMI.
+--
+-- This (ASN.1) spec contains (some of the) types from the SNMPv2-SMI mib:
+-- - 0 (64) IpAddress
+-- + 1 (65) Counter32
+-- - 2 (..) Gauge32 (same as Unsigned32, even the same tag)
+-- + 2 (66) Unsigned32
+-- + 3 (67) TimeTicks
+-- - 4 (68) Opaque
+-- + 6 (70) Counter64
+
+SNMP-PDUS-BASIC DEFINITIONS ::=
+BEGIN
+
+-- 65
+Counter32  ::= [APPLICATION 1] IMPLICIT INTEGER (0..4294967295)
+
+-- 66
+Unsigned32 ::= [APPLICATION 2] IMPLICIT INTEGER (0..4294967295)
+
+-- 67
+TimeTicks  ::= [APPLICATION 3] IMPLICIT INTEGER (0..4294967295)
+
+-- 70
+Counter64  ::= [APPLICATION 6] IMPLICIT INTEGER (0..18446744073709551615)
+
+END

--- a/lib/snmp/src/misc/snmp_pdus_basic.set.asn
+++ b/lib/snmp/src/misc/snmp_pdus_basic.set.asn
@@ -1,10 +1,7 @@
-#-*-makefile-*-   ; force emacs to enter makefile-mode
-
+#
 # %CopyrightBegin%
 #
-# SPDX-License-Identifier: Apache-2.0
-#
-# Copyright Ericsson AB 2004-2025. All Rights Reserved.
+# Copyright Ericsson AB 2025-2025. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,22 +17,4 @@
 #
 # %CopyrightEnd%
 
-# The module 'snmp_pdus_basic' is generated from a hand crafted ASN.1 spec
-MODULES = \
-	snmp_pdus_basic \
-	snmp_conf       \
-	snmp_config     \
-	snmp_log        \
-	snmp_mini_mib   \
-	snmp_misc       \
-	snmp_note_store \
-	snmp_pdus       \
-	snmp_usm        \
-        snmp_verbosity
-
-HRLS = \
-	snmp_verbosity \
-	snmp_debug \
-	snmp_usm
-
-ASN1_SPECS = snmp_pdus_basic
+snmp_pdus_basic.asn

--- a/lib/snmp/test/Makefile
+++ b/lib/snmp/test/Makefile
@@ -42,17 +42,28 @@ SNMP_ROOT = ..
 
 ERL_FILES = $(MODULES:%=%.erl)
 
-SNMP_TEST_DATA = snmp_test_data
+SNMP_TEST_DATA    = snmp_test_data
+NETSNMP_TEST_DATA = snmp_to_snmpnet_SUITE_data
 
-SNMP_MIB_DIR = $(SNMP_TEST_DATA)
+SNMP_MIB_DIR    = $(SNMP_TEST_DATA)
+NETSNMP_MIB_DIR = $(NETSNMP_TEST_DATA)
 
-SNMP_BIN_TARGET_DIR = $(SNMP_TEST_DATA)
+SNMP_BIN_TARGET_DIR    = $(SNMP_TEST_DATA)
+NETSNMP_BIN_TARGET_DIR = $(NETSNMP_TEST_DATA)
 
-MIB_SOURCE  = $(MIB_FILES:%.mib=$(SNMP_MIB_DIR)/%.mib)
+SNMP_MIB_SOURCES    = $(MIB_FILES:%.mib=$(SNMP_MIB_DIR)/%.mib)
+NETSNMP_MIB_SOURCES = $(NETSNMP_MIB_FILES:%.mib=$(NETSNMP_MIB_DIR)/%.mib)
 
-MIB_TARGETS = \
+SNMP_MIB_TARGETS = \
 	$(MIB_FILES:%.mib=$(SNMP_BIN_TARGET_DIR)/%.bin) \
 	$(MIB_FILES:%.mib=$(SNMP_BIN_TARGET_DIR)/%.hrl)
+NETSNMP_MIB_TARGETS = \
+	$(NETSNMP_MIB_FILES:%.mib=$(NETSNMP_BIN_TARGET_DIR)/%.bin) \
+	$(NETSNMP_MIB_FILES:%.mib=$(NETSNMP_BIN_TARGET_DIR)/%.hrl)
+MIB_TARGETS = \
+	$(SNMP_MIB_TARGETS) \
+	$(NETSNMP_MIB_TARGETS)
+
 ERL_TARGETS = $(MODULES:%=$(EBIN)/%.$(EMULATOR))
 
 TEST_SERVER_TARGETS = $(TEST_SERVER_MODULES:%=$(EBIN)/%.$(EMULATOR))
@@ -175,6 +186,12 @@ $(SNMP_BIN_TARGET_DIR)/%.bin: $(SNMP_MIB_DIR)/%.mib
 $(SNMP_BIN_TARGET_DIR)/%.hrl: $(SNMP_BIN_TARGET_DIR)/%.bin
 	$(ERLC) $(ERL_SNMP_FLAGS) -o $(SNMP_BIN_TARGET_DIR) $<
 
+$(NETSNMP_BIN_TARGET_DIR)/%.hrl: $(NETSNMP_BIN_TARGET_DIR)/%.bin
+	$(ERLC) $(ERL_SNMP_FLAGS) -o $(NETSNMP_BIN_TARGET_DIR) $<
+
+$(NETSNMP_BIN_TARGET_DIR)/%.bin: $(NETSNMP_MIB_DIR)/%.mib
+	$(ERLC) $(ERL_SNMP_FLAGS) -o $(NETSNMP_MIB_DIR) $<
+
 
 # ----------------------------------------------------
 # Targets
@@ -244,26 +261,34 @@ release_docs_spec:
 
 
 info:
-	@echo "SNMP_DEBUG        = $(SNMP_DEBUG)"
-	@echo "SNMP_FLAGS        = $(SNMP_FLAGS)"
+	@echo "SNMP_DEBUG             = $(SNMP_DEBUG)"
+	@echo "SNMP_FLAGS             = $(SNMP_FLAGS)"
 	@echo ""
-	@echo "SNMP_MIB_DIR      = $(SNMP_MIB_DIR)"
-	@echo "MIB_SOURCE        = $(MIB_SOURCE)"
-	@echo "MIB_TARGETS       = $(MIB_TARGETS)"
-	@echo "SNMP_MIB_FLAGS    = $(SNMP_MIB_FLAGS)"
+	@echo "SNMP_MIB_DIR           = $(SNMP_MIB_DIR)"
+	@echo "NETSNMP_MIB_DIR        = $(NETSNMP_MIB_DIR)"
 	@echo ""
-	@echo "ERL_COMPILE_FLAGS = $(ERL_COMPILE_FLAGS)"
+	@echo "SNMP_BIN_TARGET_DIR    = $(SNMP_BIN_TARGET_DIR)"
+	@echo "NETSNMP_BIN_TARGET_DIR = $(NETSNMP_BIN_TARGET_DIR)"
 	@echo ""
-	@echo "RELSYSDIR         = "$(RELSYSDIR)""
+	@echo "SNMP_MIB_SOURCES    = $(SNMP_MIB_SOURCES)"
+	@echo "NETSNMP_MIB_SOURCES = $(NETSNMP_MIB_SOURCES)"
 	@echo ""
-	@echo "SOURCE            = $(SOURCE)"
+	@echo "MIB_TARGETS         = $(MIB_TARGETS)"
 	@echo ""
-	@echo "TARGET_FILES      = $(TARGET_FILES)"
+	@echo "SNMP_MIB_FLAGS      = $(SNMP_MIB_FLAGS)"
 	@echo ""
-	@echo "EMAKEFILE         = $(EMAKEFILE)"
-	@echo "MAKE_EMAKE        = $(MAKE_EMAKE)"
-	@echo "BUILDTARGET       = $(BUILDTARGET)"
-	@echo "RELTEST_FILES     = $(RELTEST_FILES)"
+	@echo "ERL_COMPILE_FLAGS   = $(ERL_COMPILE_FLAGS)"
+	@echo ""
+	@echo "RELSYSDIR           = "$(RELSYSDIR)""
+	@echo ""
+	@echo "SOURCE              = $(SOURCE)"
+	@echo ""
+	@echo "TARGET_FILES        = $(TARGET_FILES)"
+	@echo ""
+	@echo "EMAKEFILE           = $(EMAKEFILE)"
+	@echo "MAKE_EMAKE          = $(MAKE_EMAKE)"
+	@echo "BUILDTARGET         = $(BUILDTARGET)"
+	@echo "RELTEST_FILES       = $(RELTEST_FILES)"
 	@echo ""
 
 

--- a/lib/snmp/test/modules.mk
+++ b/lib/snmp/test/modules.mk
@@ -83,5 +83,8 @@ MIB_FILES = \
 	Test2.mib \
 	Test3.mib
 
+NETSNMP_MIB_FILES = \
+	OTP-C64-MIB.mib
+
 SPECS = snmp.spec
 

--- a/lib/snmp/test/snmp_to_snmpnet_SUITE_data/OTP-C64-MIB.mib
+++ b/lib/snmp/test/snmp_to_snmpnet_SUITE_data/OTP-C64-MIB.mib
@@ -1,0 +1,102 @@
+-- %CopyrightBegin%
+--
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Copyright Ericsson AB 2025-2025. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- %CopyrightEnd%
+
+--
+-- Test mib for Counter64 tests
+--
+
+OTP-C64-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    otpExpr
+        FROM OTP-REG
+    MODULE-IDENTITY, Counter64
+        FROM SNMPv2-SMI
+    OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+
+otpC64MIB MODULE-IDENTITY
+    LAST-UPDATED "202410080000Z"
+    ORGANIZATION "Erlang/OTP"
+    CONTACT-INFO
+        "flipp@flopp.org"
+     DESCRIPTION
+         "Initial version of this MIB module."
+     ::= { otpExpr 42 }
+
+
+otpC64Objects     OBJECT IDENTIFIER ::= { otpC64MIB 1 }
+
+otpC64Conformance OBJECT IDENTIFIER ::= { otpC64MIB 2 }
+
+otpC64Groups      OBJECT IDENTIFIER ::= { otpC64Conformance 1}
+
+otpC64            OBJECT IDENTIFIER ::= { otpC64Objects 1 }
+
+otpC64Num1 OBJECT-TYPE
+    SYNTAX       Counter64
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "This object shows nothing..."
+   DEFVAL { 18446744073709551615 }
+    ::= { otpC64 1 }
+
+otpC64Num2 OBJECT-TYPE
+    SYNTAX       Counter64
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "This object shows nothing..."
+   DEFVAL { 9223372036854775807 }
+    ::= { otpC64 2 }
+
+otpC64Num3 OBJECT-TYPE
+    SYNTAX       Counter64
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "This object shows nothing..."
+   DEFVAL { 9223372036854775808 }
+    ::= { otpC64 3 }
+
+otpC64Num4 OBJECT-TYPE
+    SYNTAX       Counter64
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "This object shows nothing..."
+   DEFVAL { 9223372036854775809 }
+    ::= { otpC64 4 }
+
+otpC64Numbers    OBJECT-GROUP
+    OBJECTS {
+              otpC64Num1,
+              otpC64Num2,
+              otpC64Num3,
+              otpC64Num4
+            }
+    STATUS  current
+    DESCRIPTION
+            "The collection of fake counter objects."
+    ::= { otpC64Groups 1 }
+
+END


### PR DESCRIPTION
Use ASN.1 for encode/decode of basic types in messages. Specifically Counter64.