### PR TITLE
fix scanner and vex statements for next release

### DIFF
--- a/.github/scripts/otp-compliance.es
+++ b/.github/scripts/otp-compliance.es
@@ -1621,8 +1621,7 @@ maint_to_otp_conversion(Branch) ->
     case Branch of
         ~"master" ->
             %% Master corresponds to possible patched versions of OTP_VERSION-1.
-            VersionNumber = erlang:list_to_integer(string:trim(os:cmd("cat OTP_VERSION | cut -d. -f1"))),
-            BinVersionNumber = erlang:integer_to_binary(VersionNumber-1),
+            BinVersionNumber = erlang:list_to_binary(string:trim(os:cmd("cat OTP_VERSION | cut -d. -f1"))),
             <<"otp-", BinVersionNumber/binary>>;
         <<"maint-", Vers/binary>> ->
             <<"otp-", Vers/binary>>;
@@ -1758,7 +1757,7 @@ vendor_by_version(_) ->
 %% any vulnerability. The user should still look into possible
 %% issues with wx if they link to it.
 non_vulnerable_vendor_packages() ->
-    [~"wx"].
+    [~"wx-doc-src"].
 
 ignore_non_vulnerable_vendors(Packages) ->
     lists:filter(fun (#{~"ID" := Id}) -> not lists:member(Id, non_vulnerable_vendor_packages())

--- a/.github/workflows/reusable-vendor-vulnerability-scanner.yml
+++ b/.github/workflows/reusable-vendor-vulnerability-scanner.yml
@@ -124,9 +124,6 @@ jobs:
         with:
           app-id: ${{ secrets.ERLANG_VENDOR_SCANNER_APP_ID }}
           private-key: ${{ secrets.ERLANG_VENDOR_SCANNER_BOT_PRIVATE_KEY }}
-          permissions: |
-            issues: write
-            security_events: read
 
       # PRs comming from a fork can use their own GH_TOKEN instead.
       # this is for security reasons that forked PRs cannot work with Github App tokens

--- a/make/openvex.table
+++ b/make/openvex.table
@@ -547,6 +547,34 @@
         ],
         "not_affected": "vulnerable_code_not_present"
       }
+    },
+    {
+      "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d": "CVE-2016-2183",
+      "status": {
+        "apps": [
+          "pkg:otp/erts@16.0",
+          "pkg:otp/erl_interface@5.6"
+        ],
+        "not_affected": "vulnerable_code_not_present"
+      }
+    }
+  ],
+  "otp-29": [
+    {
+      "pkg:github/madler/zlib@1a8db63788c34a50e39e273d39b7e1033208aea2": "CVE-2023-45853",
+      "status": { "not_affected": "vulnerable_code_not_present" }
+    },
+    {
+      "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2025-4575",
+      "status": {
+        "not_affected": "vulnerable_code_not_present"
+      }
+    },
+    {
+      "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d": "CVE-2016-2183",
+      "status": {
+        "not_affected": "vulnerable_code_not_present"
+      }
     }
   ]
 }

--- a/vex/otp-28.openvex.json
+++ b/vex/otp-28.openvex.json
@@ -3,8 +3,8 @@
   "@id": "https://openvex.dev/docs/public/otp/vex-otp-28",
   "author": "vexctl",
   "timestamp": "2025-08-21T10:55:45.714759+02:00",
-  "last_updated": "2025-09-18T09:59:20.278041735+02:00",
-  "version": 25,
+  "last_updated": "2025-09-19T10:34:52.749902956+02:00",
+  "version": 27,
   "statements": [
     {
       "vulnerability": {
@@ -469,6 +469,68 @@
       "products": [
         {
           "@id": "pkg:github/wxWidgets/wxWidgets@dc585039bbd426829e3433002023a93f9bedd0c2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2016-2183"
+      },
+      "timestamp": "2025-09-19T10:34:52.73417131+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/erlang/otp@OTP-28.0"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-28.0.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-28.0.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-28.0.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-28.0.4"
+        },
+        {
+          "@id": "pkg:otp/erl_interface@5.6"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-28.1"
+        },
+        {
+          "@id": "pkg:otp/erl_interface@5.6.1"
+        },
+        {
+          "@id": "pkg:otp/erts@16.0"
+        },
+        {
+          "@id": "pkg:otp/erts@16.0.1"
+        },
+        {
+          "@id": "pkg:otp/erts@16.0.2"
+        },
+        {
+          "@id": "pkg:otp/erts@16.0.3"
+        },
+        {
+          "@id": "pkg:otp/erts@16.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2016-2183"
+      },
+      "timestamp": "2025-09-19T10:34:52.749903353+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d"
         }
       ],
       "status": "not_affected",

--- a/vex/otp-29.openvex.json
+++ b/vex/otp-29.openvex.json
@@ -1,0 +1,49 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/otp/vex-otp-29",
+  "author": "vexctl",
+  "timestamp": "2025-09-19T10:20:20.759995+02:00",
+  "last_updated": "2025-09-19T10:33:18.152632187+02:00",
+  "version": 4,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2016-2183"
+      },
+      "timestamp": "2025-09-19T10:33:18.120131746+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@636dfadc70ce26f2473870570bfd9ec352806b1d"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-4575"
+      },
+      "timestamp": "2025-09-19T10:33:18.136216491+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-45853"
+      },
+      "timestamp": "2025-09-19T10:33:18.152633759+02:00",
+      "products": [
+        {
+          "@id": "pkg:github/madler/zlib@1a8db63788c34a50e39e273d39b7e1033208aea2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present"
+    }
+  ]
+}

--- a/vex/otp-29.openvex.json.license
+++ b/vex/otp-29.openvex.json.license
@@ -1,0 +1,7 @@
+%CopyrightBegin%
+
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Ericsson AB 2025. All Rights Reserved.
+
+%CopyrightEnd%


### PR DESCRIPTION
Produce OpenVEX statements and scan vendor vulnerabilities of next release.

The reason for doing this before a release is to catch and state false positive vendor vulnerabilities. CVEs for a non-release OTP version cannot happen, but we can  already mention which vendor CVEs do not apply.

OTP-19781