### PR TITLE
Use -include_lib() instead of -include("../include/...")

### DIFF
--- a/lib/edoc/src/Makefile
+++ b/lib/edoc/src/Makefile
@@ -48,7 +48,8 @@ RELSYSDIR = $(RELEASE_PATH)/lib/edoc-$(VSN)
 
 EBIN = ../ebin
 XMERL = ../../xmerl
-ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include +warn_unused_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented +warn_deprecated_catch -Werror
+ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include -I${ERL_TOP}/lib
+ERL_COMPILE_FLAGS += +warn_unused_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented +warn_deprecated_catch -Werror
 
 include files.mk
 

--- a/lib/edoc/src/edoc_doclet.erl
+++ b/lib/edoc/src/edoc_doclet.erl
@@ -53,7 +53,7 @@
 -import(edoc_report, [report/2, warning/2]).
 
 %% @headerfile "../include/edoc_doclet.hrl"
--include("../include/edoc_doclet.hrl").
+-include_lib("edoc/include/edoc_doclet.hrl").
 
 -define(EDOC_APP, edoc).
 -define(DEFAULT_FILE_SUFFIX, ".html").

--- a/lib/edoc/src/edoc_doclet_chunks.erl
+++ b/lib/edoc/src/edoc_doclet_chunks.erl
@@ -53,7 +53,7 @@
 -import(edoc_report, [report/2]).
 
 %% @headerfile "../include/edoc_doclet.hrl"
--include("../include/edoc_doclet.hrl").
+-include_lib("edoc/include/edoc_doclet.hrl").
 
 -define(DEFAULT_FILE_SUFFIX, ".chunk").
 -define(CHUNKS_DIR, "chunks").

--- a/lib/edoc/src/edoc_doclet_markdown.erl
+++ b/lib/edoc/src/edoc_doclet_markdown.erl
@@ -58,7 +58,7 @@
 -export([run/2]).
 
 %% @headerfile "../include/edoc_doclet.hrl"
--include("../include/edoc_doclet.hrl").
+-include_lib("edoc/include/edoc_doclet.hrl").
 
 -include_lib("xmerl/include/xmerl.hrl").
 -include_lib("kernel/include/eep48.hrl").

--- a/lib/et/src/et_collector.erl
+++ b/lib/et/src/et_collector.erl
@@ -71,7 +71,7 @@ Interface module for the Event Trace (ET) application
 -compile([{nowarn_deprecated_function,[{erlang,now,0}]}]).
 
 -include("et_internal.hrl").
--include("../include/et.hrl").
+-include_lib("et/include/et.hrl").
 
 -record(state, {parent_pid,
 		auto_shutdown, % Optionally shutdown when the last subscriber dies 

--- a/lib/et/src/et_selector.erl
+++ b/lib/et/src/et_selector.erl
@@ -32,7 +32,7 @@
 
 -compile([{nowarn_deprecated_function,[{erlang,now,0}]}]).
 
--include("../include/et.hrl").
+-include_lib("et/include/et.hrl").
 
 -type event() :: #event{}.
 

--- a/lib/et/src/et_viewer.erl
+++ b/lib/et/src/et_viewer.erl
@@ -38,7 +38,7 @@
 	 stop/1, 
          get_collector_pid/1]).
 
--include("../include/et.hrl").
+-include_lib("et/include/et.hrl").
 -include("et_internal.hrl").
 
 -define(unknown, "UNKNOWN").

--- a/lib/et/src/et_wx_contents_viewer.erl
+++ b/lib/et/src/et_wx_contents_viewer.erl
@@ -37,7 +37,7 @@
          handle_call/3, handle_cast/2, handle_info/2,
 	 handle_event/2]).
 
--include("../include/et.hrl").
+-include_lib("et/include/et.hrl").
 -include("et_internal.hrl").
 -include_lib("wx/include/wx.hrl").
 

--- a/lib/et/src/et_wx_viewer.erl
+++ b/lib/et/src/et_wx_viewer.erl
@@ -35,7 +35,7 @@
 -export([init/1, terminate/2, code_change/3,
          handle_call/3, handle_cast/2, handle_info/2]).
 
--include("../include/et.hrl").
+-include_lib("et/include/et.hrl").
 -include("et_internal.hrl").
 -include_lib("wx/include/wx.hrl").
 

--- a/lib/kernel/src/auth.erl
+++ b/lib/kernel/src/auth.erl
@@ -61,7 +61,7 @@ Manual.
 	 }).
 -type state() :: #state{}.
 
--include("../include/file.hrl").
+-include_lib("kernel/include/file.hrl").
 
 %%----------------------------------------------------------------------
 %% Exported functions

--- a/lib/stdlib/src/erl_bits.erl
+++ b/lib/stdlib/src/erl_bits.erl
@@ -28,7 +28,7 @@
 	 set_bit_type/2,
 	 as_list/1]).
 
--include("../include/erl_bits.hrl").
+-include_lib("stdlib/include/erl_bits.hrl").
 
 %% Dummies.
 

--- a/lib/wx/api_gen/wx_extra/wxEvtHandler.erl
+++ b/lib/wx/api_gen/wx_extra/wxEvtHandler.erl
@@ -28,7 +28,7 @@ wxWidgets docs:
 [wxEvtHandler](https://docs.wxwidgets.org/3.2/classwx_evt_handler.html)
 """.
 -include("wxe.hrl").
--include("../include/wx.hrl").
+-include_lib("wx/include/wx.hrl").
 
 %% API
 -export([connect/2, connect/3, disconnect/1, disconnect/2, disconnect/3]).

--- a/lib/wx/src/Makefile
+++ b/lib/wx/src/Makefile
@@ -28,7 +28,7 @@ EGEN = gen
 EBIN = ../ebin
 ERLC = erlc
 ERLINC = ../include
-ERL_COMPILE_FLAGS += -I$(ERLINC) +warn_unused_vars +nowarn_missing_doc
+ERL_COMPILE_FLAGS += -I$(ERLINC) -I${ERL_TOP}/lib +warn_unused_vars +nowarn_missing_doc
 
 ifeq ($(CAN_BUILD_DRIVER), true)
 ERL_COMPILE_FLAGS += -DCAN_BUILD_DRIVER

--- a/lib/wx/src/gen/wxEvtHandler.erl
+++ b/lib/wx/src/gen/wxEvtHandler.erl
@@ -85,7 +85,7 @@ wxWidgets docs:
 [wxEvtHandler](https://docs.wxwidgets.org/3.2/classwx_evt_handler.html)
 """.
 -include("wxe.hrl").
--include("../include/wx.hrl").
+-include_lib("wx/include/wx.hrl").
 
 %% API
 -export([connect/2, connect/3, disconnect/1, disconnect/2, disconnect/3]).

--- a/lib/wx/src/wx.erl
+++ b/lib/wx/src/wx.erl
@@ -195,7 +195,7 @@ Global (classless) functions are located in the wx_misc module.
 	      wx_enum/0, wx_wxMouseState/0, wx_wxHtmlLinkInfo/0]).
 
 -include("wxe.hrl").
--include("../include/wx.hrl").
+-include_lib("wx/include/wx.hrl").
 
 -type wx_object() :: #wx_ref{}.  %% Opaque object reference
 -type wx_env() :: #wx_env{}.     %% Opaque process environment

--- a/lib/wx/src/wx_object.erl
+++ b/lib/wx/src/wx_object.erl
@@ -198,7 +198,7 @@ Example:
   [wx:wx_object()](`m:wx#type-wx_object`) | atom() | pid()**
 """.
 -include("wxe.hrl").
--include("../include/wx.hrl").
+-include_lib("wx/include/wx.hrl").
 
 %% API
 -export([start/3, start/4,

--- a/lib/wx/src/wxe_server.erl
+++ b/lib/wx/src/wxe_server.erl
@@ -47,7 +47,7 @@
 -define(log(S,A), log(?MODULE_STRING,?LINE,S,A)).
 
 -include("wxe.hrl").
--include("../include/wx.hrl").
+-include_lib("wx/include/wx.hrl").
 
 %%====================================================================
 %% API


### PR DESCRIPTION
Usage of `-include("../include/foo.hrl").` force code-analysis tools to handle relative paths that escape the root, which adds unnecessary complexity. We can instead be consistent and use only `-include_lib()`