### PR TITLE
`snmp`: Remove usages of `and` and `or`

### DIFF
--- a/lib/snmp/src/agent/snmpa_conf.erl
+++ b/lib/snmp/src/agent/snmpa_conf.erl
@@ -29,8 +29,6 @@ manipulating (write/read/append) the config files of the SNMP agent.
 
 """.
 
--compile(nowarn_obsolete_bool_op).
-
 -include("snmp_internal.hrl").
 
 
@@ -442,7 +440,7 @@ info.
       Conf :: [agent_entry()].
 
 write_agent_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_framework_mib:order_agent/2,
     Check = fun snmp_framework_mib:check_agent/2,
     Write = fun (Fd, Entries) -> write_agent_conf(Fd, Hdr, Entries) end,
@@ -462,7 +460,7 @@ info.
       Conf :: [agent_entry()].
 
 append_agent_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_framework_mib:order_agent/2,
     Check = fun snmp_framework_mib:check_agent/2,
     Write = fun write_agent_conf/2,
@@ -572,7 +570,7 @@ See [Contexts](snmp_agent_config_files.md#context) for more info.
       Conf :: [context_entry()].
 
 write_context_config(Dir, Hdr, Conf) 
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_context/2,
     Write = fun (Fd, Entries) -> write_context_conf(Fd, Hdr, Entries) end,
@@ -591,7 +589,7 @@ See [Contexts](snmp_agent_config_files.md#context) for more info.
       Conf :: [context_entry()].
 
 append_context_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_context/2,
     Write = fun write_context_conf/2,
@@ -730,7 +728,7 @@ See [Community](snmp_agent_config_files.md#community) for more info.
       Conf :: [community_entry()].
 
 write_community_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_community/2,
     Write = fun (Fd, Entries) -> write_community_conf(Fd, Hdr, Entries) end,
@@ -749,7 +747,7 @@ See [Community](snmp_agent_config_files.md#community) for more info.
       Conf :: [community_entry()].
 
 append_community_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_community/2,
     Write = fun write_community_conf/2,
@@ -886,7 +884,7 @@ info.
       Conf :: [standard_entry()].
 
 write_standard_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_standard/2,
     Write = fun (Fd, Entries) -> write_standard_conf(Fd, Hdr, Entries) end,
@@ -906,7 +904,7 @@ info.
       Conf :: [standard_entry()].
 
 append_standard_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_standard/2,
     Write = fun write_standard_conf/2,
@@ -1242,7 +1240,7 @@ more info.
       Conf :: [target_addr_entry()].
 
 write_target_addr_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_target_addr/2,
     Write = fun (Fd, Entries) -> write_target_addr_conf(Fd, Hdr, Entries) end,
@@ -1262,7 +1260,7 @@ more info.
       Conf :: [target_addr_entry()].
 
 append_target_addr_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_target_addr/2,
     Write = fun write_target_addr_conf/2,
@@ -1474,7 +1472,7 @@ for more info.
       Conf :: [target_params_entry()].
 
 write_target_params_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_target_params/2,
     Write = fun (Fd, Entries) -> write_target_params_conf(Fd, Hdr, Entries) end,
@@ -1494,7 +1492,7 @@ for more info.
       Conf :: [target_params_entry()].
 
 append_target_params_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_target_params/2,
     Write = fun write_target_params_conf/2,
@@ -1600,7 +1598,7 @@ See [Notify Definitions](snmp_agent_config_files.md#notify) for more info.
       Conf :: [notify_entry()].
 
 write_notify_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_notify/2,
     Write = fun (Fd, Entries) -> write_notify_conf(Fd, Hdr, Entries) end,
@@ -1619,7 +1617,7 @@ See [Notify Definitions](snmp_agent_config_files.md#notify) for more info.
       Conf :: [notify_entry()].
 
 append_notify_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_notify/2,
     Write = fun write_notify_conf/2,
@@ -1779,7 +1777,7 @@ See [Security data for USM](snmp_agent_config_files.md#usm) for more info.
       Conf :: [usm_entry()].
 
 write_usm_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_usm/2,
     Write = fun (Fd, Entries) -> write_usm_conf(Fd, Hdr, Entries) end,
@@ -1798,7 +1796,7 @@ See [Security data for USM](snmp_agent_config_files.md#usm) for more info.
       Conf :: [usm_entry()].
 
 append_usm_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_usm/2,
     Write = fun write_usm_conf/2,
@@ -1986,7 +1984,7 @@ See [MIB Views for VACM](snmp_agent_config_files.md#vacm) for more info.
       Conf :: [vacm_entry()].
 
 write_vacm_config(Dir, Hdr, Conf)
-  when is_list(Dir) and is_list(Hdr) and is_list(Conf) ->
+  when is_list(Dir), is_list(Hdr), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_vacm/2,
     Write = fun (Fd, Entries) -> write_vacm_conf(Fd, Hdr, Entries) end,
@@ -2005,7 +2003,7 @@ See [MIB Views for VACM](snmp_agent_config_files.md#vacm) for more info.
       Conf :: [vacm_entry()].
 
 append_vacm_config(Dir, Conf)
-  when is_list(Dir) and is_list(Conf) ->
+  when is_list(Dir), is_list(Conf) ->
     Order = fun snmp_conf:no_order/2,
     Check = fun check_vacm/2,
     Write = fun write_vacm_conf/2,

--- a/lib/snmp/src/agent/snmpa_get.erl
+++ b/lib/snmp/src/agent/snmpa_get.erl
@@ -25,8 +25,6 @@
 
 -behaviour(snmpa_get_mechanism).
 
--compile(nowarn_obsolete_bool_op).
-
 %%%-----------------------------------------------------------------
 %%% snmpa_get_mechanism exports
 %%%-----------------------------------------------------------------
@@ -1097,7 +1095,7 @@ do_get_bulk(MibView, NonRepeaters, MaxRepetitions,
  		{error, Idx, Reason} ->
 		    ?LIB:user_err("failed encoding varbind ~w:~n~p", [Idx, Reason]),
                     {genErr, Idx, []};
-                {SizeLeft, Res} when is_integer(SizeLeft) and is_list(Res) ->
+                {SizeLeft, Res} when is_integer(SizeLeft), is_list(Res) ->
  		    ?vtrace("do_get_bulk -> encoded: "
 			    "~n   SizeLeft: ~p"
 			    "~n   Res:      ~w", [SizeLeft, Res]),

--- a/lib/snmp/src/agent/snmpa_supervisor.erl
+++ b/lib/snmp/src/agent/snmpa_supervisor.erl
@@ -30,8 +30,6 @@ sub-agent).
 
 -behaviour(supervisor).
 
--compile(nowarn_obsolete_bool_op).
-
 %% External exports
 -export([start_link/2, stop/0, stop/1]).
 -export([start_sub_sup/1, start_master_sup/1]).
@@ -636,7 +634,7 @@ erase(Key) ->
 get_mibs(Mibs, Vsns) ->
     MibDir = filename:join(code:priv_dir(snmp), "mibs"),
     StdMib = 
-	case (lists:member(v2, Vsns) or lists:member(v3, Vsns)) of
+	case lists:member(v2, Vsns) orelse lists:member(v3, Vsns) of
 	    true  -> filename:join([MibDir, "SNMPv2-MIB"]);
 	    false -> filename:join([MibDir, "STANDARD-MIB"])
 	end,
@@ -707,7 +705,7 @@ conf1(Dir, Vsns, Func) ->
     snmp_notification_mib:Func(Dir),
     ?vdebug("~w snmp_view_based_acm_mib",[Func]),
     snmp_view_based_acm_mib:Func(Dir),
-    case lists:member(v1, Vsns) or lists:member(v2, Vsns) of
+    case lists:member(v1, Vsns) orelse lists:member(v2, Vsns) of
 	true ->
 	    ?vdebug("we need to handle v1 and/or v2 =>~n"
 		    "   ~w snmp_community_mib",[Func]),

--- a/lib/snmp/src/misc/snmp_config.erl
+++ b/lib/snmp/src/misc/snmp_config.erl
@@ -28,8 +28,6 @@
 -include("snmp_usm.hrl").
 -include("snmp_internal.hrl").
 
--compile(nowarn_obsolete_bool_op).
-
 %% Avoid warning for local function error/1 clashing with autoimported BIF.
 -compile({no_auto_import,[error/1]}).
 -export([config/0]).
@@ -586,7 +584,7 @@ config_agent_snmp(Dir, Vsns) ->
 		     "minimum", 
 		    fun verify_sec_type/1),
     Passwd = 
-	case lists:member(v3, Vsns) and (SecType /= none) of
+	case lists:member(v3, Vsns) andalso (SecType /= none) of
 	    true ->
 		ensure_crypto_started(),
 		ask("8b. Give a password of at least length 8. It is used to "
@@ -640,7 +638,7 @@ config_agent_snmp(Dir, Vsns) ->
 	     "read/write~n"
 	     "         access to the \"internet\" subtree."),
 	   i("      3. Standard traps are sent to the manager."),
-	   case lists:member(v1, Vsns) or lists:member(v2, Vsns) of
+	   case lists:member(v1, Vsns) orelse lists:member(v2, Vsns) of
 	       true ->
 		   i("      4. Community \"public\" is mapped to security name"
 		     " \"initial\"."),
@@ -1016,7 +1014,7 @@ default_dir(Component, DefDir) ->
 	    IsManagerDir = is_members(ManagerConfs, Files),
 	    Warning = 
 		if
-		    IsAgentDir and IsManagerDir ->
+		    IsAgentDir, IsManagerDir ->
 			"Note that the default directory contains both agent and manager config files";
 		    IsAgentDir ->
 			"Note that the default directory contains agent config files";

--- a/lib/snmp/src/misc/snmp_log.erl
+++ b/lib/snmp/src/misc/snmp_log.erl
@@ -23,8 +23,6 @@
 -module(snmp_log).
 -moduledoc false.
 
--compile(nowarn_obsolete_bool_op).
-
 -export([
 	 create/4, create/5, create/6, open/1, open/2, 
 	 change_size/2, close/1, sync/1, info/1, 
@@ -958,7 +956,7 @@ dat2str({{Y,M,D},{H,Min,S}}) ->
 
 
 timestamp_filter({Local,Universal},Start,Stop) ->
-    tsf_ge(Local,Universal,Start) and tsf_le(Local,Universal,Stop);
+    tsf_ge(Local,Universal,Start) andalso tsf_le(Local,Universal,Stop);
 timestamp_filter(_,_Start,_Stop) -> 
     true.
 


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `snmp`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.