### PR TITLE
otp fixes upload of security events to github

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ env:
 permissions:
   contents: read
   pull-requests: read
-  security-events: read
+  security-events: write
 
 jobs:
 

--- a/.github/workflows/ossf-compiler-flags-scanner.yaml
+++ b/.github/workflows/ossf-compiler-flags-scanner.yaml
@@ -30,7 +30,7 @@ on:
 
 permissions:
   contents: read
-  security-events: read
+  security-events: write
 
 jobs:
   schedule-scan:


### PR DESCRIPTION
the ossf-compiler-flags-scanner.yaml needs security-events set to
'write' because it will submit the security events. otherwise the
workflow will fail, as seen below

https://github.com/erlang/otp/actions/runs/22557929580/job/65339264936
