### PR TITLE
`diameter`: Remove usages of `and` and `or`

### DIFF
--- a/lib/diameter/src/info/diameter_info.erl
+++ b/lib/diameter/src/info/diameter_info.erl
@@ -28,8 +28,6 @@
 -module(diameter_info).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([usage/1,
          format/1,
          format/2,
@@ -213,7 +211,7 @@ format(Local, Remote, SFun, CFun)
 %%% ----------------------------------------------------------
 
 format(Tables, SFun)
-  when is_list(Tables), (is_function(SFun, 2) or is_function(SFun, 3)) ->
+  when is_list(Tables), is_function(SFun, 2) orelse is_function(SFun, 3) ->
     format(Tables, SFun, fun tab2list/1);
 
 format(Tables, CFun)


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `diameter`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.