### PR TITLE
asn1: Fix JER decoding for non-legacy constrained bitstrings

### DIFF
--- a/lib/asn1/src/asn1rtt_jer.erl
+++ b/lib/asn1/src/asn1rtt_jer.erl
@@ -296,6 +296,9 @@ decode_jer({choice,ChoiceTypes},ChoiceVal) ->
     end;
 decode_jer(bit_string,#{<<"value">> := Str, <<"length">> := Length}) ->
     json2bitstring(binary_to_list(Str),Length);
+decode_jer({bit_string, {_, _}},
+           #{<<"value">> := Str, <<"length">> := Length}) ->
+    json2bitstring(binary_to_list(Str), Length);
 decode_jer({bit_string,FixedLength},Str) when is_binary(Str) ->
     json2bitstring(binary_to_list(Str),FixedLength);
 decode_jer({{bit_string_nnl,NNL},{_,_}},#{<<"value">> := Str, <<"length">> := Length}) ->


### PR DESCRIPTION
Looks to have been missed in f71cd8402248dbea7854f4efd755df1750e57ac0
Now decoding JER with "normal" bitstrings works again.