### PR TITLE
add application:ensure_all_stopped/1,2

### DIFF
--- a/lib/kernel/src/application.erl
+++ b/lib/kernel/src/application.erl
@@ -2,9 +2,9 @@
 %% %CopyrightBegin%
 %%
 %% SPDX-License-Identifier: Apache-2.0
-%% 
+%%
 %% Copyright Ericsson AB 1996-2025. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -16,7 +16,7 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(application).
@@ -51,7 +51,7 @@ For details about applications and behaviours, see
 """.
 -export([ensure_all_started/1, ensure_all_started/2, ensure_all_started/3,
 	 start/1, start/2,
-	 start_boot/1, start_boot/2, stop/1, 
+	 start_boot/1, start_boot/2, stop/1,
 	 load/1, load/2, unload/1, takeover/2,
 	 which_applications/0, which_applications/1,
 	 loaded_applications/0, permit/2]).
@@ -755,13 +755,13 @@ and `vsn` application specification keys, respectively.
       Description :: string(),
       Vsn :: string().
 
-loaded_applications() -> 
+loaded_applications() ->
     application_controller:loaded_applications().
 
 -doc false.
 -spec info() -> term().
 
-info() -> 
+info() ->
     application_controller:info().
 
 -doc(#{equiv => set_env(Config, [])}).
@@ -821,7 +821,7 @@ set_env(Config, Opts) when is_list(Config), is_list(Opts) ->
       Par :: atom(),
       Val :: term().
 
-set_env(Application, Key, Val) -> 
+set_env(Application, Key, Val) ->
     application_controller:set_env(Application, Key, Val).
 
 -doc """
@@ -866,7 +866,7 @@ set_env(Application, Key, Val, Opts) when is_list(Opts) ->
       Application :: atom(),
       Par :: atom().
 
-unset_env(Application, Key) -> 
+unset_env(Application, Key) ->
     application_controller:unset_env(Application, Key).
 
 -doc """
@@ -905,7 +905,7 @@ unset_env(Application, Key, Opts) when is_list(Opts) ->
       Par :: atom(),
       Val :: term().
 
-get_env(Key) -> 
+get_env(Key) ->
     application_controller:get_pid_env(group_leader(), Key).
 
 -doc """
@@ -922,7 +922,7 @@ Returns `undefined` if any of the following applies:
       Par :: atom(),
       Val :: term().
 
-get_env(Application, Key) -> 
+get_env(Application, Key) ->
     application_controller:get_env(Application, Key).
 
 -doc """
@@ -943,7 +943,7 @@ get_env(Application, Key, Default) ->
 -spec get_all_env() -> Env when
       Env :: [{Par :: atom(), Val :: term()}].
 
-get_all_env() -> 
+get_all_env() ->
     application_controller:get_pid_all_env(group_leader()).
 
 -doc """
@@ -956,7 +956,7 @@ does not belong to any application, the function returns `[]`.
       Application :: atom(),
       Env :: [{Par :: atom(), Val :: term()}].
 
-get_all_env(Application) -> 
+get_all_env(Application) ->
     application_controller:get_all_env(Application).
 
 -doc(#{equiv => get_key(application:get_application(), Key)}).
@@ -964,7 +964,7 @@ get_all_env(Application) ->
       Key :: atom(),
       Val :: term().
 
-get_key(Key) -> 
+get_key(Key) ->
     application_controller:get_pid_key(group_leader(), Key).
 
 -doc """
@@ -981,7 +981,7 @@ Returns `undefined` if any of the following applies:
       Key :: atom(),
       Val :: term().
 
-get_key(Application, Key) -> 
+get_key(Application, Key) ->
     application_controller:get_key(Application, Key).
 
 -doc(#{equiv => get_all_key(application:get_application())}).
@@ -1004,14 +1004,14 @@ returns `[]`.
       Application :: atom(),
       Keys :: {'ok', [{Key :: atom(),Val :: term()},...]}.
 
-get_all_key(Application) -> 
+get_all_key(Application) ->
     application_controller:get_all_key(Application).
 
 -doc(#{equiv => get_application(self())}).
 -spec get_application() -> 'undefined' | {'ok', Application} when
       Application :: atom().
 
-get_application() -> 
+get_application() ->
     application_controller:get_application(group_leader()).
 
 -doc """

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -29,6 +29,7 @@
 	 load_application/1, unload_application/1,
 	 start_application/2, start_application_request/2,
 	 start_boot_application/2, stop_application/1,
+	 stop_application_request/1,
 	 control_application/1, is_running/1,
 	 change_application_data/2, prep_config_change/0, config_change/1,
 	 which_applications/0, which_applications/1,
@@ -143,7 +144,7 @@
 -type appname() :: atom().
 
 -record(state, {loading = [], starting = [], start_p_false = [], running = [],
-		control = [], started = [], start_req = [], conf_data}).
+		control = [], started = [], start_req = [], stop_req = [], conf_data}).
 -type state() :: #state{}.
 
 %%-----------------------------------------------------------------
@@ -160,6 +161,7 @@
 %%                 permission = false)
 %% conf_data   = [{AppName, Env}]
 %% start_req   = [{AppName, From}] - list of all start requests
+%% stop_req    = [{AppName, From}] - list of all stop requests
 %% Id          = AMPid | undefined | {distributed, Node}
 %% Env         = [{Key, Value}]
 %%-----------------------------------------------------------------
@@ -281,6 +283,9 @@ start_boot_application(Application, RestartType) ->
 
 stop_application(AppName) ->
     call({stop_application, AppName}, infinity).
+
+stop_application_request(AppName) ->
+    gen_server:send_request(?AC, {stop_application, AppName}).
 
 %%-----------------------------------------------------------------
 %% Returns: [{Name, Descr, Vsn}]
@@ -838,25 +843,31 @@ handle_call({permit_application, AppName, Bool}, From, S) ->
 	    end
     end;
 
-handle_call({stop_application, AppName}, _From, S) ->
-    #state{running = Running, started = Started} = S,
-    case lists:keyfind(AppName, 1, Running) of
-	{_AppName, Id} ->
-	    {_AppName2, Type} = lists:keyfind(AppName, 1, Started),
-	    stop_appl(AppName, Id, Type),
-	    NRunning = keydelete(AppName, 1, Running),
-	    NStarted = keydelete(AppName, 1, Started),
-	    cntrl(AppName, S, {ac_application_stopped, AppName}),
-	    {reply, ok, S#state{running = NRunning, started = NStarted}};
+handle_call({stop_application, AppName}, From, S) ->
+    #state{running = Running, starting = _Starting, started = Started,
+	   start_req = _Start_req, stop_req = Stop_req} = S,
+    %% Check if already stopping
+    case lists:keyfind(AppName, 1, Stop_req) of
 	false ->
-	    case lists:keymember(AppName, 1, Started) of
-		true ->
-		    NStarted = keydelete(AppName, 1, Started),
-		    cntrl(AppName, S, {ac_application_stopped, AppName}),
-		    {reply, ok, S#state{started = NStarted}};
+	    case lists:keyfind(AppName, 1, Running) of
+		{_AppName, Id} ->
+		    {_AppName2, Type} = lists:keyfind(AppName, 1, Started),
+		    spawn_stopper(AppName, Id, Type),
+		    {noreply, S#state{stop_req = [{AppName, From} | Stop_req]}};
 		false ->
-		    {reply, {error, {not_started, AppName}}, S}
-	    end
+		    case lists:keymember(AppName, 1, Started) of
+			true ->
+			    NStarted = keydelete(AppName, 1, Started),
+			    cntrl(AppName, S, {ac_application_stopped, AppName}),
+			    {reply, ok, S#state{started = NStarted}};
+			false ->
+			    {reply, {error, {not_started, AppName}}, S}
+		    end
+	    end;
+	{AppName, _FromX} ->
+	    %% Already stopping, add requester to list
+	    SS = S#state{stop_req = [{AppName, From} | Stop_req]},
+	    {noreply, SS}
     end;
 
 handle_call({change_application_data, Applications, Config}, _From, S) ->
@@ -960,11 +971,23 @@ handle_call(info, _From, S) ->
 	     {starting, S#state.starting}],
     {reply, Reply, S}.
 
--spec handle_cast({'application_started', appname(), _}, state()) ->
+-spec handle_cast({'application_started', appname(), _} |
+                  {'application_stopped', appname()}, state()) ->
         {'noreply', state()} | {'stop', string(), state()}.
 
 handle_cast({application_started, AppName, Res}, S) ->
-    handle_application_started(AppName, Res, S).
+    handle_application_started(AppName, Res, S);
+
+handle_cast({application_stopped, AppName}, S) ->
+    handle_application_stopped(S,AppName).
+
+handle_application_stopped(S,AppName) ->
+    #state{running = Running, started = Started, stop_req = Stop_req} = S,
+    NRunning = keydelete(AppName, 1, Running),
+    NStarted = keydelete(AppName, 1, Started),
+    cntrl(AppName, S, {ac_application_stopped, AppName}),
+    Stop_reqN = reply_to_stop_requester(AppName, Stop_req),
+    {noreply, S#state{running = NRunning, started = NStarted, stop_req = Stop_reqN}}.
 
 handle_application_started(AppName, Res, S) ->
     #state{starting = Starting, running = Running, started = Started,
@@ -1209,17 +1232,23 @@ handle_info({'EXIT', Pid, Reason}, S) ->
     NewS = S#state{running = NRunning},
     case lists:keyfind(Pid, 2, S#state.running) of
 	{AppName, _AmPid} ->
-	    cntrl(AppName, S, {ac_application_stopped, AppName}),
-	    case lists:keyfind(AppName, 1, S#state.started) of
-		{_AppName, temporary} ->
-		    info_exited(AppName, Reason, temporary),
-		    {noreply, NewS};
-		{_AppName, transient} when Reason =:= normal ->
-		    info_exited(AppName, Reason, transient),
-		    {noreply, NewS};
-		{_AppName, Type} ->
-		    info_exited(AppName, Reason, Type),
-		    {stop, to_string({application_terminated, AppName, Reason}), NewS}
+	    %% check wether the application is in the process of being stopped
+	    %% and if so, ignore the message
+	    case lists:keyfind(AppName, 1, S#state.stop_req) of
+		{_AppName, _Req} -> {noreply, S};
+		false ->
+		    cntrl(AppName, S, {ac_application_stopped, AppName}),
+		    case lists:keyfind(AppName, 1, S#state.started) of
+			{_AppName, temporary} ->
+			    info_exited(AppName, Reason, temporary),
+		    	    {noreply, NewS};
+			{_AppName, transient} when Reason =:= normal ->
+		    	    info_exited(AppName, Reason, transient),
+		    	    {noreply, NewS};
+			{_AppName, Type} ->
+		    	    info_exited(AppName, Reason, Type),
+		    	    {stop, to_string({application_terminated, AppName, Reason}), NewS}
+	    	    end
 	    end;
 	false ->
 	    {noreply, S#state{control = del_cntrl(S#state.control, Pid)}}
@@ -1417,6 +1446,12 @@ spawn_starter(Appl, S, Type) ->
         false ->
             application_master:start_link(Appl#appl.appl_data, Type)
     end.
+
+spawn_stopper(AppName, Id, Type) ->
+    spawn(fun() ->
+		  stop_appl(AppName, Id, Type),
+		  gen_server:cast(?AC, {application_stopped, AppName})
+	  end).
 
 reply(undefined, _Reply) ->
     ok;
@@ -2291,6 +2326,22 @@ reply_to_requester(AppName, Start_req, Res) ->
 		end,
 		[],
 		Start_req).
+
+%%-----------------------------------------------------------------
+%% Reply to all processes waiting this application to be stopped.
+%%-----------------------------------------------------------------
+reply_to_stop_requester(AppName, Stop_req) ->
+    lists:foldl(fun(Sp, AccIn) ->
+			case Sp of
+			    {AppName, From} ->
+				reply(From, ok),
+				AccIn;
+			    _ ->
+				[Sp | AccIn]
+			end
+		end,
+		[],
+		Stop_req).
 
 
 %%-----------------------------------------------------------------

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -25,8 +25,8 @@
 -compile(nowarn_deprecated_catch).
 
 %% External exports
--export([start/1, 
-	 load_application/1, unload_application/1, 
+-export([start/1,
+	 load_application/1, unload_application/1,
 	 start_application/2, start_application_request/2,
 	 start_boot_application/2, stop_application/1,
 	 control_application/1, is_running/1,
@@ -69,7 +69,7 @@
 %%% may be running on one node at the time.
 %%%
 %%% The external API to this module is in the module 'application'.
-%%% 
+%%%
 %%% The process that controls distributed applications (called dist
 %%% ac).  calls application_controller:control_application(Name) to
 %%% take responsibility for an application.  The interface between AC
@@ -205,7 +205,7 @@ start(KernelApp) ->
 	{'EXIT', _Pid, Reason} ->
 	    to_string(Reason)
     end.
-	
+
 %%-----------------------------------------------------------------
 %% Func: load_application/1
 %% Args: Application = appl_descr() | atom()
@@ -261,7 +261,7 @@ is_running(AppName) when is_atom(AppName) ->
 %% Func: start_boot_application/2
 %% The same as start_application/2 expect that this function is
 %% called from the boot script file. It must not be used by the operator.
-%% This function will cause a node crash if a permanent application 
+%% This function will cause a node crash if a permanent application
 %% fails to boot start
 %%-----------------------------------------------------------------
 start_boot_application(Application, RestartType) ->
@@ -434,16 +434,16 @@ get_all_key(AppName) ->
 		  {mod, (Appl#appl.appl_data)#appl_data.mod},
 		  {start_phases, (Appl#appl.appl_data)#appl_data.phases}
 		 ]};
-	_ -> 
+	_ ->
 	    undefined
     end.
 
 
 start_type(Master) ->
     case ets:match(ac_tab, {{application_master, '$1'}, Master}) of
-	[[AppName]] -> 
+	[[AppName]] ->
 	    call({start_type, AppName}, infinity);
-	_X -> 
+	_X ->
 	    undefined
     end.
 
@@ -688,7 +688,7 @@ handle_call({unload_application, AppName}, _From, S) ->
     end;
 
 handle_call({start_application, AppName, RestartType}, From, S) ->
-    #state{running = Running, starting = Starting, start_p_false = SPF, 
+    #state{running = Running, starting = Starting, start_p_false = SPF,
 	   started = Started, start_req = Start_req} = S,
     %% Check if the commandline environment variables are OK.
     %% In case of erroneous variables do not start the application,
@@ -782,7 +782,7 @@ handle_call({permit_application, AppName, Bool}, From, S) ->
 		%% only loaded
 		{true, {true, _Appl}, false, false, false, false} ->
 		    update_permissions(AppName, Bool),
-                    {reply, ok, S}; 
+                    {reply, ok, S};
 		%% starting
 		{true, {true, _Appl}, {value, _Tuple}, false, false, false} ->
 		    update_permissions(AppName, Bool),
@@ -820,7 +820,7 @@ handle_call({permit_application, AppName, Bool}, From, S) ->
 		%% only loaded
 		{false, {true, _Appl}, false, false, false, false} ->
 		    update_permissions(AppName, Bool),
-                    {reply, ok, S}; 
+                    {reply, ok, S};
 		%% starting
 		{false, {true, _Appl}, {value, _Tuple}, false, false, false} ->
 		    update_permissions(AppName, Bool),
@@ -967,7 +967,7 @@ handle_cast({application_started, AppName, Res}, S) ->
     handle_application_started(AppName, Res, S).
 
 handle_application_started(AppName, Res, S) ->
-    #state{starting = Starting, running = Running, started = Started, 
+    #state{starting = Starting, running = Running, started = Started,
 	   start_req = Start_req} = S,
     Start_reqN = reply_to_requester(AppName, Start_req, Res),
     {AppName, RestartType, _Type, _From} = lists:keyfind(AppName, 1, Starting),
@@ -1002,7 +1002,7 @@ handle_application_started(AppName, Res, S) ->
 				    stop_appl(AppName, Id, Type),
 				    NStopRunning = keydelete(AppName, 1, StopRunning),
 				    cntrl(AppName, NewS, {ac_application_stopped, AppName}),
-				    {noreply, NewS#state{running = NStopRunning, 
+				    {noreply, NewS#state{running = NStopRunning,
 							started = StopStarted}};
 				false ->
 				    {noreply, NewS}
@@ -1079,14 +1079,14 @@ handle_info({ac_start_application_reply, AppName, Res}, S) ->
 		    spawn_starter(Appl, S, Type),
 		    {noreply, S};
 		{started, Node} ->
-		    handle_application_started(AppName, 
-					       {ok, {distributed, Node}}, 
+		    handle_application_started(AppName,
+					       {ok, {distributed, Node}},
 					       S);
 		not_started ->
 		    Started = S#state.started,
 		    Start_reqN =
 			reply_to_requester(AppName, Start_req, ok),
-		    {noreply, 
+		    {noreply,
 		     S#state{starting = keydelete(AppName, 1, Starting),
 			     started = [{AppName, RestartType} | Started],
 			     start_req = Start_reqN}};
@@ -1134,7 +1134,7 @@ handle_info({ac_change_application_req, AppName, Msg}, S) ->
 		    case application:get_key(AppName, start_phases) of
 			{ok, undefined} ->
 			    %% to be backwards compatible the application
-			    %% is not started as failover if start_phases  
+			    %% is not started as failover if start_phases
 			    %% is not defined in the .app file
 			    NewS = do_start(AppName, RT, normal, undefined, S),
 			    {noreply, NewS};
@@ -1145,7 +1145,7 @@ handle_info({ac_change_application_req, AppName, Msg}, S) ->
 		stop_it ->
 		    stop_appl(AppName, Id, Type),
 		    cntrl(AppName, S, {ac_application_not_run, AppName}),
-		    NRunning = keyreplace(AppName, 1, Running, 
+		    NRunning = keyreplace(AppName, 1, Running,
 					 {AppName, {distributed, []}}),
 		    {noreply, S#state{running = NRunning}};
 		%% We should not try to start a running application!
@@ -1224,7 +1224,7 @@ handle_info({'EXIT', Pid, Reason}, S) ->
 	false ->
 	    {noreply, S#state{control = del_cntrl(S#state.control, Pid)}}
     end;
-    
+
 handle_info(_, S) ->
     {noreply, S}.
 
@@ -1242,7 +1242,7 @@ terminate(Reason, S) ->
 	    undefined -> infinity;
 	    {ok,T} -> T
 	end,
-    foreach(fun({_AppName, Id}) when is_pid(Id) -> 
+    foreach(fun({_AppName, Id}) when is_pid(Id) ->
 		    Ref = erlang:monitor(process, Id),
 		    unlink(Id),
 		    exit(Id, shutdown),
@@ -1286,7 +1286,7 @@ cntrl(AppName, #state{control = Control}, Msg) ->
 	{_AppName, Pid} ->
 	    Pid ! Msg,
 	    true;
-	false -> 
+	false ->
 	    false
     end.
 
@@ -1294,7 +1294,7 @@ notify_cntrl_started(_AppName, {distributed, _Node}, _S, _Res) ->
     ok;
 notify_cntrl_started(AppName, _Id, S, Res) ->
     cntrl(AppName, S, {ac_application_run, AppName, Res}).
-    
+
 del_cntrl([{_, Pid}|T], Pid) ->
     del_cntrl(T, Pid);
 del_cntrl([H|T], Pid) ->
@@ -1304,7 +1304,7 @@ del_cntrl([], _Pid) ->
 
 get_loaded(App) ->
     AppName = get_appl_name(App),
-    case ets:lookup(ac_tab, {loaded, AppName}) of 
+    case ets:lookup(ac_tab, {loaded, AppName}) of
 	[{_Key, Appl}] -> {true, Appl};
 	_  -> false
     end.
@@ -1386,7 +1386,7 @@ do_start(AppName, RT, Type, From, S) ->
 		      false ->
 			  RT
 		  end,
-    %% UW 990913: We check start_req instead of starting, because starting 
+    %% UW 990913: We check start_req instead of starting, because starting
     %% has already been checked.
     case lists:keymember(AppName, 1, S#state.start_req) of
 	false ->
@@ -1396,12 +1396,12 @@ do_start(AppName, RT, Type, From, S) ->
 	    Starting = case lists:keymember(AppName, 1, S#state.starting) of
 			   false ->
 			       %% UW: don't know if this is necessary
-			       [{AppName, RestartType, Type, From} | 
+			       [{AppName, RestartType, Type, From} |
 				S#state.starting];
 			   true ->
 			       S#state.starting
 		       end,
-	    S#state{starting = Starting, 
+	    S#state{starting = Starting,
 		    start_req = [{AppName, From} | Start_req]};
 	true -> % otherwise we're already starting the app...
 	    S
@@ -1439,7 +1439,7 @@ stop_appl(AppName, undefined, Type) ->
     info_exited(AppName, stopped, Type);
 stop_appl(_AppName, _Id, _Type) ->
     %% Distributed application stopped
-    ok. 
+    ok.
 
 keysearchdelete(Key, Pos, List) ->
     ksd(Key, Pos, List, []).
@@ -1450,7 +1450,7 @@ ksd(Key, Pos, [H | T], Rest) ->
     ksd(Key, Pos, T, [H | Rest]);
 ksd(_Key, _Pos, [], _Rest) ->
     false.
-    
+
 keyreplaceadd(Key, Pos, List, New) ->
     %% Maintains the order!
     case lists:keymember(Key, Pos, List) of
@@ -1466,7 +1466,7 @@ validRestartType(RestartType) ->
 
 nd({distributed, Node}) -> Node;
 nd(_) -> node().
-	  
+
 get_restart_type(undefined, OldRT) ->
     OldRT;
 get_restart_type(RT, _OldRT) ->
@@ -1485,7 +1485,7 @@ make_appl(Name) when is_atom(Name) ->
 	    case prim_consult(FullName) of
 		{ok, [Application]} ->
 		    {ok, make_appl_i(Application)};
-		{error, Reason} -> 
+		{error, Reason} ->
 		    {error, {file:format_error(Reason), FName}};
                 error ->
                     {error, "bad encoding"}
@@ -1567,7 +1567,7 @@ make_appl_i(Appl) -> throw({error, {bad_application, Appl}}).
 
 
 %%-----------------------------------------------------------------
-%% Merge current applications with changes.  
+%% Merge current applications with changes.
 %%-----------------------------------------------------------------
 
 %% do_change_apps(Applications, Config, OldAppls) -> NewAppls
@@ -1653,9 +1653,9 @@ conv([Key, Val | T]) ->
     [{make_term(Key), make_term(Val)} | conv(T)];
 conv(_) -> [].
 
-make_term(Str) -> 
+make_term(Str) ->
     case erl_scan:string(Str) of
-	{ok, Tokens, _} ->		  
+	{ok, Tokens, _} ->
 	    case erl_parse:parse_term(Tokens ++ [{dot, erl_anno:new(1)}]) of
 		{ok, Term} ->
 		    Term;
@@ -1752,7 +1752,7 @@ do_prep_config_change([], EnvBefore) ->
 do_prep_config_change([{App, _Id} | Apps], EnvBefore) ->
     Env = application:get_all_env(App),
     do_prep_config_change(Apps, [{App, Env} | EnvBefore]).
-    
+
 
 
 %%-----------------------------------------------------------------
@@ -1773,7 +1773,7 @@ do_config_change([{App, _Id} | Apps], EnvBefore, Errors) ->
 		       {App, AppEnvBeforeT} ->
 			   lists:sort(AppEnvBeforeT)
 		   end,
-    Res = 
+    Res =
 	case AppEnvNow of
 	    AppEnvBefore ->
 		ok;
@@ -1784,12 +1784,12 @@ do_config_change([{App, _Id} | Apps], EnvBefore, Errors) ->
 		    {Changed, New, Removed} ->
 			case application:get_key(App, mod) of
 			    {ok, {Mod, _Para}} ->
-				case catch Mod:config_change(Changed, New, 
+				case catch Mod:config_change(Changed, New,
 							     Removed) of
 				    ok ->
 					ok;
 				    %% It is not considered as an error
-				    %% if the cb-function is not defined 
+				    %% if the cb-function is not defined
 				    {'EXIT', {undef, _}} ->
 					ok;
 				    {error, _} = Error ->
@@ -1804,7 +1804,7 @@ do_config_change([{App, _Id} | Apps], EnvBefore, Errors) ->
 			end
 		end
 	end,
-    
+
     case Res of
 	ok ->
 	    do_config_change(Apps, EnvBefore, Errors);
@@ -1829,7 +1829,7 @@ do_config_diff([{Env, Value} | AppEnvNow], AppEnvBefore, {Changed, New}) ->
 	{Env, Value} ->
 	    do_config_diff(AppEnvNow, lists:keydelete(Env,1,AppEnvBefore), {Changed, New});
 	{Env, _OtherValue} ->
-	    do_config_diff(AppEnvNow, lists:keydelete(Env,1,AppEnvBefore), 
+	    do_config_diff(AppEnvNow, lists:keydelete(Env,1,AppEnvBefore),
 			   {[{Env, Value} | Changed], New});
 	false ->
 	    do_config_diff(AppEnvNow, AppEnvBefore, {Changed, [{Env, Value}|New]})
@@ -2101,7 +2101,7 @@ only_ws([C|Cs]) when C =< $\s -> only_ws(Cs);
 only_ws([$%|Cs]) -> only_ws(strip_comment(Cs));   % handle comment
 only_ws([_|_]) -> false;
 only_ws([]) -> true.
-    
+
 strip_comment([$\n|Cs]) -> Cs;
 strip_comment([_|Cs]) -> strip_comment(Cs);
 strip_comment([]) -> [].
@@ -2268,7 +2268,7 @@ mod(latin1) -> "";
 mod(_) -> "t".
 
 %%-----------------------------------------------------------------
-%% Reply to all processes waiting this application to be started.  
+%% Reply to all processes waiting this application to be started.
 %%-----------------------------------------------------------------
 reply_to_requester(AppName, Start_req, Res) ->
     R = case Res of
@@ -2291,10 +2291,10 @@ reply_to_requester(AppName, Start_req, Res) ->
 		end,
 		[],
 		Start_req).
-    
+
 
 %%-----------------------------------------------------------------
-%% Update the environment variable permission for an application.  
+%% Update the environment variable permission for an application.
 %%-----------------------------------------------------------------
 update_permissions(AppName, Bool) ->
     T = {env, kernel, permissions},
@@ -2307,7 +2307,7 @@ update_permissions(AppName, Bool) ->
     end.
 
 %%-----------------------------------------------------------------
-%% These functions are only to be used from testsuites.  
+%% These functions are only to be used from testsuites.
 %%-----------------------------------------------------------------
 test_change_apps(Apps, Conf) ->
     Res = test_make_apps(Apps, []),

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -24,7 +24,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2
      ]).
 
@@ -35,7 +35,7 @@
 	 otp_5606/1,
 	 start_phases/1, get_key/1, get_env/1, get_supervisor/1,
 	 set_env/1, set_env_persistent/1, set_env_errors/1, optional_applications/1,
-	 permit_false_start_local/1, permit_false_start_dist/1, script_start/1, 
+	 permit_false_start_local/1, permit_false_start_dist/1, script_start/1,
 	 nodedown_start/1, init2973/0, loop2973/0, loop5606/1, otp_16504/1]).
 
 -export([config_change/1, persistent_env/1, invalid_app_file/1,
@@ -50,14 +50,14 @@
 -define(TESTCASE, testcase_name).
 -define(testcase, proplists:get_value(?TESTCASE, Config)).
 
--export([init_per_testcase/2, end_per_testcase/2, start_type/0, 
+-export([init_per_testcase/2, end_per_testcase/2, start_type/0,
 	 start_phase/0, conf_change/0]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{minutes,2}}].
 
-all() -> 
+all() ->
     [failover, failover_comp, permissions, load,
      load_use_cache, ensure_started, {group, reported_bugs}, start_phases,
      script_start, nodedown_start, permit_false_start_local,
@@ -68,7 +68,7 @@ all() ->
      persistent_env, handle_many_config_files, format_log_1, format_log_2,
      configfd_bash, configfd_port_program, invalid_app_file].
 
-groups() -> 
+groups() ->
     [{reported_bugs, [],
       [otp_1586, otp_2078, otp_2012, otp_2718, otp_2973,
        otp_3002, otp_3184, otp_4066, otp_4227, otp_5363,
@@ -143,10 +143,10 @@ failover(Conf) when is_list(Conf) ->
     wait_for_ready_net(),
 
     %% Start app1 and make sure cp1 starts it
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app1()]),
     ?UNTIL(is_loaded(app1, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app1, permanent]),
     ?UNTIL(is_started(app1, Cp1)),
     false = is_started(app1, Cp2),
@@ -170,18 +170,18 @@ failover(Conf) when is_list(Conf) ->
     %% Start app_sp and make sure cp2 starts it (cp1 has more apps started)
     {[ok,ok,ok],[]} =
         rpc:multicall([Cp1_2, Cp2, Cp3], application, load, [app_sp()]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1_2, Cp2, Cp3], application, start,[app_sp,permanent]),
     ?UNTIL(is_started(app_sp, Cp2)),
     false = is_started(app_sp, Cp1),
     false = is_started(app_sp, Cp3),
     ok = get_start_type(#st{normal = 3}),
-	
+
     %% Stop cp2 and make sure cp1 starts app_sp
     stop_node_nice(Cp2),
     ?UNTIL(is_started(app_sp, Cp1_2)),
     ok = get_start_type(#st{failover = 3}),
-	
+
     %% Stop cp1 and make sure cp3 starts app_sp
     stop_node_nice(Cp1_2),
     ?UNTIL(is_started(app_sp, Cp3)),
@@ -222,7 +222,7 @@ failover(Conf) when is_list(Conf) ->
     stop_node_nice(Cp2_2),
     stop_node_nice(Cp3),
     ok.
-    
+
 %%-----------------------------------------------------------------
 %% Should be started in a CC view with:
 %% erl -sname XXX -rsh ctrsh where XX not in [cp1, cp2, cp3]
@@ -247,10 +247,10 @@ failover_comp(Conf) when is_list(Conf) ->
     wait_for_ready_net(),
 
     %% Start app1 and make sure cp1 starts it
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app1()]),
     ?UNTIL(is_loaded(app1, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app1, permanent]),
     ?UNTIL(is_started(app1, Cp1)),
     false = is_started(app1, Cp2),
@@ -276,18 +276,18 @@ failover_comp(Conf) when is_list(Conf) ->
     {[ok,ok,ok],[]} =
         rpc:multicall([Cp1_2, Cp2, Cp3], application, load, [app3()]),
     ?UNTIL(is_loaded(app3, [Cp1_2, Cp2, Cp3])),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1_2, Cp2, Cp3], application, start,[app3,permanent]),
     ?UNTIL(is_started(app3, Cp2)),
     false = is_started(app3, Cp1),
     false = is_started(app3, Cp3),
     ok = get_start_type(#st{normal = 3}),
-	
+
     %% Stop cp2 and make sure cp1 starts app3
     stop_node_nice(Cp2),
     ?UNTIL(is_started(app3, Cp1_2)),
     ok = get_start_type(#st{normal = 3}),
-	
+
     %% Stop cp1 and make sure cp3 starts app3
     stop_node_nice(Cp1_2),
     ?UNTIL(is_started(app3, Cp3)),
@@ -376,10 +376,10 @@ permissions(Conf) when is_list(Conf) ->
     true = is_started(app1, Cp2),
 
     %% Start app3, make sure no one starts it
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app3()]),
     ?UNTIL(is_loaded(app3, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app3, permanent]),
     ct:sleep(1000),
     false = is_started(app3, Cp1),
@@ -426,17 +426,17 @@ load(Conf) when is_list(Conf) ->
     Cps = [Cp1, Cp2, Cp3],
     wait_for_ready_net(),
 
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app1(), d1(NodeNames)]),
     ?UNTIL(is_loaded(app1, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app1, permanent]),
     ?UNTIL(is_started(app1, Cp1)),
     false = is_started(app1, Cp2),
     false = is_started(app1, Cp3),
 
     %% Load app1 with different specs and make sure we get an error
-    {[{error,_},{error,_}],[]} = 
+    {[{error,_},{error,_}],[]} =
         rpc:multicall([Cp1, Cp2], application, load, [app1(), d1(NodeNames)]),
     {error, _} = rpc:call(Cp3, application, load, [app1(), d2(NodeNames)]),
 
@@ -444,7 +444,7 @@ load(Conf) when is_list(Conf) ->
     stop_node_nice(Cp2),
     stop_node_nice(Cp3),
     ok.
-    
+
 %%-----------------------------------------------------------------
 %% Same test as load/1, only with code path cache enabled.
 %%-----------------------------------------------------------------
@@ -461,16 +461,16 @@ load_use_cache(Conf) when is_list(Conf) ->
     Cps = [Cp1, Cp2, Cp3],
     wait_for_ready_net(),
 
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app1(), d1(NodeNames)]),
     ?UNTIL(is_loaded(app1, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app1, permanent]),
     ?UNTIL(is_started(app1, Cp1)),
     false = is_started(app1, Cp2),
 
     %% Load app1 with different specs and make sure we get an error
-    {[{error,_},{error,_}],[]} = 
+    {[{error,_},{error,_}],[]} =
         rpc:multicall([Cp1, Cp2], application, load, [app1(), d1(NodeNames)]),
     {error, _} = rpc:call(Cp3, application, load, [app1(), d2(NodeNames)]),
 
@@ -498,7 +498,7 @@ start_phases(Conf) when is_list(Conf) ->
     %%=============================
     %%Example 1 in the user's guide
     %%=============================
-    ok = rpc:call(Cp1, application, load, [myApp, 
+    ok = rpc:call(Cp1, application, load, [myApp,
                                                  d_any3(myApp, NodeNames)]),
     ?UNTIL(is_loaded(myApp, Cp1)),
     ok = rpc:call(Cp1, application, start, [myApp, permanent]),
@@ -509,18 +509,18 @@ start_phases(Conf) when is_list(Conf) ->
     %%=============================
     %%Example 2 in the user's guide
     %%=============================
-    ok = rpc:call(Cp1, application, load, [topApp, 
+    ok = rpc:call(Cp1, application, load, [topApp,
                                                  d_any3(topApp, NodeNames)]),
     ?UNTIL(is_loaded(topApp, Cp1)),
     ok = rpc:call(Cp1, application, start, [topApp, permanent]),
     ?UNTIL(is_started(topApp, Cp1)),
     ok = get_start_phase({sp, 0, 1, 0, 0, 1}),
     ok = rpc:call(Cp1, application, stop, [topApp]),
-	
+
     %%=============================
     %%Example 3 in the user's guide
     %%=============================
-    ok = rpc:call(Cp1, application, load, [topApp2, 
+    ok = rpc:call(Cp1, application, load, [topApp2,
                                                  d_any3(topApp2, NodeNames)]),
     ?UNTIL(is_loaded(topApp2, Cp1)),
     ok = rpc:call(Cp1, application, start, [topApp2, permanent]),
@@ -531,14 +531,14 @@ start_phases(Conf) when is_list(Conf) ->
     %%=============================
     %%Example 4 in the user's guide
     %%=============================
-    ok = rpc:call(Cp1, application, load, [topApp3, 
+    ok = rpc:call(Cp1, application, load, [topApp3,
                                                  d_any3(topApp3, NodeNames)]),
     ?UNTIL(is_loaded(topApp3, Cp1)),
     ok = rpc:call(Cp1, application, start, [topApp3, permanent]),
     ?UNTIL(is_started(topApp3, Cp1)),
     ok = get_start_phase({sp, 1, 3, 3, 2, 4}),
     ok = rpc:call(Cp1, application, stop, [topApp3]),
-	
+
     global:send(start_phase, kill),
 
     stop_node_nice(Cp1),
@@ -588,7 +588,7 @@ script_start(Conf) when is_list(Conf) ->
     ?UNTIL(is_started(app2, Cp2)),
     ?UNTIL(is_started(app_sp, Cp2)),
     ok = get_start_type(#st{normal = 6, failover = 3}),
-	
+
     %% Restart cp1, Cp1 takesover app1 and app2
     {ok, Cp1_2} = start_node_boot_config(Ncp1, NoSyncTime, Conf, latest),
     global:sync(),
@@ -599,20 +599,20 @@ script_start(Conf) when is_list(Conf) ->
     ?UNTIL(not is_started(app1, Cp2)),
     ?UNTIL(not is_started(app2, Cp2)),
     ok = get_start_type(#st{takeover = 6}),
-	
+
     %% Stop cp2 and make sure cp1 starts app_sp.
     false = is_started(app_sp, Cp1_2),
     stop_node_nice(Cp2),
     ?UNTIL(is_started(app_sp, Cp1_2)),
     ok = get_start_type(#st{failover = 3}),
-	
+
     %% Stop cp1 and make sure cp3 starts app1, app2 and app_sp
     stop_node_nice(Cp1_2),
     ?UNTIL(is_started(app_sp, Cp3)),
     ?UNTIL(is_started(app1, Cp3)),
     ?UNTIL(is_started(app2, Cp3)),
     ok = get_start_type(#st{normal = 6, failover = 3}),
-	
+
     %% Restart cp2 and make sure it takesover app1, app2 and app_sp
     {ok, Cp2_2} = start_node_boot_config(Ncp2, NoSyncTime, Conf, latest),
     global:sync(),
@@ -645,13 +645,13 @@ script_start(Conf) when is_list(Conf) ->
     PP = global:whereis_name({ch,3}),
     exit(PP, kill),
     ok = get_start_type(#st{local = 1}),
-	
+
     global:send(st_type, kill),
 
     stop_node_nice(Cp1_3),
     stop_node_nice(Cp2_2),
     stop_node_nice(Cp3),
-    
+
     ok = file:delete("latest.boot"),
     ok = file:delete("latest.rel"),
     ok = file:delete("latest.script"),
@@ -671,15 +671,15 @@ permit_false_start_local(Conf) when is_list(Conf) ->
     {ok, Cp3} = start_node(Ncp3, Config),
     wait_for_ready_net(),
 
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1, Cp2, Cp3], application, load, [app1()]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1, Cp2, Cp3], application, start, [app1, permanent]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1, Cp2, Cp3], application, load, [app2()]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1, Cp2, Cp3], application, start, [app2, permanent]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1, Cp2, Cp3], application, load, [app3()]),
 
     ct:sleep(1000),
@@ -695,7 +695,7 @@ permit_false_start_local(Conf) when is_list(Conf) ->
     false = is_started(app3, Cp3),
 
     %% Permit a not loaded application
-    {error,{not_loaded,app_notloaded}} = 
+    {error,{not_loaded,app_notloaded}} =
 	rpc:call(Cp1, application, permit, [app_notloaded, true]),
     ct:sleep(1000),
     false = is_started(app_notloaded, Cp1),
@@ -710,7 +710,7 @@ permit_false_start_local(Conf) when is_list(Conf) ->
     false = is_started(app3, Cp3),
 
     %% Unpermit a not loaded application
-    {error,{not_loaded,app_notloaded}} = 
+    {error,{not_loaded,app_notloaded}} =
 	rpc:call(Cp1, application, permit, [app_notloaded, false]),
     ct:sleep(1000),
     false = is_started(app_notloaded, Cp1),
@@ -784,7 +784,7 @@ permit_false_start_local(Conf) when is_list(Conf) ->
     stop_node_nice(Cp2),
     stop_node_nice(Cp3),
     ok.
-    
+
 
 %% Start distributed applications with permission false.  Set
 %% permit true on different nodes.
@@ -800,12 +800,12 @@ permit_false_start_dist(Conf) when is_list(Conf) ->
     Cps = [Cp1, Cp2, Cp3],
     wait_for_ready_net(),
 
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app1()]),
     ?UNTIL(is_loaded(app1, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app1, permanent]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app2()]),
 
     ct:sleep(1000),
@@ -821,7 +821,7 @@ permit_false_start_dist(Conf) when is_list(Conf) ->
     false = is_started(app2, Cp3),
 
     %% Permit a not loaded application
-    {error,{not_loaded,app3}} = 
+    {error,{not_loaded,app3}} =
 	rpc:call(Cp1, application, permit, [app3, true]),
     ct:sleep(1000),
     false = is_started(app3, Cp1),
@@ -830,7 +830,7 @@ permit_false_start_dist(Conf) when is_list(Conf) ->
 
     %% Unpermit a not started application
     ok = rpc:call(Cp1, application, permit, [app2, false]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall([Cp1, Cp2, Cp3], application, start, [app2, permanent]),
     ct:sleep(1000),
     false = is_started(app2, Cp1),
@@ -838,12 +838,12 @@ permit_false_start_dist(Conf) when is_list(Conf) ->
     false = is_started(app2, Cp3),
 
     %% Unpermit a not loaded application
-    {error,{not_loaded,app3}} = 
+    {error,{not_loaded,app3}} =
 	rpc:call(Cp1, application, permit, [app3, false]),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app3()]),
     ?UNTIL(is_loaded(app3, Cps)),
-    {[ok,ok,ok],[]} = 
+    {[ok,ok,ok],[]} =
         rpc:multicall(Cps, application, start, [app3, permanent]),
     ct:sleep(1000),
     false = is_started(app3, Cp1),
@@ -932,7 +932,7 @@ nodedown_start(Conf) when is_list(Conf) ->
     wait_for_ready_net(),
 
     %% Start app1 and make sure cp1 starts it
-    {[ok,ok],[]} = 
+    {[ok,ok],[]} =
         rpc:multicall([Cp1, Cp2], application, load, [app1()]),
     _ = rpc:cast(Cp2, application, start, [app1, permanent]),
     ct:sleep(1000),
@@ -940,7 +940,7 @@ nodedown_start(Conf) when is_list(Conf) ->
     %% Crash CP1 and make sure app1 is started on CP2
     stop_node_nice(Cp1),
     ?UNTIL(is_started(app1, Cp2)),
-    
+
     stop_node_nice(Cp2),
     ok.
 
@@ -1155,7 +1155,7 @@ otp_2078(Conf) when is_list(Conf) ->
     wait_for_ready_net(),
 
     %% Start app1 and make sure cp1 starts it
-    {[ok,ok],[]} = 
+    {[ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app1()]),
     ?UNTIL(is_loaded(app1, Cps)),
     ok = rpc:call(Cp1, application, start, [app1, permanent]),
@@ -1167,7 +1167,7 @@ otp_2078(Conf) when is_list(Conf) ->
     ok = rpc:call(Cp2, application, start, [app1, permanent]),
     true = is_started(app1, Cp1),
     false = is_started(app1, Cp2),
-    
+
     stop_node_nice(Cp1),
     stop_node_nice(Cp2),
     ok.
@@ -1192,27 +1192,27 @@ otp_2012(Conf) when is_list(Conf) ->
 
     %% Read the current configuration parameters, and change them
     EnvBefore = application_controller:prep_config_change(),
-    application_controller:test_change_apps([app1],[[{app1,[{new1, hi}, 
+    application_controller:test_change_apps([app1],[[{app1,[{new1, hi},
                                                             {new2, moi}]}]]),
     ok = application_controller:config_change(EnvBefore),
     ok = get_conf_change([{[], [{new1, hi}, {new2, moi}], []}]),
-    
+
     %% Start app2
     ok = application:load(app2()),
     ok = application:start(app2, permanent),
 
     %% Read the current configuration parameters, and change them again
     EnvBefore2 = application_controller:prep_config_change(),
-    application_controller:test_change_apps([app1],[[{app1,[{new1, hello}, 
+    application_controller:test_change_apps([app1],[[{app1,[{new1, hello},
                                                             {new3, mors}]}]]),
-    application_controller:test_change_apps([app2],[[{app2,[{new1, si}, 
+    application_controller:test_change_apps([app2],[[{app2,[{new1, si},
                                                             {new2, no}]}]]),
     _EnvBefore22 = application_controller:prep_config_change(),
     ok = application_controller:config_change(EnvBefore2),
-    
+
     ok = get_conf_change([{[],[{new1,si},{new2,no}],[]},
                                 {[{new1,hello}],[{new3,mors}],[new2]}]),
-    
+
     ok = application:stop(app1),
     ok = application:stop(app2),
     ok.
@@ -1259,17 +1259,17 @@ otp_2973(Conf) when is_list(Conf) ->
 
     Pid1 ! {start, self(), app0},
     Pid2 ! {start, self(), app0},
-    
-    {Res1, Res2} = receive 
+
+    {Res1, Res2} = receive
 			     {Pid1, res, Res1x} ->
-				 receive 
+				 receive
 				     {Pid2, res, Res2x} ->
 					 {Res1x, Res2x}
 				   after 2000 ->
 					   ct:fail(timeout_pid2)
 				   end;
 			     {Pid2, res, Res2x} ->
-				 receive 
+				 receive
 				     {Pid1, res, Res1x} ->
 					 {Res1x, Res2x}
 				 after 2000 ->
@@ -1298,17 +1298,17 @@ otp_2973(Conf) when is_list(Conf) ->
 
     Pid1 ! {start, self(), app_start_error},
     Pid2 ! {start, self(), app_start_error},
-    
-    {Res1a, Res2a} = receive 
+
+    {Res1a, Res2a} = receive
 			       {Pid1, res, Res1y} ->
-				   receive 
+				   receive
 				       {Pid2, res, Res2y} ->
 					   {Res1y, Res2y}
 				   after 2000 ->
 					   ct:fail(timeout_pid2)
 				   end;
 			       {Pid2, res, Res2y} ->
-				   receive 
+				   receive
 				       {Pid1, res, Res1y} ->
 					   {Res1y, Res2y}
 				   after 2000 ->
@@ -1317,7 +1317,7 @@ otp_2973(Conf) when is_list(Conf) ->
 			   end,
 
     case {Res1a, Res2a} of
-	{{error,{'start error',{app_start_error,start,[normal,[]]}}}, 
+	{{error,{'start error',{app_start_error,start,[normal,[]]}}},
 	 {error,{'start error',{app_start_error,start,[normal,[]]}}}} ->
 	    ok;
 	_ ->
@@ -1347,7 +1347,7 @@ otp_3184(Conf) when is_list(Conf) ->
     wait_for_ready_net(),
 
     %% Start app1 and make sure it is not started
-    {[ok,ok],[]} = 
+    {[ok,ok],[]} =
         rpc:multicall([Cp1, Cp2], application, load, [app1()]),
     ct:sleep(3000),
     false = is_started(app1, Cp1),
@@ -1359,7 +1359,7 @@ otp_3184(Conf) when is_list(Conf) ->
     ok = rpc:call(Cp2, application, start, [app1, permanent]),
     ?UNTIL(is_started(app1, Cp1)),
     false = is_started(app1, Cp2),
-    
+
     %% Check that the application is marked as running in application_controller
     X = rpc:call(Cp1, application_controller, info, []),
     {value, {running, Xrunning}} = lists:keysearch(running, 1, X),
@@ -1483,7 +1483,7 @@ print_dac_state(Node) when is_atom(Node) ->
                        [Node, State]);
 print_dac_state(Nodes) when is_list(Nodes) ->
     lists:foreach(fun (N) -> print_dac_state(N) end, Nodes).
-				
+
 
 %%-----------------------------------------------------------------
 %% Ticket: OTP-4227
@@ -1502,12 +1502,12 @@ otp_4227(Conf) when is_list(Conf) ->
     wait_for_ready_net(),
 
     %% Try to start app10 which should fail since app9 is not started
-    {[ok,ok],[]} = 
+    {[ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app9()]),
     ?UNTIL(is_loaded(app9, Cps)),
-    {[ok,ok],[]} = 
+    {[ok,ok],[]} =
         rpc:multicall(Cps, application, load, [app10([app9], [])]),
-    {error, {not_started, app9}} = 
+    {error, {not_started, app9}} =
 	rpc:call(Cp1, application, start, [app10]),
 
     %% Start app9 and brutally kill it, then try to start app10
@@ -1519,7 +1519,7 @@ otp_4227(Conf) when is_list(Conf) ->
     ct:sleep(1000),
 
     %% This gave {error, no_report} before the patch
-    {error, {not_running, app9}} = 
+    {error, {not_running, app9}} =
 	rpc:call(Cp1, application, start, [app10]),
 
     stop_node_nice(Cp1),
@@ -1529,7 +1529,7 @@ otp_4227(Conf) when is_list(Conf) ->
 config_4227([Ncp1, Ncp2]) ->
     fun(Fd, SyncNodesTimeout) ->
             M = from($@, atom_to_list(node())),
-            io:format(Fd, 
+            io:format(Fd,
                       "[{kernel, "
                       "  [{sync_nodes_optional, ['~s@~s','~s@~s']},"
                       "   {sync_nodes_timeout, ~w},"
@@ -1537,9 +1537,9 @@ config_4227([Ncp1, Ncp2]) ->
                       "   {distributed, "
                       "    [{app9,  ['~s@~s','~s@~s']}, "
                       "     {app10, ['~s@~s','~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M,  
-                       SyncNodesTimeout,  
-                       Ncp1, M, Ncp2, M,  
+                      [Ncp1, M, Ncp2, M,
+                       SyncNodesTimeout,
+                       Ncp1, M, Ncp2, M,
                        Ncp1, M, Ncp2, M])
     end.
 
@@ -1591,7 +1591,7 @@ otp_5606(Conf) when is_list(Conf) ->
     (config4(NodeNames))(Fd, 10000),
     file:close(Fd),
     Config = filename:join(Dir, "sys"),
-    
+
     %% Test [cp1, cp2]
     {ok, Cp1} = start_node(Ncp1, Config),
     {ok, Cp2} = start_node(Ncp2, Config),
@@ -1624,7 +1624,7 @@ otp_5606(Conf) when is_list(Conf) ->
 	    ct:fail(lists:flatten(Txt))
     end,
 
-    {error, {already_started, app1}} = 
+    {error, {already_started, app1}} =
 	rpc:call(Cp1, application, start, [app1]),
 
     stop_node_nice(Cp1),
@@ -1632,7 +1632,7 @@ otp_5606(Conf) when is_list(Conf) ->
     ok.
 
 otp_5606_loop(ResL) when length(ResL)<4 ->
-    receive 
+    receive
 	{_Pid, Res} ->
 	    otp_5606_loop([Res|ResL])
     after 5000 ->
@@ -1696,13 +1696,13 @@ get_key(Conf) when is_list(Conf) ->
     ?UNTIL(is_loaded(appinc, Cp1)),
     ok = rpc:call(Cp1, application, start, [appinc, permanent]),
     ?UNTIL(is_started(appinc, Cp1)),
-    
+
     {ok, "Test of new app file, including appnew"} =
 	rpc:call(Cp1, application, get_key, [appinc, description]),
     {ok, "CXC 138 ai"} = rpc:call(Cp1, application, get_key, [appinc ,id]),
     {ok, "2.0"} = rpc:call(Cp1, application, get_key, [appinc, vsn]),
     {ok, [kernel]} = rpc:call(Cp1, application, get_key, [appinc, applications]),
-    {ok, [appinc1, appinc2]} = 
+    {ok, [appinc1, appinc2]} =
 	rpc:call(Cp1, application, get_key, [appinc, included_applications]),
     {ok, []} = rpc:call(Cp1, application, get_key, [appinc, registered]),
     {ok, [{init, [kalle]}, {takeover, []}, {go, [sune]}]} =
@@ -1710,73 +1710,73 @@ get_key(Conf) when is_list(Conf) ->
     {ok, Env} = rpc:call(Cp1, application, get_key, [appinc ,env]),
     [{own2,val2},{own_env1,value1}] = lists:sort(Env),
     {ok, []} = rpc:call(Cp1, application, get_key, [appinc, modules]),
-    {ok, {application_starter, [ch_sup, {appinc, 41, 43}] }} = 
+    {ok, {application_starter, [ch_sup, {appinc, 41, 43}] }} =
 	rpc:call(Cp1, application, get_key, [appinc, mod]),
     {ok, infinity} = rpc:call(Cp1, application, get_key, [appinc, maxP]),
     {ok, infinity} = rpc:call(Cp1, application, get_key, [appinc, maxT]),
     undefined = rpc:call(Cp1, application, get_key, [appinc, very_unknown]),
 
-    {ok, [{description, "Test of new app file, including appnew"}, 
-		{id, "CXC 138 ai"}, 
-		{vsn, "2.0"}, 
-		{modules, []}, 
-		{maxP, infinity}, 
-		{maxT, infinity}, 
-		{registered, []}, 
-		{included_applications, [appinc1, appinc2]}, 
+    {ok, [{description, "Test of new app file, including appnew"},
+		{id, "CXC 138 ai"},
+		{vsn, "2.0"},
+		{modules, []},
+		{maxP, infinity},
+		{maxT, infinity},
+		{registered, []},
+		{included_applications, [appinc1, appinc2]},
 		{optional_applications, []},
-		{applications, [kernel]}, 
-		{env, Env}, 
-		{mod, {application_starter, [ch_sup, {appinc, 41, 43}] }}, 
-		{start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]}]} = 
+		{applications, [kernel]},
+		{env, Env},
+		{mod, {application_starter, [ch_sup, {appinc, 41, 43}] }},
+		{start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]}]} =
 	rpc:call(Cp1, application, get_all_key, [appinc]),
     [{own2,val2},{own_env1,value1}] = lists:sort(Env),
 
     {ok, "Test of new app file, including appnew"} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, description}),
-    {ok, "CXC 138 ai"} = 
+    {ok, "CXC 138 ai"} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, id}),
-    {ok, "2.0"} = 
+    {ok, "2.0"} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, vsn}),
-    {ok, [kernel]} = 
+    {ok, [kernel]} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, applications}),
-    {ok, [appinc1, appinc2]} = 
+    {ok, [appinc1, appinc2]} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, included_applications}),
-    {ok, []} = 
+    {ok, []} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, registered}),
     {ok, [{init, [kalle]}, {takeover, []}, {go, [sune]}]} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, start_phases}),
     {ok, Env} = gen_server:call({global, {ch,41}}, {get_pid_key, env}),
     [{own2,val2},{own_env1,value1}] = lists:sort(Env),
-    {ok, []} = 
+    {ok, []} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, modules}),
-    {ok, {application_starter, [ch_sup, {appinc, 41, 43}] }} = 
+    {ok, {application_starter, [ch_sup, {appinc, 41, 43}] }} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, mod}),
-    {ok, infinity} = 
+    {ok, infinity} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, maxP}),
-    {ok, infinity} = 
+    {ok, infinity} =
 	gen_server:call({global, {ch,41}}, {get_pid_key, maxT}),
-    undefined = 
+    undefined =
 	gen_server:call({global, {ch,41}}, {get_pid_key, very_unknown}),
 
 
 
-    {ok, [{description, "Test of new app file, including appnew"}, 
-		{id, "CXC 138 ai"}, 
-		{vsn, "2.0"}, 
-		{modules, []}, 
-		{maxP, infinity}, 
-		{maxT, infinity}, 
-		{registered, []}, 
-		{included_applications, [appinc1, appinc2]}, 
+    {ok, [{description, "Test of new app file, including appnew"},
+		{id, "CXC 138 ai"},
+		{vsn, "2.0"},
+		{modules, []},
+		{maxP, infinity},
+		{maxT, infinity},
+		{registered, []},
+		{included_applications, [appinc1, appinc2]},
 		{optional_applications, []},
-		{applications, [kernel]}, 
-		{env, Env}, 
-		{mod, {application_starter, [ch_sup, {appinc, 41, 43}] }}, 
-		{start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]}]} = 
+		{applications, [kernel]},
+		{env, Env},
+		{mod, {application_starter, [ch_sup, {appinc, 41, 43}] }},
+		{start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]}]} =
 	gen_server:call({global, {ch,41}}, get_pid_all_key),
     [{own2,val2},{own_env1,value1}] = lists:sort(Env),
-    
+
     stop_node_nice(Cp1),
     ok.
 
@@ -1787,7 +1787,7 @@ get_key(Conf) when is_list(Conf) ->
 %% Test change of distributed parameter.
 distr_changed_tc1(Conf) when is_list(Conf) ->
 
-    {OldKernel, OldEnv, {Cp1, Cp2, Cp3}, {_Ncp1, _Ncp2, _Ncp3}, _Config2} = 
+    {OldKernel, OldEnv, {Cp1, Cp2, Cp3}, {_Ncp1, _Ncp2, _Ncp3}, _Config2} =
 	distr_changed_prep(Conf),
 
     NewDist = {distributed, [{app1, [Cp3]},
@@ -1796,21 +1796,21 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
 				   {app6, [Cp1, {Cp3, Cp2}]},
 				   {app7, 1000, [Cp3]},
 				   {app8, [Cp1, {Cp2, Cp3}]}]},
-    
+
     NewKernel = [{kernel, lists:keyreplace(distributed, 1, OldKernel, NewDist)}],
-    ok = rpc:call(Cp1, application_controller, test_change_apps, 
+    ok = rpc:call(Cp1, application_controller, test_change_apps,
 			[[kernel], [NewKernel]]),
-    ok = rpc:call(Cp2, application_controller, test_change_apps, 
+    ok = rpc:call(Cp2, application_controller, test_change_apps,
 			[[kernel], [NewKernel]]),
-    ok = rpc:call(Cp3, application_controller, test_change_apps, 
+    ok = rpc:call(Cp3, application_controller, test_change_apps,
 			[[kernel], [NewKernel]]),
-    
-    {[ok,ok,ok],[]} = 
-	rpc:multicall([Cp1, Cp2, Cp3], 
+
+    {[ok,ok,ok],[]} =
+	rpc:multicall([Cp1, Cp2, Cp3],
 		      application_controller, config_change, [OldEnv]),
-    
+
     ct:sleep(7000),
-    
+
     DcInfo1 = rpc:call(Cp1, dist_ac, info, []),
     DcInfo2 = rpc:call(Cp2, dist_ac, info, []),
     DcInfo3 = rpc:call(Cp3, dist_ac, info, []),
@@ -1818,7 +1818,7 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
     DcWa1 = which_applications(Cp1),
     DcWa2 = which_applications(Cp2),
     DcWa3 = which_applications(Cp3),
-    
+
     Wa1 = lists:foldl(fun({A1, _N1, _V1}, AccIn) -> [A1 | AccIn] end,
 			    [], DcWa1),
     Wa2 = lists:foldl(fun({A2, _N2, _V2}, AccIn) -> [A2 | AccIn] end,
@@ -1832,7 +1832,7 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
 		  X1 = io_lib:format("distribution error: Cp1 ~p ",[EWa1]),
 		  ct:fail(lists:flatten(X1))
 	  end,
-		  
+
     case lists:sort(Wa2) of
 	      [app6, app8, kernel, stdlib] ->
 		  ok;
@@ -1840,7 +1840,7 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
 		  X2 = io_lib:format("distribution error: Cp2 ~p ",[EWa2]),
 		  ct:fail(lists:flatten(X2))
 	  end,
-		  
+
     case lists:sort(Wa3) of
 	      [app7, kernel, stdlib] ->
 		  ok;
@@ -1848,7 +1848,7 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
 		  X3 = io_lib:format("distribution error: Cp3 ~p ",[EWa3]),
 		  ct:fail(lists:flatten(X3))
 	  end,
-		  
+
     DcInfo1n = rpc:call(Cp1, dist_ac, info, []),
     DcInfo2n = rpc:call(Cp2, dist_ac, info, []),
     DcInfo3n = rpc:call(Cp3, dist_ac, info, []),
@@ -1859,8 +1859,8 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
     true = DcInfo3 =:= DcInfo3n,
 
     stop_node_nice(Cp1),
-    stop_node_nice(Cp2),   
-    stop_node_nice(Cp3),   
+    stop_node_nice(Cp2),
+    stop_node_nice(Cp3),
 
     ok = file:delete("dc.boot"),
     ok = file:delete("dc.rel"),
@@ -1871,7 +1871,7 @@ distr_changed_tc1(Conf) when is_list(Conf) ->
 %% Test change of distributed parameter, move appls by crashing a node.
 distr_changed_tc2(Conf) when is_list(Conf) ->
 
-    {OldKernel, OldEnv, {Cp1, Cp2, Cp3}, {Ncp1, _Ncp2, _Ncp3}, Config2} = 
+    {OldKernel, OldEnv, {Cp1, Cp2, Cp3}, {Ncp1, _Ncp2, _Ncp3}, Config2} =
 	distr_changed_prep(Conf),
 
     NewDist = {distributed, [{app1, [Cp3]},
@@ -1880,21 +1880,21 @@ distr_changed_tc2(Conf) when is_list(Conf) ->
 				   {app6, [Cp1, {Cp3, Cp2}]},
 				   {app7, 1000, [Cp3]},
 				   {app8, [Cp1, {Cp2, Cp3}]}]},
-    
+
     NewKernel = [{kernel, lists:keyreplace(distributed, 1, OldKernel, NewDist)}],
-    ok = rpc:call(Cp1, application_controller, test_change_apps, 
+    ok = rpc:call(Cp1, application_controller, test_change_apps,
 			[[kernel], [NewKernel]]),
-    ok = rpc:call(Cp2, application_controller, test_change_apps, 
+    ok = rpc:call(Cp2, application_controller, test_change_apps,
 			[[kernel], [NewKernel]]),
-    ok = rpc:call(Cp3, application_controller, test_change_apps, 
+    ok = rpc:call(Cp3, application_controller, test_change_apps,
 			[[kernel], [NewKernel]]),
-    
-    {[ok,ok,ok],[]} = 
-	rpc:multicall([Cp1, Cp2, Cp3], 
+
+    {[ok,ok,ok],[]} =
+	rpc:multicall([Cp1, Cp2, Cp3],
 		      application_controller, config_change, [OldEnv]),
-    
+
     ct:sleep(4000),
-    stop_node_nice(Cp1),   
+    stop_node_nice(Cp1),
     ct:sleep(10000),
 
     _DcInfo2 = rpc:call(Cp2, dist_ac, info, []),
@@ -1902,12 +1902,12 @@ distr_changed_tc2(Conf) when is_list(Conf) ->
 
     DcWa2 = which_applications(Cp2),
     DcWa3 = which_applications(Cp3),
-    
+
     Wa2 = lists:foldl(fun({A2, _N2, _V2}, AccIn) -> [A2 | AccIn] end,
 			    [], DcWa2),
     Wa3 = lists:foldl(fun({A3, _N3, _V3}, AccIn) -> [A3 | AccIn] end,
 			    [], DcWa3),
-		  
+
 
     case lists:sort(Wa2) of
 	      [app2, app6, app8, kernel, stdlib] ->
@@ -1916,7 +1916,7 @@ distr_changed_tc2(Conf) when is_list(Conf) ->
 		  X2 = io_lib:format("distribution error: Cp2 ~p ",[EWa2]),
 		  ct:fail(lists:flatten(X2))
 	  end,
-		  
+
     case lists:sort(Wa3) of
 	      [app1, app3, app7, kernel, stdlib] ->
 		  ok;
@@ -1936,14 +1936,14 @@ distr_changed_tc2(Conf) when is_list(Conf) ->
     DcWa1rs = which_applications(Cp1),
     DcWa2rs = which_applications(Cp2),
     DcWa3rs = which_applications(Cp3),
-    
+
     Wa1rs = lists:foldl(fun({A1, _N1, _V1}, AccIn) -> [A1 | AccIn] end,
 			      [], DcWa1rs),
     Wa2rs = lists:foldl(fun({A2, _N2, _V2}, AccIn) -> [A2 | AccIn] end,
 			      [], DcWa2rs),
     Wa3rs = lists:foldl(fun({A3, _N3, _V3}, AccIn) -> [A3 | AccIn] end,
 			      [], DcWa3rs),
-		  
+
     case lists:sort(Wa1rs) of
 	      [app6, app8, kernel, stdlib] ->
 		  ok;
@@ -1951,7 +1951,7 @@ distr_changed_tc2(Conf) when is_list(Conf) ->
 		  X1rs = io_lib:format("distribution error: Cp1 ~p ",[EWa1rs]),
 		  ct:fail(lists:flatten(X1rs))
 	  end,
-		  
+
     case lists:sort(Wa2rs) of
 	      [app2, kernel, stdlib] ->
 		  ok;
@@ -1959,7 +1959,7 @@ distr_changed_tc2(Conf) when is_list(Conf) ->
 		  X2rs = io_lib:format("distribution error: Cp2 ~p ",[EWa2rs]),
 		  ct:fail(lists:flatten(X2rs))
 	  end,
-		  
+
     case lists:sort(Wa3rs) of
 	      [app1, app3, app7, kernel, stdlib] ->
 		  ok;
@@ -2340,7 +2340,7 @@ get_appls({script, _, Script}) ->
     get_appls(Script, []).
 
 %% kernel is taken care of separately
-get_appls([{kernelProcess, application_controller, 
+get_appls([{kernelProcess, application_controller,
 	    {application_controller, start, [App]}} | T], Res) ->
     get_appls(T, [App | Res]);
 %% other applications but kernel
@@ -2527,7 +2527,7 @@ shutdown_func(Config) when is_list(Config) ->
     {ok,Cp1} = start_node(?MODULE_STRING++"_shutdown_func"),
     wait_for_ready_net(),
     Tag = make_ref(),
-    ok = rpc:call(Cp1, application, set_env, 
+    ok = rpc:call(Cp1, application, set_env,
                         [kernel, shutdown_func, {?MODULE, do_shutdown}]),
     ok = rpc:call(Cp1, application, set_env,
                         [kernel, shutdown_func_test, {self(), Tag}]),
@@ -2551,8 +2551,8 @@ shutdown_func(Config) when is_list(Config) ->
 do_shutdown(Reason) ->
     {ok, {Pid, Tag}} = application:get_env(kernel, shutdown_func_test),
     Pid ! {self(), Tag, shutting_down, Reason},
-    receive 
-	{Pid, Tag, ok} -> ok 
+    receive
+	{Pid, Tag, ok} -> ok
     end.
 
 
@@ -2809,7 +2809,7 @@ appinc() ->
       {env, [{own_env1, value1}, {own2, val2}]},
       {included_applications, [appinc1, appinc2]},
       {start_phases, [{init, [kalle]}, {takeover, []}, {go, [sune]}]},
-      {mod, {application_starter, [ch_sup, {appinc, 41, 43}] }}]}. 
+      {mod, {application_starter, [ch_sup, {appinc, 41, 43}] }}]}.
 
 
 app_sp() ->
@@ -2820,7 +2820,7 @@ app_sp() ->
       {applications, [kernel]},
       {modules, []},
       {registered, []},
-      {mod, {application_starter, [ch_sup, {app_sp, 31, 33}] }}]}. 
+      {mod, {application_starter, [ch_sup, {app_sp, 31, 33}] }}]}.
 
 app_trans_normal() ->
     {application, trans_normal,
@@ -2910,9 +2910,9 @@ config([Ncp1, Ncp2, Ncp3]) ->
                       "{distributed, [{app1, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{app2, 1000, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{app3, 1000, [{'~s@~s', '~s@~s'}, '~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
-                       SyncNodesTimeout,  Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
+                       SyncNodesTimeout,  Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
                        Ncp1, M, Ncp2, M, Ncp3, M])
     end.
 
@@ -2926,10 +2926,10 @@ config2([Ncp1, Ncp2, Ncp3]) ->
                       "{distributed, [{app1, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{app2, 10000, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{app3, 5000, [{'~s@~s', '~s@~s'}, '~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
-                       SyncNodesTimeout,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
+                       SyncNodesTimeout,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
                        Ncp1, M, Ncp2, M, Ncp3, M])
     end.
 
@@ -2941,7 +2941,7 @@ config3([Ncp1, Ncp2, Ncp3]) ->
                       "{sync_nodes_timeout, ~w},"
                       "{start_dist_ac, true},"
                       "{permissions, [{app3, false}]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
                        SyncNodesTimeout])
     end.
 
@@ -2953,7 +2953,7 @@ config4([Ncp1, Ncp2]) ->
                       "{sync_nodes_timeout, ~w},"
                       "{start_dist_ac, true},"
                       "{distributed, [{app1, ['~s@~s', '~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M,  SyncNodesTimeout,  
+                      [Ncp1, M, Ncp2, M,  SyncNodesTimeout,
                        Ncp1, M, Ncp2, M])
     end.
 
@@ -2965,7 +2965,7 @@ config3184([Ncp1, Ncp2]) ->
                       "{sync_nodes_timeout, ~w},"
                       "{permissions, [{app1, false}]},"
                       "{distributed, [{app1, ['~s@~s', '~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M,  SyncNodesTimeout,  
+                      [Ncp1, M, Ncp2, M,  SyncNodesTimeout,
                        Ncp1, M, Ncp2, M])
     end.
 
@@ -2999,10 +2999,10 @@ config_inc([Ncp1, Ncp2, Ncp3]) ->
                       "{distributed, [{appinc, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{app2, 10000, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{app3, 5000, [{'~s@~s', '~s@~s'}, '~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
-                       SyncNodesTimeout,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
+                       SyncNodesTimeout,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
                        Ncp1, M, Ncp2, M, Ncp3, M])
     end.
 
@@ -3021,16 +3021,16 @@ config_sf([Ncp1, Ncp2, Ncp3]) ->
                       "{incl2B, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{with, ['~s@~s', '~s@~s', '~s@~s']},"
                       "{wrapper, ['~s@~s', '~s@~s', '~s@~s']}]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
-                       SyncNodesTimeout,   
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp1, M, Ncp2, M, Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
+                       SyncNodesTimeout,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp1, M, Ncp2, M, Ncp3, M,
                        Ncp1, M, Ncp2, M, Ncp3, M])
     end.
 
@@ -3063,13 +3063,13 @@ config_dc([Ncp1, Ncp2, Ncp3]) ->
                       "               {app7, ['~s@~s']}, "
                       "               {app8, ['~s@~s', {'~s@~s', '~s@~s'}]}"
                       "              ]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
-                       SyncNodesTimeout,  
-                       Ncp1, M, Ncp2, M,  
-                       Ncp1, M,  
-                       Ncp1, M, Ncp2, M,  
-                       Ncp3, M, Ncp2, M,  
-                       Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
+                       SyncNodesTimeout,
+                       Ncp1, M, Ncp2, M,
+                       Ncp1, M,
+                       Ncp1, M, Ncp2, M,
+                       Ncp3, M, Ncp2, M,
+                       Ncp3, M,
                        Ncp2, M, Ncp1, M, Ncp3, M])
     end.
 
@@ -3086,12 +3086,12 @@ config_dc2([Ncp1, Ncp2, Ncp3]) ->
                       "               {app7, 1000, ['~s@~s']}, "
                       "               {app8, ['~s@~s', {'~s@~s', '~s@~s'}]}"
                       "              ]}]}].~n",
-                      [Ncp1, M, Ncp2, M, Ncp3, M,  
-                       Ncp3, M, 
-                       Ncp2, M, 
-                       Ncp3, M, Ncp1, M, Ncp2, M, 
-                       Ncp1, M, Ncp3, M, Ncp2, M, 
-                       Ncp3, M,  
+                      [Ncp1, M, Ncp2, M, Ncp3, M,
+                       Ncp3, M,
+                       Ncp2, M,
+                       Ncp3, M, Ncp1, M, Ncp2, M,
+                       Ncp1, M, Ncp3, M, Ncp2, M,
+                       Ncp3, M,
                        Ncp1, M, Ncp2, M, Ncp3, M])
     end.
 
@@ -3201,9 +3201,9 @@ start_node(Name, ConfigFile) ->
 
 start_node(Name, ConfigFile, ExtraArgs) ->
     Pa = filename:dirname(code:which(?MODULE)),
-    test_server:start_node(Name, slave, [{args, 
-                                          " -pa " ++ Pa ++ 
-                                          " -config " ++ ConfigFile ++ 
+    test_server:start_node(Name, slave, [{args,
+                                          " -pa " ++ Pa ++
+                                          " -config " ++ ConfigFile ++
                                           ExtraArgs}]).
 
 start_node_with_cache(Name, SysConfigFun, Conf) ->
@@ -3220,10 +3220,10 @@ start_node_boot_3002(Name, Boot) ->
 	   [" -pa " ++ Pa ++ " -env ERL_CRASH_DUMP erl_crash_dump." ++
 		atom_to_list(Name) ++ " -boot " ++ Boot ++
 		" -sasl dummy \"missing "]),
-    test_server:start_node(Name, slave, 
+    test_server:start_node(Name, slave,
                            [{args, " -pa " ++ Pa ++
                              " -env ERL_CRASH_DUMP erl_crash_dump." ++
-                             atom_to_list(Name) ++ " -boot " ++ Boot ++ 
+                             atom_to_list(Name) ++ " -boot " ++ Boot ++
                              " -sasl dummy \"missing "}]).
 
 start_node_boot_config(Name, SysConfigFun, Conf, Boot) ->
@@ -3276,12 +3276,12 @@ get_start_type(Expected, Times, Ack0) ->
     global:send(st_type, {st, read, self()}),
     receive
         {st, N, L, T, F} ->
-            Ack = #st{normal = N0 + N, local = L0 + L, 
+            Ack = #st{normal = N0 + N, local = L0 + L,
                       takeover = T0 + T, failover = F0 + F},
             if
                 Ack =:= Expected ->
                     ok;
-                true -> 
+                true ->
                     timer:sleep(200),
                     get_start_type(Expected, Times-1, Ack)
             end
@@ -3484,7 +3484,7 @@ distr_changed_prep(Conf) when is_list(Conf) ->
 	  end,
 
     ok = systools:make_script("dc", Options),
-    
+
     NodeNames = [Ncp1, Ncp2, Ncp3] = node_names([cp1, cp2, cp3], Conf),
     NoSyncTime = config_fun_fast(config_dc(NodeNames)),
     WithSyncTime = config_fun(config_dc(NodeNames)),
@@ -3494,7 +3494,7 @@ distr_changed_prep(Conf) when is_list(Conf) ->
     (config_dc2(NodeNames))(Fd_dc2),
     file:close(Fd_dc2),
     Config2 = filename:join(Dir, "sys2"),
-    
+
     %% Test [cp1, cp2, cp3]
     {ok, Cp1} = start_node_boot_config(Ncp1, NoSyncTime, Conf, dc),
     {ok, Cp2} = start_node_boot_config(Ncp2, NoSyncTime, Conf, dc),
@@ -3703,12 +3703,12 @@ is_real_system(KernelVsn, StdlibVsn) ->
 	_ ->
 	    false
     end.
-    
-init2973() -> 
+
+init2973() ->
     loop2973().
 
 
-loop2973() -> 
+loop2973() ->
     receive
 	{start, From, App} ->
 	    Res = application:start(App),
@@ -3723,7 +3723,7 @@ wait_for_ready_net() ->
     Nodes = lists:sort([node() | nodes()]),
     ?UNTIL(begin
                lists:all(fun(N) -> Nodes =:= get_known(N) end, Nodes) and
-               lists:all(fun(N) -> 
+               lists:all(fun(N) ->
                                  LNs = rpc:call(N, erlang, nodes, []),
                                  Nodes =:= lists:sort([N | LNs])
                          end, Nodes)
@@ -3733,7 +3733,7 @@ get_known(Node) ->
     case catch gen_server:call({global_name_server,Node}, get_known) of
         {'EXIT', _} ->
             [list, without, nodenames];
-        Known -> 
+        Known ->
             lists:sort([Node | Known])
     end.
 

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -2657,8 +2657,12 @@ shutdown_deadlock(Config) when is_list(Config) ->
 	    erlang:display({self(), "Sending Continue", Server}),
 	    Server ! continue
     end,
+    %% Wait for stop to complete before unloading
+    receive
+        {stop, ok} -> ok
+    end,
     [_|_] = application:which_applications(),
-    application:unload(deadlock), % clean up!
+    ok = application:unload(deadlock), % clean up!
     ok.
 
 

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -41,6 +41,7 @@
 -export([config_change/1, persistent_env/1, invalid_app_file/1,
 	 distr_changed_tc1/1, distr_changed_tc2/1,
 	 ensure_started/1, ensure_all_started/1, ensure_all_started_limit/1,
+	 ensure_all_stopped/1, ensure_all_stopped_limit/1,
 	 shutdown_func/1, do_shutdown/1, shutdown_timeout/1,
          shutdown_application_call/1,shutdown_deadlock/1,
          config_relative_paths/1, handle_many_config_files/1,
@@ -62,6 +63,7 @@ all() ->
      load_use_cache, ensure_started, {group, reported_bugs}, start_phases,
      script_start, nodedown_start, permit_false_start_local,
      permit_false_start_dist, get_key, get_env, ensure_all_started, ensure_all_started_limit,
+     ensure_all_stopped, ensure_all_stopped_limit,
      set_env, set_env_persistent, set_env_errors, get_supervisor,
      {group, distr_changed}, config_change, shutdown_func, shutdown_timeout,
      shutdown_application_call, shutdown_deadlock, config_relative_paths, optional_applications,
@@ -1078,6 +1080,103 @@ ensure_all_started_limit(_Conf) ->
         ok = application:stop(app9),
         ok = application:unload(app9),
         ok = application:stop(app10),
+        ok = application:unload(app10)
+    end, [1, 2, 10, inf]),
+    ok.
+
+%% Test application:ensure_all_stopped/1-2.
+ensure_all_stopped(_Conf) ->
+    do_ensure_all_stopped(serial),
+    do_ensure_all_stopped(concurrent),
+    ok.
+
+do_ensure_all_stopped(Mode) ->
+    {ok, Fd1} = file:open("app1.app", [write]),
+    w_app1(Fd1),
+    file:close(Fd1),
+    {ok, Fd9} = file:open("app9.app", [write]),
+    w_app9(Fd9),
+    file:close(Fd9),
+    {ok, Fd10} = file:open("app10.app", [write]),
+    w_app10(Fd10, [app9], []),
+    file:close(Fd10),
+
+    %% Single app stop - app not running should return empty list
+    false = lists:keyfind(app1, 1, application:which_applications()),
+    {ok, []} = application:ensure_all_stopped(app1, Mode),
+
+    %% Start and stop single app
+    {ok, [app1]} = application:ensure_all_started(app1, temporary),
+    {app1, _, _} = lists:keyfind(app1, 1, application:which_applications()),
+    {ok, [app1]} = application:ensure_all_stopped(app1, Mode),
+    false = lists:keyfind(app1, 1, application:which_applications()),
+    ok = application:unload(app1),
+
+    %% Already stopped app returns empty list
+    {ok, [app1]} = application:ensure_all_started(app1, temporary),
+    {ok, [app1]} = application:ensure_all_stopped(app1, Mode),
+    {ok, []} = application:ensure_all_stopped(app1, Mode), % already stopped
+    ok = application:unload(app1),
+
+    %% Stop app with dependencies - should stop dependents first
+    %% app10 depends on app9, so stopping app9 should also stop app10
+    {ok, [app9, app10]} = application:ensure_all_started(app10, temporary),
+    {app9, _, _} = lists:keyfind(app9, 1, application:which_applications()),
+    {app10, _, _} = lists:keyfind(app10, 1, application:which_applications()),
+    {ok, StoppedApps} = application:ensure_all_stopped(app9, Mode),
+    %% Both app10 (dependent) and app9 should be stopped
+    true = lists:member(app9, StoppedApps),
+    true = lists:member(app10, StoppedApps),
+    false = lists:keyfind(app9, 1, application:which_applications()),
+    false = lists:keyfind(app10, 1, application:which_applications()),
+    ok = application:unload(app9),
+    ok = application:unload(app10),
+
+    %% Stop only the leaf app (app10) - should not stop app9
+    {ok, [app9, app10]} = application:ensure_all_started(app10, temporary),
+    {ok, [app10]} = application:ensure_all_stopped(app10, Mode),
+    {app9, _, _} = lists:keyfind(app9, 1, application:which_applications()),
+    false = lists:keyfind(app10, 1, application:which_applications()),
+    ok = application:stop(app9),
+    ok = application:unload(app9),
+    ok = application:unload(app10),
+
+    %% Stop multiple apps at once
+    {ok, _} = application:ensure_all_started([app1, app10], temporary),
+    {app1, _, _} = lists:keyfind(app1, 1, application:which_applications()),
+    {app9, _, _} = lists:keyfind(app9, 1, application:which_applications()),
+    {app10, _, _} = lists:keyfind(app10, 1, application:which_applications()),
+    {ok, StoppedMultiple} = application:ensure_all_stopped([app1, app9], Mode),
+    %% app1, app9, and app10 (dependent of app9) should all be stopped
+    true = lists:member(app1, StoppedMultiple),
+    true = lists:member(app9, StoppedMultiple),
+    true = lists:member(app10, StoppedMultiple),
+    false = lists:keyfind(app1, 1, application:which_applications()),
+    false = lists:keyfind(app9, 1, application:which_applications()),
+    false = lists:keyfind(app10, 1, application:which_applications()),
+    ok = application:unload(app1),
+    ok = application:unload(app9),
+    ok = application:unload(app10),
+    ok.
+
+%% Test application:ensure_all_stopped/2 with limit option.
+ensure_all_stopped_limit(_Conf) ->
+    {ok, Fd9} = file:open("app9.app", [write]),
+    w_app9(Fd9),
+    file:close(Fd9),
+    {ok, Fd10} = file:open("app10.app", [write]),
+    w_app10(Fd10, [app9], []),
+    file:close(Fd10),
+
+    %% Test various limit values
+    lists:foreach(fun(Limit) ->
+        {ok, [app9, app10]} = application:ensure_all_started(app10, temporary),
+        {ok, Stopped} = application:ensure_all_stopped(app9,
+                                                        #{mode => concurrent, limit => Limit}),
+        %% Both apps should be stopped (app10 depends on app9)
+        true = lists:member(app9, Stopped),
+        true = lists:member(app10, Stopped),
+        ok = application:unload(app9),
         ok = application:unload(app10)
     end, [1, 2, 10, inf]),
     ok.

--- a/lib/kernel/test/logger_disk_log_h_SUITE.erl
+++ b/lib/kernel/test/logger_disk_log_h_SUITE.erl
@@ -1251,7 +1251,7 @@ restart_after(Config) ->
     ok = logger:update_handler_config(?MODULE, NewHConfig1),
     MRef1 = erlang:monitor(process, whereis(h_proc_name())),
     %% kill handler
-    send_burst({n,1000}, {spawn,5,0}, {chars,79}, notice),
+    send_burst({n,5000}, {spawn,5,0}, {chars,79}, notice),
     receive
         {'DOWN', MRef1, _, _, _Reason1} ->
             file_delete(Log),
@@ -1274,7 +1274,7 @@ restart_after(Config) ->
     Pid0 = whereis(h_proc_name()),
     MRef2 = erlang:monitor(process, Pid0),
     %% kill handler
-    send_burst({n,500}, {spawn,5,0}, {chars,79}, notice),
+    send_burst({n,5000}, {spawn,5,0}, {chars,79}, notice),
     receive
         {'DOWN', MRef2, _, _, _Reason2} ->
             file_delete(Log),


### PR DESCRIPTION
NOTE: This is on-top of [PR10581](https://github.com/erlang/otp/pull/10581)

This PR adds `application:ensure_all_stopped/1,2` which stops a set of applications and their dependents. It's the inverse to `application:ensure_all_started/1,2,3` and has the same options `serial | concurrent | #{mode := serial | concurrent, limit => pos_integer() | inf}`.

It uses the stop requests introduced in [PR9558](https://github.com/erlang/otp/pull/9558)