### PR TITLE
Skip doc build (and do not fail) if an app is skipped by configure

### DIFF
--- a/system/doc/top/Makefile
+++ b/system/doc/top/Makefile
@@ -81,9 +81,11 @@ man_index.md: src/otp_man_index.beam $(wildcard $(ERL_TOP)/erts/ebin/*.beam) $(w
 
 core/erts.md: Makefile | core
 	$(gen_verbose)echo "# erts" > $@
+
+MISSING_APP_DISCLAIMER="The documentation for this application was not generated because the application was skipped during the source build."
 %.md: Makefile | core database oam interfaces tools testing documentation
 	$(gen_verbose)APP=$(basename $(notdir $@)) && \
-		echo "# $${APP}" > $@
+		echo "# $${APP}\n\n$(MISSING_APP_DISCLAIMER)\n" > $@
 
 HTML_DEPS=README.md man_index.md ../guides $(REDIRECTS)
 EPUB=false


### PR DESCRIPTION
## The Observed

The build `make docs` fails if some application was skipped by the configure for whatever reason or by the user's request. In the original bug report the application was `odbc`.

## The Expected

The build doesn't fail even if docs are partially not built for the reason of some app being skipped.

## The Solution

Elixir doc script was modified to read the `lib/SKIP-APPLICATIONS` and then the documentation redirects for those applications would be skipped too. This results in stub markdown file being shown, containing only application name as a title. Additional change to the Help-makefile: adding a line of explanation to the markdown stub files:
```Makefile
MISSING_APP_DISCLAIMER="The documentation for this application was not generated because ..."
```
<img width="2117" height="551" alt="screenshot" src="https://github.com/user-attachments/assets/30b5cbee-90cd-45f6-ab0e-f34980b118c8" />
