### PR TITLE
jinterface: Allow to build determenistic OtpErlang.jar

### DIFF
--- a/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
+++ b/lib/jinterface/java_src/com/ericsson/otp/erlang/Makefile
@@ -79,9 +79,18 @@ CLASSPATH = $(JAVA_SRC_ROOT)
 
 JAVADOCFLAGS=-d $(DOCDIR)
 JAVAFLAGS=-d $(JAVA_DEST_ROOT) 
-JARFLAGS=-cf
-ifneq ($(V),0)
-JARFLAGS=-cfv
+ifeq ($(V),0)
+	JARFLAGS=-cf
+	JARFLAGS2=-c -f
+else
+	JARFLAGS=-cvf
+	JARFLAGS2=-c -v -f
+endif
+ifdef SOURCE_DATE_EPOCH
+# We hardcode the date, because the complexity of converting
+# seconds to a date string to work on all OSes is not worth it.
+# The --date option requires openjdk-17 or later.
+	JARFLAGS := --date=1980-01-01T12:00:00Z $(JARFLAGS2)
 endif
 
 JAVA_OPTIONS = -Xlint -encoding UTF-8


### PR DESCRIPTION
This is a simpler alternative to PR #5580

It lets us get closer to reproducible builds for erlang. See https://reproducible-builds.org/ for why this is good.

Note: when using options with double-dash,
  jar does not understand merged options such as -cf anymore
  so we have to split them up to work again.

Closes #5580