### PR TITLE
kernel: Fix line_history to not be reset by io:setopts

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -415,12 +415,11 @@ xterm(data, Buf, Data = #state{ input = #input_state{
                     send_drv_reqs(Data#state.driver, [{redraw_prompt, Pbs, MultiLinePrompt, LineCont1},new_prompt]),
 
                     NewHistory =
-
                         if SaveHistory ->
                                 %% Save into history buffer if issued from shell process
                                 save_line_buffer(string:trim(FormattedLine, both)++"\n",
                                                  Data#state.line_history);
-                           true ->
+                           not SaveHistory ->
                                 Data#state.line_history
                         end,
 
@@ -761,7 +760,7 @@ do_setopts(Opts, Data) ->
             false ->
                 list
         end,
-    LineHistory = proplists:get_value(line_history, Opts, Data#state.line_history),
+    LineHistory = proplists:get_value(line_history, Opts, Data#state.save_history),
     Log = proplists:get_value(log, Opts, Data#state.log),
     {ok, Data#state{ expand_fun = ExpandFun, echo = Echo, read_type = ReadType,
                      save_history = LineHistory, log = Log }}.

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -2432,6 +2432,17 @@ shell_history_toggle(_Config) ->
        {putdata, [$\^n]},  %% Down key
        {expect, ~s'> $'},
 
+       %% Test that io:setopts without line_history preserves it enabled
+       {putline, "io:setopts([])."},
+       {expect, "ok\r\n"},
+       {putline, ~s'io:get_line("> ").'},
+       {putline, ~s'hello again'},
+       {expect, ~s'\\Q"hello again\\n"\r\n\\E'},
+       {putdata, [$\^p]}, %% Up key
+       {expect, ~s'hello again'},
+       {putdata, [$\^n]},  %% Down key
+       {expect, ~s'> $'},
+
        %% Test that io:get_line does not save into history buffer when disabled
        {putline, "io:setopts([{line_history, false}])."},
        {putline, ~s'io:get_line("| ").'},


### PR DESCRIPTION
When io:setopts is called without specifying line_history it would be set to a list, which would be interpreted as false.

closes #9863