### PR TITLE
erts, kernel: Little-endian packet header lengths

### DIFF
--- a/erts/emulator/beam/erl_bif_port.c
+++ b/erts/emulator/beam/erl_bif_port.c
@@ -1489,25 +1489,57 @@ BIF_RETTYPE decode_packet_3(BIF_ALIST_3)
     int   code;
     char  delimiter = '\n';
 
-    switch (BIF_ARG_1) {
-    case make_small(0): case am_raw: type = TCP_PB_RAW; break;
-    case make_small(1): type = TCP_PB_1; break;
-    case make_small(2): type = TCP_PB_2; break;
-    case make_small(4): type = TCP_PB_4; break;
-    case am_asn1: type = TCP_PB_ASN1; break;
-    case am_sunrm: type = TCP_PB_RM; break;
-    case am_cdr: type = TCP_PB_CDR; break;
-    case am_fcgi: type = TCP_PB_FCGI; break;
-    case am_line: type = TCP_PB_LINE_LF; break;
-    case am_tpkt: type = TCP_PB_TPKT; break;
-    case am_http: type = TCP_PB_HTTP; break;
-    case am_httph: type = TCP_PB_HTTPH; break;
-    case am_http_bin: type = TCP_PB_HTTP_BIN; break;
-    case am_httph_bin: type = TCP_PB_HTTPH_BIN; break;
-    case am_ssl_tls: type = TCP_PB_SSL_TLS; break;
-    default:
-        BIF_P->fvalue = am_badopt;
-        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    if (is_tuple(BIF_ARG_1)) {
+        Eterm *tpl = tuple_val(BIF_ARG_1);
+
+        if (tpl[0] == make_arityval(2)) {
+            switch (tpl[2]) {
+            case am_little:
+                switch (tpl[1]) {
+                case make_small(2): type = TCP_PB_2_LITTLE; break;
+                case make_small(3): type = TCP_PB_3_LITTLE; break;
+                case make_small(4): type = TCP_PB_4_LITTLE; break;
+                default: goto badarg;
+                };
+                break;
+            case am_big:
+                switch (tpl[1]) {
+                case make_small(2): type = TCP_PB_2; break;
+                case make_small(3): type = TCP_PB_3; break;
+                case make_small(4): type = TCP_PB_4; break;
+                default: goto badarg;
+                };
+                break;
+            default:
+                goto badarg;
+            }
+        } else {
+        badarg:
+            BIF_P->fvalue = am_badopt;
+            BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+        }
+    } else {
+        switch (BIF_ARG_1) {
+        case make_small(0): case am_raw: type = TCP_PB_RAW; break;
+        case make_small(1): type = TCP_PB_1; break;
+        case make_small(2): type = TCP_PB_2; break;
+        case make_small(3): type = TCP_PB_3; break;
+        case make_small(4): type = TCP_PB_4; break;
+        case am_asn1: type = TCP_PB_ASN1; break;
+        case am_sunrm: type = TCP_PB_RM; break;
+        case am_cdr: type = TCP_PB_CDR; break;
+        case am_fcgi: type = TCP_PB_FCGI; break;
+        case am_line: type = TCP_PB_LINE_LF; break;
+        case am_tpkt: type = TCP_PB_TPKT; break;
+        case am_http: type = TCP_PB_HTTP; break;
+        case am_httph: type = TCP_PB_HTTPH; break;
+        case am_http_bin: type = TCP_PB_HTTP_BIN; break;
+        case am_httph_bin: type = TCP_PB_HTTPH_BIN; break;
+        case am_ssl_tls: type = TCP_PB_SSL_TLS; break;
+        default:
+            BIF_P->fvalue = am_badopt;
+            BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+        }
     }
 
     if (!is_bitstring(BIF_ARG_2) ||

--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -276,11 +276,39 @@ int packet_get_length(enum PacketParseType htype,
         plen = get_int16(ptr);
         goto remain;
 
+    case TCP_PB_2_LITTLE:
+        /* TCP_PB_2_LITTLE: [L0,L1 | Data] */
+        hlen = 2;
+        if (n < hlen) goto more;
+        plen = get_little_int16(ptr);
+        goto remain;
+
+    case TCP_PB_3:
+        /* TCP_PB_3: [L2,L1,L0 | Data] */
+        hlen = 3;
+        if (n < hlen) goto more;
+        plen = get_int24(ptr);
+        goto remain;
+
+    case TCP_PB_3_LITTLE:
+        /* TCP_PB_3_LITTLE: [L0,L1,L2 | Data] */
+        hlen = 3;
+        if (n < hlen) goto more;
+        plen = get_little_int24(ptr);
+        goto remain;
+
     case TCP_PB_4:
         /* TCP_PB_4:    [L3,L2,L1,L0 | Data] */
         hlen = 4;
         if (n < hlen) goto more;
         plen = get_int32(ptr);
+        goto remain;
+
+    case TCP_PB_4_LITTLE:
+        /* TCP_PB_4_LITTLE: [L0,L1,L2,L3 | Data] */
+        hlen = 4;
+        if (n < hlen) goto more;
+        plen = get_little_int32(ptr);
         goto remain;
 
     case TCP_PB_RM:

--- a/erts/emulator/beam/packet_parser.h
+++ b/erts/emulator/beam/packet_parser.h
@@ -46,7 +46,11 @@ enum PacketParseType {
     TCP_PB_HTTPH    = 11,
     TCP_PB_SSL_TLS  = 12,
     TCP_PB_HTTP_BIN = 13,
-    TCP_PB_HTTPH_BIN = 14
+    TCP_PB_HTTPH_BIN = 14,
+    TCP_PB_2_LITTLE = 15,
+    TCP_PB_3        = 16,
+    TCP_PB_3_LITTLE = 17,
+    TCP_PB_4_LITTLE = 18
 };
 
 typedef struct http_atom {
@@ -153,7 +157,11 @@ void packet_get_body(enum PacketParseType htype, const char** bufp, int* lenp)
 {
     switch (htype) {
     case TCP_PB_1:  *bufp += 1; *lenp -= 1; break;
+    case TCP_PB_2_LITTLE: /* fall through */
     case TCP_PB_2:  *bufp += 2; *lenp -= 2; break;
+    case TCP_PB_3_LITTLE: /* fall through */
+    case TCP_PB_3:  *bufp += 3; *lenp -= 3; break;
+    case TCP_PB_4_LITTLE: /* fall through */
     case TCP_PB_4:  *bufp += 4; *lenp -= 4; break;
     case TCP_PB_FCGI:
 	*lenp -= ((struct fcgi_head*)*bufp)->paddingLength;

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -1270,9 +1270,19 @@ ERTS_GLB_INLINE size_t sys_strlen(const char *s)
                             ((byte*)(s))[3] = (byte)(i)         & 0xff;} \
                         while (0)
 
+#define put_little_int32(i, s) do {((byte*)(s))[3] = (byte)((i) >> 24) & 0xff;  \
+                                   ((byte*)(s))[2] = (byte)((i) >> 16) & 0xff;  \
+                                   ((byte*)(s))[1] = (byte)((i) >> 8)  & 0xff;  \
+                                   ((byte*)(s))[0] = (byte)(i)         & 0xff;} \
+                               while (0)
+
 #define get_int24(s) ((((byte*) (s))[0] << 16) | \
                       (((byte*) (s))[1] << 8)  | \
                       (((byte*) (s))[2]))
+
+#define get_little_int24(s) ((((byte*) (s))[2] << 16) | \
+                             (((byte*) (s))[1] << 8)  | \
+                             (((byte*) (s))[0]))
 
 
 #define put_int24(i, s) do {((byte*)(s))[0] = (byte)((i) >> 16) & 0xff;  \
@@ -1280,13 +1290,25 @@ ERTS_GLB_INLINE size_t sys_strlen(const char *s)
                             ((byte*)(s))[2] = (byte)(i)         & 0xff;} \
                         while (0)
 
+#define put_little_int24(i, s) do {((byte*)(s))[2] = (byte)((i) >> 16) & 0xff;  \
+                                   ((byte*)(s))[1] = (byte)((i) >> 8)  & 0xff;  \
+                                   ((byte*)(s))[0] = (byte)(i)         & 0xff;} \
+                               while (0)
+
 #define get_int16(s) ((((byte*)  (s))[0] << 8) | \
                       (((byte*)  (s))[1]))
+
+#define get_little_int16(s) ((((byte*)  (s))[1] << 8) | \
+                             (((byte*)  (s))[0]))
 
 
 #define put_int16(i, s) do {((byte*)(s))[0] = (byte)((i) >> 8) & 0xff;  \
                             ((byte*)(s))[1] = (byte)(i)        & 0xff;} \
                         while (0)
+
+#define put_little_int16(i, s) do {((byte*)(s))[1] = (byte)((i) >> 8) & 0xff;  \
+                                   ((byte*)(s))[0] = (byte)(i)        & 0xff;} \
+                               while (0)
 
 #define get_int8(s) ((((byte*)  (s))[0] ))
 

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -12702,7 +12702,11 @@ static int packet_header_length(tcp_descriptor *desc) {
      * Set hlen to the minimal header bytes, for starters.
      */
     case TCP_PB_1:          hlen = 1; break;
+    case TCP_PB_2_LITTLE:   /* fall through */
     case TCP_PB_2:          hlen = 2; break;
+    case TCP_PB_3_LITTLE:   /* fall through */
+    case TCP_PB_3:          hlen = 3; break;
+    case TCP_PB_4_LITTLE:   /* fall through */
     case TCP_PB_4:          hlen = 4; break;
     case TCP_PB_RM:         hlen = 4; break;
     case TCP_PB_ASN1:       hlen = 2; break;
@@ -13544,8 +13548,24 @@ static int tcp_sendv(tcp_descriptor* desc, ErlIOVec* ev)
          put_int16(len, buf);
          h_len = 2;
          break;
+     case TCP_PB_2_LITTLE:
+         put_little_int16(len, buf);
+         h_len = 2;
+         break;
+     case TCP_PB_3:
+         put_int24(len, buf);
+         h_len = 3;
+         break;
+     case TCP_PB_3_LITTLE:
+         put_little_int24(len, buf);
+         h_len = 3;
+         break;
      case TCP_PB_4:
          put_int32(len, buf);
+         h_len = 4;
+         break;
+     case TCP_PB_4_LITTLE:
+         put_little_int32(len, buf);
          h_len = 4;
          break;
      default:
@@ -13660,9 +13680,25 @@ static int tcp_send(tcp_descriptor* desc, char* ptr, ErlDrvSizeT len)
 	put_int16(len, buf);
 	h_len = 2; 
 	break;
+    case TCP_PB_2_LITTLE:
+	put_little_int16(len, buf);
+	h_len = 2;
+	break;
+    case TCP_PB_3:
+	put_int24(len, buf);
+	h_len = 3;
+	break;
+    case TCP_PB_3_LITTLE:
+	put_little_int24(len, buf);
+	h_len = 3;
+	break;
     case TCP_PB_4: 
 	put_int32(len, buf);
 	h_len = 4; 
+	break;
+    case TCP_PB_4_LITTLE:
+	put_little_int32(len, buf);
+	h_len = 4;
 	break;
     default:
 	h_len = 0;

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -1761,10 +1761,13 @@ returned.
 - **`raw | 0`** - No packet handling is done. The entire binary is returned
   unless it is empty.
 
-- **`1 | 2 | 4`** - Packets consist of a header specifying the number of bytes
+- **`1 | 2 | 3 | 4`** - Packets consist of a header specifying the number of bytes
   in the packet, followed by that number of bytes. The length of the header can
-  be one, two, or four bytes; the order of the bytes is big-endian. The header
+  be one, two, three, or four bytes; the order of the bytes is big-endian. The header
   is stripped off when the packet is returned.
+
+- **`{TypeLength, Endianness}`** - Same as previous option, but allows configuring
+  the endianness of the length of the header, when it's two, three or four bytes.
 
 - **`line`** - A packet is a line-terminated by a delimiter byte, default is the
   latin-1 newline character. The delimiter byte is included in the returned
@@ -1837,8 +1840,11 @@ Options:
                                   {ok, Packet, Rest} |
                                   {more, Length} |
                                   {error, Reason} when
-      Type :: 'raw' | 0 | 1 | 2 | 4 | 'asn1' | 'cdr' | 'sunrm' | 'fcgi'
-            | 'tpkt' | 'line' | 'http' | 'http_bin' | 'httph' | 'httph_bin',
+      Type :: 'raw' | 0 | 1 | 2 | 3 | 4 | 'asn1' | 'cdr' | 'sunrm' | 'fcgi'
+            | 'tpkt' | 'line' | 'http' | 'http_bin' | 'httph' | 'httph_bin'
+            | {TypeLength, Endianness},
+      TypeLength :: 2 | 3 | 4,
+      Endianness :: big | little,
       Bin :: binary(),
       Options :: [Opt],
       Opt :: {packet_size, non_neg_integer()}

--- a/erts/preloaded/src/prim_inet.erl
+++ b/erts/preloaded/src/prim_inet.erl
@@ -1728,7 +1728,14 @@ type_opt_1(packet) ->
     {enum,[{0, ?TCP_PB_RAW},
 	   {1, ?TCP_PB_1},
 	   {2, ?TCP_PB_2},
+       {{2, big}, ?TCP_PB_2},
+       {{2, little}, ?TCP_PB_2_LITTLE},
+       {3, ?TCP_PB_3},
+       {{3, big}, ?TCP_PB_3},
+       {{3, little}, ?TCP_PB_3_LITTLE},
 	   {4, ?TCP_PB_4},
+       {{4, big}, ?TCP_PB_4},
+       {{4, little}, ?TCP_PB_4_LITTLE},
 	   {raw,?TCP_PB_RAW},
 	   {sunrm, ?TCP_PB_RM},
 	   {asn1, ?TCP_PB_ASN1},
@@ -1912,6 +1919,8 @@ type_value_1(Q, {record,Types}, undefined) ->
 type_value_1(Q, {record,Types}, Values)
   when tuple_size(Types) =:= tuple_size(Values) ->
     type_value_record(Q, Types, Values, 2);
+type_value_1(_, {enum, _} = Type, Value) ->
+    type_value_2(Type, Value);
 type_value_1(Q, Types, Values)
   when tuple_size(Types) =:= tuple_size(Values) ->
     type_value_tuple(Q, Types, Values, 1);
@@ -2114,6 +2123,8 @@ enc_value_1(Q, {record,Types}, undefined) ->
 enc_value_1(Q, {record,Types}, Values)
   when tuple_size(Types) =:= tuple_size(Values) ->
     enc_value_tuple(Q, Types, Values, 2);
+enc_value_1(_, {enum, _} = Type, Value) ->
+    enc_value_2(Type, Value);
 enc_value_1(Q, Types, Values) when tuple_size(Types) =:= tuple_size(Values) ->
     enc_value_tuple(Q, Types, Values, 1);
 enc_value_1(_, Type, Value) ->

--- a/lib/kernel/src/inet_int.hrl
+++ b/lib/kernel/src/inet_int.hrl
@@ -216,6 +216,10 @@
 -define(TCP_PB_SSL_TLS, 12).
 -define(TCP_PB_HTTP_BIN,13).
 -define(TCP_PB_HTTPH_BIN,14).
+-define(TCP_PB_2_LITTLE, 15).
+-define(TCP_PB_3,        16).
+-define(TCP_PB_3_LITTLE, 17).
+-define(TCP_PB_4_LITTLE, 18).
 
 
 %% getstat, INET_REQ_GETSTAT

--- a/lib/kernel/test/bif_SUITE.erl
+++ b/lib/kernel/test/bif_SUITE.erl
@@ -36,6 +36,7 @@
 
 	  run_fun/1,
 	  decode_packet_delim/1,
+	  decode_packet_endianness/1,
 	  wilderness/1]).
 
 -export([init_per_testcase/2, end_per_testcase/2]).
@@ -54,7 +55,8 @@ suite() ->
 
 all() -> 
     [{group, spawn_tests}, {group, spawn_link_tests},
-     {group, spawn_opt_tests}, spawn_failures, wilderness].
+     {group, spawn_opt_tests}, spawn_failures, wilderness,
+     decode_packet_endianness].
 
 groups() -> 
     [{spawn_tests, [], [spawn1, spawn2, spawn3, spawn4]},
@@ -494,6 +496,20 @@ decode_packet_delim(Config) when is_list(Config) ->
     {ok,<<"abc",0>>,<<"efg",0>>} =
         erlang:decode_packet(line, <<"abc",0,"efg",0>>, [{line_delimiter, 0}]),
     {more, undefined} = erlang:decode_packet(line, <<"abc",0,"efg",0>>, []).
+
+decode_packet_endianness(Config) when is_list(Config) ->
+    {ok, <<"abc">>, <<>>} =
+        erlang:decode_packet({2, big}, <<0, 3, "abc">>, []),
+    {ok, <<"abc">>, <<>>} =
+        erlang:decode_packet({2, little}, <<3, 0, "abc">>, []),
+    {ok, <<"abc">>, <<>>} =
+        erlang:decode_packet({3, big}, <<0, 0, 3, "abc">>, []),
+    {ok, <<"abc">>, <<>>} =
+        erlang:decode_packet({3, little}, <<3, 0, 0, "abc">>, []),
+    {ok, <<"abc">>, <<>>} =
+        erlang:decode_packet({4, big}, <<0, 0, 0, 3, "abc">>, []),
+    {ok, <<"abc">>, <<>>} =
+        erlang:decode_packet({4, little}, <<3, 0, 0, 0, "abc">>, []).
 
 %% This testcase should probably be moved somewhere else
 

--- a/lib/kernel/test/gen_tcp_echo_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_echo_SUITE.erl
@@ -200,7 +200,14 @@ echo_test(Config, SockOpts_0, EchoFun, EchoOpts_0) ->
 
     echo_packet(Config, [{packet, 1}|SockOpts], EchoFun, EchoOpts),
     echo_packet(Config, [{packet, 2}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, 3}|SockOpts], EchoFun, EchoOpts),
     echo_packet(Config, [{packet, 4}|SockOpts], EchoFun, EchoOpts),
+    %echo_packet(Config, [{packet, {2, big}}|SockOpts], EchoFun, EchoOpts),
+    %echo_packet(Config, [{packet, {3, big}}|SockOpts], EchoFun, EchoOpts),
+    %echo_packet(Config, [{packet, {4, big}}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, {2, little}}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, {3, little}}|SockOpts], EchoFun, EchoOpts),
+    echo_packet(Config, [{packet, {4, little}}|SockOpts], EchoFun, EchoOpts),
     echo_packet(Config, [{packet, sunrm}|SockOpts], EchoFun, EchoOpts),
     echo_packet(Config, [{packet, cdr}|SockOpts], EchoFun,
 		[{type, {cdr, big}}|EchoOpts]),
@@ -438,6 +445,10 @@ packet({Size, _RecvLimit}, Type) ->
 packet(Size, 1) when Size > 255 ->
     false;
 packet(Size, 2) when Size > 65535 ->
+    false;
+packet(Size, {2, big}) when Size > 65535 ->
+    false;
+packet(Size, {2, little}) when Size > 65535 ->
     false;
 packet(Size, {asn1, _, Tag}) when Size < 128 ->
     Tag++[Size|random_packet(Size)];


### PR DESCRIPTION
Add support for little-endian packet header lengths in `gen_tcp` and `erlang:decode_packet`, for lengths of two, three and four.

Add support for packet header lengths of three, both LE and BE.

The `packet` option can now be a tuple `{Len, Endianness}`, where `Len` can be 2, 3 or 4 and `Endianness` can be `big` or `little`. If endianness is `big` the behavior is the same as the old options.

Requested in issue #7265.

Other notes:
- the tuple option was suggested in the issue, I added `big` for symmetry
- for the inet backend I used the enum meta-type and had to change the `type_val_1` clauses for it to work;  there could be a better way, the option now has different possible types
- the code I added in `gen_tcp_socket:send` could be simplified since at that stage the option is already validated?
- the tests for the tuple with big-endian option were commented out to reduce the total test time, but maybe they should be enabled;  I tested locally, and they passed, I commented out after the fact.