### PR TITLE
syntax_tools: Backport fix for annotating maybe to OTP-27

### DIFF
--- a/lib/syntax_tools/src/erl_syntax_lib.erl
+++ b/lib/syntax_tools/src/erl_syntax_lib.erl
@@ -561,14 +561,19 @@ vann_match_expr(Tree, Env) ->
     {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}.
 
 vann_maybe_expr(Tree, Env) ->
+    Bound = [],
     Body = erl_syntax:maybe_expr_body(Tree),
     {B1, {_, Free1}} = vann_body(Body, Env),
-    Else = erl_syntax:maybe_expr_else(Tree),
-    {Else1, _, Free2} = vann_else_expr(Else, Env),
-    Free = ordsets:union(Free1, Free2),
-    Tree1 = rewrite(Tree, erl_syntax:maybe_expr(B1, Else1)),
-    Bound = [],
-    {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}.
+    case erl_syntax:maybe_expr_else(Tree) of
+        none ->
+            Tree1 = rewrite(Tree, erl_syntax:maybe_expr(B1)),
+            {ann_bindings(Tree1, Env, Bound, Free1), Bound, Free1};
+        Else ->
+            {Else1, _, Free2} = vann_else_expr(Else, Env),
+            Free = ordsets:union(Free1, Free2),
+            Tree1 = rewrite(Tree, erl_syntax:maybe_expr(B1, Else1)),
+            {ann_bindings(Tree1, Env, Bound, Free), Bound, Free}
+    end.
 
 vann_maybe_match_expr(Tree, Env) ->
     E = erl_syntax:maybe_match_expr_body(Tree),

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -455,7 +455,17 @@ test_maybe_expr_ann(Config) when is_list(Config) ->
     [Env4, Bound4, Free4] = erl_syntax:get_ann(ElseAnn),
     {'env',[]} = Env4,
     {'bound',[]} = Bound4,
-    {'free',[]} = Free4.
+    {'free',[]} = Free4,
+
+    %% Test that it also works when there is no else clause
+    MaybeNoElse = erl_syntax:maybe_expr([MaybeMatch1, MaybeMatch2, Match1]),
+    MaybeNoElseAnn = erl_syntax_lib:annotate_bindings(MaybeNoElse, []),
+    [Env, Bound, Free] = erl_syntax:get_ann(MaybeNoElseAnn),
+    [MaybeMatchAnn1, MaybeMatchAnn2, MatchAnn1] = erl_syntax:maybe_expr_body(MaybeNoElseAnn),
+    NoElseAnn = erl_syntax:maybe_expr_else(MaybeNoElseAnn),
+    [] = erl_syntax:get_ann(NoElseAnn),
+
+    ok.
 
 test_files(Config) ->
     DataDir = ?config(data_dir, Config),


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/10103. This fix is already in 28 as https://github.com/erlang/otp/pull/9782.