### PR TITLE
kernel: Add option for erl_boot_server listen port

### DIFF
--- a/lib/kernel/test/erl_boot_server_SUITE.erl
+++ b/lib/kernel/test/erl_boot_server_SUITE.erl
@@ -100,6 +100,14 @@ start(Config) when is_list(Config) ->
     {error, {badarg, [Host1, BadHost]}} =
 	erl_boot_server:start([Host1, BadHost]),
 
+    %% Bad arguments - Options.
+    {error, {badarg, {}}} = erl_boot_server:start([Host1], {}),
+    {error, {badarg, []}} = erl_boot_server:start([Host1], []),
+    {error, {badarg, atom}} = erl_boot_server:start([Host1], atom),
+    {error, {badarg, 1234}} = erl_boot_server:start([Host1], 1234),
+    {error, {badarg, #{port := 1234}}} =
+        erl_boot_server:start([Host1], #{port => 1234}),
+
     %% Test once.
     {ok, Pid1} = erl_boot_server:start([Host1]),
     {error, {already_started, Pid1}} =
@@ -112,6 +120,20 @@ start(Config) when is_list(Config) ->
     {error, {already_started, Pid2}} =
 	erl_boot_server:start([Host1, Host2]),
     exit(Pid2, kill),
+    ct:sleep(1),
+
+    %% Test default options.
+    ct:sleep(1),
+    {ok, Pid3} = erl_boot_server:start([Host1, Host2], #{}),
+    {error, {already_started, Pid3}} = erl_boot_server:start([Host1, Host2]),
+    exit(Pid3, kill),
+    ct:sleep(1),
+
+    %% Test explicit options.
+    ct:sleep(1),
+    {ok, Pid4} = erl_boot_server:start([Host1, Host2], #{listen_port => 1234}),
+    {error, {already_started, Pid4}} = erl_boot_server:start([Host1, Host2]),
+    exit(Pid4, kill),
     ct:sleep(1),
 
     ok.
@@ -127,6 +149,14 @@ start_link(Config) when is_list(Config) ->
     {error, {badarg, [atom, BadHost]}} =
 	erl_boot_server:start_link([atom, BadHost]),
 
+    %% Bad arguments - Options.
+    {error, {badarg, {}}} = erl_boot_server:start_link([Host1], {}),
+    {error, {badarg, []}} = erl_boot_server:start_link([Host1], []),
+    {error, {badarg, atom}} = erl_boot_server:start_link([Host1], atom),
+    {error, {badarg, 1234}} = erl_boot_server:start_link([Host1], 1234),
+    {error, {badarg, #{port := 1234}}} =
+        erl_boot_server:start_link([Host1], #{port => 1234}),
+
     {ok, Pid1} = erl_boot_server:start_link([Host1]),
     {error, {already_started, Pid1}} =
 	erl_boot_server:start_link([Host1]),
@@ -136,6 +166,19 @@ start_link(Config) when is_list(Config) ->
     {error, {already_started, Pid2}} =
 	erl_boot_server:start_link([Host1, Host2]),
     shutdown(Pid2),
+
+    %% Test default options.
+    {ok, Pid3} = erl_boot_server:start_link([Host1, Host2], #{}),
+    {error, {already_started, Pid3}} =
+        erl_boot_server:start_link([Host1, Host2]),
+    shutdown(Pid3),
+
+    %% Test explicit options.
+    {ok, Pid4} =
+        erl_boot_server:start_link([Host1, Host2], #{listen_port => 1234}),
+    {error, {already_started, Pid4}} =
+        erl_boot_server:start_link([Host1, Host2]),
+    shutdown(Pid4),
     process_flag(trap_exit, OldFlag),
 
     ok.


### PR DESCRIPTION
Implements `start/2` and `start_link/2` for `erl_boot_server`, which accept a map with configuration options.

The map key `listen_port` allows the configuration of the boot server listening port. If an empty map is provided, or the `listen_port` is zero, the old behavior is kept, i.e. an ephemeral port is used.

Requested in issue #7365.