### PR TITLE
`rand:bytes` optimization and extended tests

### DIFF
--- a/lib/stdlib/test/rand_SUITE.erl
+++ b/lib/stdlib/test/rand_SUITE.erl
@@ -214,7 +214,7 @@ seed(Config) when is_list(Config) ->
 seed_1(Alg) ->
     %% For all repeatable PRNGS, the initial state should be
     %% possible to clone, but not necessarily compare,
-    %% since we want to be able to optimize the implementatin
+    %% since we want to be able to optimize the implementation
     %%
     %% Choosing algo and seed
     S1 = rand_crypto_seed(Alg, {0, 0, 0}),


### PR DESCRIPTION
Back to my pet peeve, the `rand` module.

There are tests in `rand_SUITE` that the base generators follow their reference implementation, but that is really not sufficient.  This PR adds tests that the algorithms that limit or expand the numbers to a requested range, creates floating point numbers and shuffles, are not accidentally altered to produce a different sequence.

The PR also adds a new internal plug-in callback function for the algorithm handlers, to generate bytes.  This new callback is also used from module `crypto` to optimize the `crypto` and `crypto_cache` algorithms.  By this, using the `crypto` generator in module `crypto` from `rand:bytes` is no longer embarrassingly slow since it does not take the detour to generate bytes from integers from bytes.

Also in this PR is a new algorithm in `crypto` - `crypto_prng1`, that can create a repeatable sequence with cryptographical unpredictability, as the existing `crypto_aes`, but with much better performance.  This is also because it does not take the unnecessary detour over generating integers, and also uses the new internal plug-in callback for bytes.

And, as usual, the documentation got some attention...