### PR TITLE
Restore broken optimization of unicode conversion function

### DIFF
--- a/erts/emulator/beam/erl_unicode.c
+++ b/erts/emulator/beam/erl_unicode.c
@@ -885,15 +885,25 @@ static BIF_RETTYPE characters_to_utf8_trap(BIF_ALIST_4)
 
 BIF_RETTYPE unicode_bin_is_7bit_1(BIF_ALIST_1)
 {
-    Sint need;
-    if(!is_bitstring(BIF_ARG_1)) {
-	BIF_RET(am_false);
+    const byte *temp_alloc = NULL, *bytes;
+    Uint size;
+    Eterm ret;
+
+    bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
+    if (bytes == NULL) {
+        BIF_RET(am_false);
     }
-    need = latin1_binary_need(BIF_ARG_1);
-    if(need >= 0 && aligned_binary_size(BIF_ARG_1) == need) {
-	BIF_RET(am_true);
+
+    ret = am_true;
+    for (Uint i = 0; i < size; i++) {
+        if (bytes[i] & ((byte) 0x80)) {
+            ret = am_false;
+            break;
+        }
     }
-    BIF_RET(am_false);
+
+    erts_free_aligned_binary_bytes(temp_alloc);
+    BIF_RET(ret);
 }
 
 static int is_valid_utf8(Eterm orig_bin)

--- a/lib/stdlib/test/unicode_SUITE.erl
+++ b/lib/stdlib/test/unicode_SUITE.erl
@@ -36,6 +36,7 @@
 	 ex_binaries_errors_utf32_big/1,
          normalize/1,
          huge_illegal_code_points/1,
+         bin_is_7bit/1,
          error_info/1
         ]).
 
@@ -51,6 +52,7 @@ all() ->
      normalize,
      {group,binaries_errors},
      huge_illegal_code_points,
+     bin_is_7bit,
      error_info].
 
 groups() -> 
@@ -1407,6 +1409,20 @@ make_unaligned(Bin0) when is_binary(Bin0) ->
     Sz = byte_size(Bin0),
     <<0:3,Bin:Sz/binary,31:5>> = id(Bin1),
     Bin.
+
+bin_is_7bit(_Config) ->
+    %% This BIF is undocumented, but the unicode module uses it to
+    %% avoid unnecessary conversion work.
+    true = do_bin_is_7bit(~""),
+    true = do_bin_is_7bit(~"abc"),
+    false = do_bin_is_7bit(~"björn"),
+    false = unicode:bin_is_7bit(<<0:7>>),
+    ok.
+
+do_bin_is_7bit(Bin) ->
+    Res = unicode:bin_is_7bit(Bin),
+    Res = unicode:bin_is_7bit(make_unaligned(Bin)),
+    Res.
 
 error_info(_Config) ->
     L = [{characters_to_binary, [abc]},


### PR DESCRIPTION
When used to convert from `latin1` to `utf8` or vice versa, the `unicode:characters_to_binary/3` function would return the original binary unchanged if it only contained 7-bit ASCII characters. For example:

    unicode:characters_to_binary("abc", latin1, utf8)

To determine whether the input was a binary with only 7-bit characters, the undocument BIF `unicode:bin_is_7bit/1` is used.

In Erlang/OTP 27, this optimization broke because `bin_is_7bit/1` accidentally started to always return `false`.

Resolves #10072