### PR TITLE
erts: Fix bug in erlang:monitor_node for rare reconnect case

### DIFF
--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -6443,7 +6443,7 @@ monitor_node(Process* p, Eterm Node, Eterm Bool, Eterm Options)
                                              THE_NON_VALUE));
                 mon2 = &mdep2->md.origin;
                 inserted =
-                    erts_monitor_dist_insert(&mdep->md.u.target, dep->mld);
+                    erts_monitor_dist_insert(&mdep2->md.u.target, dep->mld);
                 ASSERT(inserted); (void)inserted;
                 ASSERT(mdep2->dist->connection_id == dep->connection_id);
 


### PR DESCRIPTION
Can only happen if a repeated call to `erlang:monitor_node(Node, true)` is made from the same process with the same `Node` in the short time span after the connection to `Node` has gone down but before `{nodedown, Node}` has been delivered.