### PR TITLE
compiler: Fix crash when zip generator contains a map pattern

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -2126,14 +2126,17 @@ replace_vars(#c_cons{hd=H,tl=T}, Vars) ->
     H1 = replace_vars(H, Vars),
     no_vars(#c_cons{hd=H1,tl=T1});
 replace_vars(#c_tuple{es=Es0}, Vars) ->
-    Es1 = replace_list_vars(Es0, Vars),
+    Es1 = replace_list_vars(tuple, Es0, Vars),
     no_vars(#c_tuple{es=Es1});
 replace_vars(#imap{es=Es0}=M, Vars) ->
-    Es1 = replace_list_vars(Es0, Vars),
+    Es1 = replace_list_vars(map, Es0, Vars),
     no_vars(M#imap{es=Es1});
 replace_vars(#imappair{val=V}=M, Vars) ->
     V1 = replace_vars(V, Vars),
-    no_vars(M#imappair{val=V1});
+    case no_vars(M#imappair{val=V1}) of
+        #c_var{name='_'} -> [];
+        Pat -> Pat
+    end;
 replace_vars(#c_var{name='_'}=V, _) ->
     V;
 replace_vars(#c_var{name=Var}=V, Vars) ->
@@ -2143,7 +2146,9 @@ replace_vars(#c_var{name=Var}=V, Vars) ->
     end;
 replace_vars(V, _) -> V.
 
-replace_list_vars(Es, Vars) ->
+replace_list_vars(map, Es, Vars) ->
+    [replace_vars(E, Vars) || E <- Es, replace_vars(E, Vars) =/= []];
+replace_list_vars(tuple, Es, Vars) ->
     [replace_vars(E, Vars) || E <- Es].
 
 %% If the pattern contains no named variables, collapse it to '_'.

--- a/lib/compiler/test/zlc_SUITE.erl
+++ b/lib/compiler/test/zlc_SUITE.erl
@@ -27,7 +27,7 @@
          basic/1,mixed_zlc/1,zmc/1,filter_guard/1,
          filter_pattern/1,cartesian/1,nomatch/1,bad_generators/1,
          strict_list/1,strict_binary/1,
-         cover/1,strict_pat/1]).
+         cover/1,strict_pat/1,gh10002/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -52,7 +52,8 @@ groups() ->
        strict_list,
        strict_binary,
        cover,
-       strict_pat
+       strict_pat,
+       gh10002
       ]}].
 
 init_per_suite(Config) ->
@@ -526,6 +527,14 @@ strict_pat_5(G1, G2, G3) ->
     Res = [{Key,Y} || Key <- G1, #{Key := Y} <- G2 && Y <:- G3],
     Res = [{Key,Y} || Key <- G1, Y <:- G3 && #{Key := Y} <- G2],
     Res.
+
+gh10002(Config) when is_list(Config) ->
+    [] = [X || X <:- [] && #{key1 := X, key2 := _} <- [] ],
+    [1] = [X || X <:- [1] && #{key1 := X, key2 := _} <- [#{key1=>1,key2=>1}]],
+    [] = [X || X <:- [1] && #{key1 := X, key2 := _} <- [#{key1=>1}]],
+    ?assertError({bad_generators,{[1],[#{key1:=0}]}},
+                [X || X <:- [1] && #{key1 := X, key2 := _} <- [#{key1=>0}]]),
+    ok.
 
 -file("bad_zlc.erl", 1).
 bad_generators(L1,L2) ->                        %Line 2


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/10002.