### PR TITLE
erts: fix tcp_send_error econnaborted for win32

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -13522,7 +13522,7 @@ static int tcp_send_error(tcp_descriptor* desc, int err)
      * show_econnreset socket option enabled to receive {error, econnreset} on
      * both send and recv operations to indicate that an RST has been received.
      */
-#ifdef __WIN_32__
+#ifdef __WIN32__
     if (err == ECONNABORTED)
 	err = ECONNRESET;
 #endif


### PR DESCRIPTION
```
otp$ fgrep -r __WIN_32__ . | wc -l
1
otp$ fgrep -r __WIN32__ . | wc -l
896
```
found with pvs studio, see https://pvs-studio.ru/ru/blog/posts/cpp/1305/