### PR TITLE
wx: check WXE_WEBVIEW before include wx/webview.h

### DIFF
--- a/lib/wx/c_src/gen/wxe_macros.h
+++ b/lib/wx/c_src/gen/wxe_macros.h
@@ -71,9 +71,11 @@
 #include <wx/sysopt.h>
 #include <wx/overlay.h>
 #include <wx/notifmsg.h>
+#if WXE_WEBVIEW
 #include <wx/webview.h>
 #if wxUSE_WEBVIEW && wxUSE_WEBVIEW_IE
 #include <wx/msw/webview_ie.h>
+#endif
 #endif
 #if wxUSE_GLCANVAS_EGL && !wxCHECK_VERSION(3,2,3)
 #include <EGL/egl.h>


### PR DESCRIPTION
Hi,

There are cases where wx/configure.ac detects that wxwidgets does not have support for webview.


This check https://github.com/erlang/otp/blob/master/lib/wx/configure.ac#L373 checks
if wxwidget has webview support. Then, if 'yes' the define WXE_WEBVIEW is defined.

However in c_src/gen/wxe_macros.h the include wx/webview.h is included without respecting
WXE_WEBVIEW, leading to compilation errors like below:

```
| In file included from gen/wxe_wrapper_8.cpp:30:  
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory                                                                                                                                                             
|    74 | #include <wx/webview.h>                                                                                    
|       |          ^~~~~~~~~~~~~~                                                                                                                                                                                                          
| compilation terminated.                                                                                                                                                                                                                  
| In file included from gen/wxe_init.cpp:25:                                                                                                                                                                                               
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory                                                                                                                                                             
|    74 | #include <wx/webview.h>                                                                                    
|       |          ^~~~~~~~~~~~~~                                                                                    
| compilation terminated.                                                                                                                                                                                                                  
| In file included from gen/wxe_wrapper_2.cpp:30:                                                                    
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory                                                                                                                                                             
|    74 | #include <wx/webview.h>                                                                                                                                                                                                          
|       |          ^~~~~~~~~~~~~~                                                                                                                                                                                                          
| compilation terminated.                                                                                                                                                                                                                  
| In file included from gen/wxe_wrapper_7.cpp:30:                                                                                                                                                                                          
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory                                                                                                                                                             
|    74 | #include <wx/webview.h>                                                                                                                                                                                                          
|       |          ^~~~~~~~~~~~~~                                                                                                                                                                                                          
| compilation terminated.                                                                                                                                                                                                                  
| In file included from gen/wxe_events.cpp:28:                                                                                                                                                                                             
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory                                                                                                                                                             
|    74 | #include <wx/webview.h>                                                                                                                                                                                                          
|       |          ^~~~~~~~~~~~~~                                                                                                                                                                                                          
| compilation terminated.
| In file included from gen/wxe_wrapper_5.cpp:30:
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory
|    74 | #include <wx/webview.h>
|       |          ^~~~~~~~~~~~~~
| compilation terminated.
| In file included from gen/wxe_wrapper_4.cpp:30:
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory
|    74 | #include <wx/webview.h>
|       |          ^~~~~~~~~~~~~~
| In file included from gen/wxe_wrapper_6.cpp:30:
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory
|    74 | #include <wx/webview.h>
|       |          ^~~~~~~~~~~~~~
| compilation terminated.
| compilation terminated.
| In file included from gen/wxe_wrapper_3.cpp:30:
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory
|    74 | #include <wx/webview.h>
|       |          ^~~~~~~~~~~~~~
| compilation terminated.
| In file included from gen/wxe_wrapper_1.cpp:30:
| gen/wxe_macros.h:74:10: fatal error: wx/webview.h: No such file or directory
|    74 | #include <wx/webview.h>
|       |          ^~~~~~~~~~~~~~
```

It's clear from configure that webview is not available, but wx will still work, I believed:

```
checking for GL/gl.h... yes
checking for GL/glu.h... yes
checking for wx-config... (cached) /build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-erlang/28.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/bin/crossscripts/wx-config --prefix=/build/
tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-erlang/28.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr --baselib=lib
checking for wxWidgets version >= 3.0.2 (--unicode)... yes (version 3.2.8)
checking for wxWidgets static library... no
checking for wxwidgets webview... no
checking for wx-config... (cached) /build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-erlang/28.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/bin/crossscripts/wx-config --prefix=/build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-erlang/28.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr --baselib=lib
checking for wxWidgets version >= 3.0.2 (--unicode --debug=yes)... yes (version 3.2.8)
checking for wxWidgets static library... no
checking for debug build of wxWidgets... yes
checking for wx-config... (cached) /build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-erlang/28.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/bin/crossscripts/wx-config --prefix=/build/tmp/work/x86_64-nativesdk-pokysdk-linux/nativesdk-erlang/28.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr --baselib=lib
checking for wxWidgets version >= 3.0.2 (--unicode --debug=no)... yes (version 3.2.8)
checking for wxWidgets static library... no
checking for standard build of wxWidgets... yes
checking for wxwidgets 3.0 compatibility ... yes
checking for wxwidgets opengl support... yes
```

```
*********************************************************************
**********************  APPLICATIONS INFORMATION  *******************
*********************************************************************

wx             : wxWidgets was not compiled with --enable-webview or wxWebView developer package is not installed, wxWebView will NOT be available

*********************************************************************
```


Thanks