### PR TITLE
Fix regression after f4825e7

### DIFF
--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -14496,7 +14496,9 @@ static ErlDrvSSizeT packet_inet_ctl(ErlDrvData e, unsigned int cmd, char* buf,
         switch(buf[2]) {
         case INET_PROTO_DEFAULT: protocol = 0; break;
         case INET_PROTO_UDP: protocol = IPPROTO_UDP; break;
+#ifdef HAVE_SCTP
         case INET_PROTO_SCTP: protocol = IPPROTO_SCTP; break;
+#endif
         default:
             return ctl_xerror(str_eprotonosupport, rbuf, rsize);
         }


### PR DESCRIPTION
https://github.com/erlang/otp/commit/f4825e70a966a52c443e195bdf9dd817073ce09e unconditionally added IPPROTO_SCTP usage, which breaks the build when SCTP is not supported.