### PR TITLE
feat: "atomic" get_handler_configs

### DIFF
--- a/lib/kernel/src/logger_config.erl
+++ b/lib/kernel/src/logger_config.erl
@@ -25,7 +25,7 @@
 -export([new/1,delete/2,
          exist/2,
          allow/1,allow/2,
-         get/2, get/3,
+         get/1, get/2, get/3,
          create/3, set/3,
          set_module_level/2,unset_module_level/1,
          get_module_level/0,
@@ -89,6 +89,10 @@ exist(Tid,What) ->
 
 get_primary_level() ->
     persistent_term:get({?MODULE,?PRIMARY_KEY},?NOTICE).
+
+get(Tid) ->
+    Configs = ets:match(Tid, {{?HANDLER_KEY, '_'}, '$1'}),
+    lists:flatten(Configs).
 
 get(Tid,What) ->
     case ets:lookup(Tid,table_key(What)) of


### PR DESCRIPTION
I think the root issue is eliminated by matching on a ETS table instead of looking up repeatedly.

Testcase is a bit shady, but hope its good enough (any tips are more than welcome).

Closes #9997 

P.S. Something to note before review: in the issue, @jhogberg mentioned that previous behavior might not be unexpected, but I can't think of a reason where one would want this to fail.