### PR TITLE
add app-id as a secret

### DIFF
--- a/.github/workflows/reusable-vendor-vulnerability-scanner.yml
+++ b/.github/workflows/reusable-vendor-vulnerability-scanner.yml
@@ -106,7 +106,7 @@ jobs:
         id: app-token
         with:
           # required
-          app-id: ${{ vars.ERLANG_VENDOR_SCANNER_APP_ID }}
+          app-id: ${{ secrets.ERLANG_VENDOR_SCANNER_APP_ID }}
           private-key: ${{ secrets.ERLANG_VENDOR_SCANNER_BOT_PRIVATE_KEY }}
 
       - name: 'Analysis of dependencies from OpenVEX in ${{ inputs.version }}'


### PR DESCRIPTION
app-id is not a secret, but the reusable workflow would need to add yet one more parameter for `uses` call in `maint.yml`, while the dispatch workflow and scheduled job perform an API query and runs in a different environment, so the app-id can be fetched as a `vars` from the repo variable.

to make the integration consistent, we will just make the app-id private and save passing one more argument.

Relates to https://github.com/erlang/otp/pull/10206