### PR TITLE
ssh: fix cross builds of tests

### DIFF
--- a/lib/ssh/test/Makefile
+++ b/lib/ssh/test/Makefile
@@ -146,3 +146,7 @@ release_tests_spec: opt
 	@tar cf - *_SUITE_data property_test | (cd "$(RELSYSDIR)"; tar xf -)
 
 release_docs_spec:
+
+# Dependencies
+
+$(TARGET_FILES):	$(HRL_FILES)

--- a/lib/ssh/test/ssh_trpt_test_lib.erl
+++ b/lib/ssh/test/ssh_trpt_test_lib.erl
@@ -32,9 +32,9 @@
        ).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("ssh/src/ssh.hrl").		% ?UINT32, ?BYTE, #ssh{} ...
--include_lib("ssh/src/ssh_transport.hrl").
--include_lib("ssh/src/ssh_auth.hrl").
+-include("../src/ssh.hrl").		% ?UINT32, ?BYTE, #ssh{} ...
+-include("../src/ssh_transport.hrl").
+-include("../src/ssh_auth.hrl").
 
 %%%----------------------------------------------------------------
 -record(s, {


### PR DESCRIPTION
- mark test files as depending on header files from src
- use include