### PR TITLE
erl_parse: fix binary_op() type

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -1214,7 +1214,7 @@ processed (see section [Error Information](#module-error-information)).
 -type binary_op() :: '/' | '*' | 'div' | 'rem' | 'band' | 'and' | '+' | '-'
                    | 'bor' | 'bxor' | 'bsl' | 'bsr' | 'or' | 'xor' | '++'
                    | '--' | '==' | '/=' | '=<' | '<'  | '>=' | '>' | '=:='
-                   | '=/=' | '!'.
+                   | '=/=' | '!' | 'andalso' | 'orelse'.
 
 -type af_unary_op(T) :: {'op', anno(), unary_op(), T}.
 


### PR DESCRIPTION
Those operators were "obviously" missing. Found when adding specs and type-checking `erl_expand_records`