### PR TITLE
Fix `erl_anno:is_anno/1` for end location

### DIFF
--- a/lib/stdlib/src/erl_anno.erl
+++ b/lib/stdlib/src/erl_anno.erl
@@ -219,6 +219,10 @@ is_anno2(location, Line) when ?LN(Line) ->
     true;
 is_anno2(location, {Line, Column}) when ?LN(Line), ?COL(Column) ->
     true;
+is_anno2(end_location, Line) when ?LN(Line) ->
+    true;
+is_anno2(end_location, {Line, Column}) when ?LN(Line), ?COL(Column) ->
+    true;
 is_anno2(generated, true) ->
     true;
 is_anno2(file, Filename) ->

--- a/lib/stdlib/test/erl_anno_SUITE.erl
+++ b/lib/stdlib/test/erl_anno_SUITE.erl
@@ -103,6 +103,8 @@ is_anno(_Config) ->
     true = erl_anno:is_anno(A4),
     A5 = erl_anno:set_file(<<"filename">>, A4),
     true = erl_anno:is_anno(A5),
+    A6 = erl_anno:set_end_location({2, 17}, A5),
+    true = erl_anno:is_anno(A6),
     ok.
 
 %% Test 'generated'.


### PR DESCRIPTION
Found while writing tests for https://github.com/ash-project/spark/pull/216