### PR TITLE
Slave module deprecation: Replace slave to follower in code and comments

### DIFF
--- a/lib/inets/examples/httpd_load_test/hdlt_ctrl.erl
+++ b/lib/inets/examples/httpd_load_test/hdlt_ctrl.erl
@@ -52,7 +52,7 @@
 -define(NODE_START_TIMEOUT,         5000).
 -define(LOCAL_PROXY_START_TIMEOUT,  ?NODE_START_TIMEOUT * 4).
 -define(DEFAULT_DEBUGS, 
-	[{ctrl, info}, {slave, silence}, {proxy, silence}, {client, silence}]).
+	[{ctrl, info}, {follower, silence}, {proxy, silence}, {client, silence}]).
 -define(DEFAULT_WORK_SIM,           10000).
 -define(DEFAULT_DATA_SIZE_START,    500).
 -define(DEFAULT_DATA_SIZE_END,      1500).
@@ -331,11 +331,11 @@ create_server_content(Sftp, ServerRoot, SocketType, CertFile) ->
     {ok, ServerModBin} = file:read_file(LocalServerMod),
     ok = ssh_sftp:write_file(Sftp, RemoteServerMod, ServerModBin),
 
-    LocalSlaveMod = local_slave_module(), 
-    ?DEBUG("copy slave module ~s", [LocalSlaveMod]), 
-    RemoteSlaveMod = remote_slave_module(EBIN), 
-    {ok, SlaveModBin} = file:read_file(LocalSlaveMod),
-    ok = ssh_sftp:write_file(Sftp, RemoteSlaveMod, SlaveModBin),
+    LocalFollowerMod = local_follower_module(),
+    ?DEBUG("copy follower module ~s", [LocalFollowerMod]),
+    RemoteFollowerMod = remote_follower_module(EBIN),
+    {ok, FollowerModBin} = file:read_file(LocalFollowerMod),
+    ok = ssh_sftp:write_file(Sftp, RemoteFollowerMod, FollowerModBin),
 
     LocalLoggerMod = local_logger_module(), 
     ?DEBUG("copy logger module ~s", [LocalLoggerMod]), 
@@ -445,11 +445,11 @@ create_client_content(Sftp, WorkDir, SocketType, CertFile) ->
     {ok, ClientModBin} = file:read_file(LocalClientMod),
     ok = ssh_sftp:write_file(Sftp, RemoteClientMod, ClientModBin),
 
-    LocalSlaveMod = local_slave_module(), 
-    ?DEBUG("copy slave module ~s", [LocalSlaveMod]), 
-    RemoteSlaveMod = remote_slave_module(EBIN), 
-    {ok, SlaveModBin} = file:read_file(LocalSlaveMod),
-    ok = ssh_sftp:write_file(Sftp, RemoteSlaveMod, SlaveModBin),
+    LocalFollowerMod = local_follower_module(),
+    ?DEBUG("copy follower module ~s", [LocalFollowerMod]),
+    RemoteFollowerMod = remote_follower_module(EBIN),
+    {ok, FollowerModBin} = file:read_file(LocalFollowerMod),
+    ok = ssh_sftp:write_file(Sftp, RemoteFollowerMod, FollowerModBin),
 
     LocalLoggerMod = local_logger_module(), 
     ?DEBUG("copy logger module ~s", [LocalLoggerMod]), 
@@ -494,21 +494,21 @@ client_module() ->
     module(?CLIENT_MOD).
 
 
-remote_slave_module(Path) ->
-    Mod = slave_module(), 
+remote_follower_module(Path) ->
+    Mod = follower_module(),
     filename:join(Path, Mod).
 
-local_slave_module() ->
-    Mod = slave_module(), 
+local_follower_module() ->
+    Mod = follower_module(),
     case code:where_is_file(Mod) of
 	Path when is_list(Path) ->
 	    Path;
 	_ ->
-	    exit({slave_module_not_found, Mod})
+	    exit({follower_module_not_found, Mod})
     end.
 
-slave_module() ->
-    module(hdlt_slave).
+follower_module() ->
+    module(hdlt_follower_node).
 
 
 remote_logger_module(Path) ->
@@ -617,8 +617,8 @@ start_node(Host, NodeName, ErlPath, Paths, Args, Module, Debugs) ->
 			ProxyDebug),
 
     ?DEBUG("start_node -> local proxy started - now start node", []),
-    SlaveDebug = proplists:get_value(slave, Debugs, silence), 
-    Node = proxy_start_node(Proxy, SlaveDebug),
+    FollowerDebug = proplists:get_value(follower, Debugs, silence),
+    Node = proxy_start_node(Proxy, FollowerDebug),
 
     ?DEBUG("start_node -> sync global", []),
     global:sync(),
@@ -725,9 +725,8 @@ proxy_loop(#proxy{mode      = started,
     receive
 	{proxy_request, Ref, From, {start_node, Debug}} ->
 	    ?LOG("[starting] received start_node order", []),
-	    case hdlt_slave:start_link(Host, NodeName, 
-				       ErlPath, Paths, Args, 
-				       Debug) of
+	    case hdlt_follower_node:start_link(Host, NodeName,
+                ErlPath, Paths, Args, Debug) of
 		{ok, Node} ->
 		    ?DEBUG("[starting] node ~p started - now monitor", [Node]),
 		    erlang:monitor_node(Node, true),
@@ -1242,7 +1241,7 @@ verify_debugs([{Tag, Debug}|Debugs]) ->
     verify_debugs(Debugs).
 
 verify_debug(Tag, Debug) ->
-    case lists:member(Tag, [ctrl, proxy, slave, client]) of
+    case lists:member(Tag, [ctrl, proxy, follower, client]) of
 	true ->
 	    ok;
 	false ->

--- a/lib/inets/examples/httpd_load_test/hdlt_follower_node.erl
+++ b/lib/inets/examples/httpd_load_test/hdlt_follower_node.erl
@@ -19,13 +19,13 @@
 %%
 %% %CopyrightEnd%
 %%
--module(hdlt_slave).
+-module(hdlt_follower_node).
 
 
 -export([start_link/4, start_link/5, start_link/6, stop/1]).
 
 %% Internal exports 
--export([wait_for_slave/9, slave_start/1, wait_for_master_to_die/3]).
+-export([wait_for_follower_node/9, follower_node_start/1, wait_for_master_to_die/3]).
 
 -include("hdlt_logger.hrl").
 
@@ -37,15 +37,15 @@
 %% ***********************************************************************
 %% start_link/4,5 --
 %%
-%% The start/4,5 functions are used to start a slave Erlang node.
+%% The start/4,5 functions are used to start a follower Erlang node.
 %% The node on which the start/N functions are used is called the
 %% master in the description below.
 %%
-%% If hostname is the same for the master and the slave,
+%% If hostname is the same for the master and the follower,
 %% the Erlang node will simply be spawned.  The only requirement for
 %% this to work is that the 'erl' program can be found in PATH.
 %%
-%% If the master and slave are on different hosts, start/N uses
+%% If the master and follower are on different hosts, start/N uses
 %% the 'ssh' program to spawn an Erlang node on the other host.
 %% Alternative, if the master was started as
 %% 'erl -sname xxx -rsh my_rsh...', then 'my_rsh' will be used instead
@@ -59,9 +59,9 @@
 %% 2. The hosts must be configured to allow 'ssh' access without
 %%    prompts for password.
 %%
-%% The slave node will have its filer and user server redirected
-%% to the master.  When the master node dies, the slave node will
-%% terminate.  For the start_link functions, the slave node will
+%% The follower node will have its filer and user server redirected
+%% to the master.  When the master node dies, the follower node will
+%% terminate.  For the start_link functions, the follower node will
 %% terminate also if the process which called start_link terminates.
 %%
 %% Returns: {ok, Name@Host} |
@@ -93,37 +93,38 @@ stop(Node) ->
     ok.
 
 
-%% Starts a new slave node.
+%% Starts a new follower node.
 
 start_it(Host, Name, Node, ErlPath, Paths, Args, DebugLevel) ->
     Prog = filename:join([ErlPath, "erl"]), 
-    spawn(?MODULE, wait_for_slave, [self(), Host, Name, Node, Paths, Args, self(), Prog, DebugLevel]),
+    spawn(?MODULE, wait_for_follower_node,
+         [self(), Host, Name, Node, Paths, Args, self(), Prog, DebugLevel]),
     receive
 	{result, Result} -> Result
     end.
 
-%% Waits for the slave to start.
+%% Waits for the follower node to start.
 
-wait_for_slave(Parent, Host, Name, Node, Paths, Args, 
-	       LinkTo, Prog, DebugLevel) ->
-    ?SET_NAME("HDLT SLAVE STARTER"), 
+wait_for_follower_node(Parent, Host, Name, Node, Paths, Args,
+                       LinkTo, Prog, DebugLevel) ->
+    ?SET_NAME("HDLT FOLLOWER STARTER"),
     ?SET_LEVEL(DebugLevel),
     ?DEBUG("begin", []),
     Waiter = register_unique_name(0),
     case (catch mk_cmd(Host, Name, Paths, Args, Waiter, Prog)) of
 	{ok, Cmd} ->
   	    ?DEBUG("command generated: ~n~s", [Cmd]),
-	    case (catch ssh_slave_start(Host, Cmd)) of
+	    case (catch ssh_follower_start(Host, Cmd)) of
 		{ok, Conn, _Chan} ->
  		    ?DEBUG("ssh channel created", []),
 		    receive
-			{SlavePid, slave_started} ->
- 			    ?DEBUG("slave started: ~p", [SlavePid]),
+			{FollowerPid, follower_started} ->
+ 			    ?DEBUG("follower started: ~p", [FollowerPid]),
 			    unregister(Waiter),
-			    slave_started(Parent, LinkTo, SlavePid, Conn, 
-					  DebugLevel)
+			    follower_started(Parent, LinkTo, FollowerPid, Conn,
+					     DebugLevel)
 		    after 32000 ->
-			    ?INFO("slave node failed to report in on time", 
+			    ?INFO("follower node failed to report in on time",
 				  []),
 			    %% If it seems that the node was partially started,
 			    %% try to kill it.
@@ -149,8 +150,8 @@ wait_for_slave(Parent, Host, Name, Node, Paths, Args,
     end.
 
 
-ssh_slave_start(Host, ErlCmd) ->
-    ?DEBUG("ssh_slave_start -> try connect to ~p", [Host]),
+ssh_follower_start(Host, ErlCmd) ->
+    ?DEBUG("ssh_follower_start -> try connect to ~p", [Host]),
     Connection = 
 	case (catch ssh:connect(Host, ?SSH_PORT, 
 				[{silently_accept_hosts, true}])) of
@@ -195,41 +196,41 @@ clean_ssh_msg() ->
     end.
     
 
-slave_started(ReplyTo, Master, Slave, Conn, Level) 
-  when is_pid(Master) andalso is_pid(Slave) ->
+follower_started(ReplyTo, Master, Follower, Conn, Level)
+  when is_pid(Master) andalso is_pid(Follower) ->
     process_flag(trap_exit, true),
     SName = lists:flatten(
-	      io_lib:format("HDLT SLAVE CTRL[~p,~p]", 
-			    [self(), node(Slave)])), 
+	      io_lib:format("HDLT FOLLOWER CTRL[~p,~p]",
+			    [self(), node(Follower)])),
     ?SET_NAME(SName),
     ?SET_LEVEL(Level), 
     ?LOG("initiating", []),
-    MasterRef = erlang:monitor(process, Master),
-    SlaveRef  = erlang:monitor(process, Slave),
-    ReplyTo ! {result, {ok, node(Slave)}},
-    slave_running(Master, MasterRef, Slave, SlaveRef, Conn).
+    MasterRef   = erlang:monitor(process, Master),
+    FollowerRef = erlang:monitor(process, Follower),
+    ReplyTo ! {result, {ok, node(Follower)}},
+    follower_running(Master, MasterRef, Follower, FollowerRef, Conn).
 
 
-%% The slave node will be killed if the master process terminates, 
-%% The master process will not be killed if the slave node terminates.
+%% The follower node will be killed if the master process terminates,
+%% The master process will not be killed if the follower node terminates.
 
-slave_running(Master, MasterRef, Slave, SlaveRef, Conn) ->
+follower_running(Master, MasterRef, Follower, FollowerRef, Conn) ->
     ?DEBUG("await message", []),
     receive
 	{'DOWN', MasterRef, process, _Object, _Info} ->
 	    ?LOG("received DOWN from master", []),
-	    erlang:demonitor(SlaveRef, [flush]),
-	    Slave ! {nodedown, node()},
+	    erlang:demonitor(FollowerRef, [flush]),
+	    Follower ! {nodedown, node()},
 	    ssh:close(Conn);
 
-	{'DOWN', SlaveRef, process, Object, _Info} ->
-	    ?LOG("received DOWN from slave (~p)", [Object]),
+	{'DOWN', FollowerRef, process, Object, _Info} ->
+	    ?LOG("received DOWN from follower (~p)", [Object]),
 	    erlang:demonitor(MasterRef, [flush]),
 	    ssh:close(Conn);
 
 	Other ->
 	    ?DEBUG("received unknown: ~n~p", [Other]),
-	    slave_running(Master, MasterRef, Slave, SlaveRef, Conn)
+	    follower_running(Master, MasterRef, Follower, FollowerRef, Conn)
 
     end.
 
@@ -254,29 +255,29 @@ mk_cmd(Host, Name, Paths, Args, Waiter, Prog) ->
 			 " -detached -nopinput ", 
 			 Args, " ", 
 			 " -sname ", Name, "@", Host,
-			 " -s ", ?MODULE, " slave_start ", node(),
+			 " -s ", ?MODULE, " follower_node_start ", node(),
 			 " ", Waiter,
 			 " ", PaPaths]))}.
 
 
-%% This function will be invoked on the slave, using the -s option of erl.
+%% This function will be invoked on the follower, using the -s option of erl.
 %% It will wait for the master node to terminate.
 
-slave_start([Master, Waiter]) ->
+follower_node_start([Master, Waiter]) ->
     spawn(?MODULE, wait_for_master_to_die, [Master, Waiter, silence]);
-slave_start([Master, Waiter, Level]) ->
+follower_node_start([Master, Waiter, Level]) ->
     spawn(?MODULE, wait_for_master_to_die, [Master, Waiter, Level]).
 	
 
 wait_for_master_to_die(Master, Waiter, Level) ->
     process_flag(trap_exit, true),
     SName = lists:flatten(
-	      io_lib:format("HDLT-SLAVE MASTER MONITOR[~p,~p,~p]", 
+	      io_lib:format("HDLT-FOLLOWER MASTER MONITOR[~p,~p,~p]",
 			    [self(), node(), Master])), 
     ?SET_NAME(SName),
     ?SET_LEVEL(Level), 
     erlang:monitor_node(Master, true),
-    {Waiter, Master} ! {self(), slave_started},
+    {Waiter, Master} ! {self(), follower_started},
     wloop(Master).
 
 wloop(Master) ->

--- a/lib/inets/examples/httpd_load_test/modules.mk
+++ b/lib/inets/examples/httpd_load_test/modules.mk
@@ -39,7 +39,7 @@ MODULES = \
 	hdlt_logger \
 	hdlt_random_html \
 	hdlt_server \
-	hdlt_slave
+	hdlt_follower_node
 
 INTERNAL_HRL_FILES = \
         hdlt_logger.hrl

--- a/lib/inets/test/httpd_bench_SUITE.erl
+++ b/lib/inets/test/httpd_bench_SUITE.erl
@@ -227,7 +227,7 @@ setup(_Config, _LocalNode) ->
 		   RemHost
 	   end,
     Node = list_to_atom("inets_perf_server@" ++ Host),
-    SlaveArgs = case init:get_argument(pa) of
+    PeerArgs = case init:get_argument(pa) of
 	       {ok, PaPaths} ->
 		   lists:append([" -pa " ++ P || [P] <- PaPaths]);
 	       _ -> []
@@ -240,7 +240,14 @@ setup(_Config, _LocalNode) ->
     case net_adm:ping(Node) of
 	pong -> ok;
 	pang ->
-	    {ok, Node} = slave:start(Host, inets_perf_server, SlaveArgs, no_link, Prog)
+%%	    {ok, Node} = slave:start(Host, inets_perf_server, PeerArgs, no_link, Prog)
+	    {ok, Node} = peer:start(#{
+                host => Host,
+                name => inets_perf_server,
+                args => PeerArgs,
+                peer_down => continue, % old option: no_link
+                exec => Prog
+            })
     end,
     Path = code:get_path(),
     true = rpc:call(Node, code, set_path, [Path]),

--- a/lib/inets/test/inets_test_lib.erl
+++ b/lib/inets/test/inets_test_lib.erl
@@ -139,7 +139,7 @@ start_node(Name) ->
               end,
     A = Args ++ " -pa " ++ Pa,
     Opts = [{cleanup,false}, {args, A}],
-    case (catch test_server:start_node(Name, slave, Opts)) of
+    case (catch test_server:start_node(Name, peer, Opts)) of
         {ok, Node} ->
             Node;
         Else ->


### PR DESCRIPTION
## Summary of changes

`slave` is removed from comments and private APIs as a unwelcome word.
New word is used for this, `follower`

As `slave` module is also deprecated, usage of `slave:start` in the tests is updated to `peer:start`