### PR TITLE
Bugfix: in NSIS installer - on Windows 64, 32-bit uninstaller leaves some registry keys

### DIFF
--- a/erts/etc/win32/nsis/erlang20.nsi
+++ b/erts/etc/win32/nsis/erlang20.nsi
@@ -493,6 +493,9 @@ continue_delete:
 noshortcuts:
 ; We delete both in HKCU and HKLM, we don't really know were they might be...
   	DeleteRegKey /ifempty HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
+	; When the installer runs as a 32-bit process on 64-bit Windows, registry writes
+	; to HKLM\SOFTWARE are automatically redirected to HKLM\SOFTWARE\WOW6432Node
+	DeleteRegKey /ifempty HKLM "SOFTWARE\WOW6432Node\Ericsson\Erlang\${ERTS_VERSION}"
   	DeleteRegKey /ifempty HKCU "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
   	DeleteRegKey HKLM \
 		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"


### PR DESCRIPTION
Fixes #9884

Attempt to additionally delete a key in WOW6432Node, which is created when a 32-bit installer runs on 64-bit Windows
See the #9884