### PR TITLE
compiler: Fix compiler crash with multiple phi patches

### DIFF
--- a/lib/compiler/src/beam_ssa_check.erl
+++ b/lib/compiler/src/beam_ssa_check.erl
@@ -210,7 +210,7 @@ post_args(Pattern, Args, _Env) ->
 post_phi_args([{'...',_}], _, Env) ->
     Env;
 post_phi_args([{tuple,_,[PVar,PLbl]}|PArgs], [{AVar,ALbl}|AArgs], Env0) ->
-    Env = env_post(PVar, AVar, env_post(PLbl, ALbl, Env0)),
+    Env = env_post(PVar, AVar, env_post(PLbl, #b_literal{val=ALbl}, Env0)),
     post_phi_args(PArgs, AArgs, Env);
 post_phi_args([], [], Env) ->
     Env.

--- a/lib/compiler/src/beam_ssa_destructive_update.erl
+++ b/lib/compiler/src/beam_ssa_destructive_update.erl
@@ -822,9 +822,19 @@ patch_f([{Lbl,Blk=#b_blk{is=Is0,last=Last0}}|Rest],
     patch_f(Rest, Cnt, PD, Acc, BlockAdditions++BlockAdditions0);
 patch_f([], Cnt, _PD, Acc, BlockAdditions) ->
     ?DP("BlockAdditions: ~p~n", [BlockAdditions]),
-    Linear = insert_block_additions(Acc, maps:from_list(BlockAdditions), []),
+    Merged = merge_block_additions(BlockAdditions, #{}),
+    Linear = insert_block_additions(Acc, Merged, []),
     ?DP("SSA-result:~n~p~n", [Linear]),
     {Linear, Cnt}.
+
+merge_block_additions([{Lbl, Extra} | Rest], Acc) ->
+    Is = case Acc of
+             #{ Lbl := Is0 } -> Extra ++ Is0;
+             #{} -> Extra
+         end,
+    merge_block_additions(Rest, Acc#{ Lbl => Is });
+merge_block_additions([], Acc) ->
+    Acc.
 
 patch_is([I0=#b_set{dst=Dst}|Rest], PD0, Cnt0, Acc, BlockAdditions0)
   when is_map_key(Dst, PD0) ->

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1738,7 +1738,8 @@ kernel_passes() ->
      {iff,dssa,{listing,"ssa"}},
      {iff,ssalint,{pass,beam_ssa_lint}},
      {delay,
-      [{unless,no_bool_opt,{pass,beam_ssa_bool}},
+      [make_ssa_check_pass(pre_ssa_opt),
+       {unless,no_bool_opt,{pass,beam_ssa_bool}},
        {iff,dbool,{listing,"bool"}},
        {unless,no_bool_opt,{iff,ssalint,{pass,beam_ssa_lint}}},
 

--- a/lib/compiler/test/beam_ssa_check_SUITE.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE.erl
@@ -40,7 +40,8 @@
          ret_annotation_checks/1,
          sanity_checks/1,
          tuple_inplace_checks/1,
-         non_throwing_bifs/1]).
+         non_throwing_bifs/1,
+         phis_checks/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -58,7 +59,8 @@ groups() ->
        ret_annotation_checks,
        sanity_checks,
        tuple_inplace_checks,
-       non_throwing_bifs]},
+       non_throwing_bifs,
+       phis_checks]},
      {post_ssa_opt_dynamic,test_lib:parallel(),
       [bs_size_unit_checks]}].
 
@@ -132,9 +134,20 @@ sanity_checks(Config) when is_list(Config) ->
 non_throwing_bifs(Config) when is_list(Config) ->
     run_post_ssa_opt(non_throwing_bifs, Config).
 
+phis_checks(Config) when is_list(Config) ->
+    run_pre_ssa_opt(phis, Config),
+    run_post_ssa_opt(phis, Config).
+
 dynamic_workdir(Config) ->
     PrivDir = proplists:get_value(priv_dir, Config),
     filename:join(PrivDir, "dynamic").
+
+run_pre_ssa_opt(Module, Config) ->
+    File = atom_to_list(Module) ++ ".erl",
+
+    DataDir = proplists:get_value(data_dir, Config),
+    Source = filename:join(DataDir, File),
+    run_checks(Source, pre_ssa_opt, Config).
 
 run_post_ssa_opt(Module, Config) ->
     File = atom_to_list(Module) ++ ".erl",


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/9987.
Previously, when patching multiple phi nodes with the same from-label, only one of them was used because we used `maps:from_list`.