### PR TITLE
Scan SKIP files in addition to scanning SKIP-APPLICATIONS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -994,3 +994,7 @@ APPS_TEST=$(patsubst %, %_test,$(APPS))
 $(NO_DIALYZER_APPS): $$(patsubst %,%_build,$$@)
 $(APPS_TEST): $$(patsubst %_test,%_build,$$@)
 	ERL_TOP=$(ERL_TOP) TYPE=$(TYPE) $(MAKE) -C lib/$(patsubst %_test,%,$@) test
+
+.PHONY: clean_docs
+clean_docs:
+	rm -rf $(ERL_TOP)/doc $(ERL_TOP)/make/otp_doc_built

--- a/system/doc/top/Makefile
+++ b/system/doc/top/Makefile
@@ -28,8 +28,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 # ----------------------------------------------------
 APPLICATION=Erlang/OTP
 VSN=$(shell cat $(ERL_TOP)/OTP_VERSION)
-SKIP_FILE := $(wildcard $(ERL_TOP)/lib/SKIP_APPLICATIONS)
-SKIP_APPLICATIONS=$(if $(SKIP_FILE),$(shell cat $(ERL_TOP)/lib/SKIP-APPLICATIONS),)
+
 APP_DIR=../../../lib/erl_interface
 INDEX_DIR=.
 HTMLDIR=../../../doc
@@ -44,6 +43,13 @@ TOOLS=debugger dialyzer et observer parsetools reltool runtime_tools syntax_tool
 TESTING=common_test eunit
 DOCUMENTATION=edoc
 SYSTEM:=$(shell awk -F: '{print $$1}' ../guides)
+
+# The applications skipped by $(ERL_TOP)/configure are not added SKIP-APPLICATIONS.
+# Solution: read both SKIP-APPLICATIONS and names of libraries which contain a lib/*/SKIP file.
+# $(pathsubst %/,%,_) clears trailing slash, $(dir _) = directory name, $(notdir _) = last component of the path
+SKIP_FILE := $(wildcard $(ERL_TOP)/lib/SKIP-APPLICATIONS)
+SKIP_APPLICATIONS=$(if $(SKIP_FILE),$(shell cat $(ERL_TOP)/lib/SKIP-APPLICATIONS),) \
+                  $(foreach f,$(wildcard $(ERL_TOP)/lib/*/SKIP),$(notdir $(patsubst %/,%,$(dir $(f)))))
 
 REDIRECTS=$(foreach guide,$(SYSTEM),system/$(guide).md) \
 	$(foreach app, $(filter-out $(SKIP_APPLICATIONS),$(CORE)),          core/$(app).md) \


### PR DESCRIPTION
## Problem
The documentation build step `make docs` displays a warning when an application has failed its configure step and was not built
## Solution
Additional fix for documentation build warnings.
Covered case previously:
* Application was skipped with user CLI option `--without-XX`

Covers a new case:
* The application failed its configure step (for example a hard dependency is not found).

Additionally: new target added to the root Makefile to reset the generated documentation state: `make clean_docs`

## Result
* The generated documentation still has the application name in the left bar
* The generated documentation correctly shows the placeholder when clicking the skipped application.