### PR TITLE
erts: fix double quotes on windows

### DIFF
--- a/erts/etc/common/dialyzer.c
+++ b/erts/etc/common/dialyzer.c
@@ -517,6 +517,12 @@ possibly_quote(char* arg)
 	    continue;
 	}
     }
+    if (*(s-1) == '"' && arg[0] == '"') {
+        /*
+        * Already quoted, nothing to do.
+        */
+        return arg;
+    }
     if (!mustQuote) {
 	return arg;
     }

--- a/erts/etc/common/erlc.c
+++ b/erts/etc/common/erlc.c
@@ -1166,6 +1166,12 @@ possibly_quote(char* arg)
 	    continue;
 	}
     }
+    if (*(s-1) == '"' && arg[0] == '"') {
+        /*
+        * Already quoted, nothing to do.
+        */
+        return arg;
+    }
     if (!mustQuote) {
 	return arg;
     }

--- a/erts/etc/common/typer.c
+++ b/erts/etc/common/typer.c
@@ -441,6 +441,12 @@ possibly_quote(char* arg)
 	    continue;
 	}
     }
+    if (*(s-1) == '"' && arg[0] == '"') {
+        /*
+        * Already quoted, nothing to do.
+        */
+        return arg;
+    }
     if (!mustQuote) {
 	return arg;
     }


### PR DESCRIPTION
A previous fix https://github.com/erlang/otp/pull/8937, that made spaces in the emulator path on linux work broke it for windows (in cmd and powershell).
It removed a function, push_words, that split the path on each space in the path.
Now it will quote the whole path, with spaces. But it was quoted twice.

With this commit the path will only be quoted once.
