### PR TITLE
ensure to #include our own pcre2.h

### DIFF
--- a/erts/emulator/beam/erl_bif_re.c
+++ b/erts/emulator/beam/erl_bif_re.c
@@ -36,7 +36,7 @@
 #define PCRE2_STATIC
 //#include "pcre.h"
 #define PCRE2_CODE_UNIT_WIDTH 8
-#include "pcre2.h"
+#include "../pcre/pcre2.h"
 
 #define LOOP_FACTOR 10
 


### PR DESCRIPTION
Otherwise the build may pick up a different one which won't work since BEAM depends on its own modifications to `pcre2.h`.

Fixes:
```
beam/erl_bif_re.c:747:2: error: call to undeclared function 'pcre2_free_restart_data'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  747 |         pcre2_free_restart_data(rc->match_data);
      |         ^
```
(and several more) when building OTP-28.0 on a mac with `pcre2.h` installed in `/opt/homebrew/include/`.

The issue can occur on any system where CFLAGS has `-I` addons set to pick up additional headers not installed in the traditional locations known natively by the compiler, i.e. outside of `/usr/include/`. The end result is a compile command where those `-I` addons precede the `-Ipcre` that BEAM adds, and the wrong `pcre2.h` is selected.

Since BEAM _has_ to use its own `pcre2.h`, the fix is to use an absolute path relative the source file when including it.