### PR TITLE
erts: Fix records to correctly use the atom cache

### DIFF
--- a/erts/emulator/beam/dist.c
+++ b/erts/emulator/beam/dist.c
@@ -163,6 +163,8 @@ static char *erts_dop_to_string(enum dop dop) {
         return "UNLINK_ID";
     if (dop == DOP_UNLINK_ID_ACK)
         return "UNLINK_ID_ACK";
+    if (dop == DOP_ALTACT_SIG_SEND)
+        return "DOP_ALTACT_SIG_SEND";
     ASSERT(0);
     return "UNKNOWN";
 }

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -5266,11 +5266,11 @@ dec_term_atom_common:
                 ep++;
 
                 /* Module */
-                if ((ep = dec_atom(edep, ep, &defp->module, 0)) == NULL) {
+                if ((ep = dec_atom(edep, ep, &defp->module, flags)) == NULL) {
                     goto error;
                 }
                 /* Name */
-                if ((ep = dec_atom(edep, ep, &defp->name, 0)) == NULL) {
+                if ((ep = dec_atom(edep, ep, &defp->name, flags)) == NULL) {
                     goto error;
                 }
 
@@ -5280,7 +5280,7 @@ dec_term_atom_common:
                 for (int i = 0; i < num_fields; i++) {
                     Eterm key;
 
-                    if ((ep = dec_atom(edep, ep, &key, 0)) == NULL) {
+                    if ((ep = dec_atom(edep, ep, &key, flags)) == NULL) {
                         erts_free(ERTS_ALC_T_TMP, fields);
                         goto error;
                     }


### PR DESCRIPTION
Without this fix the distribution cannot decode native records that uses the atom cache.