### PR TITLE
Add bench test group to the load suite

### DIFF
--- a/lib/megaco/test/megaco_bench.spec
+++ b/lib/megaco/test/megaco_bench.spec
@@ -21,3 +21,4 @@
 %%
 
 {groups,"../megaco_test",megaco_examples_SUITE,[bench]}.
+{groups,"../megaco_test",megaco_load_SUITE,[bench]}.


### PR DESCRIPTION
Add bench(mark) related groups.
Cleanup of the load suite in prep for bench-ification. Also fixed calculation for multi-user-load cases.
Add value checks to ensure usefull result
Add megaco_load_SUITE (bench) to the bench spec file