### PR TITLE
Fix `merl:compile_and_load/1` with comments

### DIFF
--- a/lib/syntax_tools/src/merl.erl
+++ b/lib/syntax_tools/src/merl.erl
@@ -429,7 +429,7 @@ compile(Code, Options) when not is_list(Code)->
         _ -> compile([Code], Options)
     end;
 compile(Code, Options0) when is_list(Options0) ->
-    Forms = [erl_syntax:revert(F) || F <- Code],
+    Forms = erl_syntax:revert_forms(Code),
     Options = [verbose, report_errors, report_warnings, binary | Options0],
     compile:noenv_forms(Forms, Options).
 

--- a/lib/syntax_tools/test/merl_SUITE.erl
+++ b/lib/syntax_tools/test/merl_SUITE.erl
@@ -1,4 +1,11 @@
-%% ``Licensed under the Apache License, Version 2.0 (the "License");
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 1996-2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
 %%
@@ -9,11 +16,9 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
-%% The Initial Developer of the Original Code is Ericsson Utvecklings AB.
-%% Portions created by Ericsson are Copyright 1999, Ericsson Utvecklings
-%% AB. All Rights Reserved.''
-%% 
+%%
+%% %CopyrightEnd%
+%%
 -module(merl_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
@@ -25,19 +30,21 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Test server specific exports
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2]).
 
 %% Test cases
 -export([merl_smoke_test/1,
-         transform_parse_error_test/1, otp_15291/1]).
+         transform_parse_error_test/1, otp_15291/1,
+         compile_and_load_with_comments/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [merl_smoke_test,
      transform_parse_error_test,
-     otp_15291].
+     otp_15291,
+     compile_and_load_with_comments].
 
 groups() -> 
     [].
@@ -110,6 +117,18 @@ otp_15291(_Config) ->
     {clause,A1,[{var,A1,'_'},{var,A1,'_'}],[],[{atom,A1,ok}]} = C2,
     C1 = merl:quote("(_) -> ok"),
     {clause,A1,[{var,A1,'_'}],[],[{atom,A1,ok}]} = C1,
+    ok.
+
+compile_and_load_with_comments(_Config) ->
+    ?assertMatch({ok, _},
+                 merl:compile_and_load(merl:quote(
+                     ~"-module(merl_test_module_1)."))),
+    ?assertMatch({ok, _},
+                 merl:compile_and_load(merl:quote(
+                     ~"-module(merl_test_module_2). % comment"))),
+    ?assertMatch({ok, _},
+                 merl:compile_and_load(merl:quote(
+                     ~"\n-module(merl_test_module_3).\n% comment"))),
     ok.
 
 %% utilities


### PR DESCRIPTION
## Problem

`merl:compile_and_load/1` fails when quoted code contains comment lines:

```bash
$ erl
Erlang/OTP 28 [erts-16.0.3] [source] [64-bit] [smp:24:24] [ds:24:24:10] [async-threads:1] [jit:ns]

Eshell V16.0.3 (press Ctrl+G to abort, type help(). for help)
1> Q = merl:quote(~"""
   -module(foo).
   % comment
   """).
[{attribute,1,module,foo},
 {tree,comment,{attr,2,[],none},{comment,0,[" comment"]}}]
2> merl:compile_and_load(Q).
: internal error in pass lint_module:
exception error: no function clause matching erl_lint:function_state({tree,comment,{attr,2,[],none},{comment,0,[" comment"]}},
 {lint,function,foo,[],
       {2,{{module_info,1},{{module_info,0},nil,nil},nil}},
       [],#{},
       [binary,verbose,report_errors,report_warnings,binary],
       #{},
       {0,nil},
       {set,{0,nil}},
       {3,
        {{module_info,1},{{module_info,0},nil,nil},{{record_info,2},nil,nil}}},
       [],0,[],[],
       {0,nil},
       [],[],1,
       [behaviours,bif_clash,conflicting_behaviours,deprecated_callback,
        deprecated_function,deprecated_type,export_all,
        ill_defined_behaviour_callbacks,ill_defined_optional_callbacks,
        match_float_zero,nif_inline,obsolete_guard,redefined_builtin_type,
        removed,shadow_vars,undefined_behaviour,undefined_behaviour_callbacks,
        undefined_behaviour_func,underscore_match,unexported_function,
        unused_function,unused_record,unused_type,unused_vars,update_literal],
       [],[],[],[],false,false,
       [{{module_info,0},0},{{module_info,1},0},{{record_info,2},0}],
       undefined,
       {usage,#{{module_info,1} =>
                    [{module_info,0},{module_info,1},{record_info,2}]},
              [],
              {0,nil},
              #{}},
       #{},#{},#{},#{},#{},
       {0,nil},
       #{'maybe' => maybe_expr,'else' => maybe_expr},
       none,guard,false,false,false}) (erl_lint.erl:1137)
  in function  lists:foldl_1/3 (lists.erl:2471)
  in call from erl_lint:forms/2 (erl_lint.erl:949)
  in call from erl_lint:module/3 (erl_lint.erl:750)
  in call from compile:lint_module/2 (compile.erl:2177)
  in call from compile:fold_comp/4 (compile.erl:1239)
  in call from compile:internal_comp/5 (compile.erl:1214)
  in call from compile:'-internal_fun/2-anonymous-0-'/2 (compile.erl:1040)
error
```

## Fix

Replace manual form reversion with `erl_syntax:revert_forms/1` in `merl:compile/2`:

```diff
- Forms = [erl_syntax:revert(F) || F <- Code],
+ Forms = erl_syntax:revert_forms(Code),
```

## Test

Added test covering standalone comments, inline comments, and mixed scenarios.
