### PR TITLE
Store size in tag for small maps

### DIFF
--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -2138,7 +2138,7 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
          * some values were changed. We can retain the old key tuple.
          */
         ASSERT(n == 0);
-        mp->thing_word = make_flatmap_header(flatmap_get_size(old_mp));
+        mp->thing_word = old_mp->thing_word
         mp->keys = old_mp->keys;
         while (num_old-- > 0) {
             *hp++ = *old_vals++;

--- a/erts/emulator/beam/beam_common.c
+++ b/erts/emulator/beam/beam_common.c
@@ -1861,7 +1861,7 @@ erts_gc_new_map(Process* p, Eterm* reg, Uint live,
                 Uint n, const Eterm* ptr)
 {
     Uint i;
-    Uint need = n + 1 /* hdr */ + 1 /*size*/ + 1 /* ptr */ + 1 /* arity */;
+    Uint need = n + 1 /* arity */ + MAP_HEADER_FLATMAP_SZ;
     Eterm keys;
     Eterm *mhp,*thp;
     Eterm *E;
@@ -1905,8 +1905,7 @@ erts_gc_new_map(Process* p, Eterm* reg, Uint live,
         *thp++ = make_arityval(n/2);
     }
     mp = (flatmap_t *)mhp; mhp += MAP_HEADER_FLATMAP_SZ;
-    mp->thing_word = MAP_HEADER_FLATMAP;
-    mp->size = n/2;
+    mp->thing_word = make_flatmap_header(n/2);
     mp->keys = keys;
 
     for (i = 0; i < n/2; i++) {
@@ -1923,7 +1922,7 @@ erts_gc_new_small_map_lit(Process* p, Eterm* reg, Eterm keys_literal,
 {
     Eterm* keys = tuple_val(keys_literal);
     Uint n = arityval(*keys);
-    Uint need = n + 1 /* hdr */ + 1 /*size*/ + 1 /* ptr */ + 1 /* arity */;
+    Uint need = n + MAP_HEADER_FLATMAP_SZ;
     Uint i;
     flatmap_t *mp;
     Eterm *mhp;
@@ -1939,8 +1938,7 @@ erts_gc_new_small_map_lit(Process* p, Eterm* reg, Eterm keys_literal,
     E   = p->stop;
 
     mp = (flatmap_t *)mhp; mhp += MAP_HEADER_FLATMAP_SZ;
-    mp->thing_word = MAP_HEADER_FLATMAP;
-    mp->size = n;
+    mp->thing_word = make_flatmap_header(n);
     mp->keys = keys_literal;
 
     for (i = 0; i < n; i++) {
@@ -2023,8 +2021,6 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
      * +-----------------------------------+
      * | MAP_HEADER_FLATMAP                |
      * +-----------------------------------+
-     * | (Space for number of keys/values) |
-     * +-----------------------------------+
      * | Boxed tuple pointer            >----------------+
      * +-----------------------------------+             |
      * | (Space for value 1)               |             |    <-- hp
@@ -2054,7 +2050,7 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
     res = make_flatmap(hp);
     mp = (flatmap_t *)hp;
     hp += MAP_HEADER_FLATMAP_SZ;
-    mp->thing_word = MAP_HEADER_FLATMAP;
+    mp->thing_word = make_flatmap_header(0); /* Updated below when size is known */
 
     kp = hp + num_old + num_updates; /* Point to key tuple. */
 
@@ -2142,7 +2138,7 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
          * some values were changed. We can retain the old key tuple.
          */
         ASSERT(n == 0);
-        mp->size = old_mp->size;
+        mp->thing_word = make_flatmap_header(flatmap_get_size(old_mp));
         mp->keys = old_mp->keys;
         while (num_old-- > 0) {
             *hp++ = *old_vals++;
@@ -2175,8 +2171,8 @@ erts_gc_update_map_assoc(Process* p, Eterm* reg, Uint live,
      */
 
     n = hp - (Eterm *)mp - MAP_HEADER_FLATMAP_SZ;	/* Actual number of keys/values */
-    ASSERT(n <= old_mp->size + num_updates);
-    mp->size = n;
+    ASSERT(n <= (Sint)(flatmap_get_size(old_mp) + num_updates));
+    mp->thing_word = make_flatmap_header(n);
     *(boxed_val(mp->keys)) = make_arityval(n);
     p->htop  = kp;
 
@@ -2288,8 +2284,7 @@ erts_gc_update_map_exact(Process* p, Eterm* reg, Uint live,
     res = make_flatmap(hp);
     mp = (flatmap_t *)hp;
     hp += MAP_HEADER_FLATMAP_SZ;
-    mp->thing_word = MAP_HEADER_FLATMAP;
-    mp->size = num_old;
+    mp->thing_word = make_flatmap_header(num_old);
     mp->keys = old_mp->keys;
 
     /* Get array of key/value pairs to be updated */

--- a/erts/emulator/beam/copy.c
+++ b/erts/emulator/beam/copy.c
@@ -176,8 +176,8 @@ Uint size_object_x(Eterm obj, erts_literal_area_t *litopt)
                                 ptr = (Eterm *)mp;
                                 n   = flatmap_get_size(mp) + 1;
                                 ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
-                                sum += n + 2;
-                                ptr += 2; /* hdr + size words */
+                                sum += n + 1;
+                                ptr += 1; /* hdr word */
                                 while (n--) {
                                     obj = *ptr++;
                                     if (!IS_CONST(obj)) {
@@ -440,8 +440,8 @@ Uint size_shared(Eterm obj)
                         Uint n = flatmap_get_size(mp) + 1;
                         ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
                         ptr  = (Eterm *)mp;
-                        sum += n + 2;
-                        ptr += 2; /* hdr + size words */
+                        sum += n + 1;
+                        ptr += 1; /* hdr word */
                         while (n--) {
                             obj = *ptr++;
                             if (!IS_CONST(obj)) {
@@ -582,7 +582,7 @@ cleanup:
                         flatmap_t *mp = (flatmap_t *) ptr;
                         Uint n = flatmap_get_size(mp) + 1;
                         ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
-                        ptr += 2; /* hdr + size words */
+                        ptr += 1; /* hdr word */
                         while (n--) {
                             obj = *ptr++;
                             if (!IS_CONST(obj)) {
@@ -890,7 +890,7 @@ Eterm copy_struct_x(Eterm obj, Uint sz, Eterm** hpp, ErlOffHeap* off_heap,
 		tp = htop;
 		switch (MAP_HEADER_TYPE(hdr)) {
 		    case MAP_HEADER_TAG_FLATMAP_HEAD :
-                        i = flatmap_get_size(objp) + 3;
+                        i = flatmap_get_size(objp) + MAP_HEADER_FLATMAP_SZ;
                         ASSERT(flatmap_get_size(objp) <= MAP_SMALL_MAP_LIMIT);
                         *argp = make_flatmap(htop);
                         while (i--) {
@@ -1286,8 +1286,8 @@ Uint copy_shared_calculate(Eterm obj, erts_shcopy_t *info)
                         flatmap_t *mp = (flatmap_t *) ptr;
                         Uint n = flatmap_get_size(mp) + 1;
                         ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
-                        sum += n + 2;
-                        ptr += 2; /* hdr + size words */
+                        sum += n + 1;
+                        ptr += 1; /* hdr word */
                         while (n--) {
                             obj = *ptr++;
                             if (!IS_CONST(obj)) {
@@ -1589,8 +1589,8 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                 switch (MAP_HEADER_TYPE(hdr)) {
                     case MAP_HEADER_TAG_FLATMAP_HEAD : {
                         flatmap_t *mp = (flatmap_t *) ptr;
-                        Uint n = flatmap_get_size(mp) + 1;
-                        ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
+                        Uint n = flatmap_get_size(mp);
+                        ASSERT(n <= MAP_SMALL_MAP_LIMIT);
                         *hp++  = *++ptr; /* keys */
                         while (n--) {
                             obj = *++ptr;
@@ -1771,7 +1771,7 @@ Uint copy_shared_perform_x(Eterm obj, Uint size, erts_shcopy_t *info,
                                     flatmap_t *mp = (flatmap_t *) hscan;
                                     remaining = flatmap_get_size(mp) + 1;
                                     ASSERT(flatmap_get_size(mp) <= MAP_SMALL_MAP_LIMIT);
-                                    hscan += 2;
+                                    hscan += 1; /* skip hdr word */
                                     break;
                                 }
                                 case MAP_HEADER_TAG_HAMT_HEAD_BITMAP :

--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -6895,7 +6895,7 @@ save_nodes_monitor(ErtsMonitor *mon, void *vctxt, Sint reds)
      + 4 /* top 3-tuple */)
 #define ERTS_MON_NODES_MAX_INFO_MAP_SZ__(MAX_ELEMS)             \
     ((MAX_ELEMS)*2 /* keys and values */                        \
-     + 1 /* key tuple header */ + MAP_HEADER_FLATMAP_SZ /* 3 */ \
+     + 1 /* key tuple header */ + MAP_HEADER_FLATMAP_SZ /* 2 */ \
      + BIG_UINT_HEAP_SIZE /* connection id value */             \
      + 4 /* top 3-tuple */)
 #define ERTS_MON_NODES_MAX_INFO_SZ__(MAX_ELEMS)                 \

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -2452,8 +2452,7 @@ restart:
             t = *--esp;
             {
                 flatmap_t *m = (flatmap_t *)ehp;
-                m->thing_word = MAP_HEADER_FLATMAP;
-                m->size = n;
+                m->thing_word = make_flatmap_header(n);
                 m->keys = t;
             }
             t = make_flatmap(ehp);
@@ -2491,7 +2490,7 @@ restart:
                     erts_factory_proc_init(&factory, build_proc);
 
                     /* build flat structure */
-                    hp    = erts_produce_heap(&factory, 3 + (n==0 ? 0 : 1) + (2 * n), 0);
+                    hp    = erts_produce_heap(&factory, MAP_HEADER_FLATMAP_SZ + (n==0 ? 0 : 1) + (2 * n), 0);
                     if (n == 0) {
                         keys = ERTS_GLOBAL_LIT_EMPTY_TUPLE;
                     } else {
@@ -2504,8 +2503,7 @@ restart:
                     hp   += MAP_HEADER_FLATMAP_SZ;
                     vs    = hp;
 
-                    mp->thing_word = MAP_HEADER_FLATMAP;
-                    mp->size = n;
+                    mp->thing_word = make_flatmap_header(n);
                     mp->keys = keys;
 
                     hashmap_iterator_init(&wstack, t, 0);
@@ -5847,8 +5845,8 @@ static Uint my_size_object(Eterm t, bool is_hashmap_node)
                 /* Calculate size of values */
                 p = (Eterm *)mp;
                 n   = flatmap_get_size(mp);
-                sum += n + 3;
-                p += 3; /* hdr + size + keys words */
+                sum += n + MAP_HEADER_FLATMAP_SZ;
+                p += MAP_HEADER_FLATMAP_SZ; /* hdr + keys words */
                 while (n--) {
                     sum += my_size_object(*p++, false);
                 }
@@ -5949,11 +5947,10 @@ static Eterm my_copy_struct(Eterm t, Eterm **hp, ErlOffHeap* off_heap,
                 ret = make_flatmap(savep);
                 n = flatmap_get_size(mp);
                 p = (Eterm *)mp;
-                *hp += n + 3;
+                *hp += n + MAP_HEADER_FLATMAP_SZ;
                 *savep++ = mp->thing_word;
-                *savep++ = mp->size;
                 *savep++ = keys;
-                p += 3; /* hdr + size + keys words */
+                p += MAP_HEADER_FLATMAP_SZ; /* hdr + keys words */
                 for (i = 0; i < n; i++)
                     *savep++ = my_copy_struct(p[i], hp, off_heap, false);
                 erts_usort_flatmap((flatmap_t*)flatmap_val(ret));

--- a/erts/emulator/beam/erl_map.h
+++ b/erts/emulator/beam/erl_map.h
@@ -56,14 +56,12 @@ erts_ihash_t hashmap_bitcount(erts_ihash_t x);
 
 typedef struct flatmap_s {
     Eterm thing_word;
-    Uint  size;
     Eterm keys;      /* tuple */
 } flatmap_t;
 /* map node
  *
  * -----------
- * Eterm   THING	
- * Uint    size
+ * Eterm   THING (size encoded in header tag)
  * Eterm   Keys -> {K1, K2, K3, ..., Kn} where n = size
  * ----
  * Eterm   V1
@@ -88,7 +86,7 @@ typedef struct flatmap_s {
 /* erl_term.h stuff */
 #define flatmap_get_values(x)        (((Eterm *)(x)) + sizeof(flatmap_t)/sizeof(Eterm))
 #define flatmap_get_keys(x)          (((Eterm *)tuple_val(((flatmap_t *)(x))->keys)) + 1)
-#define flatmap_get_size(x)          (((flatmap_t*)(x))->size)
+#define flatmap_get_size(x)          MAP_HEADER_VAL(((flatmap_t*)(x))->thing_word)
 
 #ifdef DEBUG
 #define MAP_SMALL_MAP_LIMIT    (3)
@@ -181,8 +179,8 @@ typedef struct hashmap_head_s {
     (_make_header(((((Uint16)(Val)) << MAP_HEADER_ARITY_SZ) | \
      (Arity)) << MAP_HEADER_TAG_SZ | (Type) , _TAG_HEADER_MAP))
 
-#define MAP_HEADER_FLATMAP \
-    MAKE_MAP_HEADER(MAP_HEADER_TAG_FLATMAP_HEAD,0x1,0x0)
+#define make_flatmap_header(Size) \
+    MAKE_MAP_HEADER(MAP_HEADER_TAG_FLATMAP_HEAD,0x0,(Size))
 
 #define MAP_HEADER_HAMT_HEAD_ARRAY \
     MAKE_MAP_HEADER(MAP_HEADER_TAG_HAMT_HEAD_ARRAY,0x1,0xffff)

--- a/erts/emulator/beam/erl_msacc.c
+++ b/erts/emulator/beam/erl_msacc.c
@@ -200,8 +200,7 @@ Eterm erts_msacc_gather_stats(ErtsMsAcc *msacc, ErtsHeapFactory *factory) {
     hp = erts_produce_heap(factory, MAP_HEADER_FLATMAP_SZ + 3, 0);
     map = (flatmap_t*)hp;
     hp += MAP_HEADER_FLATMAP_SZ;
-    map->thing_word = MAP_HEADER_FLATMAP;
-    map->size = 3;
+    map->thing_word = make_flatmap_header(3);
     map->keys = key;
     hp[0] = state_map;
     hp[1] = msacc->id;

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -3604,8 +3604,7 @@ ERL_NIF_TERM enif_make_new_map(ErlNifEnv* env)
 
     tup   = ERTS_GLOBAL_LIT_EMPTY_TUPLE;
     mp    = (flatmap_t*)hp;
-    mp->thing_word = MAP_HEADER_FLATMAP;
-    mp->size = 0;
+    mp->thing_word = make_flatmap_header(0);
     mp->keys = tup;
 
     return make_flatmap(mp);

--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -9197,7 +9197,7 @@ prio_queue_check_recv_marks(Eterm obj, Eterm *ref,
                                 n   = flatmap_get_size(mp) + 1;
                                 ASSERT(flatmap_get_size(mp)
                                        <= MAP_SMALL_MAP_LIMIT);
-                                ptr += 2; /* hdr + size words */
+                                ptr += 1; /* hdr word */
                                 while (n--) {
                                     obj = *ptr++;
                                     if (!IS_CONST(obj)) {

--- a/erts/emulator/beam/erl_process_dump.c
+++ b/erts/emulator/beam/erl_process_dump.c
@@ -634,7 +634,7 @@ heap_dump(fmtfn_t to, void *to_arg, Eterm x)
                     if (is_flatmap_header(hdr)) {
                         flatmap_t* fmp = (flatmap_t *) flatmap_val(x);
                         Eterm* values = ptr + sizeof(flatmap_t) / sizeof(Eterm);
-                        Uint map_size = fmp->size;
+                        Uint map_size = flatmap_get_size(fmp);
                         int i;
 
                         erts_print(to, to_arg, "Mf" ETERM_FMT ":", map_size);
@@ -975,7 +975,7 @@ dump_module_literals(fmtfn_t to, void *to_arg, ErtsLiteralArea* lit_area)
                 if (is_flatmap_header(w)) {
                     flatmap_t* fmp = (flatmap_t *) flatmap_val(term);
                     Eterm* values = htop + sizeof(flatmap_t) / sizeof(Eterm);
-                    Uint map_size = fmp->size;
+                    Uint map_size = flatmap_get_size(fmp);
                     int i;
 
                     erts_print(to, to_arg, "Mf" ETERM_FMT ":", map_size);

--- a/erts/emulator/beam/erl_term.h
+++ b/erts/emulator/beam/erl_term.h
@@ -1292,9 +1292,8 @@ _ET_DECLARE_CHECKED(struct erl_node_*,external_ref_node,Eterm)
 #define is_not_map(x)          (!is_map(x))
 
 #define MAP_HEADER(hp, sz, keys)                \
-    ((hp)[0] = MAP_HEADER_FLATMAP,              \
-     (hp)[1] = sz,                              \
-     (hp)[2] = keys)
+    ((hp)[0] = make_flatmap_header(sz),         \
+     (hp)[1] = keys)
 
 /* NB. When sz is 0, TUPLE0 is shared, so takes no space */
 #define MAP_SZ(sz) (MAP_HEADER_FLATMAP_SZ + 2*sz + !!sz)

--- a/erts/emulator/beam/erl_trace.c
+++ b/erts/emulator/beam/erl_trace.c
@@ -3186,7 +3186,7 @@ send_to_tracer_nif_raw(Process *c_p, Process *tracee,
 {
     if (tnif || (tnif = lookup_tracer_nif(tracer)) != NULL) {
 #define MAP_SIZE 4
-        Eterm argv[5], local_heap[3+MAP_SIZE /* values */ + (MAP_SIZE+1 /* keys */)];
+        Eterm argv[5], local_heap[MAP_HEADER_FLATMAP_SZ+MAP_SIZE /* values */ + (MAP_SIZE+1 /* keys */)];
         flatmap_t *map = (flatmap_t*)(local_heap+(MAP_SIZE+1));
         Eterm *map_values = flatmap_get_values(map);
         Eterm *map_keys = local_heap + 1;
@@ -3201,7 +3201,7 @@ send_to_tracer_nif_raw(Process *c_p, Process *tracee,
         argv[3] = msg;
         argv[4] = make_flatmap(map);
 
-        map->thing_word = MAP_HEADER_FLATMAP;
+        map->thing_word = make_flatmap_header(0); /* Updated below when size is known */
 
         if (extra != THE_NON_VALUE) {
             map_keys[map_elem_count] = am_extra;
@@ -3230,7 +3230,7 @@ send_to_tracer_nif_raw(Process *c_p, Process *tracee,
         else if (tracee_flags & F_MON_TS)
             map_values[map_elem_count++] = am_monotonic;
 
-        map->size = map_elem_count;
+        map->thing_word = make_flatmap_header(map_elem_count);
         if (map_elem_count == 0) {
             map->keys = ERTS_GLOBAL_LIT_EMPTY_TUPLE;
         } else {

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -5002,8 +5002,7 @@ dec_term_atom_common:
                     map->objp = NULL;
                     map->u.flatmap = mp;
 
-                    mp->thing_word = MAP_HEADER_FLATMAP;
-                    mp->size       = size;
+                    mp->thing_word = make_flatmap_header(size);
                     mp->keys       = keys;
                     *objp          = make_flatmap(mp);
 
@@ -6073,7 +6072,7 @@ init_done:
 	    n = get_uint32(ep);
 	    ep += 4;
             if (n <= MAP_SMALL_MAP_LIMIT) {
-                heap_size += 3 + n;
+                heap_size += MAP_HEADER_FLATMAP_SZ + n;
 
                 /* When decoding the empty tuple we always use the canonical
                  * global literal, so it won't occupy any heap space in the

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -6126,8 +6126,7 @@ driver_deliver_term(Port *prt, Eterm to, ErlDrvTermData* data, int len)
                     *tp = make_arityval(size);
                 }
                 mp = (flatmap_t*) (tp + (size==0 ? 0 : 1) + size);
-                mp->thing_word = MAP_HEADER_FLATMAP;
-                mp->size = size;
+                mp->thing_word = make_flatmap_header(size);
                 mp->keys = (size!= 0 ? make_tuple(tp) : ERTS_GLOBAL_LIT_EMPTY_TUPLE);
                 mess = make_flatmap(mp);
 

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -1825,9 +1825,8 @@ void BeamModuleAssembler::emit_is_eq_exact(const ArgLabel &Fail,
             comment("optimized equality test with empty map", literal);
             emit_is_boxed(resolve_beam_label(Fail, dispUnknown), X, x.reg);
             emit_untag_ptr(ARG1, x.reg);
-            a.ldp(TMP1, TMP2, arm::Mem(ARG1));
-            cmp(TMP1, MAP_HEADER_FLATMAP);
-            a.ccmp(TMP2, imm(0), imm(NZCV::kNone), imm(arm::CondCode::kEQ));
+            a.ldr(TMP1, arm::Mem(ARG1));
+            cmp(TMP1, make_flatmap_header(0));
             a.b_ne(resolve_beam_label(Fail, disp1MB));
 
             return;
@@ -1981,9 +1980,8 @@ void BeamModuleAssembler::emit_is_ne_exact(const ArgLabel &Fail,
             comment("optimized non-equality test with empty map", literal);
             emit_is_boxed(next, X, x.reg);
             emit_untag_ptr(ARG1, x.reg);
-            a.ldp(TMP1, TMP2, arm::Mem(ARG1));
-            cmp(TMP1, MAP_HEADER_FLATMAP);
-            a.ccmp(TMP2, imm(0), imm(NZCV::kNone), imm(arm::CondCode::kEQ));
+            a.ldr(TMP1, arm::Mem(ARG1));
+            cmp(TMP1, make_flatmap_header(0));
             a.b_eq(resolve_beam_label(Fail, disp1MB));
 
             a.bind(next);

--- a/erts/emulator/beam/jit/arm/instr_map.cpp
+++ b/erts/emulator/beam/jit/arm/instr_map.cpp
@@ -272,8 +272,7 @@ void BeamModuleAssembler::emit_i_new_small_map_lit(const ArgRegister &Dst,
 
     std::vector<ArgVal> data;
     data.reserve(args.size() + MAP_HEADER_FLATMAP_SZ + 1);
-    data.push_back(ArgWord(MAP_HEADER_FLATMAP));
-    data.push_back(Size);
+    data.push_back(ArgWord(make_flatmap_header(Size.get())));
     data.push_back(Keys);
 
     bool dst_is_src = false;

--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -1897,9 +1897,7 @@ void BeamModuleAssembler::emit_is_eq_exact(const ArgLabel &Fail,
             mov_arg(ARG1, X);
             emit_is_boxed(resolve_beam_label(Fail), X, ARG1);
             (void)emit_ptr_val(ARG1, ARG1);
-            a.cmp(emit_boxed_val(ARG1, 0, sizeof(Uint32)), MAP_HEADER_FLATMAP);
-            a.jne(resolve_beam_label(Fail));
-            a.cmp(emit_boxed_val(ARG1, sizeof(Eterm), sizeof(Uint32)), imm(0));
+            a.cmp(emit_boxed_val(ARG1, 0, sizeof(Uint32)), make_flatmap_header(0));
             a.jne(resolve_beam_label(Fail));
 
             return;
@@ -2060,9 +2058,7 @@ void BeamModuleAssembler::emit_is_ne_exact(const ArgLabel &Fail,
             mov_arg(ARG1, X);
             emit_is_boxed(next, X, ARG1, dShort);
             (void)emit_ptr_val(ARG1, ARG1);
-            a.cmp(emit_boxed_val(ARG1, 0, sizeof(Uint32)), MAP_HEADER_FLATMAP);
-            a.short_().jne(next);
-            a.cmp(emit_boxed_val(ARG1, sizeof(Eterm), sizeof(Uint32)), imm(0));
+            a.cmp(emit_boxed_val(ARG1, 0, sizeof(Uint32)), make_flatmap_header(0));
             a.je(resolve_beam_label(Fail));
 
             a.bind(next);

--- a/erts/emulator/beam/jit/x86/instr_map.cpp
+++ b/erts/emulator/beam/jit/x86/instr_map.cpp
@@ -285,8 +285,7 @@ void BeamModuleAssembler::emit_i_new_small_map_lit(const ArgRegister &Dst,
 
     std::vector<ArgVal> data;
     data.reserve(args.size() + MAP_HEADER_FLATMAP_SZ + 1);
-    data.push_back(ArgWord(MAP_HEADER_FLATMAP));
-    data.push_back(Size);
+    data.push_back(ArgWord(make_flatmap_header(Size.get())));
     data.push_back(Keys);
 
     for (auto arg : args) {

--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -1430,8 +1430,8 @@ tailrecur_ne:
 		    if (sz != flatmap_get_size((flatmap_t*)bb)) goto not_equal;
 		    if (sz == 0) goto pop_next;
 
-		    aa += 2;
-		    bb += 2;
+		    aa += MAP_HEADER_FLATMAP_SZ - 1; /* skip non-term header fields */
+		    bb += MAP_HEADER_FLATMAP_SZ - 1;
 		    sz += 1; /* increment for tuple-keys */
 		    goto term_array;
 

--- a/erts/etc/unix/etp-commands.in
+++ b/erts/etc/unix/etp-commands.in
@@ -367,8 +367,8 @@ define etp-boxed-1
 	    printf "#{Keys:"
 	    etp-1 ((flatmap_t*)(($arg0)&etp_ptr_mask))->keys (($arg1)+1)
 	    printf " Values:{"
-	    etp-array-1 ((Eterm*)(($arg0)&etp_ptr_mask)+3) ($arg1) ($arg1) \
-                        0 ((flatmap_t*)(($arg0)&etp_ptr_mask))->size '}'
+	    etp-array-1 ((Eterm*)(($arg0)&etp_ptr_mask)+2) ($arg1) ($arg1) \
+                        0 (((((Eterm*)(($arg0)&etp_ptr_mask))[0])>>(6+2+8))&0xffff) '}'
 	    printf "}"
           else
 	    # Hashmap

--- a/system/doc/efficiency_guide/memory.md
+++ b/system/doc/efficiency_guide/memory.md
@@ -82,7 +82,7 @@ for a running system can be determined by calling
 <tr>
   <td align="left" valign="middle">Small Map</td>
   <td align="left" valign="middle">(up to 32 keys)<br>
-    5 words + the size of all keys and values.</td>
+    4 words + the size of all keys and values.</td>
 </tr>
 <tr>
   <td align="left" valign="middle">Large Map</td>


### PR DESCRIPTION
This pull request stores the size in the header tag for small maps, as done for tuples, reducing their memory usage.

There are a couple disclaimers here:

* I have introduced the `make_flatmap_header` macro and removed `MAP_HEADER_FLATMAP` manually, however AI was used to find all possible places where word sizes were hardcoded (I have then converted those to use `MAP_HEADER_FLATMAP_SZ`)

* This pull request is incomplete as it doesn't change most of the JIT code. I expect changes to be necessary around: `emit_i_get_map_element_shared`, `emit_i_get_map_elements`, `emit_i_get_map_element_hash_shared`, `emit_bif_map_size`, and `emit_flatmap_get_element`. Unfortunately I don't have the skills to do so

* I did have AI generate a patch for the JIT (with the help of Chris McCord and Peter Marrick), so I could verify the other changes work, but I have decided to not include it here to avoid AI copyright concerns

* I am unsure if this PR is, overall, beneficial. I have created it when exploring the possibility of unifying native records with small maps. It does the most annoying part of the job, which is to find all places where constants have been hardcoded, so it might be useful. If this is not useful or is not in the plans, feel free to close this PR! Alternatively, I can also send a PR that simply replaces all of the hardcoded `3` by `MAP_HEADER_FLATMAP_SZ`

Thank you for the time!