### PR TITLE
Fix ms_transform:format_error/1 spec to match actual clause patterns

### DIFF
--- a/lib/stdlib/src/ms_transform.erl
+++ b/lib/stdlib/src/ms_transform.erl
@@ -80,7 +80,8 @@ Takes an error code returned by one of the other functions in the module and
 creates a textual description of the error.
 """.
 -spec(format_error(Error) -> Chars when
-      Error :: {error, module(), term()},
+      Error :: Code | {Code, _} | {Code, _, _} | {Code, _, _, _},
+      Code :: non_neg_integer(),
       Chars :: io_lib:chars()).
 
 format_error({?WARN_SHADOW_VAR,Name}) ->


### PR DESCRIPTION
The original spec declared `Error :: {error, module(), term()}` (a 3-tuple), but the function clauses match integer error codes and various code-tagged tuples. We could also go with just `Error :: Code | tuple()` for simplicity.

This original spec has looked like that at least since stdlib-6.2.1 / Erlang 27.3.