### PR TITLE
Mnesia: allow delete node

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -1808,6 +1808,7 @@ update_where_to_wlock(Tab) ->
 %% This code is rpc:call'ed from the tab_copier process
 %% when it has *not* released it's table lock
 unannounce_add_table_copy(Tab, To) ->
+    verbose("unannounce_add_table_copy ~w ~w~n", [Tab,To]),
     ?CATCH(del_active_replica(Tab, To)),
     try To = val({Tab , where_to_read}),
 	 mnesia_lib:set_remote_where_to_read(Tab)

--- a/lib/mnesia/src/mnesia_lib.erl
+++ b/lib/mnesia/src/mnesia_lib.erl
@@ -904,12 +904,12 @@ vcore_elem({_Item, Info}) ->
     show("~tp~n", [Info]).
 
 fix_error(X) ->
-    set(last_error, X), %% for debugabililty
+    set(last_error, X), %% for debugging
     case X of
 	{aborted, Reason} -> Reason;
 	{abort, Reason} -> Reason;
 	Y when is_atom(Y) -> Y;
-	{'EXIT', {_Reason, {Mod, _, _}}} when is_atom(Mod) ->
+	{_Reason, [{Mod, _, _}|_]} when is_atom(Mod) ->
 	    save(X),
 	    case atom_to_list(Mod) of
 		[$m, $n, $e|_] -> badarg;

--- a/lib/mnesia/src/mnesia_schema.erl
+++ b/lib/mnesia/src/mnesia_schema.erl
@@ -1780,7 +1780,10 @@ remove_node_from_tabs([Tab|Rest], Node) ->
 		     remove_node_from_tabs(Rest, Node)];
 		_Ns ->
 		    Cs3 = verify_cstruct(Cs2),
-		    get_tid_ts_and_lock(Tab, write),
+                    case ?catch_val({Tab, active_replicas}) of
+                        [] -> ok;
+                        _ -> get_tid_ts_and_lock(Tab, write)
+                    end,
 		    [{op, del_table_copy, ram_copies, Node, vsn_cs2list(Cs3)}|
 		     remove_node_from_tabs(Rest, Node)]
 	    end
@@ -2841,6 +2844,7 @@ undo_prepare_commit(Tid, Commit) ->
 	[] ->
 	    ignore;
 	Ops ->
+            verbose("undo prepare: ~w:~n ~p~n", [Tid, Ops]),
 	    %% Catch to allow failure mnesia_controller may not be started
 	    ?SAFE(mnesia_controller:release_schema_commit_lock()),
 	    undo_prepare_ops(Tid, Ops)

--- a/lib/mnesia/test/Makefile
+++ b/lib/mnesia/test/Makefile
@@ -92,7 +92,7 @@ RELSYSDIR = $(RELEASE_PATH)/mnesia_test
 # ----------------------------------------------------
 # FLAGS
 # ----------------------------------------------------
-#ERL_COMPILE_FLAGS +=
+ERL_COMPILE_FLAGS += +nowarn_missing_spec_documented -Werror
 ERL_COMPILE_FLAGS := $(filter-out +deterministic,$(ERL_COMPILE_FLAGS))
 
 EBIN = .

--- a/lib/mnesia/test/ext_test.erl
+++ b/lib/mnesia/test/ext_test.erl
@@ -121,7 +121,7 @@ delete_table(Alias, Tab) ->
     try error_if_not_initialized() of
         ok ->
             call({?FUNCTION_NAME, Alias, Tab})
-    catch error : {backend_not_initialized, _} = Reason ->
+    catch error : {backend_not_initialized, _} ->
         ok
     end.
 
@@ -253,8 +253,8 @@ repair_continuation(Cont, Ms) ->
 call(Req) ->
     error_if_not_initialized(),
     case gen_server:call({global, mnesia_test_lib:get_ext_test_server_name()}, Req) of
-        #exception{c = Class, r = Reason, st = ST} = Ex ->
-            ?DBG("call ~p resulted in an exception: ~p~n", [Req, Ex]),
+        #exception{c = Class, r = Reason, st = ST} = _Ex ->
+            ?DBG("call ~p resulted in an exception: ~p~n", [Req, _Ex]),
             erlang:raise(Class, Reason, ST);
         Res ->
             Res

--- a/lib/mnesia/test/ext_test_server.erl
+++ b/lib/mnesia/test/ext_test_server.erl
@@ -41,8 +41,8 @@ init(_) ->
 
 create_table(ext_ram_copies, Tab, Props, #state{tables = Tables} = State) when is_atom(Tab) ->
     case maps:get(Tab, Tables, undefined) of
-        #table{state = opened, tid = Tid} ->
-            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tab), Tid]),
+        #table{state = opened, tid = _Tid} ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tab), _Tid]),
             {ok, State};
         _ ->
             ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p~n", [tab_to_list(Tab)]),
@@ -62,10 +62,10 @@ create_table(ext_disc_only_copies, Tab, Props, #state{tables = Tables} = State) 
             ?DBG("create_table Alias: ext_disc_only_copies after dets:open_file, Tab: ~p~n", [tab_to_list(Tab)]),
             {ok, State#state{tables = maps:put(Tab, #table{state = opened, tid = Tab}, Tables)}}
     end;
-create_table(ext_ram_copies, Tag={Tab, index, {_Where, Type}}, _Opts, #state{tables = Tables} = State) ->
+create_table(ext_ram_copies, Tag={_Tab, index, {_Where, Type}}, _Opts, #state{tables = Tables} = State) ->
     case maps:get(Tag, Tables, undefined) of
-        #table{state = opened, tid = Tid} ->
-            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tag), Tid]),
+        #table{state = opened, tid = _Tid} ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tag), _Tid]),
             {ok, State};
         _ ->
             ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p~n", [tab_to_list(Tag)]),
@@ -73,7 +73,7 @@ create_table(ext_ram_copies, Tag={Tab, index, {_Where, Type}}, _Opts, #state{tab
             ?DBG("create_table, Alias, ext_ram_copies, Tab: ~p(~p)~n", [tab_to_list(Tag), Tid]),
             {ok, State#state{tables = maps:put(Tag, #table{state = opened, tid = Tid}, Tables)}}
     end;
-create_table(ext_disc_only_copies, Tag={Tab, index, {_Where, Type}}, _Opts, #state{tables = Tables} = State) ->
+create_table(ext_disc_only_copies, Tag={_Tab, index, {_Where, Type}}, _Opts, #state{tables = Tables} = State) ->
     case maps:get(Tag, Tables, undefined) of
         #table{state = opened, tid = Tag} ->
             ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tag), Tag]),
@@ -85,10 +85,10 @@ create_table(ext_disc_only_copies, Tag={Tab, index, {_Where, Type}}, _Opts, #sta
             ?DBG("create_table Alias: ext_disc_only_copies after dets:open_file, Tab: ~p~n", [tab_to_list(Tag)]),
             {ok, State#state{tables = maps:put(Tag, #table{state = opened, tid = Tag}, Tables)}}
     end;
-create_table(ext_ram_copies, Tag={_Tab, retainer, ChkPName}, _Opts, #state{tables = Tables} = State) ->
+create_table(ext_ram_copies, Tag={_Tab, retainer, _ChkPName}, _Opts, #state{tables = Tables} = State) ->
     case maps:get(Tag, Tables, undefined) of
-        #table{state = opened, tid = Tid} ->
-            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tag), Tid]),
+        #table{state = opened, tid = _Tid} ->
+            ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tag), _Tid]),
             {ok, State};
         _ ->
             ?DBG("create_table, Alias: ext_ram_copies, Tab: ~p~n", [tab_to_list(Tag)]),
@@ -96,7 +96,7 @@ create_table(ext_ram_copies, Tag={_Tab, retainer, ChkPName}, _Opts, #state{table
             ?DBG("create_table, Alias, ext_ram_copies, Tab: ~p(~p)~n", [tab_to_list(Tag), Tid]),
             {ok, State#state{tables = maps:put(Tag, #table{state = opened, tid = Tid}, Tables)}}
     end;
-create_table(ext_disc_only_copies, Tag={_Tab, retainer, ChkPName}, _Opts, #state{tables = Tables} = State) ->
+create_table(ext_disc_only_copies, Tag={_Tab, retainer, _ChkPName}, _Opts, #state{tables = Tables} = State) ->
     case maps:get(Tag, Tables, undefined) of
         #table{state = opened, tid = Tag} ->
             ?DBG("create_table, Alias: ext_disc_only_copies, Tab: ~p(~p) is already opened~n", [tab_to_list(Tag), Tag]),
@@ -109,15 +109,15 @@ create_table(ext_disc_only_copies, Tag={_Tab, retainer, ChkPName}, _Opts, #state
             {ok, State#state{tables = maps:put(Tag, #table{state = opened, tid = Tag}, Tables)}}
     end.
 
-receive_data(Data, ext_ram_copies, Name, Sender, {Name, Tab, Sender} = MnesiaState, State) ->
+receive_data(Data, ext_ram_copies, Name, Sender, {Name, Tab, Sender} = _MnesiaState, State) ->
     ?DBG({Data, ext_ram_copies, Name, Sender, {Name, tab_to_list(Tab), Sender}}),
     true = ets:insert(tab_to_tid(Tab, State), Data),
     {more, State};
-receive_data(Data, ext_disc_only_copies, Name, Sender, {Name, Tab, Sender} = MnesiaState, State) ->
+receive_data(Data, ext_disc_only_copies, Name, Sender, {Name, Tab, Sender} = _MnesiaState, State) ->
     ?DBG({Data, ext_disc_only_copies, Name, Sender, {Name, tab_to_list(Tab), Sender}}),
     ok = dets:insert(tab_to_tid(Tab, State), Data),
     {more, State};
-receive_data(Data, Alias, Tab, Sender, {Name, Sender} = MnesiaState, State) ->
+receive_data(Data, Alias, Tab, Sender, {Name, Sender} = _MnesiaState, State) ->
     ?DBG({Data, Alias, tab_to_list(Tab), State}),
     receive_data(Data, Alias, Tab, Sender, {Name, Tab, Sender}, State).
 
@@ -162,7 +162,7 @@ handle_call({delete_table, ext_ram_copies, Tab}, _From, #state{tables = Tables} 
             case ?TRY(ets:delete(Tid)) of
                 #exception{} = Res ->
                     {reply, Res, State};
-                Res ->
+                _Res ->
                     NewState = State#state{tables = maps:remove(Tab, Tables)},
                     {reply, ok, NewState}
             end;
@@ -395,8 +395,8 @@ handle_call({repair_continuation, ext_ram_copies, Cont, Ms}, _From, State) ->
     Res = ?TRY(ets:repair_continuation(Cont, Ms)),
     {reply, Res, State}.
 
-terminate(Reason, _State) ->
-    ?DBG(Reason).
+terminate(_Reason, _State) ->
+    ?DBG(_Reason).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/lib/mnesia/test/mnesia_dirty_access_test.erl
+++ b/lib/mnesia/test/mnesia_dirty_access_test.erl
@@ -919,19 +919,19 @@ add_table(CallFrom, AddNode, [Node1, Node2, Node3], Def) ->
     ?verify_mnesia([Node1, Node2, Node3], []).
 
 
-tracer({trace_ts, From, send, Msg, To, {_,S,Ms}}) ->
-    io:format("~p:~p ~p(~p) >>~p ~w ~n",[S,Ms,From,node(From),To,Msg]);
-tracer({trace_ts, Pid, 'receive', Msg, {_,S,Ms}}) ->
-    io:format("~p:~p ~p(~p) << ~w ~n",[S,Ms,Pid,node(Pid),Msg]);
+%% tracer({trace_ts, From, send, Msg, To, {_,S,Ms}}) ->
+%%     io:format("~p:~p ~p(~p) >>~p ~w ~n",[S,Ms,From,node(From),To,Msg]);
+%% tracer({trace_ts, Pid, 'receive', Msg, {_,S,Ms}}) ->
+%%     io:format("~p:~p ~p(~p) << ~w ~n",[S,Ms,Pid,node(Pid),Msg]);
 
-tracer({trace_ts, Pid, call, MFA, ST, {_,S,Ms}}) ->
-    io:format("~p:~p ~p(~p) ~w ~w ~n",[S,Ms,Pid,node(Pid),MFA, ST]);
-tracer({trace_ts, Pid, return_from, MFA, Ret, {_,S,Ms}}) ->
-    io:format("~p:~p ~p(~p) ~w => ~w ~n",[S,Ms,Pid,node(Pid),MFA,Ret]);
+%% tracer({trace_ts, Pid, call, MFA, ST, {_,S,Ms}}) ->
+%%     io:format("~p:~p ~p(~p) ~w ~w ~n",[S,Ms,Pid,node(Pid),MFA, ST]);
+%% tracer({trace_ts, Pid, return_from, MFA, Ret, {_,S,Ms}}) ->
+%%     io:format("~p:~p ~p(~p) ~w => ~w ~n",[S,Ms,Pid,node(Pid),MFA,Ret]);
 
-tracer(Msg) ->
-    io:format("UMsg ~p ~n",[Msg]),
-    ok.
+%% tracer(Msg) ->
+%%     io:format("UMsg ~p ~n",[Msg]),
+%%     ok.
 
 
 move_table_copy_1(suite) -> [];

--- a/lib/mnesia/test/mnesia_evil_coverage_test.erl
+++ b/lib/mnesia/test/mnesia_evil_coverage_test.erl
@@ -369,16 +369,17 @@ evil_delete_db_node(Config) when is_list(Config) ->
     Tab = evil_delete_db_node,
 
     ?match({atomic, ok}, mnesia:create_table(Tab, [{disc_copies, AllNodes}])),
-    
+    ?match({atomic, ok}, mnesia:create_table(foobar, [{ram_copies, [Node2, Node3]}])),
+
     ?match([], mnesia_test_lib:stop_mnesia([Node2, Node3])),
 
     ?match({atomic, ok}, mnesia:del_table_copy(schema, Node2)),
-    
+
     RemNodes = AllNodes -- [Node2],
-    
+
     ?match(RemNodes, mnesia:system_info(db_nodes)),
     ?match(RemNodes, mnesia:table_info(Tab, disc_copies)),
-    
+
     ?verify_mnesia([Node1], []).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1438,20 +1439,44 @@ dump_log(N, Tester) when N > 0 ->
 dump_log(_, Tester) ->
     Tester ! finished.
 
-
-wait_for_tables(doc) -> 
+wait_for_tables(doc) ->
     ["Intf. test of wait_for_tables, see also force_load_table"];
 wait_for_tables(suite) -> [];
 wait_for_tables(Config) when is_list(Config) ->
     [Node1, Node2] = Nodes = ?acquire_nodes(2, Config),
-    Tab = wf_tab,
-    Schema = [{name, Tab}, {ram_copies, [Node1, Node2]}],
-    ?match({atomic, ok}, mnesia:create_table(Schema)),
-    ?match(ok, mnesia:wait_for_tables([wf_tab], infinity)),
+    Tabs = [list_to_atom("wf_tab_" ++ integer_to_list(N)) || N <- lists:seq(1, 500)],
+    Schema = [{ram_copies, [Node1, Node2]}],
+    [{atomic, ok} = mnesia:create_table(Tab, Schema) || Tab <- Tabs],
+    ?match(stopped,mnesia:stop()),
+
+    ?match(ok, mnesia:start()),
+    ?match(timeout, element(1, mnesia:wait_for_tables(Tabs, 0))),
+    Check = fun(Time) ->
+                    {Waited, ok} = timer:tc(mnesia, wait_for_tables, [Tabs, Time]),
+                    io:format("~w Waited: ~wms~n", [node(), Waited div 1000]),
+                    Waited div 1_000_000 < Time
+            end,
+    ?match(true, Check(timer:seconds(5))),
     ?match(ok, mnesia:wait_for_tables([], timer:seconds(5))),
-    ?match({timeout, [bad_tab]}, mnesia:wait_for_tables([bad_tab], timer:seconds(5))),
-    ?match(ok, mnesia:wait_for_tables([wf_tab], 0)),
+    ?match({timeout, [bad_tab]}, mnesia:wait_for_tables([bad_tab], timer:seconds(1))),
+    ?match(ok, mnesia:wait_for_tables([wf_tab_1], 0)),
     ?match({error,_}, mnesia:wait_for_tables([wf_tab], -1)),
+
+    ?match(stopped, erpc:call(Node2, mnesia, stop, [])),
+    fun Wait () ->  %% Sync node_down
+            case mnesia:table_info(schema, active_replicas) of
+                [Node1] -> ok;
+                _ ->
+                    timer:sleep(100),
+                    _ = mnesia_controller:get_info(1000),
+                    Wait()
+            end
+    end (),
+    {ok, foo, _} = mnesia:activate_checkpoint([{name, foo}, {max, Tabs}, {ram_overrides_dump, true}]),
+    ?match(ok, erpc:call(Node2, mnesia, start, [])),
+    ?match(true, erpc:call(Node2, fun() -> Check(5000) end)),
+    ?match(ok, mnesia:deactivate_checkpoint(foo)),
+
     ?verify_mnesia(Nodes, []).
 
 force_load_table(suite) -> [];
@@ -1467,7 +1492,7 @@ force_load_table(Config) when is_list(Config) ->
     mnesia_test_lib:kill_mnesia([Node2]),
     %%    timer:sleep(timer:seconds(5)),
     ?match(ok, mnesia:start()),
-    ?match({timeout, [Tab]}, mnesia:wait_for_tables([Tab], 5)),
+    ?match({timeout, [Tab]}, mnesia:wait_for_tables([Tab], 2)),
     ?match({'EXIT', _}, mnesia:dirty_read({Tab, 1})),
     ?match(yes, mnesia:force_load_table(Tab)),
     ?match([{Tab, 1, test_ok}], mnesia:dirty_read({Tab, 1})),

--- a/lib/mnesia/test/mnesia_evil_coverage_test.erl
+++ b/lib/mnesia/test/mnesia_evil_coverage_test.erl
@@ -51,6 +51,8 @@
 
 -export([info_check/8, index_size/1]).
 
+-compile({nowarn_deprecated_function, {mnesia_registry, create_table, 2}}).
+
 -define(cleanup(N, Config),
 	mnesia_test_lib:prepare_test_case([{reload_appls, [mnesia]}],
 					  N, Config, ?FILE, ?LINE)).

--- a/lib/mnesia/test/mnesia_isolation_test.erl
+++ b/lib/mnesia/test/mnesia_isolation_test.erl
@@ -629,8 +629,8 @@ sticky_sync(Config) when is_list(Config) ->
         end,
 
     %% Fill 1000 dc records. At the end all dc records should have value 1.
-    {Time, ok} = timer:tc(fun() -> lists:foreach(TestFun, lists:seq(1,200)) end),
-    io:format("Written, check content~n",[]),
+    {_Time, ok} = timer:tc(fun() -> lists:foreach(TestFun, lists:seq(1,200)) end),
+    io:format("Written, check content ~w~n",[_Time]),
     All = fun() -> mnesia:select(dc, [ {{dc, '_', 0}, [] ,['$_']} ]) end,
     ?match({atomic, []}, rpc:call(N1, mnesia, sync_transaction, [All])),
     ?match({atomic, []}, rpc:call(N2, mnesia, sync_transaction, [All])),

--- a/lib/mnesia/test/mnesia_registry_test.erl
+++ b/lib/mnesia/test/mnesia_registry_test.erl
@@ -29,6 +29,8 @@
 
 -include("mnesia_test_lib.hrl").
 
+-compile(nowarn_deprecated_function).
+
 init_per_testcase(Func, Conf) ->
     mnesia_test_lib:init_per_testcase(Func, Conf).
 

--- a/lib/mnesia/test/mt
+++ b/lib/mnesia/test/mt
@@ -1,5 +1,12 @@
 #! /bin/sh -f
-# ``Licensed under the Apache License, Version 2.0 (the "License");
+#
+# %CopyrightBegin%
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright Ericsson AB 1999-2025. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
@@ -10,12 +17,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
-# The Initial Developer of the Original Code is Ericsson Utvecklings AB.
-# Portions created by Ericsson are Copyright 1999, Ericsson Utvecklings
-# AB. All Rights Reserved.''
-# 
-#     $Id$
+#
+# %CopyrightEnd%
 #
 #
 # Author: Hakan Mattsson <hakan@erix.ericsson.se>
@@ -30,9 +33,9 @@ p="-pa $top/examples -pa $top/ebin -pa $top/test -mnesia_test_verbose true"
 log=test_log$$
 latest=test_log_latest
 args=${1+"$@"}
-erlcmd="erl -sname a $p $args -mnesia_test_timeout"
-erlcmd1="erl -sname a1 $p $args"
-erlcmd2="erl -sname a2 $p $args"
+erlcmd="erl -sname a@localhost $p $args -mnesia_test_timeout"
+erlcmd1="erl -sname a1@localhost $p $args"
+erlcmd2="erl -sname a2@localhost $p $args"
 
 if test z"$MT_TERM" = z ; then
     MT_TERM=xterm


### PR DESCRIPTION
Delete node `mnesia:del_table_copy(schema, Node)` failed if there was tables that only exited on Nodes that 
where not currently available.