### PR TITLE
wx: Fix pre-built source package

### DIFF
--- a/lib/wx/prebuild.skip
+++ b/lib/wx/prebuild.skip
@@ -1,2 +1,3 @@
+ebin/gl.beam
 config.mk
 c_src/Makefile


### PR DESCRIPTION
Don't include `gl.beam` in pre-built source tar file, since it depends on local configure results.