### PR TITLE
debugger: Fix unbounded error in interpreted module

### DIFF
--- a/lib/debugger/src/dbg_ieval.erl
+++ b/lib/debugger/src/dbg_ieval.erl
@@ -681,7 +681,7 @@ expr({record_update,Line,Es},Bs,#ieval{level=Le}=Ieval0) ->
     Ieval = Ieval0#ieval{top=false, line=Line, level=Le+1},
     Seq = fun(E, {_, _, Bs1}) -> expr(E, Bs1, Ieval) end,
     {value,Value,Bs1} = lists:foldl(Seq, {value, true, Bs}, Es),
-    {value,Value,remove_temporary_bindings(Bs1)};
+    {value,Value,remove_temporary_bindings(Bs1, Bs)};
 
 %% A block of statements
 expr({block,Line,Es},Bs,Ieval) ->
@@ -1846,8 +1846,9 @@ add_binding(N,Val,[B1|Bs]) ->
 add_binding(N,Val,[]) ->
     [{N,Val}].
 
-remove_temporary_bindings(Bs0) ->
-    [{Var,Val} || {Var, Val} <- Bs0, hd(atom_to_list(Var)) =/= $%].
+remove_temporary_bindings(Bs0, Bs) ->
+    [{Var,Val} || {Var, Val} <- Bs0, hd(atom_to_list(Var)) =/= $% orelse
+                      lists:keymember(Var, 1, Bs)].
 
 %% get_stacktrace() -> Stacktrace
 %%  Return the latest stacktrace for the process.

--- a/lib/debugger/test/record_SUITE.erl
+++ b/lib/debugger/test/record_SUITE.erl
@@ -29,7 +29,7 @@
 	 init_per_testcase/2,end_per_testcase/2,
 	 init_per_suite/1,end_per_suite/1,
          errors/1,record_test/1,eval_once/1,
-         nested_in_guard/1]).
+         nested_in_guard/1, gh10057/1]).
 
 -export([debug/0]).
 
@@ -51,7 +51,7 @@ end_per_group(_GroupName, Config) ->
 
 
 cases() -> 
-    [errors, record_test, eval_once, nested_in_guard].
+    [errors, record_test, eval_once, nested_in_guard, gh10057].
 
 init_per_testcase(_Case, Config) ->
     test_lib:interpret(?MODULE),
@@ -319,6 +319,14 @@ do_nested_in_guard(F) ->
         true ->
             not_ok
     end.
+
+gh10057(_Config) ->
+    N = #foo{b = #bar{c = '$expecting_key'}},
+    do_gh10057(N, ss),
+    ok.
+
+do_gh10057(#foo{b = #bar{c = '$expecting_key'} = B} = N, Key) ->
+    N#foo{a = {map, Key},b = B#bar{c = Key}}.
 
 id(I) ->
     I.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/10057. When updating a record, the previous logic in `remove_temporary_bindings/2` could remove bindings that are still useful. Now only bindings that did not exist before the update are eligible for removal.