### PR TITLE
Fix repeated binary segment bug

### DIFF
--- a/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
+++ b/lib/compiler/test/beam_ssa_check_SUITE_data/private_append.erl
@@ -78,6 +78,7 @@
          not_transformable13/1,
          not_transformable14/0,
          not_transformable15/2,
+         not_transformable16/1,
 
          id/1,
 
@@ -995,6 +996,18 @@ not_transformable15(V, _) when V ->
     << ok || catch <<(not_transformable15(id(ok), ok))/binary>> >>;
 not_transformable15(_, V) ->
     id(ok) bor V.
+
+%% Check that we don't use private_append when the same binary variable
+%% is used multiple times in a single bs_create_bin instruction.
+%% Using private_append would corrupt the binary after the first use,
+%% causing the second and third appends to read garbage data.
+not_transformable16(N) ->
+%ssa% (_) when post_ssa_opt ->
+%ssa% A = bs_init_writable(_),
+%ssa% B = call(_, _, A),
+%ssa% _ = bs_create_bin(append, _, B, ...).
+    Label = << <<$a>> || _ <- lists:seq(1, N) >>,
+    <<Label/binary, Label/binary, Label/binary>>.
 
 id(I) ->
     I.


### PR DESCRIPTION
The following snippet reads garbage memory and even often triggers ***segfaults***. It barely ever happens with small Ns, but for around larger than 40 it is almost guaranteed to segfault in my machine.

```erl
generate_max_length_names(N) ->
    Label = <<<<$a>> || _ <- lists:seq(1, N)>>,
    <<Label/binary, Label/binary, Label/binary>>.
```

I found this while trying to write some tests for bencharking dns packet parsing logic. It did not trigger with only two labels, but with three it is enough. These labels trigger or fail to trigger too:

```erl
    BadLabel = <<<<$a>> || <<_>> <= <<1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1>> >>,
    GoodLabel = <<1, 1, 1, 1, 1,1, 1, 1, 1, 1,1, 1, 1, 1, 1,1, 1, 1, 1, 1,1, 1, 1, 1, 1>>,
    GoodLabel = iolist_to_binary(lists:duplicate(63, <<$a>>)),
```

My findings:

When the same binary variable is used multiple times in a single bs_create_bin instruction (e.g., `<<Label/binary, Label/binary, Label/binary>>`), the `private_append` optimization was incorrectly applied. This caused memory corruption because:

1. The first segment uses `private_append` to destructively extend the binary
2. The `ErlSubBits` structure is modified to reflect the new size
3. Subsequent segments read this modified size, not the original
4. The runtime copies more bytes than the original contained, reading uninitialized/garbage memory

The fix adds a check to ensure that before setting `first_fragment_dies` to true (which enables `private_append`), we verify the first fragment variable doesn't appear in any other segment of the instruction.