### PR TITLE
Remove duplicate module in public_key.app.src

### DIFF
--- a/lib/public_key/src/public_key.app.src
+++ b/lib/public_key/src/public_key.app.src
@@ -21,7 +21,6 @@
               'OCSP-2024-08',
               'OTP-PKIX',
               'OTP-PKIX-Relaxed',
-              'X509-ML-DSA-2025',
               'PKCS-1',
               'PKCS-10',
               'PKCS-3',


### PR DESCRIPTION
Module was listed twice, preventing other applications like `systool` from working correctly.

Issue introduced in https://github.com/erlang/otp/commit/6db81aacec54a014a5487d4a97eaaade06c73545#diff-e8e792502f5896330ea5efdc71afe31f797801154bd8d493461a27619e0505e6