### PR TITLE
EUNIT: feature - add randomDelay macro for race condition testing

### DIFF
--- a/lib/eunit/doc/guides/chapter.md
+++ b/lib/eunit/doc/guides/chapter.md
@@ -760,16 +760,16 @@ compiled with testing enabled.
 ### Macros for instrumentation
 
 To help with instrumenting, EUnit defines a macro that can introduce
-delays into the runtime.  This can help uncover subtle timing bugs
+delays into the runtime. This can help uncover subtle timing bugs
 that may not be evident when timing is perfect.
 
 If the macro `NODEBUG` is defined before the EUnit header file is included,
 these macros have no effect; see
 [Compilation control macros](chapter.md#Compilation_control_macros) for details.
 
-- **`randomDelay(Probability, Min, Max)`** This macro is used to cause
-non-deterministic latency into execution, which is useful for uncovering 
-race conditions and timing-dependent bugs during testing.
+- **`randomDelay(Probability, Min, Max)`** - This macro is used to cause
+  non-deterministic latency into execution, which is useful for uncovering
+  race conditions and timing-dependent bugs during testing.
 
 [](){: #Debugging_macros }
 

--- a/lib/eunit/include/eunit.hrl
+++ b/lib/eunit/include/eunit.hrl
@@ -246,7 +246,7 @@
             case rand:uniform() < (Prob) of
                 true ->
                     %% Convert seconds to milliseconds for timer:sleep
-                    Delay = (MinSec) + rand:uniform() * ((MaxSec) - (MinSec))
+                    Delay = (MinSec) + rand:uniform() * ((MaxSec) - (MinSec)),
                     timer:sleep(round(Delay * 1000));
                 false ->
                     ok


### PR DESCRIPTION
Introduces a new eunit macro to inject non-deterministic delays during test execution. This assists in uncovering timing-dependent bugs and race conditions by artificially shifting process execution order.

- Defined as a no-op when NODEBUG is set.
- Takes Probability (0.0-1.0), Min, and Max duration in seconds.
- Includes documentation in the instrumentation section.

This was discussed on Richard Carlsson's github issue and submitted here by request:

	https://github.com/richcarl/eunit/issues/23