### PR TITLE
Use wxwidgets 3.2.8.1 for CI MacOS build for it has fp.h problem fixed

### DIFF
--- a/.github/scripts/build-macos-wxwidgets.sh
+++ b/.github/scripts/build-macos-wxwidgets.sh
@@ -22,23 +22,29 @@
 
 set -e
 
-export MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)
+MAKEFLAGS=-j$(getconf _NPROCESSORS_ONLN)
+export MAKEFLAGS
 
 if [ -z "$WXWIDGETS_VERSION" ]; then
-  WXWIDGETS_VERSION=3.1.5
+  # Value is set in .github/workflows/main.yaml for MacOS only, this here is the fallback value
+  WXWIDGETS_VERSION=3.2.8.1
 fi
 
-vsn=$WXWIDGETS_VERSION
-curl --fail -LO https://github.com/wxWidgets/wxWidgets/releases/download/v$vsn/wxWidgets-$vsn.tar.bz2
-tar -xf wxWidgets-$vsn.tar.bz2
-mv wxWidgets-$vsn/ wxWidgets
+WX_SELECTED_VERSION=${WXWIDGETS_VERSION}
+WX_DOWNLOAD_URL=https://github.com/wxWidgets/wxWidgets/releases/download/v${WX_SELECTED_VERSION}/wxWidgets-${WX_SELECTED_VERSION}.tar.bz2
+echo "Downloading WxWidgets from ${WX_DOWNLOAD_URL}"
+curl --fail -LO "${WX_DOWNLOAD_URL}"
+tar -xf "wxWidgets-${WX_SELECTED_VERSION}.tar.bz2"
+mv "wxWidgets-${WX_SELECTED_VERSION}/" wxWidgets
 
 cd wxWidgets
 ./configure \
   --disable-shared \
-  --prefix=$PWD/release \
+  --prefix="${PWD}/release" \
   --with-cocoa \
   --with-macosx-version-min=10.15 \
-  --disable-sys-libs
+  --with-libtiff=builtin
+#  --disable-sys-libs
+
 make
 make install

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -194,7 +194,7 @@ jobs:
     needs: pack
     if: needs.pack.outputs.build-c-code == 'true'
     env:
-      WXWIDGETS_VERSION: 3.2.6
+      WXWIDGETS_VERSION: 3.2.8.1
       MACOS_VERSION: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4.2.2


### PR DESCRIPTION
## Problem
Compile errors appear when building `wxWidgets` on MacOS using `.github/scripts/build-macos-wxwidgets.sh` with latest Clang 17.

## Solution
1. Replaced via `sed`: `#include <fp.h>` to `#include <math.h>` in the `wxWidgets/src/png/pngpriv.h`
2. Commented out via `sed`: `#define fdopen`  in `wxWidgets/src/zlib/zutil.h`
3. Minor changes (addressing issues found in sh file by `shellcheck` tool).

## Other Solutions
The problem caused by the changes in standard library in Clang 17. Alternative solution is installing and using previous Clang 16 via Homebrew or somehow else.
