### PR TITLE
Fix crypto:hash/2 for default SHAKE-128/256 on OpenSSL 3.4+

### DIFF
--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -1589,6 +1589,12 @@ hash_xof(Type, DefaultLen, [Msg | RestMsg], [Digest | RestDigest], [Length | Res
                     ok;
                 Other2 ->
                     ct:fail({{crypto, hash_xof, [Type, Msg, Length]}, {expected, Digest}, {got, Other2}})
+            end,
+            case crypto:hash(Type, Msg) of
+                Digest ->
+                    ok;
+                Other3 ->
+                    ct:fail({{crypto, hash, [Type, Msg]}, {expected, Digest}, {got, Other3}})
             end;
         _ ->
             ok % No crypto:hash_init({Type,Length}) support yet


### PR DESCRIPTION
Fix #9901.