### PR TITLE
Fix tab erroring with "Unbalanced parenthesis" in erlang-shell .

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -5799,6 +5799,7 @@ Also see the description of `ielm-prompt-read-only'."
 The following special commands are available:
 \\{erlang-shell-mode-map}"
   (erlang-mode-variables)
+  (kill-local-variable 'indent-line-function)
   ;; Needed when compiling directly from the Erlang shell.
   (setq next-error-last-buffer (current-buffer))
   (setq comint-prompt-regexp "^[^>=]*> *")


### PR DESCRIPTION
From the github issue: https://github.com/erlang/otp/issues/8569

  This bug is caused by the code for erlang-calculate-indent, which calls
  erlang-beginning-of-clause to move to the beginning of the previous clause
  in order to calculate the appropriate indentation.

  If erlang-shell was just started, this causes the point to move before the
  beginning of the first prompt, to the Eshell version string

  (Eshell V15.0 (press Ctrl+G to abort, type help(). for help)).

  Then, erlang-partial-parse is invoked, which results in a parse error
  giving rise to the message.

I am unaware how to write a test for this in emacs, but at least now it doesn't present the problem as shown in the issue.

<img width="1358" height="245" alt="erlang-shell-tab-pressed" src="https://github.com/user-attachments/assets/73807220-d823-4c62-9805-83075100dc40" />
