### PR TITLE
Improve file_op/0 type precision in stdlib/src/erl_tar.hrl

### DIFF
--- a/lib/stdlib/src/erl_tar.hrl
+++ b/lib/stdlib/src/erl_tar.hrl
@@ -195,11 +195,10 @@
 -type user_data() :: term().
 
 %% Type for the I/O primitive wrapper function
--type file_op() :: fun((write | close | read2 | position,
-                       {user_data(), iodata()} | user_data() | {user_data(), non_neg_integer()}
-                        | {user_data(), non_neg_integer()}) ->
-                              ok | eof | {ok, string() | binary()} | {ok, non_neg_integer()}
-                                 | {error, term()}).
+-type file_op() :: fun((close, file:io_device()) -> ok | {error, term()})
+                 | fun((position, {file:io_device(), file:location()}) -> {ok, integer()} | {error, term()})
+                 | fun((read2, {file:io_device(), non_neg_integer()}) -> {ok, string() | binary()} | eof | {error, term()})
+                 | fun((write, {file:io_device(), iodata()}) -> ok | {error, term()}).
 
 %% These constants (except S_IFMT) are
 %% used to determine what type of device


### PR DESCRIPTION
This enables tools that can check exhaustiveness to dispatch to the proper `fun` and therefore check that `case do_position(Reader, {cur, 0})` clauses in `erl_tar:open1/4` exhaust the possible return values:

```erlang
open1({file, Fd}=Handle, read, [raw], Opts) ->
    case not lists:member(compressed, Opts) of
        true ->
            Reader = #reader{handle=Fd,access=read,func=fun file_op/2},
            case do_position(Reader, {cur, 0}) of
                {ok, Pos, Reader2} ->
                    {ok, Reader2#reader{pos=Pos}};
                {error, Reason} ->
                    {error, {Handle, Reason}}
            end;
        false ->
            {error, {Handle, {incompatible_option, compressed}}}
    end;
```