### PR TITLE
Add persistent_term:has_key/1

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -66,7 +66,7 @@ atom undefined_lambda
 #
 atom nil no none
 
-# All other atoms.  Try to keep the order alphabetic.
+# All other atoms.  Try to keep the order alphabetical.
 #
 atom DOWN='DOWN'
 atom UP='UP'
@@ -354,6 +354,7 @@ atom Gt='>'
 atom grun
 atom group_leader
 atom handle
+atom has_key
 atom have_dt_utag
 atom heap_block_size
 atom heap_size

--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -834,3 +834,4 @@ bif erl_debugger:peek_xreg/3
 bif erts_debug:unaligned_bitstring/2
 bif re:import/1
 bif persistent_term:put_new/2
+bif persistent_term:has_key/1

--- a/erts/emulator/beam/erl_bif_persistent.c
+++ b/erts/emulator/beam/erl_bif_persistent.c
@@ -397,6 +397,18 @@ BIF_RETTYPE persistent_term_get_2(BIF_ALIST_2)
     BIF_RET(result);
 }
 
+BIF_RETTYPE persistent_term_has_key_1(BIF_ALIST_1)
+{
+    Eterm result = persistent_term_get(BIF_ARG_1);
+    if (is_non_value(result)) {
+        result = am_false;
+    } else {
+        result = am_true;
+    }
+
+    BIF_RET(result);
+}
+
 static int persistent_term_erase_1_ctx_bin_dtor(Binary *context_bin)
 {
     ErtsPersistentTermErase1Context* ctx = ERTS_MAGIC_BIN_DATA(context_bin);

--- a/erts/emulator/test/persistent_term_SUITE.erl
+++ b/erts/emulator/test/persistent_term_SUITE.erl
@@ -98,11 +98,13 @@ basic(_Config) ->
 
              {'EXIT',{badarg,_}} = (catch persistent_term:get(Key)),
              {not_present,Key} = persistent_term:get(Key, {not_present,Key}),
+             false = persistent_term:has_key(Key),
 
              ok = persistent_term:put_new(Key, {value, I}),
              ok = persistent_term:put_new(Key, {value, I}),
              {'EXIT',{badarg,_}} = (catch persistent_term:put_new(Key, {new_value, I})),
              {value, I} = persistent_term:get(Key),
+             true = persistent_term:has_key(Key),
              true = persistent_term:erase(Key)
          end || I <- Seq],
     [] = [P || {{?MODULE,_},_}=P <- pget(Chk)],
@@ -190,7 +192,7 @@ purging_tester(Parent, Key) ->
     Parent ! {self(),gotten},
     receive
         {Parent,erased} ->
-            {'EXIT',{badarg,_}} = (catch persistent_term:get(Key)),
+            false = persistent_term:has_key(Key),
             purging_tester_1(Term, 1);
         {Parent,replaced} ->
             {?MODULE,new} = persistent_term:get(Key),

--- a/erts/preloaded/src/persistent_term.erl
+++ b/erts/preloaded/src/persistent_term.erl
@@ -139,7 +139,7 @@ tables are stored as a single persistent term:
 """.
 -moduledoc(#{since => "OTP 21.2"}).
 
--export([erase/1,get/0,get/1,get/2,info/0,put/2, put_new/2]).
+-export([erase/1,get/0,get/1,get/2,has_key/1,info/0,put/2,put_new/2]).
 
 -doc "Any Erlang term.".
 -type key() :: term().
@@ -213,6 +213,19 @@ process.
       Default :: value(),
       Value :: value().
 get(_Key, _Default) ->
+    erlang:nif_error(undef).
+
+-doc """
+Check if a persistent term associated with the key `Key` exists.
+
+The lookup will be made in constant time and the value will not be copied to the
+heap of the calling process.
+
+Returns a boolean.
+""".
+-doc(#{since => <<"OTP ...">>}).
+-spec has_key(Key :: key()) -> boolean().
+has_key(_Key) ->
     erlang:nif_error(undef).
 
 -doc """


### PR DESCRIPTION
This commit adds the persistent_term:has_key/1 function along with tests
and documentation to check if a key exists in the persistent term.

Closes #10533.
