### PR TITLE
Update macro_log typespec

### DIFF
--- a/lib/kernel/src/logger.erl
+++ b/lib/kernel/src/logger.erl
@@ -598,7 +598,7 @@ allow(Level,Module) when is_atom(Module) ->
 
 -doc false.
 -spec macro_log(Location,Level,StringOrReport)  -> ok when
-      Location :: location(),
+      Location :: location() | #{},
       Level :: level(),
       StringOrReport :: unicode:chardata() | report().
 macro_log(Location,Level,StringOrReport) ->
@@ -606,17 +606,17 @@ macro_log(Location,Level,StringOrReport) ->
 
 -doc false.
 -spec macro_log(Location,Level,StringOrReport,Meta)  -> ok when
-      Location :: location(),
+      Location :: location() | #{},
       Level :: level(),
       StringOrReport :: unicode:chardata() | report(),
       Meta :: metadata();
                (Location,Level,Format,Args) -> ok when
-      Location :: location(),
+      Location :: location() | #{},
       Level :: level(),
       Format :: io:format(),
       Args ::[term()];
                (Location,Level,Fun,FunArgs) -> ok when
-      Location :: location(),
+      Location :: location() | #{},
       Level :: level(),
       Fun :: msg_fun(),
       FunArgs :: term().
@@ -628,7 +628,7 @@ macro_log(Location,Level,FunOrFormat,Args) ->
 
 -doc false.
 -spec macro_log(Location,Level,Format,Args,Meta)  -> ok when
-      Location :: location(),
+      Location :: location() | #{},
       Level :: level(),
       Format :: io:format(),
       Args ::[term()],


### PR DESCRIPTION
`log_allowed` which is called by `macro_log` actually accepts `location()` or `#{}`. I noticed this issue when running dialyzer on elixir codebase. There are justified usages of `macro_log` with an empty map argument and dialyzer emits:

```
lib/logger.ex:1005:41: The call 'Elixir.Logger':'__do_log__'
         (_level@2 ::
              'alert' | 'critical' | 'debug' | 'emergency' | 'error' |
              'info' | 'notice' | 'warning',
          _message_or_fun@1 :: any(),
          #{},
          map()) will never return since it differs in the 3rd argument from the success typing arguments: 
         ('alert' | 'critical' | 'debug' | 'emergency' | 'error' |
          'info' | 'notice' | 'warning',
          any(),
          #{'file' := string(),
            'line' := non_neg_integer(),
            'mfa' := {atom(), atom(), non_neg_integer()}},
          map())
```