### PR TITLE
Fix race condition in standard_error process registration

### DIFF
--- a/lib/kernel/src/standard_error.erl
+++ b/lib/kernel/src/standard_error.erl
@@ -62,12 +62,11 @@ init([]) ->
     end.
 
 start() ->
-    Id = spawn(fun server/0),
-    register(?NAME, Id),
-    Id.
+    spawn(fun server/0).
 
 server() ->
     process_flag(trap_exit, true),
+    register(?NAME, self()),
     ok = prim_tty:load(),
     TTY = prim_tty:init(#{ input => disabled,
                            output => cooked,


### PR DESCRIPTION
Fix a race condition where the standard_error process could call prim_tty:init/1 before being registered, causing a crash when prim_tty's writer and reader processes attempt to derive their own registered names from the parent process.

The issue was introduced in commit ead74245e1dc632b8f20ee795092de04d2510e36 (PR #9116), which changed prim_tty's reader and writer processes to dynamically derive their registered names from their parent process name (e.g., `standard_error` -> `standard_error_reader`, `standard_error_writer`). This was done to support multiple TTY instances (stdout and stderr) with distinct process names.

However, the `standard_error:start/0` function had a race condition:
1. `spawn(fun server/0)` - creates process, starts executing immediately
2. `register(?NAME, Id)` - parent registers the spawned process
3. `server()` calls `prim_tty:init()` - may execute before step 2

When `prim_tty:init/1` spawns writer/reader processes, they call `set_name(Parent, Postfix)` which does: `erlang:process_info(Parent, registered_name)`

If this executes before the parent completes registration, it returns [] instead of {registered_name, standard_error}, causing a pattern match failure: "no match of right hand side value: []" at prim_tty.erl:674.

The fix moves the `register/2` call into the spawned process itself, ensuring it completes before `prim_tty:init/1` is called. This eliminates the race condition entirely.

Closes #10174

---

For the record, this bug prevents the VM from starting altogether in a dockerised deployment at my workplace and we've had to stick to 27.x so far.