### PR TITLE
otp: increment renovate number of PRs

### DIFF
--- a/.github/scripts/update-gh-actions-versions.es
+++ b/.github/scripts/update-gh-actions-versions.es
@@ -93,7 +93,7 @@ run(Opts) ->
     SupportedMajorVersions = string:split(cmd(Opts, ".github/scripts/get-supported-versions.sh"),"\n", all),
 
     %% Fetch all PRs done by renovate
-    PRs = cmd(Opts, ["gh pr -R ", Upstream, " list | grep 'renovate/' | awk '{print $1}'"]),
+    PRs = cmd(Opts, ["gh pr -R ", Upstream, " list -L 100 | grep 'renovate/[a-z0-9-]\\+github-actions' | awk '{print $1}'"]),
 
     %% If string is non-empty we have some PRs that we need to deal with
     case not string:equal(PRs,"") of


### PR DESCRIPTION
increment the number of pull requests that
`update-gh-actions-versions.es` downloads. before this change, the
renovate open PRs had to be the last 30 open PRs, or the script would
not detect them. with this change, the opened renovate PRs can be in the
last 100 opened PRs.
