### PR TITLE
`global`: use priority monitors

### DIFF
--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -2108,7 +2108,7 @@ can_set_lock({ResourceId, LockRequesterId}) ->
     end.
 
 insert_lock({ResourceId, LockRequesterId}=Id, Pid, PidRefs, S) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = erlang:monitor(process, Pid, [priority]),
     save_node_resource_info(node(Pid), Ref),
     true = ets:insert(global_pid_ids, {Pid, ResourceId}),
     true = ets:insert(global_pid_ids, {Ref, ResourceId}),
@@ -2226,7 +2226,7 @@ sync_other(Node, N) ->
     % exit(normal).
 
 insert_global_name(Name, Pid, Method, FromPidOrNode, ExtraInfo, S) ->
-    Ref = erlang:monitor(process, Pid),
+    Ref = erlang:monitor(process, Pid, [priority]),
     save_node_resource_info(node(Pid), Ref),
     true = ets:insert(global_names, {Name, Pid, Method, Ref}),
     true = ets:insert(global_pid_names, {Pid, Name}),


### PR DESCRIPTION
OTP 28 introduced priority messages and prioritization of monitor messages. I think the `global` module is a good place to use them, in order to reduce (albeit not _eliminate_) the rejection of registrations when a registered process has just died but the resulting `'DOWN'` message has not yet been processed by `global`.