### PR TITLE
Fix bug in examples, did not pass atom into outter call

### DIFF
--- a/system/doc/getting_started/seq_prog.md
+++ b/system/doc/getting_started/seq_prog.md
@@ -357,7 +357,7 @@ Compile and test:
 {ok,tut3}
 15> tut3:convert_length({inch, 5}).
 {centimeter,12.7}
-16> tut3:convert_length(tut3:convert_length({inch, 5})).
+16> tut3:convert_length({centimeter, tut3:convert_length({inch, 5})}).
 {inch,5.0}
 ```
 


### PR DESCRIPTION
I got started reading:
https://www.erlang.org/doc/system/seq_prog.html

This line:
```erl
tut3:convert_length(tut3:convert_length({inch, 5})).
```
Should be:
```erl
tut3:convert_length({centimeter, tut3:convert_length({inch, 5})}).
```
I.e. the outter call is missing an atom as the first clause:

Heres `convert_length` for context:
```erl
-module(tut3).
-export([convert_length/1]).

convert_length({centimeter, X}) ->
    {inch, X / 2.54};
convert_length({inch, Y}) ->
    {centimeter, Y * 2.54}.
```