### PR TITLE
ssl: Enhance connection_information

### DIFF
--- a/lib/ssl/src/tls_dtls_server_connection.erl
+++ b/lib/ssl/src/tls_dtls_server_connection.erl
@@ -364,7 +364,8 @@ do_server_hello(Type, #{next_protocol_negotiation := NextProtocols} =
 
     State = server_hello(ServerHello,
 			 State1#state{handshake_env =
-                                          HsEnv#handshake_env{expecting_next_protocol_negotiation =
+                                          HsEnv#handshake_env{resumption = (Type == resumed),
+                                                              expecting_next_protocol_negotiation =
                                                                   NextProtocols =/= undefined}},
                          Connection),
     case Type of


### PR DESCRIPTION
Let session_resumption return correct information for TLS-1.2 also. Although it was introduced for TLS-1.3 testing purposes, where session resumption is not as observable as for TLS-1.2, it is visible in the API and it makes more sense to make it work for TL-1.2 then to document that it does not.

closes #10470