### PR TITLE
Fixes to the vendor vulnerability scanner

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -475,14 +475,13 @@ jobs:
   # this is a call to a workflow_call
   pr-vendor-vulnerability-analysis:
     needs: modified-vendor-files
-    if: ${{ needs.modified-vendor-files.outputs.vendor-files == 'true' && github.event_name == 'pull_request'}}
+    if: ${{ needs.modified-vendor-files.outputs.vendor-files == 'true' && github.event_name == 'pull_request' && github.repository == 'erlang/otp'}}
     permissions:
-      security-events: read
-      issues: write
+      actions: read
     name: Vendor Vulnerability Scanning
     uses: ./.github/workflows/reusable-vendor-vulnerability-scanner.yml
     with:
-      fail_if_cve: false
+      fail_if_cve: true
       checkout: true
       version: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
       # equivalent of ${{ env.BASE_BRANCH }} but reusable-workflows do not allow to pass env.

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -57,11 +57,7 @@ jobs:
         type: ${{ fromJson(needs.schedule-scan.outputs.versions) }}
       fail-fast: false
     permissions:
-      security-events: read
-      issues: write
-      actions: write
-      contents: write
-      pull-requests: write
+      actions: read
     steps:
       # this call to a workflow_dispatch ref=master is important because
       # using ref={{matrix.type}} would trigger the workflow

--- a/.github/workflows/reusable-vendor-vulnerability-scanner.yml
+++ b/.github/workflows/reusable-vendor-vulnerability-scanner.yml
@@ -92,8 +92,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
-      security-events: read
-      issues: write
+      actions: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2
         with:


### PR DESCRIPTION
- Creates now GH Issues for possible vendor vulnerabilities using an Erlang Bot with minimum privileges.
- Fixes the vendor vulnerability scanner from creating issues targeting `maint-29`, when those should have been `maint`