### PR TITLE
otp: Fix all nif/driver loading to use win32 for windows

### DIFF
--- a/lib/asn1/src/asn1rt_nif.erl
+++ b/lib/asn1/src/asn1rt_nif.erl
@@ -67,9 +67,13 @@ load_nif() ->
     Status = case erlang:load_nif(Lib, ?ASN1_NIF_VSN) of
 		 ok -> ok;
 		 {error, {load_failed, _}}=Error1 ->
-		     ArchLibDir =
-			 filename:join([PrivDir, "lib",
-					erlang:system_info(system_architecture)]),
+		     Arch = case os:type() of
+                                {win32, _} -> win32;
+                                _ ->
+                                    erlang:system_info(system_architecture)
+                            end,
+                     ArchLibDir =
+                         filename:join([PrivDir, "lib", Arch]),
 		     Candidate =
 			 filelib:wildcard(
                            filename:join([ArchLibDir,LibName ++ "*" ]),

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -3529,9 +3529,13 @@ on_load() ->
     Status = case erlang:load_nif(Lib, {?CRYPTO_NIF_VSN,LibBin,FipsMode}) of
 		 ok -> ok;
 		 {error, {load_failed, _}}=Error1 ->
-		     ArchLibDir =
-			 filename:join([PrivDir, "lib",
-					erlang:system_info(system_architecture)]),
+                     Arch = case os:type() of
+                                {win32, _} -> win32;
+                                _ ->
+                                    erlang:system_info(system_architecture)
+                            end,
+                     ArchLibDir =
+                         filename:join([PrivDir, "lib", Arch]),
 		     Candidate =
 			 filelib:wildcard(
                            filename:join(

--- a/lib/os_mon/src/os_mon.erl
+++ b/lib/os_mon/src/os_mon.erl
@@ -91,10 +91,13 @@ open_port(Name, Opts) ->
 	true ->
 	    erlang:open_port({spawn, "\""++ReleasedPath++"\""}, Opts);
 	false ->
-	    %% Use os_mon*/priv/bin/Arch/Name
-	    ArchPath =
-		filename:join(
-		  [PrivDir,"bin",erlang:system_info(system_architecture),Name]),
+            %% Use os_mon*/priv/bin/Arch/Name
+            Arch = case os:type() of
+                       {win32, _} -> win32;
+                       _ ->
+                           erlang:system_info(system_architecture)
+                   end,
+            ArchPath = filename:join([PrivDir,"bin",Arch,Name]),
 	    erlang:open_port({spawn, "\""++ArchPath++"\""}, Opts)
     end.
 

--- a/lib/public_key/src/pubkey_os_cacerts.erl
+++ b/lib/public_key/src/pubkey_os_cacerts.erl
@@ -275,7 +275,11 @@ load_nif() ->
     case erlang:load_nif(Lib, 0) of
         ok -> ok;
         {error, {load_failed, _}}=Error1 ->
-            Arch = erlang:system_info(system_architecture),
+            Arch = case os:type() of
+                       {win32, _} -> win32;
+                       _ ->
+                           erlang:system_info(system_architecture)
+                   end,
             ArchLibDir = filename:join([PrivDir, "lib", Arch]),
             Candidate =
                 filelib:wildcard(

--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -1323,9 +1323,12 @@ trace_port(ip, {Portno, Qsiz}) when is_integer(Portno), is_integer(Qsiz) ->
 		ok ->
 		    ok;
 		_ ->
-		    Dir2 = filename:join(
-			     Dir1, 
-			     erlang:system_info(system_architecture)),
+                    Arch = case os:type() of
+                                {win32, _} -> win32;
+                                _ ->
+                                    erlang:system_info(system_architecture)
+                            end,
+		    Dir2 = filename:join(Dir1, Arch),
 		    catch erl_ddll:load_driver(Dir2, Driver)
 	    end,
 	    L = lists:flatten(
@@ -1361,9 +1364,12 @@ trace_port1(file, Filename, Options) ->
 		ok ->
 		    ok;
 		_ ->
-		    Dir2 = filename:join(
-			     Dir1, 
-			     erlang:system_info(system_architecture)),
+                    Arch = case os:type() of
+                                {win32, _} -> win32;
+                                _ ->
+                                    erlang:system_info(system_architecture)
+                            end,
+		    Dir2 = filename:join(Dir1, Arch),
 		    catch erl_ddll:load_driver(Dir2, Driver)
 	    end,
 	    if 	element(1, Options) == wrap ->

--- a/lib/runtime_tools/src/dyntrace.erl
+++ b/lib/runtime_tools/src/dyntrace.erl
@@ -157,9 +157,13 @@ on_load() ->
     Status = case erlang:load_nif(Lib, 0) of
                  ok -> ok;
                  {error, {load_failed, _}}=Error1 ->
-                     ArchLibDir = 
-                         filename:join([PrivDir, "lib", 
-                                        erlang:system_info(system_architecture)]),
+                     Arch = case os:type() of
+                                {win32, _} -> win32;
+                                _ ->
+                                    erlang:system_info(system_architecture)
+                            end,
+                     ArchLibDir =
+                         filename:join([PrivDir, "lib", Arch]),
                      Candidate =
                          filelib:wildcard(
                            filename:join([ArchLibDir,LibName ++ "*" ]),

--- a/lib/wx/api_gen/gl_gen_erl.erl
+++ b/lib/wx/api_gen/gl_gen_erl.erl
@@ -105,7 +105,12 @@ gl_api(Fs, _GluNifs) ->
     w("init_nif() ->~n", []),
     w("  Base = \"erl_gl\",\n"
       "  Priv = code:priv_dir(wx),\n"
-      "  SrcTree = filename:join(Priv,erlang:system_info(system_architecture)),\n"
+      "  Arch = case os:type() of\n"
+      "             {win32, _} -> win32;\n"
+      "             _ ->\n"
+      "                 erlang:system_info(system_architecture)\n"
+      "         end,\n"
+      "  SrcTree = filename:join(Priv,Arch),\n"
       "  NifFile = case filelib:is_dir(SrcTree) of\n"
       "                true -> filename:absname(filename:join(SrcTree, Base));\n"
       "                false -> filename:absname(filename:join(Priv, Base))\n"

--- a/lib/wx/src/gen/gl.erl
+++ b/lib/wx/src/gen/gl.erl
@@ -325,7 +325,12 @@ nif_stub_error(Line) ->
 init_nif() ->
   Base = "erl_gl",
   Priv = code:priv_dir(wx),
-  SrcTree = filename:join(Priv,erlang:system_info(system_architecture)),
+  Arch = case os:type() of
+             {win32, _} -> win32;
+             _ ->
+                 erlang:system_info(system_architecture)
+         end,
+  SrcTree = filename:join(Priv,Arch),
   NifFile = case filelib:is_dir(SrcTree) of
                 true -> filename:absname(filename:join(SrcTree, Base));
                 false -> filename:absname(filename:join(Priv, Base))

--- a/lib/wx/src/wxe_util.erl
+++ b/lib/wx/src/wxe_util.erl
@@ -182,7 +182,12 @@ priv_dir(Driver0, Silent) ->
 	{ok, _} ->
 	    {Priv, Priv};
 	{error, _} ->
-	    SrcPriv = filename:join(Priv, erlang:system_info(system_architecture)),
+            Arch = case os:type() of
+                       {win32, _} -> win32;
+                       _ ->
+                           erlang:system_info(system_architecture)
+                   end,
+            SrcPriv = filename:join(Priv, Arch),
 	    case file:read_file_info(filename:join(SrcPriv, Driver)) of
 		{ok, _} ->
 		    {Priv, SrcPriv};


### PR DESCRIPTION
A recent change made erlang:system_info(system_architecture) return x86_64-pc-windows instead of win32 which broke all priv dir lookups on windows.