### PR TITLE
zip: Improve returned errors

### DIFF
--- a/lib/stdlib/test/zip_SUITE.erl
+++ b/lib/stdlib/test/zip_SUITE.erl
@@ -692,7 +692,7 @@ create_files([]) ->
 %% Try zip:unzip/1 on some corrupted zip files.
 bad_zip(Config) when is_list(Config) ->
     ok = file:set_cwd(get_value(priv_dir, Config)),
-    try_bad("bad_crc",    {bad_crc, "abc.txt"}, Config),
+    try_bad("bad_crc",    {"abc.txt", bad_crc}, Config),
     try_bad("bad_central_directory", bad_central_directory, Config),
     try_bad("bad_file_header",    bad_file_header, Config),
     try_bad("bad_eocd",    bad_eocd, Config),
@@ -1077,8 +1077,8 @@ fd_leak(Config) ->
     do_fd_leak(BadExtract, 1),
 
     BadCreate = fun() ->
-                        {error,enoent} = zip:zip("failed.zip",
-                                                 ["none"]),
+                        {error,{"none", {_, enoent}}} = zip:zip("failed.zip",
+                                                      ["none"]),
                         ok
                 end,
     do_fd_leak(BadCreate, 1),


### PR DESCRIPTION
Before this change, if any operation failed on files within the archive only a generic badarg/enoent error would be returned. Now the filename and arguments used will be returned which makes it a lot easier to debug.