### PR TITLE
 ERIERL-1251 Skip building docs for skipped applications

### DIFF
--- a/system/doc/top/Makefile
+++ b/system/doc/top/Makefile
@@ -28,6 +28,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # ----------------------------------------------------
 APPLICATION=Erlang/OTP
 VSN=$(shell cat $(ERL_TOP)/OTP_VERSION)
+SKIP_APPLICATIONS=$(shell cat $(ERL_TOP)/lib/SKIP-APPLICATIONS)
 APP_DIR=../../../lib/erl_interface
 INDEX_DIR=.
 HTMLDIR=../../../doc
@@ -44,13 +45,13 @@ DOCUMENTATION=edoc
 SYSTEM:=$(shell awk -F: '{print $$1}' ../guides)
 
 REDIRECTS=$(foreach guide,$(SYSTEM),system/$(guide).md) \
-	$(foreach app,$(CORE),core/$(app).md) \
-	$(foreach app,$(DATABASE),database/$(app).md) \
-	$(foreach app,$(OAM),oam/$(app).md) \
-	$(foreach app,$(INTERFACES),interfaces/$(app).md) \
-	$(foreach app,$(TOOLS),tools/$(app).md) \
-	$(foreach app,$(TESTING),testing/$(app).md) \
-	$(foreach app,$(DOCUMENTATION),documentation/$(app).md)
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(CORE)),          core/$(app).md) \
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(DATABASE)),      database/$(app).md) \
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(OAM)),           oam/$(app).md) \
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(INTERFACES)),    interfaces/$(app).md) \
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(TOOLS)),         tools/$(app).md) \
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(TESTING)),       testing/$(app).md) \
+	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(DOCUMENTATION)), documentation/$(app).md)
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
Fixes additional problem found with the delivered solution for ERIERL-1251
The ticket reporter confirmed that `make docs` works as they want

1. The applications, skipped by `configure` are written into `lib/SKIP-APPLICATIONS`.
2. The `make docs` scripts read it and use words as skip list for docs building.
3. The missing apps links in doc side bar menu are pointing to placeholder pages which now contain a line explaining that the app was skipped.
4. If all applications are built correctly and SKIP-APPLICATIONS does not exist, the warning is now not displayed, and the file contents is assumed to be an empty list