### PR TITLE
`ssl`: Remove usages of `and` and `or`

### DIFF
--- a/lib/ssl/src/ssl_cipher.erl
+++ b/lib/ssl/src/ssl_cipher.erl
@@ -29,8 +29,6 @@
 -module(ssl_cipher).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -include("ssl_internal.hrl").
 -include("ssl_record.hrl").
 -include("ssl_cipher.hrl").
@@ -893,8 +891,8 @@ hash_algorithm(?SHA224) -> sha224;
 hash_algorithm(?SHA256) -> sha256;
 hash_algorithm(?SHA384) -> sha384;
 hash_algorithm(?SHA512) -> sha512;
-hash_algorithm(Other)  when is_integer(Other) andalso ((Other >= 7) and (Other =< 223)) -> unassigned;
-hash_algorithm(Other)  when is_integer(Other) andalso ((Other >= 224) and (Other =< 255)) -> Other.
+hash_algorithm(Other)  when is_integer(Other), Other >= 7, Other =< 223 -> unassigned;
+hash_algorithm(Other)  when is_integer(Other), Other >= 224, Other =< 255 -> Other.
 
 sign_algorithm(anon)  -> ?ANON;
 sign_algorithm(rsa)   -> ?RSA;
@@ -904,8 +902,8 @@ sign_algorithm(?ANON) -> anon;
 sign_algorithm(?RSA) -> rsa;
 sign_algorithm(?DSA) -> dsa;
 sign_algorithm(?ECDSA) -> ecdsa;
-sign_algorithm(Other) when is_integer(Other) andalso ((Other >= 4) and (Other =< 223)) -> unassigned;
-sign_algorithm(Other) when is_integer(Other) andalso ((Other >= 224) and (Other =< 255)) -> Other.
+sign_algorithm(Other) when is_integer(Other), Other >= 4, Other =< 223 -> unassigned;
+sign_algorithm(Other) when is_integer(Other), Other >= 224, Other =< 255 -> Other.
 
 
 signature_algorithm_to_scheme(#'SignatureAlgorithm'{algorithm = ?'id-RSASSA-PSS',

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -28,8 +28,6 @@
 -module(ssl_gen_statem).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -include("ssl_api.hrl").
 -include("ssl_internal.hrl").
 -include("ssl_connection.hrl").
@@ -1768,8 +1766,8 @@ deliver_app_data(UserSocket, #socket_options{active=Active, packet=Type} = SOpts
     SO =
         case Data of
             {P, _, _, _}
-              when ((P =:= http_request) or (P =:= http_response)),
-                   ((Type =:= http) or (Type =:= http_bin)) ->
+              when P =:= http_request orelse P =:= http_response,
+                   Type =:= http orelse Type =:= http_bin ->
                 SOpts#socket_options{packet={Type, headers}};
             http_eoh when tuple_size(Type) =:= 2 ->
                 %% End of headers - expect another Request/Response line

--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -27,8 +27,6 @@
 -module(ssl_handshake).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -include("ssl_handshake.hrl").
 -include("ssl_record.hrl").
 -include("ssl_cipher.hrl").
@@ -2102,8 +2100,8 @@ validation_fun_and_state(undefined, VerifyState, CertPath, LogLevel) ->
 				      Extension,
 				      SslState,
                                       LogLevel);
-	(OtpCert, _DerCert, VerifyResult, SslState) when (VerifyResult == valid) or
-                                                        (VerifyResult == valid_peer) ->
+	(OtpCert, _DerCert, VerifyResult, SslState) when VerifyResult == valid;
+                                                         VerifyResult == valid_peer ->
 	     case cert_status_check(OtpCert, SslState, VerifyResult, CertPath, LogLevel) of
 		 valid ->
                      ssl_certificate:validate(OtpCert, VerifyResult, SslState, LogLevel);
@@ -2122,7 +2120,7 @@ path_validation_options(Opts, ValidationFunAndState) ->
      {verify_fun, ValidationFunAndState} | PolicyOpts].
 
 apply_user_fun(Fun, OtpCert, DerCert, VerifyResult0, UserState0, SslState, CertPath, LogLevel) when
-      (VerifyResult0 == valid) or (VerifyResult0 == valid_peer) ->
+      VerifyResult0 == valid; VerifyResult0 == valid_peer ->
     VerifyResult = maybe_check_hostname(OtpCert, VerifyResult0, SslState, LogLevel),
     case apply_fun(Fun, OtpCert, DerCert, VerifyResult, UserState0) of
 	{Valid, UserState} when (Valid == valid) orelse (Valid == valid_peer) ->


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `ssl`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.