### PR TITLE
ssh: modernize FIPS mode handling in tests

### DIFF
--- a/lib/ssh/test/Makefile
+++ b/lib/ssh/test/Makefile
@@ -29,6 +29,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 
 MODULES= \
 	cth_events \
+	cth_fips \
 	ssh_cth \
 	ssh_algorithms_SUITE \
 	ssh_options_SUITE \

--- a/lib/ssh/test/cth_fips.erl
+++ b/lib/ssh/test/cth_fips.erl
@@ -1,0 +1,35 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025-2025. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(cth_fips).
+-moduledoc false.
+
+-export([id/1, init/2]).
+
+-behaviour(ct_hooks).
+
+id(_Opts) ->
+    ?MODULE.
+
+init(?MODULE, _Opts) ->
+    application:set_env(crypto, fips_mode, true),
+    {ok, undefined}.

--- a/lib/ssh/test/ssh_agent_SUITE.erl
+++ b/lib/ssh/test/ssh_agent_SUITE.erl
@@ -48,7 +48,7 @@
 %% Test configuration
 
 suite() ->
-    [{timetrap, {seconds, 30}}].
+    [{ct_hooks,[cth_fips]}, {timetrap, {seconds, 30}}].
 
 all() ->
     [request_identities, sign_request, connect_with_ssh_agent].

--- a/lib/ssh/test/ssh_algorithms_SUITE.erl
+++ b/lib/ssh/test/ssh_algorithms_SUITE.erl
@@ -58,7 +58,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,120}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_basic_SUITE.erl
+++ b/lib/ssh/test/ssh_basic_SUITE.erl
@@ -109,7 +109,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth,
+    [{ct_hooks,[ts_install_cth, cth_fips,
                 {cth_events,
                  [{verify_fun, fun verify_events/2}]}]},
      {timetrap,{seconds,90}}].

--- a/lib/ssh/test/ssh_bench_SUITE.erl
+++ b/lib/ssh/test/ssh_bench_SUITE.erl
@@ -49,7 +49,7 @@
 %%% Suite declarations
 %%% 
 
-suite() -> [{ct_hooks,[{ts_install_cth,[{nodenames,2}]}]},
+suite() -> [{ct_hooks,[{ts_install_cth,[{nodenames,2}]}, cth_fips]},
 	    {timetrap,{minutes,1}}
 	   ].
 all() -> [connect,

--- a/lib/ssh/test/ssh_chan_behaviours_SUITE.erl
+++ b/lib/ssh/test/ssh_chan_behaviours_SUITE.erl
@@ -49,7 +49,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,60}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_collect_labmachine_info_SUITE.erl
+++ b/lib/ssh/test/ssh_collect_labmachine_info_SUITE.erl
@@ -59,7 +59,7 @@ save_ssh_data(Host, Data, Config0) ->
 %% Common Test interface functions -----------------------------------
 %%--------------------------------------------------------------------
 
-suite() -> [{timetrap,{seconds,40}}].
+suite() -> [{ct_hooks,[cth_fips]}, {timetrap,{seconds,40}}].
 
 all() -> [ssh_info_lib].
 

--- a/lib/ssh/test/ssh_compat_SUITE.erl
+++ b/lib/ssh/test/ssh_compat_SUITE.erl
@@ -61,7 +61,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{timetrap,{seconds,90}}].
+    [{ct_hooks,[cth_fips]}, {timetrap,{seconds,90}}].
 
 all() ->
 %%    [check_docker_present] ++

--- a/lib/ssh/test/ssh_connection_SUITE.erl
+++ b/lib/ssh/test/ssh_connection_SUITE.erl
@@ -121,11 +121,9 @@
 %% Common Test interface functions -----------------------------------
 %%--------------------------------------------------------------------
 
-%% suite() ->
-%%     [{ct_hooks,[ts_install_cth]}].
-
 suite() ->
     [{ct_hooks,[ts_install_cth,
+                cth_fips,
                 {cth_events,
                  [{verify_fun, fun verify_events/2}]}]},
      {timetrap,{seconds,40}}].

--- a/lib/ssh/test/ssh_dbg_SUITE.erl
+++ b/lib/ssh/test/ssh_dbg_SUITE.erl
@@ -57,7 +57,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,60}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_engine_SUITE.erl
+++ b/lib/ssh/test/ssh_engine_SUITE.erl
@@ -48,7 +48,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,40}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -113,7 +113,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,15}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_property_test_SUITE.erl
+++ b/lib/ssh/test/ssh_property_test_SUITE.erl
@@ -49,6 +49,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include("ssh_test_lib.hrl").
 
+suite() ->
+    [{ct_hooks,[cth_fips]}].
 
 all() -> [{group, messages},
 	  client_sends_info_timing,

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -142,7 +142,7 @@ suite() ->
     SkipTc = [kex_strict_negotiated,
               kex_strict_violation,
               kex_strict_violation_2],
-    [{ct_hooks,[ts_install_cth,
+    [{ct_hooks,[ts_install_cth, cth_fips,
                 {cth_events,
                  [{verify_fun, VerifyFun},
                   {skip_tc, SkipTc}]}]},

--- a/lib/ssh/test/ssh_pubkey_SUITE.erl
+++ b/lib/ssh/test/ssh_pubkey_SUITE.erl
@@ -100,7 +100,7 @@
 %%%----------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,20}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_renegotiate_SUITE.erl
+++ b/lib/ssh/test/ssh_renegotiate_SUITE.erl
@@ -77,7 +77,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,90}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_sftp_SUITE.erl
+++ b/lib/ssh/test/ssh_sftp_SUITE.erl
@@ -94,7 +94,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,20}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_sftpd_SUITE.erl
+++ b/lib/ssh/test/ssh_sftpd_SUITE.erl
@@ -83,7 +83,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{timetrap,{seconds,20}}].
+    [{ct_hooks,[cth_fips]}, {timetrap,{seconds,20}}].
 
 all() -> 
     [open_close_file, 

--- a/lib/ssh/test/ssh_sftpd_erlclient_SUITE.erl
+++ b/lib/ssh/test/ssh_sftpd_erlclient_SUITE.erl
@@ -57,7 +57,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,20}}].
 
 all() -> 

--- a/lib/ssh/test/ssh_sup_SUITE.erl
+++ b/lib/ssh/test/ssh_sup_SUITE.erl
@@ -63,7 +63,7 @@
 %% Common Test interface functions -----------------------------------
 %%--------------------------------------------------------------------
 suite() ->
-    [{ct_hooks,[ts_install_cth]},
+    [{ct_hooks,[ts_install_cth, cth_fips]},
      {timetrap,{seconds,50}}].
 
 all() ->

--- a/lib/ssh/test/ssh_test_lib.erl
+++ b/lib/ssh/test/ssh_test_lib.erl
@@ -1051,39 +1051,34 @@ ntoa(A) ->
     
 %%%----------------------------------------------------------------
 try_enable_fips_mode() ->
+    %% FIPS mode must be configured before crypto app starts
+    %% This function can only check, not enable
     case crypto:info_fips() of
         enabled ->
-            report("FIPS mode already enabled", ?LINE),
+            report("FIPS mode enabled", ?LINE),
             ok;
         not_enabled ->
-            %% Erlang/crypto configured with --enable-fips
-            case crypto:enable_fips_mode(true) of
-		true ->
-                    %% and also the cryptolib is fips enabled
-                    report("FIPS mode enabled", ?LINE),
-		    enabled = crypto:info_fips(),
-		    ok;
-		false ->
-                    case is_cryptolib_fips_capable() of
-                        false ->
-                            report("No FIPS mode in cryptolib", ?LINE),
-                            {skip, "FIPS mode not supported in cryptolib"};
-                        true ->
-                            ct:fail("Failed to enable FIPS mode", [])
-                    end
-	    end;
+            report("FIPS mode not enabled (must be set via -crypto fips_mode true)", ?LINE),
+            {skip, "FIPS mode requires VM startup configuration"};
         not_supported ->
             report("FIPS mode not supported by Erlang/OTP", ?LINE),
             {skip, "FIPS mode not supported"}
     end.
 
 is_cryptolib_fips_capable() ->
-    [{_,_,Inf}] = crypto:info_lib(),
-    nomatch =/= re:run(Inf, "(F|f)(I|i)(P|p)(S|s)").
+    try
+        [{_,_,LibInfo}] = crypto:info_lib(),
+        case re:run(LibInfo, "\\bFIPS\\b", [caseless]) of
+            {match, _} -> true;
+            nomatch -> false
+        end
+    catch
+        _:_ -> false
+    end.
 
 report(Comment, Line) ->
     ct:comment(Comment),
-    ct:log("~p:~p  try_enable_fips_mode~n"
+    ct:log("~p:~p  FIPS check~n"
            "crypto:info_lib() = ~p~n"
            "crypto:info_fips() = ~p~n"
            "crypto:supports() =~n~p~n", 

--- a/lib/ssh/test/ssh_to_openssh_SUITE.erl
+++ b/lib/ssh/test/ssh_to_openssh_SUITE.erl
@@ -64,7 +64,7 @@
 %%--------------------------------------------------------------------
 
 suite() ->
-    [{timetrap,{seconds,30}}].
+    [{ct_hooks,[cth_fips]}, {timetrap,{seconds,30}}].
 
 all() -> 
     case os:find_executable("ssh") of

--- a/lib/ssh/test/ssh_upgrade_SUITE.erl
+++ b/lib/ssh/test/ssh_upgrade_SUITE.erl
@@ -56,7 +56,8 @@
 %%% CommonTest callbacks
 %%% 
 suite() ->
-    [{timetrap,{seconds,180}}].
+    [{ct_hooks,[cth_fips]},
+     {timetrap,{seconds,180}}].
 
 all() -> 
     [


### PR DESCRIPTION
- Add FIPS mode VM startup flag to ssh.spec
- Replace deprecated crypto:enable_fips_mode/1 with check-only approach
- Improve FIPS capability detection with word boundary regex
- Add exception safety to cryptolib capability check
- Update function to reflect it only checks, doesn't enable FIPS