### PR TITLE
michal/kernel/fix-ct-comment-crashing/ERIERL-1264/OTP-19776

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -527,8 +527,6 @@ handle_info(_State, {'EXIT',Shell,R}, #state{ shell = Shell, driver = Drv }) ->
 
 handle_info(_State, _UnknownEvent, _Data) ->
     %% Ignore this unknown message.
-    erlang:display({unknown, _UnknownEvent}),
-    ok = _UnknownEvent,
     keep_state_and_data.
 
 %% When we get an input request while already serving another, we


### PR DESCRIPTION
Fixes: ERIERL-1264.

Didn't add any tests yet, since I'm not sure where to put them, group.erl doesn't seem to have it's own test suite.