### PR TITLE
Generate macros for BEAM opcodes and arities in beam_opcodes.hrl

### DIFF
--- a/erts/emulator/utils/beam_makeops
+++ b/erts/emulator/utils/beam_makeops
@@ -1255,7 +1255,11 @@ sub compiler_output {
 	print "-define(tag_$tag_type[$i], $i).\n";
     }
     print "\n";
-
+    for ($i = 0; $i < @gen_opname; $i++) {
+        next unless defined $gen_opname[$i];
+        print "-define(BEAMop_$gen_opname[$i], $i).\n";
+        print "-define(BEAMop_ARGS_$gen_opname[$i], $gen_arity[$i]).\n";
+    }
 }
 
 #


### PR DESCRIPTION
This makes it possible to write efficient traversing, decomposition and recomposition of BEAM code without doing an expensive complete disassembly to symbolic form. (PRs depending on this will follow later.)