### PR TITLE
socket: Don't support AUTHINFO on solaris

### DIFF
--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -14747,7 +14747,7 @@ BOOLEAN_T esock_cmsg_decode_sctp_prinfo(ErlNifEnv*      env,
 }
 #endif
 
-#if defined(SCTP_AUTHINFO)
+#if defined(SCTP_AUTHINFO) && !(defined(__sun) && defined(__SVR4))
 /* Do we actually need this function since this info is for sendmsg: decode */
 static
 BOOLEAN_T esock_cmsg_encode_sctp_authinfo(ErlNifEnv     *env,
@@ -15492,7 +15492,7 @@ static ESockCmsgSpec cmsgLevelSCTP[] =
          &esock_atom_prinfo},
 #endif
 
-#if defined(SCTP_AUTHINFO)
+#if defined(SCTP_AUTHINFO) && !(defined(__sun) && defined(__SVR4))
         /*
          * Intended for: sendmsg()
          *


### PR DESCRIPTION
According to the docs (https://docs.oracle.com/cd/E36784_01/html/E36861/sockets-18.html#NETPROTOglmdg) authinfo is not supported by solaris.

I found this while fixing the gh actions build for Solaris 11.4, see #10724 for that fix.