### PR TITLE
refactor: standardize EPMD_ prefixed message names

### DIFF
--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -90,7 +90,7 @@ sequenceDiagram
     client ->> EPMD: ALIVE_CLOSE_REQ
 
     Note over client: Get the Distribution Port of Another Node
-    client ->> EPMD: PORT_PLEASE2_REQ
+    client ->> EPMD: EPMD_PORT2_REQ
     EPMD -->> client: PORT2_RESP
 
     Note over client: Get All Registered Names from EPMD
@@ -212,7 +212,7 @@ sequenceDiagram
 ### Get the Distribution Port of Another Node
 
 When one node wants to connect to another node it starts with a
-`PORT_PLEASE2_REQ` request to the EPMD on the host where the node resides to get
+`EPMD_PORT2_REQ` request to the EPMD on the host where the node resides to get
 the distribution port that the node listens to:
 
 ```mermaid
@@ -223,7 +223,7 @@ sequenceDiagram
     participant client as Client (or Node)
     participant EPMD
     
-    client ->> EPMD: PORT_PLEASE2_REQ
+    client ->> EPMD: EPMD_PORT2_REQ
     EPMD -->> client: PORT2_RESP
 ```
 
@@ -232,7 +232,7 @@ sequenceDiagram
 | ----- | ---------- |
 | `122` | `NodeName` |
 
-_Table: PORT_PLEASE2_REQ (122)_
+_Table: EPMD_PORT2_REQ (122)_
 
 where N = `Length` \- 1.
 

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -94,7 +94,7 @@ sequenceDiagram
     EPMD -->> client: EPMD_PORT2_RESP
 
     Note over client: Get All Registered Names from EPMD
-    client ->> EPMD: NAMES_REQ
+    client ->> EPMD: EPMD_NAMES_REQ
     EPMD -->> client: NAMES_RESP
 
     Note over EPMD: Dump all Data from EPMD
@@ -268,7 +268,7 @@ sequenceDiagram
     participant client as Client (or Node)
     participant EPMD
     
-    client ->> EPMD: NAMES_REQ
+    client ->> EPMD: EPMD_NAMES_REQ
     EPMD -->> client: NAMES_RESP
 ```
 
@@ -276,9 +276,9 @@ sequenceDiagram
 | ----- |
 | `110` |
 
-_Table: NAMES_REQ (110)_
+_Table: EPMD_NAMES_REQ (110)_
 
-The response for a `NAMES_REQ` is as follows:
+The response for a `EPMD_NAMES_REQ` is as follows:
 
 | 4            |             |
 | ------------ | ----------- |

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -79,7 +79,7 @@ sequenceDiagram
     participant EPMD
 
     Note over EPMD: Register a Node in EPMD
-    client ->> EPMD: ALIVE2_REQ
+    client ->> EPMD: EPMD_ALIVE2_REQ
     alt
         EPMD -->> client: ALIVE2_X_RESP
     else
@@ -123,7 +123,7 @@ _Table: Request Format_
 ### Register a Node in EPMD
 
 When a distributed node is started it registers itself in the EPMD. The message
-`ALIVE2_REQ` described below is sent from the node to the EPMD. The response
+`EPMD_ALIVE2_REQ` described below is sent from the node to the EPMD. The response
 from the EPMD is `ALIVE2_X_RESP` (or `ALIVE2_RESP`):
 
 ```mermaid
@@ -134,7 +134,7 @@ sequenceDiagram
     participant client as Client (or Node)
     participant EPMD
 
-    client ->> EPMD: ALIVE2_REQ
+    client ->> EPMD: EPMD_ALIVE2_REQ
     alt
         EPMD -->> client: ALIVE2_X_RESP
     else
@@ -146,7 +146,7 @@ sequenceDiagram
 | ----- | -------- | ---------- | ---------- | ---------------- | --------------- | ------ | ---------- | ------ | ------- |
 | `120` | `PortNo` | `NodeType` | `Protocol` | `HighestVersion` | `LowestVersion` | `Nlen` | `NodeName` | `Elen` | `Extra` |
 
-_Table: ALIVE2_REQ (120)_
+_Table: EPMD_ALIVE2_REQ (120)_
 
 - **`PortNo`** - The port number on which the node accept connection requests.
 

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -83,7 +83,7 @@ sequenceDiagram
     alt
         EPMD -->> client: ALIVE2_X_RESP
     else
-        EPMD -->> client: ALIVE2_RESP
+        EPMD -->> client: EPMD_ALIVE2_RESP
     end
 
     Note over EPMD: Unregister a Node in EPMD
@@ -124,7 +124,7 @@ _Table: Request Format_
 
 When a distributed node is started it registers itself in the EPMD. The message
 `EPMD_ALIVE2_REQ` described below is sent from the node to the EPMD. The response
-from the EPMD is `ALIVE2_X_RESP` (or `ALIVE2_RESP`):
+from the EPMD is `ALIVE2_X_RESP` (or `EPMD_ALIVE2_RESP`):
 
 ```mermaid
 ---
@@ -138,7 +138,7 @@ sequenceDiagram
     alt
         EPMD -->> client: ALIVE2_X_RESP
     else
-        EPMD -->> client: ALIVE2_RESP
+        EPMD -->> client: EPMD_ALIVE2_RESP
     end
 ```
 
@@ -174,9 +174,9 @@ The connection created to the EPMD must be kept as long as the node is a
 distributed node. When the connection is closed, the node is automatically
 unregistered from the EPMD.
 
-The response message is either `ALIVE2_X_RESP` or `ALIVE2_RESP` depending on
+The response message is either `ALIVE2_X_RESP` or `EPMD_ALIVE2_RESP` depending on
 distribution version. If both the node and EPMD support distribution version 6
-then the response is `ALIVE2_X_RESP` otherwise it is the older `ALIVE2_RESP`:
+then the response is `ALIVE2_X_RESP` otherwise it is the older `EPMD_ALIVE2_RESP`:
 
 | 1     | 1        | 4          |
 | ----- | -------- | ---------- |
@@ -188,7 +188,7 @@ _Table: ALIVE2_X_RESP (118) with 32 bit creation_
 | ----- | -------- | ---------- |
 | `121` | `Result` | `Creation` |
 
-_Table: ALIVE2_RESP (121) with 16-bit creation_
+_Table: EPMD_ALIVE2_RESP (121) with 16-bit creation_
 
 Result = 0 -> ok, result > 0 -> error.
 

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -91,7 +91,7 @@ sequenceDiagram
 
     Note over client: Get the Distribution Port of Another Node
     client ->> EPMD: EPMD_PORT2_REQ
-    EPMD -->> client: PORT2_RESP
+    EPMD -->> client: EPMD_PORT2_RESP
 
     Note over client: Get All Registered Names from EPMD
     client ->> EPMD: NAMES_REQ
@@ -224,7 +224,7 @@ sequenceDiagram
     participant EPMD
     
     client ->> EPMD: EPMD_PORT2_REQ
-    EPMD -->> client: PORT2_RESP
+    EPMD -->> client: EPMD_PORT2_RESP
 ```
 
 
@@ -240,7 +240,7 @@ where N = `Length` \- 1.
 | ----- | -------- |
 | `119` | `Result` |
 
-_Table: PORT2_RESP (119) Response Indicating Error, Result > 0_
+_Table: EPMD_PORT2_RESP (119) Response Indicating Error, Result > 0_
 
 or
 
@@ -248,7 +248,7 @@ or
 | ----- | -------- | -------- | ---------- | ---------- | ---------------- | --------------- | ------ | ---------- | ------ | -------- |
 | `119` | `Result` | `PortNo` | `NodeType` | `Protocol` | `HighestVersion` | `LowestVersion` | `Nlen` | `NodeName` | `Elen` | >`Extra` |
 
-_Table: PORT2_RESP, Result = 0_
+_Table: EPMD_PORT2_RESP, Result = 0_
 
 If `Result` > 0, the packet only consists of `[119, Result]`.
 

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -102,7 +102,7 @@ sequenceDiagram
     EPMD -->> client: DUMP_RESP
 
     Note over EPMD: Kill EPMD
-    client ->> EPMD: KILL_REQ
+    client ->> EPMD: EPMD_KILL_REQ
     EPMD -->> client: KILL_RESP
 
     Note over EPMD: STOP_REQ (Not Used)
@@ -355,7 +355,7 @@ sequenceDiagram
     participant client as Client (or Node)
     participant EPMD
     
-    client ->> EPMD: KILL_REQ
+    client ->> EPMD: EPMD_KILL_REQ
     EPMD -->> client: KILL_RESP
 ```
 
@@ -363,9 +363,9 @@ sequenceDiagram
 | ----- |
 | `107` |
 
-_Table: KILL_REQ_
+_Table: EPMD_KILL_REQ_
 
-The response for a `KILL_REQ` is as follows:
+The response for a `EPMD_KILL_REQ` is as follows:
 
 | 2          |
 | ---------- |

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -98,7 +98,7 @@ sequenceDiagram
     EPMD -->> client: NAMES_RESP
 
     Note over EPMD: Dump all Data from EPMD
-    client ->> EPMD: DUMP_REQ
+    client ->> EPMD: EPMD_DUMP_REQ
     EPMD -->> client: DUMP_RESP
 
     Note over EPMD: Kill EPMD
@@ -307,7 +307,7 @@ sequenceDiagram
     participant client as Client (or Node)
     participant EPMD
     
-    client ->> EPMD: DUMP_REQ
+    client ->> EPMD: EPMD_DUMP_REQ
     EPMD -->> client: DUMP_RESP
 ```
 
@@ -316,9 +316,9 @@ sequenceDiagram
 | ----- |
 | `100` |
 
-_Table: DUMP_REQ_
+_Table: EPMD_DUMP_REQ_
 
-The response for a `DUMP_REQ` is as follows:
+The response for a `EPMD_DUMP_REQ` is as follows:
 
 | 4            |             |
 | ------------ | ----------- |

--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -81,7 +81,7 @@ sequenceDiagram
     Note over EPMD: Register a Node in EPMD
     client ->> EPMD: EPMD_ALIVE2_REQ
     alt
-        EPMD -->> client: ALIVE2_X_RESP
+        EPMD -->> client: EPMD_ALIVE2_X_RESP
     else
         EPMD -->> client: EPMD_ALIVE2_RESP
     end
@@ -124,7 +124,7 @@ _Table: Request Format_
 
 When a distributed node is started it registers itself in the EPMD. The message
 `EPMD_ALIVE2_REQ` described below is sent from the node to the EPMD. The response
-from the EPMD is `ALIVE2_X_RESP` (or `EPMD_ALIVE2_RESP`):
+from the EPMD is `EPMD_ALIVE2_X_RESP` (or `EPMD_ALIVE2_RESP`):
 
 ```mermaid
 ---
@@ -136,7 +136,7 @@ sequenceDiagram
 
     client ->> EPMD: EPMD_ALIVE2_REQ
     alt
-        EPMD -->> client: ALIVE2_X_RESP
+        EPMD -->> client: EPMD_ALIVE2_X_RESP
     else
         EPMD -->> client: EPMD_ALIVE2_RESP
     end
@@ -174,15 +174,15 @@ The connection created to the EPMD must be kept as long as the node is a
 distributed node. When the connection is closed, the node is automatically
 unregistered from the EPMD.
 
-The response message is either `ALIVE2_X_RESP` or `EPMD_ALIVE2_RESP` depending on
+The response message is either `EPMD_ALIVE2_X_RESP` or `EPMD_ALIVE2_RESP` depending on
 distribution version. If both the node and EPMD support distribution version 6
-then the response is `ALIVE2_X_RESP` otherwise it is the older `EPMD_ALIVE2_RESP`:
+then the response is `EPMD_ALIVE2_X_RESP` otherwise it is the older `EPMD_ALIVE2_RESP`:
 
 | 1     | 1        | 4          |
 | ----- | -------- | ---------- |
 | `118` | `Result` | `Creation` |
 
-_Table: ALIVE2_X_RESP (118) with 32 bit creation_
+_Table: EPMD_ALIVE2_X_RESP (118) with 32 bit creation_
 
 | 1     | 1        | 2          |
 | ----- | -------- | ---------- |

--- a/erts/doc/notes.md
+++ b/erts/doc/notes.md
@@ -18273,7 +18273,7 @@ This document describes the changes made to the ERTS application.
   Own Id: OTP-8345
 
 - EPMD now correctly handles the extra data field which can be given in the
-  ALIVE2_REQ request and retrieved in the PORT2_RESP response. (Thanks to Klas
+  EPMD_ALIVE2_REQ request and retrieved in the PORT2_RESP response. (Thanks to Klas
   Johansson.)
 
   Own Id: OTP-8361

--- a/erts/doc/notes.md
+++ b/erts/doc/notes.md
@@ -18273,7 +18273,7 @@ This document describes the changes made to the ERTS application.
   Own Id: OTP-8345
 
 - EPMD now correctly handles the extra data field which can be given in the
-  EPMD_ALIVE2_REQ request and retrieved in the PORT2_RESP response. (Thanks to Klas
+  EPMD_ALIVE2_REQ request and retrieved in the EPMD_PORT2_RESP response. (Thanks to Klas
   Johansson.)
 
   Own Id: OTP-8361

--- a/erts/epmd/src/epmd_int.h
+++ b/erts/epmd/src/epmd_int.h
@@ -266,7 +266,7 @@ static const struct in6_addr in6addr_loopback =
 /*
  * Largest request: EPMD_ALIVE2_REQ
  *  2 + 13 + 2*MAXSYMLEN
- * Largest response: PORT2_RESP
+ * Largest response: EPMD_PORT2_RESP
  *  2 + 14 + 2*MAXSYMLEN
  *
  * That is, 3*MAXSYMLEN should be large enough

--- a/erts/epmd/src/epmd_int.h
+++ b/erts/epmd/src/epmd_int.h
@@ -264,7 +264,7 @@ static const struct in6_addr in6addr_loopback =
 #define MAX_LISTEN_SOCKETS 16
 
 /*
- * Largest request: ALIVE2_REQ
+ * Largest request: EPMD_ALIVE2_REQ
  *  2 + 13 + 2*MAXSYMLEN
  * Largest response: PORT2_RESP
  *  2 + 14 + 2*MAXSYMLEN

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -891,20 +891,20 @@ static void do_request(EpmdVars *g, int fd, Connection *s, char *buf, int bsize)
 		offset += node->extralen;
 		if (!reply(g, fd, wbuf, offset))
 		  {
-		    dbg_tty_printf(g,1,"** failed to send PORT2_RESP (ok) for \"%s\"",name);
+		    dbg_tty_printf(g,1,"** failed to send EPMD_PORT2_RESP (ok) for \"%s\"",name);
 		    return;
 		  }
-		dbg_tty_printf(g,1,"** sent PORT2_RESP (ok) for \"%s\"",name);
+		dbg_tty_printf(g,1,"** sent EPMD_PORT2_RESP (ok) for \"%s\"",name);
 		return;
 	    }
 	}
 	wbuf[1] = 1; /* error */
 	if (!reply(g, fd, wbuf, 2))
 	  {
-	    dbg_tty_printf(g,1,"** failed to send PORT2_RESP (error) for \"%s\"",name);
+	    dbg_tty_printf(g,1,"** failed to send EPMD_PORT2_RESP (error) for \"%s\"",name);
 	    return;
 	  }
-	dbg_tty_printf(g,1,"** sent PORT2_RESP (error) for \"%s\"",name);
+	dbg_tty_printf(g,1,"** sent EPMD_PORT2_RESP (error) for \"%s\"",name);
 	return;
       }
       break;

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -832,12 +832,12 @@ static void do_request(EpmdVars *g, int fd, Connection *s, char *buf, int bsize)
 	if (!reply(g, fd, wbuf, replylen))
 	  {
             node_unreg(g, name);
-	    dbg_tty_printf(g,1,"** failed to send ALIVE2_RESP for \"%s\"",
+	    dbg_tty_printf(g,1,"** failed to send EPMD_ALIVE2_RESP for \"%s\"",
 			   name);
 	    return;
 	  }
 
-	dbg_tty_printf(g,1,"** sent ALIVE2_RESP for \"%s\"",name);
+	dbg_tty_printf(g,1,"** sent EPMD_ALIVE2_RESP for \"%s\"",name);
 	s->keep = EPMD_TRUE;		/* Don't close on inactivity */
       }
       break;

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -1017,23 +1017,23 @@ static void do_request(EpmdVars *g, int fd, Connection *s, char *buf, int bsize)
 
     case EPMD_KILL_REQ:
       if (!s->local_peer) {
-	   dbg_printf(g,0,"KILL_REQ from non local address");
+	   dbg_printf(g,0,"EPMD_KILL_REQ from non local address");
 	   return;
       }
-      dbg_printf(g,1,"** got KILL_REQ");
+      dbg_printf(g,1,"** got EPMD_KILL_REQ");
 
       if (!g->brutal_kill && (g->nodes.reg != NULL)) {
-	  dbg_printf(g,0,"Disallowed KILL_REQ, live nodes");
+	  dbg_printf(g,0,"Disallowed EPMD_KILL_REQ, live nodes");
 	  if (!reply(g, fd,"NO",2))
-	      dbg_printf(g,0,"failed to send reply to KILL_REQ");
+	      dbg_printf(g,0,"failed to send reply to EPMD_KILL_REQ");
 	  return;
       }
 
       if (!reply(g, fd,"OK",2))
-	dbg_printf(g,0,"failed to send reply to KILL_REQ");
+	dbg_printf(g,0,"failed to send reply to EPMD_KILL_REQ");
       dbg_tty_printf(g,1,"epmd killed");
       conn_close_fd(g,fd);	/* We never return to caller so close here */
-      dbg_printf(g,0,"got KILL_REQ - terminates normal");
+      dbg_printf(g,0,"got EPMD_KILL_REQ - terminates normal");
       epmd_cleanup_exit(g,0);			/* Normal exit */
 
     case EPMD_STOP_REQ:

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -950,9 +950,9 @@ static void do_request(EpmdVars *g, int fd, Connection *s, char *buf, int bsize)
       break;
 
     case EPMD_DUMP_REQ:
-      dbg_printf(g,1,"** got DUMP_REQ");
+      dbg_printf(g,1,"** got EPMD_DUMP_REQ");
       if (!s->local_peer) {
-	   dbg_printf(g,0,"DUMP_REQ from non local address");
+	   dbg_printf(g,0,"EPMD_DUMP_REQ from non local address");
 	   return;
       }
       {

--- a/erts/epmd/src/epmd_srv.c
+++ b/erts/epmd/src/epmd_srv.c
@@ -910,7 +910,7 @@ static void do_request(EpmdVars *g, int fd, Connection *s, char *buf, int bsize)
       break;
 
     case EPMD_NAMES_REQ:
-      dbg_printf(g,1,"** got NAMES_REQ");
+      dbg_printf(g,1,"** got EPMD_NAMES_REQ");
       {
 	Node *node;
 

--- a/erts/epmd/test/epmd_SUITE.erl
+++ b/erts/epmd/test/epmd_SUITE.erl
@@ -96,7 +96,7 @@
 % Message codes in epmd protocol
 -define(EPMD_ALIVE2_REQ,	$x).
 -define(EPMD_ALIVE2_RESP,	$y).
--define(EPMD_PORT_PLEASE2_REQ,	$z).
+-define(EPMD_PORT2_REQ,	$z).
 -define(EPMD_PORT2_RESP,	$w).
 -define(EPMD_NAMES_REQ,	$n).
 -define(EPMD_DUMP_REQ,	$d).
@@ -249,7 +249,7 @@ register_node_v2(Addr, Port, NodeType, Prot, HVsn, LVsn, Name, Extra) ->
 % Internal function to fetch information about a node
 
 port_please_v2(Name) ->
-    case send_req([?EPMD_PORT_PLEASE2_REQ,
+    case send_req([?EPMD_PORT2_REQ,
                    binary_to_list(unicode:characters_to_binary(Name))]) of
         {ok,Sock} ->
             case recv_until_sock_closes(Sock) of
@@ -394,11 +394,11 @@ parse_name([], _Name) -> error.
 
 %% Register a name on a port and ask about port nr
 get_port_nr(Config) when is_list(Config) ->
-    port_request([?EPMD_PORT_PLEASE2_REQ,"foo"]).
+    port_request([?EPMD_PORT2_REQ,"foo"]).
 
 %% Register with slow write and ask about port nr
 slow_get_port_nr(Config) when is_list(Config) ->
-    port_request([?EPMD_PORT_PLEASE2_REQ,d,$f,d,$o,d,$o]).
+    port_request([?EPMD_PORT2_REQ,d,$f,d,$o,d,$o]).
 
 
 % Internal function used above

--- a/lib/erl_interface/src/epmd/epmd_publish.c
+++ b/lib/erl_interface/src/epmd/epmd_publish.c
@@ -127,7 +127,7 @@ static int ei_epmd_r4_publish (int port, const char *alive, unsigned ms)
     return -1;
   }
 
-  EI_TRACE_CONN0("ei_epmd_r4_publish","<- ALIVE2_RESP");
+  EI_TRACE_CONN0("ei_epmd_r4_publish","<- EPMD_ALIVE2_RESP");
 
   if (((res=get8(s)) != 0)) {           /* 0 == success */
       EI_TRACE_ERR1("ei_epmd_r4_publish"," result=%d (fail)",res);

--- a/lib/erl_interface/src/epmd/epmd_publish.c
+++ b/lib/erl_interface/src/epmd/epmd_publish.c
@@ -99,7 +99,7 @@ static int ei_epmd_r4_publish (int port, const char *alive, unsigned ms)
   }
 
   EI_TRACE_CONN6("ei_epmd_r4_publish",
-		 "-> ALIVE2_REQ alive=%s port=%d ntype=%d "
+		 "-> EPMD_ALIVE2_REQ alive=%s port=%d ntype=%d "
 		 "proto=%d dist-high=%d dist-low=%d",
 		 alive,port,'H',EI_MYPROTO,EI_DIST_HIGH,EI_DIST_LOW);
 

--- a/lib/kernel/src/erl_epmd.erl
+++ b/lib/kernel/src/erl_epmd.erl
@@ -525,7 +525,7 @@ get_port(Node, EpmdAddress, Timeout) ->
 	{ok, Socket} ->
 	    Name = to_string(Node),
 	    Len = 1+length(Name),
-	    Msg = [?int16(Len),?EPMD_PORT_PLEASE2_REQ,Name],
+	    Msg = [?int16(Len),?EPMD_PORT2_REQ,Name],
 	    case gen_tcp:send(Socket, Msg) of
 		ok ->
 		    wait_for_port_reply(Socket, []);

--- a/lib/kernel/src/erl_epmd.hrl
+++ b/lib/kernel/src/erl_epmd.hrl
@@ -21,7 +21,7 @@
 %%
 
 -define(EPMD_ALIVE2_REQ, $x).
--define(EPMD_PORT_PLEASE2_REQ, $z).
+-define(EPMD_PORT2_REQ, $z).
 -define(EPMD_ALIVE2_RESP, $y).
 -define(EPMD_PORT2_RESP, $w).
 -define(EPMD_NAMES, $n).


### PR DESCRIPTION
Fixes #10071 