### PR TITLE
Make export table size configurable

### DIFF
--- a/erts/emulator/beam/erl_init.c
+++ b/erts/emulator/beam/erl_init.c
@@ -135,6 +135,8 @@ Uint32 verbose;             /* See erl_debug.h for information about verbose */
 
 int erts_atom_table_size = ATOM_LIMIT;	/* Maximum number of atoms */
 
+int erts_export_table_size = EXPORT_LIMIT;	/* Maximum number of exports */
+
 int erts_pd_initial_size = 8;  /* must be power of 2 */
 
 int erts_modified_timing_level;
@@ -691,6 +693,10 @@ __decl_noreturn void __noreturn  erts_usage(void)
     erts_fprintf(stderr, "-t size        set the maximum number of atoms the emulator can handle;\n");
     erts_fprintf(stderr, "               valid range is [%d-%d]\n",
 		 MIN_ATOM_TABLE_SIZE, MAX_ATOM_TABLE_SIZE);
+    erts_fprintf(stderr, "\n");
+
+    erts_fprintf(stderr, "-E number      set export index limit; valid range is [%d-%d]\n",
+		 EXPORT_INITIAL_SIZE, EXPORT_MAX_SIZE);
     erts_fprintf(stderr, "\n");
 
     erts_fprintf(stderr, "-T number      set modified timing level; valid range is [0-%d]\n",
@@ -2216,6 +2222,22 @@ erl_start(int argc, char **argv)
 		     erts_atom_table_size));
 	    break;
         }
+
+    case 'E': {
+        long val;
+        arg = get_arg(argv[i]+2, argv[i+1], &i);
+        errno = 0;
+        val = strtol(arg, NULL, 10);
+        if (errno != 0 || val < EXPORT_INITIAL_SIZE || val > EXPORT_MAX_SIZE) {
+            erts_fprintf(stderr, "bad export table size %s\n", arg);
+            erts_usage();
+        }
+        erts_export_table_size = val;
+        VERBOSE(DEBUG_SYSTEM,
+                ("setting maximum number of exports to %d\n",
+                 erts_export_table_size));
+        break;
+    }
 
 	case 'T' :
 	    arg = get_arg(argv[i]+2, argv[i+1], &i);

--- a/erts/emulator/beam/erl_vm.h
+++ b/erts/emulator/beam/erl_vm.h
@@ -262,6 +262,7 @@ extern Uint H_MAX_SIZE;          /* maximum (heap + stack) */
 extern int H_MAX_FLAGS;         /* maximum heap flags  */
 
 extern int erts_atom_table_size;/* Atom table size */
+extern int erts_export_table_size;/* Export table size */
 extern int erts_pd_initial_size;/* Initial Process dictionary table size */
 
 /* macros for extracting bytes from uint16's */

--- a/erts/emulator/beam/export.c
+++ b/erts/emulator/beam/export.c
@@ -32,9 +32,6 @@
 #include "jit/beam_asm.h"
 #include "erl_global_literals.h"
 
-#define EXPORT_INITIAL_SIZE   4000
-#define EXPORT_LIMIT          (512*1024)
-
 #ifdef DEBUG
 #  define IF_DEBUG(x) x
 #else
@@ -115,7 +112,7 @@ static void export_stage(Export *export,
 #define ERTS_CODE_STAGED_OBJECT_ALLOC_TYPE ERTS_ALC_T_EXPORT
 #define ERTS_CODE_STAGED_TABLE_ALLOC_TYPE ERTS_ALC_T_EXPORT_TABLE
 #define ERTS_CODE_STAGED_TABLE_INITIAL_SIZE EXPORT_INITIAL_SIZE
-#define ERTS_CODE_STAGED_TABLE_LIMIT EXPORT_LIMIT
+#define ERTS_CODE_STAGED_TABLE_LIMIT erts_export_table_size
 
 #define ERTS_CODE_STAGED_WANT_GET
 #define ERTS_CODE_STAGED_WANT_PUT

--- a/erts/emulator/beam/export.h
+++ b/erts/emulator/beam/export.h
@@ -37,6 +37,10 @@
 #define OP_PAD
 #endif
 
+#define EXPORT_INITIAL_SIZE   4000
+#define EXPORT_MAX_SIZE        (2048*1024)
+#define EXPORT_LIMIT          (512*1024)
+
 typedef struct export_
 {
     /* !! WARNING !!


### PR DESCRIPTION
This is a change to the emulator that allows the export table size to be configured at runtime.

The minimum size is `4000`, which is the same as the initial size of the export table. 

I've set the maximum size to 2048*1024. Which I believe is a reasonable limit. The default limit is 512*1024, which is the original hard coded limit.

The reason i made this change is that in sufficiently large systems the export list table can grow to exhaust the maximum number of indexes.

closes #10015