### PR TITLE
`parsetools`: Remove usages of `and` and `or`

### DIFF
--- a/lib/parsetools/src/leex.erl
+++ b/lib/parsetools/src/leex.erl
@@ -250,8 +250,6 @@ Floats (\+|-)?[0-9]+\.[0-9]+((E|e)(\+|-)?[0-9]+)?
 > current version of `leex` and generates a parse error.
 """.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([compile/3,file/1,file/2,format_error/1]).
 
 -import(lists, [member/2,reverse/1,sort/1,keysort/2,
@@ -2140,10 +2138,10 @@ prep_out_actions(As) ->
             ({A,Code,TokenChars,TokenLen,TokenLine,TokenCol,TokenLoc}) ->
                 Vs = [{TokenChars,"TokenChars"},
                       {TokenLen,"TokenLen"},
-                      {TokenLine or TokenLoc,"TokenLine"},
-                      {TokenCol or TokenLoc,"TokenCol"},
+                      {TokenLine orelse TokenLoc,"TokenLine"},
+                      {TokenCol orelse TokenLoc,"TokenCol"},
                       {TokenChars,"YYtcs"},
-                      {TokenLen or TokenChars,"TokenLen"}],
+                      {TokenLen orelse TokenChars,"TokenLen"}],
                 Vars = [if F -> S; true -> "_" end || {F,S} <- Vs],
                 Name = list_to_atom(lists:concat([yyaction_,A])),
                 [Chars,Len,Line,Col,_,_] = Vars,

--- a/lib/parsetools/src/yecc.erl
+++ b/lib/parsetools/src/yecc.erl
@@ -487,8 +487,6 @@ lib/parsetools/include/yeccpre.hrl
 * Kernighan & Pike: The UNIX programming environment, 1984.
 """.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([compile/3, file/1, file/2, format_error/1]).
 
 -export_type([option/0, yecc_ret/0]).
@@ -1489,7 +1487,7 @@ check_expected(St0) ->
           end,
     NStates = NStates0 + 1,
     if
-        (not Done) or (ExpStates =:= []) or (NStates =:= ExpStates) ->
+        not Done; ExpStates =:= []; NStates =:= ExpStates ->
             St1;
         true ->
             add_warning(none, {n_states, ExpStates, NStates}, St1)


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `parsetools`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.