### PR TITLE
compiler: Add +to_abstr flag to match +from_abstr

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1665,7 +1665,8 @@ standard_passes() ->
      {iff,'P',{src_listing,"P"}},
      {iff,'to_pp',{done,"P"}},
 
-     {iff,'dabstr',{listing,"abstr"}}
+     {iff,'dabstr',{listing,"abstr"}},
+     {iff,'to_abstr',{done,"abstr"}}
      | abstr_passes(verified_abstr)].
 
 abstr_passes(AbstrStatus) ->
@@ -1689,7 +1690,7 @@ abstr_passes(AbstrStatus) ->
          {iff,'dexp',{listing,"expand"}},
          {iff,'E',?pass(legalize_vars)},
          {iff,'E',{src_listing,"E"}},
-         {iff,'to_exp',{done,"E"}},
+         {iff,'to_exp',{done,"abstr"}},
 
          %% Conversion to Core Erlang.
          ?pass(core),

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -552,7 +552,8 @@ do_file_listings(DataDir, PrivDir, [File|Files]) ->
 
     %% Test options that produce a listing file if 'binary' is not given.
     do_listing(Simple, TargetDir, to_pp, ".P"),
-    do_listing(Simple, TargetDir, to_exp, ".E"),
+    do_listing(Simple, TargetDir, to_abstr, ".abstr"),
+    do_listing(Simple, TargetDir, to_exp, ".abstr"),
     do_listing(Simple, TargetDir, to_core0, ".core"),
     ok = file:delete(filename:join(TargetDir, File ++ ".core")),
     do_listing(Simple, TargetDir, to_core, ".core"),


### PR DESCRIPTION
Also change extension produced by +to_exp flag to .abstr (the .E extension should only be for source listings).

Note that these flags are not documented; only the from_x flags are.