### PR TITLE
jit: Suppress i_mul_add optimization when adding squares

### DIFF
--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -1315,14 +1315,16 @@ gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
   gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S3) |
   equal(Dst1, Dst2) |
-  equal(Fail1, Fail2) =>
+  equal(Fail1, Fail2) |
+  distinct(S3, S4) =>
     i_mul_add Fail1 S1 S2 S3 S4 Dst1
 
 gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
   gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S4) |
   equal(Dst1, Dst2) |
-  equal(Fail1, Fail2) =>
+  equal(Fail1, Fail2) |
+  distinct(S3, S4) =>
     i_mul_add Fail1 S1 S2 S4 S3 Dst1
 
 gc_bif2 Fail Live u$bif:erlang:stimes/2 S1 S2 Dst =>

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -1256,14 +1256,16 @@ gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
   gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S3) |
   equal(Dst1, Dst2) |
-  equal(Fail1, Fail2) =>
+  equal(Fail1, Fail2) |
+  distinct(S3, S4) =>
     i_mul_add Fail1 S1 S2 S3 S4 Dst1
 
 gc_bif2 Fail1 Live1 u$bif:erlang:stimes/2 S1 S2 Dst1 |
   gc_bif2 Fail2 Live2 u$bif:erlang:splus/2 S3 S4 Dst2 |
   equal(Dst1, S4) |
   equal(Dst1, Dst2) |
-  equal(Fail1, Fail2) =>
+  equal(Fail1, Fail2) |
+  distinct(S3, S4) =>
     i_mul_add Fail1 S1 S2 S4 S3 Dst1
 
 gc_bif2 Fail Live u$bif:erlang:stimes/2 S1 S2 Dst =>

--- a/erts/emulator/test/small_SUITE.erl
+++ b/erts/emulator/test/small_SUITE.erl
@@ -27,7 +27,8 @@
          multiplication/1, mul_add/1, division/1,
          test_bitwise/1, test_bsl/1, test_bsr/1,
          element/1,
-         range_optimization/1]).
+         range_optimization/1,
+         confused_squaring/1]).
 -export([mul_add/0, division/0]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -45,7 +46,8 @@ groups() ->
        addition, subtraction, negation, multiplication, mul_add, division,
        test_bitwise, test_bsl, test_bsr,
        element,
-       range_optimization]}].
+       range_optimization,
+       confused_squaring]}].
 
 edge_cases(Config) when is_list(Config) ->
     {MinSmall, MaxSmall} = Limits = determine_small_limits(0),
@@ -1523,6 +1525,16 @@ any_integer(I) ->
     case id(I) of
         N when is_integer(N) -> N
     end.
+
+%%
+%% GH-10454: `X * X + X * X` was mishandled by the JIT.
+%%
+confused_squaring(_Config) ->
+  X = id(2),
+  [1, 2, 8] =
+    lists:append(lists:map(fun(Y) -> Y end, [1, 2]), [X * X + X * X]),
+
+  ok.
 
 %%%
 %%% Helpers.


### PR DESCRIPTION
The `i_mul_add` instruction did not handle `X * X + X * X` correctly because *both* source registers for the addition was the same as the destination register for `X * X`. While the LHS was correctly set to `X * X`, the RHS was read before the computation of `X * X`, reading a stale value that could result in anything.

Fixes #10454