### PR TITLE
crypto: Fix segfault seen at init:restart with OpenSSL statically linked

### DIFF
--- a/lib/crypto/c_src/mac.c
+++ b/lib/crypto/c_src/mac.c
@@ -141,7 +141,7 @@ void fini_mac_types(void)
 #if defined(HAS_3_0_API)
     struct mac_type_t* p = mac_types;
 
-    for (p = mac_types; p->name.str; p++) {
+    for (p = mac_types; p->name.atom != atom_false; p++) {
         EVP_MAC_free(p->evp_mac);
         p->evp_mac = NULL;
     }
@@ -158,7 +158,7 @@ ERL_NIF_TERM mac_types_as_list(ErlNifEnv* env)
     hd = enif_make_list(env, 0);
     prev = atom_undefined;
 
-    for (p = mac_types; (p->name.atom & (p->name.atom != atom_false)); p++) {
+    for (p = mac_types; p->name.atom != atom_false; p++) {
         if (prev == p->name.atom)
             continue;
 


### PR DESCRIPTION
Fix #10061.

The static linking was not the direct cause of the crash. The crash was caused by function `fini_mac_types()` indexing array `mac_types[]` beyond bounds which just happened to have benign values when OpenSSL was dynamically linked for some reason.
