### PR TITLE
erlang: Add int/1 and uint/1 as built-in types

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -136,6 +136,20 @@ An unique identifier for some entity, for example a
 -doc "An Erlang [integer](`e:system:data_types.md#number`).".
 -type integer() :: integer().
 -doc """
+An Erlang [integer](`e:system:data_types.md#number`) with the range of a signed
+two's complement integer of width `N`.
+
+This is equivalent to `-1 bsl (N - 1) .. (1 bsl (N - 1)) - 1`
+""".
+-type int(N) :: int(N).
+-doc """
+An Erlang [integer](`e:system:data_types.md#number`) with the range of an
+unsigned two's complement integer of width `N`.
+
+This is equivalent to `0 .. (1 bsl N) - 1`
+""".
+-type uint(N) :: uint(N).
+-doc """
 A binary or list containing bytes and/or iodata.
 
 This datatype is used to represent data that is meant to be output using
@@ -255,7 +269,8 @@ A timeout value that can be passed to a
               nonempty_list/0, nonempty_list/1, nonempty_maybe_improper_list/0,
               nonempty_maybe_improper_list/2, nonempty_string/0, number/0, pid/0,
               port/0, pos_integer/0, reference/0, string/0, term/0, timeout/0,
-              tuple/0]).
+              tuple/0,
+              int/1, uint/1]).
 
 %% Datatypes that need an erlang: prefix
 -export_type([timestamp/0]).

--- a/lib/dialyzer/src/erl_types.erl
+++ b/lib/dialyzer/src/erl_types.erl
@@ -4133,6 +4133,20 @@ from_form({type, _Anno, identifier, []}, _S, _D, L, C) ->
   {t_identifier(), L, C};
 from_form({type, _Anno, integer, []}, _S, _D, L, C) ->
   {t_integer(), L, C};
+from_form({type, _Anno, int, [Width0]}, S, D, L0, C0) ->
+  {Width, L, C} = from_form(Width0, S, D, L0, C0),
+  case t_inf(Width, t_non_neg_integer()) of
+    ?int_range(_From, To) when is_integer(To) ->
+      Span = 1 bsl (To - 1),
+      {t_from_range(-Span, Span - 1), L, C};
+    ?int_set(Set) ->
+      Span = 1 bsl (set_max(Set) - 1),
+      {t_from_range(-Span, Span - 1), L, C};
+    ?integer(_) ->
+      {t_integer(), L, C};
+    ?none ->
+      {t_none(), L, C}
+  end;
 from_form({type, _Anno, iodata, []}, _S, _D, L, C) ->
   {t_iodata(), L, C};
 from_form({type, _Anno, iolist, []}, _S, _D, L, C) ->
@@ -4248,6 +4262,20 @@ from_form({type, _Anno, tuple, Args}, S, D, L, C) ->
 from_form({type, _Anno, union, Args}, S, D, L, C) ->
   {Lst, L1, C1} = list_from_form(Args, S, D, L, C),
   {t_sup(Lst), L1, C1};
+from_form({type, _Anno, uint, [Width0]}, S, D, L0, C0) ->
+  {Width, L, C} = from_form(Width0, S, D, L0, C0),
+  case t_inf(Width, t_non_neg_integer()) of
+    ?int_range(_From, To) when is_integer(To) ->
+      Span = 1 bsl To,
+      {t_from_range(0, Span - 1), L, C};
+    ?int_set(Set) ->
+      Span = 1 bsl set_max(Set),
+      {t_from_range(0, Span - 1), L, C};
+    ?integer(_) ->
+      {t_integer(), L, C};
+    ?none ->
+      {t_none(), L, C}
+  end;
 from_form({user_type, _Anno, Name, Args}, S, D, L, C) ->
   type_from_form(Name, Args, S, D, L, C).
 

--- a/lib/stdlib/src/erl_internal.erl
+++ b/lib/stdlib/src/erl_internal.erl
@@ -476,6 +476,7 @@ is_type(float, 0) -> true;
 is_type(function, 0) -> true;
 is_type(identifier, 0) -> true;
 is_type(integer, 0) -> true;
+is_type(int, 1) -> true;
 is_type(iodata, 0) -> true;
 is_type(iolist, 0) -> true;
 is_type(list, 0) -> true;
@@ -508,6 +509,7 @@ is_type(string, 0) -> true;
 is_type(term, 0) -> true;
 is_type(timeout, 0) -> true;
 is_type(tuple, 0) -> true;
+is_type(uint, 1) -> true;
 is_type(_, _) -> false.
 
 %%%

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3415,6 +3415,8 @@ check_type_2({remote_type, A, [{atom, _, Mod}, {atom, _, Name}, Args]},
 			end, {SeenVars, St}, Args)
     end;
 check_type_2({integer, _A, _}, SeenVars, St) -> {SeenVars, St};
+check_type_2({type, A, int, [Width]}, SeenVars, St) ->
+    check_int_type(A, Width, SeenVars, St);
 check_type_2({atom, _A, _}, SeenVars, St) -> {SeenVars, St};
 check_type_2({var, _A, '_'}, SeenVars, St) -> {SeenVars, St};
 check_type_2({var, A, Name}, SeenVars, St) ->
@@ -3497,6 +3499,8 @@ check_type_2({type, _A, union, Args}=_F, SeenVars0, St) ->
                                         end, AccSeenVars0, SeenVars1),
                         {AccSeenVars, St0}
                 end, {SeenVars0, St}, Args);
+check_type_2({type, A, uint, [Width]}, SeenVars, St) ->
+    check_int_type(A, Width, SeenVars, St);
 check_type_2({type, Anno, TypeName, Args}, SeenVars, St) ->
     #lint{module = Module, types=Types} = St,
     Arity = length(Args),
@@ -3537,6 +3541,26 @@ check_type_2(I, SeenVars, St) ->
         {integer,_A,_Integer} -> {SeenVars, St};
         _Other ->
             {SeenVars, add_error(element(2, I), {type_syntax, integer}, St)}
+    end.
+
+check_int_type(A, Width, SeenVars0, St) ->
+    case erl_eval:partial_eval(Width) of
+        {integer, _, X} when X >= 1, X < (1 bsl 20) ->
+            {SeenVars0, St};
+        {var, _Anno, Name} ->
+            SeenVars = case maps:find(Name, SeenVars0) of
+                           {ok, {seen_once, _}} ->
+                               maps:put(Name, seen_multiple, SeenVars0);
+                           {ok, {seen_once_union, _}} ->
+                               maps:put(Name, seen_multiple, SeenVars0);
+                           {ok, seen_multiple} ->
+                               SeenVars0;
+                           error ->
+                               maps:put(Name, {seen_once, A}, SeenVars0)
+                       end,
+            {SeenVars, St};
+        _ ->
+            {SeenVars0, add_error(A, {type_syntax, integer}, St)}
     end.
 
 check_record_types(Anno, Name, Fields, SeenVars, St) ->


### PR DESCRIPTION
This PR adds convenience types for expressing integers of a certain width and signedness, letting us remove ad-hoc definitions in various places.