### PR TITLE
zstd: Fix compressing empty data

### DIFF
--- a/lib/stdlib/src/zstd.erl
+++ b/lib/stdlib/src/zstd.erl
@@ -682,7 +682,11 @@ compress(Data, Options) when is_map(Options) ->
         close(Ref)
     end;
 compress(Data, {compress, Ref}) ->
-    IOV = erlang:iolist_to_iovec(Data),
+    IOV = case erlang:iolist_to_iovec(Data) of
+        %% Empty data must still become an empty compressed frame.
+        [] -> [<<>>];
+        IOV0 -> IOV0
+    end,
     ok = set_pledged_src_size_nif(Ref, erlang:iolist_size(IOV)),
     codec_loop(fun compress_stream_nif/3,
                Ref,

--- a/lib/stdlib/test/zstd_SUITE.erl
+++ b/lib/stdlib/test/zstd_SUITE.erl
@@ -94,6 +94,16 @@ end_per_suite(_Config) ->
 
 bulk(_Config) ->
 
+    %% Empty frame content.
+    EmptyCompressed = zstd:compress(<<>>),
+    ?assertEqual(<<>>, iob(zstd:decompress(EmptyCompressed))),
+
+    EmptyCompressed = zstd:compress([]),
+    ?assertEqual(<<>>, iob(zstd:decompress(EmptyCompressed))),
+
+    EmptyCompressed = zstd:compress([<<>>,[<<>>]]),
+    ?assertEqual(<<>>, iob(zstd:decompress(EmptyCompressed))),
+
     Data = ~"abc",
     Compressed = zstd:compress(Data),
     ?assertEqual(Data, iob(zstd:decompress(Compressed))),


### PR DESCRIPTION
Fix for https://github.com/erlang/otp/issues/10650