### PR TITLE
crypto: Remove unsafe OpenSSL cleanup

### DIFF
--- a/lib/crypto/c_src/crypto.c
+++ b/lib/crypto/c_src/crypto.c
@@ -394,17 +394,16 @@ static void unload(ErlNifEnv* env, void* priv_data)
         destroy_curve_mutex();
         destroy_engine_mutex(env);
 
-#ifdef HAS_3_0_API
-        fini_mac_types();
-# ifdef FIPS_SUPPORT
-        if (fips_provider) {
-            OSSL_PROVIDER_unload(fips_provider);
-        }
-# endif
-        while (prov_cnt > 0) {
-            OSSL_PROVIDER_unload(prov[--prov_cnt]);
-        }
-#endif
+        /*
+         * We do not do any OpenSSL cleanup here as we are not sure the lib
+         * will actually be unloaded. For example
+         * + With  musl libc, dlclose() is a no-op.
+         * + On MacOS with statically linked OpenSSL crypto.so has been seen to
+         *   be locked in place after OSSL_provider_load() has been called.
+         *
+         * So, we rely on OpenSSL doing automatic cleanup with its own "atexit"
+         * handler if the lib is actually unloaded.
+         */
     }
 }
 

--- a/lib/crypto/c_src/mac.c
+++ b/lib/crypto/c_src/mac.c
@@ -136,20 +136,6 @@ void init_mac_types(ErlNifEnv* env)
     p->name.atom = atom_false;  /* end marker */
 }
 
-void fini_mac_types(void)
-{
-#if defined(HAS_3_0_API)
-    struct mac_type_t* p = mac_types;
-
-    for (p = mac_types; p->name.atom != atom_false; p++) {
-        EVP_MAC_free(p->evp_mac);
-        p->evp_mac = NULL;
-    }
-#endif
-}
-
-
-
 ERL_NIF_TERM mac_types_as_list(ErlNifEnv* env)
 {
     struct mac_type_t* p;

--- a/lib/crypto/c_src/mac.h
+++ b/lib/crypto/c_src/mac.h
@@ -28,7 +28,6 @@
 int init_mac_ctx(ErlNifEnv *env, ErlNifBinary* rt_buf);
 
 void init_mac_types(ErlNifEnv* env);
-void fini_mac_types(void);
 
 ERL_NIF_TERM mac_types_as_list(ErlNifEnv* env);
 


### PR DESCRIPTION
Fix #10079

Seen symptom:
`crypto:strong_rand_bytes()` failing with `low_entropy` after `init:restart` on MacOS with statically linked OpenSSL.


Caused by the cleanup done in `unload()` followed by dlclose() not actually unloading the lib (because reasons). When loaded again after `init:restart`, crypto.so had intact static data in some inconsistent state.