### PR TITLE
fix: handle tokenizer error in config file

### DIFF
--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -558,7 +558,7 @@ init(Init, Kernel) ->
 	    ReasonStr =
 		lists:flatten(io_lib:format("error in config file "
 					    "~tp (~w): ~ts",
-					    [File, Line, Str])),
+					    [File, Line, to_string(Str)])),
 	    Init ! {ack, self(), {error, to_string(ReasonStr)}};
         {error, {file_descriptor, FDString, Line, Str}} ->
 	    ReasonStr =
@@ -2035,8 +2035,8 @@ scan_file(Str) ->
 		Error ->
 		    Error
 	    end;
-	{done, Result, _} ->
-	    {error, {none, parse_file, tuple_to_list(Result)}};
+	{done, {error, {Line, Module, Description}, _}, _} ->
+	    {error, {Line, parse_file, {Module, Description}}};
 	{more, _} ->
 	    {error, {none, load_file, "no ending <dot> found"}}
     end.


### PR DESCRIPTION
The problem was that tokenizer returned a tuple `{1, {erl_scan, {illegel, integer}}}` tuple which was converted to a list but `~ts` in `io_lib:format` required `unicode` and `string` modules.

Also, tokenizer error is now matched to embed line number correctly. I assume that tokenizer can't return `eof` when being run without continuation as first param so I didn't match that clause.

Error message you'll get for `sys.config` that contains `7k` is the following:

`Could not start kernel pid (application_controller) ("error in config file \"/tmp/sys.config\" (1): {erl_scan,{illegal,integer}}")`

I tried testing this in the `application_controller_SUITE` but with no success - I tried starting slave node and match on error message, but I only got `timeout`. Anyone got an idea on how to test this?

Submitting fix to `master` branch because it occurred after in OTP28.

Ping @eproxus 

Props to @richcarl for posting hints on what's going on.

Closes #10214 