### PR TITLE
adds nsis to windows-2025

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -279,7 +279,7 @@ jobs:
     env:
       WXWIDGETS_VERSION: 3.2.6
     name: Build Erlang/OTP (Windows)
-    runs-on: windows-2022
+    runs-on: windows-2025
     needs: pack
     if: needs.pack.outputs.build-c-code == 'true'
     steps:
@@ -289,6 +289,11 @@ jobs:
 
       - name: Install WSL dependencies
         run: apt update && apt install -y make autoconf unzip
+
+      - name: Install NSIS
+        shell: cmd
+        run: |
+          choco install nsis --version 3.11.0
 
       - name: Install openssl
         shell: cmd
@@ -349,6 +354,7 @@ jobs:
           cp -R wxWidgets /mnt/c/opt/local64/pgm/wxWidgets-${{ env.WXWIDGETS_VERSION }}
           tar -xzf ./otp_src.tar.gz
           cd otp
+          export PATH="/mnt/c/Program Files (x86)/NSIS/bin":$PATH
           export ERL_TOP=`pwd`
           export MAKEFLAGS=-j$(($(nproc) + 2))
           export ERLC_USE_SERVER=true

--- a/erts/etc/win32/nsis/Makefile
+++ b/erts/etc/win32/nsis/Makefile
@@ -82,7 +82,9 @@ release_spec:
 	@NSIS_VER=`makensis.exe -version`; \
 	case $$NSIS_VER in \
 	v2.* | v3.0 | v3.01) \
-	  echo "Unsupported NSIS version: $$NSIS_VER";;\
+	  echo "Unsupported NSIS version: $$NSIS_VER";\
+		exit -1;\
+	  ;;\
 	v3.*) \
 	  echo '!define OTP_RELEASE "$(SYSTEM_VSN)"' > $(VERSION_HEADER);\
 	  echo '!define OTP_VERSION "$(OTP_VERSION)"' >> $(VERSION_HEADER);\
@@ -113,7 +115,9 @@ release_spec:
 	  echo "Running $(MAKENSIS) $(MAKENSISFLAGS) erlang20.nsi";\
 	  $(MAKENSIS) $(MAKENSISFLAGS) erlang20.nsi;;\
 	*) \
-	  echo "Unsupported NSIS version: $$NSIS_VER";;\
+	  echo "Unsupported NSIS version: $$NSIS_VER";\
+	  exit -1;\
+	  ;;\
 	esac	
 
 release_docs release_docs_spec docs:


### PR DESCRIPTION
`windows-2022` comes with `makensis` but `windows-2025` removed it (https://github.com/actions/runner-images/issues/12677)

The changes of this PR may need to be incorporated into #9957 #9959 #9961 
The creation of this PR is to test that these changes do not break anything on Windows.