### PR TITLE
asn1: Avoid warning for exported variables

### DIFF
--- a/lib/asn1/src/asn1ct_constructed_per.erl
+++ b/lib/asn1/src/asn1ct_constructed_per.erl
@@ -1865,11 +1865,9 @@ gen_dec_choice1(Erule, TopType, CompList, noext=Ext) ->
 gen_dec_choice1(Erule, TopType, CompList, {ext,_,_}=Ext) ->
     emit_getchoice(Erule, CompList, Ext),
     Imm = asn1ct_imm:per_dec_open_type(is_aligned(Erule)),
-    emit(["begin",nl]),
     BytesVar = asn1ct_gen:mk_var(asn1ct_name:curr(bytes)),
     {Dst,DstBuf} = asn1ct_imm:dec_slim_cg(Imm, BytesVar),
-    emit([nl,
-	  "end,",nl,
+    emit([",",nl,
 	  "case Choice of",nl]),
     Pre = {safe,fun(St) ->
 			emit(["{TmpVal,_} = "]),

--- a/lib/asn1/test/asn1_test_lib.erl
+++ b/lib/asn1/test/asn1_test_lib.erl
@@ -91,7 +91,7 @@ module(F0) ->
 %%    filename:join(CaseDir, F ++ ".beam").
 
 compile_file(File, Options0) ->
-    Options = [warnings_as_errors|Options0],
+    Options = [warn_export_vars,warnings_as_errors|Options0],
     try
         ok = asn1ct:compile(File, Options),
         ok = compile_maps(File, Options)


### PR DESCRIPTION
Compiling a CHOICE with extensions using the `warn_exported_vars` compiler option would result in a warning that variables were exported out of begin block. It turns out that there is no need for a begin block in this particular code.