### PR TITLE
rename renovate actor name in gh action

### DIFF
--- a/.github/workflows/renovate-vendored-deps.yaml
+++ b/.github/workflows/renovate-vendored-deps.yaml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   update-vendored-deps:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.title, 'Update dependency') && github.actor == 'renovate[bot]'
+    if: contains(github.event.pull_request.title, 'Update dependency') && github.actor == 'renovate-bot'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
Renovate uses as actor `renovate[bot]`, but forking renovate uses as actor `renovate-bot`. 

OTP uses forking renovate to not give write access to renovate, and forking renovate works by forking repositories and submitting PRs to them, using only `read` privileges.

it seems like a mistake that we only update dependencies based on name `renovate[bot]`, it should be based on PRs submitted under the actor name `renovate-bot`.