### PR TITLE
Include doc attributes in .abstr files

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1656,8 +1656,6 @@ standard_passes() ->
 
      {iff,'dpp',{listing,"pp"}},
      ?pass(lint_module),
-     {unless,no_docs,?pass(beam_docs)},
-     ?pass(remove_doc_attributes),
 
      {iff,'P',{src_listing,"P"}},
      {iff,'to_pp',{done,"P"}},
@@ -1668,12 +1666,15 @@ standard_passes() ->
 
 abstr_passes(AbstrStatus) ->
     case AbstrStatus of
-        non_verified_abstr -> [{unless, no_lint, ?pass(lint_module)},
-                               {unless,no_docs,?pass(beam_docs)},
-                               ?pass(remove_doc_attributes)];
-        verified_abstr -> []
+        non_verified_abstr ->
+            [{unless, no_lint, ?pass(lint_module)}];
+        verified_abstr ->
+            []
     end ++
         [
+         {unless,no_docs,?pass(beam_docs)},
+         ?pass(remove_doc_attributes),
+
          %% Add all -compile() directives to #compile.options
          ?pass(compile_directives),
 


### PR DESCRIPTION
When compiling with the `to_abstr` option, the resulting `.abstr` file would not include documentation attributes. That means that the BEAM file resulting from the following commands would not include documentation:

    erlc +to_abstr some_module.erl
    erlc some_module.abstr