### PR TITLE
Fix ETP new fun arity format

### DIFF
--- a/erts/emulator/beam/erl_etp.c
+++ b/erts/emulator/beam/erl_etp.c
@@ -131,6 +131,8 @@ const Eterm etp_tag_header_map = _TAG_HEADER_MAP;
 const Eterm etp_tag_header_mask = _TAG_HEADER_MASK;
 const Eterm etp_header_subtag_mask = _HEADER_SUBTAG_MASK;
 const Eterm etp_header_arity_offs = _HEADER_ARITY_OFFS;
+const Eterm etp_header_fun_kind_offs = FUN_HEADER_KIND_OFFS;
+const Eterm etp_header_fun_env_size_offs = FUN_HEADER_ENV_SIZE_OFFS;
 
 const Eterm etp_tag_primary_size = _TAG_PRIMARY_SIZE;
 const Eterm etp_tag_primary_mask = _TAG_PRIMARY_MASK;

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -426,8 +426,17 @@ define etp-boxed-immediate-1
                 else
                   # Hexdump the rest
                   if ($etp_boxed_immediate_h == etp_fun_subtag)
-                    printf "#Fun<"
+                    set $etp_boxed_immediate_arity = \
+                      ((($etp_boxed_immediate_p[0] >> \
+                         etp_header_fun_env_size_offs) & 0xff) + 1)
+                    if ($etp_boxed_immediate_p[0] >> etp_header_fun_kind_offs)
+                      printf "#FunX<"
+                    else
+                      printf "#FunL<"
+                    end
                   else
+                    set $etp_boxed_immediate_arity = \
+                      ($etp_boxed_immediate_p[0] >> etp_header_arity_offs)
                     if ($etp_boxed_immediate_h == etp_bin_ref_subtag)
                       printf "#BinRef<"
                     else
@@ -442,8 +451,6 @@ define etp-boxed-immediate-1
                       end
                     end
                   end
-                  set $etp_boxed_immediate_arity = \
-                    ($etp_boxed_immediate_p[0] >> etp_header_arity_offs)
                   while $etp_boxed_immediate_arity > 0
                     set $etp_boxed_immediate_p++
                     if $etp_boxed_immediate_arity > 1


### PR DESCRIPTION
The Fun heap header word has evolved to not have just the size of the heap object in the arity field, but instead 3 different fields.  When this change was introduced, the ETP utility was not updated so it now prints Fun:s badly.

This is a fix for that...
