### PR TITLE
Fix `snmp:config()` when run from Elixir

### DIFF
--- a/lib/snmp/src/misc/snmp_config.erl
+++ b/lib/snmp/src/misc/snmp_config.erl
@@ -1678,7 +1678,7 @@ print_q(Q, Default) when is_list(Default) ->
 %% Defval = string() | mandatory
 ask(Q, Default, Verify) when is_list(Q) andalso is_function(Verify) ->
     print_q(Q, Default),
-    PrelAnsw = io:get_line(''),
+    PrelAnsw = conv_bin_to_list(io:get_line('')),
     Answer = 
 	case remove_newline(PrelAnsw) of
 	    "" when Default =/= mandatory -> Default;
@@ -1741,7 +1741,12 @@ guess_engine_name() ->
 % 	{_,_} -> "user_id"
 %     end.
 
-    
+% This is neccessary as in Elixir io:get_line returns a binary
+conv_bin_to_list(Bin) when is_binary(Bin) ->
+	binary:bin_to_list(Bin);
+conv_bin_to_list(Str) ->
+	Str.
+
 remove_newline(Str) -> 
     lists:delete($\n, Str).
 


### PR DESCRIPTION
A device read in Elixir returns a binary, not a char list (as in Erlang).

Quoting Jose Valim: "Any device may return a binary on read, therefore, all Erlang/Elixir code needs to be aware of this possibility and handle it accordingly."

See: https://github.com/elixir-lang/elixir/issues/14757

How to reproduce the bug:

```
~ % iex
Erlang/OTP 28 [erts-16.0.2] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit:ns]

Interactive Elixir (1.18.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> :snmp.config()

Simple SNMP configuration tool (version 5.19)
------------------------------------------------
Note: Non-trivial configurations still has to be
      done manually. IP addresses may be entered
      as dront.ericsson.se (UNIX only) or
      123.12.13.23
------------------------------------------------

y
{:error,
 {:function_clause,
  [
    {:lists, :delete, [10, "y\n"], [file: ~c"lists.erl", line: 725]},
    {:snmp_config, :ask, 3, [file: ~c"snmp_config.erl", line: 1683]},
    {:snmp_config, :snmp_agent2, 0, [file: ~c"snmp_config.erl", line: 173]},
    {:snmp_config, :config_agent, 0, [file: ~c"snmp_config.erl", line: 159]},
    {:snmp_config, :config2, 0, [file: ~c"snmp_config.erl", line: 130]},
    {:snmp_config, :config, 0, [file: ~c"snmp_config.erl", line: 117]},
    {:elixir, :eval_external_handler, 3, [file: ~c"src/elixir.erl", line: 386]},
    {:erl_eval, :do_apply, 7, [file: ~c"erl_eval.erl", line: 924]}
  ]}}
```