### PR TITLE
ssl: For TLS-1.2 cert signature must be compatible with cipher suite

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -1165,7 +1165,6 @@ dss_dhe_suites(Ciphers) ->
 %% Certs key is an ECC key
 ec_keyed_suites(Ciphers) ->
     filter_kex(Ciphers, fun (ecdh_ecdsa)  -> true;
-                            (ecdh_rsa)    -> true;
                             (ecdhe_ecdsa) -> true;
                             (_)           -> false
                         end).

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -3894,8 +3894,7 @@ cert_curve(_, _, no_suite) ->
     {no_curve, no_suite};
 cert_curve(Cert, ECCCurve0, CipherSuite) ->
     case ssl_cipher_format:suite_bin_to_map(CipherSuite) of
-        #{key_exchange := Kex} when Kex == ecdh_ecdsa; 
-                                    Kex == ecdh_rsa ->
+        #{key_exchange := Kex} when Kex == ecdh_ecdsa  ->
             OtpCert = public_key:pkix_decode_cert(Cert, otp),
             TBSCert = OtpCert#'OTPCertificate'.tbsCertificate,
             #'OTPSubjectPublicKeyInfo'{algorithm = AlgInfo} 


### PR DESCRIPTION
In TLS-1.3 this is negotiated separtly