### PR TITLE
trailing comma

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -325,6 +325,7 @@ list -> '[' expr tail : {cons,?anno('$1'),'$2','$3'}.
 tail -> ']' : {nil,?anno('$1')}.
 tail -> '|' expr ']' : '$2'.
 tail -> ',' expr tail : {cons,first_anno('$2'),'$2','$3'}.
+tail -> ',' ']' : {nil,?anno('$2')}.
 
 
 binary -> '<<' '>>' : {bin,?anno('$1'),[]}.
@@ -394,6 +395,7 @@ map_tuple -> '{' map_fields '}' : '$2'.
 
 map_fields -> map_field : ['$1'].
 map_fields -> map_field ',' map_fields : ['$1' | '$3'].
+map_fields -> map_field ',' : ['$1'].
 
 map_field -> map_field_assoc : '$1'.
 map_field -> map_field_exact : '$1'.
@@ -429,6 +431,7 @@ record_tuple -> '{' record_fields '}' : '$2'.
 
 record_fields -> record_field : ['$1'].
 record_fields -> record_field ',' record_fields : ['$1' | '$3'].
+record_fields -> record_field ',' : ['$1'].
 
 record_field -> var '=' expr : {record_field,?anno('$1'),'$1','$3'}.
 record_field -> atom '=' expr : {record_field,?anno('$1'),'$1','$3'}.
@@ -545,6 +548,7 @@ pat_argument_list -> '(' pat_exprs ')' : {'$2',?anno('$1')}.
 
 exprs -> expr : ['$1'].
 exprs -> expr ',' exprs : ['$1' | '$3'].
+exprs -> expr ',' : ['$1'].
 
 clause_body_exprs -> ssa_check_when_clauses exprs : '$1' ++ '$2'.
 clause_body_exprs -> exprs : '$1'.

--- a/lib/stdlib/test/erl_eval_SUITE.erl
+++ b/lib/stdlib/test/erl_eval_SUITE.erl
@@ -63,7 +63,8 @@
          binary_and_map_aliases/1,
          eep58/1,
          strict_generators/1,
-         binary_skip/1]).
+         binary_skip/1,
+         trailing_comma/1]).
 
 %%
 %% Define to run outside of test server
@@ -106,7 +107,7 @@ all() ->
      funs, custom_stacktrace, try_catch, eval_expr_5, zero_width,
      eep37, eep43, otp_15035, otp_16439, otp_14708, otp_16545, otp_16865,
      eep49, binary_and_map_aliases, eep58, strict_generators, binary_skip,
-     zlc, zbc, zmc].
+     trailing_comma, zlc, zbc, zmc].
 
 groups() ->
     [].
@@ -2329,6 +2330,70 @@ binary_skip(Config) when is_list(Config) ->
     check(fun() -> [a || <<0:64/float>> <= <<0:64, 1:64, 0:64, 0:64>> ] end,
 	  "begin [a || <<0:64/float>> <= <<0:64, 1:64, 0:64, 0:64>> ] end.",
 	  [a,a,a]),
+    ok.
+
+%% Test trailing comma support in lists, maps, tuples, and records.
+trailing_comma(Config) when is_list(Config) ->
+    %% List with trailing comma
+    check(fun() -> [1, 2, 3,] end,
+          "[1, 2, 3,].",
+          [1, 2, 3]),
+    check(fun() -> [a,] end,
+          "[a,].",
+          [a]),
+    check(fun() -> [] end,
+          "[].",
+          []),
+    
+    %% Map with trailing comma
+    check(fun() -> #{a => 1, b => 2,} end,
+          "#{a => 1, b => 2,}.",
+          #{a => 1, b => 2}),
+    check(fun() -> #{x => y,} end,
+          "#{x => y,}.",
+          #{x => y}),
+    check(fun() -> #{} end,
+          "#{}.",
+          #{}),
+    
+    %% Tuple with trailing comma
+    check(fun() -> {1, 2, 3,} end,
+          "{1, 2, 3,}.",
+          {1, 2, 3}),
+    check(fun() -> {single,} end,
+          "{single,}.",
+          {single}),
+    check(fun() -> {} end,
+          "{}.",
+          {}),
+    
+    %% Nested structures with trailing comma
+    check(fun() -> [#{a => 1,}, {2, 3,},] end,
+          "[#{a => 1,}, {2, 3,},].",
+          [#{a => 1}, {2, 3}]),
+    check(fun() -> #{list => [1, 2,], tuple => {a, b,},} end,
+          "#{list => [1, 2,], tuple => {a, b,},}.",
+          #{list => [1, 2], tuple => {a, b}}),
+    
+    %% Function calls with trailing comma
+    check(fun() -> lists:append([1, 2,], [3, 4,]) end,
+          "lists:append([1, 2,], [3, 4,]).",
+          [1, 2, 3, 4]),
+    
+    %% Pattern matching with trailing comma
+    check(fun() -> 
+              [H,] = [42,],
+              H
+          end,
+          "begin [H,] = [42,], H end.",
+          42),
+    check(fun() ->
+              #{a := V,} = #{a => 100,},
+              V
+          end,
+          "begin #{a := V,} = #{a => 100,}, V end.",
+          100),
+    
     ok.
 
 %% Check the string in different contexts: as is; in fun; from compiled code.


### PR DESCRIPTION
We've seen a lot of code with such style: https://github.com/fogfish/esq/blob/0e3ae1e7474f122ac67120b2649311fe2c468710/src/esq_file.erl#L22 

With trailing comma support for list, map, tuple etc, instead, we can have a better way to write the code like this:
```erlang
-export([
   new/1,
   free/1,
   length/1,
   enq/2,
   deq/2,
   sync/1,
]).

%%
%% internal state
-record(file, {
   writer = undefined :: any(),
   reader = undefined :: any(),
   length = undefined :: integer(),
}).
```

I've confirmed that Elixir, Python and Ruby, they all have such trailing comma support.