### PR TITLE
forbid non-maintainers from committing beam files

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,7 +81,7 @@ jobs:
           MODIFIED_BEAM_FILES=$(git diff --name-only ${{github.event.pull_request.base.sha}} \
                                                      ${{ github.event.pull_request.head.sha }} | grep '\.beam$' || true)
           if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" && "$PERMISSION" != "Security Master" && -n "$MODIFIED_BEAM_FILES" ]]; then
-             echo "::error::Workflow failer: Only maintainers can make modifications to '*.beam' files:"
+             echo "::error::Workflow failed: Only maintainers can make modifications to '*.beam' files:"
              echo "$MODIFIED_BEAM_FILES"
              exit 1
           fi


### PR DESCRIPTION
this job checks whether the pull request has modified beam files. if it
does, then we check that only maintainers can commit beam files. the
action will fail if a non-maintainer adds beam files.

this action happens as the first step in the pipeline, so there will be
no build of Erlang/OTP if the job fails.
