### PR TITLE
ssl: Avoid sending internal message to client

### DIFF
--- a/lib/ssl/src/ssl_trace.erl
+++ b/lib/ssl/src/ssl_trace.erl
@@ -491,7 +491,7 @@ trace_profiles() ->
       fun(M, F, A) -> dbg:ctpl(M, F, A) end,
       [{tls_gen_connection_1_3, [{handle_key_update, 2}]},
        {tls_sender, [{init, 3}, {time_to_rekey, 5},
-                     {send_post_handshake_data, 4}]},
+                     {send_post_handshake_data, 5}]},
        {tls_v1, [{update_traffic_secret, 2}]}]},
      {rle, %% role
       fun(M, F, A) -> dbg:tpl(M, F, A, x) end,


### PR DESCRIPTION
When key_update is initiated by the TLS sender process, and not by the peer, no internal ack is needed for post_handshake_data event to the reciver process. Previously an ack message was incorrectly sent to socket user process instead of just doing nothing when that happened.

closes #10273