### PR TITLE
erts: Fix use-before-initialization bug, and related errors

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -64,6 +64,8 @@ struct BeamAssembler : public BeamAssemblerCommon {
     BeamAssembler() : BeamAssemblerCommon(a) {
         Error err = code.attach(&a);
         ERTS_ASSERT(!err && "Failed to attach codeHolder");
+
+        lateInit();
     }
 
     BeamAssembler(const std::string &log) : BeamAssembler() {

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -55,12 +55,15 @@ BeamAssemblerCommon::BeamAssemblerCommon(BaseAssembler &assembler_)
                           8);
     ERTS_ASSERT(!err && "Failed to create .rodata section");
 
+    code.setErrorHandler(this);
+}
+
+void BeamAssemblerCommon::lateInit() {
 #ifdef DEBUG
     assembler.addDiagnosticOptions(DiagnosticOptions::kValidateAssembler);
 #endif
     assembler.addEncodingOptions(EncodingOptions::kOptimizeForSize |
                                  EncodingOptions::kOptimizedAlign);
-    code.setErrorHandler(this);
 }
 
 BeamAssemblerCommon::~BeamAssemblerCommon() {

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -85,6 +85,8 @@ protected:
     BeamAssemblerCommon(BaseAssembler &assembler);
     ~BeamAssemblerCommon();
 
+    void lateInit();
+
     void codegen(JitAllocator *allocator,
                  const void **executable_ptr,
                  void **writable_ptr);

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -57,6 +57,8 @@ struct BeamAssembler : public BeamAssemblerCommon {
     BeamAssembler() : BeamAssemblerCommon(a) {
         Error err = code.attach(&a);
         ERTS_ASSERT(!err && "Failed to attach codeHolder");
+
+        lateInit();
     }
 
     BeamAssembler(const std::string &log) : BeamAssembler() {

--- a/erts/emulator/beam/jit/x86/instr_arith.cpp
+++ b/erts/emulator/beam/jit/x86/instr_arith.cpp
@@ -1063,13 +1063,13 @@ void BeamModuleAssembler::emit_i_mul_add(const ArgLabel &Fail,
             p = ptr(RET, RET, 1, increment);
             break;
         case 4:
-            p = ptr(x86::Gp(), RET, 2, increment);
+            p = ptr_abs(increment, RET, 2);
             break;
         case 5:
             p = ptr(RET, RET, 2, increment);
             break;
         case 8:
-            p = ptr(x86::Gp(), RET, 3, increment);
+            p = ptr_abs(increment, RET, 3);
             break;
         case 9:
             p = ptr(RET, RET, 3, increment);

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -1203,7 +1203,7 @@ void BeamModuleAssembler::emit_is_binary(const ArgLabel &Fail,
                 a.mov(RET,
                       emit_boxed_val(boxed_ptr, offsetof(ErlHeapBits, size)));
 
-                a.mov(ARG2d, emit_boxed_val(boxed_ptr));
+                a.mov(ARG2d, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
                 a.cmp(ARG2d, imm(HEADER_SUB_BITS));
                 a.short_().jne(not_sub_bits);
                 {
@@ -1862,7 +1862,7 @@ void BeamModuleAssembler::emit_is_eq_exact(const ArgLabel &Fail,
                 a.cmp(emit_boxed_val(boxed_ptr), imm(HEADER_SUB_BITS));
             } else {
                 a.mov(RETd, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
-                a.cmp(RETb, imm(HEADER_SUB_BITS));
+                a.cmp(RETd, imm(HEADER_SUB_BITS));
             }
             a.short_().jne(not_sub_bits);
 
@@ -2021,7 +2021,7 @@ void BeamModuleAssembler::emit_is_ne_exact(const ArgLabel &Fail,
                 a.cmp(emit_boxed_val(boxed_ptr), imm(HEADER_SUB_BITS));
             } else {
                 a.mov(RETd, emit_boxed_val(boxed_ptr, 0, sizeof(Uint32)));
-                a.cmp(RETb, imm(HEADER_SUB_BITS));
+                a.cmp(RETd, imm(HEADER_SUB_BITS));
             }
             a.short_().jne(not_sub_bits);
 


### PR DESCRIPTION
Fixes a bug reported by https://pvs-studio.com/en/blog/posts/cpp/1305/, which turns out to have hidden two other bugs.