### PR TITLE
ssh: fix typo in ssh_file.erl doc section

### DIFF
--- a/lib/ssh/src/ssh_file.erl
+++ b/lib/ssh/src/ssh_file.erl
@@ -235,7 +235,7 @@ memory. The `space` variant shrinks the memory requirements, but with a higher
 time consumption.
 
 To set it, set the option `{key_cb, {ssh_file, [{optimize,TimeOrSpace}]}` in the
-call of ["ssh:connect/3](`ssh:connect/3`), `ssh:daemon/2` or similar function
+call of [ssh:connect/3](`ssh:connect/3`), `ssh:daemon/2` or similar function
 call that initiates an ssh connection.
 """.
 -doc(#{group => <<"Options">>}).


### PR DESCRIPTION
@u3s @Mikaka27 I noticed this while reading the code. It breaks emacs syntax highlighting that's why I noticed it :)