### PR TITLE
dialyzer: fix broken test

### DIFF
--- a/lib/dialyzer/test/opaque_SUITE_data/results/ewgi
+++ b/lib/dialyzer/test/opaque_SUITE_data/results/ewgi
@@ -1,7 +1,7 @@
 
-ewgi_api.erl:47:31: The call gb_trees:to_list({non_neg_integer(),'nil' | {_,_,_,_}}) does not have an opaque term of type gb_trees:tree(_,_) as 1st argument
-ewgi_testapp.erl:26:91: The call ewgi_testapp:htmlise_data("request_data",{non_neg_integer(),'nil' | {_,_,_,_}}) does not have a term of type [{_,_}] | gb_trees:tree(_,_) (with opaque subterms) as 2nd argument
-ewgi_testapp.erl:34:27: The call gb_trees:to_list(T::{non_neg_integer(),'nil' | {_,_,_,_}}) does not have an opaque term of type gb_trees:tree(_,_) as 1st argument
+ewgi_api.erl:48:31: The call gb_trees:to_list({non_neg_integer(),'nil' | {_,_,_,_}}) does not have an opaque term of type gb_trees:tree(_,_) as 1st argument
+ewgi_testapp.erl:27:91: The call ewgi_testapp:htmlise_data("request_data",{non_neg_integer(),'nil' | {_,_,_,_}}) does not have a term of type [{_,_}] | gb_trees:tree(_,_) (with opaque subterms) as 2nd argument
+ewgi_testapp.erl:35:27: The call gb_trees:to_list(T::{non_neg_integer(),'nil' | {_,_,_,_}}) does not have an opaque term of type gb_trees:tree(_,_) as 1st argument
 
 %% %CopyrightBegin%
 %%


### PR DESCRIPTION
the addition of licenses to a file changed the line number in which dialyzer used to detect some errors. as such, the test breaks even when it should not. this commit simply fixes the line number in which it happens.

Introduced in #10428 (OTP-19878)
