### PR TITLE
beam_ssa_type: Fix invalid type subtraction in #b_switch{} handling

### DIFF
--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -2007,7 +2007,11 @@ update_successors(#b_ret{}=Last, _Ts, _Ds, Ls, _UsedOnce) ->
 
 update_switch([{Val, Lbl}=Sw | List],
               V, FailType0, Ts, Ds, Ls0, IsTempVar, Acc) ->
-    FailType = beam_types:subtract(FailType0, concrete_type(Val, Ts)),
+    ValType = concrete_type(Val, Ts),
+    FailType = case beam_types:is_singleton_type(ValType) of
+                   true -> beam_types:subtract(FailType0, ValType);
+                   false -> FailType0
+               end,
     case infer_types_switch(V, Val, Ts, IsTempVar, Ds) of
         none ->
             update_switch(List, V, FailType, Ts, Ds, Ls0, IsTempVar, Acc);

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -1054,6 +1054,10 @@ type_subtraction(Config) when is_list(Config) ->
     ok = catch type_subtraction_4(id(ok)),
     {'EXIT', _} = catch type_subtraction_4(id(false)),
 
+    outside = id(type_subtraction_5(<<"c">>)),
+    {inside, 1} = id(type_subtraction_5(<<"a">>)),
+    {inside, 2} = id(type_subtraction_5(<<"b">>)),
+
     ok.
 
 
@@ -1116,6 +1120,16 @@ type_subtraction_4(_V0) ->
             >>
     end.
 
+%% GH-10562: Types were erroneously applied in #b_switch{} over bitstrings.
+type_subtraction_5(X) ->
+    _ = id(X),
+    case X =:= <<"a">> orelse X =:= <<"b">> of
+        false -> outside;
+        true ->
+            Y = case X of <<"a">> -> 1; _ -> 2 end,
+            {inside, Y}
+    end.
+    
 %% GH-4774: The validator didn't update container contents on type subtraction.
 container_subtraction(Config) when is_list(Config) ->
     A = id(baz),


### PR DESCRIPTION
Fixes #10562