### PR TITLE
Avoid parallel make invocations

### DIFF
--- a/make/run_make.mk
+++ b/make/run_make.mk
@@ -42,3 +42,5 @@ emu jit:
 clean generate depend docs release release_spec release_docs release_docs_spec \
   tests release_tests release_tests_spec static_lib format format-check compdb:
 	$(make_verbose)$(MAKE) -f $(TARGET)/Makefile $@
+
+.NOTPARALLEL:


### PR DESCRIPTION
For example:

`> make opt debug`

will build one target at a time (`opt` then `debug`) but each targets sub-makefile may still parallelize its sub targets.

This to avoid corrupted files when the same file is generated in parallel from two Makefile invocations.