### PR TITLE
ERL-1046: Document -nocookie argument

### DIFF
--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -349,6 +349,18 @@ described in the corresponding application documentation.
   > extension the cluster. When using un-secure distributed nodes, make sure
   > that the network is configured to keep potential attackers out.
 
+- **`-nocookie`** - Prevents the node from creating or using the magic
+  cookie.
+
+  When this flag is used, the node will not read the `~/.erlang.cookie` file on startup.
+
+  The node's own cookie will remain "undefined" unless explicitly set later via
+  `erlang:set_cookie/1` or `erlang:set_cookie/2`.
+
+  This effectively prevents the node from participating in a distributed Erlang
+  cluster with nodes that require cookie authentication. It is primarily used
+  for nodes that are intended to be isolated.
+
 - **`-no_epmd`** - Specifies that the distributed node does not need
   [epmd](epmd_cmd.md) at all.
 


### PR DESCRIPTION
This fix documents the -nocookie argument used in lib/kernel/src/auth.erl because it is useful for preventing $HOME/.erlang.cookie from being automatically being automatically created.

This patch was made in response to:
	https://github.com/erlang/otp/issues/3814

I noted some of the findings in the linked above issue that I believe can be addressed in another PR if required.