### PR TITLE
[mnesia] Slave module deprecation: Replace slave to peer in code and comments

### DIFF
--- a/lib/mnesia/examples/bench/README
+++ b/lib/mnesia/examples/bench/README
@@ -1,3 +1,23 @@
+> %CopyrightBegin%
+>
+> SPDX-License-Identifier: Apache-2.0
+>
+> Copyright Ericsson AB 2001-2025. All Rights Reserved.
+>
+> Licensed under the Apache License, Version 2.0 (the "License");
+> you may not use this file except in compliance with the License.
+> You may obtain a copy of the License at
+>
+>     http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software
+> distributed under the License is distributed on an "AS IS" BASIS,
+> WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+> See the License for the specific language governing permissions and
+> limitations under the License.
+>
+> %CopyrightEnd%
+
 Author  : Hakan Mattsson <hakan@cslab.ericsson.se>
 Created : 21 Jun 2001 by Hakan Mattsson <hakan@cslab.ericsson.se>
 
@@ -85,10 +105,10 @@ the invocation of
 
 is equivalent with:
 
-   SlaveNodes = bench:start_all(Args).
+   Peers = bench:start_all(Args).
    bench:populate(Args).
    bench:generate(Args).
-   bench:stop_slave_nodes(SlaveNodes).
+   bench:stop_peer_nodes(Peers).
 
 In case you cannot get the automatic start of remote Erlang nodes to
 work (implied by bench:start_all/1) , you may need to manually start
@@ -202,7 +222,7 @@ always_try_nearest_node
   (fragmented) tables were distributed over all nodes. In
   such a system the transactions should be evenly distributed
   over all nodes. When this option is set to true it is possible
-  to make fair measurements of master/slave configurations, when
+  to make fair measurements of master/peer configurations, when
   all transactions are performed on on one node. Default is false.
 
 cookie

--- a/lib/mnesia/test/README
+++ b/lib/mnesia/test/README
@@ -1,3 +1,23 @@
+> %CopyrightBegin%
+>
+> SPDX-License-Identifier: Apache-2.0
+>
+> Copyright Ericsson AB 2010-2025. All Rights Reserved.
+>
+> Licensed under the Apache License, Version 2.0 (the "License");
+> you may not use this file except in compliance with the License.
+> You may obtain a copy of the License at
+>
+>     http://www.apache.org/licenses/LICENSE-2.0
+>
+> Unless required by applicable law or agreed to in writing, software
+> distributed under the License is distributed on an "AS IS" BASIS,
+> WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+> See the License for the specific language governing permissions and
+> limitations under the License.
+>
+> %CopyrightEnd%
+
 This directory contains the test suite of Mnesia.
 Compile it with "erl -make".
 
@@ -66,7 +86,7 @@ in the debugger. This demands a little bit of preparations:
   - Start the necessary number of nodes (normally 3).
     This may either be done by running the mt script or
     by starting the main node and then invoke mt:start_nodes()
-    to start the extra nodes with slave.
+    to start the extra nodes with `peer`.
 
   - Ensure that the nodes are connected. The easiest way to do
     this is by invoking mt:ping().


### PR DESCRIPTION
# Mnesia
## Summary of changes

`slave` is removed from comments and private APIs as a unwelcome word.
New word is used for this, `follower`

As `slave` module is also deprecated, usage of `slave:start` in the tests is updated to `peer:start`