### PR TITLE
Add erlang:system_info(bif_timer_count)

### DIFF
--- a/erts/doc/src/erlang_system_info.md
+++ b/erts/doc/src/erlang_system_info.md
@@ -55,6 +55,7 @@ order to make it easier to navigate.
   [`port_limit`](`m:erlang#system_info_port_limit`),
   [`process_count`](`m:erlang#system_info_process_count`),
   [`process_limit`](`m:erlang#system_info_process_limit`)
+  [`bif_timer_count`](`m:erlang#system_info_bif_timer_count`),
 
 - [`System Time`](`m:erlang#system_info/1-system-time`) -
   [`end_time`](`m:erlang#system_info_end_time`),
@@ -396,6 +397,13 @@ Returns information about the current system (emulator) limits as specified by `
   number of simultaneously existing processes at the local node. The value is
   given as an integer. This limit can be configured at startup by using
   command-line flag [`+P`](erl_cmd.md#+P) in `erl(1)`.
+
+- `bif_timer_count`{: #system_info_bif_timer_count } - Returns the number of bif
+  timers currently existing at the local node. Bif timers are those created by `erlang:send_after`
+  and `erlang:start_timer`, but not those implicitly created by receive statements with timeouts.
+  The value is given as an integer.
+
+  Since OTP 29.0
 
 ## System Time
 

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -733,6 +733,7 @@ atom threads
 atom time_offset
 atom timeout
 atom timeout_value
+atom bif_timer_count
 atom Times='*'
 atom timestamp
 atom total

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2937,6 +2937,8 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 	hp = HAlloc(BIF_P, 3);
 	res = TUPLE2(hp, am_min_bin_vheap_size,make_small(BIN_VH_MIN_SIZE));
 	BIF_RET(res);
+    } else if (BIF_ARG_1 == am_bif_timer_count) {
+	BIF_RET(make_small(erts_bif_timer_count()));
     } else if (BIF_ARG_1 == am_process_count) {
 	BIF_RET(make_small(erts_ptab_count(&erts_proc)));
     } else if (BIF_ARG_1 == am_process_limit) {

--- a/erts/emulator/beam/erl_hl_timer.h
+++ b/erts/emulator/beam/erl_hl_timer.h
@@ -87,4 +87,6 @@ erts_debug_callback_timer_foreach(void (*tclbk)(void *),
 					       ErtsMonotonicTime,
 					       void *),
 				  void *arg);
+
+Uint erts_bif_timer_count_in_timer_service(ErtsHLTimerService *service);
 #endif /* ERL_HL_TIMER_H__ */

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -15248,6 +15248,16 @@ void erts_halt(int code, ErtsMonotonicTime htmo)
     }
 }
 
+Uint erts_bif_timer_count()
+{
+    Uint result = 0;
+    ERTS_FOREACH_RUNQ(rq,
+        ErtsHLTimerService *srv = rq->scheduler->timer_service;
+        result += erts_bif_timer_count_in_timer_service(srv);
+    );
+    return result;
+}
+
 #if defined(ERTS_ENABLE_LOCK_CHECK)
 int
 erts_dbg_check_halloc_lock(Process *p)

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -759,6 +759,7 @@ extern ErtsAlignedSchedulerData * ERTS_WRITE_UNLIKELY(erts_aligned_scheduler_dat
 extern ErtsAlignedSchedulerData * ERTS_WRITE_UNLIKELY(erts_aligned_dirty_cpu_scheduler_data);
 extern ErtsAlignedSchedulerData * ERTS_WRITE_UNLIKELY(erts_aligned_dirty_io_scheduler_data);
 
+Uint erts_bif_timer_count(void);
 
 #if defined(ERTS_ENABLE_LOCK_CHECK)
 int erts_lc_runq_is_locked(ErtsRunQueue *);

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -10251,6 +10251,7 @@ the `CpuTopology` type to change.
       Alloc :: atom();
          (atom_count) -> pos_integer();
          (atom_limit) -> pos_integer();
+         (bif_timer_count) -> non_neg_integer();
          (build_type) -> opt | debug |
                          gcov | valgrind | gprof | lcnt | frmptr;
          (c_compiler_used) -> {atom(), term()};

--- a/lib/dialyzer/src/erl_bif_types.erl
+++ b/lib/dialyzer/src/erl_bif_types.erl
@@ -957,6 +957,8 @@ type(erlang, system_info, 1, Xs) ->
 		     t_non_neg_fixnum();
 		   ['trace_control_word'] ->
 		     t_integer();
+		   ['bif_timer_count'] ->
+		     t_non_neg_fixnum();
 		   ['version'] ->
 		     t_string();
 		   ['wordsize'] ->


### PR DESCRIPTION
This is helpful to detect when a process is accidentally generating an excessive number of bif timers.

We only count bif timers and not proc timers, because the latter are bounded by the number of processes.