### PR TITLE
ssh: Introduce option to limit the size of user_auth requests

### DIFF
--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1281,8 +1281,9 @@ in the User's Guide chapter.
 
 - **`max_auth_request_size`{:
   #hardening_daemon_options-max_auth_request_size }** - The maximum size allowed
-  in bytes for SSH_MSG_USERAUTH_REQUEST packets. The default is maximum allowed
-  packet size which is 262144 bytes, which is the same as no check being made,
+  in bytes for the SSH_MSG_USERAUTH_REQUEST messages. The default value
+  is the maximum allowed packet size, 262144 bytes,
+  which is the same as no check being made,
   since maximum allowed packet size check is performed earlier.
 """.
 -doc(#{group => <<"Daemon Options">>}).

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1278,13 +1278,19 @@ in the User's Guide chapter.
   #hardening_daemon_options-minimal_remote_max_packet_size }** - The least
   maximum packet size that the daemon will accept in channel open requests from
   the client. The default value is 0.
+
+- **`max_auth_request_size`{:
+  #hardening_daemon_options-max_auth_request_size }** - The maximum size allowed
+  in bytes for SSH_MSG_USERAUTH_REQUEST packets. The default is maximum allowed
+  packet size which is 262144 bytes.
 """.
 -doc(#{group => <<"Daemon Options">>}).
 -type hardening_daemon_options() ::
         {max_sessions, pos_integer()}
       | {max_channels, pos_integer()}
       | {parallel_login, boolean()}
-      | {minimal_remote_max_packet_size, pos_integer()}.
+      | {minimal_remote_max_packet_size, pos_integer()}
+      | {max_auth_request_size, pos_integer()}.
 
 -doc """
 - **`connectfun`** - Provides a fun to implement your own logging when a user

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1282,7 +1282,8 @@ in the User's Guide chapter.
 - **`max_auth_request_size`{:
   #hardening_daemon_options-max_auth_request_size }** - The maximum size allowed
   in bytes for SSH_MSG_USERAUTH_REQUEST packets. The default is maximum allowed
-  packet size which is 262144 bytes.
+  packet size which is 262144 bytes, which is the same as no check being made,
+  since maximum allowed packet size check is performed earlier.
 """.
 -doc(#{group => <<"Daemon Options">>}).
 -type hardening_daemon_options() ::

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1206,6 +1206,20 @@ handle_event(info, {Proto, Sock, NewData}, StateName,
                 #ssh_msg_channel_failure{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
                 #ssh_msg_channel_success{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
 
+                #ssh_msg_userauth_request{} = Msg ->
+                    case ?GET_OPT(max_auth_request_size, (D2#data.ssh_params)#ssh.opts) of
+                        MaxAuthRequestSize when size(DecryptedBytes) > MaxAuthRequestSize ->
+                            {Shutdown, D} =
+                                ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
+                                                 "Auth length exceeded.", "Auth length exceeded.",
+                                                 StateName, D2),
+                            {stop, Shutdown, D};
+                        _ ->
+                            {keep_state, D2, [{next_event, internal, prepare_next_packet},
+                                              {next_event, internal, Msg}
+                                             ]}
+                    end;
+
 		Msg ->
 		    {keep_state, D2, [{next_event, internal, prepare_next_packet},
                                       {next_event, internal, Msg}

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1207,11 +1207,16 @@ handle_event(info, {Proto, Sock, NewData}, StateName,
                 #ssh_msg_channel_success{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
 
                 #ssh_msg_userauth_request{} = Msg ->
+                    DecryptedSize = byte_size(DecryptedBytes),
                     case ?GET_OPT(max_auth_request_size, (D2#data.ssh_params)#ssh.opts) of
-                        MaxAuthRequestSize when size(DecryptedBytes) > MaxAuthRequestSize ->
+                        MaxAuthRequestSize when DecryptedSize > MaxAuthRequestSize ->
+                            DetailedMsg = io_lib:format("Auth length exceeded, packet has ~B bytes"
+                                                        " and the maximum is ~B bytes.",
+                                                       [DecryptedSize, MaxAuthRequestSize]),
                             {Shutdown, D} =
                                 ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
-                                                 "Auth length exceeded.", "Auth length exceeded.",
+                                                 "Auth length exceeded.",
+                                                 DetailedMsg,
                                                  StateName, D2),
                             {stop, Shutdown, D};
                         _ ->

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1210,7 +1210,7 @@ handle_event(info, {Proto, Sock, NewData}, StateName,
                     DecryptedSize = byte_size(DecryptedBytes),
                     case ?GET_OPT(max_auth_request_size, (D2#data.ssh_params)#ssh.opts) of
                         MaxAuthRequestSize when DecryptedSize > MaxAuthRequestSize ->
-                            DetailedMsg = io_lib:format("Auth length exceeded, packet has ~B bytes"
+                            DetailedMsg = io_lib:format("Auth length exceeded, message has ~B bytes"
                                                         " and the maximum is ~B bytes.",
                                                        [DecryptedSize, MaxAuthRequestSize]),
                             {Shutdown, D} =

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -627,6 +627,12 @@ default(server) ->
             class => user_option
            },
 
+      max_auth_request_size =>
+          #{default => ?SSH_MAX_PACKET_SIZE,
+            chk => fun(V) -> check_pos_integer(V) end,
+            class => user_option
+           },
+
 %%%%% Undocumented
       infofun =>
           #{default => fun(_,_,_) -> void end,

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -94,7 +94,10 @@
          daemon_replace_options_not_found/1,
          daemon_loopback_binding/1,
          pk_check_user_option/1,
-         pwdfun_lockout_ets/1
+         pwdfun_lockout_ets/1,
+         max_auth_request_size_large_enough/1,
+         max_auth_request_size_too_small/1,
+         max_auth_request_size_invalid_option/1
 	]).
 
 %%% Common test callbacks
@@ -167,7 +170,8 @@ all() ->
      daemon_replace_options_algs_connect,
      daemon_replace_options_algs_conf_file,
      daemon_replace_options_not_found,
-     {group, hardening_tests}
+     {group, hardening_tests},
+     {group, max_auth_request_size}
     ].
 
 groups() ->
@@ -186,7 +190,10 @@ groups() ->
 			   ]},
      {dir_options, [], [user_dir_option,
                         user_dir_fun_option,
-			system_dir_option]}
+			system_dir_option]},
+     {max_auth_request_size, [], [max_auth_request_size_large_enough,
+                                  max_auth_request_size_too_small,
+                                  max_auth_request_size_invalid_option]}
     ].
 
 
@@ -2095,6 +2102,68 @@ daemon_replace_options_not_found(_Config) ->
     %% which is {error, bad_daemon_ref}
     Error = ssh:daemon_info(self()),
     Error = ssh:daemon_replace_options(self(), []).
+
+
+%%--------------------------------------------------------------------
+%%% Test that a normal-sized auth request succeeds with an explicit large limit
+max_auth_request_size_large_enough(Config) when is_list(Config) ->
+    UserDir = proplists:get_value(user_dir, Config),
+    SysDir = proplists:get_value(data_dir, Config),
+    %% Set a large enough limit that normal auth requests pass through
+    {Pid, Host, Port} = ssh_test_lib:daemon([{system_dir, SysDir},
+					     {user_dir, UserDir},
+					     {password, "morot"},
+					     {max_auth_request_size, 1024},
+					     {failfun, fun ssh_test_lib:failfun/2}]),
+
+    ConnectionRef =
+	ssh_test_lib:connect(Host, Port, [{silently_accept_hosts, true},
+					  {user, "foo"},
+					  {password, "morot"},
+					  {user_interaction, false},
+					  {user_dir, UserDir}]),
+    ssh:close(ConnectionRef),
+    ssh:stop_daemon(Pid).
+
+%%--------------------------------------------------------------------
+%%% Test that a normal-sized auth request is rejected when max_auth_request_size
+%%% is set to small value
+max_auth_request_size_too_small(Config) when is_list(Config) ->
+    UserDir = proplists:get_value(user_dir, Config),
+    SysDir = proplists:get_value(data_dir, Config),
+    %% Set a very small limit so that even a normal password auth request
+    %% exceeds the max_auth_request_size and the server disconnects
+    {Pid, Host, Port} = ssh_test_lib:daemon([{system_dir, SysDir},
+					     {user_dir, UserDir},
+					     {password, "morot"},
+					     {max_auth_request_size, 1},
+					     {failfun, fun ssh_test_lib:failfun/2}]),
+
+    {error, "Auth length exceeded."} =
+	ssh:connect(Host, Port, [{silently_accept_hosts, true},
+                                 {save_accepted_host, false},
+				 {user, "foo"},
+				 {password, "morot"},
+				 {user_interaction, false},
+				 {user_dir, UserDir}]),
+    ssh:stop_daemon(Pid).
+
+%%--------------------------------------------------------------------
+%%% Test that the option validation rejects invalid max_auth_request_size values
+max_auth_request_size_invalid_option(Config) when is_list(Config) ->
+    SysDir = proplists:get_value(data_dir, Config),
+    %% zero value should be rejected
+    {error, {eoptions, _}} = ssh:daemon(0, [{system_dir, SysDir},
+                                            {max_auth_request_size, 0}]),
+    %% Negative value should be rejected
+    {error, {eoptions, _}} = ssh:daemon(0, [{system_dir, SysDir},
+                                            {max_auth_request_size, -1}]),
+    %% Non-integer value should be rejected
+    {error, {eoptions, _}} = ssh:daemon(0, [{system_dir, SysDir},
+                                            {max_auth_request_size, "not_an_integer"}]),
+    %% Atom value should be rejected
+    {error, {eoptions, _}} = ssh:daemon(0, [{system_dir, SysDir},
+                                            {max_auth_request_size, infinity}]).
 
 %%--------------------------------------------------------------------
 daemon_loopback_binding(Config) ->

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -190,7 +190,7 @@ groups() ->
 			   ]},
      {dir_options, [], [user_dir_option,
                         user_dir_fun_option,
-			system_dir_option]},
+                        system_dir_option]},
      {max_auth_request_size, [], [max_auth_request_size_large_enough,
                                   max_auth_request_size_too_small,
                                   max_auth_request_size_invalid_option]}
@@ -2111,17 +2111,17 @@ max_auth_request_size_large_enough(Config) when is_list(Config) ->
     SysDir = proplists:get_value(data_dir, Config),
     %% Set a large enough limit that normal auth requests pass through
     {Pid, Host, Port} = ssh_test_lib:daemon([{system_dir, SysDir},
-					     {user_dir, UserDir},
-					     {password, "morot"},
-					     {max_auth_request_size, 1024},
-					     {failfun, fun ssh_test_lib:failfun/2}]),
+                                             {user_dir, UserDir},
+                                             {password, "morot"},
+                                             {max_auth_request_size, 1024},
+                                             {failfun, fun ssh_test_lib:failfun/2}]),
 
     ConnectionRef =
-	ssh_test_lib:connect(Host, Port, [{silently_accept_hosts, true},
-					  {user, "foo"},
-					  {password, "morot"},
-					  {user_interaction, false},
-					  {user_dir, UserDir}]),
+        ssh_test_lib:connect(Host, Port, [{silently_accept_hosts, true},
+                                          {user, "foo"},
+                                          {password, "morot"},
+                                          {user_interaction, false},
+                                          {user_dir, UserDir}]),
     ssh:close(ConnectionRef),
     ssh:stop_daemon(Pid).
 
@@ -2134,18 +2134,18 @@ max_auth_request_size_too_small(Config) when is_list(Config) ->
     %% Set a very small limit so that even a normal password auth request
     %% exceeds the max_auth_request_size and the server disconnects
     {Pid, Host, Port} = ssh_test_lib:daemon([{system_dir, SysDir},
-					     {user_dir, UserDir},
-					     {password, "morot"},
-					     {max_auth_request_size, 1},
-					     {failfun, fun ssh_test_lib:failfun/2}]),
+                                             {user_dir, UserDir},
+                                             {password, "morot"},
+                                             {max_auth_request_size, 1},
+                                             {failfun, fun ssh_test_lib:failfun/2}]),
 
     {error, "Auth length exceeded."} =
-	ssh:connect(Host, Port, [{silently_accept_hosts, true},
+        ssh:connect(Host, Port, [{silently_accept_hosts, true},
                                  {save_accepted_host, false},
-				 {user, "foo"},
-				 {password, "morot"},
-				 {user_interaction, false},
-				 {user_dir, UserDir}]),
+                                 {user, "foo"},
+                                 {password, "morot"},
+                                 {user_interaction, false},
+                                 {user_dir, UserDir}]),
     ssh:stop_daemon(Pid).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Introduce option to limit the size of ssh_msg_userauth_request requests.

It can be possible to cause harm to an erlang system that uses SSH by sending several big ssh_msg_user_auth_requests.

Without MaxAuthTries (https://man7.org/linux/man-pages/man5/sshd_config.5.html) a malicious actor can use the same connection. Without a single connection can be used to generate harmful garbage and trigger issues.

I believe that both options have their place hardening the system. Depending on how the erlang system uses SSH one option or both may be useful.