### PR TITLE
Improve pattern matching of binary segments

### DIFF
--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -1088,6 +1088,12 @@ bit_syntax(Config) ->
                 end.
               d(<<16#110000/utf8>>) -> error;
               d(_) -> ok.
+              e(<<X:1/big-signed-unit:64>>) -> {int, X};
+              e(<<X:1/big-unsigned-float-unit:64>>) -> {float, X}.
+              f(<<X:1/big-unsigned-float-unit:64>>) -> {float, X};
+              f(<<X:1/big-signed-unit:64>>) -> {int, X}.
+              g(<<X:4/signed-binary>>) -> X;
+              g(<<X:1/unsigned-binary-unit:32>>) -> X.
              ">>,
 	   [],
            {warnings,[{{2,15},sys_core_fold,{nomatch,no_clause}},
@@ -1107,7 +1113,9 @@ bit_syntax(Config) ->
                       {{12,37},sys_core_fold,{nomatch,{bit_syntax_size,bad}}},
                       {{15,21},sys_core_fold,{nomatch,{bit_syntax_unsigned,-42}}},
                       {{17,21},sys_core_fold,{nomatch,{bit_syntax_type,42,binary}}},
-                      {{19,19},sys_core_fold,{nomatch,{bit_syntax_unicode,1114112}}}
+                      {{19,19},sys_core_fold,{nomatch,{bit_syntax_unicode,1114112}}},
+                      {{22,15},beam_core_to_ssa,{nomatch,{shadow,21}}},
+                      {{26,15},beam_core_to_ssa,{nomatch,{shadow,25}}}
                      ]}
           }],
     run(Config, Ts),


### PR DESCRIPTION
In the following example, the compiler would not understand that the second clause could never succeed:

    decode(<<X:1/signed-unit:64>>) ->
        {int, X};
    decode(<<X:1/unsigned-float-unit:64>>) ->
        {float, X}.

In the following example:

    count_newlines(<<$\n,B/binary>>, Count) ->
        count_newlines(B, Count + 1);
    count_newlines(<<_:1/unit:8,B/binary>>, Count) ->
        count_newlines(B, Count);
    count_newlines(<<>>, Count) ->
        Count.

the size of the first segment is given in two different ways: in the first clause it is given as size 8 and unit 1, and in the second clause it is given as size 1 and unit 8.

The compiler would not understand that the size of segments were the same and would generate suboptimal code for the second clause.

This pull request improves the pattern matching compilation of binary segments, which results in better code for the `count_newlines/2` function, and the following warning for the `decode/1` function:

    t.erl:7:1: Warning: this clause cannot match because a previous clause at line 5 matches the same pattern as this clause
    %    7| decode(<<X:1/unsigned-float-unit:64>>) ->
    %     | ^