### PR TITLE
ERIERL-1251 warning on doc build

### DIFF
--- a/system/doc/top/Makefile
+++ b/system/doc/top/Makefile
@@ -28,7 +28,10 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # ----------------------------------------------------
 APPLICATION=Erlang/OTP
 VSN=$(shell cat $(ERL_TOP)/OTP_VERSION)
-SKIP_APPLICATIONS=$(shell cat $(ERL_TOP)/lib/SKIP-APPLICATIONS)
+
+SKIP_FILE := $(wildcard $(ERL_TOP)/lib/SKIP-APPLICATIONS)
+SKIP_APPLICATIONS := $(if $(SKIP_FILE),$(shell cat $(SKIP_FILE)),)
+
 APP_DIR=../../../lib/erl_interface
 INDEX_DIR=.
 HTMLDIR=../../../doc


### PR DESCRIPTION
Fixes additional problem found with the ticket
The ticket reporter confirmed that `make docs` work as they want

1. The applications, skipped by `configure` are written into `lib/SKIP-APPLICATIONS`.
2. The `make docs` scripts read it and use words as skip list for docs building.
3. The missing apps links in doc side bar menu are pointing to placeholder pages which now contain a line explaining that the app was skipped.
4. If all applications are built correctly and SKIP-APPLICATIONS does not exist, the warning is now not displayed, and the file contents is assumed to be an empty list