### PR TITLE
Refactor kernel_load_completed clause for conciseness

### DIFF
--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -1327,12 +1327,8 @@ eval_script([{path,Path}|T], #es{path=false,pa=Pa,pz=Pz,
 eval_script([{path,_}|T], #es{}=Es) ->
     %% Ignore, use the command line -path flag.
     eval_script(T, Es);
-eval_script([{kernel_load_completed}|T], #es{load_mode=Mode}=Es0) ->
-    Es = case Mode of
-	     embedded -> Es0;
-	     _ -> Es0#es{prim_load=false}
-	 end,
-    eval_script(T, Es);
+eval_script([{kernel_load_completed}|T], #es{load_mode=Mode}=Es) ->
+    eval_script(T, Es#es{prim_load=(Mode == embedded)});
 eval_script([{primLoad,Mods}|T], #es{init=Init,prim_load=PrimLoad,debug=Deb}=Es)
   when is_list(Mods) ->
     case PrimLoad of


### PR DESCRIPTION
Replace verbose case expression with direct boolean assignment.

This makes the code more readable and slightly more efficient by eliminating intermediate variable and pattern matching overhead.

The behavior remains identical: prim_load=true when Mode==embedded, prim_load=false otherwise.

## What changed
Refactored the `kernel_load_completed` clause in `eval_script/2` to use direct boolean assignment instead of a case expression.

## How
- **Before**: 6-line case expression with intermediate variable `Es`
- **After**: Single line with `prim_load=(Mode == embedded)`

## Why this is better
- **Readability**: The intent is immediately clear - `prim_load` directly reflects whether mode is embedded
- **Conciseness**: Reduces code from 6 lines to 2 lines
- **Performance**: Eliminates pattern matching overhead and intermediate record creation
- **Maintainability**: Less code to understand and modify

## Safety
Behavior remains functionally identical:
- When `Mode == embedded`: `prim_load = true` 
- When `Mode != embedded`: `prim_load = false`

The original logic is preserved - this is purely a code quality improvement.