### PR TITLE
Optional MADV_DONTNEED

### DIFF
--- a/erts/doc/references/erts_alloc.md
+++ b/erts/doc/references/erts_alloc.md
@@ -473,7 +473,7 @@ identifier is effected.
   Besides passing carrier pool name as value to the parameter, you can also pass
   `:`. By passing `:` instead of carrier pool name, the allocator will use the
   carrier pool associated with itself. By passing the command line argument
-  "`+Mucg :`", all allocators that have an associated carrier pool will use the
+  "`+Mucp :`", all allocators that have an associated carrier pool will use the
   carrier pool associated with themselves.
 
   The association between carrier pool and allocator is very loose. The

--- a/erts/doc/references/erts_alloc.md
+++ b/erts/doc/references/erts_alloc.md
@@ -413,6 +413,9 @@ identifier is effected.
   used. The value chosen depends on the allocator type and can be changed
   between ERTS versions.
 
+  On Unix flag [`+Mumadtn`](erts_alloc.md#Mumadtn) may also be set to pass
+  `MADV_DONTNEED` instead of `MADV_FREE` as argument to `madvise()`.
+
   See also [`acul`](erts_alloc.md#M_acul).
 
 - **`+M<S>as bf|aobf|aoff|aoffcbf|aoffcaobf|ageffcaoff|ageffcbf|ageffcaobf|gf|af`{:
@@ -580,6 +583,11 @@ All allocators based on `alloc_util` are effected.
 - **`+Musac <bool>`{: #Musac }** - Allow `sys_alloc` carriers. Defaults to
   `true`. If set to `false`, `sys_alloc` carriers are never created by
   allocators using the `alloc_util` framework.
+
+- **`+Mumadtn <bool>`{: #Mumadtn }** - Control how to mark memory as re-usable
+  on Unix when [`+M<S>acful`](erts_alloc.md#M_acful) is set. Default is `false`
+  which means `MADV_FREE` is passed to `madvise()`. If set to `true`,
+  `MADV_DONTNEED` is passed instead.
 
 ### Special Flag for literal_alloc
 

--- a/erts/emulator/beam/erl_alloc.c
+++ b/erts/emulator/beam/erl_alloc.c
@@ -1825,6 +1825,10 @@ handle_args(int *argc, char **argv, erts_alc_hndl_args_init_t *init)
 			init->alloc_util.sac
 			    = get_bool_value(argv[i]+6, argv, &i);
 		    }
+                    else if (has_prefix("madtn", argv[i]+3)) {
+                        init->alloc_util.madtn
+                            = get_bool_value(argv[i]+8, argv, &i);
+                    }
 		    else {
 			int a;
 			int start = i;

--- a/erts/emulator/beam/erl_alloc_util.c
+++ b/erts/emulator/beam/erl_alloc_util.c
@@ -7028,6 +7028,10 @@ erts_alcu_init(AlcUInit_t *init)
 #endif
     allow_sys_alloc_carriers = init->sac;
 
+#if defined(HAVE_MADVISE) && defined(MADV_FREE)
+    erts_madvise_discard_advice = (init->madtn ? MADV_DONTNEED : MADV_FREE);
+#endif
+
 #ifdef DEBUG
     carrier_alignment = sizeof(Unit_t);
 #endif

--- a/erts/emulator/beam/erl_alloc_util.h
+++ b/erts/emulator/beam/erl_alloc_util.h
@@ -42,6 +42,7 @@ typedef struct {
     UWord ycs;
     UWord mmc;
     int   sac;
+    int   madtn;
 } AlcUInit_t;
 
 typedef struct {
@@ -102,7 +103,8 @@ typedef struct {
 #define ERTS_DEFAULT_ALCU_INIT {                                           \
     .ycs = 1024*1024,		/* (bytes):    sys_alloc carrier size    */\
     .mmc = ~((UWord) 0),	/* (amount):   max mseg carriers         */\
-    .sac = 1			/* (bool):     sys_alloc carriers        */\
+    .sac = 1,			/* (bool):     sys_alloc carriers        */\
+    .madtn = 0                  /* (bool) => erts_madvise_discard_advice */\
 }
 
 #define ERTS_DEFAULT_ALLCTR_INIT {                                         \
@@ -143,7 +145,8 @@ typedef struct {
 #define ERTS_DEFAULT_ALCU_INIT {                                           \
     .ycs = 128*1024,    /* (bytes):         sys_alloc carrier size       */\
     .mmc = 1024,        /* (amount):        max mseg carriers            */\
-    .sac = 1		/* (bool):          sys_alloc carriers           */\
+    .sac = 1,		/* (bool):          sys_alloc carriers           */\
+    .madtn = 0          /* (bool) =>        erts_madvise_discard_advice  */\
 }
 
 #define ERTS_DEFAULT_ALLCTR_INIT {                                         \

--- a/erts/emulator/beam/erl_alloc_util.h
+++ b/erts/emulator/beam/erl_alloc_util.h
@@ -100,9 +100,9 @@ typedef struct {
 #ifndef SMALL_MEMORY
 
 #define ERTS_DEFAULT_ALCU_INIT {                                           \
-    1024*1024,		/* (bytes)  ycs:    sys_alloc carrier size       */\
-    ~((UWord) 0),	/* (amount) mmc:    max mseg carriers            */\
-    1			/* (bool)   sac:    sys_alloc carriers           */\
+    .ycs = 1024*1024,		/* (bytes):    sys_alloc carrier size    */\
+    .mmc = ~((UWord) 0),	/* (amount):   max mseg carriers         */\
+    .sac = 1			/* (bool):     sys_alloc carriers        */\
 }
 
 #define ERTS_DEFAULT_ALLCTR_INIT {                                         \
@@ -141,9 +141,9 @@ typedef struct {
 #else /* if SMALL_MEMORY */
 
 #define ERTS_DEFAULT_ALCU_INIT {                                           \
-    128*1024,		/* (bytes)  ycs:    sys_alloc carrier size       */\
-    1024,      		/* (amount) mmc:    max mseg carriers            */\
-    1			/* (bool)   sac:    sys_alloc carriers           */\
+    .ycs = 128*1024,    /* (bytes):         sys_alloc carrier size       */\
+    .mmc = 1024,        /* (amount):        max mseg carriers            */\
+    .sac = 1		/* (bool):          sys_alloc carriers           */\
 }
 
 #define ERTS_DEFAULT_ALLCTR_INIT {                                         \

--- a/erts/emulator/sys/common/erl_mmap.c
+++ b/erts/emulator/sys/common/erl_mmap.c
@@ -34,6 +34,13 @@
 #include <sys/mman.h>
 #endif
 
+#if defined(HAVE_MADVISE) && defined(MADV_FREE)
+/* Note that we don't default to MADV_DONTNEED since it promises that
+ * the given region will be zeroed on access, which turned out to be
+ * too much of a performance hit. */
+int erts_madvise_discard_advice = MADV_FREE;
+#endif
+
 int erts_mem_guard(void *p, UWord size, int readable, int writable) {
 
 #if defined(WIN32)

--- a/erts/etc/common/erlexec.c
+++ b/erts/etc/common/erlexec.c
@@ -100,6 +100,7 @@ static char *plusM_au_alloc_switches[] = {
 /* +M other arguments */
 static char *plusM_other_switches[] = {
     "ea",
+    "umadtn",
     "ummc",
     "uycs",
     "usac",


### PR DESCRIPTION
Introduce erl command line flag `+Mumadtn <bool>` causing `MADV_DONTNEED` to be passed to `madvise()` instead of `MADV_FREE`. Affects all alloc_util allocators where `+M<S>acful` has been enabled to mark unused memory pages as re-usable by the OS.
