### PR TITLE
Re-add priv dir

### DIFF
--- a/lib/debugger/Makefile
+++ b/lib/debugger/Makefile
@@ -28,7 +28,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # Common Macros
 # ----------------------------------------------------
 
-SUB_DIRECTORIES = src doc
+SUB_DIRECTORIES = src priv doc
 
 SPECIAL_TARGETS = 
 


### PR DESCRIPTION
Was missing and causes debugger to crash when icons can't be found.

Fixes #9858