### PR TITLE
erts: Fix proc unlock memory order

### DIFF
--- a/erts/emulator/beam/erl_process_lock.h
+++ b/erts/emulator/beam/erl_process_lock.h
@@ -774,15 +774,13 @@ erts_proc_unlock__(Process *p,
         /* What p->lock will look like with all non-waited locks released. */
         ErtsProcLocks want_lflgs = old_lflgs & (wait_locks | ~locks);
 
-        if (want_lflgs != old_lflgs) {
-            ErtsProcLocks new_lflgs =
-                ERTS_PROC_LOCK_FLGS_CMPXCHG_RELB_(&p->lock, want_lflgs, old_lflgs);
+        ErtsProcLocks new_lflgs =
+            ERTS_PROC_LOCK_FLGS_CMPXCHG_RELB_(&p->lock, want_lflgs, old_lflgs);
 
-            if (new_lflgs != old_lflgs) {
-                /* cmpxchg failed, try again. */
-                old_lflgs = new_lflgs;
-                continue;
-            }
+        if (new_lflgs != old_lflgs) {
+            /* cmpxchg failed, try again. */
+            old_lflgs = new_lflgs;
+            continue;
         }
 
         /* We have successfully unlocked every lock with no waiter. */


### PR DESCRIPTION
When unlocking a process lock, the atomic store-release operation must *always* happen to ensure acquire-release semantics of process locks. It cannot be conditionally skipped.

This fixes a rare issue where some scheduler threads get stuck in a process lock wait queue. Note that the issue can only occur on weakly-ordered CPUs such as ARM.

We stumbled upon this issue while running RabbitMQ on a high-performance 18-core ARMv8.2 system. When the issue occurs, Erlang VM is paralyzed and RabbitMQ either stops doing anything (its CPU usage drops to zero), or it starts eating memory uncontrollably until it summons the OOM killer. I suspect this is because some of its processes remain functional and internal messages start to pile up. In both variants, it's not really possible to see what's going on inside RabbitMQ at Erlang level because most of the debug stuff in the VM hangs. Only GDB works.

Reproducing the issue isn't easy. However, we have a specific test environment with RabbitMQ under high load, where the issue occurs consistently within a few minutes. This allowed nailing down the problem. With the proposed fix, it has been running for several days straight without any issues.