### PR TITLE
`megaco`: Remove usages of `and` and `or`

### DIFF
--- a/lib/megaco/src/app/megaco.erl
+++ b/lib/megaco/src/app/megaco.erl
@@ -32,8 +32,6 @@ Main API of the Megaco application
 Interface module for the Megaco application
 """.
 
--compile(nowarn_obsolete_bool_op).
-
 %%-----------------------------------------------------------------
 %% Public interface
 %%-----------------------------------------------------------------
@@ -2203,7 +2201,7 @@ token_tag2string(Tag, pretty) ->
     token_tag2string(Tag, megaco_pretty_text_encoder);
 token_tag2string(Tag, compact) ->
     token_tag2string(Tag, megaco_compact_text_encoder);
-token_tag2string(Tag, Mod) when is_atom(Tag) and is_atom(Mod) ->
+token_tag2string(Tag, Mod) when is_atom(Tag), is_atom(Mod) ->
     Mod:token_tag2string(Tag).
 
 -doc """

--- a/lib/megaco/src/engine/megaco_config.erl
+++ b/lib/megaco/src/engine/megaco_config.erl
@@ -28,8 +28,6 @@
 -module(megaco_config).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -behaviour(gen_server).
 
 %% Application internal exports
@@ -1530,7 +1528,7 @@ verify_val(Item, Val) ->
 	    megaco_config_misc:verify_uint(Val);
 
         trans_timer            -> 
-	    verify_timer(Val) and (Val >= 0);
+	    verify_timer(Val) andalso Val >= 0;
 	trans_sender when Val =:= undefined -> true;
 
         pending_timer                      -> verify_timer(Val);
@@ -1831,7 +1829,7 @@ update_trans_timer(#conn_data{trans_sender = Pid} = CD, 0) when is_pid(Pid) ->
     CD#conn_data{trans_timer = 0, trans_sender = undefined};
 
 update_trans_timer(#conn_data{trans_sender = Pid} = CD, To) 
-  when is_pid(Pid) and (To > 0) ->
+  when is_pid(Pid), To > 0 ->
     megaco_trans_sender:timeout(Pid, To),
     CD#conn_data{trans_timer = To};
 
@@ -1840,7 +1838,7 @@ update_trans_timer(CD, To) when To > 0 ->
 
 %% update trans_ack_maxcount
 update_trans_ack_maxcount(#conn_data{trans_sender = Pid} = CD, Max) 
-  when is_pid(Pid) and (Max > 0) ->
+  when is_pid(Pid), Max > 0 ->
     megaco_trans_sender:ack_maxcount(Pid, Max),
     CD#conn_data{trans_ack_maxcount = Max};
 
@@ -1851,7 +1849,7 @@ update_trans_ack_maxcount(CD, Max)
 
 %% update trans_req_maxcount
 update_trans_req_maxcount(#conn_data{trans_sender = Pid} = CD, Max) 
-  when is_pid(Pid) and (Max > 0) ->
+  when is_pid(Pid), Max > 0 ->
     megaco_trans_sender:req_maxcount(Pid, Max),
     CD#conn_data{trans_req_maxcount = Max};
 
@@ -1862,7 +1860,7 @@ update_trans_req_maxcount(CD, Max)
 
 %% update trans_req_maxsize
 update_trans_req_maxsize(#conn_data{trans_sender = Pid} = CD, Max) 
-  when is_pid(Pid) and (Max > 0) ->
+  when is_pid(Pid), Max > 0 ->
     megaco_trans_sender:req_maxsize(Pid, Max),
     CD#conn_data{trans_req_maxsize = Max};
 

--- a/lib/megaco/src/engine/megaco_digit_map.erl
+++ b/lib/megaco/src/engine/megaco_digit_map.erl
@@ -70,8 +70,6 @@ but as of 27.0, its also documented.
 """.
 -moduledoc(#{since => "OTP 27.0"}).
 
--compile(nowarn_obsolete_bool_op).
-
 -export([parse/1, eval/1, eval/2, report/2, test/2]). % Public
 -export([test_eval/2]).                               % Internal
 
@@ -856,9 +854,9 @@ report(Pid, Event) when is_pid(Pid) ->
 	$s                      -> sleep(1);  % 1 sec (1000 ms)
 	$L                      -> sleep(10); % 10 sec (10000 ms)
 	$l                      -> sleep(10); % 10 sec (10000 ms)
-        {long, I} when (I >= $0) and (I =< $9) -> cast(Pid, {long, I});
-        {long, A} when (A >= $a) and (A =< $k) -> cast(Pid, {long, A});
-        {long, A} when (A >= $A) and (A =< $K) -> cast(Pid, {long, A});
+        {long, I} when I >= $0, I =< $9 -> cast(Pid, {long, I});
+        {long, A} when A >= $a, A =< $k -> cast(Pid, {long, A});
+        {long, A} when A >= $A, A =< $K -> cast(Pid, {long, A});
 %%         {long, I} when (I >= $0) and (I =< $9) -> long(Pid, I);
 %%         {long, A} when (A >= $a) and (A =< $k) -> long(Pid, A);
 %%         {long, A} when (A >= $A) and (A =< $K) -> long(Pid, A);

--- a/lib/megaco/src/engine/megaco_erl_dist_encoder.erl
+++ b/lib/megaco/src/engine/megaco_erl_dist_encoder.erl
@@ -28,8 +28,6 @@
 -module(megaco_erl_dist_encoder).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -behaviour(megaco_encoder).
 
 -export([encode_message/3, decode_message/3,
@@ -70,7 +68,7 @@ encode_message([megaco_compressed|Config], Vsn, MegaMsg)
   when is_record(MegaMsg, 'MegacoMessage') ->
     {ok, erlang:term_to_binary(?MC_MOD:encode(MegaMsg, Vsn), Config)};
 encode_message([{megaco_compressed, Mod}|Config], Vsn, MegaMsg) 
-  when is_atom(Mod) and is_record(MegaMsg, 'MegacoMessage') ->
+  when is_atom(Mod), is_record(MegaMsg, 'MegacoMessage') ->
     {ok, erlang:term_to_binary(Mod:encode(MegaMsg, Vsn), Config)};
 encode_message(Config, _Vsn, MegaMsg) 
   when is_record(MegaMsg, 'MegacoMessage') ->

--- a/lib/megaco/src/engine/megaco_messenger.erl
+++ b/lib/megaco/src/engine/megaco_messenger.erl
@@ -28,8 +28,6 @@
 -module(megaco_messenger).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 %% Application internal export
 -export([
          process_received_message/4, process_received_message/5,
@@ -3149,8 +3147,8 @@ handle_disconnect_callback(ConnData, UserReason)
 %% 
 test_request(ConnHandle, Actions, 
 	     Version, EncodingMod, EncodingConfig)
-  when is_record(ConnHandle, megaco_conn_handle) and
-       is_integer(Version) andalso is_atom(EncodingMod) ->
+  when is_record(ConnHandle, megaco_conn_handle),
+       is_integer(Version), is_atom(EncodingMod) ->
     %% Create a fake conn_data structure
     ConnData = #conn_data{serial           = 1, 
 			  protocol_version = Version,
@@ -4123,8 +4121,8 @@ format_encode_error_reason(Reason) ->
 	case Reason of
 	    {Mod, Func, [EC, Msg], {AE, CS}} when is_atom(Mod)  andalso 
 						  is_atom(Func) andalso
-						  is_list(EC)   and
-						  is_tuple(Msg) and
+						  is_list(EC)   andalso
+						  is_tuple(Msg) andalso
 						  is_list(CS) ->
 		io_lib:format("~n   Encode module: ~w"
 			      "~n   Func:          ~w"

--- a/lib/megaco/src/engine/megaco_messenger_misc.erl
+++ b/lib/megaco/src/engine/megaco_messenger_misc.erl
@@ -30,8 +30,6 @@
 -module(megaco_messenger_misc).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 %% Application internal export
 -export([encode_body/3,
 	 encode_trans_request/2,
@@ -93,16 +91,17 @@ encode_trans_request(CD, TR) when is_record(TR, 'TransactionRequest') ->
 encode_trans_reply(#conn_data{segment_send     = SegSend, 
 			      max_pdu_size     = Max,
 			      protocol_version = V} = CD, Reply) 
-  when (SegSend == infinity) or (is_integer(SegSend) and (SegSend > 0)) and 
-       is_integer(V) and (V >= 3) and 
-       is_integer(Max) and (Max >= ?MSG_HDR_SZ) ->
+  when SegSend == infinity;
+       is_integer(SegSend), SegSend > 0,
+       is_integer(V), V >= 3,
+       is_integer(Max), Max >= ?MSG_HDR_SZ ->
     (catch encode_segmented_trans_reply(CD, Reply));
 encode_trans_reply(CD, TR) when is_record(TR, megaco_transaction_reply) ->
     ?report_debug(CD, "encode trans reply", [TR]),
     Trans = {transactionReply, transform_transaction_reply(CD, TR)},
     encode_transaction(CD, Trans);
-encode_trans_reply(CD, TR) when is_tuple(TR) and 
-				(element(1, TR) == 'TransactionReply') ->
+encode_trans_reply(CD, TR) when is_tuple(TR), 
+				element(1, TR) == 'TransactionReply' ->
     ?report_debug(CD, "encode trans reply", [TR]),
     Trans = {transactionReply, TR},
     encode_transaction(CD, Trans).
@@ -357,7 +356,7 @@ do_send_message(ConnData, SendFunc, Bin, Extra) ->
 %%%-----------------------------------------------------------------
 
 transform_transaction_reply(#conn_data{protocol_version = V}, TR) 
-  when is_integer(V) and (V >= 3) ->
+  when is_integer(V), V >= 3 ->
     #megaco_transaction_reply{transactionId        = TransId, 
 			      immAckRequired       = IAR, 
 			      transactionResult    = TransRes,

--- a/lib/megaco/src/engine/megaco_sdp.erl
+++ b/lib/megaco/src/engine/megaco_sdp.erl
@@ -38,8 +38,6 @@ but as of 27.0 its also documented.
 """.
 -moduledoc(#{since => "OTP 27.0"}).
 
--compile(nowarn_obsolete_bool_op).
-
 %%----------------------------------------------------------------------
 %% Include files
 %%----------------------------------------------------------------------
@@ -550,7 +548,7 @@ encode_PropertyParm(SDP) ->
 
 -doc false.
 get_sdp_record_from_PropertyGroup(Type, PG) 
-  when is_atom(Type) and is_list(PG) ->
+  when is_atom(Type), is_list(PG) ->
     F = fun(R) -> not is_pg_record(Type, R) end,
     lists:filter(F, PG).
 
@@ -886,7 +884,7 @@ encode_conn_data_conn_addr(ip4, CA)
   when is_record(CA, megaco_sdp_c_conn_addr) ->
     encode_conn_data_conn_addr(CA);
 encode_conn_data_conn_addr(AT, CA) 
-  when is_list(AT) and is_record(CA, megaco_sdp_c_conn_addr) ->
+  when is_list(AT), is_record(CA, megaco_sdp_c_conn_addr) ->
     case tolower(AT) of
 	"ip4" ->
 	    encode_conn_data_conn_addr(CA);
@@ -1088,7 +1086,7 @@ encode_rtimes_list_of_offsets(BadLoo) ->
 	    
 %% ===== Time Zones =====
 %% 
-decode_pp_tzones(Value) when is_list(Value) and (length(Value) > 0) ->
+decode_pp_tzones([_|_] = Value) ->
     ?d("decode_pp_ztimes -> entry with"
        "~n   Value: ~p", [Value]),
     LOA = decode_tzones_list_of_adjustments(string:tokens(Value, " \t"), []),
@@ -1185,7 +1183,7 @@ encode_pp_encryption_keys(uri = _Method, EncryptionKey)
     #'PropertyParm'{name  = "k", 
 		    value = ["uri:" ++ EncryptionKey]};
 encode_pp_encryption_keys(Method, EncryptionKey) 
-  when is_list(Method) and is_list(EncryptionKey) ->
+  when is_list(Method), is_list(EncryptionKey) ->
     ?d("encode_pp_encryption_keys -> entry with"
        "~n   Method:        ~p"
        "~n   EncryptionKey: ~p", [Method, EncryptionKey]),
@@ -1202,7 +1200,7 @@ decode_pp_attribute(Value) ->
        "~n   Value: ~p", [Value]),
     First = string:chr(Value, $:),
     if 
-	(First > 0) and (First < length(Value)) ->
+	First > 0, First < length(Value) ->
 	    ?d("decode_pp_attribute -> value attribute", []),
 	    Attr      = string:substr(Value, 1, First -1),
 	    AttrValue = string:substr(Value, First + 1),
@@ -1329,7 +1327,7 @@ decode_pp_attribute_value("fmtp", AttrValue) ->
     FMTP = AttrValue, 
     First = string:chr(FMTP, $ ),
     if 
-	(First > 0) and (First < length(FMTP)) ->
+	First > 0, First < length(FMTP) ->
 	    ?d("decode_pp_attribute_value -> valid fmtp with params", []),
 	    Format = string:substr(FMTP, 1, First - 1),
 	    Params = string:substr(FMTP, First + 1),
@@ -1550,7 +1548,7 @@ encode_pp_attribute(Attr, undefined) when is_list(Attr) ->
        "~n   Attr: ~p", [Attr]),
     #'PropertyParm'{name  = "a", 
 		    value = [Attr]};
-encode_pp_attribute(Attr, Value) when is_list(Attr) and is_list(Value) ->
+encode_pp_attribute(Attr, Value) when is_list(Attr), is_list(Value) ->
     ?d("encode_pp_attribute_rtpmap -> entry with"
        "~n   Attr:  ~p"
        "~n   Value: ~p", [Attr, Value]),

--- a/lib/megaco/src/engine/megaco_timer.erl
+++ b/lib/megaco/src/engine/megaco_timer.erl
@@ -28,8 +28,6 @@
 -module(megaco_timer).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 %% Application internal export
 -export([
 	 init/1,
@@ -50,7 +48,7 @@
 %% 
 init(SingleWaitFor) when SingleWaitFor =:= infinity ->
     {SingleWaitFor, timeout};
-init(SingleWaitFor) when is_integer(SingleWaitFor) and (SingleWaitFor >= 0) ->
+init(SingleWaitFor) when is_integer(SingleWaitFor), SingleWaitFor >= 0 ->
     {SingleWaitFor, timeout};
 init(Timer) when is_record(Timer, megaco_incr_timer) ->
     return_incr(Timer).
@@ -82,10 +80,10 @@ verify(#megaco_incr_timer{wait_for    = WaitFor,
 			  factor      = Factor,
 			  incr        = Incr,
 			  max_retries = MaxRetries}) ->
-    (megaco_config_misc:verify_strict_uint(WaitFor) and
-     megaco_config_misc:verify_strict_uint(Factor)  and
-     megaco_config_misc:verify_strict_int(Incr)     and
-     verify_max_retries(MaxRetries));
+    megaco_config_misc:verify_strict_uint(WaitFor) andalso
+    megaco_config_misc:verify_strict_uint(Factor)  andalso
+    megaco_config_misc:verify_strict_int(Incr)     andalso
+    verify_max_retries(MaxRetries);
 verify(Timer) ->
     megaco_config_misc:verify_uint(Timer).
 
@@ -108,7 +106,7 @@ return_incr(#megaco_incr_timer{wait_for    = WaitFor,
 
 return_incr(#megaco_incr_timer{wait_for    = WaitFor,
 			       max_retries = Int} = Timer) 
-  when is_integer(Int) and (Int > 0) ->
+  when is_integer(Int), Int > 0 ->
     {WaitFor, Timer};
 
 return_incr(#megaco_incr_timer{wait_for    = WaitFor,

--- a/lib/megaco/src/flex/megaco_flex_scanner.erl
+++ b/lib/megaco/src/flex/megaco_flex_scanner.erl
@@ -45,8 +45,6 @@ explicitly disable this even when flex support this. Use
 `--disable-megaco-reentrant-flex-scanner` when configuring the application.
 """.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([is_enabled/0, is_reentrant_enabled/0, is_scanner_port/2]).
 -export([start/0, start/1, stop/1, scan/2]).
 
@@ -303,7 +301,7 @@ version([_|T]) ->
     version(T).
 
 
-guess_version([C]) when (48 =< C) and (C =< 57) ->
+guess_version([C]) when 48 =< C, C =< 57 ->
     C-48;
 guess_version(Str) when is_list(Str) ->
     case (catch list_to_integer(Str)) of

--- a/lib/megaco/src/text/megaco_text_gen_v2.hrl
+++ b/lib/megaco/src/text/megaco_text_gen_v2.hrl
@@ -20,8 +20,6 @@
 %% %CopyrightEnd%
 %%
 
--compile(nowarn_obsolete_bool_op).
-
 %%
 %%----------------------------------------------------------------------
 %% Purpose: Encode V2 Megaco/H.248 text messages from internal form
@@ -2093,8 +2091,7 @@ enc_EventBufferDescriptor([], _State) ->
     [
      ?EventBufferToken
     ];
-enc_EventBufferDescriptor(EventSpecs, State) 
-  when is_list(EventSpecs) and (length(EventSpecs) >= 1) ->
+enc_EventBufferDescriptor([_|_] = EventSpecs, State) -> 
     [
      ?EventBufferToken,
      ?LBRKT_INDENT(State),

--- a/lib/megaco/src/text/megaco_text_gen_v3.hrl
+++ b/lib/megaco/src/text/megaco_text_gen_v3.hrl
@@ -20,8 +20,6 @@
 %% %CopyrightEnd%
 %%
 
--compile(nowarn_obsolete_bool_op).
-
 %%
 %%----------------------------------------------------------------------
 %% Purpose: Encode V3 Megaco/H.248 text messages from internal form
@@ -128,7 +126,7 @@ enc_Message(Val, State)
      enc_Message_messageBody(Val#'Message'.messageBody, State)
     ].
 
-enc_version(Val, State) when is_integer(Val) and (Val >= 0) ->
+enc_version(Val, State) when is_integer(Val), Val >= 0 ->
     enc_DIGIT(Val, State, 0, 99).
 
 enc_Message_messageBody({'Message_messageBody',Val}, State) ->
@@ -146,8 +144,7 @@ enc_Message_messageBody({Tag, Val}, State) ->
 enc_Message_messageBody_transactions({'Message_messageBody_transactions',Val}, 
 				     State) ->
     enc_Message_messageBody_transactions(Val, State);
-enc_Message_messageBody_transactions(Val, State)
-  when is_list(Val) and (Val /= []) ->
+enc_Message_messageBody_transactions([_|_] = Val, State) ->
     [enc_Transaction(T, State) || T <- Val].
 
 enc_MId({'MId',Val}, State) ->
@@ -678,7 +675,7 @@ do_enc_ActionReply(asn1_NOVALUE, CtxRep, [], State)
      enc_ContextRequest(CtxRep, ?INC_INDENT(State))
     ];
 do_enc_ActionReply(asn1_NOVALUE, CtxRep, CmdRep, State) 
-  when (CtxRep =/= asn1_NOVALUE) and (CmdRep =/= []) ->
+  when CtxRep =/= asn1_NOVALUE, CmdRep =/= [] ->
     [
      enc_ContextRequest(CtxRep, ?INC_INDENT(State)),
      ?COMMA_INDENT(?INC_INDENT(State)), 
@@ -692,7 +689,7 @@ do_enc_ActionReply(asn1_NOVALUE, asn1_NOVALUE, CmdRep, State)
 	      ?INC_INDENT(State))
     ];
 do_enc_ActionReply(ED, CtxRep, [], State) 
-  when (ED =/= asn1_NOVALUE) and (CtxRep =/= asn1_NOVALUE) ->
+  when ED =/= asn1_NOVALUE, CtxRep =/= asn1_NOVALUE ->
     [
      enc_ContextRequest(CtxRep, ?INC_INDENT(State)),
      ?COMMA_INDENT(?INC_INDENT(State)), 
@@ -700,16 +697,16 @@ do_enc_ActionReply(ED, CtxRep, [], State)
  	      ?INC_INDENT(State))
     ];
 do_enc_ActionReply(ED, asn1_NOVALUE, CmdRep, State) 
-  when (ED =/= asn1_NOVALUE) and (CmdRep =/= []) ->
+  when ED =/= asn1_NOVALUE, CmdRep =/= [] ->
     [
      enc_list([{CmdRep, fun enc_CommandReply/2},
 	       {[ED],   fun enc_ErrorDescriptor/2}], % Indention cosmetics
  	      ?INC_INDENT(State))
     ];
 do_enc_ActionReply(ED, CtxRep, CmdRep, State) 
-  when (ED     =/= asn1_NOVALUE) and
-       (CtxRep =/= asn1_NOVALUE) and 
-       (CmdRep =/= []) ->
+  when ED     =/= asn1_NOVALUE,
+       CtxRep =/= asn1_NOVALUE,
+       CmdRep =/= [] ->
     [
      enc_ContextRequest(CtxRep, ?INC_INDENT(State)),
      ?COMMA_INDENT(?INC_INDENT(State)), 
@@ -1095,7 +1092,7 @@ enc_TopologyRequest1(
 		     topologyDirection          = TD,
  		     streamID                   = SID,   % OPTIONAL
  		     topologyDirectionExtension = TDE},  % OPTIONAL
-  State) when (SID =/= asn1_NOVALUE) and (TDE =/= asn1_NOVALUE) ->
+  State) when SID =/= asn1_NOVALUE, TDE =/= asn1_NOVALUE ->
     [
      enc_TerminationID(From, State),
      ?COMMA_INDENT(State),
@@ -2058,8 +2055,7 @@ enc_termIDList({'TerminationIDList',Val}, State) ->
     enc_termIDList(Val, State);
 enc_termIDList([Singleton], State) ->
     enc_TerminationID(Singleton, State);
-enc_termIDList(TidList, State) 
-  when is_list(TidList) and (length(TidList) > 1) ->
+enc_termIDList([_, _|_] = TidList, State) ->
 %%     d("enc_termIDList -> entry with"
 %%       "~n   TidList: ~p", [TidList]),
     State2 = ?INC_INDENT(State),
@@ -2297,7 +2293,7 @@ enc_LocalRemoteDescriptor(Val, State)
 enc_PropertyGroup({'PropertyGroup',Val}, RequiresV, State) ->
     enc_PropertyGroup(Val, RequiresV, State);
 enc_PropertyGroup([H | _T] = List, mand_v, State) 
-  when is_record(H, 'PropertyParm') and (H#'PropertyParm'.name == "v") ->
+  when is_record(H, 'PropertyParm'), H#'PropertyParm'.name == "v" ->
     enc_PropertyGroup(List, opt_v, State);
 enc_PropertyGroup(PG, opt_v, State) ->
     [
@@ -2439,7 +2435,7 @@ enc_EventsDescriptor(#'EventsDescriptor'{requestID = asn1_NOVALUE,
     ];
 enc_EventsDescriptor(#'EventsDescriptor'{requestID = RID,
 					 eventList = Evs}, State) 
-  when (RID =/= asn1_NOVALUE) and (Evs =/= []) ->
+  when RID =/= asn1_NOVALUE, Evs =/= [] ->
     [
      ?EventsToken,
      ?EQUAL,
@@ -2505,7 +2501,7 @@ decompose_requestedActions(#'RequestedActions'{keepActive            = KA,
 					       signalsDescriptor     = SD,
 					       notifyBehaviour       = NB,
 					       resetEventsDescriptor = RED}) 
-  when (KA =/= true) and ((SD =/= asn1_NOVALUE) and (SD =/= [])) ->
+  when KA =/= true, SD =/= asn1_NOVALUE, SD =/= [] ->
     [
      {[EDM],      fun enc_EventDM/2},
      {[{SE, SD}], fun enc_embedWithSig/2},
@@ -2520,7 +2516,7 @@ decompose_requestedActions(#'RequestedActions'{keepActive            = KA,
 					       signalsDescriptor     = SD,
 					       notifyBehaviour       = NB,
 					       resetEventsDescriptor = RED}) 
-  when (SD == asn1_NOVALUE) or (SD == []) ->
+  when SD == asn1_NOVALUE; SD == [] ->
     [
      {[KA],  fun enc_keepActive/2},
      {[EDM], fun enc_EventDM/2},
@@ -2600,8 +2596,8 @@ enc_EventDM({Tag, Val}, State) ->
     end.
 
 
-enc_embedFirst(RID, Evs, State)
-  when (RID =/= asn1_NOVALUE) and (is_list(Evs) and (Evs =/= [])) ->
+enc_embedFirst(RID, [_|_] = Evs, State)
+  when RID =/= asn1_NOVALUE ->
     %%     d("enc_embedFirst -> entry with"
     %%       "~n   RID: ~p"
     %%       "~n   Evs: ~p", [RID, Evs]),
@@ -2704,7 +2700,7 @@ decompose_secondRequestedActions(
 			    signalsDescriptor     = SD,
 			    notifyBehaviour       = NB,
 			    resetEventsDescriptor = RED}) 
-  when (KA =/= true) and ((SD =/= asn1_NOVALUE) and (SD =/= [])) ->
+  when KA =/= true, SD =/= asn1_NOVALUE, SD =/= [] ->
     [
      {[EDM], fun enc_EventDM/2},
      {[SD],  fun enc_embedSig/2},
@@ -2717,7 +2713,7 @@ decompose_secondRequestedActions(
 			    signalsDescriptor     = SD,
 			    notifyBehaviour       = NB,
 			    resetEventsDescriptor = RED}) 
-  when (SD == asn1_NOVALUE) or (SD == []) ->
+  when SD == asn1_NOVALUE; SD == [] ->
     [
      {[KA],  fun enc_keepActive/2},
      {[EDM], fun enc_EventDM/2},
@@ -3176,7 +3172,7 @@ enc_serviceChangeMgcId(Val, State) ->
      enc_MId(Val, State)
     ].
 
-enc_portNumber(Val, State) when is_integer(Val) and (Val >= 0) ->
+enc_portNumber(Val, State) when is_integer(Val), Val >= 0 ->
     enc_UINT16(Val, State).
      
 enc_ServiceChangeResParm(Val, State)
@@ -3324,7 +3320,7 @@ enc_HEXDIG(Octets, State, Min, Max) when is_list(Octets) ->
     do_enc_HEXDIG(Octets, State, Min, Max, 0, []).
 
 do_enc_HEXDIG([Octet | Rest], State, Min, Max, Count, Acc) 
-  when (Octet >= 0) and (Octet =< 255)  ->
+  when Octet >= 0, Octet =< 255 ->
     Hex = hex(Octet), % OTP-4921
     if
 	Octet =< 15 ->
@@ -3335,7 +3331,7 @@ do_enc_HEXDIG([Octet | Rest], State, Min, Max, Count, Acc)
 	    do_enc_HEXDIG(Rest, State, Min, Max, Count + 2, Acc2)
     end;
 do_enc_HEXDIG([], State, Min, Max, Count, Acc)
-  when is_integer(Min) and (Count < Min) ->
+  when is_integer(Min), Count < Min ->
     do_enc_HEXDIG([0], State, Min, Max, Count, Acc);
 do_enc_HEXDIG([], _State, Min, Max, Count, Acc) -> %% OTP-4710
     verify_count(Count, Min, Max),
@@ -3386,7 +3382,7 @@ do_enc_list([], _State, _ElemEncoder, _SepEncoder, _NeedsSep) ->
 do_enc_list([asn1_NOVALUE | T], State, ElemEncoder, SepEncoder, NeedsSep) ->
     do_enc_list(T, State, ElemEncoder, SepEncoder, NeedsSep);
 do_enc_list([H | T], State, ElemEncoder, SepEncoder, NeedsSep)
-  when is_function(ElemEncoder) and is_function(SepEncoder) ->
+  when is_function(ElemEncoder), is_function(SepEncoder) ->
     case ElemEncoder(H, State) of
 	[] ->
 	    do_enc_list(T, State, ElemEncoder, SepEncoder, NeedsSep);

--- a/lib/megaco/src/text/megaco_text_scanner.erl
+++ b/lib/megaco/src/text/megaco_text_scanner.erl
@@ -27,8 +27,6 @@
 -module('megaco_text_scanner').
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([scan/1, skip_sep_chars/2]).
 
 -include_lib("megaco/include/megaco.hrl").
@@ -136,7 +134,7 @@ tokens3(Chars, Line, Acc, Version) ->
     end.
 
 
-guess_version([C]) when (48 =< C) and (C =< 57) ->
+guess_version([C]) when 48 =< C, C =< 57 ->
     {ok, C-48};
 guess_version(Str) when is_list(Str) ->
     case (catch list_to_integer(Str)) of


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `megaco`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.