### PR TITLE
Fail compilation for failed creation of a local record

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -828,6 +828,18 @@ value are listed.
   behaviour module returns a badly formed list of functions. Use this
   option to turn off this kind of warning.
 
+- **`nowarn_novalue`** - Disable warnings for creating a
+  native record without giving values for all fields. Note that this
+  kind of warning is only emitted when the module name for the record
+  is explicitly given as the current module; when no module name is
+  given, not initializing all fields is a compilation error.
+
+- **`nowarn_undefined_field`** - Disable warnings for referencing
+  field names not present in the local native record definition.  This
+  warning is emitted when accessing, matching, or updating a native
+  record. It can also be emitted when creating a record if the module
+  name for the record is explicitly given as the current module.
+
 Other kinds of warnings are _opportunistic warnings_. They are generated when
 the compiler happens to notice potential issues during optimization and code
 generation.

--- a/lib/compiler/test/native_record_SUITE.erl
+++ b/lib/compiler/test/native_record_SUITE.erl
@@ -45,10 +45,11 @@
 -record #Point{x=0,y=0,z=0}.
 
 %% Other exported records.
--export_record([b, exp_abc, exp_x]).
+-export_record([b, exp_abc, exp_x, exp_xyz]).
 -record #b{x=none, y=none, z=none}.
 -record #exp_abc{a=0, b=0}.
 -record #exp_x{x=0}.
+-record #exp_xyz{x, y, z}.
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -109,18 +110,16 @@ local_basic(_Config) ->
     a = NameFun(ARec),
     b = NameFun(BRec),
 
-    %% Test errors when constructing or updating native records.
-    ?assertError({badfield,{{?MODULE,b},foobar}},
-                 #b{foobar = some_value}),
+    %% Test errors when creating native records.
+    ?assertError({badfield,{{?MODULE,exp_abc},z}}, #?MODULE:exp_abc{z=99}),
+    ?assertError({novalue,{{?MODULE,exp_xyz},x}}, #?MODULE:exp_xyz{}),
+    ?assertError({badrecord,{?MODULE,a}}, #?MODULE:a{}),
 
+    %% Test errors when updating native records.
     ?assertError({badrecord,not_a_record}, (not_a_record)#b{x=99}),
     ?assertError({badrecord,ARec}, ARec#b{x=99}),
     ?assertError({badfield,{{?MODULE,b},bad_field}},
                  BRec#b{bad_field = some_value}),
-
-    ?assertError({novalue,{{?MODULE,a},x}}, #a{}),
-    ?assertError({novalue,{{?MODULE,a},y}}, #a{x=1}),
-    ?assertError({novalue,{{?MODULE,a},x}}, #a{y=1}),
 
     %% Test errors when accessing native records
     ?assertError({badfield,{{?MODULE,b},zoo}}, BRec#b.zoo),

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -469,10 +469,9 @@ format_error_1({redefine_local_record,R}) ->
     {~"record ~ts is already defined locally", [format_record_name(R)]};
 format_error_1({undefined_native_record,T}) ->
     {~"native record ~tw undefined", [T]};
-format_error_1({undefined_native_record_field,N,F}) ->
-    {~"field ~tw not defined in native record ~ts", [F,format_record_name(N)]};
-format_error_1({no_init_native_record_field,N,F}) ->
-    {~"field ~tw is not initialized in native record ~ts", [F,format_record_name(N)]};
+format_error_1({novalue,N,F}) ->
+    {~"field ~tw is not initialized in native record ~ts",
+     [F,format_record_name(N)]};
 format_error_1({illegal_native_record_default,N,F}) ->
     {~"illegal default value for field ~tw in native record ~tw", [F,N]};
 format_error_1({native_record_illegal_record_index,Name,F}) ->
@@ -489,9 +488,10 @@ format_error_1(tuple_record_export) ->
 format_error_1(bad_multi_field_init) ->
     {~"'_' initializes no omitted fields", []};
 format_error_1({undefined_field,T,F}) ->
-    {~"field ~tw undefined in record ~tw", [F,T]};
+    {~"field ~tw undefined in record ~ts", [F,format_record_name(T)]};
 format_error_1({undefined_field,T,F,GuessF}) ->
-    {~"field ~tw undefined in record ~tw, did you mean ~ts?", [F,T,GuessF]};
+    {~"field ~tw undefined in record ~tw, did you mean ~ts?",
+     [F,format_record_name(T),GuessF]};
 format_error_1(native_record_illegal_record_info) ->
     ~"record_info/2 is only supported for tuple records";
 format_error_1(illegal_record_info) ->
@@ -937,7 +937,10 @@ bool_options() ->
      {undefined_behaviour_callbacks,true},
      {ill_defined_behaviour_callbacks,true},
      {ill_defined_optional_callbacks,true},
-     {unexported_function,true}].
+     {unexported_function,true},
+     {novalue,true},
+     {undefined_field,true}
+    ].
 
 %% is_warn_enabled(Category, St) -> boolean().
 %%  Check whether a warning of category Category is enabled.
@@ -3515,6 +3518,17 @@ suggest_record_name(Anno, Error, Name, St) ->
             add_error(Anno, {Error,Name,GuessF}, St)
     end.
 
+suggest_field_name(Anno, Error, Name, F, Fields, St) ->
+    FieldNames = [atom_to_list(R) ||
+                     {record_field, _L, {_, _, R}, _} <:- Fields],
+    Reason = case most_possible_string(F, FieldNames) of
+                 [] ->
+                     {Error,Name,F};
+                 GuessF ->
+                     {Error,Name,F,GuessF}
+             end,
+    add_error(Anno, Reason, St).
+
 used_record(Name, #lint{usage=Usage}=St) ->
     UsedRecs = gb_sets:add_element(Name, Usage#usage.used_records),
     St#lint{usage = Usage#usage{used_records=UsedRecs}}.
@@ -3524,66 +3538,71 @@ used_record(Name, #lint{usage=Usage}=St) ->
 %% check_fields([ChkField], RecordName, [RecDefField], VarTable, State, CheckFun) ->
 %%      {UpdVarTable,State}.
 
-check_fields(Fs, Flavor, Name, Fields, Vt0, St0, CheckFun) ->
+check_fields(Fs, Flavor, Name, Fields, Vt0, St0, CheckFun, DiagFlavor) ->
     {_SeenFields,Uvt,St1} =
         foldl(fun (Field, {Rfsa,Vta,Sta}) ->
                       {Rfsb,{Vtb,Stb}} = check_field(Field, Flavor, Name, Fields,
-                                                     Vt0, Sta, Rfsa, CheckFun),
+                                                     Vt0, Sta, Rfsa, CheckFun,
+                                                     DiagFlavor),
                       {Vt1, St1} = vtmerge_pat(Vta, Vtb, Stb),
                       {Rfsb, Vt1, St1}
               end, {[],[], St0}, Fs),
     {Uvt,St1}.
 
 check_field({record_field,_Af,_F,Val}, native, _Name, unknown,
-            Vt, St0, Rfs, CheckFun) ->
+            Vt, St0, Rfs, CheckFun, _DiagFlavor) ->
     {Rfs, CheckFun(Val, Vt, St0)};
 check_field({record_field,Af,{atom,Aa,F},Val}, Flavor, Name, Fields,
-            Vt, St0, Rfs, CheckFun) ->
+            Vt, St0, Rfs, CheckFun, DiagFlavor) ->
     case member(F, Rfs) of
         true ->
             {Rfs,{[],add_error(Af, {redefine_field,Name,F}, St0)}};
         false ->
-            {[F|Rfs],
-             case find_field(F, Fields) of
-                 {ok,_} ->
-                     case Flavor of
-                         native ->
-                             case Val of
-                                 {no_value,Anno} ->
-                                     W = {no_init_native_record_field, Name, F},
-                                     {[], add_warning(Anno, W, St0)};
-                                 _ ->
-                                     CheckFun(Val, Vt, St0)
-                             end;
-                         tuple ->
-                             CheckFun(Val, Vt, St0)
-                     end;
-                 error when Flavor =:= native ->
-                     {[],add_warning(Aa, {undefined_native_record_field,Name,F}, St0)};
-                 error ->
-                     FieldNames = [atom_to_list(R) ||
-                                      {record_field, _L, {_, _, R}, _} <:- Fields],
-                     case most_possible_string(F, FieldNames) of
-                         [] ->
-                             {[],add_error(Aa, {undefined_field,Name,F}, St0)};
-                         GuessF ->
-                             {[],add_error(Aa, {undefined_field,Name,F,GuessF}, St0)}
-                     end
-             end}
+            check_existing_field(Aa, F, Val, Flavor, Name, Fields, Vt, St0,
+                                 Rfs, CheckFun, DiagFlavor)
     end;
 check_field({record_field,_Af,{var,Aa,'_'=F},Val}, tuple, _Name, _Fields,
-            Vt, St, Rfs, CheckFun) ->
+            Vt, St, Rfs, CheckFun, _DiagFlavor) ->
     %% Multi-field init for tuple records.
     case member(F, Rfs) of
         true -> {Rfs,{[],add_error(Aa, bad_multi_field_init, St)}};
         false -> {[F|Rfs],CheckFun(Val, Vt, St)}
     end;
 check_field({record_field,_Af,{var,Aa,'_'},_Val}, native, _Name, _Fields,
-            _Vt, St, Rfs, _CheckFun) ->
+            _Vt, St, Rfs, _CheckFun, _DiagFlavor) ->
     {Rfs,{[],add_error(Aa, native_record_illegal_multi_field_init, St)}};
 check_field({record_field,_Af,{var,Aa,V},_Val}, _Flavor, Name, _Fields,
-            Vt, St, Rfs, _CheckFun) ->
+            Vt, St, Rfs, _CheckFun, _DiagFlavor) ->
     {Rfs,{Vt,add_error(Aa, {field_name_is_variable,Name,V}, St)}}.
+
+check_existing_field(Aa, F, Val, Flavor, Name, Fields, Vt, St0,
+                     Rfs, CheckFun, DiagFlavor) ->
+    {[F|Rfs],
+     case find_field(F, Fields) of
+         {ok,_} ->
+             case Flavor of
+                 native ->
+                     case Val of
+                         {no_value,Anno} ->
+                             W = {novalue, Name, F},
+                             case DiagFlavor of
+                                 error ->
+                                     {[], add_error(Anno, W, St0)};
+                                 warning ->
+                                     {[], maybe_add_warning(Anno, W, St0)}
+                             end;
+                         _ ->
+                             CheckFun(Val, Vt, St0)
+                     end;
+                 tuple ->
+                     CheckFun(Val, Vt, St0)
+             end;
+         error when Flavor =:= native, DiagFlavor =:= warning ->
+             {[],maybe_add_warning(Aa, {undefined_field,Name,F}, St0)};
+         error ->
+             E = undefined_field,
+             {[], suggest_field_name(Aa, E, Name, F, Fields, St0)}
+     end}.
 
 %% pattern_field(Field, RecordName, [RecDefField], State) ->
 %%      {UpdVarTable,State}.
@@ -3591,13 +3610,11 @@ check_field({record_field,_Af,{var,Aa,V},_Val}, _Flavor, Name, _Fields,
 
 pattern_field({atom,Aa,F}, Name, Fields, St) ->
     case find_field(F, Fields) of
-        {ok,_I} -> {[],St};
+        {ok,_I} ->
+            {[],St};
         error ->
-            FieldNames = [atom_to_list(R) || {record_field, _L, {_, _, R}, _} <- Fields],
-            case most_possible_string(F, FieldNames) of
-                [] -> {[],add_error(Aa, {undefined_field,Name,F}, St)};
-                GuessF -> {[],add_error(Aa, {undefined_field,Name,F,GuessF}, St)}
-            end
+            E = undefined_field,
+            {[],suggest_field_name(Aa, E, Name, F, Fields, St)}
     end.
 
 %% pattern_fields([PatField],RecordName,[RecDefField],
@@ -3609,7 +3626,7 @@ pattern_fields(Fs, Name, Fields, Vt0, Old, St0) ->
     {_SeenFields,Uvt,Unew,St1} =
         foldl(fun (Field, {Rfsa,Vta,Newa,Sta}) ->
                       case check_field(Field, tuple, Name, Fields,
-                                       Vt0, Sta, Rfsa, CheckFun) of
+                                       Vt0, Sta, Rfsa, CheckFun, false) of
                           {Rfsb,{Vtb,Stb}} ->
                               {Vt, St1} = vtmerge_pat(Vta, Vtb, Stb),
                               {Rfsb, Vt, [], St1};
@@ -3631,15 +3648,9 @@ record_field({atom,Anno,F}, Flavor, Name, Fields, St) ->
     case find_field(F, Fields) of
         {ok,_I} -> {[],St};
         error when Flavor =:= native ->
-            {[],add_warning(Anno, {undefined_native_record_field,Name,F}, St)};
+            {[],maybe_add_warning(Anno, {undefined_field,Name,F}, St)};
         error ->
-            FieldNames = [atom_to_list(R) || {record_field, _L, {_, _, R}, _} <- Fields],
-            case most_possible_string(F, FieldNames) of
-                [] ->
-                    {[],add_error(Anno, {undefined_field,Name,F}, St)};
-                GuessF ->
-                    {[],add_error(Anno, {undefined_field,Name,F,GuessF}, St)}
-            end
+            {[],suggest_field_name(Anno, undefined_field, Name, F, Fields, St)}
     end.
 
 %% init_fields([InitField], InitAnno, RecordName, [DefField], VarTable, State) ->
@@ -3658,17 +3669,25 @@ init_fields(native, Ifs, _Anno, Name, unknown, Vt0, St0) ->
     check_nn_fields(Name, Ifs, Vt0, St0);
 init_fields(Flavor, Ifs, Anno, Name, Dfs, Vt0, St0)
   when Flavor =:= tuple; Flavor =:= native ->
-    {Vt1,St1} = check_fields(Ifs, Flavor, Name, Dfs, Vt0, St0, fun expr/3),
+    DiagFlavor = case Name of
+                     {_, _} -> warning;
+                     _ -> error
+                 end,
+    {Vt1,St1} = check_fields(Ifs, Flavor, Name, Dfs, Vt0, St0,
+                             fun expr/3, DiagFlavor),
     if
         Flavor =:= native, St0#lint.errors =/= St1#lint.errors ->
             %% Don't check for more errors and warnings.
             {Vt1,St1};
         true ->
             Defs = init_fields(Ifs, Anno, Dfs),
-            {_,St2} = check_fields(Defs, Flavor, Name, Dfs, Vt1, St1, fun expr/3),
+            {_,St2} = check_fields(Defs, Flavor, Name, Dfs, Vt1, St1,
+                                   fun expr/3, DiagFlavor),
             case Flavor of
                 native ->
-                    {Vt1,St1#lint{usage = St2#lint.usage, warnings=St2#lint.warnings}};
+                    {Vt1,St1#lint{usage = St2#lint.usage,
+                                  errors=St2#lint.errors,
+                                  warnings=St2#lint.warnings}};
                 tuple ->
                     {Vt1,St1#lint{usage = St2#lint.usage}}
             end
@@ -3676,10 +3695,12 @@ init_fields(Flavor, Ifs, Anno, Name, Dfs, Vt0, St0)
 
 ginit_fields(Ifs, Anno, Name, Dfs, Vt0, St0) ->
     Flavor = tuple,
-    {Vt1,St1} = check_fields(Ifs, Flavor, Name, Dfs, Vt0, St0, fun gexpr/3),
+    {Vt1,St1} = check_fields(Ifs, Flavor, Name, Dfs, Vt0, St0,
+                             fun gexpr/3, error),
     Defs = init_fields(Ifs, Anno, Dfs),
     St2 = St1#lint{errors = []},
-    {_,St3} = check_fields(Defs, Flavor, Name, Dfs, Vt1, St2, fun gexpr/3),
+    {_,St3} = check_fields(Defs, Flavor, Name, Dfs, Vt1, St2,
+                           fun gexpr/3, error),
     #lint{usage = Usage, errors = IllErrors} = St3,
     St4 = St1#lint{usage = Usage, errors = IllErrors ++ St1#lint.errors},
     {Vt1,St4}.
@@ -3694,7 +3715,7 @@ init_fields(Ifs, Anno, Dfs) ->
 %%      {UpdVarTable,State}
 
 update_fields(Ufs, Flavor, Name, Dfs, Vt, St) ->
-    check_fields(Ufs, Flavor, Name, Dfs, Vt, St, fun expr/3).
+    check_fields(Ufs, Flavor, Name, Dfs, Vt, St, fun expr/3, warning).
 
 %% exist_field(FieldName, [Field]) -> boolean().
 %%  Find a record field in a field list.
@@ -3766,7 +3787,8 @@ check_native_record_fields_usage(Name, Fs, St0) ->
                               true ->
                                   St;
                               false ->
-                                  add_warning(Af, {undefined_native_record_field, Name, F}, St)
+                                  E = {undefined_field, Name, F},
+                                  maybe_add_warning(Af, E, St)
                           end
                   end, St0, Fs);
         #{} ->
@@ -4038,11 +4060,8 @@ check_record_types([{type, _, field_type, [{atom, Anno, FName}, Type]}|Left],
     St1 = case exist_field(FName, DefFields) of
               true -> St;
               false ->
-                  FieldNames = [atom_to_list(R) || {record_field, _L, {_, _, R}, _} <- DefFields],
-                  case most_possible_string(FName, FieldNames) of
-                      [] -> add_error(Anno, {undefined_field,Name,FName}, St);
-                      GuessF -> add_error(Anno, {undefined_field,Name,FName,GuessF}, St)
-                  end
+                  E = undefined_field,
+                  suggest_field_name(Anno, E, Name, FName, DefFields, St)
           end,
     %% Check for duplicates
     St2 = case ordsets:is_element(FName, SeenFields) of

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -5879,7 +5879,7 @@ native_records(Config) ->
                     {{2,35},erl_lint,{redefine_field,r2,a}},
                     {{3,30},erl_lint,{redefine_field,r3,a}}],
             []}},
-          {undefined_native_record_field,
+          {undefined_field_1,
            <<"-record #r{a=a, c=c}.
                mk() -> #r{a = a, b = b}.
                pat(#r{a = A, b = B}) -> {A, B}.
@@ -5887,19 +5887,45 @@ native_records(Config) ->
                get1(S) -> S#r.b.
                get2(S, B) when B == S#r.b -> ok.">>,
            [],
-           {warnings,[{{2,34},erl_lint,{undefined_native_record_field,r,b}},
-                      {{3,30},erl_lint,{undefined_native_record_field,r,b}},
-                      {{4,33},erl_lint,{undefined_native_record_field,r,b}},
-                      {{5,31},erl_lint,{undefined_native_record_field,r,b}},
-                      {{6,41},erl_lint,{undefined_native_record_field,r,b}}]}},
-          {no_init,
+           {error,
+            [{{2,34},erl_lint,{undefined_field,r,b}}],
+            [{{3,30},erl_lint,{undefined_field,r,b}},
+             {{4,33},erl_lint,{undefined_field,r,b}},
+             {{5,31},erl_lint,{undefined_field,r,b}},
+             {{6,41},erl_lint,{undefined_field,r,b}}]}},
+          {undefined_field_2,
+           <<"-record #r{a=a, c=c}.
+               mk() -> #r{a = a, b = b}.
+               pat(#r{a = A, b = B}) -> {A, B}.
+               update(S) -> S#r{b = b}.
+               get1(S) -> S#r.b.
+               get2(S, B) when B == S#r.b -> ok.">>,
+           [nowarn_undefined_field],
+           {errors,
+            [{{2,34},erl_lint,{undefined_field,r,b}}],
+            []}},
+          {no_init_1,
            <<"-record #r{a, b, c = c}.
                 mk1() -> #r{}.
-                mk2() -> #r{a = a}.">>,
+                mk2() -> #r{a = a}.
+                mk3() -> #?MODULE:r{}.">>,
            [],
-           {warnings,[{{2,26},erl_lint,{no_init_native_record_field,r,a}},
-                      {{2,26},erl_lint,{no_init_native_record_field,r,b}},
-                      {{3,26},erl_lint,{no_init_native_record_field,r,b}}]}},
+           {error,
+            [{{2,26},erl_lint,{novalue,r,a}},
+             {{2,26},erl_lint,{novalue,r,b}},
+             {{3,26},erl_lint,{novalue,r,b}}],
+            [{{4,26},erl_lint,{novalue,{lint_test,r},a}},
+             {{4,26},erl_lint,{novalue,{lint_test,r},b}}]}},
+          {no_init_2,
+           <<"-record #r{a, b, c = c}.
+                mk1() -> #r{}.
+                mk2() -> #r{a = a}.
+                mk3() -> #?MODULE:r{}.">>,
+           [nowarn_novalue],
+           {errors,[{{2,26},erl_lint,{novalue,r,a}},
+                    {{2,26},erl_lint,{novalue,r,b}},
+                    {{3,26},erl_lint,{novalue,r,b}}],
+            []}},
           {undefined_record_1,
            <<"t() ->
                   X = no_record,


### PR DESCRIPTION
According to EEP 79, compilation should fail when attempting to create a local native record where a field has no value or when using a field not present in the definition.