### PR TITLE
otp: reduce the number of file descriptors for OpenBSD and Solaris

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -595,7 +595,7 @@ jobs:
                 tar -xzf ./otp_src.tar.gz
                 cd otp
                 export ERL_TOP=`pwd`
-                export MAKEFLAGS=-j$(($(nproc) + 2))
+                export MAKEFLAGS=-j$($(nproc))
                 export ERLC_USE_SERVER=true
                 export ERTS_SKIP_DEPEND=true
                 ./configure
@@ -621,7 +621,7 @@ jobs:
                 tar -xzf ./otp_src.tar.gz
                 cd otp
                 export ERL_TOP=`pwd`
-                export MAKEFLAGS=-j$(($(nproc) + 2))
+                export MAKEFLAGS=-j$($(nproc))
                 export ERLC_USE_SERVER=true
                 export ERTS_SKIP_DEPEND=true
                 ./configure


### PR DESCRIPTION
reduces the number of file descriptors for OpenBSD and Solaris.

the compiler currently crashes due to too many file descriptors
open (e.g., [PR-10658](https://github.com/erlang/otp/actions/runs/21813052854/job/62938545888?pr=10658)):

```
In file included from /usr/include/c++/v1/__ranges/movable_box.h:21:
  /usr/include/c++/v1/optional:211:10: fatal error: cannot open file '/usr/include/c++/v1/__type_traits/is_trivially_destructible.h': Too many open files
    211 | #include <__type_traits/is_trivially_destructible.h>
        |          ^
  1 error generated.
  gmake[4]: *** [x86_64-unknown-openbsd7.8/Makefile:981: obj/x86_64-unknown-openbsd7.8/opt/jit/beam_asm_global.o] Error 1
```

the options are to increase `ulimit` or reduce the parallel build. given
that the time seems to be around 3 min to build on OpenBSD and
Solaris (correspondingly), I prefer to reduce the parallelism.

#10658 is blocked until this is merged
