### PR TITLE
`inets`: Remove usages of `and` and `or`

### DIFF
--- a/lib/inets/src/http_client/httpc_response.erl
+++ b/lib/inets/src/http_client/httpc_response.erl
@@ -26,8 +26,6 @@
 -include_lib("inets/src/http_lib/http_internal.hrl").
 -include("httpc_internal.hrl").
 
--compile(nowarn_obsolete_bool_op).
-
 %% API
 %% Avoid warning for local function error/2 clashing with autoimported BIF.
 -compile({no_auto_import,[error/2]}).
@@ -285,7 +283,7 @@ parse_headers(<<?CR,?LF,?CR,?LF,Body/binary>>, Header, Headers,
     HTTPHeaders = [lists:reverse(Header) | Headers],
     Length = lists:foldl(fun(H, Acc) -> length(H) + Acc end,
 			   0, HTTPHeaders),
-    case ((Length =< MaxHeaderSize) or (MaxHeaderSize == nolimit)) of
+    case Length =< MaxHeaderSize orelse MaxHeaderSize == nolimit of
  	true ->   
 	    ResponseHeaderRcord = 
 		http_response:headers(HTTPHeaders, #http_response_h{}),

--- a/lib/inets/src/http_lib/http_chunk.erl
+++ b/lib/inets/src/http_lib/http_chunk.erl
@@ -25,8 +25,6 @@
 -module(http_chunk).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -include("http_internal.hrl").
 
 %% API
@@ -239,7 +237,7 @@ decode_data(ChunkSize, TotalChunk,
 	    NewBody = <<BodySoFar/binary, Data/binary>>,
 	    {?MODULE, decode_size, [<<>>, [], 0, {MaxBodySize, NewBody, AccLength, MaxHeaderSize}]};
 	<<Data:ChunkSize/binary, ?CR, ?LF, Rest/binary>> 
-	when (AccLength < MaxBodySize) or (MaxBodySize == nolimit)  ->
+	when AccLength < MaxBodySize; MaxBodySize == nolimit  ->
 	    decode_size(Rest, [], 0,
 			{MaxBodySize, <<BodySoFar/binary, Data/binary>>,
 			 AccLength, MaxHeaderSize});

--- a/lib/inets/src/http_server/httpd_request_handler.erl
+++ b/lib/inets/src/http_server/httpd_request_handler.erl
@@ -26,7 +26,6 @@
 -module(httpd_request_handler).
 -moduledoc false.
 -compile(nowarn_deprecated_callback).
--compile(nowarn_obsolete_bool_op).
 -behaviour(gen_server).
 
 %% Application internal API
@@ -530,7 +529,7 @@ handle_body(#state{headers = Headers, body = Body,
 	_ -> 
 	    Length = list_to_integer(Headers#http_request_h.'content-length'),
 	    MaxChunk = max_client_body_chunk(ConfigDB),
-	    case ((Length =< MaxBodySize) or (MaxBodySize == nolimit)) of
+	    case Length =< MaxBodySize orelse MaxBodySize == nolimit of
 		true ->
 		    case httpd_request:body_chunk_first(Body, Length, MaxChunk) of 
                         %% This is the case that the we need more data to complete

--- a/lib/inets/src/http_server/mod_cgi.erl
+++ b/lib/inets/src/http_server/mod_cgi.erl
@@ -30,8 +30,6 @@
 %%% Callback API
 -export([do/1, store/2]).
 
--compile(nowarn_obsolete_bool_op).
-
 -include("http_internal.hrl").
 -include("httpd_internal.hrl").
 -include("httpd.hrl").
@@ -216,8 +214,8 @@ deliver_webpage(#mod{config_db = Db} = ModData, Port) ->
 		{ok, HTTPHeaders, Status} when is_binary(Body)->
 		    IsDisableChunkedSend = 
 			httpd_response:is_disable_chunked_send(Db),
-		    case (ModData#mod.http_version =/= "HTTP/1.1") or 
-			(IsDisableChunkedSend) of
+		    case ModData#mod.http_version =/= "HTTP/1.1" orelse 
+			IsDisableChunkedSend of
 			true ->
 			    send_headers(ModData, Status, 
 					 [{"connection", "close"}

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -40,8 +40,6 @@ them as common CGI scripts.
 
 -export_type([session_id/0]).
 
--compile(nowarn_obsolete_bool_op).
-
 -include("httpd.hrl").
 -include("httpd_internal.hrl").
 -include_lib("kernel/include/logger.hrl").
@@ -487,8 +485,8 @@ deliver_webpage_chunk(#mod{config_db = Db} = ModData, Pid, Timeout) ->
                 StatusCode =:= 204 orelse                      %% No Content
                 StatusCode =:= 304 orelse                      %% Not Modified
                 (100 =< StatusCode andalso StatusCode =< 199), %% Informational
-            case (ModData#mod.http_version =/= "HTTP/1.1") or
-                (IsDisableChunkedSend) of
+            case ModData#mod.http_version =/= "HTTP/1.1" orelse
+                IsDisableChunkedSend of
                 true ->
                     send_headers(ModData, StatusCode, 
                                  [{"connection", "close"} | 

--- a/lib/inets/test/httpd_test_lib.erl
+++ b/lib/inets/test/httpd_test_lib.erl
@@ -276,7 +276,7 @@ handle_http_body(Body, State = #state{headers = Headers,
 	 _ ->
 	     Length =
 		 list_to_integer(Headers#http_response_h.'content-length'),
-	     case ((Length =< MaxBodySize) or (MaxBodySize == nolimit)) of
+	     case Length =< MaxBodySize orelse MaxBodySize == nolimit of
 		 true ->
 		     case httpc_response:whole_body(Body, Length) of
 			 {ok, NewBody} ->


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `inets`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.