### PR TITLE
Correct type specs

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -340,7 +340,7 @@ file(F) ->
 
 -doc "Parse a file containing an XML document".
 -spec file(Filename :: string(), option_list()) ->
-          {document(), Rest} | {error, Reason} when
+          {dynamic(), Rest} | {error, Reason} when
       Rest   :: string(),
       Reason :: term().
 file(F, Options) ->
@@ -383,7 +383,7 @@ string(Str) ->
 
 -doc "Parse a string containing an XML document".
 -spec string(Text :: string(), option_list()) ->
-          {document(), Rest} when
+          {dynamic(), Rest} when
       Rest :: string().
 string(Str, Options) ->
      {Res, Tail, S=#xmerl_scanner{close_fun = Close}} =


### PR DESCRIPTION
The type specs of xmer_scan:file/2 and xmerl_scan:string/2 has been updated to return dynamic() due to hook functions can return any user defined term.