### PR TITLE
[snmp] add deterministic option when available for asn

### DIFF
--- a/lib/snmp/src/misc/Makefile
+++ b/lib/snmp/src/misc/Makefile
@@ -98,6 +98,9 @@ ERL_COMPILE_FLAGS += -I../../include \
                      -I$(ERL_TOP)/lib/stdlib \
                      $(SNMP_FLAGS)
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+  ASN1_OPTS += +deterministic
+endif
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
Avoid build paths for snmp_pdus_basic.beam when deterministic is enabled.