### PR TITLE
Document restrictions on node names

### DIFF
--- a/system/doc/reference_manual/distributed.md
+++ b/system/doc/reference_manual/distributed.md
@@ -51,7 +51,8 @@ the command-line flag [`-name`](`e:erts:erl_cmd.md#name`) (long names) or
 [`-sname`](`e:erts:erl_cmd.md#sname`) (short names).
 
 The format of the node name is an atom `name@host`. `name` is the name given by
-the user. `host` is the full host name if long names are used, or the first part
+the user, and consists of alphanumerics, `-`, `_`, and `\`.
+`host` is the full host name if long names are used, or the first part
 of the host name if short names are used. Function [`node()`](`erlang:node/0`)
 returns the name of the node.
 


### PR DESCRIPTION
I just got some errors when automatically deriving the nodename from other configuration and the documentation doesn't say what the restrixion actually is.

lib/kernel/src/net_kernel.erl:
```erlang
valid_name_head(Head) ->
    {ok, MP} = re:compile("^[0-9A-Za-z_\\-]+$", [unicode]),
        case re:run(Head, MP) of
            {match, _} ->
                true;
            nomatch ->
                false
    end.
```