### PR TITLE
compiler destructive update: Fix crash caused by patch order

### DIFF
--- a/lib/compiler/src/beam_ssa_destructive_update.erl
+++ b/lib/compiler/src/beam_ssa_destructive_update.erl
@@ -959,6 +959,8 @@ merge_patches({tuple_element,IA,EA,_}, {tuple_elements,Es}) ->
     {tuple_elements,[{IA,EA}|Es]};
 merge_patches({tuple_elements,Es}, {tuple_element,IA,EA,_}) ->
     {tuple_elements,[{IA,EA}|Es]};
+merge_patches(Patch, {self,heap_tuple}) ->
+    Patch;
 merge_patches({self,heap_tuple}, Other) ->
     %% We're already patching this element in Other and as it will
     %% force the term onto the heap, we can ignore the new patch.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/9903