### PR TITLE
Fixes misplaced comma and restores doc apps index

### DIFF
--- a/system/doc/top/Makefile
+++ b/system/doc/top/Makefile
@@ -28,7 +28,8 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # ----------------------------------------------------
 APPLICATION=Erlang/OTP
 VSN=$(shell cat $(ERL_TOP)/OTP_VERSION)
-SKIP_APPLICATIONS=$(shell cat $(ERL_TOP)/lib/SKIP-APPLICATIONS)
+SKIP_FILE := $(wildcard $(ERL_TOP)/lib/SKIP_APPLICATIONS)
+SKIP_APPLICATIONS=$(if $(SKIP_FILE),$(shell cat $(ERL_TOP)/lib/SKIP-APPLICATIONS),)
 APP_DIR=../../../lib/erl_interface
 INDEX_DIR=.
 HTMLDIR=../../../doc
@@ -45,13 +46,13 @@ DOCUMENTATION=edoc
 SYSTEM:=$(shell awk -F: '{print $$1}' ../guides)
 
 REDIRECTS=$(foreach guide,$(SYSTEM),system/$(guide).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(CORE)),          core/$(app).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(DATABASE)),      database/$(app).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(OAM)),           oam/$(app).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(INTERFACES)),    interfaces/$(app).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(TOOLS)),         tools/$(app).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(TESTING)),       testing/$(app).md) \
-	$(foreach app, $(filter-out,$(SKIP_APPLICATIONS),$(DOCUMENTATION)), documentation/$(app).md)
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(CORE)),          core/$(app).md) \
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(DATABASE)),      database/$(app).md) \
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(OAM)),           oam/$(app).md) \
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(INTERFACES)),    interfaces/$(app).md) \
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(TOOLS)),         tools/$(app).md) \
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(TESTING)),       testing/$(app).md) \
+	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(DOCUMENTATION)), documentation/$(app).md)
 
 # ----------------------------------------------------
 # Targets


### PR DESCRIPTION
## Problem

* A small change was missing in the delivered branch (eliminates Makefile warnings, not critical for the build)
* The sidebar does not contain all apps.

## Expected

Sidebar in the generated docs shows all apps

## Solution

* The missing change was re-applied
* The extra comma was removed