### PR TITLE
openvex: add CVE-2023-5678 not_affected statement

### DIFF
--- a/make/openvex.table
+++ b/make/openvex.table
@@ -73,6 +73,16 @@
       }
     },
     {
+      "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-5678",
+      "status": {
+        "apps": [
+          "pkg:otp/erts@14.0",
+          "pkg:otp/erl_interface@5.4"
+        ],
+        "not_affected": "vulnerable_code_not_present"
+      }
+    },
+    {
       "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-6129",
       "status": {
         "apps": [
@@ -297,6 +307,16 @@
       "status": {
         "apps": [
           "pkg:otp/erts@15.0"
+        ],
+        "not_affected": "vulnerable_code_not_present"
+      }
+    },
+    {
+      "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053": "CVE-2023-5678",
+      "status": {
+        "apps": [
+          "pkg:otp/erts@15.0",
+          "pkg:otp/erl_interface@5.5.2"
         ],
         "not_affected": "vulnerable_code_not_present"
       }

--- a/vex/otp-26.openvex.json
+++ b/vex/otp-26.openvex.json
@@ -2,15 +2,12 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://erlang.org/download/vex/otp-26.openvex.json",
   "author": "vexctl",
-  "timestamp": "2025-12-18T08:56:11.694002+01:00",
-  "last_updated": "2026-01-19T12:49:19.033564812+01:00",
-  "version": 51,
+  "version": 53,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-12-18T08:59:27.744629171+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2"
@@ -78,13 +75,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to ssl@11.1.4.6",
-      "action_statement_timestamp": "2025-12-18T08:59:27.744629171+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:27.744629171+01:00",
+      "timestamp": "2025-12-18T07:59:27.744629171Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-12-18T08:59:27.768002035+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
@@ -93,13 +90,13 @@
           "@id": "pkg:otp/ssl@11.1.4.6"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:27.768002035Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-12-18T08:59:27.788917359+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -206,13 +203,13 @@
       ],
       "status": "affected",
       "action_statement": "Workaround: set option `parallel_login` to false. Reduce `max_sessions` option.",
-      "action_statement_timestamp": "2025-12-18T08:59:27.788917359+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:27.788917359+01:00",
+      "timestamp": "2025-12-18T07:59:27.788917359Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-12-18T08:59:27.808027623+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
@@ -221,13 +218,13 @@
           "@id": "pkg:otp/ssh@5.1.4.7"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:27.808027623Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-12-18T08:59:27.826408469+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -340,13 +337,13 @@
       ],
       "status": "affected",
       "action_statement": "Mitigation: Update to pkg:otp/stdlib@5.2.3.4",
-      "action_statement_timestamp": "2025-12-18T08:59:27.826408469+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:27.826408469+01:00",
+      "timestamp": "2025-12-18T07:59:27.826408469Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-12-18T08:59:27.845069578+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
@@ -355,13 +352,13 @@
           "@id": "pkg:otp/stdlib@5.2.3.4"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:27.845069578Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-12-18T08:59:27.866747279+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.1"
@@ -450,13 +447,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to the next version",
-      "action_statement_timestamp": "2025-12-18T08:59:27.866747279+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:27.866747279+01:00",
+      "timestamp": "2025-12-18T07:59:27.866747279Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-12-18T08:59:27.885652507+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
@@ -465,13 +462,13 @@
           "@id": "pkg:otp/ssh@5.1.4.9"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:27.885652507Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-12-18T08:59:27.906444949+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -584,13 +581,13 @@
       ],
       "status": "affected",
       "action_statement": "A temporary workaround involves disabling the SSH server or to prevent access via firewall rules.",
-      "action_statement_timestamp": "2025-12-18T08:59:27.906444949+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:27.906444949+01:00",
+      "timestamp": "2025-12-18T07:59:27.906444949Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-12-18T08:59:27.925598145+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
@@ -599,13 +596,13 @@
           "@id": "pkg:otp/ssh@5.1.4.8"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:27.925598145Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-12-18T08:59:27.943982861+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -706,13 +703,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to the next version",
-      "action_statement_timestamp": "2025-12-18T08:59:27.943982861+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:27.943982861+01:00",
+      "timestamp": "2025-12-18T07:59:27.943982861Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-12-18T08:59:27.96135029+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
@@ -721,13 +718,13 @@
           "@id": "pkg:otp/ssh@5.1.4.6"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:27.96135029Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-12-18T08:59:27.978486643+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -893,26 +890,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:27.978486643Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-12-18T08:59:27.995847956+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:27.995847956Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-12-18T08:59:28.014555921+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -1078,26 +1075,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.014555921Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-12-18T08:59:28.03336707+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.03336707Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-12-18T08:59:28.051336707+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -1263,26 +1260,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.051336707Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-12-18T08:59:28.068795585+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.068795585Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-12-18T08:59:28.087715439+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -1448,26 +1445,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.087715439Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-12-18T08:59:28.107605976+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.107605976Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-12-18T08:59:28.130377954+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -1633,26 +1630,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.130377954Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-12-18T08:59:28.150306852+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.150306852Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-12-18T08:59:28.171026434+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -1818,26 +1815,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.171026434Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-12-18T08:59:28.188406827+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.188406827Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-12-18T08:59:28.207289011+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -2003,26 +2000,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.207289011Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-12-18T08:59:28.226791102+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.226791102Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-12-18T08:59:28.247003284+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -2188,26 +2185,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.247003284Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-12-18T08:59:28.267604573+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.267604573Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-12-18T08:59:28.290134863+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -2373,26 +2370,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.290134863Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-12-18T08:59:28.313278047+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.313278047Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-12-18T08:59:28.340178545+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -2558,26 +2555,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.340178545Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-12-18T08:59:28.364984081+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.364984081Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-12-18T08:59:28.388957797+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -2743,26 +2740,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.388957797Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-12-18T08:59:28.412824886+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.412824886Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-12-18T08:59:28.437246085+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -2919,26 +2916,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.437246085Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-12-18T08:59:28.461589401+01:00",
       "products": [
         {
           "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-18T07:59:28.461589401Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48038"
       },
-      "timestamp": "2025-12-18T08:59:28.485125942+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3075,13 +3072,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.1.4.12",
-      "action_statement_timestamp": "2025-12-18T08:59:28.485125942+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:28.485125942+01:00",
+      "timestamp": "2025-12-18T07:59:28.485125942Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48038"
       },
-      "timestamp": "2025-12-18T08:59:28.509545343+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.15"
@@ -3090,13 +3087,13 @@
           "@id": "pkg:otp/ssh@5.1.4.12"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:28.509545343Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48039"
       },
-      "timestamp": "2025-12-18T08:59:28.534518979+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3233,13 +3230,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.1.4.12",
-      "action_statement_timestamp": "2025-12-18T08:59:28.534518979+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:28.534518979+01:00",
+      "timestamp": "2025-12-18T07:59:28.534518979Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48039"
       },
-      "timestamp": "2025-12-18T08:59:28.559864342+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.15"
@@ -3248,13 +3245,13 @@
           "@id": "pkg:otp/ssh@5.1.4.12"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:28.559864342Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48040"
       },
-      "timestamp": "2025-12-18T08:59:28.585566336+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3391,13 +3388,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.1.4.12",
-      "action_statement_timestamp": "2025-12-18T08:59:28.585566336+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:28.585566336+01:00",
+      "timestamp": "2025-12-18T07:59:28.585566336Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48040"
       },
-      "timestamp": "2025-12-18T08:59:28.611828438+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.15"
@@ -3406,13 +3403,13 @@
           "@id": "pkg:otp/ssh@5.1.4.12"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:28.611828438Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2016-1000107"
       },
-      "timestamp": "2025-12-18T08:59:28.638873255+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3513,13 +3510,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/inets@9.1.0.3",
-      "action_statement_timestamp": "2025-12-18T08:59:28.638873255+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:28.638873255+01:00",
+      "timestamp": "2025-12-18T07:59:28.638873255Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2016-1000107"
       },
-      "timestamp": "2025-12-18T08:59:28.664035863+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.15"
@@ -3528,13 +3525,13 @@
           "@id": "pkg:otp/inets@9.1.0.3"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:28.664035863Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48041"
       },
-      "timestamp": "2025-12-18T08:59:28.6883974+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3671,13 +3668,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.1.4.12",
-      "action_statement_timestamp": "2025-12-18T08:59:28.6883974+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:28.6883974+01:00",
+      "timestamp": "2025-12-18T07:59:28.6883974Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48041"
       },
-      "timestamp": "2025-12-18T08:59:28.710579648+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.5.15"
@@ -3686,13 +3683,13 @@
           "@id": "pkg:otp/ssh@5.1.4.12"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:28.710579648Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-48795"
       },
-      "timestamp": "2025-12-18T08:59:28.733671065+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3727,13 +3724,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.1.1",
-      "action_statement_timestamp": "2025-12-18T08:59:28.733671065+01:00"
+      "action_statement_timestamp": "2025-12-18T08:59:28.733671065+01:00",
+      "timestamp": "2025-12-18T07:59:28.733671065Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-48795"
       },
-      "timestamp": "2025-12-18T08:59:28.75955561+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.2.1"
@@ -3742,13 +3739,13 @@
           "@id": "pkg:otp/ssh@5.1.1"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-18T07:59:28.75955561Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2026-22184"
       },
-      "timestamp": "2026-01-19T12:49:19.009873564+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-26.0"
@@ -3905,20 +3902,208 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-01-19T11:49:19.009873564Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2026-22184"
       },
-      "timestamp": "2026-01-19T12:49:19.033565398+01:00",
       "products": [
         {
           "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-01-19T11:49:19.033565398Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-5678"
+      },
+      "products": [
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.0"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.0.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.0.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.1.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.1.2"
+        },
+        {
+          "@id": "pkg:otp/erl_interface@5.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.1"
+        },
+        {
+          "@id": "pkg:otp/erl_interface@5.5"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.5"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.6"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.7"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.8"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.9"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.10"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.11"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.12"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.13"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.14"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.15"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-26.2.5.16"
+        },
+        {
+          "@id": "pkg:otp/erl_interface@5.5.1"
+        },
+        {
+          "@id": "pkg:otp/erts@14.0"
+        },
+        {
+          "@id": "pkg:otp/erts@14.0.1"
+        },
+        {
+          "@id": "pkg:otp/erts@14.0.2"
+        },
+        {
+          "@id": "pkg:otp/erts@14.1"
+        },
+        {
+          "@id": "pkg:otp/erts@14.1.1"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.1"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.2"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.3"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.4"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.1"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.2"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.3"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.4"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.5"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.6"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.7"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.8"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.9"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.10"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.11"
+        },
+        {
+          "@id": "pkg:otp/erts@14.2.5.12"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-02-10T10:33:17.064240928Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-5678"
+      },
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-02-10T10:33:17.112489086Z"
     }
-  ]
+  ],
+  "timestamp": "2025-12-18T07:56:11Z",
+  "last_updated": "2026-02-10T10:33:17Z"
 }

--- a/vex/otp-27.openvex.json
+++ b/vex/otp-27.openvex.json
@@ -2,15 +2,12 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://erlang.org/download/vex/otp-27.openvex.json",
   "author": "vexctl",
-  "timestamp": "2025-12-01T15:56:28.947145+01:00",
-  "last_updated": "2026-01-19T12:49:23.29483694+01:00",
-  "version": 49,
+  "version": 51,
   "statements": [
     {
       "vulnerability": {
         "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-12-01T15:58:04.676135893+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -45,13 +42,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to ssl@11.2.5",
-      "action_statement_timestamp": "2025-12-01T15:58:04.676135893+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:04.676135893+01:00",
+      "timestamp": "2025-12-01T14:58:04.676135893Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-53846"
       },
-      "timestamp": "2025-12-01T15:58:04.701737024+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.1.3"
@@ -60,13 +57,13 @@
           "@id": "pkg:otp/ssl@11.2.5"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:04.701737024Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-12-01T15:58:04.727733703+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -134,13 +131,13 @@
       ],
       "status": "affected",
       "action_statement": "Workaround: set option `parallel_login` to false. Reduce `max_sessions` option.",
-      "action_statement_timestamp": "2025-12-01T15:58:04.727733703+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:04.727733703+01:00",
+      "timestamp": "2025-12-01T14:58:04.727733703Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-30211"
       },
-      "timestamp": "2025-12-01T15:58:04.754191758+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.2"
@@ -152,13 +149,13 @@
           "@id": "pkg:otp/ssh@5.2.9"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:04.754191758Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-12-01T15:58:04.781290272+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -235,13 +232,13 @@
       ],
       "status": "affected",
       "action_statement": "Mitigation: Update to pkg:otp/stdlib@6.2.2.1",
-      "action_statement_timestamp": "2025-12-01T15:58:04.781290272+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:04.781290272+01:00",
+      "timestamp": "2025-12-01T14:58:04.781290272Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4748"
       },
-      "timestamp": "2025-12-01T15:58:04.807220844+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
@@ -250,13 +247,13 @@
           "@id": "pkg:otp/stdlib@6.2.2.1"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:04.807220844Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-12-01T15:58:04.831658376+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -339,13 +336,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to ssh@5.2.11",
-      "action_statement_timestamp": "2025-12-01T15:58:04.831658376+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:04.831658376+01:00",
+      "timestamp": "2025-12-01T14:58:04.831658376Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-46712"
       },
-      "timestamp": "2025-12-01T15:58:04.856333805+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4"
@@ -354,13 +351,13 @@
           "@id": "pkg:otp/ssh@5.2.11"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:04.856333805Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-12-01T15:58:04.882662124+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -416,13 +413,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to the next version",
-      "action_statement_timestamp": "2025-12-01T15:58:04.882662124+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:04.882662124+01:00",
+      "timestamp": "2025-12-01T14:58:04.882662124Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-26618"
       },
-      "timestamp": "2025-12-01T15:58:04.907576879+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.2.4"
@@ -431,13 +428,13 @@
           "@id": "pkg:otp/ssh@5.2.7"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:04.907576879Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-12-01T15:58:04.932616918+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -564,26 +561,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:04.932616918Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-4575"
       },
-      "timestamp": "2025-12-01T15:58:04.957167441+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:04.957167441Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-12-01T15:58:04.983234466+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -710,26 +707,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:04.983234466Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-9143"
       },
-      "timestamp": "2025-12-01T15:58:05.009435098+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.009435098Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-12-01T15:58:05.036687328+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -856,26 +853,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.036687328Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-6119"
       },
-      "timestamp": "2025-12-01T15:58:05.064139567+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.064139567Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-12-01T15:58:05.091224128+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1002,26 +999,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.091224128Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-5535"
       },
-      "timestamp": "2025-12-01T15:58:05.116158511+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.116158511Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-12-01T15:58:05.14290614+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1148,26 +1145,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.14290614Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4741"
       },
-      "timestamp": "2025-12-01T15:58:05.169815167+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.169815167Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-12-01T15:58:05.196616098+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1294,26 +1291,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.196616098Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-4603"
       },
-      "timestamp": "2025-12-01T15:58:05.223672612+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.223672612Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-12-01T15:58:05.249808322+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1440,26 +1437,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.249808322Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-2511"
       },
-      "timestamp": "2025-12-01T15:58:05.275428485+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.275428485Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-12-01T15:58:05.302915294+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1586,26 +1583,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.302915294Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-13176"
       },
-      "timestamp": "2025-12-01T15:58:05.329480876+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.329480876Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-12-01T15:58:05.356446094+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1732,26 +1729,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.356446094Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2024-0727"
       },
-      "timestamp": "2025-12-01T15:58:05.382511802+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.382511802Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-12-01T15:58:05.412368374+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -1878,26 +1875,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.412368374Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6237"
       },
-      "timestamp": "2025-12-01T15:58:05.439685196+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.439685196Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-12-01T15:58:05.469612304+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2024,26 +2021,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.469612304Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-6129"
       },
-      "timestamp": "2025-12-01T15:58:05.496467259+01:00",
       "products": [
         {
           "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.496467259Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-12-01T15:58:05.524449166+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2167,26 +2164,26 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.524449166Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2023-45853"
       },
-      "timestamp": "2025-12-01T15:58:05.551921819+01:00",
       "products": [
         {
           "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2025-12-01T14:58:05.551921819Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48038"
       },
-      "timestamp": "2025-12-01T15:58:05.580498585+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2287,13 +2284,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.2.11.3",
-      "action_statement_timestamp": "2025-12-01T15:58:05.580498585+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:05.580498585+01:00",
+      "timestamp": "2025-12-01T14:58:05.580498585Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48038"
       },
-      "timestamp": "2025-12-01T15:58:05.608470962+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4.4"
@@ -2305,13 +2302,13 @@
           "@id": "pkg:otp/ssh@5.2.11.3"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:05.608470962Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48039"
       },
-      "timestamp": "2025-12-01T15:58:05.636601008+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2412,13 +2409,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.2.11.3",
-      "action_statement_timestamp": "2025-12-01T15:58:05.636601008+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:05.636601008+01:00",
+      "timestamp": "2025-12-01T14:58:05.636601008Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48039"
       },
-      "timestamp": "2025-12-01T15:58:05.664196691+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4.4"
@@ -2430,13 +2427,13 @@
           "@id": "pkg:otp/ssh@5.2.11.3"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:05.664196691Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48040"
       },
-      "timestamp": "2025-12-01T15:58:05.691304202+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2537,13 +2534,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.2.11.3",
-      "action_statement_timestamp": "2025-12-01T15:58:05.691304202+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:05.691304202+01:00",
+      "timestamp": "2025-12-01T14:58:05.691304202Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48040"
       },
-      "timestamp": "2025-12-01T15:58:05.718530378+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4.4"
@@ -2555,13 +2552,13 @@
           "@id": "pkg:otp/ssh@5.2.11.3"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:05.718530378Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2016-1000107"
       },
-      "timestamp": "2025-12-01T15:58:05.746801093+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2632,13 +2629,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/inets@9.3.2.1",
-      "action_statement_timestamp": "2025-12-01T15:58:05.746801093+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:05.746801093+01:00",
+      "timestamp": "2025-12-01T14:58:05.746801093Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2016-1000107"
       },
-      "timestamp": "2025-12-01T15:58:05.774679617+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4.4"
@@ -2650,13 +2647,13 @@
           "@id": "pkg:otp/inets@9.3.2.1"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:05.774679617Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48041"
       },
-      "timestamp": "2025-12-01T15:58:05.803591848+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2757,13 +2754,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.2.11.3",
-      "action_statement_timestamp": "2025-12-01T15:58:05.803591848+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:05.803591848+01:00",
+      "timestamp": "2025-12-01T14:58:05.803591848Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-48041"
       },
-      "timestamp": "2025-12-01T15:58:05.831175442+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.4.4"
@@ -2775,13 +2772,13 @@
           "@id": "pkg:otp/ssh@5.2.11.3"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:05.831175442Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-12-01T15:58:05.860624884+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -2858,13 +2855,13 @@
       ],
       "status": "affected",
       "action_statement": "Update to any of the following versions: pkg:otp/ssh@5.2.10",
-      "action_statement_timestamp": "2025-12-01T15:58:05.860624884+01:00"
+      "action_statement_timestamp": "2025-12-01T15:58:05.860624884+01:00",
+      "timestamp": "2025-12-01T14:58:05.860624884Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2025-32433"
       },
-      "timestamp": "2025-12-01T15:58:05.887623095+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.3.3"
@@ -2873,13 +2870,13 @@
           "@id": "pkg:otp/ssh@5.2.10"
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": "2025-12-01T14:58:05.887623095Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2026-22184"
       },
-      "timestamp": "2026-01-19T12:49:23.276455753+01:00",
       "products": [
         {
           "@id": "pkg:github/erlang/otp@OTP-27.0"
@@ -3003,20 +3000,175 @@
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-01-19T11:49:23.276455753Z"
     },
     {
       "vulnerability": {
         "name": "CVE-2026-22184"
       },
-      "timestamp": "2026-01-19T12:49:23.294839878+01:00",
       "products": [
         {
           "@id": "pkg:github/madler/zlib@04f42ceca40f73e2978b50e93806c2a18c1281fc"
         }
       ],
       "status": "not_affected",
-      "justification": "vulnerable_code_not_present"
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-01-19T11:49:23.294839878Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-5678"
+      },
+      "products": [
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.0"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.0.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.1.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.2.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.1"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.2"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.3"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.4"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.5"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.6"
+        },
+        {
+          "@id": "pkg:github/erlang/otp@OTP-27.3.4.7"
+        },
+        {
+          "@id": "pkg:otp/erl_interface@5.5.2"
+        },
+        {
+          "@id": "pkg:otp/erts@15.0"
+        },
+        {
+          "@id": "pkg:otp/erts@15.0.1"
+        },
+        {
+          "@id": "pkg:otp/erts@15.1"
+        },
+        {
+          "@id": "pkg:otp/erts@15.1.1"
+        },
+        {
+          "@id": "pkg:otp/erts@15.1.2"
+        },
+        {
+          "@id": "pkg:otp/erts@15.1.3"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.1"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.2"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.3"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.4"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.5"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.6"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.7"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.7.1"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.7.2"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.7.3"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.7.4"
+        },
+        {
+          "@id": "pkg:otp/erts@15.2.7.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-02-10T10:33:35.32757306Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2023-5678"
+      },
+      "products": [
+        {
+          "@id": "pkg:github/openssl/openssl@01d5e2318405362b4de5e670c90d9b40a351d053"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "timestamp": "2026-02-10T10:33:35.36215105Z"
     }
-  ]
+  ],
+  "timestamp": "2025-12-01T14:56:28Z",
+  "last_updated": "2026-02-10T10:33:35Z"
 }


### PR DESCRIPTION
OpenSSL CVE-2023-5678 affects X9.42 DH key operations. Erlang/OTP crypto application hardcodes Q parameter to NULL and does not use vulnerable DH_check_pub_key functions.

Closes GH-10648