### PR TITLE
emulator tests: Update C bits

### DIFF
--- a/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
+++ b/erts/emulator/test/nif_SUITE_data/nif_SUITE.c
@@ -3765,9 +3765,9 @@ static ERL_NIF_TERM ioq(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return enif_make_badarg(env);
 }
 
-static ERL_NIF_TERM make_bool(ErlNifEnv* env, int bool)
+static ERL_NIF_TERM make_bool(ErlNifEnv* env, int b)
 {
-    return bool ? atom_true : atom_false;
+    return b ? atom_true : atom_false;
 }
 
 static ERL_NIF_TERM get_local_pid_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/erts/emulator/test/port_SUITE_data/port_test.c
+++ b/erts/emulator/test/port_SUITE_data/port_test.c
@@ -72,10 +72,10 @@ typedef struct {
 PORT_TEST_DATA* port_data;
 
 static int packet_loop();
-static void reply();
-static void write_reply();
-static void ensure_buf_big_enough();
-static int readn();
+static void reply(void *buf, int size);
+static void write_reply(void *buf, int size);
+static void ensure_buf_big_enough(int size);
+static int readn(int fd, unsigned char*buf, int size);
 static void delay(unsigned ms);
 static void dump(unsigned char* buf, int sz, int max);
 static void replace_stdout(char* filename);

--- a/erts/emulator/test/port_bif_SUITE_data/port_test.c
+++ b/erts/emulator/test/port_bif_SUITE_data/port_test.c
@@ -33,8 +33,6 @@
     exit(1); \
 }
 
-#define MAIN(argc, argv) int main(argc, argv)
-
 extern int errno;
 
 typedef struct {
@@ -70,10 +68,10 @@ typedef struct {
 PORT_TEST_DATA* port_data;
 
 static int packet_loop();
-static void reply();
-static void write_reply();
-static void ensure_buf_big_enough();
-static int readn();
+static void reply(char *buf, int size);
+static void write_reply(char *buf, int size);
+static void ensure_buf_big_enough(int size);
+static int readn(int fd, unsigned char* buf, int size);
 static void delay(unsigned ms);
 static void dump(unsigned char* buf, int sz, int max);
 static void replace_stdout(char* filename);
@@ -103,7 +101,7 @@ int err;
 }
 #endif
 
-MAIN(argc, argv)
+int main(argc, argv)
 int argc;
 char *argv[];
 {


### PR DESCRIPTION
Some C bits are using deprecated C idioms and are now failing to build with recent toolchains