### PR TITLE
Fix race condition getting date and time in mnesia_recover

### DIFF
--- a/lib/mnesia/src/mnesia_recover.erl
+++ b/lib/mnesia/src/mnesia_recover.erl
@@ -779,7 +779,8 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 do_log_mnesia_up(Node) ->
-    Yoyo = {mnesia_up, Node, Date = date(), Time = time()},
+    {Date, Time} = erlang:localtime(),
+    Yoyo = {mnesia_up, Node, Date, Time},
     case mnesia_monitor:use_dir() of
 	true ->
 	    mnesia_log:append(latest_log, Yoyo),
@@ -790,7 +791,8 @@ do_log_mnesia_up(Node) ->
     note_up(Node, Date, Time).
 
 do_log_mnesia_down(Node) ->
-    Yoyo = {mnesia_down, Node, Date = date(), Time = time()},
+    {Date, Time} = erlang:localtime(),
+    Yoyo = {mnesia_down, Node, Date, Time},
     case mnesia_monitor:use_dir() of
 	true ->
 	    mnesia_log:append(latest_log, Yoyo),


### PR DESCRIPTION
This used an "export from subexpression" variable assignment style which warranted rewriting, but also had a race condition where the time and date could be sampled on separate sides of a date change.