### PR TITLE
stdlib: edlin_expand should not crash when trying to complete a map

### DIFF
--- a/lib/stdlib/src/edlin_expand.erl
+++ b/lib/stdlib/src/edlin_expand.erl
@@ -251,7 +251,7 @@ expand_map(_, [], _, _) ->
 expand_map(Word, Bs, Binding, Keys) ->
     case proplists:get_value(list_to_atom(Binding), Bs) of
         Map when is_map(Map) ->
-            K1 = sets:from_list(maps:keys(Map)),
+            K1 = sets:from_list([Key || Key <- maps:keys(Map), is_atom(Key)]),
             K2 = sets:subtract(K1, sets:from_list([list_to_atom(K) || K <- Keys])),
             match(Word, sets:to_list(K2), "=>");
         _ -> {no, [], []}

--- a/lib/stdlib/test/edlin_expand_SUITE.erl
+++ b/lib/stdlib/test/edlin_expand_SUITE.erl
@@ -240,6 +240,9 @@ map_completion(_Config) ->
     %% test that an already specified key does not get suggested again
     {no, [], [{"a_key",_},{"c_key", _}]} = do_expand("MapBinding#{b_key=>1,"),
     %% test that unicode works
+    {yes, "'илли́ч'=>", []} = do_expand("UnicodeMap#{"),
+    %% test that non atoms are not suggested as completion
+    {no, "", []} = do_expand("NonAtomMap#{"),
     ok.
 
 function_parameter_completion(Config) ->
@@ -644,6 +647,8 @@ do_expand(String) ->
     Bs = [
           {'Binding', 0},
           {'MapBinding', #{a_key=>0, b_key=>1, c_key=>2}},
+          {'UnicodeMap', #{'илли́ч' => 0}},
+          {'NonAtomMap', #{{} => 1}},
           {'RecordBinding', {some_record, 1, 2}},
           {'TupleBinding', {0, 1, 2}},
           {'Söndag', 0},


### PR DESCRIPTION
What this code does is that it filters out all the keys that we are not able to autocomplete, leaving a list of atoms that we are able to autocomplete.
In the future we will support more key types other than atoms.

Closes #9837