### PR TITLE
Revert "chore(deps): update dependency windows to v2025"

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -279,7 +279,7 @@ jobs:
     env:
       WXWIDGETS_VERSION: 3.2.6
     name: Build Erlang/OTP (Windows)
-    runs-on: windows-2025
+    runs-on: windows-2022
     needs: pack
     if: needs.pack.outputs.build-c-code == 'true'
     steps:

--- a/.github/workflows/upload-windows-zip.yaml
+++ b/.github/workflows/upload-windows-zip.yaml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   upload-windows-zip:
-    runs-on: windows-2025
+    runs-on: windows-2022
     ## Needed to upload assets to releases
     permissions:
         contents: write


### PR DESCRIPTION
This reverts commit 7be96998c8420fc03f7adf32a53fbf5c7f00a47f.

nsis is not currently available there.