### PR TITLE
Optimize single generators in comprehensions

### DIFF
--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -151,7 +151,8 @@ mixed(Config) when is_list(Config) ->
     %% OTP-16899: Nested binary comprehensions would fail to load.
     <<0,1,0,2,0,3,99>> = mixed_nested([1,2,3]),
 
-    <<1>> = cs_default(<< <<X>> || L <- [[1]], X <- L >>),
+    <<1>> = cs(<< <<X>> || L <- [[1]], X <- L >>),
+    <<1,2>> = cs_default(<< <<X>> || L <- [[1,2]], X <- L >>),
 
     %% The compiler would crash in v3_kernel.
     <<42:32,75:32,253:32,(42 bsl 8 bor 75):32>> =


### PR DESCRIPTION
The only way to bind variables in a comprehension is via a generator. If a value needs to be calculated once and used both as a filter and as a result, one must resort to tricks such as:

    [V || E <- L, V -> [expensive_calculation(E)], some_filter(V)]

This pull request optimizes comprehensions where a generator iterates over a list known to contain a single element.