### PR TITLE
otp: Fix deterministic builds

### DIFF
--- a/lib/compiler/src/Makefile
+++ b/lib/compiler/src/Makefile
@@ -145,6 +145,7 @@ ERL_COMPILE_FLAGS += +inline +warn_unused_import \
 
 ifeq ($(ERL_DETERMINISTIC),yes)
 	DETERMINISM_FLAG = +deterministic
+	DEP_SKIP_FILES = core_parse.erl
 else
 	DETERMINISM_FLAG =
 endif

--- a/lib/edoc/src/Makefile
+++ b/lib/edoc/src/Makefile
@@ -51,6 +51,10 @@ XMERL = ../../xmerl
 ERL_COMPILE_FLAGS += -pa $(XMERL) -I../include -I$(XMERL)/include -I${ERL_TOP}/lib
 ERL_COMPILE_FLAGS += +warn_unused_vars +warn_unused_import +warn_deprecated_guard +no_docs +nowarn_missing_spec_documented +warn_deprecated_catch -Werror
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DEP_SKIP_FILES = edoc_parser.erl
+endif
+
 include files.mk
 
 OBJECTS=$(ERL_FILES:%.erl=$(EBIN)/%.$(EMULATOR)) $(APP_TARGET) $(APPUP_TARGET)

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -183,6 +183,7 @@ ERL_COMPILE_FLAGS += -I../include -I../../kernel/include
 
 ifeq ($(ERL_DETERMINISTIC),yes)
 	DETERMINISM_FLAG = +deterministic
+	DEP_SKIP_FILES = erl_parse.erl
 else
 	DETERMINISM_FLAG =
 endif

--- a/lib/tools/src/Makefile
+++ b/lib/tools/src/Makefile
@@ -82,6 +82,10 @@ CSS = $(PRIVDIR)/styles.css
 # ----------------------------------------------------
 ERL_COMPILE_FLAGS += -Werror +nowarn_deprecated_catch
 
+ifeq ($(ERL_DETERMINISTIC),yes)
+	DEP_SKIP_FILES = xref_parser.erl
+endif
+
 # ----------------------------------------------------
 # Targets
 # ----------------------------------------------------

--- a/lib/xmerl/src/Makefile
+++ b/lib/xmerl/src/Makefile
@@ -133,6 +133,14 @@ ERL_COMPILE_FLAGS += \
 
 ifeq ($(ERL_DETERMINISTIC),yes)
 	DETERMINISM_FLAG = +deterministic
+	DEP_SKIP_FILES = xmerl_b64Bin.erl \
+		xmerl_xpath_parse.erl \
+		xmerl_xsd_re_parse.erl \
+		xmerl_sax_parser_list.erl \
+		xmerl_sax_parser_latin1.erl \
+		xmerl_sax_parser_utf8.erl \
+		xmerl_sax_parser_utf16be.erl \
+		xmerl_sax_parser_utf16le.erl
 else
 	DETERMINISM_FLAG =
 endif

--- a/make/dep.mk
+++ b/make/dep.mk
@@ -30,12 +30,14 @@ DEPDIR=deps
 DEP_FILE=$(DEPDIR)/deps.mk
 $(shell mkdir -p $(dir $(DEP_FILE)) >/dev/null)
 
+DEP_FILTER_ERL_COMPILE_FLAGS=+deterministic
+
 DEP_REL_TOP?=../../
 
 deps: $(DEP_FILE)
 
 $(DEP_FILE): $(ERL_FILES) $(HRL_FILES) $(INTERNAL_HRL_FILES) $(EXTRA_DEP_DEPENDENCIES) $(ERL_TOP)/make/dep.mk Makefile
-	$(gen_verbose)erlc -M $(ERL_COMPILE_FLAGS) -o $(EBIN) $(filter-out $(DEP_SKIP_FILES), $(ERL_FILES)) \
+	$(gen_verbose)erlc -M $(filter-out $(DEP_FILTER_ERL_COMPILE_FLAGS), $(ERL_COMPILE_FLAGS)) -o $(EBIN) $(filter-out $(DEP_SKIP_FILES), $(ERL_FILES)) \
 	| perl -pe "s@ [a-zA-Z]?$(ERL_TOP_NATIVE)/(?:bootstrap/)?lib/([^/]+)@ $(DEP_REL_TOP)\1@g" 2> /dev/null \
 	> $(DEP_FILE)
 


### PR DESCRIPTION
When improving makefile dependencies, the deterministic build was accidentally broken. This skips deps for .yrl files and removes the deterministic flag from erlc -M.

closes #10734