### PR TITLE
Add repository field in renovate-vendored-deps workflow for actions/checkout

### DIFF
--- a/.github/workflows/renovate-vendored-deps.yaml
+++ b/.github/workflows/renovate-vendored-deps.yaml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workflow `renovate-vendored-deps.yaml` couldn't find `github.event.pull_request.head.ref` when trying to checkout to the PR. Changed to `github.head_ref`