### PR TITLE
`kernel`: Remove usages of `and` and `or`

### DIFF
--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -64,8 +64,6 @@ For details about applications and behaviours, see
 
 -export_type([start_type/0, restart_type/0]).
 
--compile(nowarn_obsolete_bool_op).
-
 %%%-----------------------------------------------------------------
 
 -doc "The reason for the application to be started on the current node.".
@@ -418,7 +416,7 @@ enqueue_or_start_app(Name, App, DAG, Pending, Started, Opts) ->
     %% is always empty.
     case enqueue_or_start(ChildApps, OptionalApps, DAG, [], Started, Opts) of
         {ok, NewDAG, NewPending, NewStarted}
-        when NewPending =:= [], (Mode =:= serial) or (Mod =:= []) ->
+        when NewPending =:= [], Mode =:= serial orelse Mod =:= [] ->
             case application_controller:start_application(App, Type) of
                 ok ->
                     {ok, NewDAG, Pending, [App | NewStarted]};

--- a/lib/kernel/src/disk_log_server.erl
+++ b/lib/kernel/src/disk_log_server.erl
@@ -23,8 +23,6 @@
 -moduledoc false.
 -behaviour(gen_server).
 
--compile(nowarn_obsolete_bool_op).
-
 -export([start_link/0, start/0, open/1, close/1, 
 	 get_log_pid/1, all/0]).
 
@@ -93,7 +91,7 @@ handle_info({pending_reply, Pid, Result0}, State) ->
     NP = lists:keydelete(Pid, #pending.pid, State#state.pending),
     State1 = State#state{pending = NP},
     if 
-        Attach and (Result0 =:= {error, no_such_log}) ->
+        Attach, Result0 =:= {error, no_such_log} ->
             %% The disk_log process has terminated. Try again.
             open([{Request,From} | Clients], State1);
         true -> 

--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -22,7 +22,6 @@
 -module(file_io_server).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
 -compile(nowarn_deprecated_catch).
 
 %% A simple file server for io to one file instance per server instance.
@@ -933,7 +932,7 @@ cbv({utf32,big}, <<0:8>>) ->
 cbv({utf32,big}, <<0:8,X:8>>) when X =< 16 ->
     2;
 cbv({utf32,big}, <<0:8,X:8,Y:8>>) 
-  when X =< 16, ((X > 0) or ((Y =< 215) or (Y >= 224))) ->
+  when X =< 16, X > 0 orelse Y =< 215 orelse Y >= 224 ->
     1;
 cbv({utf32,big},_) ->
     false;
@@ -944,7 +943,7 @@ cbv({utf32,little},<<_:8,_:8>>) ->
 cbv({utf32,little},<<X:8,255:8,0:8>>) when X =:= 254; X =:= 255 ->
     false;
 cbv({utf32,little},<<_:8,Y:8,X:8>>) 
-  when X =< 16, ((X > 0) or ((Y =< 215) or (Y >= 224))) ->
+  when X =< 16, X > 0 orelse Y =< 215 orelse Y >= 224 ->
     1;
 cbv({utf32,little},_) ->
     false.

--- a/lib/kernel/src/inet_dns.erl
+++ b/lib/kernel/src/inet_dns.erl
@@ -43,8 +43,6 @@
 
 -import(lists, [reverse/1]).
 
--compile(nowarn_obsolete_bool_op).
-
 -include("inet_int.hrl").
 -include("inet_dns.hrl").
 
@@ -197,7 +195,7 @@ do_decode(<<Id:16,
               %% The converse; a section marked as truncated,
               %% but not the header - is a parse error.
               %%
-              HdrTC or (not (QdTC or AnTC or NsTC or ArTC)),
+              HdrTC orelse not (QdTC orelse AnTC orelse NsTC orelse ArTC),
               true,
               begin
                   #dns_rec{header=DnsHdr,
@@ -403,7 +401,7 @@ encode_res_section_rr(
   Bin0, {Opcode,Mdns} = Opts, Comp0, Rs,
   DName, Type, Class, CacheFlush, TTL, Data) ->
     T = encode_type(Type),
-    C = encode_class(Class, Mdns and CacheFlush),
+    C = encode_class(Class, Mdns andalso CacheFlush),
     {Bin,Comp1} = encode_name(Bin0, Comp0, byte_size(Bin0), DName),
     Pos = byte_size(Bin)+2+2+byte_size(TTL)+2,
     {DataBin,Comp} = encode_data(Comp1, Pos, Type, Class, Data, Opcode),

--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -35,7 +35,6 @@ a program to run on most platforms.
 > Types" section.
 """.
 
--compile(nowarn_obsolete_bool_op).
 -compile(nowarn_deprecated_catch).
 
 %% Provides a common operating system interface.
@@ -708,7 +707,7 @@ validate2([0|Rest]) ->
 validate2([C|Rest]) when is_integer(C), C > 0 ->
     validate2(Rest);
 validate2([List|Rest]) when is_list(List) ->
-    validate2(List) or validate2(Rest);
+    validate2(List) orelse validate2(Rest);
 validate2([]) ->
     false.
 


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `kernel`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.