### PR TITLE
Simplify grammar of map/record update expressions

### DIFF
--- a/lib/compiler/test/map_SUITE.erl
+++ b/lib/compiler/test/map_SUITE.erl
@@ -975,6 +975,7 @@ t_update_map_expressions(Config) when is_list(Config) ->
     #{ b := {X} } = M1#{ a := 1, b => {X} },
 
     #{ b := 2 } = (maps:new())#{ b => 2 },
+    #{ b := 2 } = maps:new()#{ b => 2 },  % extra parens no longer required
 
     #{ a :=42, b:=42, c:=42 } = (maps:from_list([{a,1},{b,2},{c,3}]))#{ a := 42, b := 42, c := 42 },
     #{ "a" :=1, "b":=42, "c":=42 } = (maps:from_list([{"a",1},{"b",2}]))#{ "b" := 42, "c" => 42 },
@@ -989,6 +990,9 @@ t_update_map_expressions(Config) when is_list(Config) ->
     end,
 
     #{ "a" := b } = F(),
+
+    %% test expression chaining and precedence
+    #{ "a" := b, "b" := c, "c" := d } = (maps:from_list([{"a",b}]))#{"b" => c}#{"c" => d},
 
     %% Error cases.
     ?assertError({badmap,<<>>}, (id(<<>>))#{ a := 42, b => 2 }),

--- a/lib/compiler/test/record_SUITE.erl
+++ b/lib/compiler/test/record_SUITE.erl
@@ -828,6 +828,7 @@ record_updates(_Config) ->
     _ = id(0),
 
     #foo{a=42,b=99,c=3,d=999} = Foo1#foo{d=999},
+    #foo{a=0,b=99,c=4,d=999} = Foo1#foo{d=999}#foo{c=4}#foo{a=0},
 
     F2 = fun(N) when is_integer(N) ->
                  R0 = #bar{a=N},
@@ -836,6 +837,10 @@ record_updates(_Config) ->
                  R2#bar{d=N+3}
          end,
     #bar{a=100,b=101,c=102,d=103} = F2(id(100)),
+
+    %% updates on expressions and with chaining
+    #bar{a=0,b=101,c=102,d=103} = (F2(id(100)))#bar{a=0},
+    #bar{a=0,b=101,c=102,d=1} = (F2(id(100)))#bar{a=0}#bar{d=1},
 
     F3 = fun(R0, N) when is_integer(N) ->
                  R1 = R0#foo{a=N},

--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -116,8 +116,8 @@ Right 300 list_op.
 Left 400 add_op.
 Left 500 mult_op.
 Unary 600 prefix_op.
-Nonassoc 700 '#'.
-Left 750 '('.
+Left 700 '('.
+Left 750 '#' '#_'.
 Nonassoc 800 ':'.
 Nonassoc 900 clause_body_exprs.
 
@@ -425,9 +425,7 @@ tuple -> '{' exprs '}' : {tuple,?anno('$1'),'$2'}.
 
 map_expr -> '#' map_tuple :
 	{map, ?anno('$1'),'$2'}.
-map_expr -> expr_max '#' map_tuple :
-	{map, ?anno('$2'),'$1','$3'}.
-map_expr -> map_expr '#' map_tuple :
+map_expr -> expr '#' map_tuple :
 	{map, ?anno('$2'),'$1','$3'}.
 
 map_tuple -> '{' '}' : [].
@@ -452,13 +450,9 @@ record_expr -> '#' atom '.' atom :
 	{record_index,?anno('$1'),element(3, '$2'),'$4'}.
 record_expr -> '#' record_name record_tuple :
 	{record,?anno('$1'),element(3, '$2'),'$3'}.
-record_expr -> expr_max '#' record_name '.' atom :
+record_expr -> expr '#' record_name '.' atom :
 	{record_field,?anno('$2'),'$1',element(3, '$3'),'$5'}.
-record_expr -> expr_max '#' record_name record_tuple :
-	{record,?anno('$2'),'$1',element(3, '$3'),'$4'}.
-record_expr -> record_expr '#' record_name '.' atom :
-	{record_field,?anno('$2'),'$1',element(3, '$3'),'$5'}.
-record_expr -> record_expr '#' record_name record_tuple :
+record_expr -> expr '#' record_name record_tuple :
 	{record,?anno('$2'),'$1',element(3, '$3'),'$4'}.
 
 %% Native record expressions with explicit module name.
@@ -468,16 +462,16 @@ record_expr -> '#' atom ':' record_name record_tuple :
 record_expr -> '#_' record_tuple :
         Id = [],
 	{record,?anno('$1'), Id, '$2'}.
-record_expr -> expr_max '#' atom ':' record_name '.' atom :
+record_expr -> expr '#' atom ':' record_name '.' atom :
         Id = {element(3, '$3'), element(3, '$5')},
         {record_field,?anno('$2'),'$1',Id,'$7'}.
-record_expr -> expr_max '#_' '.' atom :
+record_expr -> expr '#_' '.' atom :
         Id = [],
 	{record_field,?anno('$2'),'$1',Id,'$4'}.
-record_expr -> expr_max '#' atom ':' record_name record_tuple :
+record_expr -> expr '#' atom ':' record_name record_tuple :
         Id = {element(3, '$3'), element(3, '$5')},
 	{record,?anno('$2'),'$1',Id,'$6'}.
-record_expr -> expr_max '#_' record_tuple :
+record_expr -> expr '#_' record_tuple :
         Id = [],
 	{record,?anno('$2'),'$1',Id,'$3'}.
 
@@ -2196,27 +2190,27 @@ inop_prec('div') -> {500,500,600};
 inop_prec('rem') -> {500,500,600};
 inop_prec('band') -> {500,500,600};
 inop_prec('and') -> {500,500,600};
-inop_prec('#') -> {750,700,750};
-inop_prec('(') -> {750,750,800};
+inop_prec('#') -> {750,750,800};
 inop_prec(':') -> {900,800,900};
 inop_prec('.') -> {900,900,1000}.
 
 -type pre_op() :: 'catch' | '+' | '-' | 'bnot' | 'not' | '#'.
 
 -doc false.
--spec preop_prec(pre_op()) -> {0 | 600 | 700, 100 | 700 | 800}.
+-spec preop_prec(pre_op()) -> {0 | 600 | 700 | 750, 100 | 700 | 800}.
 
+%% note that we must not print "+ + X" as "++X", but "+(+X)"
 preop_prec('catch') -> {0,100};
 preop_prec('+') -> {600,700};
 preop_prec('-') -> {600,700};
 preop_prec('bnot') -> {600,700};
 preop_prec('not') -> {600,700};
-preop_prec('#') -> {700,800}.
+preop_prec('#') -> {750,800}.
 
 -doc false.
--spec func_prec() -> {800,700}.
+-spec func_prec() -> {700,700}.
 
-func_prec() -> {800,700}.
+func_prec() -> {700,700}.  % may be chained
 
 -doc false.
 -spec max_prec() -> 900.
@@ -2248,7 +2242,7 @@ type_inop_prec('/') -> {500,500,600};
 type_inop_prec('div') -> {500,500,600};
 type_inop_prec('rem') -> {500,500,600};
 type_inop_prec('band') -> {500,500,600};
-type_inop_prec('#') -> {800,700,800}.
+type_inop_prec('#') -> {750,750,800}.
 
 -doc false.
 -spec type_preop_prec(type_preop()) -> {prec(), prec()}.
@@ -2256,7 +2250,7 @@ type_inop_prec('#') -> {800,700,800}.
 type_preop_prec('+') -> {600,700};
 type_preop_prec('-') -> {600,700};
 type_preop_prec('bnot') -> {600,700};
-type_preop_prec('#') -> {700,800}.
+type_preop_prec('#') -> {750,800}.
 
 -type erl_parse_tree() :: abstract_clause()
                         | abstract_expr()


### PR DESCRIPTION
It has always been allowed to chain map updates as well as record updates, but the way this was expressed in the grammar was hardcoded and restrictive, and it was left unmodified when the yecc grammar was refactored to use precedence levels. This change simplifies the grammar and allows map updates and record updates to be chained according to their assigned precedence.