### PR TITLE
kernel: gen_sctp: document the {sctp_error, ...} message

### DIFF
--- a/lib/kernel/src/gen_sctp.erl
+++ b/lib/kernel/src/gen_sctp.erl
@@ -613,6 +613,11 @@ client_loop(S, Peer1, Port1, AssocId1, Peer2, Port2, AssocId2) ->
             client_loop(S, Peer1, Port1, AssocId1,
                         Peer2, Port2, AssocId2);
 
+        {sctp_error, S, _Peer, _Port, {_Anc, Error}} ->
+            io:format("SCTP error: ~p~n", [Error]),
+            client_loop(S, Peer1, Port1, AssocId1,
+                        Peer2, Port2, AssocId2);
+
         Other ->
             io:format("Other ~p~n", [Other]),
             client_loop(S, Peer1, Port1, AssocId1,
@@ -816,6 +821,14 @@ received data is delivered to the controlling process as messages:
 
 ```erlang
 {sctp, Socket, FromIP, FromPort, {AncData, Data}}
+```
+
+Error-related events - such as `#sctp_send_failed{}`, `#sctp_pdapi_event{}`,
+and `#sctp_remote_error{}` - are also delivered to the controlling process
+as messages, but use a different tuple tag:
+
+```erlang
+{sctp_error, Socket, FromIP, FromPort, {AncData, Data}}
 ```
 
 See [`recv/1,2`](`recv/1`) for a description of the message fields.


### PR DESCRIPTION
The `{sctp_error, ...}` message is not documented, but it does exist. The logic that generates both `{sctp, ...}` and `{sctp_error, ...}` messages resides in inet_drv.c, specifically in `packet_binary_message()` and `sctp_parse_async_event()`. Within `sctp_parse_async_event()`, an error is indicated by replacing the initial `sctp` atom with `sctp_error`.

The following SCTP events are currently reported as errors:

* `SCTP_SEND_FAILED` (becomes `#sctp_send_failed{}`),
* `SCTP_REMOTE_ERROR` (becomes `#sctp_remote_error{}`),
* `SCTP_PARTIAL_DELIVERY_EVENT` (becomes `#sctp_pdapi_event{}`).

Document this and update the example code to print errors.
