### PR TITLE
Pause BIF timers when a process is suspended

### DIFF
--- a/erts/emulator/beam/erl_hl_timer.c
+++ b/erts/emulator/beam/erl_hl_timer.c
@@ -2793,11 +2793,10 @@ erts_pause_proc_timer(Process *c_p)
     erts_atomic_set_nob(&c_p->common.timer, (erts_aint_t) pptmr);
 }
 
-int
+void
 erts_resume_paused_proc_timer(Process *c_p)
 {
     erts_aint_t timer;
-    int resumed_timer = 0;
 
     ERTS_LC_ASSERT(ERTS_PROC_LOCK_MAIN & erts_proc_lc_my_proc_locks(c_p));
 
@@ -2809,10 +2808,10 @@ erts_resume_paused_proc_timer(Process *c_p)
 
         ASSERT(pptmr->head.roflgs & ERTS_TMR_ROFLG_PAUSED);
 
-        erts_atomic_set_nob(&c_p->common.timer, ERTS_PTMR_NONE);
-
         pptmr->count -= 1;
         if (pptmr->count == 0) {
+            erts_atomic_set_nob(&c_p->common.timer, ERTS_PTMR_NONE);
+
             if (pptmr->time_left_in_msec > 0) {
                 ASSERT((pptmr->time_left_in_msec >> 32) == 0);
                 tmo = (UWord) pptmr->time_left_in_msec;
@@ -2820,11 +2819,8 @@ erts_resume_paused_proc_timer(Process *c_p)
 
             erts_set_proc_timer_uword(c_p, tmo);
             paused_proc_timer_dec_refc(pptmr);
-            resumed_timer = 1;
         }
     }
-
-    return resumed_timer;
 }
 
 void

--- a/erts/emulator/beam/erl_hl_timer.c
+++ b/erts/emulator/beam/erl_hl_timer.c
@@ -609,6 +609,7 @@ same_time_list_lookup(ErtsHLTimer *root, ErtsHLTimer *x)
 #define ERTS_RBT_WANT_DELETE
 #define ERTS_RBT_WANT_INSERT
 #define ERTS_RBT_WANT_LOOKUP
+#define ERTS_RBT_WANT_FOREACH
 #define ERTS_RBT_WANT_FOREACH_DESTROY_YIELDING
 #define ERTS_RBT_UNDEF
 
@@ -707,14 +708,10 @@ port_timeout_common(Port *port, void *tmr)
     return 0;
 }
 
-static ERTS_INLINE erts_aint_t
-init_btm_specifics(ErtsSchedulerData *esdp,
-                   ErtsBifTimer *tmr, Eterm msg,
-                   Uint32 *refn
-    )
+static ERTS_INLINE void
+init_btm_message(ErtsBifTimer *tmr, Eterm msg)
 {
     Uint hsz = is_immed(msg) ? ((Uint) 0) : size_object(msg);
-    int refc;
     if (!hsz) {
         tmr->btm.message = msg;
         tmr->btm.bp = NULL;
@@ -725,7 +722,16 @@ init_btm_specifics(ErtsSchedulerData *esdp,
         tmr->btm.message = copy_struct(msg, hsz, &hp, &bp->off_heap);
         tmr->btm.bp = bp;
     }
-    refc = 0;
+}
+
+static ERTS_INLINE erts_aint_t
+init_btm_specifics(ErtsSchedulerData *esdp,
+                   ErtsBifTimer *tmr, Eterm msg,
+                   Uint32 *refn
+    )
+{
+    int refc = 0;
+    init_btm_message(tmr, msg);
     tmr->btm.refn[0] = refn[0];
     tmr->btm.refn[1] = refn[1];
     tmr->btm.refn[2] = refn[2];
@@ -962,6 +968,18 @@ create_tw_timer(ErtsSchedulerData *esdp,
 /*
  * Paused proc timers
  */
+
+static ERTS_INLINE Sint64
+time_left_for_timer_in_msec(ErtsTimer* tmr, ErtsSchedulerData *esdp)
+{
+    ErtsMonotonicTime timeout_pos;
+    int is_hlt = !!(tmr->head.roflgs & ERTS_TMR_ROFLG_HLT);
+    timeout_pos = (is_hlt
+            ? tmr->hlt.timeout
+            : erts_tweel_read_timeout(&tmr->twt.u.tw_tmr));
+    return get_time_left(esdp, timeout_pos);
+}
+
 static ERTS_INLINE ErtsPausedProcTimer *
 create_paused_proc_timer(Process *c_p)
 {
@@ -973,13 +991,10 @@ create_paused_proc_timer(Process *c_p)
         ErtsTimer *tmr = (ErtsTimer *)itmr;
 
         if (tmr->head.roflgs & ERTS_TMR_ROFLG_PAUSED) {
-            // The process timer was already paused, reuse the paused timer
+            /* The process timer was already paused, reuse the paused timer */
             ErtsPausedProcTimer *pptmr = (ErtsPausedProcTimer*) tmr;
             pptmr->count++;
         } else {
-            int is_hlt = !!(tmr->head.roflgs & ERTS_TMR_ROFLG_HLT);
-            ErtsMonotonicTime timeout_pos;
-
             ASSERT(tmr->head.roflgs & ERTS_TMR_ROFLG_PROC);
 
             result = erts_alloc(ERTS_ALC_T_PAUSED_TIMER,
@@ -988,10 +1003,7 @@ create_paused_proc_timer(Process *c_p)
             erts_atomic32_init_nob(&result->head.refc, 1);
             result->head.receiver.proc = tmr->head.receiver.proc;
 
-            timeout_pos = (is_hlt
-                       ? tmr->hlt.timeout
-                       : erts_tweel_read_timeout(&tmr->twt.u.tw_tmr));
-            result->time_left_in_msec = get_time_left(esdp, timeout_pos);
+            result->time_left_in_msec = time_left_for_timer_in_msec(tmr, esdp);
             result->count = 1;
         }
     }

--- a/erts/emulator/beam/erl_hl_timer.c
+++ b/erts/emulator/beam/erl_hl_timer.c
@@ -214,6 +214,17 @@ typedef struct {
     Sint count;
 } ErtsPausedProcTimer;
 
+typedef struct ErtsPausedBifTimer_ {
+    ErtsBifTimer tmr;
+    Sint64 time_left_in_msec;
+    struct ErtsPausedBifTimer_ *next;
+} ErtsPausedBifTimer;
+
+struct ErtsPausedBifTimers_ {
+    ErtsPausedBifTimer *list;
+    Sint count;
+};
+
 typedef ErtsTimer *(*ErtsCreateTimerFunc)(ErtsSchedulerData *esdp,
                                           ErtsMonotonicTime timeout_pos,
                                           int short_time, ErtsTmrType type,
@@ -966,7 +977,7 @@ create_tw_timer(ErtsSchedulerData *esdp,
 }
 
 /*
- * Paused proc timers
+ * Paused bif timers
  */
 
 static ERTS_INLINE Sint64
@@ -980,6 +991,31 @@ time_left_for_timer_in_msec(ErtsTimer* tmr, ErtsSchedulerData *esdp)
     return get_time_left(esdp, timeout_pos);
 }
 
+static ERTS_INLINE void
+create_paused_bif_timer(ErtsBifTimer *tmr, Process *c_p, ErtsSchedulerData *esdp)
+{
+    ErtsPausedBifTimer *pbtmr = erts_alloc(ERTS_ALC_T_PAUSED_TIMER,
+        sizeof(ErtsPausedBifTimer));
+
+    ASSERT(c_p->paused_bif_timers->count > 0);
+
+    ASSERT(!(tmr->type.head.roflgs & ERTS_TMR_ROFLG_PAUSED));
+
+    init_btm_message(&pbtmr->tmr, tmr->btm.message);
+
+    pbtmr->tmr.type.head.roflgs = tmr->type.head.roflgs | ERTS_TMR_ROFLG_PAUSED;
+    erts_atomic32_init_nob(&pbtmr->tmr.type.head.refc, 1);
+    pbtmr->tmr.type.head.receiver.proc = tmr->type.head.receiver.proc;
+
+    pbtmr->time_left_in_msec = time_left_for_timer_in_msec((ErtsTimer *) tmr, esdp);
+
+    pbtmr->next = c_p->paused_bif_timers->list;
+    c_p->paused_bif_timers->list = pbtmr;
+}
+
+/*
+ * Paused proc timers
+ */
 static ERTS_INLINE ErtsPausedProcTimer *
 create_paused_proc_timer(Process *c_p)
 {
@@ -1739,7 +1775,7 @@ continue_cancel_ptimer(ErtsSchedulerData *esdp, ErtsTimer *tmr)
         return;
     }
 
-    if (esdp->no != sid)
+   if (esdp->no != sid)
 	queue_canceled_timer(esdp, sid, tmr);
     else
 	cleanup_sched_local_canceled_timer(esdp, tmr);
@@ -1789,7 +1825,16 @@ setup_bif_timer(Process *c_p, int twheel, ErtsMonotonicTime timeout_pos,
 	Process *proc = erts_pid2proc_opt(c_p, ERTS_PROC_LOCK_MAIN,
 					  rcvr, ERTS_PROC_LOCK_BTM,
 					  ERTS_P2P_FLG_INC_REFC);
-	if (!proc) {
+        if (proc) {
+            tmr->type.head.receiver.proc = proc;
+            if (proc->paused_bif_timers) {
+                create_paused_bif_timer(tmr, proc, esdp);
+            } else {
+                proc_btm_rbt_insert(&proc->bif_timers, tmr);
+            }
+            erts_proc_unlock(proc, ERTS_PROC_LOCK_BTM);
+        }
+        if (!proc || proc->paused_bif_timers) {
             if (tmr->btm.tree.parent != ERTS_HLT_PFIELD_NOT_IN_TABLE) {
                 btm_rbt_delete(&esdp->timer_service->btm_tree, tmr);
                 tmr->btm.tree.parent = ERTS_HLT_PFIELD_NOT_IN_TABLE;
@@ -1801,11 +1846,6 @@ setup_bif_timer(Process *c_p, int twheel, ErtsMonotonicTime timeout_pos,
             else
                 hlt_delete_timer(esdp, &tmr->type.hlt);
             timer_destroy((ErtsTimer *) tmr, twheel, 1);
-	}
-	else {
-	    proc_btm_rbt_insert(&proc->bif_timers, tmr);
-	    erts_proc_unlock(proc, ERTS_PROC_LOCK_BTM);
-            tmr->type.head.receiver.proc = proc;
 	}
     }
 
@@ -1819,11 +1859,12 @@ badarg:
 }
 
 static int
-cancel_bif_timer(ErtsBifTimer *tmr)
+cancel_bif_timer(ErtsBifTimer *tmr, ErtsProcLocks c_p_locks)
 {
     erts_aint_t state;
     Uint32 roflgs;
     int res;
+    int proc_lock_btm_held = c_p_locks & ERTS_PROC_LOCK_BTM;
 
     state = erts_atomic32_cmpxchg_acqb(&tmr->btm.state,
 					   ERTS_TMR_STATE_CANCELED,
@@ -1843,7 +1884,9 @@ cancel_bif_timer(ErtsBifTimer *tmr)
         proc = tmr->type.head.receiver.proc;
 	ERTS_HLT_ASSERT(!(tmr->type.head.roflgs & ERTS_TMR_ROFLG_REG_NAME));
 
-	erts_proc_lock(proc, ERTS_PROC_LOCK_BTM);
+        if (!proc_lock_btm_held) {
+            erts_proc_lock(proc, ERTS_PROC_LOCK_BTM);
+        }
 	/*
 	 * If process is exiting, let it clean up
 	 * the btm tree by itself (it may be in
@@ -1855,14 +1898,16 @@ cancel_bif_timer(ErtsBifTimer *tmr)
 	    tmr->btm.proc_tree.parent = ERTS_HLT_PFIELD_NOT_IN_TABLE;
 	    res = 1;
 	}
-	erts_proc_unlock(proc, ERTS_PROC_LOCK_BTM);
+        if (!proc_lock_btm_held) {
+            erts_proc_unlock(proc, ERTS_PROC_LOCK_BTM);
+        }
     }
 
     return res;
 }
 
 static ERTS_INLINE Sint64
-access_btm(ErtsBifTimer *tmr, Uint32 sid, ErtsSchedulerData *esdp, int cancel)
+access_btm(ErtsBifTimer *tmr, Uint32 sid, ErtsSchedulerData *esdp, int cancel, ErtsProcLocks c_p_locks)
 {
     int cncl_res;
     Sint64 time_left;
@@ -1884,7 +1929,7 @@ access_btm(ErtsBifTimer *tmr, Uint32 sid, ErtsSchedulerData *esdp, int cancel)
         return -1;
     }
 
-    cncl_res = cancel_bif_timer(tmr);
+    cncl_res = cancel_bif_timer(tmr, c_p_locks);
     if (!cncl_res)
         return -1;
 
@@ -2048,11 +2093,6 @@ access_sched_local_btm(Process *c_p, Eterm pid,
 
     tmr = btm_rbt_lookup(srv->btm_tree, trefn);
 
-    time_left = access_btm(tmr, (Uint32) esdp->no, esdp, cancel);
-
-    if (async && !info)
-        return am_ok;
-
     if (c_p) {
         proc = c_p;
         proc_locks = ERTS_PROC_LOCK_MAIN;
@@ -2061,6 +2101,11 @@ access_sched_local_btm(Process *c_p, Eterm pid,
         proc = erts_proc_lookup(pid);
         proc_locks = 0;
     }
+
+    time_left = access_btm(tmr, (Uint32) esdp->no, esdp, cancel, proc_locks);
+
+    if (async && !info)
+        return am_ok;
 
     if (!async) {
         if (c_p) {
@@ -2135,7 +2180,7 @@ try_access_sched_remote_btm(ErtsSchedulerData *esdp,
     if (!tmr)
 	return 0;
 
-    time_left = access_btm(tmr, sid, esdp, cancel);
+    time_left = access_btm(tmr, sid, esdp, cancel, ERTS_PROC_LOCK_MAIN);
 
     if (!info)
 	*resp = am_ok;
@@ -2805,6 +2850,59 @@ erts_pause_proc_timer(Process *c_p)
     erts_atomic_set_nob(&c_p->common.timer, (erts_aint_t) pptmr);
 }
 
+static ERTS_INLINE int
+add_bif_timer_to_worklist(ErtsBifTimer *tmr, void *arg, Sint reds)
+{
+    ErtsWStack *s = (ErtsWStack *) arg;
+    WSTACK_PUSH((*s), (UWord) tmr);
+    return 1;
+}
+
+void
+erts_pause_bif_timers(Process *c_p, ErtsProcLocks c_p_locks)
+{
+    ErtsSchedulerData *esdp = erts_proc_sched_data(c_p);
+    int must_release_btm_lock = 0;
+
+    ASSERT(c_p_locks & ERTS_PROC_LOCK_MAIN);
+    ERTS_LC_ASSERT(ERTS_PROC_LOCK_MAIN & erts_proc_lc_my_proc_locks(c_p));
+
+    if (!(c_p_locks & ERTS_PROC_LOCK_BTM)) {
+        erts_proc_lock(c_p, ERTS_PROC_LOCK_BTM);
+        c_p_locks |= ERTS_PROC_LOCK_BTM;
+        must_release_btm_lock = 1;
+    }
+    ERTS_LC_ASSERT(ERTS_PROC_LOCK_BTM & erts_proc_lc_my_proc_locks(c_p));
+
+    if (c_p->paused_bif_timers) {
+        ASSERT(c_p->paused_bif_timers->count > 0);
+        c_p->paused_bif_timers->count++;
+    }
+    else {
+        WSTACK_DECLARE(bif_timers_worklist);
+        c_p->paused_bif_timers = erts_alloc(ERTS_ALC_T_PAUSED_TIMER,
+                                            sizeof(ErtsPausedBifTimers));
+        c_p->paused_bif_timers->list = NULL;
+        c_p->paused_bif_timers->count = 1;
+        /*
+         * It would be better in theory to use a yielding version of foreach here,
+         * but it would be a lot more complex, and since this function is only
+         * used by the debugger potential loss in responsiveness is acceptable.
+         */
+        proc_btm_rbt_foreach(c_p->bif_timers, add_bif_timer_to_worklist, &bif_timers_worklist);
+        while (!WSTACK_ISEMPTY(bif_timers_worklist)) {
+            ErtsBifTimer *tmr = (ErtsBifTimer *) WSTACK_POP(bif_timers_worklist);
+            Uint32 sid = (tmr->type.head.roflgs & ERTS_TMR_ROFLG_SID_MASK);
+            create_paused_bif_timer(tmr, c_p, esdp);
+            access_btm(tmr, sid, esdp, /* cancel = */ 1, c_p_locks);
+        }
+        WSTACK_DESTROY(bif_timers_worklist);
+    }
+    if (must_release_btm_lock) {
+        erts_proc_unlock(c_p, ERTS_PROC_LOCK_BTM);
+    }
+}
+
 void
 erts_resume_paused_proc_timer(Process *c_p)
 {
@@ -2833,6 +2931,90 @@ erts_resume_paused_proc_timer(Process *c_p)
             paused_proc_timer_dec_refc(pptmr);
         }
     }
+}
+
+void
+erts_resume_paused_bif_timers(Process *c_p)
+{
+    ErtsSchedulerData *esdp = erts_proc_sched_data(c_p);
+    ErtsPausedBifTimer *paused_bif_timer;
+
+    ERTS_LC_ASSERT(ERTS_PROC_LOCK_MAIN & erts_proc_lc_my_proc_locks(c_p));
+    ERTS_LC_ASSERT(!(ERTS_PROC_LOCK_BTM & erts_proc_lc_my_proc_locks(c_p)));
+    erts_proc_lock(c_p, ERTS_PROC_LOCK_BTM);
+
+    ASSERT(c_p->paused_bif_timers);
+    ASSERT(c_p->paused_bif_timers->count > 0);
+
+    if (--c_p->paused_bif_timers->count > 0) {
+        /* Other suspends still active; leave them paused... */
+        erts_proc_unlock(c_p, ERTS_PROC_LOCK_BTM);
+        return;
+    }
+
+    paused_bif_timer = c_p->paused_bif_timers->list;
+
+    while (paused_bif_timer != NULL) {
+        ErtsPausedBifTimer *old_timer = paused_bif_timer;
+        ErtsMonotonicTime timeout_pos;
+        ErtsBifTimer *tmr;
+        Eterm ref;
+        UWord tmo;
+        ErtsCreateTimerFunc create_timer;
+        void *hp;
+
+        tmo = (UWord) paused_bif_timer->time_left_in_msec;
+        timeout_pos = get_timeout_pos(erts_get_monotonic_time(esdp), (ErtsMonotonicTime) tmo);
+
+        /* Lifted from setup_bif_timer */
+        hp = HAlloc(c_p, ERTS_REF_THING_SIZE);
+        ref = erts_sched_make_ref_in_buffer(esdp, hp);
+        create_timer = (tmo < ERTS_TIMER_WHEEL_MSEC
+                ? create_tw_timer
+                : create_hl_timer);
+        tmr = (ErtsBifTimer *) create_timer(esdp, timeout_pos,
+                tmo < ERTS_BIF_TIMER_SHORT_TIME, ERTS_TMR_BIF,
+                NULL, c_p->common.id, paused_bif_timer->tmr.btm.message,
+                internal_ordinary_ref_numbers(ref),
+                NULL, NULL);
+        proc_btm_rbt_insert(&c_p->bif_timers, tmr);
+        tmr->type.head.receiver.proc = c_p;
+
+        check_canceled_queue(esdp, esdp->timer_service);
+
+        paused_bif_timer = paused_bif_timer->next;
+        erts_free(ERTS_ALC_T_PAUSED_TIMER, old_timer);
+
+        /* We correctly decrement the refc in the pausing of the bif timer, but for some reason recreating it does not increment it */
+        /* So we do it manually here */
+        erts_proc_inc_refc(c_p);
+    }
+
+    erts_free(ERTS_ALC_T_PAUSED_TIMER, c_p->paused_bif_timers);
+    c_p->paused_bif_timers = NULL;
+
+    erts_proc_unlock(c_p, ERTS_PROC_LOCK_BTM);
+}
+
+void
+erts_destroy_paused_bif_timers(Process *c_p)
+{
+    ErtsPausedBifTimer *ptmr, *free_ptmr;
+
+    erts_proc_lock(c_p, ERTS_PROC_LOCK_BTM);
+
+    ptmr = c_p->paused_bif_timers->list;
+
+    while (ptmr) {
+        free_ptmr = ptmr;
+        ptmr = ptmr->next;
+        erts_free(ERTS_ALC_T_PAUSED_TIMER, free_ptmr);
+    }
+
+    erts_free(ERTS_ALC_T_PAUSED_TIMER, c_p->paused_bif_timers);
+
+    c_p->paused_bif_timers = NULL;
+    erts_proc_unlock(c_p, ERTS_PROC_LOCK_BTM);
 }
 
 void

--- a/erts/emulator/beam/erl_hl_timer.h
+++ b/erts/emulator/beam/erl_hl_timer.h
@@ -24,6 +24,7 @@
 #define ERL_HL_TIMER_H__
 
 typedef struct ErtsBifTimer_ ErtsBifTimers;
+typedef struct ErtsPausedBifTimers_ ErtsPausedBifTimers;
 typedef struct ErtsHLTimerService_ ErtsHLTimerService;
 
 #include "sys.h"
@@ -57,6 +58,9 @@ void erts_set_proc_timer_uword(Process *, UWord);
 void erts_cancel_proc_timer(Process *);
 void erts_pause_proc_timer(Process *);
 void erts_resume_paused_proc_timer(Process *);
+void erts_pause_bif_timers(Process *, ErtsProcLocks);
+void erts_resume_paused_bif_timers(Process *);
+void erts_destroy_paused_bif_timers(Process *c_p);
 void erts_set_port_timer(Port *, Sint64);
 void erts_cancel_port_timer(Port *);
 Sint64 erts_read_port_timer(Port *);

--- a/erts/emulator/beam/erl_hl_timer.h
+++ b/erts/emulator/beam/erl_hl_timer.h
@@ -56,7 +56,7 @@ int erts_set_proc_timer_term(Process *, Eterm);
 void erts_set_proc_timer_uword(Process *, UWord);
 void erts_cancel_proc_timer(Process *);
 void erts_pause_proc_timer(Process *);
-int erts_resume_paused_proc_timer(Process *);
+void erts_resume_paused_proc_timer(Process *);
 void erts_set_port_timer(Port *, Sint64);
 void erts_cancel_port_timer(Port *);
 Sint64 erts_read_port_timer(Port *);

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -5438,6 +5438,7 @@ activate_suspend_monitor(Process *c_p, ErtsMonitorSuspend *msp)
     erts_aint_t mstate;
 
     erts_pause_proc_timer(c_p);
+    erts_pause_bif_timers(c_p, ERTS_PROC_LOCK_MAIN);
     mstate = erts_atomic_read_bor_acqb(&msp->state,
                                        ERTS_MSUSPEND_STATE_FLG_ACTIVE);
     ASSERT(!(mstate & ERTS_MSUSPEND_STATE_FLG_ACTIVE)); (void) mstate;
@@ -6610,6 +6611,7 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
                             if (mstate & ERTS_MSUSPEND_STATE_FLG_ACTIVE) {
                                 erts_resume(c_p, ERTS_PROC_LOCK_MAIN);
                                 erts_resume_paused_proc_timer(c_p);
+                                erts_resume_paused_bif_timers(c_p);
                             }
                             break;
                         }

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -9128,7 +9128,7 @@ erts_internal_suspend_process_2(BIF_ALIST_2)
                  | ERTS_PSFLG_DIRTY_RUNNING_SYS);
 
         rp = erts_try_lock_sig_free_proc(BIF_ARG_1,
-                                         ERTS_PROC_LOCK_MAIN|ERTS_PROC_LOCK_STATUS,
+                                         ERTS_PROC_LOCK_MAIN|ERTS_PROC_LOCK_STATUS|ERTS_PROC_LOCK_BTM,
                                          &state);
         if (!rp)
             goto noproc;
@@ -9138,11 +9138,12 @@ erts_internal_suspend_process_2(BIF_ALIST_2)
             send_sig = !suspend_process(BIF_P, rp);
             if (!send_sig) {
                 erts_pause_proc_timer(rp);
+                erts_pause_bif_timers(rp, ERTS_PROC_LOCK_MAIN|ERTS_PROC_LOCK_STATUS|ERTS_PROC_LOCK_BTM);
                 erts_monitor_list_insert(&ERTS_P_LT_MONITORS(rp), &mdp->u.target);
                 erts_atomic_read_bor_relb(&msp->state,
                                           ERTS_MSUSPEND_STATE_FLG_ACTIVE);
             }
-            erts_proc_unlock(rp, ERTS_PROC_LOCK_MAIN|ERTS_PROC_LOCK_STATUS);
+            erts_proc_unlock(rp, ERTS_PROC_LOCK_MAIN|ERTS_PROC_LOCK_STATUS|ERTS_PROC_LOCK_BTM);
         }
         if (send_sig) {
             if (erts_proc_sig_send_monitor(&BIF_P->common, BIF_P->common.id,
@@ -12740,6 +12741,7 @@ erl_create_process(Process* parent, /* Parent of process (default group leader).
     p->sig_inq.may_contain_heap_terms = 0;
 #endif
     p->bif_timers = NULL;
+    p->paused_bif_timers = NULL;
     p->mbuf = NULL;
     p->msg_frag = NULL;
     p->mbuf_sz = 0;
@@ -13268,6 +13270,7 @@ void erts_init_empty_process(Process *p)
     p->sig_inq.may_contain_heap_terms = 0;
 #endif
     p->bif_timers = NULL;
+    p->paused_bif_timers = NULL;
     p->dictionary = NULL;
     p->seq_trace_clock = 0;
     p->seq_trace_lastcnt = 0;
@@ -14295,7 +14298,9 @@ restart:
             if (reds <= 0) goto yield;
             p->bif_timers = NULL;
         }
-
+        if (p->paused_bif_timers) {
+            erts_destroy_paused_bif_timers(p);
+        }
         if (p->flags & F_SCHDLR_ONLN_WAITQ) {
             abort_sched_onln_chng_waitq(p);
             reds -= 100;

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1172,6 +1172,8 @@ struct process {
     ErtsSchedulerData *scheduler_data;
     erts_atomic_t run_queue;
 
+    ErtsPausedBifTimers* paused_bif_timers; /* BIF timers paused during suspend */
+
 #ifdef USE_VM_PROBES
     Eterm dt_utag;              /* Place to store the dynamic trace user tag */
     Uint dt_utag_flags;         /* flag field for the dt_utag */
@@ -1199,6 +1201,7 @@ struct process {
 #ifdef DEBUG
     Uint debug_reds_in;
 #endif
+
 };
 
 extern Eterm erts_init_process_id; /* pid of init process */

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -61,6 +61,10 @@
          process_info_label/1,
          suspend_process_pausing_proc_timer/1,
          suspend_process_pausing_proc_timer_multi_suspend/1,
+         suspend_process_pausing_bif_timer/1,
+         suspend_process_pausing_bif_timer_multi_suspend/1,
+         suspend_process_pausing_bif_timer_mass/1,
+         suspend_process_bif_timer_on_suspended/1,
 	 bump_reductions/1, low_prio/1, binary_owner/1, yield/1, yield2/1,
 	 otp_4725/1, dist_unlink_ack_exit_leak/1, bad_register/1,
          garbage_collect/1, otp_6237/1,
@@ -195,7 +199,11 @@ groups() ->
        process_info_label]},
      {suspend_process_bif, [],
       [suspend_process_pausing_proc_timer,
-       suspend_process_pausing_proc_timer_multi_suspend]},
+       suspend_process_pausing_proc_timer_multi_suspend,
+       suspend_process_pausing_bif_timer,
+       suspend_process_pausing_bif_timer_multi_suspend,
+       suspend_process_pausing_bif_timer_mass,
+       suspend_process_bif_timer_on_suspended]},
      {otp_7738, [],
       [otp_7738_waiting, otp_7738_suspended,
        otp_7738_resume]},
@@ -1838,6 +1846,96 @@ suspend_process_pausing_proc_timer_aux(BeforeSuspend, AfterResume) ->
     WaitForSync(),
     ok.
 
+suspend_process_pausing_bif_timer(Config) ->
+    TcProc = self(),
+    Pid = erlang:spawn_link(
+        fun() ->
+        TcProc ! {sync, self(), start},
+        receive
+            {timeout, _, timer_msg_1} -> TcProc ! {sync, self(), received_message_1};
+            {timeout, _, timer_msg_2} -> exit(timer_2_before_1_receiver)
+            after 2_000 -> exit(timer_not_resumed_receiver)
+        end,
+        receive
+            {timeout, _, timer_msg_1} -> exit(timer_1_before_2_receiver);
+            {timeout, _, timer_msg_2} -> TcProc ! {sync, self(), received_message_2}
+            after 2_000 -> exit(timer_not_resumed_receiver_2)
+        end
+    end),
+
+    % Wait for the process to start
+    receive
+        {sync, Pid, start} -> ok
+        after 10_000 -> error(timeout)
+    end,
+
+    % Start the timers, but immediately suspend the process
+    _TimerRef = erlang:start_timer(1_000, Pid, timer_msg_1),
+    _TimerRef2 = erlang:start_timer(2_000, Pid, timer_msg_2),
+    true = erlang:suspend_process(Pid),
+    timer:sleep(5_000),
+    receive
+        {sync, Pid, received_message_1} -> exit(timer_1_not_paused);
+        {sync, Pid, received_message_2} -> exit(timer_2_not_paused)
+        after 2_000 -> ok
+    end,
+
+    % Resume the process and wait for the timer to fire
+    true = erlang:resume_process(Pid),
+    receive
+        {sync, Pid, received_message_1} -> ok;
+        {sync, Pid, received_message_2} -> exit(timer_2_before_1_spawner)
+        after 2_000 -> exit(timer_not_resumed_spawner)
+    end,
+    receive
+        {sync, Pid, received_message_2} -> ok;
+        {sync, Pid, received_message_1} -> exit(timer_1_before_2_spawner)
+        after 2_000 -> exit(timer_not_resumed_spawner_2)
+    end,
+    ok.
+
+% Same idea as the previous test, but with thousand of processes and timers
+% The goal is to check that race conditions do not cause timers to be unpaused
+bif_timer_receiver_aux(OwnerPid) ->
+    receive
+        {timeout, _, _} -> bif_timer_receiver_aux(OwnerPid);
+        no_more_timeouts -> receive
+            {timeout, _, N} -> OwnerPid ! {timeout, self(), N};
+            exit -> OwnerPid ! {success, self()}
+        end
+    end.
+
+bif_timer_sender_aux(ReceiverPid, N) ->
+    % This time should be long enough to for all the receivers to be awoken and then receive the exit signal before they receive it
+    _TimerRef = erlang:start_timer(3_000, ReceiverPid, N),
+    receive
+            exit -> ok
+    after 10 -> bif_timer_sender_aux(ReceiverPid, N + 1)
+    end.
+
+suspend_process_pausing_bif_timer_mass(Config) ->
+    NumProcesses = 1000,
+    Self = self(),
+    ReceiverPids = [erlang:spawn_link(fun() -> bif_timer_receiver_aux(Self) end) || _ <- lists:seq(1, NumProcesses)],
+    SenderPids = [erlang:spawn_link(fun () -> bif_timer_sender_aux(ReceiverPid, 0) end) || ReceiverPid <- ReceiverPids],
+    % Wait for all the spawned processes to get scheduled and do stuff
+    timer:sleep(2_000),
+    [erlang:suspend_process(Pid) || Pid <- ReceiverPids],
+    [Pid ! exit || Pid <- SenderPids],
+    [Pid ! no_more_timeouts || Pid <- ReceiverPids],
+    timer:sleep(5_000),
+    % Significantly less than the length of the timers created by sender_aux - initial sleep.
+    % The goal is to detect if the iteration of all receiver processes to wake them up takes so long that the timers can fire.
+    erlang:start_timer(900, Self, slow_wakeup),
+    [erlang:resume_process(Pid) || Pid <- ReceiverPids],
+    [Pid ! exit || Pid <- ReceiverPids],
+    [receive
+        {timeout, _, slow_wakeup} -> exit({slow_wakeup, Pid});
+        {success, Pid} -> ok;
+        {timeout, Pid, N} -> exit({timeout, Pid, N})
+    end || Pid <- ReceiverPids],
+    ok.
+
 suspend_process_pausing_proc_timer_multi_suspend(_Config) ->
     TcProc = self(),
     Child = erlang:spawn_link(
@@ -1894,6 +1992,112 @@ suspend_process_pausing_proc_timer_multi_suspend(_Config) ->
     true = erlang:resume_process(Child),
     Suspender2 ! do_resume,
     WaitForSync(),
+    ok.
+
+suspend_process_pausing_bif_timer_multi_suspend(_Config) ->
+    TcProc = self(),
+    Pid = erlang:spawn_link(
+        fun() ->
+        TcProc ! {sync, self(), start},
+        receive
+            {timeout, _, timer_msg_1} -> TcProc ! {sync, self(), received_message_1};
+            {timeout, _, timer_msg_2} -> exit(timer_2_before_1_receiver)
+            after 4_000 -> exit(timer_not_resumed_receiver)
+        end,
+        receive
+            {timeout, _, timer_msg_1} -> exit(timer_1_before_2_receiver);
+            {timeout, _, timer_msg_2} -> TcProc ! {sync, self(), received_message_2}
+            after 4_000 -> exit(timer_not_resumed_receiver_2)
+        end
+    end),
+
+    receive
+        {sync, Pid, start} -> ok
+        after 10_000 -> error(timeout)
+    end,
+
+    _TimerRef = erlang:start_timer(1_000, Pid, timer_msg_1),
+    _TimerRef2 = erlang:start_timer(2_000, Pid, timer_msg_2),
+
+    Suspender = erlang:spawn_link(fun() ->
+        true = erlang:suspend_process(Pid),
+        TcProc ! {suspended, self()},
+        receive do_resume -> true = erlang:resume_process(Pid) end
+    end),
+    receive {suspended, Suspender} -> ok after 10_000 -> error(timeout) end,
+
+    true = erlang:suspend_process(Pid),
+    timer:sleep(5_000),
+    receive
+        {sync, Pid, received_message_1} -> exit(timer_1_not_paused);
+        {sync, Pid, received_message_2} -> exit(timer_2_not_paused)
+        after 2_000 -> ok
+    end,
+
+    true = erlang:resume_process(Pid),
+    timer:sleep(3_000),
+    receive
+        {sync, Pid, received_message_1} -> exit(timer_1_not_paused_after_first_resume);
+        {sync, Pid, received_message_2} -> exit(timer_2_not_paused_after_first_resume)
+        after 2_000 -> ok
+    end,
+
+    Suspender ! do_resume,
+    receive
+        {sync, Pid, received_message_1} -> ok;
+        {sync, Pid, received_message_2} -> exit(timer_2_before_1_spawner)
+        after 4_000 -> exit(timer_not_resumed_spawner)
+    end,
+    receive
+        {sync, Pid, received_message_2} -> ok;
+        {sync, Pid, received_message_1} -> exit(timer_1_before_2_spawner)
+        after 4_000 -> exit(timer_not_resumed_spawner_2)
+    end,
+    ok.
+
+suspend_process_bif_timer_on_suspended(_Config) ->
+    TcProc = self(),
+    Pid = erlang:spawn_link(
+        fun() ->
+        TcProc ! {sync, self(), start},
+        receive
+            msg_before -> TcProc ! {sync, self(), received_before}
+            after 4_000 -> exit(timer_not_resumed_receiver)
+        end,
+        receive
+            msg_during -> TcProc ! {sync, self(), received_during}
+            after 4_000 -> exit(timer_not_resumed_receiver_2)
+        end
+    end),
+
+    receive
+        {sync, Pid, start} -> ok
+        after 10_000 -> error(timeout)
+    end,
+    wait_until(fun () -> process_info(Pid, status) == {status, waiting} end),
+
+    _Ref1 = erlang:send_after(1_000, Pid, msg_before),
+    true = erlang:suspend_process(Pid),
+    _Ref2 = erlang:send_after(2_000, Pid, msg_during),
+
+    timer:sleep(5_000),
+    receive
+        {sync, Pid, received_before} -> exit(timer_before_not_paused);
+        {sync, Pid, received_during} -> exit(timer_during_not_paused)
+        after 2_000 -> ok
+    end,
+
+    true = erlang:resume_process(Pid),
+    receive
+        {sync, Pid, received_before} -> ok;
+        {sync, Pid, received_during} -> exit(during_before_before)
+        after 4_000 -> exit(timer_not_resumed_spawner)
+    end,
+    receive
+        {sync, Pid, received_during} -> ok;
+        {sync, Pid, received_before} -> exit(before_before_during)
+        after 4_000 -> exit(timer_not_resumed_spawner_2)
+    end,
     ok.
 
 %% Tests erlang:bump_reductions/1.

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -60,6 +60,7 @@
          process_info_dict_lookup/1,
          process_info_label/1,
          suspend_process_pausing_proc_timer/1,
+         suspend_process_pausing_proc_timer_multi_suspend/1,
 	 bump_reductions/1, low_prio/1, binary_owner/1, yield/1, yield2/1,
 	 otp_4725/1, dist_unlink_ack_exit_leak/1, bad_register/1,
          garbage_collect/1, otp_6237/1,
@@ -193,7 +194,8 @@ groups() ->
        process_info_dict_lookup,
        process_info_label]},
      {suspend_process_bif, [],
-      [suspend_process_pausing_proc_timer]},
+      [suspend_process_pausing_proc_timer,
+       suspend_process_pausing_proc_timer_multi_suspend]},
      {otp_7738, [],
       [otp_7738_waiting, otp_7738_suspended,
        otp_7738_resume]},
@@ -1833,6 +1835,64 @@ suspend_process_pausing_proc_timer_aux(BeforeSuspend, AfterResume) ->
     true = erlang:suspend_process(Pid),
     true = erlang:resume_process(Pid),
     AfterResume(Pid),
+    WaitForSync(),
+    ok.
+
+suspend_process_pausing_proc_timer_multi_suspend(_Config) ->
+    TcProc = self(),
+    Child = erlang:spawn_link(
+        fun() ->
+            TcProc ! {sync, self()},
+            receive go -> ok
+            after 2_000 -> exit(timer_not_paused)
+            end,
+            TcProc ! {sync, self()},
+            receive _ -> error(unexpected)
+            after 2_000 -> ok
+            end,
+            TcProc ! {sync, self()}
+        end
+    ),
+
+    WaitForSync = fun () ->
+        receive {sync, Child} -> ok
+        after 10_000 -> error(timeout)
+        end
+    end,
+    EnsureWaiting = fun() ->
+        wait_until(fun () -> process_info(Child, status) == {status, waiting} end)
+    end,
+
+    WaitForSync(),
+    EnsureWaiting(),
+
+    Suspender = erlang:spawn_link(fun() ->
+        true = erlang:suspend_process(Child),
+        TcProc ! {suspended, self()},
+        receive do_resume -> true = erlang:resume_process(Child) end
+    end),
+    receive {suspended, Suspender} -> ok after 10_000 -> error(timeout) end,
+
+    true = erlang:suspend_process(Child),
+    timer:sleep(5_000),
+    true = erlang:resume_process(Child),
+    timer:sleep(1_000),
+    Child ! go,
+    Suspender ! do_resume,
+
+    WaitForSync(),
+    EnsureWaiting(),
+
+    Suspender2 = erlang:spawn_link(fun() ->
+        true = erlang:suspend_process(Child),
+        TcProc ! {suspended, self()},
+        receive do_resume -> true = erlang:resume_process(Child) end
+    end),
+    receive {suspended, Suspender2} -> ok after 10_000 -> error(timeout) end,
+
+    true = erlang:suspend_process(Child),
+    true = erlang:resume_process(Child),
+    Suspender2 ! do_resume,
     WaitForSync(),
     ok.
 


### PR DESCRIPTION
When  `erlang:suspend_process()` is called, we now pause BIF timers in addition to the process timer. This allows step-debuggers like [edb](https://github.com/WhatsApp/edb) to prevent more spurious timeouts while stopping the world.

NB. This handles only timers set by PID, those set by registered name are currently not paused

