### PR TITLE
`mnesia`: Remove usages of `and` and `or`Remove and/or in mnesia

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -43,7 +43,6 @@
 -module(mnesia_controller).
 -moduledoc false.
 -compile([{nowarn_deprecated_function, [{erlang,phash,2}]}]).
--compile(nowarn_obsolete_bool_op).
 
 -behaviour(gen_server).
 
@@ -734,8 +733,8 @@ handle_call(disc_load_intents,From,State = #state{loader_queue=LQ,late_loader_qu
 handle_call({update_where_to_write, [add, Tab, AddNode], _From}, _Dummy, State) ->
     Current = val({current, db_nodes}),
     Res =
-	case lists:member(AddNode, Current) and
-	    (State#state.schema_is_merged == true) of
+	case lists:member(AddNode, Current) andalso
+	    State#state.schema_is_merged == true of
 	    true ->
 		mnesia_lib:add_lsort({Tab, where_to_write}, AddNode),
 		update_where_to_wlock(Tab);

--- a/lib/mnesia/src/mnesia_dumper.erl
+++ b/lib/mnesia/src/mnesia_dumper.erl
@@ -57,8 +57,6 @@
 
 -import(mnesia_lib, [fatal/2, dbg_out/2]).
 
--compile(nowarn_obsolete_bool_op).
-
 -define(REGULATOR_NAME, mnesia_dumper_load_regulator).
 -define(DumpToEtsMultiplier, 4).
 
@@ -732,7 +730,7 @@ insert_op(Tid, _, {op, restore_recreate, TabDef}, InPlace, InitBy) ->
     
     %% And create new ones..
     if
-	(InitBy == startup) or (Semantics == unknown) ->
+	InitBy == startup; Semantics == unknown ->
 	    ignore;
 	Semantics == ram_copies ->
 	    EtsProps = proplists:get_value(ets, StorageProps, []),

--- a/lib/mnesia/src/mnesia_loader.erl
+++ b/lib/mnesia/src/mnesia_loader.erl
@@ -37,8 +37,6 @@
 
 -include("mnesia.hrl").
 
--compile(nowarn_obsolete_bool_op).
-
 %% Local function in order to avoid external function call
 val(Var) ->
     case ?catch_val_and_stack(Var) of
@@ -436,7 +434,7 @@ create_table(Tab, TabSize, Storage, Cs) ->
 		    mnesia_lib:unlock_table(Tab),
 		    {error, {mktab, Reason}}
 	    end;
-	(Storage == ram_copies) or (Storage == disc_copies) ->
+	Storage == ram_copies; Storage == disc_copies ->
 	    EtsOpts = proplists:get_value(ets, StorageProps, []),
 	    Args = [{keypos, 2}, public, named_table, Cs#cstruct.type | EtsOpts],
 	    case mnesia_monitor:unsafe_mktab(Tab, Args) of

--- a/lib/mnesia/src/mnesia_monitor.erl
+++ b/lib/mnesia/src/mnesia_monitor.erl
@@ -24,8 +24,6 @@
 -module(mnesia_monitor).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -behaviour(gen_server).
 
 %% Public exports
@@ -318,8 +316,8 @@ use_dir() ->
 %% Returns true if the Mnesia directory contains
 %% important files
 non_empty_dir() ->
-    mnesia_lib:exists(mnesia_bup:fallback_bup()) or
-    mnesia_lib:exists(mnesia_lib:tab2dmp(schema)) or
+    mnesia_lib:exists(mnesia_bup:fallback_bup()) orelse
+    mnesia_lib:exists(mnesia_lib:tab2dmp(schema)) orelse
     mnesia_lib:exists(mnesia_lib:tab2dat(schema)).
 
 %%----------------------------------------------------------------------

--- a/lib/mnesia/src/mnesia_recover.erl
+++ b/lib/mnesia/src/mnesia_recover.erl
@@ -24,8 +24,6 @@
 -module(mnesia_recover).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -behaviour(gen_server).
 
 -export([
@@ -497,7 +495,7 @@ load_decision_tab(Cont, InitBy) ->
 %% From now on all decisions are logged in the transaction log file
 convert_old() ->
     HasOldStuff = 
-	mnesia_lib:exists(mnesia_log:previous_decision_log_file()) or
+	mnesia_lib:exists(mnesia_log:previous_decision_log_file()) orelse
 	mnesia_lib:exists(mnesia_log:decision_log_file()),
     case HasOldStuff of
 	true ->
@@ -1176,7 +1174,7 @@ add_remote_decision(Node, NewD, State) ->
 	Outcome == unclear ->
 	    ignore;
 	true ->
-	    case lists:member(node(), NewD#decision.disc_nodes) or
+	    case lists:member(node(), NewD#decision.disc_nodes) orelse
 		 lists:member(node(), NewD#decision.ram_nodes) of
 		true ->
 		    tell_im_certain([Node], D);
@@ -1238,8 +1236,8 @@ send_decisions([]) ->
     ok.
 
 arrange([To | ToNodes], D, Acc, ForceSend) when is_record(D, decision) ->
-    NeedsAdd = (ForceSend or
-		lists:member(To, D#decision.disc_nodes) or
+    NeedsAdd = (ForceSend orelse
+		lists:member(To, D#decision.disc_nodes) orelse
 		lists:member(To, D#decision.ram_nodes)),
     case NeedsAdd of
 	true ->

--- a/lib/mnesia/src/mnesia_schema.erl
+++ b/lib/mnesia/src/mnesia_schema.erl
@@ -31,8 +31,6 @@
 -module(mnesia_schema).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([
          add_backend_type/2,
 	 do_add_backend_type/2,
@@ -3486,7 +3484,7 @@ do_make_merge_schema(Node, NeedsConv, RemoteCs = #cstruct{name = schema}) ->
     Masters = mnesia_recover:get_master_nodes(schema),
     HasRemoteMaster = lists:member(Node, Masters),
     HasLocalMaster = lists:member(node(), Masters),
-    Force = HasLocalMaster or HasRemoteMaster,
+    Force = HasLocalMaster orelse HasRemoteMaster,
     %% What is the storage types opinions?
     StCsLocal   = mnesia_lib:cs_to_storage_type(node(), Cs),
     StRcsLocal  = mnesia_lib:cs_to_storage_type(node(), RemoteCs),
@@ -3566,7 +3564,7 @@ do_make_merge_schema(Node, NeedsConv, RemoteCs = #cstruct{}) ->
     Masters = mnesia_recover:get_master_nodes(schema),
     HasRemoteMaster = lists:member(Node, Masters),
     HasLocalMaster = lists:member(node(), Masters),
-    Force = HasLocalMaster or HasRemoteMaster,
+    Force = HasLocalMaster orelse HasRemoteMaster,
     case ?catch_val({Tab, cstruct}) of
 	{'EXIT', _} ->
 	    %% A completely new table, created while Node was down
@@ -3771,7 +3769,7 @@ verify_merge(RemoteCs) ->
 
 announce_im_running([N | Ns], SchemaCs) ->
     {L1, L2} = mnesia_recover:connect_nodes([N]),
-    case lists:member(N, L1) or lists:member(N, L2) of
+    case lists:member(N, L1) orelse lists:member(N, L2) of
 	true ->
 	    mnesia_lib:add({current, db_nodes}, N),
 	    mnesia_controller:add_active_replica(schema, N, SchemaCs);

--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -24,8 +24,6 @@
 -module(mnesia_tm).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([
 	 start/0,
 	 init/1,
@@ -2372,7 +2370,7 @@ send_to_pids([], _Msg) ->
     ok.
 
 reconfigure_participants(N, [P | Tail]) ->
-    case lists:member(N, P#participant.disc_nodes) or
+    case lists:member(N, P#participant.disc_nodes) orelse
 	 lists:member(N, P#participant.ram_nodes) of
 	false ->
 	    %% Ignore, since we are not a participant


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `mnesia`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.