### PR TITLE
add missing license header

### DIFF
--- a/FILE-HEADERS/Apache-2.0-AND-SGI-B-2.0.txt
+++ b/FILE-HEADERS/Apache-2.0-AND-SGI-B-2.0.txt
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Fixes missing license header that should have been in #10094 