### PR TITLE
erts: document the -user flag in erl man page

### DIFF
--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -503,7 +503,7 @@ described in the corresponding application documentation.
   with a custom implementation (for example, a custom communication
   protocol or a specialized embedded interface).
 
-  > #### Note {: .warning }
+  > #### Warning {: .warning }
   >
   > Because the `-user` flag replaces the standard I/O handler, the `io`
   > module will not function correctly until the replacement module


### PR DESCRIPTION
The -user flag was previously undocumented in the 'erl' command reference. This flag allows users to override the default 'user' process (the I/O server) during the boot sequence.

This commit adds the flag description and includes a warning regarding the I/O protocol requirements when replacing the default handler, as standard 'io' module calls will fail if the custom module does not implement the expected interface.

This addresses https://github.com/erlang/otp/issues/10067

Please close the issue once it has been addressed as I do not have permission to do so.