### PR TITLE
remove unnecessary 1 second sleep from user_sup terminate

### DIFF
--- a/lib/kernel/src/user_sup.erl
+++ b/lib/kernel/src/user_sup.erl
@@ -82,16 +82,9 @@ relay1(Pid) ->
 	    relay1(Pid)
     end.
 
-
-%%-----------------------------------------------------------------
-%% Sleep a while in order to let user write all (some) buffered 
-%% information before termination.
-%%-----------------------------------------------------------------
-
 -spec terminate(term(), pid()) -> 'ok'.
 
 terminate(_Reason, UserPid) ->
-    receive after 1000 -> ok end,
     exit(UserPid, kill),
     ok.
 


### PR DESCRIPTION
I talked to @jhogberg a bit ago and he believed this wait was not necessary because the buffer was handled elsewhere.

If there is a good way to test this, aside from just if the current tests pass, I'm willing to add a test.

I'm still trying to get checks to build locally, but figured I'd open this since I meant to open it weeks ago :)