### PR TITLE
otp: fixes small issues in gh actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,6 +56,7 @@ env:
 permissions:
   contents: read
   pull-requests: read
+  security-events: read
 
 jobs:
 
@@ -646,7 +647,7 @@ jobs:
       - name: Check OSSF compiler flags
         uses: ./.github/actions/ossf-compiler-flags-scanner
         with:
-          upload: true
+          upload: ${{ github.repository == 'erlang/otp' || github.event_name != 'push' }}
 
   test:
     name: Test Erlang/OTP

--- a/.github/workflows/ossf-compiler-flags-scanner.yaml
+++ b/.github/workflows/ossf-compiler-flags-scanner.yaml
@@ -30,6 +30,7 @@ on:
 
 permissions:
   contents: read
+  security-events: read
 
 jobs:
   schedule-scan:


### PR DESCRIPTION
the github action `ossf-compiler-flags-scanner.yaml` needs
`security-events: read` permissions.

Some fixes of #10724 should have been ported to `maint` (the permissions are required)
