### PR TITLE
Correct `gen_tcp:accept/2` docs

### DIFF
--- a/lib/kernel/src/gen_tcp.erl
+++ b/lib/kernel/src/gen_tcp.erl
@@ -741,7 +741,7 @@ accept(S) when is_port(S) ->
 -doc """
 Accept an incoming connection request on a listen socket.
 
-`Socket` must be a socket returned from `listen/2`. `Timeout` specifies
+`ListenSocket` must be a socket returned from `listen/2`. `Timeout` specifies
 a time-out value in milliseconds. Defaults to `infinity`.
 
 Returns:


### PR DESCRIPTION
Fixes #10403.

@IngelaAndin on a side note, looking at the `gen_tcp` docs in general, I think they have somewhat aged and could use a little dusting-off :sweat_smile: