### PR TITLE
erts: implement AF_VSOCK

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -629,6 +629,10 @@
    don't. */
 #undef HAVE_DECL_TIME2POSIX
 
+/* Define to 1 if you have the declaration of 'VMADDR_CID_LOCAL', and to 0 if
+   you don't. */
+#undef HAVE_DECL_VMADDR_CID_LOCAL
+
 /* Define to 1 if you have the <dirent.h> header file, and it defines 'DIR'.
    */
 #undef HAVE_DIRENT_H
@@ -826,6 +830,9 @@
 
 /* Define to 1 if you have the <linux/types.h> header file. */
 #undef HAVE_LINUX_TYPES_H
+
+/* Define to 1 if you have the <linux/vm_sockets.h> header file. */
+#undef HAVE_LINUX_VM_SOCKETS_H
 
 /* Define to 1 if you have the 'localtime_r' function. */
 #undef HAVE_LOCALTIME_R
@@ -1166,6 +1173,9 @@
 
 /* Define to 1 if you have the <sys/un.h> header file. */
 #undef HAVE_SYS_UN_H
+
+/* Define to 1 if you have the <sys/vsock.h> header file. */
+#undef HAVE_SYS_VSOCK_H
 
 /* Define to 1 if you have <sys/wait.h> that is POSIX.1 compatible. */
 #undef HAVE_SYS_WAIT_H

--- a/erts/configure
+++ b/erts/configure
@@ -21830,6 +21830,41 @@ fi
 printf "%s\n" "#define HAVE_DECL_IPV6_V6ONLY $ac_have_decl" >>confdefs.h
 
 
+ac_fn_c_check_header_compile "$LINENO" "linux/vm_sockets.h" "ac_cv_header_linux_vm_sockets_h" "#include <sys/socket.h>
+"
+if test "x$ac_cv_header_linux_vm_sockets_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_LINUX_VM_SOCKETS_H 1" >>confdefs.h
+
+fi
+ac_fn_c_check_header_compile "$LINENO" "sys/vsock.h" "ac_cv_header_sys_vsock_h" "#include <sys/socket.h>
+"
+if test "x$ac_cv_header_sys_vsock_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_SYS_VSOCK_H 1" >>confdefs.h
+
+fi
+
+ac_fn_check_decl "$LINENO" "VMADDR_CID_LOCAL" "ac_cv_have_decl_VMADDR_CID_LOCAL" "
+    #include <sys/socket.h>
+    #if HAVE_LINUX_VM_SOCKETS_H
+    #include <linux/vm_sockets.h>
+    #endif
+    #if HAVE_SYS_VSOCK_H
+    #include <sys/vsock.h>
+    #endif
+
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_VMADDR_CID_LOCAL" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_VMADDR_CID_LOCAL $ac_have_decl" >>confdefs.h
+
+
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sched_getaffinity/sched_setaffinity" >&5
 printf %s "checking for sched_getaffinity/sched_setaffinity... " >&6; }

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -2370,6 +2370,18 @@ AC_CHECK_DECLS([IN6ADDR_ANY_INIT, IN6ADDR_LOOPBACK_INIT, IPV6_V6ONLY], [], [],
 		#include <netinet/in.h>
 	       ])
 
+dnl Checks for AF_VSOCK socket support
+AC_CHECK_HEADERS(linux/vm_sockets.h sys/vsock.h,[],[],[#include <sys/socket.h>])
+AC_CHECK_DECLS([VMADDR_CID_LOCAL], [], [], [
+    #include <sys/socket.h>
+    #if HAVE_LINUX_VM_SOCKETS_H
+    #include <linux/vm_sockets.h>
+    #endif
+    #if HAVE_SYS_VSOCK_H
+    #include <sys/vsock.h>
+    #endif
+])
+
 dnl ----------------------------------------------------------------------
 dnl Checks for features/quirks in the system that affects Erlang.
 dnl ----------------------------------------------------------------------

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -2007,6 +2007,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(cellular);                        \
     GLOBAL_ATOM_DECL(chaos);                           \
     GLOBAL_ATOM_DECL(checksum);                        \
+    GLOBAL_ATOM_DECL(cid);                             \
     GLOBAL_ATOM_DECL(close);                           \
     GLOBAL_ATOM_DECL(closed);                          \
     GLOBAL_ATOM_DECL(close_wait);                      \
@@ -2091,6 +2092,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(hoplimit);                        \
     GLOBAL_ATOM_DECL(hopopts);                         \
     GLOBAL_ATOM_DECL(host);                            \
+    GLOBAL_ATOM_DECL(hypervisor);                      \
     GLOBAL_ATOM_DECL(hwaddr);                          \
     GLOBAL_ATOM_DECL(icmp);                            \
     GLOBAL_ATOM_DECL(icmp6);                           \
@@ -2344,6 +2346,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(use_registry);                    \
     GLOBAL_ATOM_DECL(value);                           \
     GLOBAL_ATOM_DECL(void);                            \
+    GLOBAL_ATOM_DECL(vsock);                           \
     GLOBAL_ATOM_DECL(v6only);                          \
     GLOBAL_ATOM_DECL(write_byte);                      \
     GLOBAL_ATOM_DECL(write_fails);                     \
@@ -4742,6 +4745,13 @@ ERL_NIF_TERM esock_supports_0(ErlNifEnv* env)
     is_supported = esock_atom_false;
 #endif
     TARRAY_ADD(opts, MKT2(env, esock_atom_local, is_supported));
+
+#if defined(HAS_AF_VSOCK)
+    is_supported = esock_atom_true;
+#else
+    is_supported = esock_atom_false;
+#endif
+    TARRAY_ADD(opts, MKT2(env, esock_atom_vsock, is_supported));
 
 #if defined(HAVE_SETNS)
     is_supported = esock_atom_true;

--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -81,6 +81,14 @@
 #include <netpacket/packet.h>
 #endif
 
+#if defined(HAVE_LINUX_VM_SOCKETS_H)
+#include <linux/vm_sockets.h>
+#define HAS_AF_VSOCK 1
+#elif defined(HAVE_SYS_VSOCK_H)
+#include <sys/vsock.h>
+#define HAS_AF_VSOCK 1
+#endif
+
 #endif
 
 /* Copied from sys.h
@@ -148,6 +156,10 @@ typedef union {
 
 #if defined(AF_LINK)
     struct sockaddr_dl dl;
+#endif
+
+#ifdef HAS_AF_VSOCK
+    struct sockaddr_vm vm;
 #endif
 
     /* Max size sockaddr on system */
@@ -283,6 +295,7 @@ typedef long ssize_t;
     GLOBAL_ATOM_DEF(cellular);                 \
     GLOBAL_ATOM_DEF(chaos);                    \
     GLOBAL_ATOM_DEF(checksum);                 \
+    GLOBAL_ATOM_DEF(cid);                      \
     GLOBAL_ATOM_DEF(close);                    \
     GLOBAL_ATOM_DEF(closed);                   \
     GLOBAL_ATOM_DEF(close_wait);               \
@@ -367,6 +380,7 @@ typedef long ssize_t;
     GLOBAL_ATOM_DEF(hoplimit);                 \
     GLOBAL_ATOM_DEF(hopopts);                  \
     GLOBAL_ATOM_DEF(host);                     \
+    GLOBAL_ATOM_DEF(hypervisor);               \
     GLOBAL_ATOM_DEF(hwaddr);                   \
     GLOBAL_ATOM_DEF(icmp);                     \
     GLOBAL_ATOM_DEF(icmp6);                    \
@@ -619,6 +633,7 @@ typedef long ssize_t;
     GLOBAL_ATOM_DEF(use_registry);             \
     GLOBAL_ATOM_DEF(value);                    \
     GLOBAL_ATOM_DEF(void);                     \
+    GLOBAL_ATOM_DEF(vsock);                    \
     GLOBAL_ATOM_DEF(v6only);                   \
     GLOBAL_ATOM_DEF(write_byte);               \
     GLOBAL_ATOM_DEF(write_fails);              \

--- a/erts/emulator/nifs/common/socket_util.c
+++ b/erts/emulator/nifs/common/socket_util.c
@@ -129,6 +129,12 @@ static void make_sockaddr_in6(ErlNifEnv*    env,
 static void make_sockaddr_un(ErlNifEnv*    env,
                              ERL_NIF_TERM  path,
                              ERL_NIF_TERM* sa);
+#ifdef HAS_AF_VSOCK
+static void make_sockaddr_vm(ErlNifEnv*    env,
+                             ERL_NIF_TERM  port,
+                             ERL_NIF_TERM  cid,
+                             ERL_NIF_TERM* sa);
+#endif
 #if defined(HAVE_NETPACKET_PACKET_H)
 static void make_sockaddr_ll(ErlNifEnv*    env,
                              ERL_NIF_TERM  proto,
@@ -444,6 +450,7 @@ BOOLEAN_T esock_decode_iov(ErlNifEnv*    env,
  *    inet  - sockaddr_in4: port, addr
  *    inet6 - sockaddr_in6: port, addr, flowinfo, scope_id
  *    unspec - sockaddr:    addr
+ *    vsock  - sockaddr_vm: port, cid
  *    (int)  - sockaddr:     addr
  */
 
@@ -498,6 +505,12 @@ BOOLEAN_T esock_decode_sockaddr(ErlNifEnv*    env,
     case AF_UNSPEC:
         return esock_decode_sockaddr_native(env, eSockAddr, sockAddrP,
                                             AF_UNSPEC, addrLenP);
+#endif
+
+#ifdef HAS_AF_VSOCK
+    case AF_VSOCK:
+        return esock_decode_sockaddr_vm(env, eSockAddr,
+                                        &sockAddrP->vm, addrLenP);
 #endif
 
     default:
@@ -593,6 +606,13 @@ void esock_encode_sockaddr(ErlNifEnv*    env,
                                    &sockAddrP->sa, len,
                                    esock_atom_unspec,
                                    eSockAddr);
+      break;
+#endif
+
+#ifdef HAS_AF_VSOCK
+  case AF_VSOCK:
+      len = SALEN(addrLen, sizeof(struct sockaddr_vm));
+      esock_encode_sockaddr_vm(env, &sockAddrP->vm, len, eSockAddr);
       break;
 #endif
 
@@ -1303,6 +1323,132 @@ void esock_encode_sockaddr_un(ErlNifEnv*          env,
 }
 #endif
 
+/* +++ esock_decode_sockaddr_vm +++
+ *
+ * Decode a VSock Domain socket address - sockaddr_vm. In erlang its
+ * represented as a map, which has a specific set of attributes
+ * (beside the mandatory family attribute, which is "inherited" from
+ * the "sockaddr" type):
+ *
+ *    port     :: vsock_port_number()  (integer)
+ *    cid      :: vsock_context_id()   (integer)
+ *
+ * The erlang module ensures that this value exist, so there
+ * is no need for any elaborate error handling here.
+ */
+
+#ifdef HAS_AF_VSOCK
+extern
+BOOLEAN_T esock_decode_sockaddr_vm(ErlNifEnv*          env,
+                                   ERL_NIF_TERM        eSockAddr,
+                                   struct sockaddr_vm* sockAddrP,
+                                   SOCKLEN_T*          addrLen)
+{
+    ERL_NIF_TERM ePort, eCid;
+    unsigned int port, cid;
+
+    UDBG( ("SUTIL", "esock_decode_sockaddr_vm -> entry\r\n") );
+
+    sys_memzero((char*) sockAddrP, sizeof(struct sockaddr_vm));
+    sockAddrP->svm_family = AF_VSOCK;
+
+    /* *** Extract (e) port from map *** */
+    if (! GET_MAP_VAL(env, eSockAddr, esock_atom_port, &ePort))
+        return FALSE;
+
+    if (IS_ATOM(env, ePort)) {
+        /* This can only be: 'any' */
+        if (COMPARE(esock_atom_any, ePort) == 0) {
+            port = VMADDR_PORT_ANY;
+        } else {
+            return FALSE;
+        }
+    } else {
+        /* Decode port as an unsigned integer */
+        if (! GET_UINT(env, ePort, &port))
+            return FALSE;
+    }
+
+    UDBG( ("SUTIL", "esock_decode_sockaddr_vm -> port: %d\r\n", port) );
+    sockAddrP->svm_port = port;
+
+    /* *** Extract (e) cid from map *** */
+    if (! GET_MAP_VAL(env, eSockAddr, esock_atom_cid, &eCid))
+        return FALSE;
+
+    if (IS_ATOM(env, eCid)) {
+        /* This can be one of: 'any' | 'local' | 'host' | 'hypervisor' */
+        if (COMPARE(esock_atom_any, eCid) == 0) {
+            cid = VMADDR_CID_ANY;
+        } else if (COMPARE(esock_atom_hypervisor, eCid) == 0) {
+            cid = VMADDR_CID_HYPERVISOR;
+#if HAVE_DECL_VMADDR_CID_LOCAL
+        } else if (COMPARE(esock_atom_local, eCid) == 0) {
+            cid = VMADDR_CID_LOCAL;
+#endif
+        } else if (COMPARE(esock_atom_host, eCid) == 0) {
+            cid = VMADDR_CID_HOST;
+        } else {
+            return FALSE;
+        }
+    } else {
+        /* Decode cid as an unsigned integer */
+        if (! GET_UINT(env, eCid, &cid))
+            return FALSE;
+    }
+
+    UDBG( ("SUTIL", "esock_decode_sockaddr_vm -> cid: %d\r\n", cid) );
+    sockAddrP->svm_cid = cid;
+
+    *addrLen = sizeof(struct sockaddr_vm);
+
+    UDBG( ("SUTIL", "esock_decode_sockaddr_vm -> done\r\n") );
+
+    return TRUE;
+}
+#endif
+
+
+
+/* +++ esock_encode_sockaddr_vm +++
+ *
+ * Encode a VSock socket address - sockaddr_vm. In erlang its represented as
+ * a map, which has a specific set of attributes (beside the mandatory family
+ * attribute, which is "inherited" from the "sockaddr" type):
+ *
+ *    port     :: vsock_port_number()  (integer)
+ *    cid      :: vsock_context_id()   (integer)
+ *
+ */
+
+#ifdef HAS_AF_VSOCK
+extern
+void esock_encode_sockaddr_vm(ErlNifEnv*          env,
+                              struct sockaddr_vm* sockAddrP,
+                              SOCKLEN_T           addrLen,
+                              ERL_NIF_TERM*       eSockAddr)
+{
+    ERL_NIF_TERM ePort, eCid;
+
+    UDBG( ("SUTIL", "esock_encode_sockaddr_vm -> entry\r\n") );
+
+    if (addrLen >= sizeof(struct sockaddr_vm)) {
+
+        /* Encode (e) port as an unsigned integer */
+        ePort = MKUI(env, sockAddrP->svm_port);
+
+        /* Encode (e) cid as an unsigned integer */
+        eCid = MKUI(env, sockAddrP->svm_cid);
+
+        /* And finally construct the sockaddr_vm record */
+        make_sockaddr_vm(env, ePort, eCid, eSockAddr);
+
+    } else {
+        esock_encode_sockaddr_native(env, (struct sockaddr *)sockAddrP,
+                                     addrLen, esock_atom_vsock, eSockAddr);
+    }
+}
+#endif
 
 
 /* +++ esock_encode_sockaddr_ll +++
@@ -1866,6 +2012,7 @@ BOOLEAN_T esock_decode_timeval(ErlNifEnv*      env,
  *    inet   => AF_INET
  *    inet6  => AF_INET6
  *    local  => AF_LOCAL
+ *    vsock => AF_VSOCK
  *    unspec => AF_UNSPEC
  *
  * Return -1:
@@ -1897,6 +2044,11 @@ int esock_decode_domain(ErlNifEnv*   env,
         *domain = AF_UNSPEC;
 #endif
 
+#ifdef HAS_AF_VSOCK
+    } else if (COMPARE(esock_atom_vsock, eDomain) == 0) {
+        *domain = AF_VSOCK;
+#endif
+
     } else {
         int d;
 
@@ -1920,6 +2072,7 @@ int esock_decode_domain(ErlNifEnv*   env,
  *    AF_INET    => inet
  *    AF_INET6   => inet6
  *    AF_LOCAL   => local
+ *    AF_VSOCK   => vsock
  *    AF_UNSPEC  => unspec
  *
  */
@@ -1948,6 +2101,12 @@ void esock_encode_domain(ErlNifEnv*    env,
 #ifdef AF_UNSPEC
     case AF_UNSPEC:
         *eDomain = esock_atom_unspec;
+        break;
+#endif
+
+#ifdef HAS_AF_VSOCK
+    case AF_VSOCK:
+        *eDomain = esock_atom_vsock;
         break;
 #endif
 
@@ -3373,6 +3532,26 @@ void make_sockaddr_dl(ErlNifEnv*    env,
 }
 #endif
 
+/* Construct the VSock socket address */
+#ifdef HAS_AF_VSOCK
+static
+void make_sockaddr_vm(ErlNifEnv*    env,
+                      ERL_NIF_TERM  port,
+                      ERL_NIF_TERM  cid,
+                      ERL_NIF_TERM* sa)
+{
+    ERL_NIF_TERM keys[]  = {esock_atom_family,
+                            esock_atom_port,
+                            esock_atom_cid};
+    ERL_NIF_TERM vals[]  = {esock_atom_vsock,
+                            port,
+                            cid};
+    size_t       numKeys = NUM(keys);
+
+    ESOCK_ASSERT( numKeys == NUM(vals) );
+    ESOCK_ASSERT( MKMA(env, keys, vals, numKeys, sa) );
+}
+#endif
 
 extern
 ERL_NIF_TERM esock_make_new_binary(ErlNifEnv *env, void *buf, size_t size)

--- a/erts/emulator/nifs/common/socket_util.h
+++ b/erts/emulator/nifs/common/socket_util.h
@@ -166,6 +166,19 @@ void esock_encode_sockaddr_un(ErlNifEnv*          env,
                               ERL_NIF_TERM*       eSockAddr);
 #endif
 
+#ifdef HAS_AF_VSOCK
+extern
+BOOLEAN_T esock_decode_sockaddr_vm(ErlNifEnv*          env,
+                                   ERL_NIF_TERM        eSockAddr,
+                                   struct sockaddr_vm* sockAddrP,
+                                   SOCKLEN_T*          addrLen);
+extern
+void esock_encode_sockaddr_vm(ErlNifEnv*          env,
+                              struct sockaddr_vm* sockAddrP,
+                              SOCKLEN_T           addrLen,
+                              ERL_NIF_TERM*       eSockAddr);
+#endif
+
 #ifdef HAVE_NETPACKET_PACKET_H
 extern
 void esock_encode_sockaddr_ll(ErlNifEnv*          env,

--- a/erts/preloaded/src/prim_socket.erl
+++ b/erts/preloaded/src/prim_socket.erl
@@ -80,6 +80,8 @@
         (#{family => local, path => <<"">>})).
 -define(ESOCK_SOCKADDR_UNSPEC_DEFAULTS,
         (#{family => unspec, addr => <<>>})).
+-define(ESOCK_SOCKADDR_VSOCK_DEFAULTS,
+        (#{family => vsock, port => any, cid => any})).
 -define(ESOCK_SOCKADDR_NATIVE_DEFAULTS,
         (#{family => 0, addr => <<>>})).
 
@@ -1039,6 +1041,8 @@ enc_sockaddr(#{family := local} = SockAddr) ->
     throw({invalid, {sockaddr, path, SockAddr}});
 enc_sockaddr(#{family := unspec} = SockAddr) ->
     merge_sockaddr(?ESOCK_SOCKADDR_UNSPEC_DEFAULTS, SockAddr);
+enc_sockaddr(#{family := vsock} = SockAddr) ->
+    merge_sockaddr(?ESOCK_SOCKADDR_VSOCK_DEFAULTS, SockAddr);
 enc_sockaddr(#{family := Native} = SockAddr) when is_integer(Native) ->
     merge_sockaddr(?ESOCK_SOCKADDR_NATIVE_DEFAULTS, SockAddr);
 enc_sockaddr(#{family := _} = SockAddr) ->

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -344,6 +344,7 @@ server(Addr, Port) ->
               sockaddr_un/0,
               sockaddr_ll/0,
               sockaddr_dl/0,
+              sockaddr_vm/0,
               sockaddr_unspec/0,
               sockaddr_native/0,
 
@@ -368,6 +369,9 @@ server(Addr, Port) ->
               ipv6_pmtudisc/0,
               ipv6_hops/0,
               ipv6_pktinfo/0,
+
+              vsock_port_number/0,
+              vsock_context_id/0,
 
               sctp_assocparams/0,
               sctp_event_subscribe/0,
@@ -489,7 +493,7 @@ protocol domain `local` is supported.
 
 `supports/0` reports both values, but also many more, with a single call.
 """.
--type domain() :: inet | inet6 | local | unspec.
+-type domain() :: inet | inet6 | local | unspec | vsock.
 
 %% We support only a subset of all types.
 %% RDM - Reliably Delivered Messages
@@ -676,6 +680,14 @@ The value `default` is only valid to _set_ and is translated to the C value
           ifindex := integer()
          }.
 
+-doc "32-bit port number for AF_VSOCK socket".
+-type vsock_port_number() ::
+        0..16#FFFFFFFF.
+
+-doc "32-bit Context Identifier (CID) for AF_VSOCK socket".
+-type vsock_context_id() ::
+        0..16#FFFFFFFF.
+
 -doc "C: `struct sctp_assocparams`".
 -type sctp_assocparams() ::
         #{assoc_id                := integer(),
@@ -820,6 +832,18 @@ and the content of `sa_data` in the `t:map/0` key `addr`.
         #{family := 'unspec', addr := binary()}.
 
 -doc """
+C: `struct sockaddr_vm`
+
+In C, a `struct sockaddr` with `sa_family = AF_VSOCK`,
+the content of `svm_cid` in the `t:map/0` key `cid`,
+and the content of `svm_port` in the `t:map/0` key `port`.
+""".
+-type sockaddr_vm() ::
+        #{family   := 'vsock',
+          port     := vsock_port_number(),
+          cid      := 'any' | 'hypervisor' | 'local' | 'host' | vsock_context_id()}.
+
+-doc """
 C: `struct sockaddr`
 
 In C, a `struct sockaddr` with the integer value of `sa_family`
@@ -836,6 +860,7 @@ and the content of `sa_data` in the `t:map/0` key `addr`.
         sockaddr_ll()      |
         sockaddr_dl()      |
         sockaddr_unspec()  |
+        sockaddr_vm()      |
         sockaddr_native().
 
 -type sockaddr_recv() ::
@@ -1905,14 +1930,15 @@ There are several predefined `FilterRule`s and one general:
 	FilterRule ::
           'inet' | 'inet6' | 'local' |
           'stream' | 'dgram' | 'seqpacket' |
-          'sctp' | 'tcp' | 'udp' |
+          'sctp' | 'tcp' | 'udp' | 'vsock' |
           pid() |
           fun((socket_info()) -> boolean()).
 
 which_sockets(Domain)
   when Domain =:= inet;
        Domain =:= inet6;
-       Domain =:= local ->
+       Domain =:= local;
+       Domain =:= vsock ->
     ?REGISTRY:which_sockets({domain, Domain});
 
 which_sockets(Type)
@@ -2138,7 +2164,7 @@ Otherwise the same as `i/2` with the same first argument
 and the default information (see `i/0`).
 """.
 -spec i(InfoKeys :: info_keys()) -> ok;
-       (Domain :: inet | inet6 | local) -> ok;
+       (Domain :: inet | inet6 | local | vsock) -> ok;
        (Proto :: sctp | tcp | udp) -> ok;
        (Type :: dgram | seqpacket | stream) -> ok.
 
@@ -2146,7 +2172,8 @@ i(InfoKeys) when is_list(InfoKeys) ->
     do_i(which_sockets(), InfoKeys);
 i(Domain) when (Domain =:= inet) orelse
 	       (Domain =:= inet6) orelse
-	       (Domain =:= local) ->
+	       (Domain =:= local) orelse
+	       (Domain =:= vsock) ->
     do_i(which_sockets(Domain), default_info_keys());
 i(Proto) when (Proto =:= tcp) orelse
 	      (Proto =:= udp) orelse
@@ -2174,7 +2201,7 @@ all sockets of that specific `t:protocol/0`.
 If the first argument is `Type` print information for
 all sockets of that specific `t:type/0`.
 """.
--spec i(Domain :: inet | inet6 | local, InfoKeys) -> ok
+-spec i(Domain :: inet | inet6 | local | vsock, InfoKeys) -> ok
               when InfoKeys :: info_keys();
        (Proto :: sctp | tcp | udp, InfoKeys) -> ok
               when InfoKeys :: info_keys();
@@ -2184,7 +2211,8 @@ all sockets of that specific `t:type/0`.
 i(Domain, InfoKeys)
   when ((Domain =:= inet) orelse
 	(Domain =:= inet6) orelse
-	(Domain =:= local)) andalso
+	(Domain =:= local) orelse
+	(Domain =:= vsock)) andalso
        is_list(InfoKeys) ->
     do_i(which_sockets(Domain), InfoKeys);
 i(Proto, InfoKeys)
@@ -2339,6 +2367,12 @@ fmt_sockaddr(#{family := Fam,
 	{0,0,0,0,0,0,0,1} -> "localhost:" ++ fmt_service(SockAddr);
 	IP                -> inet_parse:ntoa(IP) ++ ":" ++ fmt_service(SockAddr)
     end;
+fmt_sockaddr(#{family := vsock, port := Port, cid := Cid}, _Proto) ->
+    CidStr = case Cid of
+        16#ffffffff -> "-1";
+        Cid         -> integer_to_list(Cid)
+    end,
+    "vsock:" ++ CidStr ++ ":" ++ integer_to_list(Port);
 fmt_sockaddr(#{family := local,
 	       path   := Path}, _Proto) ->
     "local:" ++
@@ -2944,6 +2978,9 @@ bind(?socket(SockRef), Addr) when is_reference(SockRef) ->
                        Domain =:= inet6 ->
                     prim_socket:bind(
                       SockRef, #{family => Domain, addr => Addr});
+                {ok, vsock} when Addr =:= any ->
+                    prim_socket:bind(
+                      SockRef, #{family => vsock, port => any, cid => any});
                 {ok, _Domain} ->
                     {error, eafnosupport};
                 {error, _} = ERROR ->

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -650,6 +650,13 @@ reg_s_single_open_and_close_and_count() ->
             _ ->
                 false
         end,
+    SupportsVSOCK =
+        case (catch has_support_vsock()) of
+            ok ->
+                true;
+            _ ->
+                false
+        end,
     InitSockInfos =
         [
          {inet, stream, tcp},
@@ -728,6 +735,15 @@ reg_s_single_open_and_close_and_count() ->
                         ?P("test open sctp socket: failed"),
                         []
                 end;
+            false ->
+                []
+        end ++
+        case SupportsVSOCK of
+            true ->
+                [
+                 {vsock, stream, default},
+                 {vsock, dgram, default}
+                ];
             false ->
                 []
         end,
@@ -14528,6 +14544,14 @@ has_support_sctp() ->
                 false ->
                     skip("Not supported")
             end
+    end.
+
+has_support_vsock() ->
+    case socket:is_supported(vsock) of
+        true ->
+            ok;
+        false ->
+            skip("Not supported")
     end.
 
 

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -128,6 +128,7 @@
          sc_rc_recv_response_tcp4/1,
          sc_rc_recv_response_tcp6/1,
          sc_rc_recv_response_tcpL/1,
+         sc_rc_recv_response_tcpV/1,
          sc_rc_recvmsg_response_tcp4/1,
          sc_rc_recvmsg_response_tcp6/1,
          sc_rc_recvmsg_response_tcpL/1,
@@ -328,6 +329,7 @@ sc_rc_cases() ->
      sc_rc_recv_response_tcp4,
      sc_rc_recv_response_tcp6,
      sc_rc_recv_response_tcpL,
+     sc_rc_recv_response_tcpV,
 
      sc_rc_recvmsg_response_tcp4,
      sc_rc_recvmsg_response_tcp6,
@@ -8076,6 +8078,24 @@ sc_rc_recv_response_tcpL(_Config) when is_list(_Config) ->
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% This test case is intended to test what happens when a socket is
+%% remotely closed while the process is calling the recv function.
+%% Socket is AF_VSOCK (stream) socket.
+
+sc_rc_recv_response_tcpV(_Config) when is_list(_Config) ->
+    ?TT(?SECS(30)),
+    tc_try(?FUNCTION_NAME,
+           fun() -> has_support_vsock() end,
+           fun() ->
+                   Recv      = fun(Sock) -> socket:recv(Sock) end,
+                   InitState = #{domain   => vsock,
+                                 protocol => default,
+                                 recv     => Recv},
+                   ok = sc_rc_receive_response_tcp(InitState)
+           end).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 sc_rc_receive_response_tcp(InitState) ->
     %% Each connection are handled by handler processes.
@@ -8919,12 +8939,7 @@ sc_rc_tcp_client_await_continue(Parent, Slogan) ->
 
 sc_rc_tcp_client_connect(Sock, ServerSA) ->
     i("sc_rc_tcp_client_connect -> entry"),
-    case socket:connect(Sock, ServerSA) of
-        ok ->
-            ok;
-        {error, Reason} ->
-            exit({connect, Reason})
-    end.
+    sock_connect(Sock, ServerSA).
 
 sc_rc_tcp_client_close(Sock, Path) ->
     i("sc_rc_tcp_client_close -> entry"),
@@ -14388,17 +14403,17 @@ sock_bind(Sock, LSA) ->
             ?FAIL({bind, C, E, S})
     end.
 
-%% sock_connect(Sock, SockAddr) ->
-%%     try socket:connect(Sock, SockAddr) of
-%%         ok ->
-%%             ok;
-%%         {error, Reason} ->
-%%             ?FAIL({connect, Reason})
-%%     catch
-%%         C:E:S ->
-%%             ?FAIL({connect, C, E, S})
-%%     end.
-    
+sock_connect(Sock, SockAddr) ->
+    try socket:connect(Sock, SockAddr) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            ?FAIL({connect, Reason, {Sock,SockAddr}})
+    catch
+        C:E:S ->
+            erlang:raise(C, {E,{Sock,SockAddr}}, S)
+    end.
+
 sock_port(S) ->
     case socket:sockname(S) of
         {ok, #{port := Port}} -> Port;
@@ -14456,6 +14471,11 @@ mk_unique_path() ->
 which_local_socket_addr(local = Domain) ->
     #{family => Domain,
       path   => mk_unique_path()};
+
+which_local_socket_addr(vsock = Domain) ->
+    #{family => Domain,
+      cid => local,
+      port => any};
 
 %% This gets the local socket address (not 127.0...)
 %% We should really implement this using the (new) net module,

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -6355,9 +6355,9 @@ sc_lc_recv_response_tcpL(_Config) when is_list(_Config) ->
 %% locally closed while the process is calling the recv function.
 %% Socket is VSOCK (stream) socket.
 
-sc_lc_recv_response_tcpL(_Config) when is_list(_Config) ->
+sc_lc_recv_response_tcpV(_Config) when is_list(_Config) ->
     ?TT(?SECS(10)),
-    tc_try(sc_lc_recv_response_tcpL,
+    tc_try(sc_lc_recv_response_tcpV,
            fun() ->
 		   has_support_vsock()
 	   end,


### PR DESCRIPTION
From https://github.com/erlang/otp/pull/7719, i've rebased it, made some small changes, and started to add tests.

> # Context
> 
> VSock is a mechanism for socket communication between virtual machines and their host operating system. The host and each VM are assigned a 32-bit CID (Context IDentifier) and may connect or bind to a 32-bit port number.
> 
> The Linux kernel provides support for `AF_VSOCK` sockets in the [`linux/vm_sockets.h` header](https://github.com/torvalds/linux/blob/master/include/uapi/linux/vm_sockets.h) and is documented in the [`vsock(7)` manual page](https://man7.org/linux/man-pages/man7/vsock.7.html).
> 
> [AWS EC2 Nitro Enclaves rely on `AF_VSOCK` as the sole communication channel between the parent instance and its secure enclaves.](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-concepts.html#term-socket)
> # Implementation
> 
> My approach was to introduce a new `vsock` Domain in the `socket` module, which is supported by the `prim_socket` NIF. The `vsock` Domain exposes the `port` and `cid` fields of the `sockaddr_vm` struct. Otherwise, this PR generally follows the existing patterns established by the other domains.
> # Known limitations
> 
> `AF_VSOCK` is only supported on Linux at this time:
> 
>     * VMware (VMCI) has been supported since Linux 3.9
> 
>     * KVM (virtio) has been supported since Linux 4.8
> 
>     * Hyper-V has been supported since Linux 4.14
> 
>     * Local communication using `VMADDR_CID_LOCAL` has been supported since Linux 5.6
> 
> 
> XNU kernel provides low-level `AF_VSOCK` support in [`sys/vsock.h`](https://opensource.apple.com/source/xnu/xnu-7195.60.75/bsd/sys/vsock.h.auto.html), however macOS requires the use of a higher-level [Virtualization framework](https://developer.apple.com/documentation/virtualization) that manages [`VZVirtioSocketDevice` objects](https://developer.apple.com/documentation/virtualization/vzvirtiosocketdevice) to work with VSock connections. **This PR makes no attempt to interface with macOS's Virtualization framework.**