### PR TITLE
Fix json:decode_continue/2 spec

### DIFF
--- a/lib/stdlib/src/json.erl
+++ b/lib/stdlib/src/json.erl
@@ -981,7 +981,7 @@ there is no more data, use `end_of_input` instead of a binary.
 ```
 """.
 -doc(#{since => <<"OTP 27.0">>}).
--spec decode_continue(binary() | end_of_input, Opaque::term()) ->
+-spec decode_continue(binary() | end_of_input, State :: continuation_state()) ->
           {Result :: dynamic(), Acc :: dynamic(), binary()} | {continue, continuation_state()}.
 decode_continue(end_of_input, State) ->
     case State of


### PR DESCRIPTION
Fix following error when running dialyzer:
```
The call json:decode_continue
         (Buf :: 'end_of_input' | bitstring(),
          Continue :: json:continuation_state()) contains an opaque term as 2nd argument when terms of different types are expected in these positions
```