### PR TITLE
Minor fix in the documentation of documentation

### DIFF
--- a/system/doc/reference_manual/documentation.md
+++ b/system/doc/reference_manual/documentation.md
@@ -256,10 +256,10 @@ For types or callbacks, the signature is derived from the type or callback
 specification. For example:
 
 ```erlang
--type number(Value) :: {number, Value}.
+-type number(Value) :: {arith, Value}.
 %% signature will be `number(Value)`
 
--opaque number() :: {number, number()}.
+-opaque number() :: {arith, number()}.
 %% signature will be `number()`
 
 -callback increment(In :: number()) -> Out.


### PR DESCRIPTION
The `-opaque number()` type is defined as `{arith, erlang:number()}` on [line 186](https://github.com/erlang/otp/blob/a87183f1eb847119b6ecc83054bf13c26b8ccfaa/system/doc/reference_manual/documentation.md?plain=1#L186), but several code examples in the file used `{number, ...}` instead of `{arith, ...}`.

This PR updates all examples to use `{arith, ...}` to match the type specification.