### PR TITLE
erts: Remove some external commands in Unix scripts

### DIFF
--- a/erts/etc/unix/erl.src.src
+++ b/erts/etc/unix/erl.src.src
@@ -51,7 +51,7 @@ fi
 
 BINDIR="$ROOTDIR/erts-%VSN%/bin"
 EMU=%EMULATOR%%EMULATOR_NUMBER%
-PROGNAME=`basename "$0"`
+PROGNAME="${0##*/}"
 export EMU
 export ROOTDIR
 export BINDIR

--- a/erts/etc/unix/start_erl.src
+++ b/erts/etc/unix/start_erl.src
@@ -34,12 +34,11 @@ shift
 DataFile=$1
 shift
 
-ERTS_VSN=`awk '{print $1}' $DataFile`
-VSN=`awk '{print $2}' $DataFile`
+read -r ERTS_VSN VSN _ < "$DataFile"
 
 BINDIR=$ROOTDIR/erts-$ERTS_VSN/bin
 EMU=beam
-PROGNAME=`echo $0 | sed 's/.*\///'`
+PROGNAME="${0##*/}"
 export EMU
 export ROOTDIR
 export BINDIR


### PR DESCRIPTION
Remove calls to some external utilities (awk, basename, sed) in the erl and start_erl scripts, replacing them with POSIX shell parameter expansion and 'read' built-ins.

This improves compatibility with embedded systems and restricted environments where these tools may be missing, particularly on older releases of Android.

Notes on the shell built-ins used:

- `"${0##*/}"`: A POSIX parameter expansion that removes the longest prefix matching '*/'. This pattern matches everything up to and including the last slash, effectively performing a 'basename' operation entirely within the shell. This also covers the case when there is no slash character at all.

- `read -r VAR1 VAR2 < File`: Read the first line of a file and assigns the first two space-separated words to each variable, replacing the 2 external calls to 'awk'.

Let me know if you have any questions.

Thanks,
Jérôme

P.S. I was waiting for https://github.com/erlang/otp/pull/10573 to be merged first, it was applied into master earlier today.