### PR TITLE
Accept 4-arg handshake complete function in dist util

### DIFF
--- a/erts/doc/guides/alt_dist.md
+++ b/erts/doc/guides/alt_dist.md
@@ -553,13 +553,16 @@ The following `#hs_data{}` record fields need to be set unless otherwise stated:
   following signature:
 
   ```erlang
-  fun (DistCtrlr, Node, DHandle) -> void()
+  fun (DistCtrlr, Node, DHandle) -> void() |
+  fun (DistCtrlr, Node, DHandle, Context) -> void()
   ```
 
   where `DistCtrlr` is the identifier of the distribution controller, `Node` is
-  the node name of the node connected at the other end, and `DHandle` is a
-  distribution handle needed by a distribution controller process when calling
-  the following BIFs:
+  the node name of the node connected at the other end. `Context` is a map of
+  `#{creation => Creation, flags => Flags}`, and `Creation` / `Flags` are the
+  node incarnation identifier / [capability flags](erl_dist_protocol.md#dflags)
+  of the node connected at the other end. `DHandle` is a distribution handle
+  needed by a distribution controller process when calling the following BIFs:
 
   - `erlang:dist_ctrl_get_data/1`
   - `erlang:dist_ctrl_get_data_notification/1`

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -494,6 +494,8 @@ convert_flags(_Undefined) ->
                 f_getopts       :: function() | 'undefined'}).
 
 connection(#hs_data{other_node = Node,
+                    other_creation = Creation,
+                    other_flags = Flags,
 		    socket = Socket,
 		    f_address = FAddress,
 		    f_setopts_pre_nodeup = FPreNodeup,
@@ -509,7 +511,11 @@ connection(#hs_data{other_node = Node,
 		ok ->
                     case HSData#hs_data.f_handshake_complete of
                         undefined -> ok;
-                        HsComplete -> HsComplete(Socket, Node, DHandle)
+                        HsComplete when is_function(HsComplete, 3) ->
+                            HsComplete(Socket, Node, DHandle);
+                        HsComplete when is_function(HsComplete, 4) ->
+                            Context = #{creation => Creation, flags => Flags},
+                            HsComplete(Socket, Node, DHandle, Context)
                     end,
 		    con_loop(#state{kernel = HSData#hs_data.kernel_pid,
                                     node = Node,


### PR DESCRIPTION
We are currently using [erldist_filter](https://github.com/WhatsApp/erldist_filter) to add extra security to all our dist connections by not allowing certain dist messages to pass through.

We have a special logic like here for us to enable the filter on dist connection setup https://github.com/WhatsApp/erldist_filter/blob/main/apps/erldist_filter/src/erldist_filter_otp_28_inet_tcp_dist.erl#L1037-L1039

If dist_util can allow a 5-arg handshake_complete function like this PR, we could avoid copying dist_util on every OTP upgrade and would be really great for us. The creation and flags of the connection also seems general enough information that the dist protocol can know.

This replaces https://github.com/erlang/otp/pull/8473 if exposing the entire HSData is too much.

Thanks!