### PR TITLE
github: Disable iOS build as it fails to compile zlib

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -273,7 +273,9 @@ jobs:
     name: Build Erlang/OTP (iOS)
     runs-on: macos-15
     needs: pack
-    if: needs.pack.outputs.build-c-code == 'true'
+    # DISABLED. Fails to build erts/emulator/zlib/
+    if: false
+    # if: needs.pack.outputs.build-c-code == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download source archive


### PR DESCRIPTION
Started to fail since zlib was updated in 7b9f48ac86cf589447d228aebde9d316bb692861.

`zlib/zconf.h:450:5: error: 'HAVE_STDARG_H' is not defined, evaluates to 0 [-Werror,-Wundef]`


@dominicletz