### PR TITLE
erts: Fix ethr_setname() for NetBSD

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -225,8 +225,11 @@
 /* Define if you have darwin style pthread_setname_np */
 #undef ETHR_HAVE_PTHREAD_SETNAME_NP_1
 
-/* Define if you have linux style pthread_setname_np */
+/* Define if you have linux style pthread_setname_np with 2 args */
 #undef ETHR_HAVE_PTHREAD_SETNAME_NP_2
+
+/* Define if you have netbsd style pthread_setname_np with 3 args */
+#undef ETHR_HAVE_PTHREAD_SETNAME_NP_3
 
 /* Define if you have bsd style pthread_set_name_np */
 #undef ETHR_HAVE_PTHREAD_SET_NAME_NP_2

--- a/erts/configure
+++ b/erts/configure
@@ -12896,6 +12896,24 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
+#define __USE_GNU
+                     #include <pthread.h>
+int
+main (void)
+{
+pthread_setname_np(pthread_self(), "%s", "name");
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  pthread_setname=netbsd
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 #define _DARWIN_C_SOURCE
                      #include <pthread.h>
 int
@@ -12917,6 +12935,9 @@ printf "%s\n" "$pthread_setname" >&6; }
         case $with_threadnames-$pthread_setname in
              yes-linux)
 printf "%s\n" "#define ETHR_HAVE_PTHREAD_SETNAME_NP_2 1" >>confdefs.h
+;;
+             yes-netbsd)
+printf "%s\n" "#define ETHR_HAVE_PTHREAD_SETNAME_NP_3 1" >>confdefs.h
 ;;
              yes-bsd)
 printf "%s\n" "#define ETHR_HAVE_PTHREAD_SET_NAME_NP_2 1" >>confdefs.h

--- a/erts/lib_src/pthread/ethread.c
+++ b/erts/lib_src/pthread/ethread.c
@@ -504,6 +504,8 @@ ethr_setname(char *name)
     pthread_set_name_np(ethr_self(), name);
 #elif defined(ETHR_HAVE_PTHREAD_SETNAME_NP_1)
     pthread_setname_np(name);
+#elif defined(ETHR_HAVE_PTHREAD_SETNAME_NP_3)
+    pthread_setname_np(ethr_self(), "%s", name);
 #elif defined(__HAIKU__)
     thread_id haiku_tid;
     haiku_tid = get_pthread_thread_id(ethr_self());

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -2120,12 +2120,16 @@ AS_CASE(
                      #include <pthread.h>]], [[pthread_setname_np(pthread_self(), "name");]])],[pthread_setname=linux],[])
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#define __USE_GNU
                      #include <pthread.h>]], [[pthread_set_name_np(pthread_self(), "name");]])],[pthread_setname=bsd],[])
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#define __USE_GNU
+                     #include <pthread.h>]], [[pthread_setname_np(pthread_self(), "%s", "name");]])],[pthread_setname=netbsd],[])
 	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#define _DARWIN_C_SOURCE
                      #include <pthread.h>]], [[pthread_setname_np("name");]])],[pthread_setname=darwin],[])
         AC_MSG_RESULT([$pthread_setname])
         case $with_threadnames-$pthread_setname in
              yes-linux) AC_DEFINE(ETHR_HAVE_PTHREAD_SETNAME_NP_2, 1,
-                          [Define if you have linux style pthread_setname_np]);;
+                          [Define if you have linux style pthread_setname_np with 2 args]);;
+             yes-netbsd) AC_DEFINE(ETHR_HAVE_PTHREAD_SETNAME_NP_3, 1,
+                          [Define if you have netbsd style pthread_setname_np with 3 args]);;
              yes-bsd) AC_DEFINE(ETHR_HAVE_PTHREAD_SET_NAME_NP_2, 1,
                           [Define if you have bsd style pthread_set_name_np]);;
              yes-darwin) AC_DEFINE(ETHR_HAVE_PTHREAD_SETNAME_NP_1, 1,


### PR DESCRIPTION
NetBSD has its own `pthread_setname_np()` with 3 arguments.