### PR TITLE
Fix unused variable warning in tut14 example

### DIFF
--- a/system/doc/getting_started/conc_prog.md
+++ b/system/doc/getting_started/conc_prog.md
@@ -49,7 +49,7 @@ module:
 
 -export([start/0, say_something/2]).
 
-say_something(What, 0) ->
+say_something(_What, 0) ->
     done;
 say_something(What, Times) ->
     io:format("~p~n", [What]),


### PR DESCRIPTION
### Summary

The example code for `tut14` currently triggers a compiler warning:

```erlang
say_something(What, 0) ->
    done;
say_something(What, Times) ->
    io:format("~p~n", [What]),
    say_something(What, Times - 1).
```

### Warning

```
1> c(tut14).
tut14.erl:5:15: Warning: variable 'What' is unused
%    5| say_something(What, 0) ->
%     |               ^

{ok,tut14}
```

**Problem**:
In the base case `(say_something(What, 0))`, the variable `What` is not used. This causes a compiler warning and may confuse learners.

**Solution**:
Rename the variable to `_What` in the base case to indicate it is intentionally unused:

```erlang
say_something(_What, 0) ->
    done;
```