### PR TITLE
ssl: Correct gen_statem behaviour modules own alert handling

### DIFF
--- a/lib/ssl/src/tls_server_connection.erl
+++ b/lib/ssl/src/tls_server_connection.erl
@@ -300,7 +300,7 @@ wait_cert_verify(internal, #certificate_verify{signature = Signature,
 				  State#state{handshake_env = HsEnv,
                                               session = Session0#session{sign_alg = HashSign}});
 	#alert{} = Alert ->
-            throw(Alert)
+            ssl_gen_statem:handle_own_alert(Alert, ?STATE(wait_cert_verify), State)
     end;
 wait_cert_verify(Type, Event, State) ->
     ssl_gen_statem:handle_common_event(Type, Event, ?STATE(wait_cert_verify), State).


### PR DESCRIPTION
Own alerts shall be handled by the function
ssl_gen_statem:handle_own_alert  and not thrown as a local return in the behaviour modules. Alerts are only thrown from helper modules and caught by the main state machine behaviour module that will then call ssl_gen_statem:handle_own_alert.