### PR TITLE
Correct the pretty-printing of `catch Expr`

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -2045,7 +2045,7 @@ inop_prec('.') -> {900,900,1000}.
 -doc false.
 -spec preop_prec(pre_op()) -> {0 | 600 | 700, 100 | 700 | 800}.
 
-preop_prec('catch') -> {700,100};
+preop_prec('catch') -> {0,100};
 preop_prec('+') -> {600,700};
 preop_prec('-') -> {600,700};
 preop_prec('bnot') -> {600,700};

--- a/lib/stdlib/test/erl_pp_SUITE.erl
+++ b/lib/stdlib/test/erl_pp_SUITE.erl
@@ -1341,11 +1341,14 @@ otp_16435(_Config) ->
     CheckF("f() ->\n    << \n      (catch <<1:4>>) ||\n"
            "          A <- []\n    >>.\n"),
     CheckF("f() ->\n    [ \n     catch foo ||\n         A <- []\n    ].\n"),
-    CheckF("f() ->\n    1 = catch 1.\n"),
-    CheckF("f() ->\n    catch 1 = catch 1.\n"),
-    CheckF("f() ->\n    A = catch 1 / 0.\n"),
+    CheckF("f() ->\n    1 = (catch 1).\n"),
+    CheckF("f() ->\n    catch 1 = (catch 1).\n"),
+    CheckF("f() ->\n    A = (catch 1 / 0).\n"),
     CheckF("f() when erlang:float(3.0) ->\n    true.\n"),
     CheckF("f() ->\n    (catch 16)#{}.\n"),
+    CheckF("f() ->\n    (catch throw(false)) =/= true.\n"),
+    CheckF("f() ->\n    (catch throw(2)) + 1.\n"),
+    CheckF("f() ->\n    (catch throw(Pid)) ! stop.\n"),
 
     Check = fun(S) -> S = flat_parse_and_pp_expr(S, 0, []) end,
     Check("5 #r4.f1"),


### PR DESCRIPTION
In 3171f2b7 and 762a18aa the precedence levels used by `erl_pp` to format `catch Expr` was adjusted to avoid parentheses in many cases. However, this only works in situations where the catch is on the right of the surrounding operator, as in `Pat = catch Expr`. If the catch is on the left, as in `(catch Expr) + 1`, the parentheses must be preserved. The `erl_pp` prettyprinter is not clever enough to distinguish between these situatuions, so for now we must accept some unnecessary parentheses.

This restores the precedence level for printing and adds test cases to validate the parsing and semantics as well as the pretty printing.