### PR TITLE
ets:update_element/counter always reject bad default tuple

### DIFF
--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -3909,10 +3909,7 @@ db_lookup_dbterm_hash(Process *p, DbTable *tbl, Eterm key, Eterm obj,
         int arity = arityval(*objp);
         Eterm *htop, *hend;
 
-        if (arity < tb->common.keypos) {
-            WUNLOCK_HASH_LCK_CTR(lck_ctr);
-            return 0;
-        }
+        ASSERT(arity >= tb->common.keypos);
         htop = HAlloc(p, arity + 1);
         hend = htop + arity + 1;
         sys_memcpy(htop, objp, sizeof(Eterm) * (arity + 1));

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -3505,9 +3505,7 @@ bool db_lookup_dbterm_tree_common(Process *p, DbTable *tbl, TreeDbTerm **root,
             int arity = arityval(*objp);
             Eterm *htop, *hend;
 
-            if (arity < tbl->common.keypos) {
-                return 0;
-            }
+            ASSERT(arity >= tbl->common.keypos);
             htop = HAlloc(p, arity + 1);
             hend = htop + arity + 1;
             sys_memcpy(htop, objp, sizeof(Eterm) * (arity + 1));

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -1728,14 +1728,15 @@ If a default object `Default` is specified, it is used as the object to be
 updated if the key is missing from the table. The value in place of the key is
 ignored and replaced by the proper key value. The return value is as if the
 default object had not been used, that is, a single updated element or a list of
-them.
+them. An invalid default object will fail the function even if the key exists in
+the table.
 
 The function fails with reason `badarg` in the following situations:
 
 - The table type is not `set` or `ordered_set`.
 - No object with the correct key exists and no default object was supplied.
 - The object has the wrong arity.
-- The default object arity is smaller than `<keypos>`.
+- The default object is not a tuple with an arity of at least `<keypos>` of the table.
 - Any field from the default object that is updated is not an integer.
 - The element to update is not an integer.
 - The element to update is also the key.
@@ -1790,14 +1791,15 @@ of an object in a `set` table, or _compare equal_ to the key of an object in an
 
 If a default object `Default` is specified, it is used as the object to be
 updated if the key is missing from the table. The value in place of the key is
-ignored and replaced by the proper key value.
+ignored and replaced by the proper key value. An invalid default object will
+fail the function even if the key exists in the table.
 
 The function fails with reason `badarg` in the following situations:
 
 - The table type is not `set` or `ordered_set`.
 - `Pos` < 1.
 - `Pos` > object arity.
-- The default object arity is smaller than `<keypos>`.
+- The default object is not a tuple with an arity of at least `<keypos>` of the table.
 - The element to update is also the key.
 """.
 -doc(#{since => <<"OTP 27.0">>}).


### PR DESCRIPTION
Based upon #10616 that avoids inserting keyless default tuples.

This PR, aimed for OTP 29, goes one step further and _always_ rejects invalid default tuples even if the key exists in the table and the invalid default tuple would been ignored. We deem this to be a better semantic for development and testing to catch such errors early and not cause `badarg` crashes in production.