### PR TITLE
`xmerl`: Remove usages of `and` and `or`

### DIFF
--- a/lib/xmerl/src/xmerl_scan.erl
+++ b/lib/xmerl/src/xmerl_scan.erl
@@ -53,8 +53,6 @@ See also the
 
 -export_type([xmlElement/0, document/0]).
 
--compile(nowarn_obsolete_bool_op).
-
 %-define(debug, 1).
 -include("xmerl.hrl").		% record def, macros
 -include("xmerl_internal.hrl").
@@ -1199,8 +1197,8 @@ scan_pi(Str = [H1,H2,H3 | T],S0=#xmerl_scanner{line = L, col = C}, Pos, Ps)
     %% names beginning with [xX][mM][lL] are reserved for future use.
     ?bump_col(3),
     if
-	((H2==$m) or (H2==$M)) and
-	((H3==$l) or (H3==$L)) ->
+	H2==$m orelse H2==$M,
+	H3==$l orelse H3==$L ->
 	    scan_wellknown_pi(T,S,Pos,Ps);
 	true ->
 	    {Target, _NamespaceInfo, T1, S1} = scan_name(Str, S),

--- a/lib/xmerl/src/xmerl_xpath_pred.erl
+++ b/lib/xmerl/src/xmerl_xpath_pred.erl
@@ -25,8 +25,6 @@
 -module(xmerl_xpath_pred).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 %% API
 -export([eval/2]).
 
@@ -181,9 +179,9 @@ comp_expr('!=', E1, E2, C) ->
     ?boolean(compare_eq_format(N1,N2,C) /= compare_eq_format(N2,N1,C)).
 
 bool_expr('or', E1, E2, C) ->
-    ?boolean(mk_boolean(C, E1) or mk_boolean(C, E2));
+    ?boolean(mk_boolean(C, E1) orelse mk_boolean(C, E2));
 bool_expr('and', E1, E2, C) ->
-    ?boolean(mk_boolean(C, E1) and mk_boolean(C, E2)).
+    ?boolean(mk_boolean(C, E1) andalso mk_boolean(C, E2)).
 
 %% According to chapter 3.4 in XML Path Language ver 1.0 the format of
 %% the compared objects are depending on the type of the other


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `xmerl`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.