### PR TITLE
Fix typos equvalent -> equivalent

### DIFF
--- a/lib/kernel/src/gen_udp.erl
+++ b/lib/kernel/src/gen_udp.erl
@@ -476,7 +476,7 @@ send(S, Host, Port, Packet) when is_port(S) ->
 -doc """
 Send a packet to the specified destination, with ancillary data.
 
-Equvalent to [`send(Socket, Host, Port, Packet)`](`send/4`)
+Equivalent to [`send(Socket, Host, Port, Packet)`](`send/4`)
 regarding `Host` and `Port` and also equivalent to
 [`send(Socket, Destination, AncData, Packet)`](#send-4-AncData)
 regarding the ancillary data: `AncData`.

--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -1198,7 +1198,7 @@ bytes_r(N, AlgHandler, Next, R0, Bytes, _GoodBytes, GoodBits, _Shift) ->
 Jump the generator state forward.
 
 Performs an algorithm specific [`State`](`t:state/0`) jump calculation
-that is equvalent to a large number of state iterations.
+that is equivalent to a large number of state iterations.
 See this module's [algorithms list](#algorithms).
 
 Returns the [`NewState`](`t:state/0`).
@@ -1623,7 +1623,7 @@ exsplus_jump({AlgHandler, S}) ->
 Jump the generator state forward.
 
 Performs a [`State`](`t:state/0`) jump calculation
-that is equvalent to a 2^64 state iterations.
+that is equivalent to a 2^64 state iterations.
 
 Returns the [`NewState`](`t:state/0`).
 


### PR DESCRIPTION
Found while reading the docs for `rand`.