### PR TITLE
Update remaining usages of app-less -include_lib()

### DIFF
--- a/lib/common_test/doc/guides/dependencies_chapter.md
+++ b/lib/common_test/doc/guides/dependencies_chapter.md
@@ -80,7 +80,7 @@ into one test case. The resulting suite can look as follows:
 ```erlang
 -module(my_server_SUITE).
 -compile(export_all).
--include_lib("ct.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 %%% init and end functions...
 
@@ -184,7 +184,7 @@ _Example:_
 ```erlang
 -module(server_b_SUITE).
 -compile(export_all).
--include_lib("ct.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 %%% init and end functions...
 

--- a/lib/dialyzer/test/opaque_SUITE_data/src/ewgi/ewgi_api.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/ewgi/ewgi_api.erl
@@ -25,7 +25,7 @@
 %%%-------------------------------------------------------------------
 -module(ewgi_api).
 
--include_lib("ewgi.hrl").
+-include("ewgi.hrl").
 
 -export([get_all_headers/1, get_all_data/1]).
 

--- a/lib/dialyzer/test/opaque_SUITE_data/src/ewgi/ewgi_testapp.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/ewgi/ewgi_testapp.erl
@@ -26,7 +26,7 @@
 
 -export([htmlise/1]).
 
--include_lib("ewgi.hrl").
+-include("ewgi.hrl").
 
 htmlise(C) ->
     iolist_to_binary(

--- a/lib/dialyzer/test/opaque_SUITE_data/src/ewgi2/ewgi_api.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/ewgi2/ewgi_api.erl
@@ -25,7 +25,7 @@
 %%%-------------------------------------------------------------------
 -module(ewgi_api).
 
--include_lib("ewgi.hrl").
+-include("ewgi.hrl").
 
 -export([get_all_headers/1, get_all_data/1]).
 

--- a/lib/dialyzer/test/opaque_SUITE_data/src/ewgi2/ewgi_testapp.erl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/ewgi2/ewgi_testapp.erl
@@ -26,7 +26,7 @@
 
 -export([htmlise/1]).
 
--include_lib("ewgi.hrl").
+-include("ewgi.hrl").
 
 htmlise(C) ->
     iolist_to_binary(

--- a/lib/inets/doc/guides/http_server.md
+++ b/lib/inets/doc/guides/http_server.md
@@ -364,7 +364,7 @@ the schema and the tables are already created.
 ```erlang
 -module(mnesia_test).
 -export([start/0,load_data/0]).
--include_lib("mod_auth.hrl").
+-include_lib("inets/include/mod_auth.hrl").
 
 first_start() ->
     mnesia:create_schema([node()]),

--- a/lib/stdlib/src/erl_tar.erl
+++ b/lib/stdlib/src/erl_tar.erl
@@ -110,7 +110,7 @@ opens a tar file on a remote machine using an SFTP channel.
          format_error/1]).
 
 -include_lib("kernel/include/file.hrl").
--include_lib("erl_tar.hrl").
+-include("erl_tar.hrl").
 
 %% Converts the short error reason to a descriptive string.
 -doc "Converts an error reason term to a human-readable error message string.".


### PR DESCRIPTION
`erl_tar.hrl` is a private header file of stdlib, but `erl_tar.erl` is including it with:

```
-include_lib("erl_tar.hrl").
```

While this works, it breaks some code-analysis tools that (too strictly?) expect an `-include_lib()` argument to be of the form `"APP/include/HEADER.hrl"`.

There doesn't seem to be any advantage to it this way, so let's use `-include("erl_tar.hrl").` instead.

In fact, this was almost the only case in otp where something was included this way. There were a couple of similar usages of `-include_lib()` in some dialyzer tests and in documentation, so we update those places here as well.