### PR TITLE
stdlib: Fix terminal application example

### DIFF
--- a/lib/stdlib/doc/assets/tic-tac-toe.es
+++ b/lib/stdlib/doc/assets/tic-tac-toe.es
@@ -91,8 +91,6 @@ draw_state({_, Turn, _} = State) ->
 draw_marker(Pos, Turn) ->
     [set_position(Pos), "\e[C\e[C\e[C\n", Turn].
 
-handle_input({ok, Chars}, State) ->
-    handle_input({ok, Chars}, State);
 handle_input(eof, _State) ->
     stop;
 handle_input("\e[A" ++ Rest, {Pos, Turn, State}) ->

--- a/lib/stdlib/doc/guides/terminal_interface.md
+++ b/lib/stdlib/doc/guides/terminal_interface.md
@@ -106,7 +106,7 @@ main(_Args) ->
 loop(Pos) ->
     io:put_chars(draw_selection(Pos)),
     %% Read at most 1024 characters from stdin.
-    {ok, Chars} = io:get_chars("", 1024),
+    Chars = io:get_chars("", 1024),
     case handle_input(Chars, Pos) of
         stop -> stop;
         NewPos ->


### PR DESCRIPTION
The example code read `{ok, Chars} = io:get_chars(...)`, but [`io:get_chars/2`](https://www.erlang.org/doc/apps/stdlib/io.html#get_chars/2) returns string() | unicode:unicode_binary() or {error, _} | eof, so update the example.