### PR TITLE
Fix user-defined function support when using the restricted shell.

### DIFF
--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -1159,7 +1159,7 @@ not_restricted(exit, []) ->
     true;
 not_restricted(fl, []) ->
     true;
-not_restricted(fd, [_,_]) ->
+not_restricted(fd, [_,_,_]) ->
     true;
 not_restricted(ft, [_]) ->
     true;


### PR DESCRIPTION
The local function defined in `shell.erl` is `fd/3`, not `fd/2`.

This enables user-defined functions in a restricted shell.

Without this patch, the current user experience looks like this:

```erl
1> foo() -> 1.
** exception error: undefined shell command fd/3
2> foo().
** exception error: undefined shell command foo/0
```

After the patch:

```erl
1> foo() -> 1.
ok
2> foo().
1
```