### PR TITLE
`dialyzer`: Remove usages of `and` and `or`

### DIFF
--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -32,7 +32,6 @@
 -module(dialyzer_dataflow).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
 -compile(nowarn_deprecated_catch).
 
 -export([get_fun_types/5, get_warnings/5, format_args/3]).
@@ -3648,7 +3647,7 @@ find_terminals_list(List) ->
 
 find_terminals_list([Tree|Left], Explicit1, Normal1) ->
   {Explicit2, Normal2} = find_terminals(Tree),
-  case {Explicit1 or Explicit2, Normal1 or Normal2} of
+  case {Explicit1 orelse Explicit2, Normal1 orelse Normal2} of
     {true, true} = Ans -> Ans;
     {NewExplicit, NewNormal} ->
       find_terminals_list(Left, NewExplicit, NewNormal)

--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -31,8 +31,6 @@
 -module(dialyzer_utils).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([
 	 format_sig/1,
 	 format_sig/2,
@@ -560,7 +558,7 @@ get_optional_callbacks(Tuples, ModName) ->
 
 get_spec_info([{Contract, Ln, [{Id, TypeSpec}]}|Left],
 	      SpecMap, CallbackMap, RecordsMap, ModName, OptCb, File)
-  when ((Contract =:= 'spec') or (Contract =:= 'callback')),
+  when Contract =:= 'spec' orelse Contract =:= 'callback',
        is_list(TypeSpec) ->
   MFA = case Id of
 	  {_, _, _} = T -> T;
@@ -1026,11 +1024,11 @@ pp_flags([Flag|Flags]) ->
 				  pp_flags(Flags))).
 
 keep_endian(Flags) ->
-  [cerl:c_atom(X) || X <- Flags, (X =:= little) or (X =:= native)].
+  [cerl:c_atom(X) || X <- Flags, X =:= little orelse X =:= native].
 
 keep_all(Flags) ->
   [cerl:c_atom(X) || X <- Flags,
-		     (X =:= little) or (X =:= native) or (X =:= signed)].
+		     X =:= little orelse X =:= native orelse X =:= signed].
 
 pp_unit(Unit, Ctxt, Cont) ->
   case cerl:concrete(Unit) of
@@ -1164,7 +1162,7 @@ refold_concrete_pat(Val) ->
     [H|T] ->
       HP = refold_concrete_pat(H),
       TP = refold_concrete_pat(T),
-      case  cerl:is_literal(HP) and cerl:is_literal(TP) of
+      case cerl:is_literal(HP) andalso cerl:is_literal(TP) of
 	true -> cerl:abstract(Val);
 	false -> label(cerl:c_cons_skel(HP, TP))
       end;

--- a/lib/dialyzer/src/erl_types.erl
+++ b/lib/dialyzer/src/erl_types.erl
@@ -36,8 +36,6 @@
 -module(erl_types).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([any_none/1,
 	 any_none_or_unit/1,
 	 lookup_record/3,
@@ -3292,7 +3290,7 @@ t_subtract_aux(?int_range(From, To) = T1, ?int_set(Set)) ->
 	    true -> To - 1;
 	    false -> To
 	  end,
-  if (NewFrom =:= From) and (NewTo =:= To) -> T1;
+  if NewFrom =:= From, NewTo =:= To -> T1;
      true -> t_from_range(NewFrom, NewTo)
   end;
 t_subtract_aux(?int_set(Set), ?int_range(From, To)) ->


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `dialyzer`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.