### PR TITLE
Fix suspend_process() issue on processes in dirty schedulers

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -5086,6 +5086,7 @@ sync_suspend_reply(Process *c_p, ErtsMessage *mp, erts_aint32_t state)
      */
     Process *rp;
     ErtsSyncSuspendRequest *ssusp;
+    int is_managed;
 
     ssusp = (ErtsSyncSuspendRequest *) (char *) (&mp->hfrag.mem[0]
                                                  + mp->hfrag.used_size);
@@ -5105,7 +5106,10 @@ sync_suspend_reply(Process *c_p, ErtsMessage *mp, erts_aint32_t state)
     mp->data.attached = ERTS_MSG_COMBINED_HFRAG;
     mp->next = NULL;
 
-    rp = erts_proc_lookup(ssusp->requester);
+    is_managed = erts_thr_progress_is_managed_thread();
+    rp = (is_managed
+          ? erts_proc_lookup(ssusp->requester)
+          : erts_proc_lookup_inc_refc(ssusp->requester));
     if (!rp)
         erts_cleanup_messages(mp);
     else {
@@ -5124,6 +5128,8 @@ sync_suspend_reply(Process *c_p, ErtsMessage *mp, erts_aint32_t state)
         }
         ERL_MESSAGE_TOKEN(mp) = am_undefined;
         erts_queue_proc_message(c_p, rp, 0, mp, ssusp->message);
+        if (!is_managed)
+            erts_proc_dec_refc(rp);
     }
 }
 

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -5269,6 +5269,8 @@ erts_proc_sig_handle_pending_suspend(Process *c_p)
         msp = next_msp;
     }
 
+    state = erts_atomic32_read_nob(&c_p->state);
+
     sync = psusp->sync;
 
     while (sync) {

--- a/erts/emulator/test/dirty_bif_SUITE.erl
+++ b/erts/emulator/test/dirty_bif_SUITE.erl
@@ -39,7 +39,8 @@
 	 dirty_process_register/1,
 	 dirty_process_trace/1,
 	 code_purge/1,
-         otp_15688/1]).
+         otp_15688/1,
+         suspend_process/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -66,7 +67,8 @@ all() ->
      dirty_process_register,
      dirty_process_trace,
      code_purge,
-     otp_15688].
+     otp_15688,
+     suspend_process].
 
 init_per_suite(Config) ->
     case erlang:system_info(dirty_cpu_schedulers) of
@@ -539,7 +541,92 @@ otp_15688(Config) when is_list(Config) ->
             exit(See, kill),
             ct:fail({suspendee_stuck, PI})
     end.
-    
+
+suspend_process(Config) when is_list(Config) ->
+    Go = make_ref(),
+    AS = make_ref(),
+    Tester = self(),
+    P = spawn_link(fun () ->
+                           receive {Go, 1} -> ok end,
+                           Tester ! {Go, 2},
+                           erts_debug:dirty_io(wait, 500),
+                           receive {Go, 3}-> ok end,
+                           Tester ! {Go, 4},
+                           erts_debug:dirty_io(wait, 500),
+                           receive {Go, 5} -> ok end,
+                           Tester ! {Go, 6},
+                           erts_debug:dirty_cpu(wait, 500),
+                           receive {Go, 7} -> ok end,
+                           Tester ! {Go, 8},
+                           erts_debug:dirty_cpu(wait, 500)
+                   end),
+
+    %% Sync DIO
+    {status, Status1} = erlang:process_info(P, status),
+    false = Status1 == suspended,
+
+    P ! {Go, 1},
+    receive {Go, 2} -> ok end,
+    erlang:yield(),
+    true = erlang:suspend_process(P),
+
+    {status, Status2} = erlang:process_info(P, status),
+    true = Status2 == suspended,
+
+    true = erlang:resume_process(P),
+
+    %% Async DIO
+    {status, Status3} = erlang:process_info(P, status),
+    false = Status3 == suspended,
+
+    P ! {Go, 3},
+    receive {Go, 4} -> ok end,
+    erlang:yield(),
+
+    true = erlang:suspend_process(P, [{asynchronous, AS}]),
+    receive {AS, What1} -> suspended = What1 end,
+
+    {status, Status4} = erlang:process_info(P, status),
+    true = Status4 == suspended,
+
+    true = erlang:resume_process(P),
+
+    %% Sync DCPU
+    {status, Status5} = erlang:process_info(P, status),
+    false = Status5 == suspended,
+
+    P ! {Go, 5},
+    receive {Go, 6} -> ok end,
+    erlang:yield(),
+
+    true = erlang:suspend_process(P),
+
+    {status, Status6} = erlang:process_info(P, status),
+    true = Status6 == suspended,
+
+    true = erlang:resume_process(P),
+
+    %% Async DCPU
+    {status, Status7} = erlang:process_info(P, status),
+    false = Status7 == suspended,
+
+    P ! {Go, 7},
+    receive {Go, 8} -> ok end,
+    erlang:yield(),
+
+    true = erlang:suspend_process(P, [{asynchronous, AS}]),
+    receive {AS, What2} -> suspended = What2 end,
+
+    {status, Status8} = erlang:process_info(P, status),
+    true = Status8 == suspended,
+
+    true = erlang:resume_process(P),
+
+    unlink(P),
+    exit(P, kill),
+    false = is_process_alive(P),
+
+    ok.
 
 %%
 %% Internal...


### PR DESCRIPTION
# Context
`erlang:suspend_process()` was broken when applied on processes that happened to be in a dirty-scheduler. The symptom was:
  - `internal_error` would be returned when called synchronously
  - `not_suspended` would be delivered when called asynchronously, even though the process was in fact suspended

# Problem
When trying to suspend a processes in a dirty-scheduler, it is actually the dirty-scheduler who suspends the process, by calling `erts_proc_sig_handle_pending_suspend()`. This essentially activates all pending suspend monitors and finally sends all pending sync messages, by calling `sync_suspend_reply()`.

The problem is that when calling the latter, it is passing the process state *before* activating the monitors. In particular, the SUSPENDED flag is not set, what makes `sync_suspend_reply()` assume that something is wrong.