### PR TITLE
Fix erl_tar:extract/1,2 spec mismatch

### DIFF
--- a/lib/stdlib/src/erl_tar.erl
+++ b/lib/stdlib/src/erl_tar.erl
@@ -317,10 +317,10 @@ The following options modify the defaults for the extraction as follows:
 > with `{file,Fd}`. The file is assumed to have been opened with the appropriate
 > flags.
 """.
--spec extract(Open :: open_type(), [extract_opt()]) ->
-                     {ok, [{string(), binary()}]} |
-                     {error, term()} |
-                     ok.
+-spec extract(Open :: open_type(), []) ->
+                     ok | {error, term()};
+             (Open :: open_type(), [extract_opt(), ...]) ->
+                     ok | {ok, [{string(), binary()}]} | {error, term()}.
 extract({binary, Bin}, Opts) when is_list(Opts) ->
     do_extract({binary, Bin}, Opts);
 extract({file, Fd}, Opts) when is_list(Opts) ->


### PR DESCRIPTION
This allows a set-theoretic type checker to tell when `extract/2` might or might not return `{ok, [{string(), binary()}]}`, so when checking `extract/1` it can ensure compatibility by picking the right spec clause of `extract/2`.

Alternatively, we could extend the spec of `extract/1` to include `{ok, [{string(), binary()}]}`, though that would be less precise.