### PR TITLE
beam_ssa: fix non-sensical type

### DIFF
--- a/lib/compiler/src/beam_ssa.hrl
+++ b/lib/compiler/src/beam_ssa.hrl
@@ -27,7 +27,7 @@
                    body :: [beam_ssa:b_function()]}).
 -record(b_function, {anno=#{} :: beam_ssa:anno(),
                      args :: [beam_ssa:b_var()],
-                     bs :: #{beam_ssa:label():=beam_ssa:b_blk()},
+                     bs :: #{beam_ssa:label()=>beam_ssa:b_blk()},
                      cnt :: beam_ssa:label()}).
 
 -record(b_blk, {anno=#{} :: beam_ssa:anno(),


### PR DESCRIPTION
required associations make sense only with literal types 
(found by eqwalizer)