### PR TITLE
inets: Do not send Content-Length header for bodyless requests

### DIFF
--- a/lib/inets/src/http_client/httpc_request.erl
+++ b/lib/inets/src/http_client/httpc_request.erl
@@ -198,6 +198,17 @@ is_client_closing(Headers) ->
 %%%========================================================================
 %%% Internal functions
 %%%========================================================================
+post_data(Method, Headers, {[], []}, [])
+  when Method =:= get;
+       Method =:= head;
+       Method =:= options;
+       Method =:= trace;
+       Method =:= delete ->
+    %% RFC 9110: A user agent SHOULD NOT send a Content-Length header field
+    %% when the request message does not contain content and the method
+    %% semantics do not anticipate such data.
+    {Headers#http_request_h{'content-length' = undefined}, ""};
+
 post_data(Method, Headers, {ContentType, Body}, HeadersAsIs)
     when (Method =:= post)
          orelse (Method =:= put)


### PR DESCRIPTION
RFC 9110 states: "A user agent SHOULD NOT send a Content-Length header field when the request message does not contain content and the method semantics do not anticipate such data."

Previously, httpc sent Content-Length: 0 for all requests including GET, HEAD, OPTIONS, TRACE, and DELETE without body. This caused issues with strict HTTP validators like AWS Elastic Load Balancers.

Now, Content-Length is omitted for these methods when no body is provided in the request.

Fixes https://github.com/erlang/otp/issues/10513