### PR TITLE
optimize beam_trim

### DIFF
--- a/lib/compiler/src/beam_trim.erl
+++ b/lib/compiler/src/beam_trim.erl
@@ -24,7 +24,7 @@
 -moduledoc false.
 -export([module/2]).
 
--import(lists, [any/2,merge/1,reverse/2,seq/2,sort/1]).
+-import(lists, [any/2,merge/1,reverse/1,reverse/2,seq/2,sort/1]).
 
 -include("beam_asm.hrl").
 
@@ -151,18 +151,15 @@ construct_recipes(_, _, _, Acc) ->
     Acc.
 
 take_last_dead(L) ->
-    take_last_dead_1(L, []).
+    take_last_dead_1(reverse(L)).
 
-take_last_dead_1([{live,_}|T], Acc) ->
-    take_last_dead_1(T, Acc);
-take_last_dead_1([{kill,Reg}|T], Acc) ->
-    {Reg,reverse(T, Acc)};
-take_last_dead_1([{dead,Reg}|T], Acc) ->
-    {Reg,reverse(T, Acc)};
-take_last_dead_1([], _) ->
-    none;
-take_last_dead_1([H|T], Acc) ->
-    take_last_dead_1(T, [H|Acc]).
+take_last_dead_1([{live,_}|Is]) ->
+    take_last_dead_1(Is);
+take_last_dead_1([{kill,Reg}|Is]) ->
+    {Reg,reverse(Is)};
+take_last_dead_1([{dead,Reg}|Is]) ->
+    {Reg,reverse(Is)};
+take_last_dead_1(_) -> none.
 
 %% Is trimming too expensive?
 is_too_expensive({Ks,_,Moves}, NumOrigKills, IsTooExpensive) ->
@@ -209,7 +206,7 @@ is_recipe_viable({_,Trim,Moves}, UsedRegs) ->
     UsedEliminated = gb_sets:intersection(gb_sets:from_list(Eliminated), UsedRegs),
     case gb_sets:is_subset(UsedEliminated, Moved) andalso gb_sets:is_disjoint(Illegal, UsedRegs) of
         true ->
-            UsedEliminated = Moved,                        %Assertion.
+            true = gb_sets:is_equal(UsedEliminated, Moved),                        %Assertion.
             true;
         _ ->
             false


### PR DESCRIPTION
This PR optimize the beam_trim pass to avoid quadratic slowdown, it does so by leveraging the sets module and ignore the pass for small functions, the 50 value is currently arbitery and could be changed based on empiracal tests.

As this is my first time trying to contribute, please be kind has I have no idea what I'm doing and how this impact other parts of the compiler, but it seams to work on my project :)

From my own testing this shave of almost two seconds in my library and should be more for even bigger projects:

with changes:

```
mix compile  69.50s user 7.60s system 191% cpu 40.330 total
```

OTP 28.1

```
mix compile  72.18s user 7.74s system 194% cpu 41.047 total
```

master

```
mix compile  71.73s user 7.77s system 190% cpu 41.663 total
```