### PR TITLE
compiler: Guarantee that BEAM files cannot be loaded below OTP 26

### DIFF
--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -208,6 +208,9 @@ erts_prepare_loading(Binary* magic, Process *c_p, Eterm group_leader,
          * OTP 28 artificially sets the highest op code to `bs_create_bin`
          * introduced in OTP 25.
          *
+         * OTP 29 artificially sets the highest op code to `update_record`
+         * introduced in OTP 26.
+         *
          * Old BEAM files produced by OTP R12 and earlier may be
          * incompatible with the current runtime system. We used to
          * reject such BEAM files using transformation rules that

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -90,7 +90,7 @@ module(Code0, ExtraChunks, CompileInfo, CompilerOpts) ->
 reject_unsupported_versions(Dict) ->
     %% Emit an instruction that was added in our lowest supported
     %% version so that it cannot be loaded by earlier releases.
-    Instr = beam_opcodes:opcode(bs_create_bin, 6),  %OTP 25
+    Instr = beam_opcodes:opcode(update_record, 5),  %OTP 26
     beam_dict:opcode(Instr, Dict).
 
 on_load(Fs0, Attr0) ->

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1725,23 +1725,23 @@ bc_options(Config) ->
 
     DataDir = proplists:get_value(data_dir, Config),
 
-    L = [{177, small_float, []},
+    L = [{181, small_float, []},
 
-         {177, funs, [no_ssa_opt_record,
+         {181, funs, [no_ssa_opt_record,
                       no_ssa_opt_float,
                       no_line_info,
                       no_stack_trimming,
                       no_type_opt]},
 
-         {177, small_maps, [no_type_opt]},
+         {181, small_maps, [no_type_opt]},
 
-         {177, big, [no_ssa_opt_record,
+         {181, big, [no_ssa_opt_record,
                      no_ssa_opt_float,
                      no_line_info,
                      no_type_opt]},
 
-         {178, funs, []},
-         {178, big, []},
+         {181, funs, []},
+         {181, big, []},
 
          {182, small, [r26]},
          {182, small, []},


### PR DESCRIPTION
We makes sure that OTP ~26~25 and lower can never load BEAM files compiled by OTP 29. That means that the runtime system will never have to worry about BEAM files compiled before OTP ~27~26.