### PR TITLE
Initial tests using OpenVex

### DIFF
--- a/HOWTO/SBOM.md
+++ b/HOWTO/SBOM.md
@@ -225,8 +225,7 @@ and re-run the source SBOM generation steps ([Erlang/OTP source SBOM]).
 ### Add a New Vendor Dependency
 
 Follow the same steps as in [Update SPDX Vendor Packages].
-When running the SBOM generator, make sure to check that the new vendor dependency exists
-in its own package.
+When running the SBOM generator, make sure to check that the new vendor dependency exists in its own package.
 
 The [`renovate.json5`](../renovate.json5) file also needs to be updated
 to make sure that the new vendored dependency gets updated as it should.
@@ -237,3 +236,292 @@ Delete the code and any remaining `vendor.info` files.
 Re-run the source SBOM generation steps ([Erlang/OTP source SBOM]). 
 
 Delete the proper sections in [`renovate.json5`](../renovate.json5).
+
+## VEX
+
+VEX files allow to communicate which vulnerabilities are false positives and which ones are actual vulnerabilities. VEX files are important to explicitly state that some vendor dependencies are (not) vulnerabilities in your software.
+
+Erlang/OTP has chosen to communicate VEX information using the OpenVex implementation.
+
+### HOW-TO
+
+Erlang/OTP needs to add VEX files for the latests three releases.
+Because of this, Erlang/OTP will always contain the latest information in the `master` branch.
+Any OpenVex file in other branches is considered outdated.
+
+The OpenVex files are located in `.openvex/maint-26.openvex.json`, `.openvex/maint-27.openvex.json`, and `.openvex/maint-28.openvex.json` (e.g.). These files are generated from the `make/openvex.table` and the script `.github/scripts/otp-compliance.es`.
+
+- `make/openvex.table` contains all known CVEs on a per release basis, with top-level objects for `maint-XX` branches, where each `maint-XX` object has as value a list of dependencies with their CVE and the status.
+
+  Example:
+
+  ```json
+      "maint-28":
+      [
+          {
+              "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d" : "CVE-2025-4575",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/PCRE2Project/pcre2@2dce7761b1831fd3f82a9c2bd5476259d945da4d": "OSV-2025-300",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+          ...
+      ]
+  ```
+
+The `status` corresponds to the possible status from the [OpenVex specification](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md).
+In case of `not_affected`, a reason must be provided (similar to the [specification](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md)).
+**The `make/openvex.table` is considered to be an append-only structure, where one should not do modifications to existing data nor removal**.
+
+### Use Cases
+
+In all the cases explained below, the running of the tool `.github/scripts/otp-compliance.es vex` does not commit changes.
+One has to do that to save the introduced changes.
+
+#### Init
+
+This will only be needed once, but if you need to initialize and provide existing known CVEs, you can use `.github/scripts/otp-compliance.es`.
+
+The first time that we generate OpenVex statements we call `.github/scripts/otp-compliance.es vex init --input-file make/openvex.table -b maint-28`. This init script outputs instructions to execute in the shell, which invokes commands from `vexctl` ([Installation steps here](https://github.com/openvex/vexctl)). You can run and execute the scripts as follows, `.github/scripts/otp-compliance.es vex init --input-file make/openvex.table -b maint-28 | bash` (if you use bash).
+
+The script is idempotent, meaning that running consecutive times the script will not change its input, modulo the time field.
+Because of this, you run this command only for a new OTP release, and for coming CVEs you use `.github/scripts/otp-compliance.es vex run ...`.
+This last command will not update the time and assumes that the `otp-XX.openvex.json` exists (because the `init` command must be run first).
+
+**Example for new Release**
+
+To release VEX files for a new release, OTP-29, add the name branch to `make/openvex.table` (assuming there are known CVEs):
+
+```
+{
+    "maint-29": []
+}
+```
+
+Execute the script to create the VEX statements for OTP-29:
+
+```bash
+.github/scripts/otp-compliance.es vex init --input-file make/openvex.table -b maint-29
+```
+
+There are no known vulnerabilities, so this VEX statement can be published as is.
+
+
+#### Add `under_investigation`
+
+For vendor CVEs, it may make sense to communicate with the ecosystem that a CVE for vendor X is under investigation.
+If it is trivial to know whether we are affected, one could skip this step and add directly the `fixed`, or `vulnerable` statements.
+
+To update or insert VEX statements for OTP-29, update the `make/openvex.table` and run:
+
+```bash
+.github/scripts/otp-compliance.es vex run --input-file make/openvex.table -b maint-29
+```
+
+The script will output commands to run (similar to a dry-run). One piped to `bash` they are executed.
+
+```
+.github/scripts/otp-compliance.es vex run --input-file make/openvex.table -b maint-29 | bash
+```
+
+Add and commit the changes.
+
+**Example**
+
+`make/openvex.table` contains:
+
+```
+{
+    "maint-29": []
+}
+```
+
+Lets assume there is `FIKA-2026-BROD` detected in `zlib`. We can issue an `under_investigation` statement update the `make/openvex.table`
+
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          }
+    ]
+}
+```
+
+Execute the command below to update the OpenVEX statements.
+              
+```bash
+.github/scripts/otp-compliance.es vex run --input-file make/openvex.table -b maint-29 | bash
+```
+
+Erlang/OTP should not issue an `under_investigation` unless if it known that it will take some days to understand if Erlang/OTP is vulnerable to a vendor dependency.
+
+#### Add `not_affected`
+
+If the vulnerability under investigation is a false positive, one can convey this information using OpenVEX statements.
+To do this, one has too add a reason for why the vulnerability does not apply. These justifications can be found in the [OpenVEX spec](https://github.com/openvex/spec/blob/main/OPENVEX-SPEC.md#status-justifications).
+
+**Example**
+
+OTP was investigating the CVE `FIKA-2026-BROD` and found themselves not affected.
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          }
+    ]
+}
+```
+
+One can update the `make/openvex.table` with the reason of code no present, meaning, the component is included
+in OTP but the vulnerable code is not present.
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          },
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          }
+    ]
+}
+```
+
+To update the OpenVex statements, run:
+
+```bash
+.github/scripts/otp-compliance.es vex run --input-file make/openvex.table -b maint-29 | bash
+```
+
+It produces a new entry in the openvex statements for OTP-29 stating that OTP-29 is not vulnerable to the CVE `FIKA-2026-BROD`. 
+
+
+#### Add `affected`
+
+When OTP is affected by a CVE, one can communicate this using the `affected` status.
+
+**Example**
+
+OTP was investigating the CVE `FIKA-2026-BROD` and found themselves affected.
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          }
+    ]
+}
+```
+
+One can write then in `make/openvex.table`:
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          },
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "affected"
+          }
+    ]
+}
+```
+
+where the version affected is written as part of the package url `pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc`.
+
+Execute the command below to update the OpenVEX statements.
+              
+```bash
+.github/scripts/otp-compliance.es vex run --input-file make/openvex.table -b maint-29 | bash
+```
+
+It produces a new entry in the openvex statements for OTP-29.
+One can run multiple times the same statement without introducing each time the same statement.
+(the script makes the operation idempotent).
+
+In some cases, it may be useful to provide additional information to mitigate the vulnerability.
+To specy this, write the `status` value as an object with free text.
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          },
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": {"affected" : "do not use this component until there is a fix"}
+          }
+    ]
+}
+```
+ and run the `otp-compliance` script as stated above.
+
+#### Fixed
+
+One can specify that the CVE is fixed in a specific version using the `fixed` keyword in the `make/openvex.table` statements.
+
+**Example**
+
+OTP was affected the CVE `FIKA-2026-BROD`, reported in `make/openvex.table`.
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          },
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "affected"
+          }
+    ]
+}
+```
+
+OTP creates an emergency patch to fix this vendor dependency, and states that the package url (product and version)
+`pkg:github/madler/zlib@04f42cecafika2026brod` fixes the vulnerability.
+
+```json
+{
+    "maint-29": [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "under_investigation"
+          },
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "FIKA-2026-BROD",
+              "status": "affected"
+          },
+          {
+              "pkg:github/madler/zlib@04f42cecafika2026brod": "FIKA-2026-BROD",
+              "status": "fix"
+          },
+    ]
+}
+```
+
+
+Execute the command below to update the OpenVEX statements.
+              
+```bash
+.github/scripts/otp-compliance.es vex run --input-file make/openvex.table -b maint-29 | bash
+```

--- a/make/openvex.table
+++ b/make/openvex.table
@@ -1,0 +1,221 @@
+{
+    "otp-28":
+      [
+          {
+              "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d" : "CVE-2025-4575",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/PCRE2Project/pcre2@2dce7761b1831fd3f82a9c2bd5476259d945da4d": "OSV-2025-300",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/madler/zlib@1a8db63788c34a50e39e273d39b7e1033208aea2": "CVE-2023-45853",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2": "CVE-2024-58249",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          }
+      ],
+
+    "otp-27":
+      [
+          {
+              "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "CVE-2023-45853",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2": "CVE-2024-58249",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-6129",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-6237",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-0727",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-13176",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-2511",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-4603",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-4741",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-5535",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-6119",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-9143",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+          },
+
+          {
+              "pkg:otp/ssh@5.2.10": "CVE-2025-26618",
+              "status": {"affected": "Update to the next version"}
+          },
+
+          {
+              "pkg:otp/ssh@5.2.11": "CVE-2025-26618",
+              "status": "fixed"
+          },
+
+          {
+              "pkg:otp/ssh@5.2.9": "CVE-2025-32433",
+              "status": {"affected": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules."}
+          },
+
+          {
+              "pkg:otp/ssh@5.2.10": "CVE-2025-32433",
+              "status": "fixed"
+          },
+
+          {
+              "pkg:otp/ssh@5.2.10": "CVE-2025-46712",
+              "status": {"affected": "Update to the next version"}
+          },
+
+          {
+              "pkg:otp/ssh@5.2.11": "CVE-2025-46712",
+              "status": "fixed"
+          }
+      ],
+
+    "otp-26" :
+        [
+            {
+                "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc": "CVE-2023-45853",
+                "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+                "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2": "CVE-2024-58249",
+                "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-6129",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-6237",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-0727",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-13176",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-2511",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-4603",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-4741",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-5535",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-6119",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+              "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2024-9143",
+              "status": {"not_affected": "vulnerable_code_not_present"}
+            },
+
+            {
+                "pkg:otp/ssh@5.1": "CVE-2023-48795",
+                "status": {"affected" : "Mitigation: If strict KEX availability cannot be ensured on both connection sides, affected encryption modes(CHACHA and CBC) can be disabled with standard ssh configuration. This will provide protection against vulnerability, but at a cost of affecting interoperability"}
+            },
+
+            {
+                "pkg:otp/ssh@5.1.1": "CVE-2023-48795",
+                "status": "fixed"
+            },
+
+
+            {
+                "pkg:otp/ssh@5.1.4.5": "CVE-2025-26618",
+                "status": {"affected": "Update to the next version"}
+            },
+
+            {
+                "pkg:otp/ssh@5.1.4.6": "CVE-2025-26618",
+                "status": "fixed"
+            },
+
+            {
+                "pkg:otp/ssh@5.1.4.7": "CVE-2025-32433",
+                "status": {"affected": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules."}
+            },
+
+            {
+                "pkg:otp/ssh@5.1.4.8": "CVE-2025-32433",
+                "status": "fixed"
+            },
+
+            {
+                "pkg:otp/ssh@5.1.4.8": "CVE-2025-46712",
+                "status": {"affected": "Update to the next version"}
+            },
+
+            {
+                "pkg:otp/ssh@5.1.4.9": "CVE-2025-46712",
+                "status": "fixed"
+            }
+        ]
+}

--- a/vex/otp-26.openvex.json
+++ b/vex/otp-26.openvex.json
@@ -1,0 +1,428 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/otp/vex-otp-26",
+  "author": "vexctl",
+  "timestamp": "2025-06-10T15:10:59.471126+02:00",
+  "last_updated": "2025-06-10T15:10:59.883243843+02:00",
+  "version": 29,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45853"
+      },
+      "timestamp": "2025-06-10T15:10:59.490729518+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-58249"
+      },
+      "timestamp": "2025-06-10T15:10:59.506823487+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-6129"
+      },
+      "timestamp": "2025-06-10T15:10:59.520822446+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-6237"
+      },
+      "timestamp": "2025-06-10T15:10:59.535596683+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-0727"
+      },
+      "timestamp": "2025-06-10T15:10:59.549271589+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-13176"
+      },
+      "timestamp": "2025-06-10T15:10:59.564868+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-2511"
+      },
+      "timestamp": "2025-06-10T15:10:59.579436578+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4603"
+      },
+      "timestamp": "2025-06-10T15:10:59.59431912+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4741"
+      },
+      "timestamp": "2025-06-10T15:10:59.608212908+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-5535"
+      },
+      "timestamp": "2025-06-10T15:10:59.622496602+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-6119"
+      },
+      "timestamp": "2025-06-10T15:10:59.636318953+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-9143"
+      },
+      "timestamp": "2025-06-10T15:10:59.650612546+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-48795"
+      },
+      "timestamp": "2025-06-10T15:10:59.66476092+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Mitigation: If strict KEX availability cannot be ensured on both connection sides, affected encryption modes(CHACHA and CBC) can be disabled with standard ssh configuration. This will provide protection against vulnerability, but at a cost of affecting interoperability",
+      "action_statement_timestamp": "2025-06-10T15:10:59.66476092+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-48795"
+      },
+      "timestamp": "2025-06-10T15:10:59.680189883+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.12"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.11"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.10"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.9"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.8"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.7"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.6"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.5"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.4"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.3"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.2"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.1"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.4"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.3"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.2"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.1"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Mitigation: If strict KEX availability cannot be ensured on both connection sides, affected encryption modes(CHACHA and CBC) can be disabled with standard ssh configuration. This will provide protection against vulnerability, but at a cost of affecting interoperability",
+      "action_statement_timestamp": "2025-06-10T15:10:59.680189883+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-48795"
+      },
+      "timestamp": "2025-06-10T15:10:59.693864084+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.1"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-48795"
+      },
+      "timestamp": "2025-06-10T15:10:59.70893559+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.1"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:10:59.723517904+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.4.5"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:10:59.723517904+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:10:59.738014954+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.8"
+        },
+        {
+          "@id": "pkg:otp/erlang@26.2.5.7"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:10:59.738014954+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:10:59.753367189+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.4.6"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:10:59.767360951+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.9"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:10:59.78292099+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.4.7"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
+      "action_statement_timestamp": "2025-06-10T15:10:59.78292099+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:10:59.796892891+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.10"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
+      "action_statement_timestamp": "2025-06-10T15:10:59.796892891+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:10:59.811734653+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.4.8"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:10:59.825379871+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.11"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:10:59.840248039+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.4.8"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:10:59.840248039+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:10:59.854193907+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.11"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:10:59.854193907+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:10:59.868606488+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.1.4.9"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:10:59.883244235+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@26.2.5.12"
+        }
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/vex/otp-27.openvex.json
+++ b/vex/otp-27.openvex.json
@@ -1,0 +1,325 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/otp/vex-otp-27",
+  "author": "vexctl",
+  "timestamp": "2025-06-10T15:11:03.07398+02:00",
+  "last_updated": "2025-06-10T15:11:03.428076207+02:00",
+  "version": 25,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45853"
+      },
+      "timestamp": "2025-06-10T15:11:03.093004442+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-58249"
+      },
+      "timestamp": "2025-06-10T15:11:03.107748134+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-6129"
+      },
+      "timestamp": "2025-06-10T15:11:03.12168153+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-6237"
+      },
+      "timestamp": "2025-06-10T15:11:03.136242546+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-0727"
+      },
+      "timestamp": "2025-06-10T15:11:03.149978946+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-13176"
+      },
+      "timestamp": "2025-06-10T15:11:03.165195201+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-2511"
+      },
+      "timestamp": "2025-06-10T15:11:03.178897301+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4603"
+      },
+      "timestamp": "2025-06-10T15:11:03.194110871+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-4741"
+      },
+      "timestamp": "2025-06-10T15:11:03.207890099+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-5535"
+      },
+      "timestamp": "2025-06-10T15:11:03.222409914+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-6119"
+      },
+      "timestamp": "2025-06-10T15:11:03.237112153+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-9143"
+      },
+      "timestamp": "2025-06-10T15:11:03.252217816+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:11:03.265933188+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.2.10"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:11:03.265933188+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:11:03.281197095+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@27.3.3"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:11:03.281197095+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:11:03.2948494+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.2.11"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-26618"
+      },
+      "timestamp": "2025-06-10T15:11:03.309843504+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@27.3.4"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:11:03.32480181+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.2.9"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
+      "action_statement_timestamp": "2025-06-10T15:11:03.32480181+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:11:03.338688684+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@27.3.2"
+        },
+        {
+          "@id": "pkg:otp/erlang@27.3.1"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
+      "action_statement_timestamp": "2025-06-10T15:11:03.338688684+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:11:03.354369934+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.2.10"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32433"
+      },
+      "timestamp": "2025-06-10T15:11:03.368267816+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@27.3.3"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:11:03.384303023+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.2.10"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:11:03.384303023+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:11:03.398704586+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@27.3.3"
+        }
+      ],
+      "status": "affected",
+      "action_statement": "Update to the next version",
+      "action_statement_timestamp": "2025-06-10T15:11:03.398704586+02:00"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:11:03.414054343+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/ssh@5.2.11"
+        }
+      ],
+      "status": "fixed"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-46712"
+      },
+      "timestamp": "2025-06-10T15:11:03.428076631+02:00",
+      "products": [
+        {
+          "@id": "pkg:otp/erlang@27.3.4"
+        }
+      ],
+      "status": "fixed"
+    }
+  ]
+}

--- a/vex/otp-28.openvex.json
+++ b/vex/otp-28.openvex.json
@@ -1,0 +1,62 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/otp/vex-otp-28",
+  "author": "vexctl",
+  "timestamp": "2025-06-10T15:11:06.894018+02:00",
+  "last_updated": "2025-06-10T15:11:06.95368461+02:00",
+  "version": 5,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-4575"
+      },
+      "timestamp": "2025-06-10T15:11:06.910432285+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "OSV-2025-300"
+      },
+      "timestamp": "2025-06-10T15:11:06.924217273+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/PCRE2Project/pcre2@2dce7761b1831fd3f82a9c2bd5476259d945da4d"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45853"
+      },
+      "timestamp": "2025-06-10T15:11:06.938788037+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/madler/zlib@1a8db63788c34a50e39e273d39b7e1033208aea2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2024-58249"
+      },
+      "timestamp": "2025-06-10T15:11:06.953684966+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds 
- `openvex.table` which is similar to the otp.table except that it contains all CVEs on a per branch basis
   the main idea is that instead of having to write an otp.table per branch to maintain, we have a centralised
   point in `master` branch that contains all CVEs classified per branch. Many `openssl` CVEs are repeated over
   and over from one branch to another so a central place makes it easy to maintain.
  
- `.openvex/maint-26.openvex.json` is a generated file that we use to express openvex statements.

- `.openvex/templates/XXXX.openvex.json` are empty templates. we are not using them as OpenVex templates since I do not
  think we gain much from them.
  
 The main idea is to add all CVEs in `openvex.table` and run an otp-compliance script that generates and updates the `.openvex/maint-26.openvex.json` (and others) statements. Blindly running `vexctl add` multiple times generates the same entry multiple times, and the script (not yet implemented) should prevent us from generating the same entry multiple times.
  
we can express false positives running the command manually, and the `master` branch contains the OpenVex files up to date.
on each release, these files are push to the release page (github action to add next week).

This design is not final, but I think it makes sense to have the VEX files in the repo. If we place them in other repo, we make difficult to find them, e.g., `erlang/vex` where it is not clear if `erlang/vex` is for otp, rebar3, or any of the projects from the `erlang` organisation.