### PR TITLE
`erts/preloaded`: Remove usages of `and` and `or`

### DIFF
--- a/erts/preloaded/src/prim_zip.erl
+++ b/erts/preloaded/src/prim_zip.erl
@@ -41,8 +41,6 @@
 -include_lib("stdlib/include/zip.hrl").  % #zip_file, #zip_comment
 -include("zip_internal.hrl").            % #cd_file_header etc
 
--compile(nowarn_obsolete_bool_op).
-
 %% max bytes read from files and archives (and fed to zlib)
 -define(READ_BLOCK_SIZE, 16*1024).
 
@@ -616,7 +614,7 @@ splitter(Left, Right, 0) ->
     {Left, Right};
 splitter(<<>>, Right, RelPos) ->
     split_iolist(Right, RelPos);
-splitter(Left, [A | Right], RelPos) when is_list(A) or is_binary(A) ->
+splitter(Left, [A | Right], RelPos) when is_list(A); is_binary(A) ->
     Sz = erlang:iolist_size(A),
     case Sz > RelPos of
 	true ->
@@ -640,7 +638,7 @@ skip_iolist(L, Pos) when is_list(L) ->
 
 skipper(Right, 0) ->
     Right;
-skipper([A | Right], RelPos) when is_list(A) or is_binary(A) ->
+skipper([A | Right], RelPos) when is_list(A); is_binary(A) ->
     Sz = erlang:iolist_size(A),
     case Sz > RelPos of
 	true ->


### PR DESCRIPTION
This PR removes remaining usages of `and` and `or` from `erts/preloaded`, as well as the then unneeded `nowarn_obsolete_bool_op` directives.