### PR TITLE
erts: cwd should not be in the path

### DIFF
--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -1160,7 +1160,7 @@ sleep(T) -> receive after T -> ok end.
 
 start_prim_loader(Init, Path0, {Pa,Pz}) ->
     Path = case Path0 of
-	       false -> Pa ++ ["."|Pz];
+	       false -> Pa ++ Pz;
 	       _ -> Path0
 	   end,
     case erl_prim_loader:start() of

--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -107,7 +107,7 @@ init(Ref, Parent, [Root,Mode]) ->
 		{ok,Dirs} = erl_prim_loader:list_dir(LibDir),
 		Paths = make_path(LibDir, Dirs),
 		UserLibPaths = get_user_lib_dirs(),
-		["."] ++ UserLibPaths ++ Paths;
+		UserLibPaths ++ Paths;
 	    _ ->
 		[]
 	end,

--- a/system/doc/general_info/upcoming_incompatibilities.md
+++ b/system/doc/general_info/upcoming_incompatibilities.md
@@ -267,3 +267,8 @@ occurrences of `maybe` without quotes.
 
 As of OTP 29, the `cprof` and `eprof` will be removed in favor of `m:tprof`
 added in OTP 27.
+
+### CWD or '.' is no longer in the path
+
+As of OTP 29, the CWD is no longer added to the path. It can be added with
+-pa '.' or -pz '.' if needed.


### PR DESCRIPTION
Having '.' in the path implicitly is a security risk and can produce confusing behavior.
Instead, add it explicitly using -pa or -pz.