### PR TITLE
Change type ets:tid() from opaque to nominal

### DIFF
--- a/lib/dialyzer/test/opaque_SUITE_data/results/ets
+++ b/lib/dialyzer/test/opaque_SUITE_data/results/ets
@@ -1,3 +1,1 @@
 
-ets_use.erl:12:9: Guard test is_integer(T::atom() | ets:tid()) can never succeed
-ets_use.erl:7:9: Guard test is_integer(T::ets:tid()) can never succeed

--- a/lib/dialyzer/test/r9c_SUITE_data/results/asn1
+++ b/lib/dialyzer/test/r9c_SUITE_data/results/asn1
@@ -1,6 +1,4 @@
 
-asn1ct.erl:1224:2: Body yields the type atom() | ets:tid() which violates the opacity of the other clauses.
-asn1ct.erl:1227:2: Body yields the type 'ok' which violates the opacity of the other clauses.
 asn1ct.erl:1500:2: The variable Err can never match since previous clauses completely covered the type #type{}
 asn1ct.erl:1596:2: The variable _ can never match since previous clauses completely covered the type 'ber_bin_v2'
 asn1ct.erl:1673:2: The pattern 'all' can never match the type 'asn1_module' | 'exclusive_decode' | 'partial_decode'

--- a/lib/dialyzer/test/r9c_SUITE_data/results/mnesia
+++ b/lib/dialyzer/test/r9c_SUITE_data/results/mnesia
@@ -29,21 +29,9 @@ mnesia_frag_old_hash.erl:105:6: Call to missing or unexported function erlang:ha
 mnesia_frag_old_hash.erl:23:2: Callback info about the mnesia_frag_hash behaviour is not available
 mnesia_index.erl:52:45: The call mnesia_lib:other_val(Var::{_,'commit_work' | 'index' | 'setorbag' | 'storage_type' | {'index',_}},_ReASoN_::any()) will never return since it differs in the 1st argument from the success typing arguments: ({_,'active_replicas' | 'where_to_read' | 'where_to_write'},any())
 mnesia_lib.erl:1028:2: The pattern {'EXIT', Reason} can never match the type [any()] | {'error',_}
-mnesia_lib.erl:1110:2: Body yields the type atom() | {'error',_} | ets:tid() which violates the opacity of the other clauses.
-mnesia_lib.erl:1114:2: Body yields the type {_,_} which violates the opacity of the other clauses.
-mnesia_lib.erl:1118:1: Body yields the type 'loaded' which violates the opacity of the other clauses.
-mnesia_lib.erl:1119:1: Body yields the type atom() | {'error',_} | ets:tid() which violates the opacity of the other clauses.
 mnesia_lib.erl:957:2: The pattern {'ok', {0, _}} can never match the type 'eof' | {'error',atom() | {'no_translation','unicode','latin1'}} | {'ok',binary() | string()}
 mnesia_lib.erl:959:2: The pattern {'ok', {_, Bin}} can never match the type 'eof' | {'error',atom() | {'no_translation','unicode','latin1'}} | {'ok',binary() | string()}
-mnesia_loader.erl:101:5: Body yields the type 'false' which violates the opacity of the other clauses.
-mnesia_loader.erl:105:3: Body yields the type 'false' which violates the opacity of the other clauses.
 mnesia_loader.erl:36:43: The call mnesia_lib:other_val(Var::{_,'access_mode' | 'cstruct' | 'db_nodes' | 'setorbag' | 'snmp' | 'storage_type'},Reason::any()) will never return since it differs in the 1st argument from the success typing arguments: ({_,'active_replicas' | 'where_to_read' | 'where_to_write'},any())
-mnesia_loader.erl:85:2: Body yields the type 'ignore' which violates the opacity of the other clauses.
-mnesia_loader.erl:87:2: Body yields the type atom() | number() | {_,_} | ets:tid() which violates the opacity of the other clauses.
-mnesia_loader.erl:93:3: Body yields the type atom() | number() | {_,_} | ets:tid() which violates the opacity of the other clauses.
-mnesia_loader.erl:95:4: Body yields the type number() which violates the opacity of the other clauses.
-mnesia_loader.erl:96:4: Body yields the type atom() | {_,_} | ets:tid() which violates the opacity of the other clauses.
-mnesia_loader.erl:98:5: Body yields the type atom() | {_,_} | ets:tid() which violates the opacity of the other clauses.
 mnesia_locker.erl:1017:1: Function system_terminate/4 has no local return
 mnesia_log.erl:715:23: The test {'error',{[1..255,...],[any(),...]}} | {'ok',_} == atom() can never evaluate to 'true'
 mnesia_log.erl:735:13: The created fun has no local return
@@ -56,7 +44,6 @@ mnesia_schema.erl:1258:2: Guard test FromS::'disc_copies' | 'disc_only_copies' |
 mnesia_schema.erl:1639:2: The pattern {'false', 'mandatory'} can never match the type {'false','optional'}
 mnesia_schema.erl:2434:2: The variable Reason can never match since previous clauses completely covered the type {'error',_} | {'ok',_}
 mnesia_schema.erl:451:36: Guard test UseDirAnyway::'false' == 'true' can never succeed
-mnesia_schema.erl:496:13: Body yields the type atom() | ets:tid() which violates the opacity of the other clauses.
 mnesia_text.erl:180:3: The variable T can never match since previous clauses completely covered the type {'error',{(erl_anno:location() :: {(erl_anno:line() :: non_neg_integer()),pos_integer()} | (erl_anno:line() :: non_neg_integer())),atom(),_}} | {'ok',_}
 mnesia_tm.erl:1522:1: Function commit_participant/5 has no local return
 mnesia_tm.erl:2169:1: Function system_terminate/4 has no local return

--- a/lib/dialyzer/test/user_SUITE_data/results/gcpFlowControl
+++ b/lib/dialyzer/test/user_SUITE_data/results/gcpFlowControl
@@ -1,3 +1,2 @@
 
-gcpFlowControl.erl:130:1: Body yields the type atom() | ets:tid() which violates the opacity of the other clauses.
 gcpFlowControl.erl:171:2: The pattern <Key, 'errors', X> can never match the type <_,'available' | 'bucket' | 'rejectable' | 'rejects' | 'window',0 | 1 | 20>

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -270,8 +270,13 @@ Opaque continuation used by [`select/1,3`](`select/1`),
                        | {table(),integer(),integer(),compiled_match_spec(),list(),integer()}
                        | {table(),_,_,integer(),compiled_match_spec(),list(),integer(),integer()}.
 
--doc "A table identifier, as returned by `new/2`.".
--opaque tid()         :: reference().
+-doc """
+A table identifier, as returned by `new/2`.
+
+The actual type of `tid()` is undefined and can change at any time.
+No assumptions can be made, except it cannot be an atom.
+""".
+-nominal tid()         :: dynamic().
 
 -type match_pattern() :: atom() | tuple().
 -doc "A match specification, see [Match Specifications](`m:ets#match_spec`).".


### PR DESCRIPTION
Will avoid dialyzer warnings about using `ets:tid()` in union with atoms. Both `ets:new/2` and `ets:whereis/1` return such unions.

The drawback is that dialyzer will no longer catch real violations of the opaqueness of `ets:tid()`.