### PR TITLE
compiler: Fix inplace tuple updates for an edge case

### DIFF
--- a/lib/compiler/src/beam_ssa_ss.erl
+++ b/lib/compiler/src/beam_ssa_ss.erl
@@ -645,12 +645,7 @@ set_alias([], State) ->
     State.
 
 get_alias_edges(V, State) ->
-    OutEdges = [To
-                || {#b_var{},To,Kind} <- beam_digraph:out_edges(State, V),
-                   case Kind of
-                       {embed,_} -> false;
-                       _ -> true
-                   end],
+    OutEdges = [To || {#b_var{},To,_} <- beam_digraph:out_edges(State, V)],
     EmbedEdges = [Src
                   || {#b_var{}=Src,_,Lbl} <- beam_digraph:in_edges(State, V),
                      case Lbl of


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/10367.
This reverts a30e40ee9ae41ec50128bb5e89f631cfb30dccda. In certain edge cases, aggregates are incorrectly marked as unique when their contained records are not unique. This leads to unsafe destructive updates and strange runtime behaviours.

If there is a less conservative fix that is more specific for this edge case, we can revisit.