### PR TITLE
otp: fix automatic migration of vendor lib

### DIFF
--- a/.github/workflows/renovate-vendored-deps.yaml
+++ b/.github/workflows/renovate-vendored-deps.yaml
@@ -32,25 +32,25 @@ permissions:
 jobs:
   update-vendored-deps:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.title, 'Update dependency') && github.actor == 'renovate[bot]'
+    if: contains(toLower(github.event.pull_request.title), 'update dependency') && github.actor == 'renovate-bot'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Set up Git user
         run: |
           git config user.name "Erlang/OTP"
           git config user.email "otp@erlang.org"
-          
+
       - name: Find and process modified vendor.info files
         id: update-deps
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/renovate-vendored-deps.sh origin '${{ github.event.pull_request.base.sha }}' '${{ github.event.pull_request.head.sha }}' | tee vendor.log
-    
+
       - name: Comment on PR with failure log
         if: ${{ failure() }}
         env:
@@ -71,5 +71,5 @@ jobs:
           \`\`\`text
           $LOG_CONTENT
           \`\`\`
-          
+
           [🔗 View full GitHub Actions run log]($RUN_URL)"


### PR DESCRIPTION
fixes the renovate action to perform automatic migration of vendor
dependencies based on insensitive case of PR title
