### PR TITLE
gh: Use correct old erlang versions for testing

### DIFF
--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -43,13 +43,19 @@ ENV OTP_STRICT_INSTALL=yes
 
 RUN mkdir /buildroot /tests /otp && chown ${USER}:${GROUP} /buildroot /tests /otp
 
+ARG LATEST_ERLANG_VERSION=unknown
+
 ## We install the latest version of the previous three releases in order to do
 ## backwards compatability testing of Erlang.
 RUN apt-get update && apt-get install -y git curl && \
     curl -L https://raw.githubusercontent.com/kerl/kerl/master/kerl > /usr/bin/kerl && \
     chmod +x /usr/bin/kerl && \
     kerl update releases && \
-    LATEST=$(kerl list releases | grep "\*$" | tail -1 | awk -F '.' '{print $1}') && \
+    if [ ${LATEST_ERLANG_VERSION} = "unknown" ]; then \
+        LATEST=$(kerl list releases | grep "\*$" | tail -1 | awk -F '.' '{print $1}'); \
+    else \
+        LATEST=${LATEST_ERLANG_VERSION}; \
+    fi && \
     for release in $(seq $(( LATEST - 2 )) $(( LATEST ))); do \
       VSN=$(kerl list releases | grep "^$release" | tail -1 | awk '{print $1}'); \
       if [ $release = $LATEST ]; then \

--- a/.github/scripts/build-base-image.sh
+++ b/.github/scripts/build-base-image.sh
@@ -3,10 +3,14 @@
 set -eo pipefail
 
 BASE_BRANCH="$1"
+LATEST_ERLANG_VERSION="unknown"
 
 case "${BASE_BRANCH}" in
-    master|maint|maint-*)
-    ;;
+    maint-*)
+        LATEST_ERLANG_VERSION=${BASE_BRANCH#"maint-"}
+        ;;
+    master|maint)
+        ;;
     *)
         BASE_BRANCH="master"
         ;;
@@ -60,6 +64,7 @@ else
        --build-arg MAKEFLAGS=-j$(($(nproc) + 2)) \
        --build-arg USER=otptest --build-arg GROUP=uucp \
        --build-arg uid="$(id -u)" \
+       --build-arg LATEST_ERLANG_VERSION="${LATEST_ERLANG_VERSION}" \
        --build-arg BASE="${BASE}" .github/
 
     NEW_BASE_IMAGE_ID=$(docker images -q "${BASE_TAG}:latest")


### PR DESCRIPTION
When building the base image for old releases we should include the old release - 2 and not the currently newest release -2.