### PR TITLE
stdlib: Fix mistake in zstd docs

### DIFF
--- a/lib/stdlib/src/zstd.erl
+++ b/lib/stdlib/src/zstd.erl
@@ -644,7 +644,7 @@ decompress(Data) ->
 -doc """
 decompress(Data, CtxOrOptions)
 
-Decompress `Data` using the given `t:compress_parameters/0` or the `t:context/0`.
+Decompress `Data` using the given `t:decompress_parameters/0` or the `t:context/0`.
 
 Example:
 


### PR DESCRIPTION
Fix a mistake that briefly confused me, since I thought the same parameters were used for compression and decompression.