### PR TITLE
Fix split list item in xref documentation

### DIFF
--- a/lib/tools/doc/guides/xref_chapter.md
+++ b/lib/tools/doc/guides/xref_chapter.md
@@ -264,10 +264,8 @@ xref:add_release(s, code:root_dir()).
   All exported functions of the `digraph` module used (in)directly by some
   function in `digraph`.
 
-- **`xref:q(s, "L * yeccparser:Mod - range (closure (E |`**
-
-- **`yeccparser:Mod) | (X * yeccparser:Mod))").`** - The interpretation is left
-  as an exercise.
+- **`xref:q(s, "L * yeccparser:Mod - range (closure (E | yeccparser:Mod) | (X * yeccparser:Mod))").`** -
+  The interpretation is left as an exercise.
 
 ## Graph Analysis
 


### PR DESCRIPTION
Notice a problem when reading `xref` documentation [here](https://www.erlang.org/doc/apps/tools/xref_chapter.html):

<img width="1800" height="560" alt="CleanShot 2026-01-11 at 15 33 21@2x" src="https://github.com/user-attachments/assets/64bed02d-2d70-4981-8744-e975a291972e" />

P.S. wasn't sure what is the policy for small passer-by contributions like this, but decided to open a PR anyway as it was a relatively simple thing to do.
