### PR TITLE
renovate: update actions in lockstep

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -53,6 +53,16 @@
                 ".github/actions/*/*.yaml"
             ]
         },
+        // This is used to always update upload and download in lockstep
+        // e.g., if upload is update to version 5, so does need to be download.
+        {
+            "matchManagers": ["github-actions"],
+            "groupName": "github-actions-artifacts",
+            "matchPackageNames": [
+                "actions/upload-artifact",
+                "actions/download-artifact"
+            ]
+         }
         // This is used to match out the current version from vendor.info
         {
             "matchFileNames": ["**/vendor.info"],


### PR DESCRIPTION
update `upload-artifact` and `download-artifact` only in a lockstep fashion,
i.e., if `upload-artifact` is updated to version 5, so does need to be
`download-artifact`. this is necessary to keep compatibility guarantees
between the actions
