### PR TITLE
[xmerl] XSD Validation fails for mixed content

### DIFF
--- a/lib/xmerl/src/xmerl_xsd.erl
+++ b/lib/xmerl/src/xmerl_xsd.erl
@@ -2620,6 +2620,9 @@ check_element_type(XML=[#xmlText{}|_],
     {ResolvedType,_} = resolve({simple_or_complex_Type,BT},S),
     check_element_type(XML,ResolvedType,Env,Block,S,Checked);
 
+check_element_type(_C, optional_text, _Env, _Block, S, _Checked) ->
+    {[], [], S};
+
 %% single schema object
 check_element_type(XML=[_H|_],
 		   #schema_complex_type{name=Name,block=Bl,content=C},
@@ -3055,12 +3058,16 @@ allow_empty_content([{extension,{_BT,_CM=[]}}]) ->
     true;
 allow_empty_content([{_,{_,{0,_}}}|Rest]) ->
     allow_empty_content(Rest);
+allow_empty_content([{any,{_,{0,_},_}}|Rest]) ->
+    allow_empty_content(Rest);
 allow_empty_content([{_,{Content,_}}|Rest]) ->
      case allow_empty_content(Content) of
 	 true ->
 	     allow_empty_content(Rest);
 	 _ -> false
      end;
+allow_empty_content([optional_text|Rest]) ->
+    allow_empty_content(Rest);
 allow_empty_content(_) ->
     false.
 
@@ -3913,6 +3920,8 @@ is_optional(G={group,_},S) ->
 	{#schema_group{content=[CM]},_} ->
 	    is_optional(CM,S)
     end;
+is_optional(optional_text,_) ->
+    true;
 is_optional(_,_) ->
     false.
 

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -309,7 +309,7 @@ export(Config) ->
     {ok, B} = file:read_file(TestFile),
     ok.
 
-export_cdata(Config) ->
+export_cdata(_Config) ->
     InData = <<"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
 <doc>
    <a>Test...</a>

--- a/lib/xmerl/test/xmerl_xsd_SUITE.erl
+++ b/lib/xmerl/test/xmerl_xsd_SUITE.erl
@@ -66,7 +66,7 @@ groups() ->
        sis2, state2file_file2state, union]},
      {ticket_tests, [],
       [ticket_6910, ticket_7165, ticket_7190, ticket_7288,
-       ticket_7736, ticket_8599, ticket_9410]},
+       ticket_7736, ticket_8599, ticket_9410, ticket_19792]},
      {facets, [],
       [length, minLength, maxLength, pattern, enumeration,
        whiteSpace, maxInclusive, maxExclusive, minExclusive,
@@ -969,6 +969,22 @@ ticket_8599(Config) ->
 ticket_9410(Config) ->
     file:set_cwd(datadir_join(Config,[".."])),
     {ok, _S} = xmerl_xsd:process_schema("xmerl_xsd_SUITE_data/small.xsd").
+
+
+ticket_19792(Config) ->
+    {ok, S} = xmerl_xsd:process_schema(datadir_join(Config,["ticket_19792.xsd"])),
+    {E0,_} = xmerl_scan:file(datadir_join(Config,["ticket_19792_0.xml"])),
+    {{xmlElement,file,file,_,_,_,_,_,_,_,_,_},_GlobalState1} = xmerl_xsd:validate(E0, S),
+    {E1,_} = xmerl_scan:file(datadir_join(Config,["ticket_19792_1.xml"])),
+    {{xmlElement,file,file,_,_,_,_,_,_,_,_,_},_GlobalState1} = xmerl_xsd:validate(E1, S),
+    {E2,_} = xmerl_scan:file(datadir_join(Config,["ticket_19792_2.xml"])),
+    {{xmlElement,file,file,_,_,_,_,_,_,_,_,_},_GlobalState2} = xmerl_xsd:validate(E2, S),
+    {E3,_} = xmerl_scan:file(datadir_join(Config,["ticket_19792_3.xml"])),
+    {{xmlElement,file,file,_,_,_,_,_,_,_,_,_},_GlobalState3} = xmerl_xsd:validate(E3, S),
+    {E4,_} = xmerl_scan:file(datadir_join(Config,["ticket_19792_4.xml"])),
+    {{xmlElement,file,file,_,_,_,_,_,_,_,_,_},_GlobalState4} = xmerl_xsd:validate(E4, S),
+    ok.
+
 
 %%======================================================================
 %% Support Functions

--- a/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792.xsd
+++ b/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <xs:element name="file">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="body"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="sequenceNumber" type="xs:unsignedShort"/>
+
+  <xs:element name="body">
+    <xs:complexType>
+      <xs:sequence>
+	<xs:element ref="sequenceNumber"/>
+	<xs:element ref="description"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="description">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+	<xs:any minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_0.xml
+++ b/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-->
+<file>
+  <body>
+    <sequenceNumber>100</sequenceNumber>
+    <description></description>
+  </body>
+</file>
+
+

--- a/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_1.xml
+++ b/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-->
+<file>
+  <body>
+    <sequenceNumber>100</sequenceNumber>
+    <description>teststring</description>
+  </body>
+</file>
+
+

--- a/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_2.xml
+++ b/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-->
+<file>
+  <body>
+    <sequenceNumber>100</sequenceNumber>
+    <description>teststring<sequenceNumber>100</sequenceNumber></description>
+  </body>
+</file>
+
+

--- a/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_3.xml
+++ b/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_3.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-->
+<file>
+  <body>
+    <sequenceNumber>100</sequenceNumber>
+    <description><sequenceNumber>100</sequenceNumber>teststring</description>
+  </body>
+</file>
+
+

--- a/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_4.xml
+++ b/lib/xmerl/test/xmerl_xsd_SUITE_data/ticket_19792_4.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+-->
+<file>
+  <body>
+    <sequenceNumber>100</sequenceNumber>
+    <description>teststring<sequenceNumber>100</sequenceNumber>teststring</description>
+  </body>
+</file>
+
+


### PR DESCRIPTION
The validation failed due to not handling the optional text blocks correctly in an XSD complex type with attribute mixed=true.