### PR TITLE
`wx`: Remove usages of `and` and `or`

### DIFF
--- a/lib/wx/examples/simple/menu.erl
+++ b/lib/wx/examples/simple/menu.erl
@@ -32,8 +32,6 @@
 
 -export([start/0]).
 
--compile(nowarn_obsolete_bool_op).
-
 %%%Lots of IDs to declare!
 -define(menuID_FILE_QUIT,           ?wxID_EXIT).
 -define(menuID_FILE_CLEAR_LOG,      100).
@@ -532,7 +530,7 @@ onMenuAction(#wx{id=?menuID_MENU_APPEND_SUB, obj=Frame}, #state{} = State) ->
 
     State;
 
-onMenuAction(#wx{id=Id, obj=Frame}, #state{}=State) when ((Id >= ?menuID_DUMMY_FIRST) and (Id =< ?menuID_DUMMY_LAST)) ->
+onMenuAction(#wx{id=Id, obj=Frame}, #state{}=State) when Id >= ?menuID_DUMMY_FIRST, Id =< ?menuID_DUMMY_LAST ->
     logMessage(Frame, "Dummy item #~p ~n", [Id - ?menuID_DUMMY_FIRST + 1]),
     State;
 

--- a/lib/wx/examples/sudoku/sudoku_game.erl
+++ b/lib/wx/examples/sudoku/sudoku_game.erl
@@ -25,8 +25,6 @@
          indx/1, rcm/1, level/1]).
 -include("sudoku.hrl").
 
--compile(nowarn_obsolete_bool_op).
-
 init(GFX) ->
     Empty = empty_table(#s{}),
     Add = fun({Butt,Val},SN) ->
@@ -244,10 +242,10 @@ solve([Index|Rest],All, St, S, US, Orig) ->
 
 solve_1(RCM={R,C,_M}, Avail, St) ->
     All = all(RCM),
-    Poss = fun({RI,CI},Acc) when (RI == R) and (CI == C) -> Acc;
+    Poss = fun({RI,CI},Acc) when RI == R, CI == C -> Acc;
 	      ({RI,CI},Acc) -> gb_sets:union(poss(rcm({RI,CI}),St),Acc)
 	   end, 
-    D = fun({RI,CI},Acc) when (RI == R) and (CI == C) -> 
+    D = fun({RI,CI},Acc) when RI == R, CI == C -> 
 		io:format("~p:~p: ignore~n",[RI,CI]), 
 		Acc;	      
 	   ({RI,CI},Acc) -> 


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `wx`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.