### PR TITLE
ssl: Stop the sender socket side if error

### DIFF
--- a/lib/ssl/src/inet_epmd_tls_socket.erl
+++ b/lib/ssl/src/inet_epmd_tls_socket.erl
@@ -168,6 +168,12 @@ connect(
               Socket,
               inet_epmd_dist:merge_options(
                 ConnectOptions, [{nodelay, true}], [])),
+        BindAddress =
+            #{ family => Family,
+               addr => any,
+               port => proplists:get_value(port, ConnectOptions, 0)},
+        ok ?=
+            socket:bind(Socket, BindAddress),
         ConnectAddress =
             #{ family => Family,
                addr => Ip,


### PR DESCRIPTION
When socket reports an error close down the socket sender process to avoid trying to send something else.