### PR TITLE
Add limit option to application:ensure_all_started/3 to control max concurrency

### DIFF
--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -2,9 +2,9 @@
 %% %CopyrightBegin%
 %%
 %% SPDX-License-Identifier: Apache-2.0
-%% 
+%%
 %% Copyright Ericsson AB 1996-2025. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(application).
@@ -51,7 +51,7 @@ For details about applications and behaviours, see
 """.
 -export([ensure_all_started/1, ensure_all_started/2, ensure_all_started/3,
 	 start/1, start/2,
-	 start_boot/1, start_boot/2, stop/1, 
+	 start_boot/1, start_boot/2, stop/1,
 	 load/1, load/2, unload/1, takeover/2,
 	 which_applications/0, which_applications/1,
 	 loaded_applications/0, permit/2]).
@@ -753,13 +753,13 @@ and `vsn` application specification keys, respectively.
       Description :: string(),
       Vsn :: string().
 
-loaded_applications() -> 
+loaded_applications() ->
     application_controller:loaded_applications().
 
 -doc false.
 -spec info() -> term().
 
-info() -> 
+info() ->
     application_controller:info().
 
 -doc(#{equiv => set_env(Config, [])}).
@@ -819,7 +819,7 @@ set_env(Config, Opts) when is_list(Config), is_list(Opts) ->
       Par :: atom(),
       Val :: term().
 
-set_env(Application, Key, Val) -> 
+set_env(Application, Key, Val) ->
     application_controller:set_env(Application, Key, Val).
 
 -doc """
@@ -864,7 +864,7 @@ set_env(Application, Key, Val, Opts) when is_list(Opts) ->
       Application :: atom(),
       Par :: atom().
 
-unset_env(Application, Key) -> 
+unset_env(Application, Key) ->
     application_controller:unset_env(Application, Key).
 
 -doc """
@@ -903,7 +903,7 @@ unset_env(Application, Key, Opts) when is_list(Opts) ->
       Par :: atom(),
       Val :: term().
 
-get_env(Key) -> 
+get_env(Key) ->
     application_controller:get_pid_env(group_leader(), Key).
 
 -doc """
@@ -920,7 +920,7 @@ Returns `undefined` if any of the following applies:
       Par :: atom(),
       Val :: term().
 
-get_env(Application, Key) -> 
+get_env(Application, Key) ->
     application_controller:get_env(Application, Key).
 
 -doc """
@@ -941,7 +941,7 @@ get_env(Application, Key, Default) ->
 -spec get_all_env() -> Env when
       Env :: [{Par :: atom(), Val :: term()}].
 
-get_all_env() -> 
+get_all_env() ->
     application_controller:get_pid_all_env(group_leader()).
 
 -doc """
@@ -954,7 +954,7 @@ does not belong to any application, the function returns `[]`.
       Application :: atom(),
       Env :: [{Par :: atom(), Val :: term()}].
 
-get_all_env(Application) -> 
+get_all_env(Application) ->
     application_controller:get_all_env(Application).
 
 -doc(#{equiv => get_key(application:get_application(), Key)}).
@@ -962,7 +962,7 @@ get_all_env(Application) ->
       Key :: atom(),
       Val :: term().
 
-get_key(Key) -> 
+get_key(Key) ->
     application_controller:get_pid_key(group_leader(), Key).
 
 -doc """
@@ -979,7 +979,7 @@ Returns `undefined` if any of the following applies:
       Key :: atom(),
       Val :: term().
 
-get_key(Application, Key) -> 
+get_key(Application, Key) ->
     application_controller:get_key(Application, Key).
 
 -doc(#{equiv => get_all_key(application:get_application())}).
@@ -1002,14 +1002,14 @@ returns `[]`.
       Application :: atom(),
       Keys :: {'ok', [{Key :: atom(),Val :: term()},...]}.
 
-get_all_key(Application) -> 
+get_all_key(Application) ->
     application_controller:get_all_key(Application).
 
 -doc(#{equiv => get_application(self())}).
 -spec get_application() -> 'undefined' | {'ok', Application} when
       Application :: atom().
 
-get_application() -> 
+get_application() ->
     application_controller:get_application(group_leader()).
 
 -doc """

--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -335,6 +335,10 @@ graph is built and the leaves of the graph are started concurrently and
 recursively. In both modes, no assertion can be made about the order the
 applications are started. If not supplied, it defaults to `serial`.
 
+`Mode` can also be `{concurrent, Limit}` where `Limit` is a positive integer
+or `infinity`. `Limit` controls the maximum number of concurrent application
+starts when in `concurrent` mode. Defaults to `infinity` (no limit).
+
 Returns `{ok, AppNames}` for a successful start or for an already started
 application (which is, however, omitted from the `AppNames` list).
 
@@ -349,18 +353,30 @@ bring the set of running applications back to its initial state.
 -spec ensure_all_started(Applications, Type, Mode) -> {'ok', Started} | {'error', AppReason} when
       Applications :: atom() | [atom()],
       Type :: restart_type(),
-      Mode :: serial | concurrent,
+      Mode :: serial | concurrent | {concurrent, Limit :: pos_integer() | infinity},
       Started :: [atom()],
       AppReason :: {atom(), term()}.
 ensure_all_started(Application, Type, Mode) when is_atom(Application) ->
     ensure_all_started([Application], Type, Mode);
-ensure_all_started(Applications, Type, Mode) when is_list(Applications) ->
-    Opts = #{type => Type, mode => Mode},
+ensure_all_started(Applications, Type, serial) when is_list(Applications) ->
+    ensure_all_started_1(Applications, Type, serial, infinity);
+ensure_all_started(Applications, Type, concurrent) when is_list(Applications) ->
+    ensure_all_started_1(Applications, Type, concurrent, infinity);
+ensure_all_started(Applications, Type, {concurrent, Limit}) when is_list(Applications),
+      is_integer(Limit), Limit > 0 ->
+    ensure_all_started_1(Applications, Type, concurrent, Limit);
+ensure_all_started(Applications, Type, {concurrent, infinity}) when is_list(Applications) ->
+    ensure_all_started_1(Applications, Type, concurrent, infinity);
+ensure_all_started(_Applications, _Type, _Mode) ->
+    erlang:error(badarg).
 
-    case enqueue_or_start(Applications, [], #{}, [], [], Opts) of
+ensure_all_started_1(Applications, Type, Mode, Limit) ->
+    InternalOpts = #{type => Type, mode => Mode, limit => Limit},
+
+    case enqueue_or_start(Applications, [], #{}, [], [], InternalOpts) of
         {ok, DAG, _Pending, Started} when Mode =:= concurrent ->
             ReqIDs = gen_server:reqids_new(),
-            concurrent_dag_start(maps:to_list(DAG), ReqIDs, [], Started, Type);
+            concurrent_dag_start(maps:to_list(DAG), ReqIDs, [], Started, InternalOpts);
         {ok, DAG, _Pending, Started} when Mode =:= serial ->
             0 = map_size(DAG),
             {ok, lists:reverse(Started)};
@@ -431,29 +447,37 @@ enqueue_or_start_app(Name, App, DAG, Pending, Started, Opts) ->
             ErrorAppReasonStarted
     end.
 
-concurrent_dag_start([], ReqIDs, _Done, Started, _Type) ->
+concurrent_dag_start([], ReqIDs, _Done, Started, _Opts) ->
     wait_all_enqueued(ReqIDs, Started, false);
-concurrent_dag_start(Pending0, ReqIDs0, Done, Started0, Type) ->
-    {Pending1, ReqIDs1} = enqueue_dag_leaves(Pending0, ReqIDs0, [], Done, Type),
+concurrent_dag_start(Pending0, ReqIDs0, Done, Started0, Opts) ->
+    #{type := Type, limit := Limit} = Opts,
+    {Pending1, ReqIDs1} = enqueue_dag_leaves(Pending0, ReqIDs0, [], Done, Type, Limit),
 
     case wait_one_enqueued(ReqIDs1, Started0) of
         {ok, App, ReqIDs2, Started1} ->
-            concurrent_dag_start(Pending1, ReqIDs2, [App], Started1, Type);
+            concurrent_dag_start(Pending1, ReqIDs2, [App | Done], Started1, Opts);
         {error, AppReason, ReqIDs2} ->
             wait_all_enqueued(ReqIDs2, Started0, AppReason)
     end.
 
-enqueue_dag_leaves([{App, Children} | Rest], ReqIDs, Acc, Done, Type) ->
-    case Children -- Done of
-        [] ->
-            Req = application_controller:start_application_request(App, Type),
-            NewReqIDs = gen_server:reqids_add(Req, App, ReqIDs),
-            enqueue_dag_leaves(Rest, NewReqIDs, Acc, Done, Type);
-        NewChildren ->
-            NewAcc = [{App, NewChildren} | Acc],
-            enqueue_dag_leaves(Rest, ReqIDs, NewAcc, Done, Type)
+enqueue_dag_leaves([{App, Children} | Rest], ReqIDs, Acc, Done, Type, Limit) ->
+    CurrentSize = gen_server:reqids_size(ReqIDs),
+    case (Limit =:= infinity) orelse (CurrentSize < Limit) of
+        true ->
+            case Children -- Done of
+                [] ->
+                    Req = application_controller:start_application_request(App, Type),
+                    NewReqIDs = gen_server:reqids_add(Req, App, ReqIDs),
+                    enqueue_dag_leaves(Rest, NewReqIDs, Acc, Done, Type, Limit);
+                NewChildren ->
+                    NewAcc = [{App, NewChildren} | Acc],
+                    enqueue_dag_leaves(Rest, ReqIDs, NewAcc, Done, Type, Limit)
+            end;
+        false ->
+            %% Limit reached, keep this and remaining items for later
+            enqueue_dag_leaves([], ReqIDs, [{App, Children} | Rest] ++ Acc, Done, Type, Limit)
     end;
-enqueue_dag_leaves([], ReqIDs, Acc, _Done, _Type) ->
+enqueue_dag_leaves([], ReqIDs, Acc, _Done, _Type, _Limit) ->
     {Acc, ReqIDs}.
 
 wait_one_enqueued(ReqIDs0, Started) ->

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -40,7 +40,7 @@
 
 -export([config_change/1, persistent_env/1, invalid_app_file/1,
 	 distr_changed_tc1/1, distr_changed_tc2/1,
-	 ensure_started/1, ensure_all_started/1,
+	 ensure_started/1, ensure_all_started/1, ensure_all_started_limit/1,
 	 shutdown_func/1, do_shutdown/1, shutdown_timeout/1,
          shutdown_application_call/1,shutdown_deadlock/1,
          config_relative_paths/1, handle_many_config_files/1,
@@ -61,7 +61,7 @@ all() ->
     [failover, failover_comp, permissions, load,
      load_use_cache, ensure_started, {group, reported_bugs}, start_phases,
      script_start, nodedown_start, permit_false_start_local,
-     permit_false_start_dist, get_key, get_env, ensure_all_started,
+     permit_false_start_dist, get_key, get_env, ensure_all_started, ensure_all_started_limit,
      set_env, set_env_persistent, set_env_errors, get_supervisor,
      {group, distr_changed}, config_change, shutdown_func, shutdown_timeout,
      shutdown_application_call, shutdown_deadlock, config_relative_paths, optional_applications,
@@ -1059,6 +1059,32 @@ do_ensure_all_started(Mode) ->
     ok = application:unload(app10),
     ok = application:unload(app_chain_error2),
     ok = application:unload(app_chain_error),
+    ok.
+
+%% Test application:ensure_all_started/3 with limit option.
+ensure_all_started_limit(_Conf) ->
+    {ok, Fd9} = file:open("app9.app", [write]),
+    w_app9(Fd9),
+    file:close(Fd9),
+    {ok, Fd10} = file:open("app10.app", [write]),
+    w_app10(Fd10, [app9], []),
+    file:close(Fd10),
+
+    %% Test various limit values
+    lists:foreach(fun(Limit) ->
+        {ok, Started} = application:ensure_all_started(app10, temporary,
+                                                        {concurrent, Limit}),
+        [app10, app9] = lists:sort(Started),
+        ok = application:stop(app9),
+        ok = application:unload(app9),
+        ok = application:stop(app10),
+        ok = application:unload(app10)
+    end, [1, 2, 10, infinity]),
+
+    %% Test invalid limit values
+    ?assertError(badarg, application:ensure_all_started(app10, temporary, {concurrent, 0})),
+    ?assertError(badarg, application:ensure_all_started(app10, temporary, {concurrent, -1})),
+    ?assertError(badarg, application:ensure_all_started(app10, temporary, {concurrent, foo})),
     ok.
 
 optional_applications(_Conf) ->


### PR DESCRIPTION
NOTE: This is on-top of [PR9558](https://github.com/erlang/otp/pull/9558)

We have experienced issues with parallel application startup in cases where many applications get ready to start at once (several hundred). This results in a large queue size and overloading the controller. 

We solved this by adding a limit to how many applications can start in parallel.

This PR adds this option to application:ensure_all_started/3