### PR TITLE
kernel: prevent crash when calling io:getopts when user_drv is down

### DIFF
--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -800,9 +800,13 @@ getopts(Data) ->
                          true -> unicode;
                          _ -> latin1
                      end},
-    Terminal = get_terminal_state(Data#state.driver),
-    Tty = {terminal, maps:get(stdout, Terminal)},
-    [Exp,Echo,LineHistory,Log,Bin,Uni,Tty|maps:to_list(Terminal)].
+    case get_terminal_state(Data#state.driver) of
+        Terminal when is_map(Terminal) ->
+            Tty = {terminal, maps:get(stdout, Terminal)},
+            [Exp,Echo,LineHistory,Log,Bin,Uni,Tty|maps:to_list(Terminal)];
+        Error ->
+            Error
+    end.
 
 %% Convert error code to make it look as before
 err_func(io_lib, get_until, {_,F,_}) ->

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -397,8 +397,11 @@ get_command(Prompt, Eval, Bs, RT, FT, Ds) ->
     Parse =
         fun() ->
                 put('$ancestors', Ancestors),
-                PreviousHistory = proplists:get_value(line_history, io:getopts()),
-                [ok = io:setopts([{line_history, true}]) || PreviousHistory =/= undefined],
+                PreviousHistory = case io:getopts() of
+                        {error,_} -> undefined;
+                        Opts0 -> proplists:get_value(line_history, Opts0)
+                    end,
+                _ = [io:setopts([{line_history, true}]) || PreviousHistory =/= undefined],
                 Res = io:scan_erl_exprs(group_leader(), Prompt, {1,1},
                                         [text,{reserved_word_fun,ResWordFun}]),
                 _ = [io:setopts([{line_history, PreviousHistory}]) || PreviousHistory =/= undefined],


### PR DESCRIPTION
The shell would crash when the `io:getopts()` call got timeout when fetching state from the io process. 
 Before `io:scan_erl_exprs` would have returned `{error,terminated}` but as of introduction of explicit handling of when to save shell history, the failure is happening earlier. 
In this commit I add a check that makes `io:getopts()` able to return error in the case the driver process is not responding.
A check is also added on the shell side.