### PR TITLE
[Installer] API change in NSIS in DeleteRegKey use /ifnosubkeys for old behaviour

### DIFF
--- a/erts/etc/win32/nsis/erlang20.nsi
+++ b/erts/etc/win32/nsis/erlang20.nsi
@@ -492,12 +492,14 @@ continue_delete:
 
 noshortcuts:
 ; We delete both in HKCU and HKLM, we don't really know were they might be...
-  	DeleteRegKey /ifnosubkeys HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
-  	DeleteRegKey /ifnosubkeys HKCU "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
-  	DeleteRegKey HKLM \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
-  	DeleteRegKey HKCU \
-		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
+	DeleteRegKey /ifnosubkeys HKCU "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
+
+	DeleteRegKey /ifnosubkeys HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
+	DeleteRegKey /ifnosubkeys HKLM "SOFTWARE\Ericsson\Erlang"
+	DeleteRegKey /ifnosubkeys HKLM "SOFTWARE\Ericsson"
+
+	DeleteRegKey HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
+	DeleteRegKey HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
 
 
 ; Now remove shell/file associations we'we made...

--- a/erts/etc/win32/nsis/erlang20.nsi
+++ b/erts/etc/win32/nsis/erlang20.nsi
@@ -492,8 +492,8 @@ continue_delete:
 
 noshortcuts:
 ; We delete both in HKCU and HKLM, we don't really know were they might be...
-  	DeleteRegKey /ifempty HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
-  	DeleteRegKey /ifempty HKCU "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
+  	DeleteRegKey /ifnosubkeys HKLM "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
+  	DeleteRegKey /ifnosubkeys HKCU "SOFTWARE\Ericsson\Erlang\${ERTS_VERSION}"
   	DeleteRegKey HKLM \
 		"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Erlang OTP"
   	DeleteRegKey HKCU \


### PR DESCRIPTION
Fixes #9884 
The installer for Windows leaves registry keys on uninstall
Change in API has been reported as of 3.0.6 (July 2020) 