### PR TITLE
ssh: use new supervisor:stop/1 function for stopping system

### DIFF
--- a/lib/ssh/src/ssh_system_sup.erl
+++ b/lib/ssh/src/ssh_system_sup.erl
@@ -72,13 +72,12 @@ start_system(Address0, Options) ->
 
 %%%----------------------------------------------------------------
 stop_system(SysSup) when is_pid(SysSup) ->
-    case lists:keyfind(SysSup, 2, supervisor:which_children(sup(server))) of
-        {{?MODULE, Id}, SysSup, _, _} -> stop_system(Id);
-        false -> ok
-    end;
-stop_system(Id) ->
-    supervisor:terminate_child(sup(server), {?MODULE, Id}).
-
+    try
+        supervisor:stop(SysSup)
+    catch
+        exit:noproc ->
+            ok
+    end.
 
 %%%----------------------------------------------------------------
 stop_listener(SystemSup) when is_pid(SystemSup) ->

--- a/lib/ssh/test/ssh_connection_SUITE.erl
+++ b/lib/ssh/test/ssh_connection_SUITE.erl
@@ -1715,7 +1715,6 @@ stop_listener(Config) when is_list(Config) ->
 					      {user_dir, UserDir},
 					      {password, "morot"},
 					      {exec, fun ssh_exec_echo/1}]),
-
     ConnectionRef0 = ssh_test_lib:connect(Host, Port,
                                           [{silently_accept_hosts, true},
                                            {user, "foo"},
@@ -1763,8 +1762,9 @@ stop_listener(Config) when is_list(Config) ->
                                                   {user_dir, UserDir}]),
 	    ssh:close(ConnectionRef0),
 	    ssh:close(ConnectionRef1),
-	    ssh:stop_daemon(Pid0),
-	    ssh:stop_daemon(Pid1);
+            Pid0 = Pid1,
+	    ok = ssh:stop_daemon(Pid0),
+	    ok = ssh:stop_daemon(Pid1);
 	Error ->
 	    ssh:close(ConnectionRef0),
 	    ssh:stop_daemon(Pid0),


### PR DESCRIPTION
- catch noproc exception and return ok
- improve ssh_connection_SUITE:stop_listener test