### PR TITLE
Fix ?FUNCTION_ARITY for a bracket-only first argument

### DIFF
--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -1909,7 +1909,12 @@ update_fun_name_1([Tok|Toks], L, FA, St) ->
 		    update_fun_name_1(Toks, L, FA, St)
 	    end;
 	left ->
-	    update_fun_name_1(Toks, L+1, FA, St);
+            case FA of
+                {Name,0} ->
+                    update_fun_name_1(Toks, L+1, {Name,1}, St);
+                {_,_} ->
+                    update_fun_name_1(Toks, L+1, FA, St)
+            end;
 	right when L =:= 1 ->
 	    FA;
 	right ->

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -1807,7 +1807,15 @@ function_macro(Config) ->
 	     "b(?FUNCTION_ARITY, ?__) -> ok.\n"
 	     "c(?FF) -> ok.\n"
 	     "t() -> a(1, 2), b(3, 1, 2), c(c, 2), ok.\n">>,
-	   ok}
+	   ok},
+
+          {f_5,
+           <<"a([]) -> 1 = ?FUNCTION_ARITY.\n"
+             "b({}) -> 1 = ?FUNCTION_ARITY.\n"
+             "c([], []) -> 2 = ?FUNCTION_ARITY.\n"
+             "d([], _) -> 2 = ?FUNCTION_ARITY.\n"
+             "t() -> a([]), b({}), c([], []), d([], 42), ok.\n">>,
+           ok}
 	 ],
     [] = run(Config, Ts),
 


### PR DESCRIPTION
`?FUNCTION_ARITY` would evaluate to one less the actual arity if the first argument of the function were a bracket-only pattern, as in the following example:

    foo([]) -> ?FUNCTION_ARITY.

Fixes #10705