### PR TITLE
Verification of GH Securities included in OpenVEX statements

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -473,6 +473,7 @@ jobs:
     if: ${{ needs.modified-vendor-files.outputs.vendor-files != 0 && github.event_name == 'pull_request'}}
     permissions:
       security-events: read
+      issues: write
     name: Vendor Vulnerability Scanning
     uses: ./.github/workflows/reusable-vendor-vulnerability-scanner.yml
     with:

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -58,6 +58,7 @@ jobs:
       fail-fast: false
     permissions:
       actions: write
+      issues: write
     steps:
       # this call to a workflow_dispatch ref=master is important because
       # using ref={{matrix.type}} would trigger the workflow

--- a/.github/workflows/reusable-vendor-vulnerability-scanner.yml
+++ b/.github/workflows/reusable-vendor-vulnerability-scanner.yml
@@ -93,6 +93,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       security-events: read
+      issues: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
         with:

--- a/.github/workflows/reusable-vendor-vulnerability-scanner.yml
+++ b/.github/workflows/reusable-vendor-vulnerability-scanner.yml
@@ -118,3 +118,4 @@ jobs:
           .github/scripts/otp-compliance.es sbom osv-scan \
                --version ${{ inputs.version }} \
                --fail_if_cve ${{ inputs.fail_if_cve }}
+          .github/scripts/otp-compliance.es vex verify -b ${{ inputs.version }}

--- a/make/openvex.table
+++ b/make/openvex.table
@@ -73,7 +73,7 @@
                 }
     },
     {
-      "pkg:otp/ssh@5.1.4.7": "CVE-2025-32433",
+      "pkg:otp/ssh@5.0": "CVE-2025-32433",
       "status": { "affected": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
                   "fixed": ["pkg:otp/ssh@5.1.4.8"]
                 }
@@ -97,7 +97,7 @@
                 }
     },
     {
-      "pkg:otp/ssl@11.1": "CVE-2025-53846",
+      "pkg:otp/ssl@11.1": "CVE-2024-53846",
       "status": { "affected": "Update to ssl@11.1.4.6",
                   "fixed": ["pkg:otp/ssl@11.1.4.6"]
                 }
@@ -171,7 +171,7 @@
                 }
     },
     {
-      "pkg:otp/ssh@5.2.9": "CVE-2025-32433",
+      "pkg:otp/ssh@5.2": "CVE-2025-32433",
       "status": { "affected": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
                   "fixed": ["pkg:otp/ssh@5.2.10"]
                 }
@@ -195,7 +195,7 @@
                 }
     },
     {
-      "pkg:otp/ssl@11.2": "CVE-2025-53846",
+      "pkg:otp/ssl@11.2": "CVE-2024-53846",
       "status": { "affected": "Update to ssl@11.2.5",
                   "fixed": ["pkg:otp/ssl@11.2.5"]
                 }

--- a/vex/otp-26.openvex.json
+++ b/vex/otp-26.openvex.json
@@ -2,156 +2,156 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/otp/vex-otp-26",
   "author": "vexctl",
-  "timestamp": "2025-08-21T10:56:51.352964+02:00",
-  "last_updated": "2025-08-21T10:57:18.466086841+02:00",
+  "timestamp": "2025-08-28T16:31:28.818462+02:00",
+  "last_updated": "2025-08-28T16:31:55.660152624+02:00",
   "version": 39,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-08-21T10:57:17.822976152+02:00",
+      "timestamp": "2025-08-28T16:31:55.029114897+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
           "@id": "pkg:otp/erts@14.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
           "@id": "pkg:otp/erts@14.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
           "@id": "pkg:otp/erts@14.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
           "@id": "pkg:otp/erts@14.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erts@14.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
           "@id": "pkg:otp/erts@14.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erts@14.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
           "@id": "pkg:otp/erts@14.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
           "@id": "pkg:otp/erts@14.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
           "@id": "pkg:otp/erts@14.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
           "@id": "pkg:otp/erts@14.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erts@14.2.5.11"
@@ -164,7 +164,7 @@
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-08-21T10:57:17.838572327+02:00",
+      "timestamp": "2025-08-28T16:31:55.045486705+02:00",
       "products": [
         {
           "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
@@ -177,91 +177,91 @@
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-08-21T10:57:17.854663547+02:00",
+      "timestamp": "2025-08-28T16:31:55.063693842+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -340,7 +340,7 @@
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-08-21T10:57:17.870865298+02:00",
+      "timestamp": "2025-08-28T16:31:55.079739995+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -353,91 +353,91 @@
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-08-21T10:57:17.887761585+02:00",
+      "timestamp": "2025-08-28T16:31:55.096285731+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -516,7 +516,7 @@
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-08-21T10:57:17.902536215+02:00",
+      "timestamp": "2025-08-28T16:31:55.111514072+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -529,91 +529,91 @@
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-08-21T10:57:17.918592468+02:00",
+      "timestamp": "2025-08-28T16:31:55.128132987+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -692,7 +692,7 @@
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-08-21T10:57:17.93416404+02:00",
+      "timestamp": "2025-08-28T16:31:55.143175048+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -705,91 +705,91 @@
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-08-21T10:57:17.949944484+02:00",
+      "timestamp": "2025-08-28T16:31:55.159744964+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -868,7 +868,7 @@
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-08-21T10:57:17.96533611+02:00",
+      "timestamp": "2025-08-28T16:31:55.175145774+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -881,91 +881,91 @@
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-08-21T10:57:17.980859866+02:00",
+      "timestamp": "2025-08-28T16:31:55.192243703+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -1044,7 +1044,7 @@
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-08-21T10:57:17.996629277+02:00",
+      "timestamp": "2025-08-28T16:31:55.20791825+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1057,91 +1057,91 @@
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-08-21T10:57:18.012608222+02:00",
+      "timestamp": "2025-08-28T16:31:55.225863181+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -1220,7 +1220,7 @@
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-08-21T10:57:18.029498892+02:00",
+      "timestamp": "2025-08-28T16:31:55.242417476+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1233,91 +1233,91 @@
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-08-21T10:57:18.05289133+02:00",
+      "timestamp": "2025-08-28T16:31:55.261081431+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -1396,7 +1396,7 @@
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-08-21T10:57:18.071457042+02:00",
+      "timestamp": "2025-08-28T16:31:55.279844704+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1409,91 +1409,91 @@
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-08-21T10:57:18.090268971+02:00",
+      "timestamp": "2025-08-28T16:31:55.296948372+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -1572,7 +1572,7 @@
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-08-21T10:57:18.10914946+02:00",
+      "timestamp": "2025-08-28T16:31:55.314429632+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1585,91 +1585,91 @@
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-08-21T10:57:18.126555717+02:00",
+      "timestamp": "2025-08-28T16:31:55.330535133+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -1748,7 +1748,7 @@
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-08-21T10:57:18.145001757+02:00",
+      "timestamp": "2025-08-28T16:31:55.348214348+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1761,91 +1761,91 @@
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-08-21T10:57:18.16294088+02:00",
+      "timestamp": "2025-08-28T16:31:55.364788347+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -1924,7 +1924,7 @@
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-08-21T10:57:18.179983356+02:00",
+      "timestamp": "2025-08-28T16:31:55.381752889+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1937,91 +1937,91 @@
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-08-21T10:57:18.198993543+02:00",
+      "timestamp": "2025-08-28T16:31:55.398898447+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.14"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.1"
@@ -2100,7 +2100,7 @@
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-08-21T10:57:18.218784524+02:00",
+      "timestamp": "2025-08-28T16:31:55.415390248+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -2113,10 +2113,10 @@
       "vulnerability": {
         "name": "CVE-2023-48795"
       },
-      "timestamp": "2025-08-21T10:57:18.237876861+02:00",
+      "timestamp": "2025-08-28T16:31:55.433429189+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
           "@id": "pkg:otp/ssh@5.1"
@@ -2124,16 +2124,16 @@
       ],
       "status": "affected",
       "action_statement": "Mitigation: If strict KEX availability cannot be ensured on both connection sides, affected encryption modes(CHACHA and CBC) can be disabled with standard ssh configuration. This will provide protection against vulnerability, but at a cost of affecting interoperability",
-      "action_statement_timestamp": "2025-08-21T10:57:18.237876861+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.433429189+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-48795"
       },
-      "timestamp": "2025-08-21T10:57:18.254933692+02:00",
+      "timestamp": "2025-08-28T16:31:55.449852183+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
           "@id": "pkg:otp/ssh@5.1.1"
@@ -2145,67 +2145,67 @@
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-08-21T10:57:18.272581233+02:00",
+      "timestamp": "2025-08-28T16:31:55.467500309+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
           "@id": "pkg:otp/ssh@5.0"
@@ -2246,16 +2246,16 @@
       ],
       "status": "affected",
       "action_statement": "Update to the next version",
-      "action_statement_timestamp": "2025-08-21T10:57:18.272581233+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.467500309+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-08-21T10:57:18.289408763+02:00",
+      "timestamp": "2025-08-28T16:31:55.484858368+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
           "@id": "pkg:otp/ssh@5.1.4.6"
@@ -2267,10 +2267,112 @@
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-08-21T10:57:18.307530288+02:00",
+      "timestamp": "2025-08-28T16:31:55.503170489+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.0"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.0.1"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.1"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.2"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.3"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4.1"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4.2"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4.3"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4.4"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4.5"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.1.4.6"
         },
         {
           "@id": "pkg:otp/ssh@5.1.4.7"
@@ -2278,16 +2380,16 @@
       ],
       "status": "affected",
       "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
-      "action_statement_timestamp": "2025-08-21T10:57:18.307530288+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.503170489+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-08-21T10:57:18.325700745+02:00",
+      "timestamp": "2025-08-28T16:31:55.519994676+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
           "@id": "pkg:otp/ssh@5.1.4.8"
@@ -2299,55 +2401,55 @@
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-08-21T10:57:18.343313891+02:00",
+      "timestamp": "2025-08-28T16:31:55.538537108+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
           "@id": "pkg:otp/ssh@5.1.1"
@@ -2388,16 +2490,16 @@
       ],
       "status": "affected",
       "action_statement": "Update to the next version",
-      "action_statement_timestamp": "2025-08-21T10:57:18.343313891+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.538537108+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-08-21T10:57:18.359467613+02:00",
+      "timestamp": "2025-08-28T16:31:55.55674843+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
           "@id": "pkg:otp/ssh@5.1.4.9"
@@ -2409,79 +2511,79 @@
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-08-21T10:57:18.376876691+02:00",
+      "timestamp": "2025-08-28T16:31:55.573170701+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.11"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.12"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
         },
         {
           "@id": "pkg:otp/stdlib@5.0"
@@ -2522,16 +2624,16 @@
       ],
       "status": "affected",
       "action_statement": "Mitigation: Update to pkg:otp/stdlib@5.2.3.4",
-      "action_statement_timestamp": "2025-08-21T10:57:18.376876691+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.573170701+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-08-21T10:57:18.392930374+02:00",
+      "timestamp": "2025-08-28T16:31:55.590601204+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.13"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
         },
         {
           "@id": "pkg:otp/stdlib@5.2.3.4"
@@ -2543,70 +2645,70 @@
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-08-21T10:57:18.410315436+02:00",
+      "timestamp": "2025-08-28T16:31:55.606487306+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0"
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.0.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.7"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.8"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.9"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
         },
         {
           "@id": "pkg:otp/ssh@5.0"
@@ -2650,16 +2752,16 @@
       ],
       "status": "affected",
       "action_statement": "Workaround: set option `parallel_login` to false. Reduce `max_sessions` option.",
-      "action_statement_timestamp": "2025-08-21T10:57:18.410315436+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.606487306+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-08-21T10:57:18.427381585+02:00",
+      "timestamp": "2025-08-28T16:31:55.624228684+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.10"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
         },
         {
           "@id": "pkg:otp/ssh@5.1.4.7"
@@ -2669,42 +2771,42 @@
     },
     {
       "vulnerability": {
-        "name": "CVE-2025-53846"
+        "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-08-21T10:57:18.445588761+02:00",
+      "timestamp": "2025-08-28T16:31:55.640907555+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.1"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.2"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.3"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.4"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.5"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
         },
         {
           "@id": "pkg:otp/ssl@11.1"
@@ -2739,16 +2841,16 @@
       ],
       "status": "affected",
       "action_statement": "Update to ssl@11.1.4.6",
-      "action_statement_timestamp": "2025-08-21T10:57:18.445588761+02:00"
+      "action_statement_timestamp": "2025-08-28T16:31:55.640907555+02:00"
     },
     {
       "vulnerability": {
-        "name": "CVE-2025-53846"
+        "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-08-21T10:57:18.46608756+02:00",
+      "timestamp": "2025-08-28T16:31:55.660153121+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-26.2.5.6"
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
         },
         {
           "@id": "pkg:otp/ssl@11.1.4.6"

--- a/vex/otp-27.openvex.json
+++ b/vex/otp-27.openvex.json
@@ -2,111 +2,111 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/otp/vex-otp-27",
   "author": "vexctl",
-  "timestamp": "2025-08-21T10:55:49.860147+02:00",
-  "last_updated": "2025-08-21T10:56:29.49388886+02:00",
+  "timestamp": "2025-08-28T14:30:22.929528+02:00",
+  "last_updated": "2025-08-28T14:31:02.898598183+02:00",
   "version": 37,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-08-21T10:56:28.907257662+02:00",
+      "timestamp": "2025-08-28T14:31:02.326498836+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
           "@id": "pkg:otp/erts@15.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
           "@id": "pkg:otp/erts@15.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
           "@id": "pkg:otp/erts@15.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
           "@id": "pkg:otp/erts@15.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
           "@id": "pkg:otp/erts@15.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
           "@id": "pkg:otp/erts@15.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
           "@id": "pkg:otp/erts@15.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
           "@id": "pkg:otp/erts@15.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
           "@id": "pkg:otp/erts@15.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
           "@id": "pkg:otp/erts@15.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
           "@id": "pkg:otp/erts@15.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
           "@id": "pkg:otp/erts@15.2.5"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
           "@id": "pkg:otp/erts@15.2.6"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
           "@id": "pkg:otp/erts@15.2.7"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erts@15.2.7.1"
@@ -119,7 +119,7 @@
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-08-21T10:56:28.923621046+02:00",
+      "timestamp": "2025-08-28T14:31:02.34175645+02:00",
       "products": [
         {
           "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
@@ -132,61 +132,61 @@
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-08-21T10:56:28.940694601+02:00",
+      "timestamp": "2025-08-28T14:31:02.359481448+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -244,7 +244,7 @@
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-08-21T10:56:28.957097597+02:00",
+      "timestamp": "2025-08-28T14:31:02.375820619+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -257,61 +257,61 @@
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-08-21T10:56:28.973310063+02:00",
+      "timestamp": "2025-08-28T14:31:02.392726583+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -369,7 +369,7 @@
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-08-21T10:56:28.988991874+02:00",
+      "timestamp": "2025-08-28T14:31:02.407683742+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -382,61 +382,61 @@
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-08-21T10:56:29.006143754+02:00",
+      "timestamp": "2025-08-28T14:31:02.424310424+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -494,7 +494,7 @@
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-08-21T10:56:29.023424181+02:00",
+      "timestamp": "2025-08-28T14:31:02.439916501+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -507,61 +507,61 @@
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-08-21T10:56:29.039936554+02:00",
+      "timestamp": "2025-08-28T14:31:02.45631406+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -619,7 +619,7 @@
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-08-21T10:56:29.055627893+02:00",
+      "timestamp": "2025-08-28T14:31:02.471250193+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -632,61 +632,61 @@
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-08-21T10:56:29.072843347+02:00",
+      "timestamp": "2025-08-28T14:31:02.488358462+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -744,7 +744,7 @@
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-08-21T10:56:29.088478654+02:00",
+      "timestamp": "2025-08-28T14:31:02.503691129+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -757,61 +757,61 @@
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-08-21T10:56:29.104822021+02:00",
+      "timestamp": "2025-08-28T14:31:02.519666312+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -869,7 +869,7 @@
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-08-21T10:56:29.120157609+02:00",
+      "timestamp": "2025-08-28T14:31:02.53503071+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -882,61 +882,61 @@
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-08-21T10:56:29.136387324+02:00",
+      "timestamp": "2025-08-28T14:31:02.551623018+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -994,7 +994,7 @@
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-08-21T10:56:29.151633049+02:00",
+      "timestamp": "2025-08-28T14:31:02.566489209+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1007,61 +1007,61 @@
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-08-21T10:56:29.168668453+02:00",
+      "timestamp": "2025-08-28T14:31:02.582198065+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -1119,7 +1119,7 @@
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-08-21T10:56:29.186156112+02:00",
+      "timestamp": "2025-08-28T14:31:02.597903014+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1132,61 +1132,61 @@
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-08-21T10:56:29.202601178+02:00",
+      "timestamp": "2025-08-28T14:31:02.615112705+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -1244,7 +1244,7 @@
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-08-21T10:56:29.218287926+02:00",
+      "timestamp": "2025-08-28T14:31:02.631032685+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1257,61 +1257,61 @@
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-08-21T10:56:29.23619712+02:00",
+      "timestamp": "2025-08-28T14:31:02.648734769+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -1369,7 +1369,7 @@
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-08-21T10:56:29.254516893+02:00",
+      "timestamp": "2025-08-28T14:31:02.664066599+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1382,61 +1382,61 @@
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-08-21T10:56:29.274864577+02:00",
+      "timestamp": "2025-08-28T14:31:02.681500198+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
         },
         {
           "@id": "pkg:otp/erl_interface@5.5.2"
@@ -1494,7 +1494,7 @@
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-08-21T10:56:29.292568488+02:00",
+      "timestamp": "2025-08-28T14:31:02.697236357+02:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
@@ -1507,37 +1507,37 @@
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-08-21T10:56:29.309033999+02:00",
+      "timestamp": "2025-08-28T14:31:02.714922947+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
           "@id": "pkg:otp/ssh@5.2"
@@ -1563,16 +1563,16 @@
       ],
       "status": "affected",
       "action_statement": "Update to the next version",
-      "action_statement_timestamp": "2025-08-21T10:56:29.309033999+02:00"
+      "action_statement_timestamp": "2025-08-28T14:31:02.714922947+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-08-21T10:56:29.32552649+02:00",
+      "timestamp": "2025-08-28T14:31:02.730850312+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
           "@id": "pkg:otp/ssh@5.2.7"
@@ -1584,13 +1584,76 @@
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-08-21T10:56:29.341333268+02:00",
+      "timestamp": "2025-08-28T14:31:02.748835869+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.1"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.2"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.3"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.4"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.5"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.6"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.7"
+        },
+        {
+          "@id": "pkg:otp/ssh@5.2.8"
         },
         {
           "@id": "pkg:otp/ssh@5.2.9"
@@ -1598,16 +1661,16 @@
       ],
       "status": "affected",
       "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
-      "action_statement_timestamp": "2025-08-21T10:56:29.341333268+02:00"
+      "action_statement_timestamp": "2025-08-28T14:31:02.748835869+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-08-21T10:56:29.358118726+02:00",
+      "timestamp": "2025-08-28T14:31:02.765127471+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
           "@id": "pkg:otp/ssh@5.2.10"
@@ -1619,52 +1682,52 @@
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-08-21T10:56:29.374406582+02:00",
+      "timestamp": "2025-08-28T14:31:02.78195315+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
           "@id": "pkg:otp/ssh@5.2"
@@ -1702,16 +1765,16 @@
       ],
       "status": "affected",
       "action_statement": "Update to ssh@5.2.11",
-      "action_statement_timestamp": "2025-08-21T10:56:29.374406582+02:00"
+      "action_statement_timestamp": "2025-08-28T14:31:02.78195315+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-08-21T10:56:29.391627434+02:00",
+      "timestamp": "2025-08-28T14:31:02.798830665+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
           "@id": "pkg:otp/ssh@5.2.11"
@@ -1723,55 +1786,55 @@
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-08-21T10:56:29.40933803+02:00",
+      "timestamp": "2025-08-28T14:31:02.814936086+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
         },
         {
           "@id": "pkg:otp/stdlib@6.0"
@@ -1800,16 +1863,16 @@
       ],
       "status": "affected",
       "action_statement": "Mitigation: Update to pkg:otp/stdlib@6.2.2.1",
-      "action_statement_timestamp": "2025-08-21T10:56:29.40933803+02:00"
+      "action_statement_timestamp": "2025-08-28T14:31:02.814936086+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-08-21T10:56:29.426231469+02:00",
+      "timestamp": "2025-08-28T14:31:02.831886627+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.4.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
         },
         {
           "@id": "pkg:otp/stdlib@6.2.2.1"
@@ -1821,43 +1884,43 @@
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-08-21T10:56:29.444026411+02:00",
+      "timestamp": "2025-08-28T14:31:02.848314515+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.2.4"
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
         },
         {
           "@id": "pkg:otp/ssh@5.2"
@@ -1889,19 +1952,19 @@
       ],
       "status": "affected",
       "action_statement": "Workaround: set option `parallel_login` to false. Reduce `max_sessions` option.",
-      "action_statement_timestamp": "2025-08-21T10:56:29.444026411+02:00"
+      "action_statement_timestamp": "2025-08-28T14:31:02.848314515+02:00"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-08-21T10:56:29.460006476+02:00",
+      "timestamp": "2025-08-28T14:31:02.86450886+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.3.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
         },
         {
           "@id": "pkg:otp/ssh@5.2.9"
@@ -1911,24 +1974,24 @@
     },
     {
       "vulnerability": {
-        "name": "CVE-2025-53846"
+        "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-08-21T10:56:29.477131167+02:00",
+      "timestamp": "2025-08-28T14:31:02.880931103+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0"
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.0.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.1"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
         },
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.2"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
         },
         {
           "@id": "pkg:otp/ssl@11.2"
@@ -1948,16 +2011,16 @@
       ],
       "status": "affected",
       "action_statement": "Update to ssl@11.2.5",
-      "action_statement_timestamp": "2025-08-21T10:56:29.477131167+02:00"
+      "action_statement_timestamp": "2025-08-28T14:31:02.880931103+02:00"
     },
     {
       "vulnerability": {
-        "name": "CVE-2025-53846"
+        "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-08-21T10:56:29.493892991+02:00",
+      "timestamp": "2025-08-28T14:31:02.898598636+02:00",
       "products": [
         {
-          "@id": "pkg:github/otp/erlang@OTP-27.1.3"
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
         },
         {
           "@id": "pkg:otp/ssl@11.2.5"


### PR DESCRIPTION
This PR makes the following contributions:
1. Verifies that OTP reported Github Securities exists in the published OpenVEX statements.
2. Open issues in the repo if vendor vulnerabilities are detected

## Verifies that OTP reported Github Securities exists in the published OpenVEX statements.
The PR uses `gh` to fetch data from GH Securities, uses the OpenVEX statements from `vex` folder and looks for a specific branch, e.g., `otp-26`, to look into the `otp-26.openvex.json`. Then, it filters out anything that is not OTP related, that is, it keeps OpenVEX statements that follow the purl pattern `pkg:otp/APP-NAME@VERSION`, since these are OTP specific. It also only considers those OpenVEX statements whose status is `fixed` or `affected`. This is because GH Securities lists CVEs, so there is no knowledge of `under_investigation` nor of `not_affected`, thus, these are ignored.

The script checks that the GH Securities and the resulting OpenVEX statements match in version ranges.

With this script, we verify that everything that is part of GH Securities exists as part of OpenVEX statements.

(Notice that we may want to check that all OpenVEX OTP statements are also covered in GH Securities. At the moment, not all CVEs can be provided by GH Securities, since they were released outside of GH, so we skip this reverse relation).

Note
The script assumes that we continue reporting CVEs in the same way in which we have reported the existing GH Securities so far. If we change a lot how this reporting changes, the script will break.

## Open issues automatically in Erlang/OTP if vendor vulnerabilities are detected

This was an addition due to missing that the OSV Vulnerability Scanner was failing in scheduled scans. 

The PR checks if vendor vulnerabilities are detected. If there is a new vendor vulnerability not reported in an OpenVEX statement, we have added logic to automatically open a ticket in this repo, similar to this other one:

https://github.com/kikofernandez/otp/issues/93

Image:
<img width="2545" height="1575" alt="image" src="https://github.com/user-attachments/assets/0c4419f6-6245-483e-80d1-208aa007aa6f" />

If there are vulnerabilities not reported in OpenVEX format but we have already (automatically) created a GH Issue, then there is no need to create another issue and nothing happens.

This automation forces us to keep track of vendor vulnerabilities and to update the OpenVEX statements for those vendor vulnerabilities.

(Notice that this is only for vendor vulnerabilities) 


