### PR TITLE
Remove remaining usages of `and`/`or`

### DIFF
--- a/lib/common_test/test/ct_test_support.erl
+++ b/lib/common_test/test/ct_test_support.erl
@@ -1139,10 +1139,10 @@ locate({TEH,tc_done,{undefined,undefined,{testcase_aborted,
 
 %% to match variable data as a result of a failed test case
 locate({TEH,tc_done,{Mod,Func,R={SkipOrFail,{_ErrInd,ErrInfo}}}},
-       Node, [Ev|Evs], Config) when ((SkipOrFail == skipped) or
-				     (SkipOrFail == failed)) and
-				    ((size(ErrInfo) == 2) or
-				     (size(ErrInfo) == 3)) ->
+       Node, [Ev|Evs], Config) when SkipOrFail == skipped orelse
+                                    SkipOrFail == failed,
+                                    size(ErrInfo) == 2 orelse
+                                    size(ErrInfo) == 3 ->
     case Ev of
 	{TEH,#event{name=tc_done, node=Node, 
 		    data={Mod,Func,Result}}} ->

--- a/lib/dialyzer/test/property_test/erl_types_prop.erl
+++ b/lib/dialyzer/test/property_test/erl_types_prop.erl
@@ -84,7 +84,7 @@ associativity_check(A, B, C) ->
     LHS_Inf = inf(A, inf(B, C)),
     RHS_Inf = inf(inf(A, B), C),
     Test2 = equal(LHS_Inf, RHS_Inf),
-    Test1 and Test2.
+    Test1 andalso Test2.
 
 commutativity() ->
     numtests(?REPETITIONS, commutativity_1()).
@@ -112,7 +112,7 @@ commutativity_check(A, B) ->
     Inf_AB = inf(A, B),
     Inf_BA = inf(B, A),
     Test2 = equal(Inf_AB, Inf_BA),
-    Test1 and Test2.
+    Test1 andalso Test2.
 
 idempotence() ->
     numtests(?REPETITIONS, idempotence_1()).
@@ -134,7 +134,7 @@ idempotence_check(Type) ->
     %% a ∧ a = a
     Inf = inf(Type, Type),
     Test2 = equal(Inf, Type),
-    Test1 and Test2.
+    Test1 andalso Test2.
 
 identity() ->
     numtests(?REPETITIONS, identity_1()).
@@ -149,7 +149,7 @@ identity_check(Type) ->
     %% a ∧ [top element] = a
     Inf = inf(Type, any),
     Test2 = equal(Inf, Type),
-    Test1 and Test2.
+    Test1 andalso Test2.
 
 limit() ->
     numtests(?REPETITIONS, limit_1()).

--- a/lib/erl_interface/test/ei_tmo_SUITE.erl
+++ b/lib/erl_interface/test/ei_tmo_SUITE.erl
@@ -251,7 +251,7 @@ do_one_send_failure(Config,From,FakeName,CName) ->
 
     {term,{Res,ETO,Iters,ETO}} = runner:get_term(P3, 20000),
     runner:recv_eot(P3),
-    true = ((Res < 0) and (Iters > 0)),
+    true = Res < 0 andalso Iters > 0,
     gen_tcp:close(SocketB),
     gen_tcp:close(EpmdSocket),
     ok.

--- a/lib/ftp/test/ftp_SUITE.erl
+++ b/lib/ftp/test/ftp_SUITE.erl
@@ -558,8 +558,8 @@ rename(Config0) ->
                     id2ftp(OldFile,Config),
                     id2ftp(NewFile,Config)),
 
-    true = (chk_file(NewFile,Contents,Config)
-            and chk_no_file([OldFile],Config)),
+    true = chk_file(NewFile,Contents,Config)
+            andalso chk_no_file([OldFile],Config),
     {error,epath} = ftp:rename(Pid,
                                id2ftp("non_existing_file",Config),
                                id2ftp(NewFile,Config)),

--- a/lib/kernel/test/application_SUITE.erl
+++ b/lib/kernel/test/application_SUITE.erl
@@ -3726,7 +3726,7 @@ loop2973() ->
 wait_for_ready_net() ->
     Nodes = lists:sort([node() | nodes()]),
     ?UNTIL(begin
-               lists:all(fun(N) -> Nodes =:= get_known(N) end, Nodes) and
+               lists:all(fun(N) -> Nodes =:= get_known(N) end, Nodes) andalso
                lists:all(fun(N) ->
                                  LNs = rpc:call(N, erlang, nodes, []),
                                  Nodes =:= lists:sort([N | LNs])

--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -965,7 +965,7 @@ analyse([], [This={M,F,A}|Path], Visited, ErrCnt0) ->
 	  gb_sets, gb_trees, erts_code_purger, erts_internal, code,
 	  prim_zip, zlib],
     ErrCnt1 =
-	case lists:member(M, OK) or erlang:is_builtin(M,F,A) of
+        case lists:member(M, OK) orelse erlang:is_builtin(M,F,A) of
 	    true ->
 		0;
 	    false ->
@@ -1989,7 +1989,7 @@ on_load_deadlock(Config) ->
 
     spawn(fun() -> code:ensure_loaded(Mod) end),
     {error,Reason} = code:ensure_loaded(Mod),
-    true = (Reason =:= deadlock) or (Reason =:= on_load_failure),
+    true = Reason =:= deadlock orelse Reason =:= on_load_failure,
 
     code:del_path(Dir),
     ok.

--- a/lib/kernel/test/file_name_SUITE.erl
+++ b/lib/kernel/test/file_name_SUITE.erl
@@ -348,7 +348,7 @@ check_icky(Mod) ->
 	%% 	    {ok,LLL} when is_list(LLL) ->
 	%% 		ok
 	%% 	end,
-	[ true = ((is_list(El) or (UniMode and is_binary(El))))  || El <- L1],
+        [ true = is_list(El) orelse UniMode andalso is_binary(El)  || El <- L1],
 	Syms = [ {S,conv(Targ),list_to_binary(get_data(Targ,IckyDir))}
 		 || {T,S,Targ} <- IckyDir, T =:= symlink ],
 	[ {ok, Cont} = Mod:read_file(SymL) || {SymL,_,Cont} <- Syms ],
@@ -384,8 +384,8 @@ check_icky(Mod) ->
 	end,
 
 	_ = make_icky_dir(Mod, treat_icky(<<"åäö_dir"/utf8>>)),
-	if 
-	    UniMode and (OS =/= win32) ->
+        if
+            UniMode andalso OS =/= win32 ->
 		{error,enoent} = Mod:set_cwd("åäö_dir");
 	    true ->
 		ok
@@ -425,7 +425,7 @@ check_icky(Mod) ->
         Mod:rename("åäö2",treat_icky(<<"åäö_fil1">>)),
         {ok, <<"åäö2">>} = Mod:read_file(treat_icky(<<"åäö_fil1">>)),
 	if
-	    UniMode and (OS =/= win32) ->
+            UniMode andalso OS =/= win32 ->
 		{error,enoent} = Mod:read_file("åäö_fil1");
 	    true ->
 		ok
@@ -474,7 +474,7 @@ check_very_icky(Mod) ->
 	Expected = lists:sort(Actual),
 	{ok,D2} = Mod:get_cwd(),
 	true = is_list(D2),
-	[ true = ((is_list(El) or is_binary(El)))  || El <- Expected],
+        [ true = is_list(El) orelse is_binary(El)  || El <- Expected],
 	Syms = [{S,conv(Targ),list_to_binary(get_data(Targ, VeryIckyDir))}
 		|| {symlink,S,Targ} <- VeryIckyDir],
 	[ {ok, Cont} = Mod:read_file(SymL) || {SymL,_,Cont} <- Syms ],

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -4406,17 +4406,17 @@ do_so_priority(Config, Addr) ->
 	    case os:type() of
 		{unix,linux} ->
 		    case os:version() of
-			{X,Y,_} when (X > 2) or ((X =:= 2) and (Y >= 4)) ->
+                        {X,Y,_} when X > 2 orelse X =:= 2 andalso Y >= 4 ->
                             ?P("so prio should work on this version: "
                                "~n      ~p", [_X]),
 			    ct:fail({error,
-					   "so_priority should work on this "
-					   "OS, but does not"});
+                                     "so_priority should work on this "
+                                     "OS, but does not"});
 			_ ->
 			    {skip, "SO_PRIORITY not suppoorted"}
 		    end;
 		_ ->
-		   {skip, "SO_PRIORITY not suppoorted"}
+                    {skip, "SO_PRIORITY not suppoorted"}
 	    end
     end.
 
@@ -4771,7 +4771,7 @@ test_pktoptions(Config, Family, Spec, CheckConnect) ->
        "~n   Result2:       ~p"
        "~n   Result3:       ~p",
       [Result1, CheckConnect, Result2, Result3]),
-    (Result1 and ((not CheckConnect) or (Result2 and Result3)))
+    Result1 andalso (not CheckConnect orelse Result2 andalso Result3)
         orelse
         exit({failed,
               [{OptsVals1,OptsVals4,OptsVals},
@@ -6430,7 +6430,7 @@ do_send_timeout_check_length(Config, Addr, RNode) ->
                    end),
     Diff = get_max_diff(Pid),
     ?P("Max time for send: ~p", [Diff]),
-    true = (Diff > (SndTimeout - 500)) and (Diff < (SndTimeout + 500)),
+    true = Diff > SndTimeout - 500 andalso Diff < SndTimeout + 500,
 
     %% Wait for the process to die.
     ?P("await (timeout checker) process death"),

--- a/lib/kernel/test/global_SUITE.erl
+++ b/lib/kernel/test/global_SUITE.erl
@@ -384,7 +384,7 @@ both_known_1_test(Config) when is_list(Config) ->
 	       N1 = lists:sort(Names1_3),
 	       N2 = lists:sort(Names2_3),
 	       N3 = lists:sort(Names3_3),
-	       (N1 =:= [p1, p2]) and (N2 =:= [p1, p2]) and (N3 =:= [p1, p2])
+               N1 =:= [p1, p2] andalso N2 =:= [p1, p2] andalso N3 =:= [p1, p2]
 	   end),
 
     write_high_level_trace(Config),
@@ -684,11 +684,11 @@ do_names(Config) ->
     %% test that it is registered at all nodes
     ?P("names -> verify process has been registered on all nodes"),
         ?UNTIL(begin
-            (Pid =:= global:whereis_name(test)) and
-            (Pid =:= rpc:call(Cp1, global, whereis_name, [test])) and
-            (Pid =:= rpc:call(Cp2, global, whereis_name, [test])) and
-            (Pid =:= rpc:call(Cp3, global, whereis_name, [test])) and
-            ([test] =:= global:registered_names() -- OrigNames)
+            Pid =:= global:whereis_name(test) andalso
+            Pid =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+            Pid =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+            Pid =:= rpc:call(Cp3, global, whereis_name, [test]) andalso
+            [test] =:= global:registered_names() -- OrigNames
            end),
     
     %% try to register the same name
@@ -702,10 +702,10 @@ do_names(Config) ->
     exit_p(Pid),
 
     ?P("names -> verify 'test' process has been automatically unregistered"),
-        ?UNTIL((undefined =:= global:whereis_name(test)) and
-           (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp2, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp3, global, whereis_name, [test]))),
+        ?UNTIL(undefined =:= global:whereis_name(test) andalso
+           undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp3, global, whereis_name, [test])),
     
     %% test re_register
     ?P("names -> start and register another process 'test'"),
@@ -735,10 +735,10 @@ do_names(Config) ->
 
     ?P("names -> unregister 'test' process"),
     _ = global:unregister_name(test),
-        ?UNTIL((undefined =:= global:whereis_name(test)) and
-           (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp2, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp3, global, whereis_name, [test]))),
+        ?UNTIL(undefined =:= global:whereis_name(test) andalso
+           undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp3, global, whereis_name, [test])),
 
     ?P("names -> terminate process 'test'"),
     exit_p(Pid3),
@@ -796,20 +796,20 @@ names_hidden(Config) when is_list(Config) ->
     Cp3 = node(HPid),
 
     %% Check that it didn't get registered on visible nodes
-        ?UNTIL((undefined =:= global:whereis_name(test)) and
-           (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp2, global, whereis_name, [test]))),
+        ?UNTIL(undefined =:= global:whereis_name(test) andalso
+           undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp2, global, whereis_name, [test])),
 
     %% start a proc on visible node and register it
     {Pid, yes} = start_proc(test),
     true = (Pid =/= HPid),
 
     %% test that it is registered at all nodes
-        ?UNTIL((Pid =:= global:whereis_name(test)) and
-           (Pid =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (Pid =:= rpc:call(Cp2, global, whereis_name, [test])) and
-           (HPid =:= rpc:call(Cp3, global, whereis_name, [test])) and
-           ([test] =:= global:registered_names() -- OrigNames)),
+        ?UNTIL(Pid =:= global:whereis_name(test) andalso
+           Pid =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           Pid =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+           HPid =:= rpc:call(Cp3, global, whereis_name, [test]) andalso
+           [test] =:= global:registered_names() -- OrigNames),
     
     %% try to register the same name
     no = global:register_name(test, self()),
@@ -818,10 +818,10 @@ names_hidden(Config) when is_list(Config) ->
     %% let process exit, check that it is unregistered automatically
     exit_p(Pid),
 
-        ?UNTIL((undefined =:= global:whereis_name(test)) and
-           (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp2, global, whereis_name, [test])) and
-           (HPid      =:= rpc:call(Cp3, global, whereis_name, [test]))),
+        ?UNTIL(undefined =:= global:whereis_name(test) andalso
+           undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+           HPid      =:= rpc:call(Cp3, global, whereis_name, [test])),
     
     %% test re_register
     {Pid2, yes} = start_proc(test),
@@ -846,16 +846,16 @@ names_hidden(Config) when is_list(Config) ->
     end,
 
     _ = rpc:call(Cp3, global, unregister_name, [test]),
-        ?UNTIL((Pid3      =:= global:whereis_name(test)) and
-           (Pid3      =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (Pid3      =:= rpc:call(Cp2, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp3, global, whereis_name, [test]))),
+        ?UNTIL(Pid3      =:= global:whereis_name(test) andalso
+           Pid3      =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           Pid3      =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp3, global, whereis_name, [test])),
 
     _ = global:unregister_name(test),
-        ?UNTIL((undefined =:= global:whereis_name(test)) and
-           (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp2, global, whereis_name, [test])) and
-           (undefined =:= rpc:call(Cp3, global, whereis_name, [test]))),
+        ?UNTIL(undefined =:= global:whereis_name(test) andalso
+           undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+           undefined =:= rpc:call(Cp3, global, whereis_name, [test])),
 
     exit_p(Pid3),
     exit_p(HPid),
@@ -1150,9 +1150,9 @@ names_and_locks(Config) when is_list(Config) ->
     global:del_lock({test_lock, self()}, [node(), Cp1]),
     
     exit_p(Pid2),
-        ?UNTIL((undefined =:= global:whereis_name(test2)) and
-           (true =:= global:set_lock({test_lock, self()}, [Cp2, Cp3], 1)) and
-           (true =:= global:set_lock({test_lock2, self()}, [Cp2, Cp3], 1))),
+        ?UNTIL(undefined =:= global:whereis_name(test2) andalso
+           true =:= global:set_lock({test_lock, self()}, [Cp2, Cp3], 1) andalso
+           true =:= global:set_lock({test_lock2, self()}, [Cp2, Cp3], 1)),
 
     global:del_lock({test_lock, self()}, [Cp2, Cp3]),
     global:del_lock({test_lock2, self()}, [Cp2, Cp3]),
@@ -3269,11 +3269,11 @@ global_groups_change(Config) ->
                TestGG5_2 = rpc:call(CpE, global, whereis_name, [test]),
                io:format("~p~n", [[TestGG4, TestGG4_1, TestGG4_2,TestGG4_3]]),
                io:format("~p~n", [[TestGG5, TestGG5_1, TestGG5_2]]),
-               (TestGG4_1 =:= TestGG4) and
-               (TestGG4_2 =:= TestGG4) and
-               (TestGG4_3 =:= TestGG4) and
-               (TestGG5_1 =:= TestGG5) and
-               (TestGG5_2 =:= TestGG5)
+               TestGG4_1 =:= TestGG4 andalso
+               TestGG4_2 =:= TestGG4 andalso
+               TestGG4_3 =:= TestGG4 andalso
+               TestGG5_1 =:= TestGG5 andalso
+               TestGG5_2 =:= TestGG5
            end),
 
     io:format( "#### nodes() ~p~n",[nodes()]),
@@ -3367,11 +3367,11 @@ global_groups_change(Config) ->
                TestGG5e = rpc:call(CpE, global, whereis_name, [test]),
                io:format("~p~n", [[TestGG4, TestGG4a, TestGG4b]]),
                io:format("~p~n", [[TestGG5, TestGG5c, TestGG5d, TestGG5e]]),
-               (TestGG4 =:= TestGG4a) and
-               (TestGG4 =:= TestGG4b) and
-               (TestGG5 =:= TestGG5c) and
-               (TestGG5 =:= TestGG5d) and
-               (TestGG5 =:= TestGG5e)
+               TestGG4 =:= TestGG4a andalso
+               TestGG4 =:= TestGG4b andalso
+               TestGG5 =:= TestGG5c andalso
+               TestGG5 =:= TestGG5d andalso
+               TestGG5 =:= TestGG5e
            end),
 
     Info1 = rpc:call(Cp1, global_group, info, []),
@@ -4571,7 +4571,7 @@ wait_for_ready_net(Nodes0, Config) ->
                                  ?P("wait_for_ready_net => ~p", [GRes]),
                                  GRes
                          end,
-                         Nodes) and
+                         Nodes) andalso
 		   lists:all(fun(N) ->
                                      ?P("wait_for_ready_net -> "
                                         "get erlang nodes for ~p", [N]),

--- a/lib/kernel/test/global_group_SUITE.erl
+++ b/lib/kernel/test/global_group_SUITE.erl
@@ -643,9 +643,9 @@ one_grp(Config) when is_list(Config) ->
     %% let process exit, check that it is unregistered automatically
     Pid ! die,
         ?UNTIL(begin
-               (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-               (undefined =:= rpc:call(Cp2, global, whereis_name, [test])) and
-               (undefined =:= rpc:call(Cp3, global, whereis_name, [test]))
+               undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+               undefined =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+               undefined =:= rpc:call(Cp3, global, whereis_name, [test])
            end),
     
     %% test re_register
@@ -732,9 +732,9 @@ one_grp_x(Config) when is_list(Config) ->
     %% let process exit, check that it is unregistered automatically
     Pid ! die,
         ?UNTIL(begin
-               (undefined =:= rpc:call(Cp1, global, whereis_name, [test])) and
-               (undefined =:= rpc:call(Cp2, global, whereis_name, [test])) and
-               (undefined =:= rpc:call(Cp3, global, whereis_name, [test]))
+               undefined =:= rpc:call(Cp1, global, whereis_name, [test]) andalso
+               undefined =:= rpc:call(Cp2, global, whereis_name, [test]) andalso
+               undefined =:= rpc:call(Cp3, global, whereis_name, [test])
            end),
     
     %% test re_register
@@ -1330,7 +1330,7 @@ global_disconnect(Config) when is_list(Config) ->
 wait_for_ready_net() ->
     Nodes = lists:sort(?NODES),
     ?UNTIL(begin
-               lists:all(fun(N) -> Nodes =:= get_known(N) end, Nodes) and
+               lists:all(fun(N) -> Nodes =:= get_known(N) end, Nodes) andalso
 		   lists:all(fun(N) ->
 				     LNs = rpc:call(N, erlang, nodes, []),
 				     Nodes =:= lists:sort([N | LNs])

--- a/lib/megaco/test/megaco_codec_v3_SUITE.erl
+++ b/lib/megaco/test/megaco_codec_v3_SUITE.erl
@@ -1232,7 +1232,7 @@ compact_otp4085_1(Msg, Conf) ->
 
 compact_otp4085_1_chk1(Reason) ->
     case lists:keysearch(reason, 1, Reason) of
-	{value, {reason, {Line, Module, Crap}}} when is_integer(Line) and
+        {value, {reason, {Line, Module, Crap}}} when is_integer(Line),
 						     is_atom(Module) ->
 	    Crap2 =
 		case (catch lists:flatten(Crap)) of
@@ -2850,7 +2850,7 @@ pretty_otp4632_msg4() ->
     M = "MEGACO/" ?VERSION_STR " [124.124.124.222]\nTransaction = 9998 {\n\tContext = - {\n\t\tServiceChange = root {\n\t\t\tServices {\n\t\t\t\tMethod = Restart,\n\t\t\t\tServiceChangeAddress = 55555,\n\t\t\t\tProfile = resgw/1,\n\t\t\t\tReason = 901\n\t\t\t}\n\t\t}\n\t}\n}",
     M.
 
-pretty_otp4632_msg4_chk(B1, B2) when is_binary(B1) and is_binary(B2) ->
+pretty_otp4632_msg4_chk(B1, B2) when is_binary(B1), is_binary(B2) ->
     S1 = binary_to_list(B1),
     S2 = binary_to_list(B2),
     %%     io:format("~n"
@@ -2905,7 +2905,7 @@ pretty_otp4710_msg2(Config) when is_list(Config) ->
 pretty_otp4710_msg2() ->
     "Authentication = 0xEFCDAB89:0x12345678:0x1234567889ABCDEF76543210\nMEGACO/" ?VERSION_STR " [124.124.124.222]\nTransaction = 9998 {\n\tContext = - {\n\t\tServiceChange = root {\n\t\t\tServices {\n\t\t\t\tMethod = Restart,\n\t\t\t\tServiceChangeAddress = 55555,\n\t\t\t\tProfile = resgw/1,\n\t\t\t\tReason = \"901 mg col boot\"\n\t\t\t}\n\t\t}\n\t}\n}".
 
-pretty_otp4710_msg2_chk(B1, B2) when is_binary(B1) and is_binary(B2) ->
+pretty_otp4710_msg2_chk(B1, B2) when is_binary(B1), is_binary(B2) ->
     S1 = binary_to_list(B1),
     S2 = binary_to_list(B2),
     pretty_otp4710_msg2_chk(S1, S2);
@@ -8265,7 +8265,7 @@ ticket_decode_only(Msg, Codec, Check, Conf0) ->
     megaco_codec_test_lib:expect_decode_only(Msg, Decode, Check).
 
 ticket_check_decode_only_error_reason(R, Check)
-  when is_list(R) and is_function(Check) ->
+  when is_list(R), is_function(Check) ->
     case lists:keysearch(reason, 1, R) of
 	{value, {reason, Reason}} ->
 	    Check(Reason);
@@ -8753,8 +8753,8 @@ cre_SecReqEv(N) ->
 cre_SecReqEv(N, EPL) ->
     ?MSG_LIB:cre_SecondRequestedEvent(N, EPL).
 
-cre_SecReqEv(N, SID, EA) when is_list(N) and
-			      is_integer(SID) and
+cre_SecReqEv(N, SID, EA) when is_list(N),
+                              is_integer(SID),
 			      is_record(EA, 'SecondRequestedActions') ->
     cre_SecReqEv(N, SID, EA, []);
 cre_SecReqEv(A, B, C) ->

--- a/lib/megaco/test/megaco_load_SUITE.erl
+++ b/lib/megaco/test/megaco_load_SUITE.erl
@@ -449,7 +449,7 @@ populate([{Key,Val}|Env]) ->
     put(Key, Val),
     populate(Env).
 
-load_controller(Config, Fun) when is_list(Config) and is_function(Fun) ->
+load_controller(Config, Fun) when is_list(Config), is_function(Fun) ->
     process_flag(trap_exit, true),
     {value, {tc_timeout, TcTimeout}} = 
 	lists:keysearch(tc_timeout, 1, Config),

--- a/lib/megaco/test/megaco_mess_SUITE.erl
+++ b/lib/megaco/test/megaco_mess_SUITE.erl
@@ -2430,9 +2430,9 @@ strar_mgc_do_verify_notify_request(AR) ->
 	      "~n   AR: ~p~n", [AR]),
     {Cid, CR} =
 	case AR of
-	    #'ActionRequest'{contextId       = CtxID, 
-			     commandRequests = [CmdReq]} when (CtxID == 1) or
-							      (CtxID == 2) ->
+            #'ActionRequest'{contextId       = CtxID,
+                             commandRequests = [CmdReq]} when CtxID == 1;
+                                                              CtxID == 2 ->
 		{CtxID, CmdReq};
 	    _ ->
                 Err1      = {invalid_action_request, AR},
@@ -2948,9 +2948,9 @@ straro_mgc_do_verify_notify_request(AR) ->
 	      "~n   AR: ~p~n", [AR]),
     {Cid, CR} =
 	case AR of
-	    #'ActionRequest'{contextId       = CtxID, 
-			     commandRequests = [CmdReq]} when (CtxID == 1) or
-							      (CtxID == 2) ->
+            #'ActionRequest'{contextId       = CtxID,
+                             commandRequests = [CmdReq]} when CtxID == 1;
+                                                              CtxID == 2 ->
 		{CtxID, CmdReq};
 	    _ ->
                 Err1      = {invalid_action_request, AR},

--- a/lib/megaco/test/megaco_sdp_SUITE.erl
+++ b/lib/megaco/test/megaco_sdp_SUITE.erl
@@ -1054,7 +1054,7 @@ cre_PropertyParm_k(base64, EncryptionKey) when is_list(EncryptionKey) ->
 cre_PropertyParm_k(uri, EncryptionKey) when is_list(EncryptionKey) ->
     cre_PropertyParm("k", "uri:" ++ EncryptionKey);
 cre_PropertyParm_k(Method, EncryptionKey) 
-  when is_list(Method) and is_list(EncryptionKey) ->
+  when is_list(Method), is_list(EncryptionKey) ->
     cre_PropertyParm("k", Method ++ ":" ++ EncryptionKey).
 
 cre_sdp_k(M) ->
@@ -1072,7 +1072,7 @@ cre_sdp_z(LOA) ->
     #megaco_sdp_z{list_of_adjustments = LOA}.
 
 cre_PropertyParm_r(Repeat, Duration, ListOfOffsets) 
-  when is_list(Repeat) and is_list(Duration) and is_list(ListOfOffsets) ->
+  when is_list(Repeat), is_list(Duration), is_list(ListOfOffsets) ->
     F = fun(Elem, Str) -> Str ++ " " ++ Elem end, 
     Val = Repeat ++ " " ++ Duration ++  lists:foldl(F, [], ListOfOffsets),
     cre_PropertyParm("r", Val).
@@ -1083,7 +1083,7 @@ cre_sdp_r(Repeat, Duration, ListOfOffsets) ->
 		  list_of_offsets = ListOfOffsets}.
 
 cre_PropertyParm_t(Start, Stop) 
-  when is_list(Start) and is_list(Stop) ->
+  when is_list(Start), is_list(Stop) ->
     cre_PropertyParm("t", Start ++ " " ++ Stop);
 cre_PropertyParm_t(Start, Stop) ->
     cre_PropertyParm_t(i2s(Start), i2s(Stop)).
@@ -1092,10 +1092,10 @@ cre_sdp_t(Start, Stop) ->
     #megaco_sdp_t{start = Start, stop = Stop}.
 
 cre_PropertyParm_b(BwType, Bandwidth) 
-  when is_list(BwType) and is_integer(Bandwidth) ->
+  when is_list(BwType), is_integer(Bandwidth) ->
     cre_PropertyParm_b(BwType, i2s(Bandwidth));
 cre_PropertyParm_b(BwType, Bandwidth) 
-  when is_list(BwType) and is_list(Bandwidth) ->
+  when is_list(BwType), is_list(Bandwidth) ->
     cre_PropertyParm("b", BwType ++ ":" ++ Bandwidth).
 
 cre_sdp_b(BWT, BW) ->
@@ -1145,9 +1145,9 @@ cre_PropertyParm_rtpmap(Payload, EncName, ClockRate) ->
     cre_PropertyParm_rtpmap(Payload, EncName, ClockRate, []).
 
 cre_PropertyParm_rtpmap(Payload, EncName, ClockRate, EncPar)
-  when is_integer(Payload) and
-       is_list(EncName) and
-       is_integer(ClockRate) and
+  when is_integer(Payload),
+       is_list(EncName),
+       is_integer(ClockRate),
        is_list(EncPar) ->
     F = fun(Elem, Str) -> Str ++ "/" ++ Elem end, 
     Val = 
@@ -1213,14 +1213,14 @@ cre_sdp_a_quality(Qa) ->
     #megaco_sdp_a_quality{quality = Qa}.
 
 cre_PropertyParm_a(Attr, AttrValue) 
-  when is_list(Attr) and is_list(AttrValue) ->
+  when is_list(Attr), is_list(AttrValue) ->
     cre_PropertyParm("a", Attr ++ ":" ++ AttrValue).
 
 cre_PropertyParm_a(Attr) when is_list(Attr) ->
     cre_PropertyParm("a", Attr).
 
 cre_PropertyParm_a_fmtp(Format, Param) 
-  when is_list(Format) and is_list(Param) ->
+  when is_list(Format), is_list(Param) ->
     cre_PropertyParm_a("fmtp", Format ++ " " ++ Param).
 
 cre_sdp_a_fmtp(Fmt, Parm) ->
@@ -1237,11 +1237,11 @@ cre_PropertyParm_o(User, SID, Version, AddrType, Addr) ->
     cre_PropertyParm_o(User, SID, Version, in, AddrType, Addr).
 
 cre_PropertyParm_o(User, SID, Version, NetType, AddrType, Addr) 
-  when is_list(User) and
-       is_integer(SID) and
-       is_integer(Version) and
-       is_list(NetType) or (NetType == in) and
-       is_list(AddrType) or ((AddrType == ip4) or (AddrType == ip6)) and
+  when is_list(User),
+       is_integer(SID),
+       is_integer(Version),
+       (is_list(NetType) orelse NetType == in),
+       (is_list(AddrType) orelse AddrType == ip4 orelse AddrType == ip6),
        is_list(Addr) ->
     NT = case NetType of
 	     in -> "IN";
@@ -1276,7 +1276,7 @@ cre_PropertyParm_m(Media, Port, Transport, FmtList)
     cre_PropertyParm_m(atom_to_list(Media), 
 		       Port, Transport, FmtList);
 cre_PropertyParm_m(Media, Port0, Transport, FmtList) 
-  when is_list(Media) and is_list(Transport) and is_list(FmtList) ->
+  when is_list(Media), is_list(Transport), is_list(FmtList) ->
     Port = i2s(Port0),
     Val = 
 	Media ++ " " ++ Port ++ " " ++ Transport ++ " " ++ val(FmtList),
@@ -1287,7 +1287,7 @@ cre_PropertyParm_m(Media, Port, NumPorts, Transport, FmtList)
     cre_PropertyParm_m(atom_to_list(Media), 
 		       Port, NumPorts, Transport, FmtList);
 cre_PropertyParm_m(Media, Port0, NumPorts0, Transport, FmtList) 
-  when is_list(Media) and is_list(Transport) and is_list(FmtList) ->
+  when is_list(Media), is_list(Transport), is_list(FmtList) ->
     Port     = i2s(Port0),
     NumPorts = i2s(NumPorts0),
     Val = 
@@ -1314,15 +1314,15 @@ cre_PropertyParm_c(ip4, ConnAddr) ->
 cre_PropertyParm_c(ip6, ConnAddr) ->
     cre_PropertyParm_c("IP6", ConnAddr);
 cre_PropertyParm_c(AddrType, ConnAddr) 
-  when is_list(AddrType) and is_list(ConnAddr) ->
+  when is_list(AddrType), is_list(ConnAddr) ->
     Val = "IN " ++ AddrType ++ " " ++ ConnAddr, 
     cre_PropertyParm("c", Val).
 
 cre_PropertyParm_c(ip4, Base, TTL) ->
     cre_PropertyParm_c("IP4", Base, i2s(TTL));
 cre_PropertyParm_c(AddrType, Base, TTL) 
-  when is_list(AddrType) and 
-       is_list(Base)     and 
+  when is_list(AddrType),
+       is_list(Base),
        is_list(TTL) ->
     Val = "IN " ++ AddrType ++ " " ++ Base ++ "/" ++ TTL, 
     cre_PropertyParm("c", Val).
@@ -1330,9 +1330,9 @@ cre_PropertyParm_c(AddrType, Base, TTL)
 cre_PropertyParm_c(ip4, Base, TTL, NumOf) ->
     cre_PropertyParm_c("IP4", Base, i2s(TTL), i2s(NumOf));
 cre_PropertyParm_c(AddrType, Base, TTL, NumOf) 
-  when is_list(AddrType) and 
-       is_list(Base)     and 
-       is_list(TTL)      and 
+  when is_list(AddrType),
+       is_list(Base),
+       is_list(TTL),
        is_list(NumOf) ->
     Val = 
 	"IN " ++ AddrType ++ " " ++ Base ++ "/" ++ TTL ++ "/" ++ NumOf,
@@ -1357,7 +1357,7 @@ cre_sdp_v(Version) ->
     #megaco_sdp_v{version = Version}.
 	
 
-cre_PropertyParm(Name, Val) when is_list(Name) and is_list(Val) ->
+cre_PropertyParm(Name, Val) when is_list(Name), is_list(Val) ->
     #'PropertyParm'{name = Name, value = [Val]}.
 
 

--- a/lib/megaco/test/megaco_segment_SUITE.erl
+++ b/lib/megaco/test/megaco_segment_SUITE.erl
@@ -6348,8 +6348,8 @@ rsmos_mg_verify_notify_reply_fun(SN, Tid) ->
 	     
 rsmos_mg_verify_notify_reply(
   {handle_trans_reply, _CH, ?VERSION, {ok, {SN, Last, [AR]}}, _}, SN, Tid) 
-  when ((SN == 1) and (Last == true)) or 
-       ((SN =/= 1) and (Last == false)) ->
+  when SN == 1, Last == true;
+       SN =/= 1, Last == false ->
     (catch rsmos_mg_do_verify_notify_reply(Tid, AR));
 rsmos_mg_verify_notify_reply(Crap, SN, Tid) ->
     io:format("rsmos_mg_verify_notify_reply -> unknown reply"
@@ -7921,8 +7921,8 @@ cre_transaction(Trans) when is_record(Trans, 'TransactionRequest') ->
 cre_transaction(Trans) when is_record(Trans, 'TransactionPending') ->
     {transactionPending, Trans};
 cre_transaction(Trans) 
-  when is_record(Trans, 'TransactionReply') or
-       (is_tuple(Trans) and (element(1, Trans) == 'TransactionReply')) ->
+  when is_record(Trans, 'TransactionReply');
+       is_tuple(Trans), element(1, Trans) == 'TransactionReply' ->
     {transactionReply, Trans};
 cre_transaction(Trans) when is_list(Trans) ->
     {transactionResponseAck, Trans};

--- a/lib/megaco/test/megaco_test_msg_v1_lib.erl
+++ b/lib/megaco/test/megaco_test_msg_v1_lib.erl
@@ -231,7 +231,7 @@ cre_Message(V, Mid, {errorDescriptor, ED} = Body)
 %% cre_ErrorText(T) when list(T) ->
 %%     T.
 
-cre_ContextID(Val) when (0 =< Val) and (Val =< 4294967295) ->
+cre_ContextID(Val) when 0 =< Val, Val =< 4294967295 ->
     Val;
 cre_ContextID(Val) ->
     exit({invalid_ContextID, Val}).
@@ -292,30 +292,30 @@ cre_TransactionRequest(TransID, ARs) when is_integer(TransID) andalso is_list(AR
 %%     #'TransactionAck'{firstAck = FirstAck, 
 %% 		      lastAck  = LastAck}.
 
-cre_ActionRequest(CtxID, CmdReqs) 
-  when is_integer(CtxID) and is_list(CmdReqs) ->
+cre_ActionRequest(CtxID, CmdReqs)
+  when is_integer(CtxID), is_list(CmdReqs) ->
     #'ActionRequest'{contextId       = CtxID,
 		     commandRequests = CmdReqs}.
 
-cre_ActionRequest(CtxID, CtxReq, CmdReqs) 
-  when is_integer(CtxID) and 
-       is_record(CtxReq, 'ContextRequest') and
+cre_ActionRequest(CtxID, CtxReq, CmdReqs)
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId       = CtxID,
 		     contextRequest  = CtxReq,
 		     commandRequests = CmdReqs};
-cre_ActionRequest(CtxID, CAAR, CmdReqs) 
-  when is_integer(CtxID) and 
-       is_record(CAAR, 'ContextAttrAuditRequest') and 
+cre_ActionRequest(CtxID, CAAR, CmdReqs)
+  when is_integer(CtxID),
+       is_record(CAAR, 'ContextAttrAuditRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId           = CtxID,
 		     contextAttrAuditReq = CAAR,
 		     commandRequests     = CmdReqs}.
 
-cre_ActionRequest(CtxID, CtxReq, CAAR, CmdReqs) 
-  when is_integer(CtxID) and 
-       is_record(CtxReq, 'ContextRequest') and 
-       is_record(CAAR, 'ContextAttrAuditRequest') and 
+cre_ActionRequest(CtxID, CtxReq, CAAR, CmdReqs)
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
+       is_record(CAAR, 'ContextAttrAuditRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId           = CtxID,
 		     contextRequest      = CtxReq,
@@ -958,12 +958,12 @@ cre_PkgdName(N) when is_list(N) ->
     end.
 cre_PkgdName(root, root) ->
     "*/*";
-cre_PkgdName(PackageName, root) 
-  when is_list(PackageName) and (length(PackageName) =< 64) ->
+cre_PkgdName(PackageName, root)
+  when length(PackageName) =< 64 ->
     PackageName ++ "/*";
-cre_PkgdName(PackageName, ItemID) 
-  when ((is_list(PackageName) and (length(PackageName) =< 64)) and
-	(is_list(ItemID)      and (length(ItemID) =< 64))) ->
+cre_PkgdName(PackageName, ItemID)
+  when length(PackageName) =< 64,
+       length(ItemID) =< 64 ->
     PackageName ++ "/" ++ ItemID;
 cre_PkgdName(PackageName, ItemID) ->
     error({invalid_PkgdName, {PackageName, ItemID}}).

--- a/lib/megaco/test/megaco_test_msg_v2_lib.erl
+++ b/lib/megaco/test/megaco_test_msg_v2_lib.erl
@@ -184,7 +184,7 @@ cre_MegacoMessage(M) when is_record(M, 'Message') ->
     #'MegacoMessage'{mess = M}.
 
 cre_MegacoMessage(AH, M) 
-  when is_record(AH, 'AuthenticationHeader') andalso 
+  when is_record(AH, 'AuthenticationHeader'),
        is_record(M, 'Message') ->
     #'MegacoMessage'{authHeader = AH,
 		     mess       = M}.
@@ -218,10 +218,10 @@ cre_Message(V, Mid, {errorDescriptor, ED} = Body)
 cre_ErrorDescriptor(EC) when is_integer(EC) ->
     #'ErrorDescriptor'{errorCode = EC}.
 
-cre_ErrorDescriptor(EC, ET) when is_integer(EC) andalso is_list(ET) ->
+cre_ErrorDescriptor(EC, ET) when is_integer(EC), is_list(ET) ->
     #'ErrorDescriptor'{errorCode = EC, errorText = ET}.
 
-cre_ErrorCode(C) when is_integer(C) andalso (0 =< C) andalso (C =< 65535) ->
+cre_ErrorCode(C) when is_integer(C), 0 =< C, C =< 65535 ->
     C;
 cre_ErrorCode(C) ->
     exit({invalid_ErrorCode, C}).
@@ -243,12 +243,12 @@ cre_Transaction(TR) when is_record(TR, 'TransactionReply') ->
 cre_Transaction(TRA) when is_list(TRA) ->
     {transactionResponseAck, TRA}.
 
-cre_TransactionId(Val) when (0 =< Val) andalso (Val =< 4294967295) ->
+cre_TransactionId(Val) when 0 =< Val, Val =< 4294967295 ->
     Val;
 cre_TransactionId(Val) ->
     exit({invalid_TransactionId, Val}).
 
-cre_TransactionRequest(TransID, ARs) when is_integer(TransID) andalso is_list(ARs) -> 
+cre_TransactionRequest(TransID, ARs) when is_integer(TransID), is_list(ARs) -> 
     #'TransactionRequest'{transactionId = TransID, 
 			  actions       = ARs}.
 
@@ -256,26 +256,26 @@ cre_TransactionPending(TransID) when is_integer(TransID) ->
     #'TransactionPending'{transactionId = TransID}.
 
 cre_TransactionReply(TransID, ED) 
-  when is_integer(TransID) andalso is_record(ED, 'ErrorDescriptor') ->
+  when is_integer(TransID), is_record(ED, 'ErrorDescriptor') ->
     Res = {transactionError, ED},
     #'TransactionReply'{transactionId     = TransID,
 			transactionResult = Res};
 cre_TransactionReply(TransID, ARs) 
-  when is_integer(TransID) andalso is_list(ARs) ->
+  when is_integer(TransID), is_list(ARs) ->
     Res = {actionReplies, ARs},
     #'TransactionReply'{transactionId     = TransID,
 			transactionResult = Res}.
 
 cre_TransactionReply(TransID, IAR, ED) 
-  when is_integer(TransID) and 
-       ((IAR == 'NULL') or (IAR == asn1_NOVALUE)) and 
+  when is_integer(TransID), 
+       IAR == 'NULL' orelse IAR == asn1_NOVALUE,
        is_record(ED, 'ErrorDescriptor') ->
     Res = {transactionError, ED},
     #'TransactionReply'{transactionId     = TransID,
 			transactionResult = Res};
 cre_TransactionReply(TransID, IAR, ARs) 
-  when is_integer(TransID) and 
-       ((IAR == 'NULL') or (IAR == asn1_NOVALUE)) and 
+  when is_integer(TransID),
+       IAR == 'NULL' orelse IAR == asn1_NOVALUE,
        is_list(ARs) ->
     Res = {actionReplies, ARs},
     #'TransactionReply'{transactionId     = TransID,
@@ -291,29 +291,29 @@ cre_TransactionAck(FirstAck, LastAck) ->
 		      lastAck  = LastAck}.
 
 cre_ActionRequest(CtxID, CmdReqs) 
-  when is_integer(CtxID) andalso is_list(CmdReqs) ->
+  when is_integer(CtxID), is_list(CmdReqs) ->
     #'ActionRequest'{contextId       = CtxID,
 		     commandRequests = CmdReqs}.
 
 cre_ActionRequest(CtxID, CtxReq, CmdReqs) 
-  when is_integer(CtxID) andalso 
-       is_record(CtxReq, 'ContextRequest') andalso 
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId       = CtxID,
 		     contextRequest  = CtxReq,
 		     commandRequests = CmdReqs};
 cre_ActionRequest(CtxID, CAAR, CmdReqs) 
-  when is_integer(CtxID) andalso 
-       is_record(CAAR, 'ContextAttrAuditRequest') andalso 
+  when is_integer(CtxID),
+       is_record(CAAR, 'ContextAttrAuditRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId           = CtxID,
 		     contextAttrAuditReq = CAAR,
 		     commandRequests     = CmdReqs}.
 
 cre_ActionRequest(CtxID, CtxReq, CAAR, CmdReqs) 
-  when is_integer(CtxID) andalso 
-       is_record(CtxReq, 'ContextRequest') andalso 
-       is_record(CAAR, 'ContextAttrAuditRequest') andalso 
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
+       is_record(CAAR, 'ContextAttrAuditRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId           = CtxID,
 		     contextRequest      = CtxReq,
@@ -321,30 +321,30 @@ cre_ActionRequest(CtxID, CtxReq, CAAR, CmdReqs)
 		     commandRequests     = CmdReqs}.
 
 cre_ActionReply(CtxID, CmdReps) 
-  when is_integer(CtxID) andalso 
+  when is_integer(CtxID),
        is_list(CmdReps) ->
     #'ActionReply'{contextId    = CtxID,
 		   commandReply = CmdReps}.
 
 cre_ActionReply(CtxID, ED, CmdReps) 
-  when is_integer(CtxID) andalso 
-       is_record(ED, 'ErrorDescriptor') andalso 
+  when is_integer(CtxID),
+       is_record(ED, 'ErrorDescriptor'),
        is_list(CmdReps) ->
     #'ActionReply'{contextId       = CtxID,
 		   errorDescriptor = ED, 
 		   commandReply    = CmdReps};
 cre_ActionReply(CtxID, CtxReq, CmdReps) 
-  when is_integer(CtxID) andalso 
-       is_record(CtxReq, 'ContextRequest') andalso 
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
        is_list(CmdReps) ->
     #'ActionReply'{contextId    = CtxID,
 		   contextReply = CtxReq, 
 		   commandReply = CmdReps}.
 
 cre_ActionReply(CtxID, ED, CtxReq, CmdReps) 
-  when is_integer(CtxID) andalso 
-       is_record(ED, 'ErrorDescriptor') andalso 
-       is_record(CtxReq, 'ContextRequest') andalso 
+  when is_integer(CtxID),
+       is_record(ED, 'ErrorDescriptor'),
+       is_record(CtxReq, 'ContextRequest'),
        is_list(CmdReps) ->
     #'ActionReply'{contextId       = CtxID,
 		   errorDescriptor = ED, 
@@ -354,26 +354,26 @@ cre_ActionReply(CtxID, ED, CtxReq, CmdReps)
 cre_ContextRequest() ->
     #'ContextRequest'{}.
 
-cre_ContextRequest(Prio) when is_integer(Prio) andalso (0 =< Prio) andalso (Prio =< 15) ->
+cre_ContextRequest(Prio) when is_integer(Prio), 0 =< Prio, Prio =< 15 ->
     #'ContextRequest'{priority = Prio};
-cre_ContextRequest(Em) when (Em =:= true) andalso (Em =:= false) andalso (Em =:= asn1_NOVALUE) ->
+cre_ContextRequest(Em) when is_boolean(Em); Em =:= asn1_NOVALUE ->
     #'ContextRequest'{emergency = Em};
 cre_ContextRequest(Top) when is_list(Top) ->
     #'ContextRequest'{topologyReq = Top}.
 
 cre_ContextRequest(Prio, Em) 
-  when (is_integer(Prio) and (0 =< Prio) and (Prio =< 15)) and 
-       ((Em == true) or (Em == false) or (Em == asn1_NOVALUE)) ->
+  when is_integer(Prio), 0 =< Prio, Prio =< 15, 
+       is_boolean(Em) orelse Em == asn1_NOVALUE ->
     #'ContextRequest'{priority  = Prio,
 		      emergency = Em};
 cre_ContextRequest(Prio, Top) 
-  when is_integer(Prio) andalso (0 =< Prio) andalso (Prio =< 15) andalso is_list(Top) ->
+  when is_integer(Prio), 0 =< Prio, Prio =< 15,  is_list(Top) ->
     #'ContextRequest'{priority    = Prio,
 		      topologyReq = Top}.
 
 cre_ContextRequest(Prio, Em, Top) 
-  when (is_integer(Prio) and (0 =< Prio) and (Prio =< 15)) and 
-       ((Em == true) or (Em == false) or (Em == asn1_NOVALUE)) and
+  when is_integer(Prio), 0 =< Prio, Prio =< 15, 
+       is_boolean(Em) orelse (Em == asn1_NOVALUE),
        is_list(Top) ->
     #'ContextRequest'{priority    = Prio,
 		      emergency   = Em,
@@ -383,9 +383,9 @@ cre_ContextAttrAuditRequest() ->
     #'ContextAttrAuditRequest'{}.
 
 cre_ContextAttrAuditRequest(Top, Em, Prio) 
-  when ((Top  == 'NULL') or (Top  == asn1_NOVALUE)) and
-       ((Em   == 'NULL') or (Em   == asn1_NOVALUE)) and
-       ((Prio == 'NULL') or (Prio == asn1_NOVALUE)) ->
+  when Top  == 'NULL' orelse Top  == asn1_NOVALUE,
+       Em   == 'NULL' orelse Em   == asn1_NOVALUE,
+       Prio == 'NULL' orelse Prio == asn1_NOVALUE ->
     #'ContextAttrAuditRequest'{topology  = Top,
 			       emergency = Em,
 			       priority  = Prio}.
@@ -394,13 +394,13 @@ cre_CommandRequest(Cmd) ->
     #'CommandRequest'{command = Cmd}.
 
 cre_CommandRequest(Cmd, Opt) 
-  when ((Opt == 'NULL') or (Opt == asn1_NOVALUE)) ->
+  when Opt == 'NULL'; Opt == asn1_NOVALUE ->
     #'CommandRequest'{command  = Cmd,
 		      optional = Opt}.
 
 cre_CommandRequest(Cmd, Opt, WR) 
-  when ((Opt == 'NULL') or (Opt == asn1_NOVALUE)) and 
-       ((WR  == 'NULL') or (WR  == asn1_NOVALUE)) ->
+  when Opt == 'NULL' orelse Opt == asn1_NOVALUE,
+       WR  == 'NULL' orelse WR  == asn1_NOVALUE ->
     #'CommandRequest'{command        = Cmd,
 		      optional       = Opt,
 		      wildcardReturn = WR}.
@@ -456,24 +456,24 @@ cre_CommandReply(serviceChangeReply = Tag, Rep)
     {Tag, Rep}.
     
 cre_TopologyRequest(From, To, Dir) 
-  when is_record(From, 'TerminationID') and
-       is_record(To, 'TerminationID') and
-       ((Dir == bothway) or (Dir == isolate) or (Dir == oneway)) ->
+  when is_record(From, 'TerminationID'),
+       is_record(To, 'TerminationID'),
+       Dir == bothway orelse Dir == isolate orelse Dir == oneway ->
     #'TopologyRequest'{terminationFrom   = From,
 		       terminationTo     = To,
 		       topologyDirection = Dir}.
 
 cre_TopologyRequest(From, To, Dir, SID) 
-  when is_record(From, 'TerminationID') and
-       is_record(To, 'TerminationID') and
-       ((Dir == bothway) or (Dir == isolate) or (Dir == oneway)) and
-       (is_integer(SID) or (SID == asn1_NOVALUE)) ->
+  when is_record(From, 'TerminationID'),
+       is_record(To, 'TerminationID'),
+       Dir == bothway orelse Dir == isolate orelse Dir == oneway,
+       is_integer(SID) orelse SID == asn1_NOVALUE ->
     #'TopologyRequest'{terminationFrom   = From,
 		       terminationTo     = To,
 		       topologyDirection = Dir,
 		       streamID          = SID}.
 
-cre_AmmRequest(TermIDs, Descs) when is_list(TermIDs) andalso is_list(Descs) ->
+cre_AmmRequest(TermIDs, Descs) when is_list(TermIDs), is_list(Descs) ->
     #'AmmRequest'{terminationID = TermIDs,
 		  descriptors   = Descs}.
 
@@ -505,7 +505,7 @@ cre_AmmDescriptor(D) when is_list(D) ->
 cre_AmmsReply(TermIDs) when is_list(TermIDs) ->
     #'AmmsReply'{terminationID = TermIDs}.
 
-cre_AmmsReply(TermIDs, TAs) when is_list(TermIDs) andalso is_list(TAs) ->
+cre_AmmsReply(TermIDs, TAs) when is_list(TermIDs), is_list(TAs) ->
     #'AmmsReply'{terminationID    = TermIDs, 
 		 terminationAudit = TAs}.
 
@@ -513,12 +513,12 @@ cre_SubtractRequest(TermIDs) when is_list(TermIDs) ->
     #'SubtractRequest'{terminationID = TermIDs}.
 
 cre_SubtractRequest(TermIDs, Audit) 
-  when is_list(TermIDs) andalso is_record(Audit, 'AuditDescriptor') ->
+  when is_list(TermIDs), is_record(Audit, 'AuditDescriptor') ->
     #'SubtractRequest'{terminationID   = TermIDs, 
 		       auditDescriptor = Audit}.
 
 cre_AuditRequest(TermID, Audit) 
-  when is_record(TermID, megaco_term_id) andalso is_record(Audit, 'AuditDescriptor') ->
+  when is_record(TermID, megaco_term_id), is_record(Audit, 'AuditDescriptor') ->
     #'AuditRequest'{terminationID   = TermID, 
 		    auditDescriptor = Audit}.
 
@@ -530,7 +530,7 @@ cre_AuditReply(Audit) when is_record(Audit, 'AuditResult') ->
     {auditResult, Audit}.
 
 cre_AuditResult(TermID, TAs) 
-  when is_record(TermID, megaco_term_id) andalso is_list(TAs) ->
+  when is_record(TermID, megaco_term_id), is_list(TAs) ->
     #'AuditResult'{terminationID          = TermID, 
 		   terminationAuditResult = TAs}.
 
@@ -602,19 +602,19 @@ cre_IndAudMediaDescriptor(Descs) when is_list(Descs) ->
     #'IndAudMediaDescriptor'{streams = Streams}.
 
 cre_IndAudMediaDescriptor(TSD, Parms) 
-  when is_record(TSD, 'IndAudTerminationStateDescriptor') andalso 
+  when is_record(TSD, 'IndAudTerminationStateDescriptor'),
        is_record(Parms, 'IndAudStreamParms') ->
     Streams = {oneStream, Parms},
     #'IndAudMediaDescriptor'{termStateDescr = TSD,
 			     streams        = Streams};
 cre_IndAudMediaDescriptor(TSD, Descs) 
-  when is_record(TSD, 'IndAudTerminationStateDescriptor') andalso is_list(Descs) ->
+  when is_record(TSD, 'IndAudTerminationStateDescriptor'), is_list(Descs) ->
     Streams = {multiStream, Descs},
     #'IndAudMediaDescriptor'{termStateDescr = TSD,
 			     streams        = Streams}.
 
 cre_IndAudStreamDescriptor(SID, Parms) 
-  when is_integer(SID) andalso is_record(Parms, 'IndAudStreamParms') ->
+  when is_integer(SID), is_record(Parms, 'IndAudStreamParms') ->
     #'IndAudStreamDescriptor'{streamID    = SID,
 			      streamParms = Parms}.
 
@@ -625,8 +625,8 @@ cre_IndAudStreamParms(LCD) when is_record(LCD, 'IndAudLocalControlDescriptor') -
     #'IndAudStreamParms'{localControlDescriptor = LCD}.
 
 cre_IndAudStreamParms(LCD, L, R) 
-  when is_record(LCD, 'IndAudLocalControlDescriptor') andalso 
-       is_record(L, 'IndAudLocalRemoteDescriptor') andalso 
+  when is_record(LCD, 'IndAudLocalControlDescriptor'),
+       is_record(L, 'IndAudLocalRemoteDescriptor'),
        is_record(R, 'IndAudLocalRemoteDescriptor') ->
     #'IndAudStreamParms'{localControlDescriptor = LCD,
 			 localDescriptor        = L,
@@ -636,10 +636,10 @@ cre_IndAudLocalControlDescriptor() ->
     #'IndAudLocalControlDescriptor'{}.
 
 cre_IndAudLocalControlDescriptor(SM, RV, RG, PP) 
-  when ((SM == 'NULL') or (SM == asn1_NOVALUE)) and
-       ((RV == 'NULL') or (RV == asn1_NOVALUE)) and
-       ((RG == 'NULL') or (RG == asn1_NOVALUE)) and
-       (is_list(PP) or (PP == asn1_NOVALUE)) ->
+  when SM == 'NULL' orelse SM == asn1_NOVALUE,
+       RV == 'NULL' orelse RV == asn1_NOVALUE,
+       RG == 'NULL' orelse RG == asn1_NOVALUE,
+       is_list(PP) orelse PP == asn1_NOVALUE ->
     #'IndAudLocalControlDescriptor'{streamMode    = SM, 
 				    reserveValue  = RV, 
 				    reserveGroup  = RG, 
@@ -653,7 +653,7 @@ cre_IndAudLocalRemoteDescriptor(Grps)
     #'IndAudLocalRemoteDescriptor'{propGrps = Grps}.
 
 cre_IndAudLocalRemoteDescriptor(GrpID, Grps) 
-  when is_integer(GrpID) andalso (0 =< GrpID) andalso (GrpID =< 65535) andalso is_list(Grps) ->
+  when is_integer(GrpID), 0 =< GrpID, GrpID =< 65535, is_list(Grps) ->
     #'IndAudLocalRemoteDescriptor'{propGroupID = GrpID,
 				   propGrps    = Grps}.
 
@@ -670,15 +670,15 @@ cre_IndAudTerminationStateDescriptor([H|_] = PP)
     #'IndAudTerminationStateDescriptor'{propertyParms = PP}.
 
 cre_IndAudTerminationStateDescriptor([] = PP, EBC, SS) 
-  when ((EBC == 'NULL') or (EBC == asn1_NOVALUE)) and
-       ((SS  == 'NULL') or (SS  == asn1_NOVALUE)) ->
+  when EBC == 'NULL' orelse EBC == asn1_NOVALUE,
+       SS  == 'NULL' orelse SS  == asn1_NOVALUE ->
     #'IndAudTerminationStateDescriptor'{propertyParms      = PP,
 					eventBufferControl = EBC,
 					serviceState       = SS};
 cre_IndAudTerminationStateDescriptor([H|_] = PP, EBC, SS) 
-  when is_record(H, 'IndAudPropertyParm') and
-       ((EBC == 'NULL') or (EBC == asn1_NOVALUE)) and
-       ((SS  == 'NULL') or (SS  == asn1_NOVALUE)) ->
+  when is_record(H, 'IndAudPropertyParm'),
+       EBC == 'NULL' orelse EBC == asn1_NOVALUE,
+       SS  == 'NULL' orelse SS  == asn1_NOVALUE ->
     #'IndAudTerminationStateDescriptor'{propertyParms      = PP,
 					eventBufferControl = EBC,
 					serviceState       = SS}.
@@ -688,14 +688,14 @@ cre_IndAudEventsDescriptor(PkgdName)
     #'IndAudEventsDescriptor'{pkgdName = PkgdName}.
 
 cre_IndAudEventsDescriptor(RID, PkgdName) 
-  when is_integer(RID) andalso is_list(PkgdName) ->
+  when is_integer(RID), is_list(PkgdName) ->
     #'IndAudEventsDescriptor'{requestID = RID, pkgdName = PkgdName};
 cre_IndAudEventsDescriptor(PkgdName, SID) 
-  when is_list(PkgdName) andalso is_integer(SID) ->
+  when is_list(PkgdName), is_integer(SID) ->
     #'IndAudEventsDescriptor'{pkgdName = PkgdName, streamID = SID}.
 
 cre_IndAudEventsDescriptor(RID, PkgdName, SID) 
-  when is_integer(RID) andalso is_list(PkgdName) andalso is_integer(SID)  ->
+  when is_integer(RID), is_list(PkgdName), is_integer(SID)  ->
     #'IndAudEventsDescriptor'{requestID = RID, 
 			      pkgdName  = PkgdName, 
 			      streamID  = SID}.
@@ -704,7 +704,7 @@ cre_IndAudEventBufferDescriptor(EventName) when is_list(EventName) ->
     #'IndAudEventBufferDescriptor'{eventName = EventName}.
 
 cre_IndAudEventBufferDescriptor(EventName, SID) 
-  when is_list(EventName) andalso is_integer(SID)  ->
+  when is_list(EventName), is_integer(SID)  ->
     #'IndAudEventBufferDescriptor'{eventName = EventName, streamID = SID}.
 
 cre_IndAudSignalsDescriptor(S) when is_record(S, 'IndAudSignal') ->
@@ -712,19 +712,19 @@ cre_IndAudSignalsDescriptor(S) when is_record(S, 'IndAudSignal') ->
 cre_IndAudSignalsDescriptor(S) when is_record(S, 'IndAudSeqSigList') ->
     {seqSigList, S}.
 
-cre_IndAudSeqSigList(ID) when is_integer(ID) andalso (0=< ID) andalso (ID =< 65535) ->
+cre_IndAudSeqSigList(ID) when is_integer(ID), 0=< ID, ID =< 65535 ->
     #'IndAudSeqSigList'{id = ID}.
 
 cre_IndAudSeqSigList(ID, S) 
-  when is_integer(ID) andalso 
-       (0 =< ID) andalso (ID =< 65535) andalso 
+  when is_integer(ID),
+       0 =< ID, ID =< 65535,
        is_record(S, 'IndAudSignal') ->
     #'IndAudSeqSigList'{id = ID, signalList = S}.
 
 cre_IndAudSignal(SigName) when is_list(SigName) ->
     #'IndAudSignal'{signalName = SigName}.
 
-cre_IndAudSignal(SigName, SID) when is_list(SigName) andalso is_integer(SID) ->
+cre_IndAudSignal(SigName, SID) when is_list(SigName), is_integer(SID) ->
     #'IndAudSignal'{signalName = SigName, streamID = SID}.
 
 cre_IndAudDigitMapDescriptor() ->
@@ -737,21 +737,21 @@ cre_IndAudStatisticsDescriptor(StatName) when is_list(StatName) ->
     #'IndAudStatisticsDescriptor'{statName = StatName}.
 
 cre_IndAudPackagesDescriptor(N, V) 
-  when is_list(N) andalso 
-       is_integer(V) andalso 
-       (0 =< V) andalso 
-       (V =< 99) ->
+  when is_list(N),
+       is_integer(V),
+       0 =< V,
+       V =< 99 ->
     #'IndAudPackagesDescriptor'{packageName    = N, 
 				packageVersion = V}.
 
 cre_NotifyRequest(TermIDs, D) 
-  when is_list(TermIDs) andalso is_record(D, 'ObservedEventsDescriptor') ->
+  when is_list(TermIDs), is_record(D, 'ObservedEventsDescriptor') ->
     #'NotifyRequest'{terminationID            = TermIDs,
 		     observedEventsDescriptor = D}.
 
 cre_NotifyRequest(TermIDs, D, ED) 
-  when is_list(TermIDs) andalso 
-       is_record(D, 'ObservedEventsDescriptor') andalso 
+  when is_list(TermIDs), 
+       is_record(D, 'ObservedEventsDescriptor'),
        is_record(ED, 'ErrorDescriptor') ->
     #'NotifyRequest'{terminationID            = TermIDs,
 		     observedEventsDescriptor = D,
@@ -761,45 +761,45 @@ cre_NotifyReply(TermIDs) when is_list(TermIDs) ->
     #'NotifyReply'{terminationID = TermIDs}.
 
 cre_NotifyReply(TermIDs, ED) 
-  when is_list(TermIDs) andalso 
+  when is_list(TermIDs),
        is_record(ED, 'ErrorDescriptor') ->
     #'NotifyReply'{terminationID   = TermIDs,
 		   errorDescriptor = ED}.
 
 cre_ObservedEventsDescriptor(RID, [H|_] = L) 
-  when is_integer(RID) andalso is_record(H, 'ObservedEvent') ->
+  when is_integer(RID), is_record(H, 'ObservedEvent') ->
     #'ObservedEventsDescriptor'{requestId        = RID, 
 				observedEventLst = L}.
 
 cre_ObservedEvent(EN, EPL) 
-  when is_list(EN) andalso is_list(EPL) ->
+  when is_list(EN), is_list(EPL) ->
     #'ObservedEvent'{eventName    = EN, 
 		     eventParList = EPL};
 cre_ObservedEvent(EN, TN) 
-  when is_list(EN) andalso 
+  when is_list(EN), 
        is_record(TN, 'TimeNotation') ->
     #'ObservedEvent'{eventName    = EN, 
 		     timeNotation = TN}.
 
 cre_ObservedEvent(EN, SID, EPL) 
-  when is_list(EN) andalso 
-       is_integer(SID) andalso 
+  when is_list(EN),
+       is_integer(SID),
        is_list(EPL) ->
     #'ObservedEvent'{eventName    = EN, 
 		     streamID     = SID, 
 		     eventParList = EPL};
 cre_ObservedEvent(EN, EPL, TN) 
-  when is_list(EN) andalso 
-       is_list(EPL) andalso 
+  when is_list(EN),
+       is_list(EPL),
        is_record(TN, 'TimeNotation') ->
     #'ObservedEvent'{eventName    = EN, 
 		     eventParList = EPL,
 		     timeNotation = TN}.
 
 cre_ObservedEvent(EN, SID, EPL, TN) 
-  when is_list(EN) andalso 
-       is_integer(SID) andalso 
-       is_list(EPL) andalso
+  when is_list(EN),
+       is_integer(SID),
+       is_list(EPL),
        is_record(TN, 'TimeNotation') ->
     #'ObservedEvent'{eventName    = EN, 
 		     streamID     = SID, 
@@ -809,37 +809,37 @@ cre_ObservedEvent(EN, SID, EPL, TN)
 cre_EventName(N) when is_list(N) ->
     N.
 
-cre_EventParameter(N, V) when is_list(N) andalso is_list(V) ->
+cre_EventParameter(N, V) when is_list(N), is_list(V) ->
     #'EventParameter'{eventParameterName = N, 
 		      value              = V}.
 
 cre_EventParameter(N, V, relation = Tag, R) 
-  when is_list(N) andalso is_list(V) andalso is_atom(R) ->
+  when is_list(N), is_list(V), is_atom(R) ->
     EI = {Tag, R},
     #'EventParameter'{eventParameterName = N, 
 		      value              = V,
 		      extraInfo          = EI};
 cre_EventParameter(N, V, range = Tag, B) 
-  when is_list(N) andalso is_list(V) andalso is_atom(B) ->
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B},
     #'EventParameter'{eventParameterName = N, 
 		      value              = V,
 		      extraInfo          = EI};
 cre_EventParameter(N, V, sublist = Tag, B) 
-  when is_list(N) andalso is_list(V) andalso is_atom(B) ->
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B},
     #'EventParameter'{eventParameterName = N, 
 		      value              = V,
 		      extraInfo          = EI}.
 
 cre_ServiceChangeRequest(TermIDs, SCP) 
-  when is_list(TermIDs) andalso 
+  when is_list(TermIDs),
        is_record(SCP, 'ServiceChangeParm') ->
     #'ServiceChangeRequest'{terminationID      = TermIDs, 
 			    serviceChangeParms = SCP}.
 
 cre_ServiceChangeReply(TermIDs, {Tag, R} = SCR) 
-  when is_list(TermIDs) andalso is_atom(Tag) andalso is_tuple(R) ->
+  when is_list(TermIDs), is_atom(Tag), is_tuple(R) ->
     #'ServiceChangeReply'{terminationID       = TermIDs, 
 			  serviceChangeResult = SCR}.
 
@@ -851,8 +851,8 @@ cre_ServiceChangeResult(SCRP) when is_record(SCRP, 'ServiceChangeResParm') ->
 %% cre_WildcardField(L) when list(L), length(L) == 1 -> L.
 
 cre_TerminationID(W, ID) 
-  when is_list(W) andalso 
-       is_list(ID) andalso (1 =< length(ID)) andalso (length(ID) =< 8) ->
+  when is_list(W),
+       1 =< length(ID), length(ID) =< 8 ->
     #'TerminationID'{wildcard = W, 
 		     id       = ID}.
 
@@ -872,19 +872,19 @@ cre_MediaDescriptor([H|_] = SDs) when is_record(H, 'StreamDescriptor') ->
     #'MediaDescriptor'{streams = Streams}.
 
 cre_MediaDescriptor(TSD, SP) 
-  when is_record(TSD, 'TerminationStateDescriptor') andalso 
+  when is_record(TSD, 'TerminationStateDescriptor'),
        is_record(SP, 'StreamParms') ->
     Streams = {oneStream, SP},
     #'MediaDescriptor'{termStateDescr = TSD,
 		       streams        = Streams};
 cre_MediaDescriptor(TSD, [H|_] = SDs) 
-  when is_record(TSD, 'TerminationStateDescriptor') andalso 
+  when is_record(TSD, 'TerminationStateDescriptor'),
        is_record(H, 'StreamDescriptor') ->
     Streams = {multiStream, SDs},
     #'MediaDescriptor'{termStateDescr = TSD,
 		       streams        = Streams}.
 
-cre_StreamDescriptor(SID, SP) when is_integer(SID) andalso is_record(SP, 'StreamParms') ->
+cre_StreamDescriptor(SID, SP) when is_integer(SID), is_record(SP, 'StreamParms') ->
     #'StreamDescriptor'{streamID    = SID, 
 			streamParms = SP}.
 
@@ -897,15 +897,15 @@ cre_StreamParms(LD) when is_record(LD, 'LocalRemoteDescriptor') ->
     #'StreamParms'{localDescriptor = LD}.
 
 cre_StreamParms(LCD, LD) 
-  when (is_record(LCD, 'LocalControlDescriptor') or (LCD == asn1_NOVALUE)) and
-       (is_record(LD,  'LocalRemoteDescriptor')  or (LD  == asn1_NOVALUE)) ->
+  when is_record(LCD, 'LocalControlDescriptor') orelse LCD == asn1_NOVALUE,
+       is_record(LD,  'LocalRemoteDescriptor') orelse LD  == asn1_NOVALUE ->
     #'StreamParms'{localControlDescriptor = LCD,
 		   localDescriptor        = LD}.
 
 cre_StreamParms(LCD, LD, RD) 
-  when (is_record(LCD, 'LocalControlDescriptor') or (LCD == asn1_NOVALUE)) and
-       (is_record(LD,  'LocalRemoteDescriptor')  or (LD  == asn1_NOVALUE)) and
-       (is_record(RD,  'LocalRemoteDescriptor')  or (RD  == asn1_NOVALUE)) ->
+  when is_record(LCD, 'LocalControlDescriptor') orelse LCD == asn1_NOVALUE,
+       is_record(LD,  'LocalRemoteDescriptor')  orelse LD  == asn1_NOVALUE,
+       is_record(RD,  'LocalRemoteDescriptor')  orelse RD  == asn1_NOVALUE ->
     #'StreamParms'{localControlDescriptor = LCD,
 		   localDescriptor        = LD,
 		   remoteDescriptor       = RD}.
@@ -916,14 +916,14 @@ cre_LocalControlDescriptor([H|_] = PP) when is_record(H, 'PropertyParm') ->
     #'LocalControlDescriptor'{propertyParms = PP}.
 
 cre_LocalControlDescriptor(SM, [H|_] = PP) 
-  when is_atom(SM) andalso is_record(H, 'PropertyParm') ->
+  when is_atom(SM), is_record(H, 'PropertyParm') ->
     #'LocalControlDescriptor'{streamMode    = SM,
 			      propertyParms = PP}.
 
 cre_LocalControlDescriptor(SM, RV, RG, [H|_] = PP) 
-  when is_atom(SM) and
-     ((RV == true) or (RV == false) or (RV == asn1_NOVALUE)) and
-     ((RG == true) or (RG == false) or (RG == asn1_NOVALUE)) and
+  when is_atom(SM),
+     is_boolean(RV) orelse RV == asn1_NOVALUE,
+     is_boolean(RG) orelse RG == asn1_NOVALUE,
      is_record(H, 'PropertyParm') ->
     #'LocalControlDescriptor'{streamMode    = SM, 
 			      reserveValue  = RV, 
@@ -941,24 +941,24 @@ cre_StreamMode(inactive = M) ->
 cre_StreamMode(loopBack = M) ->
     M.
 
-cre_PropertyParm(N, [H|_] = V) when is_list(N) andalso is_list(H) ->
+cre_PropertyParm(N, [H|_] = V) when is_list(N), is_list(H) ->
     #'PropertyParm'{name = N, value = V}.
 
 cre_PropertyParm(N, [H|_] = V, relation = Tag, R) 
-  when is_list(N) andalso is_list(H) andalso is_atom(R) ->
+  when is_list(N), is_list(H), is_atom(R) ->
     EI = {Tag, R},
     #'PropertyParm'{name = N, value = V, extraInfo = EI};
 cre_PropertyParm(N, [H|_] = V, range = Tag, B) 
-  when is_list(N) andalso is_list(H) andalso is_atom(B) ->
+  when is_list(N), is_list(H), is_atom(B) ->
     EI = {Tag, B},
     #'PropertyParm'{name = N, value = V, extraInfo = EI};
 cre_PropertyParm(N, [H|_] = V, sublist = Tag, B) 
-  when is_list(N) andalso is_list(H) andalso is_atom(B) ->
+  when is_list(N), is_list(H), is_atom(B) ->
     EI = {Tag, B},
     #'PropertyParm'{name = N, value = V, extraInfo = EI}.
 
 
-cre_Name(N) when is_list(N) andalso (length(N) =:= 2) ->
+cre_Name(N) when length(N) =:= 2 ->
     N.
 
 cre_PkgdName(N) when is_list(N) ->
@@ -971,11 +971,11 @@ cre_PkgdName(N) when is_list(N) ->
 cre_PkgdName(root, root) ->
     "*/*";
 cre_PkgdName(PackageName, root) 
-  when is_list(PackageName) and (length(PackageName) =< 64) ->
+  when length(PackageName) =< 64 ->
     PackageName ++ "/*";
 cre_PkgdName(PackageName, ItemID) 
-  when ((is_list(PackageName) and (length(PackageName) =< 64)) and
-	(is_list(ItemID)      and (length(ItemID) =< 64))) ->
+  when length(PackageName) =< 64,
+       length(ItemID) =< 64 ->
     PackageName ++ "/" ++ ItemID;
 cre_PkgdName(PackageName, ItemID) ->
     error({invalid_PkgdName, {PackageName, ItemID}}).
@@ -1018,9 +1018,9 @@ cre_TerminationStateDescriptor([H|_] = PPs, inSvc = SS)
 				  serviceState  = SS}.
 
 cre_TerminationStateDescriptor([H|_] = PPs, EMC, SS) 
-  when is_record(H, 'PropertyParm') andalso 
-       ((EMC == off)  or (EMC == lockStep)) and
-       ((SS  == test) or (SS  == outOfSvc) or (SS == inSvc)) ->
+  when is_record(H, 'PropertyParm'),
+       EMC == off orelse EMC == lockStep,
+       SS  == test orelse SS  == outOfSvc orelse SS == inSvc ->
     #'TerminationStateDescriptor'{propertyParms      = PPs,
 				  eventBufferControl = EMC,
 				  serviceState       = SS}.
@@ -1038,7 +1038,7 @@ cre_ServiceState(inSvc = SS) ->
     SS.
 
 cre_MuxDescriptor(MT, [H|_] = TL) 
-  when is_atom(MT) andalso is_record(H, 'TerminationID') ->
+  when is_atom(MT), is_record(H, 'TerminationID') ->
     #'MuxDescriptor'{muxType = MT, termList = TL}.
 
 %% cre_MuxDescriptor(MT, [H|_] = TL, NSD) 
@@ -1066,43 +1066,43 @@ cre_EventsDescriptor() ->
     #'EventsDescriptor'{eventList = []}.
 
 cre_EventsDescriptor(RID, [H|_] = EL) 
-  when is_integer(RID) andalso is_record(H, 'RequestedEvent') ->
+  when is_integer(RID), is_record(H, 'RequestedEvent') ->
     #'EventsDescriptor'{requestID = RID, eventList = EL}.
     
 cre_RequestedEvent(N) ->
     #'RequestedEvent'{pkgdName = N}.
 
 cre_RequestedEvent(N, [H|_] = EPL) 
-  when is_list(N) andalso 
+  when is_list(N),
        is_record(H, 'EventParameter') ->
     #'RequestedEvent'{pkgdName  = N,
 		      evParList = EPL};
 cre_RequestedEvent(N, EA) 
-  when is_list(N) andalso 
+  when is_list(N),
        is_record(EA, 'RequestedActions')->
     #'RequestedEvent'{pkgdName    = N,
 		      eventAction = EA}.
 
 
 cre_RequestedEvent(N, SID, [H|_] = EPL) 
-  when is_list(N) andalso 
-       is_integer(SID) andalso 
+  when is_list(N),
+       is_integer(SID),
        is_record(H, 'EventParameter') ->
     #'RequestedEvent'{pkgdName  = N,
 		      streamID  = SID, 
 		      evParList = EPL};
 cre_RequestedEvent(N, EA, [H|_] = EPL) 
-  when is_list(N) andalso 
-       is_record(EA, 'RequestedActions') andalso 
+  when is_list(N),
+       is_record(EA, 'RequestedActions'),
        is_record(H, 'EventParameter') ->
     #'RequestedEvent'{pkgdName     = N,
 		      eventAction  = EA, 
 		      evParList    = EPL}.
 
 cre_RequestedEvent(N, SID, EA, [H|_] = EPL) 
-  when is_list(N) andalso 
-       is_integer(SID) andalso 
-       is_record(EA, 'RequestedActions') andalso 
+  when is_list(N),
+       is_integer(SID),
+       is_record(EA, 'RequestedActions'),
        is_record(H, 'EventParameter') ->
     #'RequestedEvent'{pkgdName     = N,
 		      streamID     = SID, 
@@ -1113,23 +1113,23 @@ cre_RequestedActions() ->
     #'RequestedActions'{}.
 
 cre_RequestedActions(KA) 
-  when (KA == true) or (KA == true) or (KA == asn1_NOVALUE) ->
+  when is_boolean(KA); KA == asn1_NOVALUE ->
     #'RequestedActions'{keepActive = KA};
 cre_RequestedActions(SE) 
-  when is_record(SE, 'SecondEventsDescriptor') or (SE == asn1_NOVALUE) ->
+  when is_record(SE, 'SecondEventsDescriptor'); SE == asn1_NOVALUE ->
     #'RequestedActions'{secondEvent = SE};
 cre_RequestedActions(SD) 
-  when is_list(SD) or (SD == asn1_NOVALUE) ->
+  when is_list(SD); SD == asn1_NOVALUE ->
     #'RequestedActions'{signalsDescriptor = SD};
 cre_RequestedActions({Tag, _} = EDM) 
-  when is_atom(Tag) or (EDM == asn1_NOVALUE) ->
+  when is_atom(Tag); EDM == asn1_NOVALUE ->
     #'RequestedActions'{eventDM = EDM}.
 
 cre_RequestedActions(KA, {Tag, _} = EDM, SE, SD) 
-  when ((KA == true) or (KA == true) or (KA == asn1_NOVALUE)) and
-       (is_atom(Tag) or (EDM == asn1_NOVALUE)) and
-       (is_record(SE, 'SecondEventsDescriptor') or (SE == asn1_NOVALUE)) and
-       (is_list(SD) or (SD == asn1_NOVALUE)) ->
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_atom(Tag) orelse EDM == asn1_NOVALUE,
+       is_record(SE, 'SecondEventsDescriptor') orelse SE == asn1_NOVALUE,
+       is_list(SD) orelse SD == asn1_NOVALUE ->
     #'RequestedActions'{keepActive        = KA, 
 			eventDM           = EDM, 
 			secondEvent       = SE, 
@@ -1145,34 +1145,34 @@ cre_SecondEventsDescriptor([H|_] = EL)
     #'SecondEventsDescriptor'{eventList = EL}.
     
 cre_SecondEventsDescriptor(RID, [H|_] = EL) 
-  when is_integer(RID) andalso is_record(H, 'SecondRequestedEvent') ->
+  when is_integer(RID), is_record(H, 'SecondRequestedEvent') ->
     #'SecondEventsDescriptor'{requestID = RID, eventList = EL}.
     
 cre_SecondRequestedEvent(N, [H|_] = EPL) 
-  when is_list(N) andalso 
+  when is_list(N),
        is_record(H, 'EventParameter') ->
     #'SecondRequestedEvent'{pkgdName  = N,
 			    evParList = EPL}.
 
 cre_SecondRequestedEvent(N, SID, [H|_] = EPL) 
-  when is_list(N) andalso 
-       is_integer(SID) andalso 
+  when is_list(N),
+       is_integer(SID),
        is_record(H, 'EventParameter') ->
     #'SecondRequestedEvent'{pkgdName  = N,
 			    streamID  = SID, 
 			    evParList = EPL};
 cre_SecondRequestedEvent(N, EA, [H|_] = EPL) 
-  when is_list(N) andalso 
-       is_record(EA, 'SecondRequestedActions') andalso 
+  when is_list(N),
+       is_record(EA, 'SecondRequestedActions'),
        is_record(H, 'EventParameter') ->
     #'SecondRequestedEvent'{pkgdName     = N,
 			    eventAction  = EA, 
 			    evParList    = EPL}.
 
 cre_SecondRequestedEvent(N, SID, EA, [H|_] = EPL) 
-  when is_list(N) andalso 
-       is_integer(SID) andalso 
-       is_record(EA, 'SecondRequestedActions') andalso 
+  when is_list(N),
+       is_integer(SID),
+       is_record(EA, 'SecondRequestedActions'),
        is_record(H, 'EventParameter') ->
     #'SecondRequestedEvent'{pkgdName     = N,
 			    streamID     = SID, 
@@ -1183,7 +1183,7 @@ cre_SecondRequestedActions() ->
     #'SecondRequestedActions'{}.
 
 cre_SecondRequestedActions(KA) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) ->
+  when is_boolean(KA); KA == asn1_NOVALUE ->
     #'SecondRequestedActions'{keepActive = KA};
 cre_SecondRequestedActions(SD) when is_list(SD) ->
     #'SecondRequestedActions'{signalsDescriptor = SD};
@@ -1191,16 +1191,16 @@ cre_SecondRequestedActions({Tag, _} = EDM) when is_atom(Tag) ->
     #'SecondRequestedActions'{eventDM = EDM}.
 
 cre_SecondRequestedActions(KA, SD) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_list(SD) ->
     #'SecondRequestedActions'{keepActive = KA, signalsDescriptor = SD};
 cre_SecondRequestedActions(KA, {Tag, _} = EDM) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_atom(Tag) ->
     #'SecondRequestedActions'{keepActive = KA, eventDM = EDM}.
 
 cre_SecondRequestedActions(KA, {Tag, _} = EDM, SD) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_atom(Tag), 
        is_list(SD) ->
     #'SecondRequestedActions'{keepActive        = KA, 
@@ -1210,11 +1210,11 @@ cre_SecondRequestedActions(KA, {Tag, _} = EDM, SD)
 cre_EventBufferDescriptor([H|_] = D) when is_record(H, 'EventSpec') ->
     D.
 
-cre_EventSpec(N, [H|_] = EPL) when is_list(N) andalso is_record(H, 'EventParameter') ->
+cre_EventSpec(N, [H|_] = EPL) when is_list(N), is_record(H, 'EventParameter') ->
     #'EventSpec'{eventName = N, eventParList = EPL}.
 
 cre_EventSpec(N, SID, [H|_] = EPL) 
-  when is_list(N) andalso is_integer(SID) andalso is_record(H, 'EventParameter') ->
+  when is_list(N) andalso is_integer(SID), is_record(H, 'EventParameter') ->
     #'EventSpec'{eventName = N, streamID = SID, eventParList = EPL}.
     
 cre_SignalsDescriptor(D) when is_list(D) ->
@@ -1226,25 +1226,23 @@ cre_SignalRequest(S) when is_record(S, 'SeqSigList') ->
     {seqSigList, S}.
 
 cre_SeqSigList(ID, [H|_] = SL) 
-  when is_integer(ID) andalso (0 =< ID) andalso (ID =< 65535) andalso is_record(H, 'Signal') ->
+  when is_integer(ID), 0 =< ID, ID =< 65535, is_record(H, 'Signal') ->
     #'SeqSigList'{id = ID, signalList = SL}.
 
 cre_Signal(N) when is_list(N) ->
     #'Signal'{signalName = N}.
 
-cre_Signal(N, [H|_] = SPL) when is_list(N) andalso is_record(H, 'SigParameter') ->
+cre_Signal(N, [H|_] = SPL) when is_list(N), is_record(H, 'SigParameter') ->
     #'Signal'{signalName = N,
 	      sigParList = SPL}.
 
 cre_Signal(N, SID, ST, Dur, NC, KA, [H|_] = SPL) 
-  when is_list(N) and 
-       (is_integer(SID) or (SID == asn1_NOVALUE)) and 
-       ((ST == brief) or (ST == onOff) or (ST == timeOut) or 
-	(ST == asn1_NOVALUE)) and
-       ((is_integer(Dur) and (0 =< Dur) and (Dur =< 65535)) or 
-	(Dur == asm1_NOVALUE)) and
-       is_list(NC) and
-       ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+  when is_list(N),
+       is_integer(SID) orelse SID == asn1_NOVALUE,
+       ST == brief orelse ST == onOff orelse ST == timeOut orelse ST == asn1_NOVALUE,
+       is_integer(Dur) andalso 0 =< Dur andalso Dur =< 65535 orelse Dur == asn1_NOVALUE,
+       is_list(NC),
+       is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_record(H, 'SigParameter') ->
     #'Signal'{signalName       = N,
 	      streamID         = SID,
@@ -1277,19 +1275,19 @@ cre_NotifyCompletion(L) when is_list(L) ->
     lists:foreach(F, L),
     L.
 
-cre_SigParameter(N, V) when is_list(N) andalso is_list(V) ->
+cre_SigParameter(N, V) when is_list(N), is_list(V) ->
     #'SigParameter'{sigParameterName = N, value = V}.
 
 cre_SigParameter(N, V, relation = Tag, R) 
-  when is_list(N) andalso is_list(V) andalso is_atom(R) ->
+  when is_list(N) andalso is_list(V), is_atom(R) ->
     EI = {Tag, R}, 
     #'SigParameter'{sigParameterName = N, value = V, extraInfo = EI};
 cre_SigParameter(N, V, range = Tag, B) 
-  when is_list(N) andalso is_list(V) andalso is_atom(B) ->
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B}, 
     #'SigParameter'{sigParameterName = N, value = V, extraInfo = EI};
 cre_SigParameter(N, V, sublist = Tag, B) 
-  when is_list(N) andalso is_list(V) andalso is_atom(B) ->
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B}, 
     #'SigParameter'{sigParameterName = N, value = V, extraInfo = EI}.
 
@@ -1298,7 +1296,7 @@ cre_RequestID(Val) when 0 =< Val, Val =< 4294967295 ->
 cre_RequestID(Val) ->
     exit({invalid_RequestID, Val}).
 
-cre_ModemDescriptor(MTL, MPL) when is_list(MTL) andalso is_list(MPL) ->
+cre_ModemDescriptor(MTL, MPL) when is_list(MTL), is_list(MPL) ->
     #'ModemDescriptor'{mtl = MTL, mpl = MPL}.
 
 %% cre_ModemDescriptor(MTL, MPL, NSD) 
@@ -1332,7 +1330,7 @@ cre_DigitMapDescriptor(N) when is_list(N) ->
 cre_DigitMapDescriptor(V) when is_record(V, 'DigitMapValue') ->
     #'DigitMapDescriptor'{digitMapValue = V}.
 
-cre_DigitMapDescriptor(N, V) when is_list(N) andalso is_record(V, 'DigitMapValue') ->
+cre_DigitMapDescriptor(N, V) when is_list(N), is_record(V, 'DigitMapValue') ->
     #'DigitMapDescriptor'{digitMapName = N, digitMapValue = V}.
 
 cre_DigitMapName(N) ->
@@ -1345,22 +1343,18 @@ cre_DigitMapValue(Start, Short, Long, DMB) ->
     cre_DigitMapValue(Start, Short, Long, DMB, asn1_NOVALUE).
 
 cre_DigitMapValue(Start, Short, Long, DMB, Dur) 
-  when ((is_integer(Start) and (0 =< Start) and (Start =< 99)) or
-	(Start == asn1_NOVALUE)) and
-       ((is_integer(Short) and (0 =< Short) and (Short =< 99)) or
-	(Short == asn1_NOVALUE)) and
-       ((is_integer(Long) and (0 =< Long) and (Long =< 99)) or
-	(Long == asn1_NOVALUE)) and
-       is_list(DMB) and
-       ((is_integer(Dur) and (0 =< Dur) and (Dur =< 99)) or
-	(Dur == asn1_NOVALUE)) ->
+  when is_integer(Start) andalso 0 =< Start andalso Start =< 99 orelse Start == asn1_NOVALUE,
+       is_integer(Short) andalso 0 =< Short andalso Short =< 99 orelse Short == asn1_NOVALUE,
+       is_integer(Long) andalso 0 =< Long andalso Long =< 99 orelse Long == asn1_NOVALUE,
+       is_list(DMB),
+       is_integer(Dur) andalso 0 =< Dur andalso Dur =< 99 orelse Dur == asn1_NOVALUE ->
     #'DigitMapValue'{startTimer    = Start,
 		     shortTimer    = Short,
 		     longTimer     = Long,
 		     digitMapBody  = DMB,
 		     durationTimer = Dur}.
 
-cre_ServiceChangeParm(M, R) when is_atom(M) andalso is_list(R) ->
+cre_ServiceChangeParm(M, R) when is_atom(M), is_list(R) ->
     #'ServiceChangeParm'{serviceChangeMethod = M,
 			 serviceChangeReason = R}.
 
@@ -1370,21 +1364,18 @@ cre_ServiceChangeParm(M, Addr, Prof, Reason) ->
 				
 %% Addr = asn1_NOVALUE | {AddrTag, AddrVal}
 cre_ServiceChangeParm(M, Addr, Ver, Prof, R, D, Mid, TS, I) 
-  when is_atom(M) and 
-       ((is_integer(Ver) and (0 =< Ver) and (Ver =< 99)) or
-	(Ver == asn1_NOVALUE)) and
-       (is_record(Prof, 'ServiceChangeProfile') or (Prof == asn1_NOVALUE)) and
-       is_list(R) and
-       ((is_integer(D) and (0 =< D) and (D =< 4294967295)) or 
-	(D == asn1_NOVALUE)) and
-       (is_record(TS, 'TimeNotation') or (TS == asn1_NOVALUE)) and
-       (is_record(I, 'AuditDescriptor') or (I == asn1_NOVALUE)) ->
-    F = fun(A) -> 
-		(A == asn1_NOVALUE) orelse 
-				      (is_tuple(A) 
-				       andalso is_atom(element(1, A))) 
+  when is_atom(M),
+       is_integer(Ver) andalso 0 =< Ver andalso Ver =< 99 orelse Ver == asn1_NOVALUE,
+       is_record(Prof, 'ServiceChangeProfile') orelse Prof == asn1_NOVALUE,
+       is_list(R),
+       is_integer(D) andalso 0 =< D andalso D =< 4294967295 orelse D == asn1_NOVALUE,
+       is_record(TS, 'TimeNotation') orelse TS == asn1_NOVALUE,
+       is_record(I, 'AuditDescriptor') orelse I == asn1_NOVALUE ->
+    F = fun(A) ->
+                A == asn1_NOVALUE orelse
+                    is_tuple(A) andalso is_atom(element(1, A))
 	end,
-    case (F(Addr) andalso F(Mid)) of
+    case F(Addr) andalso F(Mid) of
 	true ->
 	    #'ServiceChangeParm'{serviceChangeMethod  = M,
 				 serviceChangeAddress = Addr, 
@@ -1400,7 +1391,7 @@ cre_ServiceChangeParm(M, Addr, Ver, Prof, R, D, Mid, TS, I)
     end.
 		
 cre_ServiceChangeAddress(portNumber = Tag, P) 
-  when is_integer(P) andalso (0 =< P) andalso (P =< 65535) ->
+  when is_integer(P), 0 =< P, P =< 65535 ->
     {Tag, P};
 cre_ServiceChangeAddress(ip4Address = Tag, A) when is_record(A, 'IP4Address') ->
     {Tag, A};
@@ -1419,16 +1410,14 @@ cre_ServiceChangeResParm(Addr, Prof) ->
     cre_ServiceChangeResParm(asn1_NOVALUE, Addr, asn1_NOVALUE, 
 			     Prof, asn1_NOVALUE).
 cre_ServiceChangeResParm(Mid, Addr, Ver, Prof, TS)
-  when ((is_integer(Ver) and (0 =< Ver) and (Ver =< 99)) or 
-	(Ver == asn1_NOVALUE)) and 
-       (is_record(Prof, 'ServiceChangeProfile') or (Prof == asn1_NOVALUE)) and
-       (is_record(TS, 'TimeNotation') or (TS == asn1_NOVALUE)) ->
-    F = fun(A) -> 
-		(A == asn1_NOVALUE) orelse 
-				      (is_tuple(A) 
-				       andalso is_atom(element(1, A))) 
+  when is_integer(Ver) andalso 0 =< Ver andalso Ver =< 99 orelse Ver == asn1_NOVALUE,
+       is_record(Prof, 'ServiceChangeProfile') orelse Prof == asn1_NOVALUE,
+       is_record(TS, 'TimeNotation') orelse TS == asn1_NOVALUE ->
+    F = fun(A) ->
+                A == asn1_NOVALUE orelse
+                    is_tuple(A) andalso is_atom(element(1, A))
 	end,
-    case (F(Addr) andalso F(Mid)) of
+    case F(Addr) andalso F(Mid) of
 	true ->
 	    #'ServiceChangeResParm'{serviceChangeMgcId   = Mid, 
 				    serviceChangeAddress = Addr, 
@@ -1457,16 +1446,16 @@ cre_ServiceChangeProfile(N) ->
     cre_ServiceChangeProfile(N, 1).
 
 cre_ServiceChangeProfile(N, V) 
-  when is_list(N) andalso is_integer(V) andalso (0 =< V) andalso (V =< 99) ->
+  when is_list(N), is_integer(V), 0 =< V, V =< 99 ->
     #'ServiceChangeProfile'{profileName = N, version = V}.
     
 cre_PackagesDescriptor([H|_] = D) when is_record(H, 'PackagesItem') ->
     D.
 
 cre_PackagesItem(N, Ver) 
-  when is_list(N) andalso 
-       is_integer(Ver) andalso 
-       (0 =< Ver) andalso (Ver =< 99) ->
+  when is_list(N),
+       is_integer(Ver),
+       0 =< Ver, Ver =< 99 ->
     #'PackagesItem'{packageName    = N, 
 		    packageVersion = Ver}.
 
@@ -1476,7 +1465,7 @@ cre_StatisticsDescriptor([H|_] = D) when is_record(H, 'StatisticsParameter') ->
 cre_StatisticsParameter(N) when is_list(N) ->
     #'StatisticsParameter'{statName = N}.
 
-cre_StatisticsParameter(N, V) when is_list(N) andalso is_list(V) ->
+cre_StatisticsParameter(N, V) when is_list(N), is_list(V) ->
     #'StatisticsParameter'{statName = N, statValue = V}.
 
 %% cre_NonStandardData({Tag, _} = Id, Data) when atom(Tag), list(Data) ->
@@ -1500,7 +1489,7 @@ cre_StatisticsParameter(N, V) when is_list(N) andalso is_list(V) ->
 %% 		       manufacturerCode = MC}.
        
 cre_TimeNotation(D, T) 
-  when is_list(D) andalso (length(D) =:= 8) andalso is_list(T) andalso (length(T) =:= 8) ->
+  when length(D) =:= 8, length(T) =:= 8 ->
     #'TimeNotation'{date = D, time = T}.
     
 cre_Value([H|_] = V) when is_list(H) ->
@@ -1815,19 +1804,19 @@ chk_Transaction({Tag, Val} = Trans, {Tag, Val}) ->
 	    wrong_type('Transaction', Trans, Trans)
     end;
 chk_Transaction({Tag, Val1} = Trans1, {Tag, Val2} = Trans2) ->
-    case (is_Transaction_tag(Tag) and
-	  is_Transaction_val(Tag, Val1) and
-	  is_Transaction_val(Tag, Val2)) of
+    case is_Transaction_tag(Tag) andalso
+        is_Transaction_val(Tag, Val1) andalso
+        is_Transaction_val(Tag, Val2) of
 	true ->
 	    chk_Transaction_val(Tag, Val1, Val2);
 	false ->
 	    wrong_type('Transaction', Trans1, Trans2)
     end;
 chk_Transaction({Tag1, Val1} = Trans1, {Tag2, Val2} = Trans2) ->
-    case ((is_Transaction_tag(Tag1) andalso 
-	   is_Transaction_val(Tag1, Val1)) andalso
-	  (is_Transaction_tag(Tag2) andalso 
-	   is_Transaction_val(Tag2, Val2))) of
+    case is_Transaction_tag(Tag1) andalso
+        is_Transaction_val(Tag1, Val1) andalso
+        is_Transaction_tag(Tag2) andalso
+        is_Transaction_val(Tag2, Val2) of
 	true ->
 	    not_equal('Transaction', Trans1, Trans2);
 	false ->
@@ -1860,7 +1849,7 @@ chk_opt_TransactionId(TID1, TID2) ->
 chk_TransactionId(TID, TID) ->
     chk_type(fun is_TransactionId/1, 'TransactionId', TID);
 chk_TransactionId(TID1, TID2) ->
-    case (is_TransactionId(TID1) andalso is_TransactionId(TID2)) of
+    case is_TransactionId(TID1) andalso is_TransactionId(TID2) of
 	true ->
 	    not_equal('TransactionId', TID1, TID2);
 	false ->
@@ -1978,9 +1967,9 @@ chk_TransactionReply_transactionResult(Res, Res) ->
 	     'TransactionReply_transactionResult', Res);
 chk_TransactionReply_transactionResult({Tag, Val1} = Res1, 
 				       {Tag, Val2} = Res2) ->
-    case (is_TransactionReply_transactionResult_tag(Tag) and
-	  is_TransactionReply_transactionResult_val(Tag, Val1) and
-	  is_TransactionReply_transactionResult_val(Tag, Val2)) of
+    case is_TransactionReply_transactionResult_tag(Tag) andalso
+        is_TransactionReply_transactionResult_val(Tag, Val1) andalso
+        is_TransactionReply_transactionResult_val(Tag, Val2) of
 	true ->
 	    chk_TransactionReply_transactionResult_val(Tag, Val1, Val2);
 	false ->
@@ -1988,10 +1977,10 @@ chk_TransactionReply_transactionResult({Tag, Val1} = Res1,
     end;
 chk_TransactionReply_transactionResult({Tag1, Val1} = Res1, 
 				       {Tag2, Val2} = Res2) ->
-    case ((is_TransactionReply_transactionResult_tag(Tag1) and
-	   is_TransactionReply_transactionResult_val(Tag1, Val1)) and
-	  (is_TransactionReply_transactionResult_tag(Tag2) and
-	   is_TransactionReply_transactionResult_val(Tag2, Val2))) of
+    case is_TransactionReply_transactionResult_tag(Tag1) andalso
+        is_TransactionReply_transactionResult_val(Tag1, Val1) andalso
+        is_TransactionReply_transactionResult_tag(Tag2) andalso
+        is_TransactionReply_transactionResult_val(Tag2, Val2) of
 	true ->
 	    not_equal('TransactionReply_transactionResult', Res1, Res2);
 	false ->
@@ -4692,19 +4681,19 @@ chk_PropertyParm_value(V1, V2) ->
 chk_PropertyParm_extraInfo(EI, EI) ->
     chk_type(fun is_PropertyParm_extraInfo/1, 'PropertyParm_extraInfo', EI);
 chk_PropertyParm_extraInfo({Tag, Val1} = EI1, {Tag, Val2} = EI2) ->
-    case (is_PropertyParm_extraInfo_tag(Tag) and
-	  is_PropertyParm_extraInfo_val(Tag, Val1) and
-	  is_PropertyParm_extraInfo_val(Tag, Val2)) of
+    case is_PropertyParm_extraInfo_tag(Tag) andalso
+        is_PropertyParm_extraInfo_val(Tag, Val1) andalso
+        is_PropertyParm_extraInfo_val(Tag, Val2) of
 	true ->
 	    chk_PropertyParm_extraInfo_val(Tag, Val1, Val2);
 	false ->
 	    wrong_type('PropertyParm_extraInfo', EI1, EI2)
     end;
 chk_PropertyParm_extraInfo({Tag1, Val1} = EI1, {Tag2, Val2} = EI2) ->
-    case ((is_PropertyParm_extraInfo_tag(Tag1) and
-	   is_PropertyParm_extraInfo_val(Tag1, Val1)) and
-	  (is_PropertyParm_extraInfo_tag(Tag2) and
-	   is_PropertyParm_extraInfo_val(Tag2, Val2))) of
+    case is_PropertyParm_extraInfo_tag(Tag1) andalso
+        is_PropertyParm_extraInfo_val(Tag1, Val1) andalso
+        is_PropertyParm_extraInfo_tag(Tag2) andalso
+        is_PropertyParm_extraInfo_val(Tag2, Val2) of
 	true ->
 	    not_equal('PropertyParm_extraInfo', EI1, EI2);
 	false ->
@@ -5911,19 +5900,19 @@ chk_SigParameter(P1, P2) ->
 chk_SigParameter_extraInfo(EI, EI) ->
     chk_type(fun is_SigParameter_extraInfo/1, 'SigParameter_extraInfo', EI);
 chk_SigParameter_extraInfo({Tag, Val1} = EI1, {Tag, Val2} = EI2) ->
-    case (is_SigParameter_extraInfo_tag(Tag) and
-	  is_SigParameter_extraInfo_val(Tag, Val1) and
-	  is_SigParameter_extraInfo_val(Tag, Val2)) of
+    case is_SigParameter_extraInfo_tag(Tag) andalso
+        is_SigParameter_extraInfo_val(Tag, Val1) andalso
+        is_SigParameter_extraInfo_val(Tag, Val2) of
 	true ->
 	    chk_SigParameter_extraInfo_val(Tag, Val1, Val2);
 	false ->
 	    wrong_type('SigParameter_extraInfo', EI1, EI2)
     end;
 chk_SigParameter_extraInfo({Tag1, Val1} = EI1, {Tag2, Val2} = EI2) ->
-    case ((is_SigParameter_extraInfo_tag(Tag1) and
-	   is_SigParameter_extraInfo_val(Tag1, Val1)) and
-	  (is_SigParameter_extraInfo_tag(Tag2) and
-	   is_SigParameter_extraInfo_val(Tag2, Val2))) of
+    case is_SigParameter_extraInfo_tag(Tag1) andalso
+        is_SigParameter_extraInfo_val(Tag1, Val1) andalso
+        is_SigParameter_extraInfo_tag(Tag2) andalso
+        is_SigParameter_extraInfo_val(Tag2, Val2) of
 	true ->
 	    not_equal('SigParameter_extraInfo', EI1, EI2);
 	false ->
@@ -6832,14 +6821,14 @@ is_OCTET_STRING(L) -> is_OCTET_STRING(L, any).
 
 is_OCTET_STRING(L, any) when is_list(L) ->
     true;
-is_OCTET_STRING(L, {exact, Len}) when is_list(L) andalso (length(L) =:= Len) ->
+is_OCTET_STRING(L, {exact, Len}) when length(L) =:= Len ->
     true;
-is_OCTET_STRING(L, {atleast, Len}) when is_list(L) andalso (Len =< length(L)) ->
+is_OCTET_STRING(L, {atleast, Len}) when Len =< length(L) ->
     true;
-is_OCTET_STRING(L, {atmost, Len}) when is_list(L) andalso (length(L) =< Len) ->
+is_OCTET_STRING(L, {atmost, Len}) when length(L) =< Len ->
     true;
 is_OCTET_STRING(L, {range, Min, Max}) 
-  when is_list(L) andalso (Min =< length(L)) andalso (length(L) =< Max) ->
+  when Min =< length(L), length(L) =< Max ->
     true;
 is_OCTET_STRING(_, _) ->
     false.

--- a/lib/megaco/test/megaco_test_msg_v3_lib.erl
+++ b/lib/megaco/test/megaco_test_msg_v3_lib.erl
@@ -272,7 +272,7 @@ cre_MegacoMessage(M) when is_record(M, 'Message') ->
     #'MegacoMessage'{mess = M}.
 
 cre_MegacoMessage(AH, M) 
-  when is_record(AH, 'AuthenticationHeader') and
+  when is_record(AH, 'AuthenticationHeader'),
        is_record(M, 'Message') ->
     #'MegacoMessage'{authHeader = AH,
 		     mess       = M}.
@@ -306,10 +306,10 @@ cre_Message(V, Mid, {errorDescriptor, ED} = Body)
 cre_ErrorDescriptor(EC) when is_integer(EC) ->
     #'ErrorDescriptor'{errorCode = EC}.
 
-cre_ErrorDescriptor(EC, ET) when is_integer(EC) and is_list(ET) ->
+cre_ErrorDescriptor(EC, ET) when is_integer(EC), is_list(ET) ->
     #'ErrorDescriptor'{errorCode = EC, errorText = ET}.
 
-cre_ErrorCode(C) when is_integer(C) and (0 =< C) and (C =< 65535) ->
+cre_ErrorCode(C) when is_integer(C), 0 =< C, C =< 65535 ->
     C;
 cre_ErrorCode(C) ->
     exit({invalid_ErrorCode, C}).
@@ -317,7 +317,7 @@ cre_ErrorCode(C) ->
 cre_ErrorText(T) when is_list(T) ->
     T.
 
-cre_ContextID(Val) when (0 =< Val) and (Val =< 4294967295) ->
+cre_ContextID(Val) when 0 =< Val, Val =< 4294967295 ->
     Val;
 cre_ContextID(Val) ->
     exit({invalid_ContextID, Val}).
@@ -333,26 +333,26 @@ cre_Transaction(TRA) when is_list(TRA) ->
 cre_Transaction(SR) when is_record(SR, 'SegmentReply') ->
     {segmentReply, SR}.
 
-cre_TransactionId(Val) when (0 =< Val) and (Val =< 4294967295) ->
+cre_TransactionId(Val) when 0 =< Val, Val =< 4294967295 ->
     Val;
 cre_TransactionId(Val) ->
     exit({invalid_TransactionId, Val}).
 
 cre_TransactionRequest(TransID, ARs) 
-  when is_integer(TransID) and is_list(ARs) -> 
-    #'TransactionRequest'{transactionId = TransID, 
+  when is_integer(TransID), is_list(ARs) ->
+    #'TransactionRequest'{transactionId = TransID,
 			  actions       = ARs}.
 
 cre_TransactionPending(TransID) when is_integer(TransID) ->
     #'TransactionPending'{transactionId = TransID}.
 
 cre_TransactionReply(TransID, ED) 
-  when is_integer(TransID) and is_record(ED, 'ErrorDescriptor') ->
+  when is_integer(TransID), is_record(ED, 'ErrorDescriptor') ->
     Res = {transactionError, ED},
     #'TransactionReply'{transactionId     = TransID,
 			transactionResult = Res};
 cre_TransactionReply(TransID, ARs) 
-  when is_integer(TransID) and is_list(ARs) ->
+  when is_integer(TransID), is_list(ARs) ->
     Res = {actionReplies, ARs},
     #'TransactionReply'{transactionId     = TransID,
 			transactionResult = Res};
@@ -360,31 +360,31 @@ cre_TransactionReply(TransID, Res) ->
     error({invalid_TransactionReply_values, {TransID, Res}}).
 
 cre_TransactionReply(TransID, IAR, ED) 
-  when is_integer(TransID) and 
-       ((IAR == 'NULL') or (IAR == asn1_NOVALUE)) and 
+  when is_integer(TransID),
+       IAR == 'NULL' orelse IAR == asn1_NOVALUE,
        is_record(ED, 'ErrorDescriptor') ->
     Res = {transactionError, ED},
     #'TransactionReply'{transactionId     = TransID,
 			immAckRequired    = IAR, 
 			transactionResult = Res};
 cre_TransactionReply(TransID, IAR, ARs) 
-  when is_integer(TransID) and 
-       ((IAR == 'NULL') or (IAR == asn1_NOVALUE)) and 
+  when is_integer(TransID),
+       IAR == 'NULL' orelse IAR == asn1_NOVALUE,
        is_list(ARs) ->
     Res = {actionReplies, ARs},
     #'TransactionReply'{transactionId     = TransID,
 			immAckRequired    = IAR, 
 			transactionResult = Res};
-cre_TransactionReply(TransID, Res, SN) 
-  when (is_integer(SN) and (SN > 0) and (SN =< 65535)) or 
-	(SN == asn1_NOVALUE) ->
+cre_TransactionReply(TransID, Res, SN)
+  when is_integer(SN), SN > 0, SN =< 65535;
+       SN == asn1_NOVALUE ->
     TR  = cre_TransactionReply(TransID, Res),
     TR#'TransactionReply'{segmentNumber = SN};
 cre_TransactionReply(TransID, Res, SN) ->
     error({invalid_TransactionReply_values, {TransID, Res, SN}}).
 
 cre_TransactionReply(TransID, Res, SN, SC) 
-  when is_integer(SN) and ((SC == 'NULL') or (SC == asn1_NOVALUE)) ->
+  when is_integer(SN), SC == 'NULL' orelse SC == asn1_NOVALUE ->
     TR = cre_TransactionReply(TransID, Res),
     TR#'TransactionReply'{segmentNumber        = SN,
 			  segmentationComplete = SC};
@@ -392,11 +392,11 @@ cre_TransactionReply(TransID, IAR, Res, SN) ->
     cre_TransactionReply(TransID, IAR, Res, SN, asn1_NOVALUE).
 
 cre_TransactionReply(TransID, IAR, Res, SN, SC) 
-  when (SN == asn1_NOVALUE) and (SC == asn1_NOVALUE) ->
+  when SN == asn1_NOVALUE, SC == asn1_NOVALUE ->
     cre_TransactionReply(TransID, IAR, Res);
 cre_TransactionReply(TransID, IAR, Res, SN, SC) 
-  when (is_integer(SN) and (SN > 0) and (SN =< 65535)) and 
-       ((SC == asn1_NOVALUE) or (SC == 'NULL')) ->
+  when is_integer(SN), SN > 0, SN =< 65535,
+       SC == asn1_NOVALUE orelse SC == 'NULL' ->
     TR = cre_TransactionReply(TransID, IAR, Res),
     TR#'TransactionReply'{segmentNumber        = SN,
 			  segmentationComplete = SC};
@@ -404,16 +404,16 @@ cre_TransactionReply(TransID, IAR, Res, SN, SC) ->
     error({invalid_TransactionReply_values, {TransID, IAR, Res, SN, SC}}).
 
 
-cre_SegmentReply(TransID, SN) 
-  when is_integer(TransID) and
-       is_integer(SN) and (SN > 0) and (SN =< 65535) ->
+cre_SegmentReply(TransID, SN)
+  when is_integer(TransID),
+       is_integer(SN), SN > 0, SN =< 65535 ->
     #'SegmentReply'{transactionId = TransID,
 		    segmentNumber = SN}.
 
-cre_SegmentReply(TransID, SN, SC) 
-  when is_integer(TransID) and
-       is_integer(SN) and (SN > 0) and (SN =< 65535) and
-       ((SC == 'NULL') or (SC == asn1_NOVALUE)) ->
+cre_SegmentReply(TransID, SN, SC)
+  when is_integer(TransID),
+       is_integer(SN), SN > 0, SN =< 65535,
+       SC == 'NULL' orelse SC == asn1_NOVALUE ->
     #'SegmentReply'{transactionId        = TransID,
 		    segmentNumber        = SN,
 		    segmentationComplete = SC}.
@@ -427,54 +427,54 @@ cre_TransactionAck(FirstAck, LastAck) ->
     #'TransactionAck'{firstAck = FirstAck, 
 		      lastAck  = LastAck}.
 
-cre_ActionRequest(CtxID, CmdReqs) 
-  when is_integer(CtxID) and is_list(CmdReqs) ->
+cre_ActionRequest(CtxID, CmdReqs)
+  when is_integer(CtxID), is_list(CmdReqs) ->
     #'ActionRequest'{contextId       = CtxID,
 		     commandRequests = CmdReqs}.
 
-cre_ActionRequest(CtxID, CtxReq, CmdReqs) 
-  when is_integer(CtxID) and 
-       is_record(CtxReq, 'ContextRequest') and
+cre_ActionRequest(CtxID, CtxReq, CmdReqs)
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId       = CtxID,
 		     contextRequest  = CtxReq,
 		     commandRequests = CmdReqs};
-cre_ActionRequest(CtxID, CAAR, CmdReqs) 
-  when is_integer(CtxID) and 
-       is_record(CAAR, 'ContextAttrAuditRequest') and
+cre_ActionRequest(CtxID, CAAR, CmdReqs)
+  when is_integer(CtxID),
+       is_record(CAAR, 'ContextAttrAuditRequest'),
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId           = CtxID,
 		     contextAttrAuditReq = CAAR,
 		     commandRequests     = CmdReqs}.
 
-cre_ActionRequest(CtxID, CtxReq, CAAR, CmdReqs) 
-  when is_integer(CtxID) and 
-       (is_record(CtxReq, 'ContextRequest') or 
-	(CtxReq == asn1_NOVALUE)) and
-       (is_record(CAAR, 'ContextAttrAuditRequest') or 
-	(CAAR == asn1_NOVALUE)) and
+cre_ActionRequest(CtxID, CtxReq, CAAR, CmdReqs)
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest') orelse
+       CtxReq == asn1_NOVALUE,
+       is_record(CAAR, 'ContextAttrAuditRequest') orelse
+       CAAR == asn1_NOVALUE,
        is_list(CmdReqs) ->
     #'ActionRequest'{contextId           = CtxID,
 		     contextRequest      = CtxReq,
 		     contextAttrAuditReq = CAAR,
 		     commandRequests     = CmdReqs}.
 
-cre_ActionReply(CtxID, CmdReps) 
-  when is_integer(CtxID) and 
+cre_ActionReply(CtxID, CmdReps)
+  when is_integer(CtxID),
        is_list(CmdReps) ->
     #'ActionReply'{contextId    = CtxID,
 		   commandReply = CmdReps}.
 
-cre_ActionReply(CtxID, ED, CmdReps) 
-  when is_integer(CtxID) and 
-       is_record(ED, 'ErrorDescriptor') and 
+cre_ActionReply(CtxID, ED, CmdReps)
+  when is_integer(CtxID),
+       is_record(ED, 'ErrorDescriptor'),
        is_list(CmdReps) ->
     #'ActionReply'{contextId       = CtxID,
 		   errorDescriptor = ED, 
 		   commandReply    = CmdReps};
-cre_ActionReply(CtxID, CtxReq, CmdReps) 
-  when is_integer(CtxID) and
-       is_record(CtxReq, 'ContextRequest') and
+cre_ActionReply(CtxID, CtxReq, CmdReps)
+  when is_integer(CtxID),
+       is_record(CtxReq, 'ContextRequest'),
        is_list(CmdReps) ->
     #'ActionReply'{contextId    = CtxID,
 		   contextReply = CtxReq, 
@@ -533,12 +533,12 @@ cre_ContextRequest(Prio, Em, Top, Ieps)
 			   topologyReq    = Top,
 			   iepscallind    = Ieps},
     strip_ContextRequest(CR);
-cre_ContextRequest(Prio, Em, Top, Ctx) 
-  when ((is_integer(Prio) andalso (0 =< Prio) andalso (Prio =< 15)) or 
-	(Prio =:= asn1_NOVALUE)) andalso  
-       ((Em =:= true) orelse (Em =:= false) orelse (Em =:= asn1_NOVALUE)) andalso 
-       (is_list(Top) orelse (Top =:= asn1_NOVALUE)) andalso 
-       (is_list(Ctx)) ->
+cre_ContextRequest(Prio, Em, Top, Ctx)
+  when is_integer(Prio) andalso 0 =< Prio andalso Prio =< 15 orelse
+       Prio =:= asn1_NOVALUE,
+       is_boolean(Em) orelse Em =:= asn1_NOVALUE,
+       is_list(Top) orelse Top =:= asn1_NOVALUE,
+       is_list(Ctx) ->
     CR = 
 	case context_list_or_prop(Ctx) of
 	    contextProp ->
@@ -629,9 +629,9 @@ strip_ContextRequest(#'ContextRequest'{priority    = asn1_NOVALUE,
 				       topologyReq = Top,
 				       iepscallind = Ieps,
 				       contextProp = Prop} = CR) ->
-    case (((Top  == [])    or (Top  == asn1_NOVALUE)) and
-	  ((Ieps == false) or (Ieps == asn1_NOVALUE)) and
-	  ((Prop == [])    or (Prop == asn1_NOVALUE))) of
+    case (Top  == []    orelse Top  == asn1_NOVALUE) andalso
+        (Ieps == false orelse Ieps == asn1_NOVALUE) andalso
+        (Prop == []    orelse Prop == asn1_NOVALUE) of
 	true ->
 	    asn1_NOVALUE;
 	false ->
@@ -682,8 +682,8 @@ cre_ContextAttrAuditRequest(Top, Em, Prio, Ieps, Ctx, SelPrio)
        ((Prio =:= 'NULL') orelse (Prio =:= asn1_NOVALUE)) andalso
        ((Ieps =:= 'NULL') orelse (Ieps =:= asn1_NOVALUE)) andalso
        (is_list(Ctx)      orelse (Ctx  =:= asn1_NOVALUE)) andalso
-       ((is_integer(SelPrio) andalso ((0 =< SelPrio) and (SelPrio =< 15))) orelse
-	(SelPrio =:= asn1_NOVALUE)) ->
+       (is_integer(SelPrio) andalso 0 =< SelPrio andalso SelPrio =< 15 orelse
+        SelPrio =:= asn1_NOVALUE) ->
     CAAR = #'ContextAttrAuditRequest'{topology       = Top,
 				      emergency      = Em,
 				      priority       = Prio,
@@ -718,19 +718,15 @@ cre_ContextAttrAuditRequest(Top, Em, Prio, Ieps, Ctx, SelPrio, SelLog)
 
 cre_ContextAttrAuditRequest(Top, Em, Prio, Ieps, Ctx, 
 			    SelPrio, SelEm, SelIeps) 
-  when ((Top  == 'NULL') or (Top  == asn1_NOVALUE)) and
-       ((Em   == 'NULL') or (Em   == asn1_NOVALUE)) and
-       ((Prio == 'NULL') or (Prio == asn1_NOVALUE)) and
-       ((Ieps == 'NULL') or (Ieps == asn1_NOVALUE)) and
-       (is_list(Ctx)     or (Ctx  == asn1_NOVALUE)) and
-       ((is_integer(SelPrio) and ((0 =< SelPrio) and (SelPrio =< 15))) or
-	(SelPrio == asn1_NOVALUE)) and
-       ((SelEm == true)  or 
-	(SelEm == false) or 
-	(SelEm == asn1_NOVALUE)) and
-       ((SelIeps == true)  or 
-	(SelIeps == false) or 
-	(SelIeps == asn1_NOVALUE)) ->
+  when Top  == 'NULL' orelse Top  == asn1_NOVALUE,
+       Em   == 'NULL' orelse Em   == asn1_NOVALUE,
+       Prio == 'NULL' orelse Prio == asn1_NOVALUE,
+       Ieps == 'NULL' orelse Ieps == asn1_NOVALUE,
+       is_list(Ctx)   orelse Ctx  == asn1_NOVALUE,
+       is_integer(SelPrio) andalso 0 =< SelPrio andalso SelPrio =< 15 orelse
+       SelPrio == asn1_NOVALUE,
+       is_boolean(SelEm) orelse SelEm == asn1_NOVALUE,
+       is_boolean(SelIeps) orelse SelIeps == asn1_NOVALUE ->
     CAAR = #'ContextAttrAuditRequest'{topology          = Top,
 				      emergency         = Em,
 				      priority          = Prio,
@@ -741,21 +737,17 @@ cre_ContextAttrAuditRequest(Top, Em, Prio, Ieps, Ctx,
 				      selectiepscallind = SelIeps},
     strip_ContextAttrAuditRequest(CAAR).
 
-cre_ContextAttrAuditRequest(Top, Em, Prio, Ieps, Ctx, 
-			    SelPrio, SelEm, SelIeps, SelLog) 
-  when ((Top  == 'NULL') or (Top  == asn1_NOVALUE)) and
-       ((Em   == 'NULL') or (Em   == asn1_NOVALUE)) and
-       ((Prio == 'NULL') or (Prio == asn1_NOVALUE)) and
-       ((Ieps == 'NULL') or (Ieps == asn1_NOVALUE)) and
-       (is_list(Ctx)     or (Ctx  == asn1_NOVALUE)) and
-       ((is_integer(SelPrio) and ((0 =< SelPrio) and (SelPrio =< 15))) or
-	(SelPrio == asn1_NOVALUE)) and
-       ((SelEm == true)  or 
-	(SelEm == false) or 
-	(SelEm == asn1_NOVALUE)) and
-       ((SelIeps == true)  or 
-	(SelIeps == false) or 
-	(SelIeps == asn1_NOVALUE)) ->
+cre_ContextAttrAuditRequest(Top, Em, Prio, Ieps, Ctx,
+                            SelPrio, SelEm, SelIeps, SelLog)
+  when Top  == 'NULL' orelse Top  == asn1_NOVALUE,
+       Em   == 'NULL' orelse Em   == asn1_NOVALUE,
+       Prio == 'NULL' orelse Prio == asn1_NOVALUE,
+       Ieps == 'NULL' orelse Ieps == asn1_NOVALUE,
+       is_list(Ctx)   orelse Ctx  == asn1_NOVALUE,
+       is_integer(SelPrio) andalso 0 =< SelPrio andalso SelPrio =< 15 orelse
+       SelPrio == asn1_NOVALUE,
+       is_boolean(SelEm) orelse SelEm == asn1_NOVALUE,
+       is_boolean(SelIeps) orelse SelIeps == asn1_NOVALUE ->
     case ((SelLog == asn1_NOVALUE) orelse is_SelectLogic(SelLog)) of
 	true ->
 	    CAAR = #'ContextAttrAuditRequest'{topology          = Top,
@@ -802,13 +794,13 @@ cre_CommandRequest(Cmd) ->
     #'CommandRequest'{command = Cmd}.
 
 cre_CommandRequest(Cmd, Opt) 
-  when ((Opt == 'NULL') or (Opt == asn1_NOVALUE)) ->
+  when Opt == 'NULL' orelse Opt == asn1_NOVALUE ->
     #'CommandRequest'{command  = Cmd,
 		      optional = Opt}.
 
-cre_CommandRequest(Cmd, Opt, WR) 
-  when ((Opt == 'NULL') or (Opt == asn1_NOVALUE)) and 
-       ((WR  == 'NULL') or (WR  == asn1_NOVALUE)) ->
+cre_CommandRequest(Cmd, Opt, WR)
+  when Opt == 'NULL' orelse Opt == asn1_NOVALUE,
+       WR  == 'NULL' orelse WR  == asn1_NOVALUE ->
     #'CommandRequest'{command        = Cmd,
 		      optional       = Opt,
 		      wildcardReturn = WR}.
@@ -866,44 +858,44 @@ cre_CommandReply(serviceChangeReply = Tag, Rep)
 
 %% -- TopologyRequest --
 
-cre_TopologyRequest(From, To, TD) 
-  when (is_record(From, 'TerminationID') or
-	is_record(From, megaco_term_id)) and
-       (is_record(To, 'TerminationID') or
-	is_record(To, megaco_term_id)) and
-       ((TD == bothway) or (TD == isolate) or (TD == oneway)) ->
+cre_TopologyRequest(From, To, TD)
+  when is_record(From, 'TerminationID') orelse
+       is_record(From, megaco_term_id),
+       is_record(To, 'TerminationID') orelse
+       is_record(To, megaco_term_id),
+       TD == bothway orelse TD == isolate orelse TD == oneway ->
     #'TopologyRequest'{terminationFrom   = From,
 		       terminationTo     = To,
 		       topologyDirection = TD};
-cre_TopologyRequest(From, To, TDE) 
-  when (is_record(From, 'TerminationID') or
-	is_record(From, megaco_term_id)) and
-       (is_record(To, 'TerminationID') or
-	is_record(To, megaco_term_id)) and
-       ((TDE == onewayexternal) or (TDE == onewayboth)) ->
+cre_TopologyRequest(From, To, TDE)
+  when is_record(From, 'TerminationID') orelse
+       is_record(From, megaco_term_id),
+       is_record(To, 'TerminationID') orelse
+       is_record(To, megaco_term_id),
+       TDE == onewayexternal orelse TDE == onewayboth ->
     #'TopologyRequest'{terminationFrom            = From,
 		       terminationTo              = To,
-		       topologyDirection          = oneway, 
+                       topologyDirection          = oneway,
 		       topologyDirectionExtension = TDE}.
 
-cre_TopologyRequest(From, To, TD, SID) 
-  when (is_record(From, 'TerminationID') or
-	is_record(From, megaco_term_id)) and
-       (is_record(To, 'TerminationID') or
-	is_record(To, megaco_term_id)) and
-       ((TD == bothway) or (TD == isolate) or (TD == oneway)) and
-       (is_integer(SID)) ->
+cre_TopologyRequest(From, To, TD, SID)
+  when is_record(From, 'TerminationID') orelse
+       is_record(From, megaco_term_id),
+       is_record(To, 'TerminationID') orelse
+       is_record(To, megaco_term_id),
+       TD == bothway orelse TD == isolate orelse TD == oneway,
+       is_integer(SID) ->
     #'TopologyRequest'{terminationFrom   = From,
 		       terminationTo     = To,
 		       topologyDirection = TD,
 		       streamID          = SID};
-cre_TopologyRequest(From, To, SID, TDE) 
-  when (is_record(From, 'TerminationID') or
-	is_record(From, megaco_term_id)) and
-       (is_record(To, 'TerminationID') or
-	is_record(To, megaco_term_id)) and
-       (is_integer(SID)) and
-       ((TDE == onewayexternal) or (TDE == onewayboth)) ->
+cre_TopologyRequest(From, To, SID, TDE)
+  when is_record(From, 'TerminationID') orelse
+       is_record(From, megaco_term_id),
+       is_record(To, 'TerminationID') orelse
+       is_record(To, megaco_term_id),
+       is_integer(SID),
+       TDE == onewayexternal orelse TDE == onewayboth ->
     #'TopologyRequest'{terminationFrom            = From,
 		       terminationTo              = To,
 		       topologyDirection          = oneway, 
@@ -956,7 +948,7 @@ cre_AmmDescriptor(D) when is_list(D) ->
 cre_AmmsReply(TermIDs) when is_list(TermIDs) ->
     #'AmmsReply'{terminationID = TermIDs}.
 
-cre_AmmsReply(TermIDs, TAs) when is_list(TermIDs) and is_list(TAs) ->
+cre_AmmsReply(TermIDs, TAs) when is_list(TermIDs), is_list(TAs) ->
     #'AmmsReply'{terminationID    = TermIDs, 
 		 terminationAudit = TAs}.
 
@@ -964,18 +956,18 @@ cre_SubtractRequest(TermIDs) when is_list(TermIDs) ->
     #'SubtractRequest'{terminationID = TermIDs}.
 
 cre_SubtractRequest(TermIDs, Audit) 
-  when is_list(TermIDs) and is_record(Audit, 'AuditDescriptor') ->
+  when is_list(TermIDs), is_record(Audit, 'AuditDescriptor') ->
     #'SubtractRequest'{terminationID   = TermIDs, 
 		       auditDescriptor = Audit}.
 
 cre_AuditRequest(TermID, Audit) 
-  when is_record(TermID, megaco_term_id) and 
+  when is_record(TermID, megaco_term_id),
        is_record(Audit, 'AuditDescriptor') ->
     #'AuditRequest'{terminationID   = TermID, 
 		    auditDescriptor = Audit}.
 
 cre_AuditRequest(TID, Audit, [TID|_] = TIDs) 
-  when is_record(TID, megaco_term_id) and  
+  when is_record(TID, megaco_term_id),
        is_record(Audit, 'AuditDescriptor') ->
     #'AuditRequest'{terminationID     = TID, 
 		    auditDescriptor   = Audit,
@@ -991,12 +983,12 @@ cre_AuditReply(ARTL) when is_record(ARTL, 'TermListAuditResult') ->
     {auditResultTermList, ARTL}.
 
 cre_AuditResult(TID, TAs) 
-  when is_record(TID, megaco_term_id) and is_list(TAs) ->
+  when is_record(TID, megaco_term_id), is_list(TAs) ->
     #'AuditResult'{terminationID          = TID, 
 		   terminationAuditResult = TAs}.
 
 cre_TermListAuditResult(TIDs, TA) 
-  when is_list(TIDs) and is_list(TA) ->
+  when is_list(TIDs), is_list(TA) ->
     #'TermListAuditResult'{terminationIDList      = TIDs,
 			   terminationAuditResult = TA}.
     
@@ -1072,19 +1064,19 @@ cre_IndAudMediaDescriptor(Descs) when is_list(Descs) ->
     #'IndAudMediaDescriptor'{streams = Streams}.
 
 cre_IndAudMediaDescriptor(TSD, Parms) 
-  when is_record(TSD, 'IndAudTerminationStateDescriptor') and 
+  when is_record(TSD, 'IndAudTerminationStateDescriptor'),
        is_record(Parms, 'IndAudStreamParms') ->
     Streams = {oneStream, Parms},
     #'IndAudMediaDescriptor'{termStateDescr = TSD,
 			     streams        = Streams};
 cre_IndAudMediaDescriptor(TSD, Descs) 
-  when is_record(TSD, 'IndAudTerminationStateDescriptor') and is_list(Descs) ->
+  when is_record(TSD, 'IndAudTerminationStateDescriptor'), is_list(Descs) ->
     Streams = {multiStream, Descs},
     #'IndAudMediaDescriptor'{termStateDescr = TSD,
 			     streams        = Streams}.
 
 cre_IndAudStreamDescriptor(SID, Parms) 
-  when is_integer(SID) and is_record(Parms, 'IndAudStreamParms') ->
+  when is_integer(SID), is_record(Parms, 'IndAudStreamParms') ->
     #'IndAudStreamDescriptor'{streamID    = SID,
 			      streamParms = Parms};
 cre_IndAudStreamDescriptor(SID, Parms) ->
@@ -1100,17 +1092,17 @@ cre_IndAudStreamParms(SD) when is_record(SD, 'IndAudStatisticsDescriptor') ->
     #'IndAudStreamParms'{statisticsDescriptor = SD}.
 
 cre_IndAudStreamParms(LC, L, R) 
-  when is_record(LC, 'IndAudLocalControlDescriptor') and 
-       is_record(L,  'IndAudLocalRemoteDescriptor')  and 
+  when is_record(LC, 'IndAudLocalControlDescriptor'),
+       is_record(L,  'IndAudLocalRemoteDescriptor'),
        is_record(R,  'IndAudLocalRemoteDescriptor') ->
     #'IndAudStreamParms'{localControlDescriptor = LC,
 			 localDescriptor        = L,
 			 remoteDescriptor       = R}.
 
 cre_IndAudStreamParms(LC, L, R, S) 
-  when is_record(LC, 'IndAudLocalControlDescriptor') and 
-       is_record(L,  'IndAudLocalRemoteDescriptor')  and 
-       is_record(R,  'IndAudLocalRemoteDescriptor')  and 
+  when is_record(LC, 'IndAudLocalControlDescriptor'),
+       is_record(L,  'IndAudLocalRemoteDescriptor'),
+       is_record(R,  'IndAudLocalRemoteDescriptor'),
        is_record(S,  'IndAudStatisticsDescriptor') ->
     #'IndAudStreamParms'{localControlDescriptor = LC,
 			 localDescriptor        = L,
@@ -1120,34 +1112,34 @@ cre_IndAudStreamParms(LC, L, R, S)
 cre_IndAudLocalControlDescriptor() ->
     #'IndAudLocalControlDescriptor'{}.
 
-cre_IndAudLocalControlDescriptor(SM, RV, RG, PP) 
-  when ((SM == 'NULL') or (SM == asn1_NOVALUE)) and
-       ((RV == 'NULL') or (RV == asn1_NOVALUE)) and
-       ((RG == 'NULL') or (RG == asn1_NOVALUE)) and
-       (is_list(PP) or (PP == asn1_NOVALUE)) ->
+cre_IndAudLocalControlDescriptor(SM, RV, RG, PP)
+  when SM == 'NULL' orelse SM == asn1_NOVALUE,
+       RV == 'NULL' orelse RV == asn1_NOVALUE,
+       RG == 'NULL' orelse RG == asn1_NOVALUE,
+       is_list(PP) orelse PP == asn1_NOVALUE ->
     #'IndAudLocalControlDescriptor'{streamMode    = SM, 
 				    reserveValue  = RV, 
 				    reserveGroup  = RG, 
 				    propertyParms = PP};
-cre_IndAudLocalControlDescriptor(RV, RG, PP, SMS) 
-  when ((RV == 'NULL') or (RV == asn1_NOVALUE)) and
-       ((RG == 'NULL') or (RG == asn1_NOVALUE)) and
-       (is_list(PP) or (PP == asn1_NOVALUE))    and
+cre_IndAudLocalControlDescriptor(RV, RG, PP, SMS)
+  when RV == 'NULL' orelse RV == asn1_NOVALUE,
+       RG == 'NULL' orelse RG == asn1_NOVALUE,
+       is_list(PP) orelse PP == asn1_NOVALUE,
        is_atom(SMS) ->
     #'IndAudLocalControlDescriptor'{reserveValue  = RV, 
 				    reserveGroup  = RG, 
 				    propertyParms = PP,
 				    streamModeSel = SMS}.
 
-cre_IndAudLocalControlDescriptor(SM, RV, RG, PP, SMS) 
-  when (SM == 'NULL') and 
-       (is_atom(SMS) and (SMS =/= asn1_NOVALUE)) ->
+cre_IndAudLocalControlDescriptor(SM, RV, RG, PP, SMS)
+  when SM == 'NULL',
+       is_atom(SMS), SMS =/= asn1_NOVALUE ->
     error({invalid_IndAudLocalControlDescriptor, [SM, RV, RG, PP, SMS]});
-cre_IndAudLocalControlDescriptor(SM, RV, RG, PP, SMS) 
-  when ((SM == 'NULL') or (SM == asn1_NOVALUE)) and 
-       ((RV == 'NULL') or (RV == asn1_NOVALUE)) and
-       ((RG == 'NULL') or (RG == asn1_NOVALUE)) and
-       (is_list(PP)    or (PP == asn1_NOVALUE)) and
+cre_IndAudLocalControlDescriptor(SM, RV, RG, PP, SMS)
+  when SM == 'NULL' orelse SM == asn1_NOVALUE,
+       RV == 'NULL' orelse RV == asn1_NOVALUE,
+       RG == 'NULL' orelse RG == asn1_NOVALUE,
+       is_list(PP) orelse PP == asn1_NOVALUE,
        is_atom(SMS) ->
     case is_StreamMode(SMS) of
 	true ->
@@ -1164,14 +1156,14 @@ cre_IndAudPropertyParm(PkgdName) when is_list(PkgdName) ->
     #'IndAudPropertyParm'{name = PkgdName}.
 
 cre_IndAudPropertyParm(PkgdName, PP) 
-  when is_list(PkgdName) and is_record(PP, 'PropertyParm') ->
+  when is_list(PkgdName), is_record(PP, 'PropertyParm') ->
     #'IndAudPropertyParm'{name = PkgdName, propertyParms = PP}.
 
 cre_IndAudLocalRemoteDescriptor(Grps) when is_list(Grps) ->
     #'IndAudLocalRemoteDescriptor'{propGrps = Grps}.
 
 cre_IndAudLocalRemoteDescriptor(GID, Grps) 
-  when is_integer(GID) and (0 =< GID) and (GID =< 65535) and is_list(Grps) ->
+  when is_integer(GID), 0 =< GID, GID =< 65535, is_list(Grps) ->
     #'IndAudLocalRemoteDescriptor'{propGroupID = GID,
 				   propGrps    = Grps}.
 
@@ -1186,36 +1178,36 @@ cre_IndAudTerminationStateDescriptor([H|_] = PP)
   when is_record(H, 'IndAudPropertyParm') ->
     #'IndAudTerminationStateDescriptor'{propertyParms = PP}.
 
-cre_IndAudTerminationStateDescriptor([] = PP, EBC, SS) 
-  when ((EBC == 'NULL') or (EBC == asn1_NOVALUE)) and
-       ((SS  == 'NULL') or (SS  == asn1_NOVALUE)) ->
+cre_IndAudTerminationStateDescriptor([] = PP, EBC, SS)
+  when EBC == 'NULL' orelse EBC == asn1_NOVALUE,
+       SS  == 'NULL' orelse SS  == asn1_NOVALUE ->
     #'IndAudTerminationStateDescriptor'{propertyParms      = PP,
 					eventBufferControl = EBC,
 					serviceState       = SS};
-cre_IndAudTerminationStateDescriptor([H|_] = PP, EBC, SS) 
-  when is_record(H, 'IndAudPropertyParm') and
-       ((EBC == 'NULL') or (EBC == asn1_NOVALUE)) and
-       ((SS  == 'NULL') or (SS  == asn1_NOVALUE)) ->
+cre_IndAudTerminationStateDescriptor([H|_] = PP, EBC, SS)
+  when is_record(H, 'IndAudPropertyParm'),
+       EBC == 'NULL' orelse EBC == asn1_NOVALUE,
+       SS  == 'NULL' orelse SS  == asn1_NOVALUE ->
     #'IndAudTerminationStateDescriptor'{propertyParms      = PP,
 					eventBufferControl = EBC,
 					serviceState       = SS}.
 
-cre_IndAudTerminationStateDescriptor(PP, EBC, SS, SSS) 
-  when (SS  == 'NULL') and
-       ((is_atom(SSS) and (SSS =/= asn1_NOVALUE))) ->
+cre_IndAudTerminationStateDescriptor(PP, EBC, SS, SSS)
+  when SS  == 'NULL',
+       is_atom(SSS), SSS =/= asn1_NOVALUE ->
     error({invalid_IndAudTerminationStateDescriptor, [PP, EBC, SS, SSS]});
-cre_IndAudTerminationStateDescriptor([] = PP, EBC, SS, SSS) 
-  when ((EBC == 'NULL') or (EBC == asn1_NOVALUE)) and
-       ((SS  == 'NULL') or (SS  == asn1_NOVALUE)) and
+cre_IndAudTerminationStateDescriptor([] = PP, EBC, SS, SSS)
+  when EBC == 'NULL' orelse EBC == asn1_NOVALUE,
+       SS  == 'NULL' orelse SS  == asn1_NOVALUE,
        is_atom(SSS) ->
     #'IndAudTerminationStateDescriptor'{propertyParms      = PP,
 					eventBufferControl = EBC,
 					serviceState       = SS,
 					serviceStateSel    = SSS};
-cre_IndAudTerminationStateDescriptor([H|_] = PP, EBC, SS, SSS) 
-  when is_record(H, 'IndAudPropertyParm') and
-       ((EBC == 'NULL') or (EBC == asn1_NOVALUE)) and
-       ((SS  == 'NULL') or (SS  == asn1_NOVALUE)) and
+cre_IndAudTerminationStateDescriptor([H|_] = PP, EBC, SS, SSS)
+  when is_record(H, 'IndAudPropertyParm'),
+       EBC == 'NULL' orelse EBC == asn1_NOVALUE,
+       SS  == 'NULL' orelse SS  == asn1_NOVALUE,
        is_atom(SSS) ->
     #'IndAudTerminationStateDescriptor'{propertyParms      = PP,
 					eventBufferControl = EBC,
@@ -1227,14 +1219,14 @@ cre_IndAudEventsDescriptor(PkgdName)
     #'IndAudEventsDescriptor'{pkgdName = PkgdName}.
 
 cre_IndAudEventsDescriptor(RID, PkgdName) 
-  when is_integer(RID) and is_list(PkgdName) ->
+  when is_integer(RID), is_list(PkgdName) ->
     #'IndAudEventsDescriptor'{requestID = RID, pkgdName = PkgdName};
-cre_IndAudEventsDescriptor(PkgdName, SID) 
-  when is_list(PkgdName) and is_integer(SID) ->
+cre_IndAudEventsDescriptor(PkgdName, SID)
+  when is_list(PkgdName), is_integer(SID) ->
     #'IndAudEventsDescriptor'{pkgdName = PkgdName, streamID = SID}.
 
 cre_IndAudEventsDescriptor(RID, PkgdName, SID) 
-  when is_integer(RID) and is_list(PkgdName) and is_integer(SID)  ->
+  when is_integer(RID), is_list(PkgdName), is_integer(SID) ->
     #'IndAudEventsDescriptor'{requestID = RID, 
 			      pkgdName  = PkgdName, 
 			      streamID  = SID}.
@@ -1243,7 +1235,7 @@ cre_IndAudEventBufferDescriptor(EventName) when is_list(EventName) ->
     #'IndAudEventBufferDescriptor'{eventName = EventName}.
 
 cre_IndAudEventBufferDescriptor(EventName, SID) 
-  when is_list(EventName) and is_integer(SID)  ->
+  when is_list(EventName), is_integer(SID) ->
     #'IndAudEventBufferDescriptor'{eventName = EventName, streamID = SID}.
 
 cre_IndAudSignalsDescriptor(S) when is_record(S, 'IndAudSignal') ->
@@ -1252,11 +1244,11 @@ cre_IndAudSignalsDescriptor(S) when is_record(S, 'IndAudSeqSigList') ->
     {seqSigList, S}.
 
 cre_IndAudSeqSigList(ID) 
-  when is_integer(ID) and (0=< ID) and (ID =< 65535) ->
+  when is_integer(ID), 0 =< ID, ID =< 65535 ->
     #'IndAudSeqSigList'{id = ID}.
 
-cre_IndAudSeqSigList(ID, S) 
-  when is_integer(ID) and (0=< ID) and (ID =< 65535) and 
+cre_IndAudSeqSigList(ID, S)
+  when is_integer(ID), 0 =< ID, ID =< 65535,
        is_record(S, 'IndAudSignal') ->
     #'IndAudSeqSigList'{id = ID, signalList = S}.
 
@@ -1264,7 +1256,7 @@ cre_IndAudSignal(SigName) when is_list(SigName) ->
     #'IndAudSignal'{signalName = SigName}.
 
 cre_IndAudSignal(SigName, RID) 
-  when is_list(SigName) and is_integer(RID) ->
+  when is_list(SigName), is_integer(RID) ->
     #'IndAudSignal'{signalName      = SigName, 
 		    signalRequestID = RID}.
 
@@ -1278,13 +1270,13 @@ cre_IndAudStatisticsDescriptor(StatName) when is_list(StatName) ->
     #'IndAudStatisticsDescriptor'{statName = StatName}.
 
 cre_IndAudPackagesDescriptor(N, V) 
-  when is_list(N) and 
-       is_integer(V) and (0 =< V) and (V =< 99) ->
+  when is_list(N),
+       is_integer(V), 0 =< V, V =< 99 ->
     #'IndAudPackagesDescriptor'{packageName    = N, 
 				packageVersion = V}.
 
 cre_NotifyRequest(TermIDs, D) 
-  when is_list(TermIDs) and is_record(D, 'ObservedEventsDescriptor') ->
+  when is_list(TermIDs), is_record(D, 'ObservedEventsDescriptor') ->
     #'NotifyRequest'{terminationID            = TermIDs,
 		     observedEventsDescriptor = D}.
 
@@ -1311,29 +1303,29 @@ cre_ObservedEventsDescriptor(RID, [H|_] = L)
 				observedEventLst = L}.
 
 cre_ObservedEvent(EN, EPL) 
-  when is_list(EN) and is_list(EPL) ->
-    #'ObservedEvent'{eventName    = EN, 
+  when is_list(EN), is_list(EPL) ->
+    #'ObservedEvent'{eventName    = EN,
 		     eventParList = EPL};
-cre_ObservedEvent(EN, TN) 
-  when is_list(EN) and is_record(TN, 'TimeNotation') ->
+cre_ObservedEvent(EN, TN)
+  when is_list(EN), is_record(TN, 'TimeNotation') ->
     #'ObservedEvent'{eventName    = EN, 
 		     timeNotation = TN}.
 
 cre_ObservedEvent(EN, SID, EPL) 
-  when is_list(EN) and is_integer(SID) and is_list(EPL) ->
-    #'ObservedEvent'{eventName    = EN, 
-		     streamID     = SID, 
+  when is_list(EN), is_integer(SID), is_list(EPL) ->
+    #'ObservedEvent'{eventName    = EN,
+                     streamID     = SID,
 		     eventParList = EPL};
-cre_ObservedEvent(EN, EPL, TN) 
-  when is_list(EN) and is_list(EPL) and is_record(TN, 'TimeNotation') ->
+cre_ObservedEvent(EN, EPL, TN)
+  when is_list(EN), is_list(EPL), is_record(TN, 'TimeNotation') ->
     #'ObservedEvent'{eventName    = EN, 
 		     eventParList = EPL,
 		     timeNotation = TN}.
 
 cre_ObservedEvent(EN, SID, EPL, TN) 
-  when is_list(EN)     and 
-       is_integer(SID) and 
-       is_list(EPL)    and
+  when is_list(EN),
+       is_integer(SID),
+       is_list(EPL),
        is_record(TN, 'TimeNotation') ->
     #'ObservedEvent'{eventName    = EN, 
 		     streamID     = SID, 
@@ -1343,37 +1335,37 @@ cre_ObservedEvent(EN, SID, EPL, TN)
 cre_EventName(N) when is_list(N) ->
     N.
 
-cre_EventParameter(N, V) when is_list(N) and is_list(V) ->
+cre_EventParameter(N, V) when is_list(N), is_list(V) ->
     #'EventParameter'{eventParameterName = N, 
 		      value              = V}.
 
 cre_EventParameter(N, V, relation = Tag, R) 
-  when is_list(N) and is_list(V) and is_atom(R) ->
+  when is_list(N), is_list(V), is_atom(R) ->
     EI = {Tag, R},
-    #'EventParameter'{eventParameterName = N, 
+    #'EventParameter'{eventParameterName = N,
 		      value              = V,
 		      extraInfo          = EI};
-cre_EventParameter(N, V, range = Tag, B) 
-  when is_list(N) and is_list(V) and is_atom(B) ->
+cre_EventParameter(N, V, range = Tag, B)
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B},
-    #'EventParameter'{eventParameterName = N, 
+    #'EventParameter'{eventParameterName = N,
 		      value              = V,
 		      extraInfo          = EI};
-cre_EventParameter(N, V, sublist = Tag, B) 
-  when is_list(N) and is_list(V) and is_atom(B) ->
+cre_EventParameter(N, V, sublist = Tag, B)
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B},
     #'EventParameter'{eventParameterName = N, 
 		      value              = V,
 		      extraInfo          = EI}.
 
 cre_ServiceChangeRequest(TermIDs, SCP) 
-  when is_list(TermIDs) and 
+  when is_list(TermIDs),
        is_record(SCP, 'ServiceChangeParm') ->
     #'ServiceChangeRequest'{terminationID      = TermIDs, 
 			    serviceChangeParms = SCP}.
 
 cre_ServiceChangeReply(TermIDs, {Tag, R} = SCR) 
-  when is_list(TermIDs) and is_atom(Tag) and is_tuple(R) ->
+  when is_list(TermIDs), is_atom(Tag), is_tuple(R) ->
     #'ServiceChangeReply'{terminationID       = TermIDs, 
 			  serviceChangeResult = SCR}.
 
@@ -1405,21 +1397,21 @@ cre_MediaDescriptor([H|_] = SDs) when is_record(H, 'StreamDescriptor') ->
     Streams = {multiStream, SDs},
     #'MediaDescriptor'{streams = Streams}.
 
-cre_MediaDescriptor(TSD, SP) 
-  when is_record(TSD, 'TerminationStateDescriptor') and 
+cre_MediaDescriptor(TSD, SP)
+  when is_record(TSD, 'TerminationStateDescriptor'),
        is_record(SP, 'StreamParms') ->
     Streams = {oneStream, SP},
     #'MediaDescriptor'{termStateDescr = TSD,
 		       streams        = Streams};
-cre_MediaDescriptor(TSD, [H|_] = SDs) 
-  when is_record(TSD, 'TerminationStateDescriptor') and 
+cre_MediaDescriptor(TSD, [H|_] = SDs)
+  when is_record(TSD, 'TerminationStateDescriptor'),
        is_record(H, 'StreamDescriptor') ->
     Streams = {multiStream, SDs},
     #'MediaDescriptor'{termStateDescr = TSD,
 		       streams        = Streams}.
 
 cre_StreamDescriptor(SID, SP) 
-  when is_integer(SID) and is_record(SP, 'StreamParms') ->
+  when is_integer(SID), is_record(SP, 'StreamParms') ->
     #'StreamDescriptor'{streamID    = SID, 
 			streamParms = SP}.
 
@@ -1433,32 +1425,32 @@ cre_StreamParms(LD) when is_record(LD, 'LocalRemoteDescriptor') ->
 cre_StreamParms(SD) when is_list(SD) ->
     #'StreamParms'{statisticsDescriptor = SD}.
 
-cre_StreamParms(LCD, LD) 
-  when (is_record(LCD, 'LocalControlDescriptor') or (LCD == asn1_NOVALUE)) and
-       (is_record(LD,  'LocalRemoteDescriptor')  or (LD  == asn1_NOVALUE)) ->
+cre_StreamParms(LCD, LD)
+  when is_record(LCD, 'LocalControlDescriptor') orelse LCD == asn1_NOVALUE,
+       is_record(LD,  'LocalRemoteDescriptor')  orelse LD  == asn1_NOVALUE ->
     #'StreamParms'{localControlDescriptor = LCD,
 		   localDescriptor        = LD}.
 
-cre_StreamParms(LCD, LD, RD) 
-  when (is_record(LCD, 'LocalControlDescriptor') or (LCD == asn1_NOVALUE)) and
-       (is_record(LD,  'LocalRemoteDescriptor')  or (LD  == asn1_NOVALUE)) and
-       (is_record(RD,  'LocalRemoteDescriptor')  or (RD  == asn1_NOVALUE)) ->
+cre_StreamParms(LCD, LD, RD)
+  when is_record(LCD, 'LocalControlDescriptor') orelse LCD == asn1_NOVALUE,
+       is_record(LD,  'LocalRemoteDescriptor')  orelse LD  == asn1_NOVALUE,
+       is_record(RD,  'LocalRemoteDescriptor')  orelse RD  == asn1_NOVALUE ->
     #'StreamParms'{localControlDescriptor = LCD,
 		   localDescriptor        = LD,
 		   remoteDescriptor       = RD};
-cre_StreamParms(LCD, LD, SD) 
-  when (is_record(LCD, 'LocalControlDescriptor') or (LCD == asn1_NOVALUE)) and
-       (is_record(LD,  'LocalRemoteDescriptor')  or (LD  == asn1_NOVALUE)) and
-       (is_list(SD) or (SD == asn1_NOVALUE)) ->
+cre_StreamParms(LCD, LD, SD)
+  when is_record(LCD, 'LocalControlDescriptor') orelse LCD == asn1_NOVALUE,
+       is_record(LD,  'LocalRemoteDescriptor')  orelse LD  == asn1_NOVALUE,
+       is_list(SD) orelse SD == asn1_NOVALUE ->
     #'StreamParms'{localControlDescriptor = LCD,
 		   localDescriptor        = LD,
 		   statisticsDescriptor   = SD}.
 
-cre_StreamParms(LCD, LD, RD, SD) 
-  when (is_record(LCD, 'LocalControlDescriptor') or (LCD == asn1_NOVALUE)) and
-       (is_record(LD,  'LocalRemoteDescriptor')  or (LD  == asn1_NOVALUE)) and
-       (is_record(RD,  'LocalRemoteDescriptor')  or (RD  == asn1_NOVALUE)) and
-       (is_list(SD) or (SD == asn1_NOVALUE)) ->
+cre_StreamParms(LCD, LD, RD, SD)
+  when is_record(LCD, 'LocalControlDescriptor') orelse LCD == asn1_NOVALUE,
+       is_record(LD,  'LocalRemoteDescriptor')  orelse LD  == asn1_NOVALUE,
+       is_record(RD,  'LocalRemoteDescriptor')  orelse RD  == asn1_NOVALUE,
+       is_list(SD) orelse SD == asn1_NOVALUE ->
     #'StreamParms'{localControlDescriptor = LCD,
 		   localDescriptor        = LD,
 		   remoteDescriptor       = RD,
@@ -1470,14 +1462,14 @@ cre_LocalControlDescriptor([H|_] = PP) when is_record(H, 'PropertyParm') ->
     #'LocalControlDescriptor'{propertyParms = PP}.
 
 cre_LocalControlDescriptor(SM, [H|_] = PP) 
-  when is_atom(SM) and is_record(H, 'PropertyParm') ->
+  when is_atom(SM), is_record(H, 'PropertyParm') ->
     #'LocalControlDescriptor'{streamMode    = SM,
 			      propertyParms = PP}.
 
 cre_LocalControlDescriptor(SM, RV, RG, [H|_] = PP) 
-  when is_atom(SM) and
-     ((RV == true) or (RV == false) or (RV == asn1_NOVALUE)) and
-     ((RG == true) or (RG == false) or (RG == asn1_NOVALUE)) and
+  when is_atom(SM),
+     is_boolean(RV) orelse RV == asn1_NOVALUE,
+     is_boolean(RG) orelse RG == asn1_NOVALUE,
      is_record(H, 'PropertyParm') ->
     #'LocalControlDescriptor'{streamMode    = SM, 
 			      reserveValue  = RV, 
@@ -1495,24 +1487,24 @@ cre_StreamMode(inactive = M) ->
 cre_StreamMode(loopBack = M) ->
     M.
 
-cre_PropertyParm(N, [H|_] = V) when is_list(N) and is_list(H) ->
+cre_PropertyParm(N, [H|_] = V) when is_list(N), is_list(H) ->
     #'PropertyParm'{name = N, value = V}.
 
 cre_PropertyParm(N, [H|_] = V, relation = Tag, R) 
-  when is_list(N) and is_list(H) and is_atom(R) ->
+  when is_list(N), is_list(H), is_atom(R) ->
     EI = {Tag, R},
     #'PropertyParm'{name = N, value = V, extraInfo = EI};
-cre_PropertyParm(N, [H|_] = V, range = Tag, B) 
-  when is_list(N) and is_list(H) and is_atom(B) ->
+cre_PropertyParm(N, [H|_] = V, range = Tag, B)
+  when is_list(N), is_list(H), is_atom(B) ->
     EI = {Tag, B},
     #'PropertyParm'{name = N, value = V, extraInfo = EI};
-cre_PropertyParm(N, [H|_] = V, sublist = Tag, B) 
-  when is_list(N) and is_list(H) and is_atom(B) ->
+cre_PropertyParm(N, [H|_] = V, sublist = Tag, B)
+  when is_list(N), is_list(H), is_atom(B) ->
     EI = {Tag, B},
     #'PropertyParm'{name = N, value = V, extraInfo = EI}.
 
 
-cre_Name(N) when is_list(N) and (length(N) == 2) ->
+cre_Name(N) when length(N) == 2 ->
     N.
 
 cre_PkgdName(N) when is_list(N) ->
@@ -1525,11 +1517,11 @@ cre_PkgdName(N) when is_list(N) ->
 cre_PkgdName(root, root) ->
     "*/*";
 cre_PkgdName(PackageName, root) 
-  when is_list(PackageName) and (length(PackageName) =< 64) ->
+  when length(PackageName) =< 64 ->
     PackageName ++ "/*";
-cre_PkgdName(PackageName, ItemID) 
-  when ((is_list(PackageName) and (length(PackageName) =< 64)) and
-	(is_list(ItemID)      and (length(ItemID) =< 64))) ->
+cre_PkgdName(PackageName, ItemID)
+  when length(PackageName) =< 64,
+       length(ItemID) =< 64 ->
     PackageName ++ "/" ++ ItemID;
 cre_PkgdName(PackageName, ItemID) ->
     error({invalid_PkgdName, {PackageName, ItemID}}).
@@ -1573,9 +1565,9 @@ cre_TerminationStateDescriptor([H|_] = PPs, inSvc = SS)
 				  serviceState  = SS}.
 
 cre_TerminationStateDescriptor([H|_] = PPs, EMC, SS) 
-  when is_record(H, 'PropertyParm') and 
-       ((EMC == off)  or (EMC == lockStep)) and
-       ((SS  == test) or (SS  == outOfSvc) or (SS == inSvc)) ->
+  when is_record(H, 'PropertyParm'),
+       EMC == off orelse EMC == lockStep,
+       SS  == test orelse SS  == outOfSvc orelse SS == inSvc ->
     #'TerminationStateDescriptor'{propertyParms      = PPs,
 				  eventBufferControl = EMC,
 				  serviceState       = SS}.
@@ -1593,7 +1585,7 @@ cre_ServiceState(inSvc = SS) ->
     SS.
 
 cre_MuxDescriptor(MT, [H|_] = TL) 
-  when is_atom(MT) and is_record(H, 'TerminationID') ->
+  when is_atom(MT), is_record(H, 'TerminationID') ->
     #'MuxDescriptor'{muxType = MT, termList = TL}.
 
 %% cre_MuxDescriptor(MT, [H|_] = TL, NSD) 
@@ -1611,7 +1603,7 @@ cre_MuxType(v76 = MT) ->
 cre_MuxType(nx64k = MT) ->
     MT.
 
-cre_StreamID(Val) when (0 =< Val) and (Val =< 65535) ->
+cre_StreamID(Val) when 0 =< Val, Val =< 65535 ->
     Val;
 cre_StreamID(Val) ->
     exit({invalid_ContextID, Val}).
@@ -1621,37 +1613,37 @@ cre_EventsDescriptor() ->
     #'EventsDescriptor'{eventList = []}.
 
 cre_EventsDescriptor(RID, [H|_] = EL) 
-  when is_integer(RID) and is_record(H, 'RequestedEvent') ->
+  when is_integer(RID), is_record(H, 'RequestedEvent') ->
     #'EventsDescriptor'{requestID = RID, eventList = EL}.
     
 cre_RequestedEvent(N) ->
     #'RequestedEvent'{pkgdName = N}.
 
 cre_RequestedEvent(N, EPL) 
-  when is_list(N) and is_list(EPL) ->
+  when is_list(N), is_list(EPL) ->
     #'RequestedEvent'{pkgdName  = N,
 		      evParList = EPL};
-cre_RequestedEvent(N, EA) 
-  when is_list(N) and is_record(EA, 'RequestedActions')->
+cre_RequestedEvent(N, EA)
+  when is_list(N), is_record(EA, 'RequestedActions') ->
     #'RequestedEvent'{pkgdName    = N,
 		      eventAction = EA}.
 
 
 cre_RequestedEvent(N, SID, EPL) 
-  when is_list(N) and is_integer(SID) and is_list(EPL) ->
+  when is_list(N), is_integer(SID), is_list(EPL) ->
     #'RequestedEvent'{pkgdName  = N,
-		      streamID  = SID, 
+                      streamID  = SID,
 		      evParList = EPL};
-cre_RequestedEvent(N, EA, EPL) 
-  when is_list(N) and is_record(EA, 'RequestedActions') and is_list(EPL) ->
+cre_RequestedEvent(N, EA, EPL)
+  when is_list(N), is_record(EA, 'RequestedActions'), is_list(EPL) ->
     #'RequestedEvent'{pkgdName     = N,
 		      eventAction  = EA, 
 		      evParList    = EPL}.
 
 cre_RequestedEvent(N, SID, EA, EPL) 
-  when is_list(N) and 
-       is_integer(SID) and
-       is_record(EA, 'RequestedActions') and 
+  when is_list(N),
+       is_integer(SID),
+       is_record(EA, 'RequestedActions'),
        is_list(EPL) ->
     #'RequestedEvent'{pkgdName     = N,
 		      streamID     = SID, 
@@ -1675,8 +1667,8 @@ cre_RegulatedEmbeddedDescriptor(D) ->
     end.
 
 cre_RegulatedEmbeddedDescriptor(SED, SD) 
-  when ((SED == asn1_NOVALUE) or is_record(SED, 'SecondEventsDescriptor')) and
-       ((SD  == asn1_NOVALUE) or is_list(SD)) ->
+  when SED == asn1_NOVALUE orelse is_record(SED, 'SecondEventsDescriptor'),
+       SD  == asn1_NOVALUE orelse is_list(SD) ->
     #'RegulatedEmbeddedDescriptor'{secondEvent       = SED,
 				   signalsDescriptor = SD}.
 
@@ -1694,7 +1686,7 @@ cre_RequestedActions() ->
     #'RequestedActions'{}.
 
 cre_RequestedActions(KA) 
-  when (KA == true) or (KA == true) ->
+  when is_boolean(KA) ->
     #'RequestedActions'{keepActive = KA};
 cre_RequestedActions(SE) 
   when is_record(SE, 'SecondEventsDescriptor') ->
@@ -1707,22 +1699,22 @@ cre_RequestedActions({Tag, _} = EDM)
     #'RequestedActions'{eventDM = EDM}.
 
 cre_RequestedActions(KA, {Tag, _} = EDM, SE, SD) 
-  when ((KA == true) or (KA == true) or (KA == asn1_NOVALUE)) and
-       (is_atom(Tag) or (EDM == asn1_NOVALUE)) and
-       (is_record(SE, 'SecondEventsDescriptor') or (SE == asn1_NOVALUE)) and
-       (is_list(SD) or (SD == asn1_NOVALUE)) ->
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_atom(Tag) orelse EDM == asn1_NOVALUE,
+       is_record(SE, 'SecondEventsDescriptor') orelse SE == asn1_NOVALUE,
+       is_list(SD) orelse SD == asn1_NOVALUE ->
     #'RequestedActions'{keepActive        = KA, 
 			eventDM           = EDM, 
 			secondEvent       = SE, 
 			signalsDescriptor = SD}.
 
 cre_RequestedActions(KA, {EDMTag, _} = EDM, SE, SD, {NBTag, _} = NB, RED) 
-  when ((KA == true) or (KA == true) or (KA == asn1_NOVALUE)) and
-       (is_atom(EDMTag) or (EDM == asn1_NOVALUE)) and
-       (is_record(SE, 'SecondEventsDescriptor') or (SE == asn1_NOVALUE)) and
-       (is_list(SD) or (SD == asn1_NOVALUE)) and
-       (is_atom(NBTag) or (NB == asn1_NOVALUE)) and
-       ((RED == 'NULL') or (RED == asn1_NOVALUE))  ->
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_atom(EDMTag) orelse EDM == asn1_NOVALUE,
+       is_record(SE, 'SecondEventsDescriptor') orelse SE == asn1_NOVALUE,
+       is_list(SD) orelse SD == asn1_NOVALUE,
+       is_atom(NBTag) orelse NB == asn1_NOVALUE,
+       RED == 'NULL' orelse RED == asn1_NOVALUE ->
     #'RequestedActions'{keepActive            = KA, 
 			eventDM               = EDM, 
 			secondEvent           = SE, 
@@ -1740,33 +1732,33 @@ cre_SecondEventsDescriptor([H|_] = EL)
     #'SecondEventsDescriptor'{eventList = EL}.
     
 cre_SecondEventsDescriptor(RID, [H|_] = EL) 
-  when is_integer(RID) and is_record(H, 'SecondRequestedEvent') ->
+  when is_integer(RID), is_record(H, 'SecondRequestedEvent') ->
     #'SecondEventsDescriptor'{requestID = RID, eventList = EL}.
     
 cre_SecondRequestedEvent(N, EPL) 
-  when is_list(N) and is_list(EPL) ->
+  when is_list(N), is_list(EPL) ->
     #'SecondRequestedEvent'{pkgdName  = N,
 			    evParList = EPL};
 cre_SecondRequestedEvent(N, EPL) ->
     error({invalid_SecondRequestedEvent, [N, EPL]}).
 
 cre_SecondRequestedEvent(N, SID, EPL) 
-  when is_list(N) and is_integer(SID) and is_list(EPL) ->
+  when is_list(N), is_integer(SID), is_list(EPL) ->
     #'SecondRequestedEvent'{pkgdName  = N,
-			    streamID  = SID, 
+                            streamID  = SID,
 			    evParList = EPL};
-cre_SecondRequestedEvent(N, EA, EPL) 
-  when is_list(N) and 
-       is_record(EA, 'SecondRequestedActions') and 
+cre_SecondRequestedEvent(N, EA, EPL)
+  when is_list(N),
+       is_record(EA, 'SecondRequestedActions'),
        is_list(EPL) ->
     #'SecondRequestedEvent'{pkgdName     = N,
 			    eventAction  = EA, 
 			    evParList    = EPL}.
 
 cre_SecondRequestedEvent(N, SID, EA, EPL) 
-  when is_list(N) and 
-       is_integer(SID) and 
-       is_record(EA, 'SecondRequestedActions') and 
+  when is_list(N),
+       is_integer(SID),
+       is_record(EA, 'SecondRequestedActions'),
        is_list(EPL) ->
     #'SecondRequestedEvent'{pkgdName     = N,
 			    streamID     = SID, 
@@ -1777,7 +1769,7 @@ cre_SecondRequestedActions() ->
     #'SecondRequestedActions'{}.
 
 cre_SecondRequestedActions(KA) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) ->
+  when is_boolean(KA); KA == asn1_NOVALUE ->
     #'SecondRequestedActions'{keepActive = KA};
 cre_SecondRequestedActions(SD) when is_list(SD) ->
     #'SecondRequestedActions'{signalsDescriptor = SD};
@@ -1796,12 +1788,12 @@ cre_SecondRequestedActions({Tag, _} = Val) when is_atom(Tag) ->
 cre_SecondRequestedActions('NULL' = RED) ->
     #'SecondRequestedActions'{resetEventsDescriptor = RED}.
 
-cre_SecondRequestedActions(KA, SD) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+cre_SecondRequestedActions(KA, SD)
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_list(SD) ->
     #'SecondRequestedActions'{keepActive = KA, signalsDescriptor = SD};
-cre_SecondRequestedActions(KA, {Tag, _} = Val) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+cre_SecondRequestedActions(KA, {Tag, _} = Val)
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_atom(Tag) ->
     case is_EventDM(Val) of
 	true ->
@@ -1816,27 +1808,27 @@ cre_SecondRequestedActions(KA, {Tag, _} = Val)
 		    error({invalid_SecondRequestedActions, Val})
 	    end
     end;
-cre_SecondRequestedActions(KA, 'NULL' = RED) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) ->
+cre_SecondRequestedActions(KA, 'NULL' = RED)
+  when is_boolean(KA); KA == asn1_NOVALUE ->
     #'SecondRequestedActions'{keepActive            = KA, 
 			      resetEventsDescriptor = RED}.
 
-cre_SecondRequestedActions(KA, {Tag, _} = EDM, SD) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
-       is_atom(Tag) and 
+cre_SecondRequestedActions(KA, {Tag, _} = EDM, SD)
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_atom(Tag),
        is_list(SD) ->
-    #'SecondRequestedActions'{keepActive        = KA, 
-			      eventDM           = EDM, 
+    #'SecondRequestedActions'{keepActive        = KA,
+                              eventDM           = EDM,
 			      signalsDescriptor = SD};
-cre_SecondRequestedActions(KA, SD, {Tag, _} = NB) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
-       is_list(SD) and
+cre_SecondRequestedActions(KA, SD, {Tag, _} = NB)
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_list(SD),
        is_atom(Tag) ->
     #'SecondRequestedActions'{keepActive        = KA,
 			      signalsDescriptor = SD,
 			      notifyBehaviour   = NB};
-cre_SecondRequestedActions(KA, SD, 'NULL' = RED) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+cre_SecondRequestedActions(KA, SD, 'NULL' = RED)
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_list(SD) ->
     #'SecondRequestedActions'{keepActive            = KA,
 			      signalsDescriptor     = SD,
@@ -1844,11 +1836,11 @@ cre_SecondRequestedActions(KA, SD, 'NULL' = RED)
 
 cre_SecondRequestedActions(KA, {EDMTag, _} = EDM, SD, 
 			   {NBTag, _} = NB, RED) 
-  when ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
-       (is_atom(EDMTag) or (EDM == asn1_NOVALUE)) and
-       (is_list(SD) or (SD == asn1_NOVALUE)) and 
-       (is_atom(NBTag) or (NB == asn1_NOVALUE)) and
-       ((RED == 'NULL') or (RED == asn1_NOVALUE)) ->
+  when is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_atom(EDMTag) orelse EDM == asn1_NOVALUE,
+       is_list(SD) orelse SD == asn1_NOVALUE,
+       is_atom(NBTag) orelse NB == asn1_NOVALUE,
+       RED == 'NULL' orelse RED == asn1_NOVALUE ->
     #'SecondRequestedActions'{keepActive            = KA,
 			      eventDM               = EDM, 
 			      signalsDescriptor     = SD,
@@ -1859,11 +1851,11 @@ cre_EventBufferDescriptor([H|_] = D) when is_record(H, 'EventSpec') ->
     D.
 
 cre_EventSpec(N, [H|_] = EPL) 
-  when is_list(N) and is_record(H, 'EventParameter') ->
+  when is_list(N), is_record(H, 'EventParameter') ->
     #'EventSpec'{eventName = N, eventParList = EPL}.
 
-cre_EventSpec(N, SID, [H|_] = EPL) 
-  when is_list(N) and is_integer(SID) and is_record(H, 'EventParameter') ->
+cre_EventSpec(N, SID, [H|_] = EPL)
+  when is_list(N), is_integer(SID), is_record(H, 'EventParameter') ->
     #'EventSpec'{eventName = N, streamID = SID, eventParList = EPL}.
     
 cre_SignalsDescriptor(D) ->
@@ -1880,26 +1872,26 @@ cre_SignalRequest(S) when is_record(S, 'SeqSigList') ->
     {seqSigList, S}.
 
 cre_SeqSigList(ID, [H|_] = SL) 
-  when is_integer(ID) and (0 =< ID) and (ID =< 65535) and
+  when is_integer(ID), 0 =< ID, ID =< 65535,
        is_record(H, 'Signal') ->
     #'SeqSigList'{id = ID, signalList = SL}.
 
 cre_Signal(N) when is_list(N) ->
     #'Signal'{signalName = N}.
 
-cre_Signal(N, SPL) when is_list(N) and is_list(SPL) ->
+cre_Signal(N, SPL) when is_list(N), is_list(SPL) ->
     #'Signal'{signalName = N,
 	      sigParList = SPL}.
 
-cre_Signal(N, SID, ST, Dur, NC, KA, SPL) 
-  when is_list(N) and 
-       (is_integer(SID) or (SID == asn1_NOVALUE)) and 
-       ((ST == brief) or (ST == onOff) or (ST == timeOut) or 
-	(ST == asn1_NOVALUE)) and
-       ((is_integer(Dur) and (0 =< Dur) and (Dur =< 65535)) or 
-	(Dur == asn1_NOVALUE)) and
-       (is_list(NC) or (NC == asn1_NOVALUE)) and
-       ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
+cre_Signal(N, SID, ST, Dur, NC, KA, SPL)
+  when is_list(N),
+       is_integer(SID) orelse SID == asn1_NOVALUE,
+       ST == brief orelse ST == onOff orelse ST == timeOut orelse
+       ST == asn1_NOVALUE,
+       is_integer(Dur) andalso 0 =< Dur andalso Dur =< 65535 orelse
+       Dur == asn1_NOVALUE,
+       is_list(NC) orelse NC == asn1_NOVALUE,
+       is_boolean(KA) orelse KA == asn1_NOVALUE,
        is_list(SPL) ->
     #'Signal'{signalName       = N,
 	      streamID         = SID,
@@ -1909,19 +1901,19 @@ cre_Signal(N, SID, ST, Dur, NC, KA, SPL)
 	      keepActive       = KA,
 	      sigParList       = SPL}.
 
-cre_Signal(N, SID, ST, Dur, NC, KA, SPL, Dir, RID) 
-  when is_list(N) and 
-       (is_integer(SID) or (SID == asn1_NOVALUE)) and 
-       ((ST == brief) or (ST == onOff) or (ST == timeOut) or 
-	(ST == asn1_NOVALUE)) and
-       ((is_integer(Dur) and (0 =< Dur) and (Dur =< 65535)) or 
-	(Dur == asn1_NOVALUE)) and
-       (is_list(NC) or (NC == asn1_NOVALUE)) and
-       ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
-       is_list(SPL) and
-       ((Dir == internal) or (Dir == external) or (Dir == both) or 
-	(Dir == asn1_NOVALUE)) and
-       (is_integer(RID) or (RID == asn1_NOVALUE)) ->
+cre_Signal(N, SID, ST, Dur, NC, KA, SPL, Dir, RID)
+  when is_list(N),
+       is_integer(SID) orelse SID == asn1_NOVALUE,
+       ST == brief orelse ST == onOff orelse ST == timeOut orelse
+       ST == asn1_NOVALUE,
+       is_integer(Dur) andalso 0 =< Dur andalso Dur =< 65535 orelse
+       Dur == asn1_NOVALUE,
+       is_list(NC) orelse NC == asn1_NOVALUE,
+       is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_list(SPL),
+       Dir == internal orelse Dir == external orelse Dir == both orelse
+       Dir == asn1_NOVALUE,
+       is_integer(RID) orelse RID == asn1_NOVALUE ->
     #'Signal'{signalName       = N,
 	      streamID         = SID,
 	      sigType          = ST,
@@ -1932,20 +1924,20 @@ cre_Signal(N, SID, ST, Dur, NC, KA, SPL, Dir, RID)
 	      direction        = Dir,
 	      requestID        = RID}.
 
-cre_Signal(N, SID, ST, Dur, NC, KA, SPL, Dir, RID, ISIG) 
-  when is_list(N) and 
-       (is_integer(SID) or (SID == asn1_NOVALUE)) and 
-       ((ST == brief) or (ST == onOff) or (ST == timeOut) or 
-	(ST == asn1_NOVALUE)) and
-       ((is_integer(Dur) and (0 =< Dur) and (Dur =< 65535)) or 
-	(Dur == asn1_NOVALUE)) and
-       (is_list(NC) or (NC == asn1_NOVALUE)) and
-       ((KA == true) or (KA == false) or (KA == asn1_NOVALUE)) and
-       is_list(SPL) and
-       ((Dir == internal) or (Dir == external) or (Dir == both) or 
-	(Dir == asn1_NOVALUE)) and
-       (is_integer(RID) or (RID == asn1_NOVALUE)) and
-       (is_integer(ISIG) or (ISIG == asn1_NOVALUE)) ->
+cre_Signal(N, SID, ST, Dur, NC, KA, SPL, Dir, RID, ISIG)
+  when is_list(N),
+       is_integer(SID) orelse SID == asn1_NOVALUE,
+       ST == brief orelse ST == onOff orelse ST == timeOut orelse
+       ST == asn1_NOVALUE,
+       is_integer(Dur) andalso 0 =< Dur andalso Dur =< 65535 orelse
+       Dur == asn1_NOVALUE,
+       is_list(NC) orelse NC == asn1_NOVALUE,
+       is_boolean(KA) orelse KA == asn1_NOVALUE,
+       is_list(SPL),
+       Dir == internal orelse Dir == external orelse Dir == both orelse
+       Dir == asn1_NOVALUE,
+       is_integer(RID) orelse RID == asn1_NOVALUE,
+       is_integer(ISIG) orelse ISIG == asn1_NOVALUE ->
     #'Signal'{signalName       = N,
 	      streamID         = SID,
 	      sigType          = ST,
@@ -1987,28 +1979,28 @@ cre_NotifyCompletion(L) when is_list(L) ->
     lists:foreach(F, L),
     L.
 
-cre_SigParameter(N, V) when is_list(N) and is_list(V) ->
+cre_SigParameter(N, V) when is_list(N), is_list(V) ->
     #'SigParameter'{sigParameterName = N, value = V}.
 
-cre_SigParameter(N, V, relation = Tag, R) 
-  when is_list(N) and is_list(V) and is_atom(R) ->
-    EI = {Tag, R}, 
+cre_SigParameter(N, V, relation = Tag, R)
+  when is_list(N), is_list(V), is_atom(R) ->
+    EI = {Tag, R},
     #'SigParameter'{sigParameterName = N, value = V, extraInfo = EI};
-cre_SigParameter(N, V, range = Tag, B) 
-  when is_list(N) and is_list(V) and is_atom(B) ->
-    EI = {Tag, B}, 
+cre_SigParameter(N, V, range = Tag, B)
+  when is_list(N), is_list(V), is_atom(B) ->
+    EI = {Tag, B},
     #'SigParameter'{sigParameterName = N, value = V, extraInfo = EI};
-cre_SigParameter(N, V, sublist = Tag, B) 
-  when is_list(N) and is_list(V) and is_atom(B) ->
+cre_SigParameter(N, V, sublist = Tag, B)
+  when is_list(N), is_list(V), is_atom(B) ->
     EI = {Tag, B}, 
     #'SigParameter'{sigParameterName = N, value = V, extraInfo = EI}.
 
-cre_RequestID(Val) when (0 =< Val) and (Val =< 4294967295) ->
+cre_RequestID(Val) when 0 =< Val, Val =< 4294967295 ->
     Val;
 cre_RequestID(Val) ->
     exit({invalid_RequestID, Val}).
 
-cre_ModemDescriptor(MTL, MPL) when is_list(MTL) and is_list(MPL) ->
+cre_ModemDescriptor(MTL, MPL) when is_list(MTL), is_list(MPL) ->
     #'ModemDescriptor'{mtl = MTL, mpl = MPL}.
 
 %% cre_ModemDescriptor(MTL, MPL, NSD) 
@@ -2043,7 +2035,7 @@ cre_DigitMapDescriptor(V) when is_record(V, 'DigitMapValue') ->
     #'DigitMapDescriptor'{digitMapValue = V}.
 
 cre_DigitMapDescriptor(N, V) 
-  when is_list(N) and is_record(V, 'DigitMapValue') ->
+  when is_list(N), is_record(V, 'DigitMapValue') ->
     #'DigitMapDescriptor'{digitMapName = N, digitMapValue = V}.
 
 cre_DigitMapName(N) ->
@@ -2056,22 +2048,22 @@ cre_DigitMapValue(Start, Short, Long, DMB) ->
     cre_DigitMapValue(Start, Short, Long, DMB, asn1_NOVALUE).
 
 cre_DigitMapValue(Start, Short, Long, DMB, Dur) 
-  when ((is_integer(Start) and (0 =< Start) and (Start =< 99)) or
-	(Start == asn1_NOVALUE)) and
-       ((is_integer(Short) and (0 =< Short) and (Short =< 99)) or
-	(Short == asn1_NOVALUE)) and
-       ((is_integer(Long) and (0 =< Long) and (Long =< 99)) or
-	(Long == asn1_NOVALUE)) and
-       is_list(DMB) and
-       ((is_integer(Dur) and (0 =< Dur) and (Dur =< 99)) or
-	(Dur == asn1_NOVALUE)) ->
+  when is_integer(Start) andalso 0 =< Start andalso Start =< 99 orelse
+       Start == asn1_NOVALUE,
+       is_integer(Short) andalso 0 =< Short andalso Short =< 99 orelse
+       Short == asn1_NOVALUE,
+       is_integer(Long) andalso 0 =< Long andalso Long =< 99 orelse
+       Long == asn1_NOVALUE,
+       is_list(DMB),
+       is_integer(Dur) andalso 0 =< Dur andalso Dur =< 99 orelse
+       Dur == asn1_NOVALUE ->
     #'DigitMapValue'{startTimer    = Start,
 		     shortTimer    = Short,
 		     longTimer     = Long,
 		     digitMapBody  = DMB,
 		     durationTimer = Dur}.
 
-cre_ServiceChangeParm(M, R) when is_atom(M) and is_list(R) ->
+cre_ServiceChangeParm(M, R) when is_atom(M), is_list(R) ->
     #'ServiceChangeParm'{serviceChangeMethod = M,
 			 serviceChangeReason = R}.
 
@@ -2085,16 +2077,16 @@ cre_ServiceChangeParm(M, Addr, Ver, Prof, R, D, Mid, TS, I) ->
     cre_ServiceChangeParm(M, Addr, Ver, Prof, R, D, Mid, TS, I, asn1_NOVALUE).
 		
 cre_ServiceChangeParm(M, Addr, Ver, Prof, R, D, Mid, TS, I, IF) 
-  when is_atom(M) and 
-       ((is_integer(Ver) and (0 =< Ver) and (Ver =< 99)) or
-	(Ver == asn1_NOVALUE)) and
-       (is_record(Prof, 'ServiceChangeProfile') or (Prof == asn1_NOVALUE)) and
-       is_list(R) and
-       ((is_integer(D) and (0 =< D) and (D =< 4294967295)) or 
-	(D == asn1_NOVALUE)) and
-       (is_record(TS, 'TimeNotation') or (TS == asn1_NOVALUE)) and
-       (is_record(I, 'AuditDescriptor') or (I == asn1_NOVALUE)) and
-       ((IF == 'NULL') or (IF == asn1_NOVALUE)) ->
+  when is_atom(M),
+       is_integer(Ver) andalso 0 =< Ver andalso Ver =< 99 orelse
+       Ver == asn1_NOVALUE,
+       is_record(Prof, 'ServiceChangeProfile') orelse Prof == asn1_NOVALUE,
+       is_list(R),
+       is_integer(D) andalso 0 =< D andalso D =< 4294967295 orelse
+       D == asn1_NOVALUE,
+       is_record(TS, 'TimeNotation') orelse TS == asn1_NOVALUE,
+       is_record(I, 'AuditDescriptor') orelse I == asn1_NOVALUE,
+       IF == 'NULL' orelse IF == asn1_NOVALUE ->
     F = fun(A) -> 
 		(A == asn1_NOVALUE) orelse 
 				      (is_tuple(A) 
@@ -2117,7 +2109,7 @@ cre_ServiceChangeParm(M, Addr, Ver, Prof, R, D, Mid, TS, I, IF)
     end.
 		
 cre_ServiceChangeAddress(portNumber = Tag, P) 
-  when is_integer(P) and (0 =< P) and (P =< 65535) ->
+  when is_integer(P), 0 =< P, P =< 65535 ->
     {Tag, P};
 cre_ServiceChangeAddress(ip4Address = Tag, A) 
   when is_record(A, 'IP4Address') ->
@@ -2139,10 +2131,10 @@ cre_ServiceChangeResParm(Addr, Prof) ->
     cre_ServiceChangeResParm(asn1_NOVALUE, Addr, asn1_NOVALUE, 
 			     Prof, asn1_NOVALUE).
 cre_ServiceChangeResParm(Mid, Addr, Ver, Prof, TS)
-  when ((is_integer(Ver) and (0 =< Ver) and (Ver =< 99)) or 
-	(Ver == asn1_NOVALUE)) and 
-       (is_record(Prof, 'ServiceChangeProfile') or (Prof == asn1_NOVALUE)) and
-       (is_record(TS, 'TimeNotation') or (TS == asn1_NOVALUE)) ->
+  when is_integer(Ver) andalso 0 =< Ver andalso Ver =< 99 orelse
+       Ver == asn1_NOVALUE,
+       is_record(Prof, 'ServiceChangeProfile') orelse Prof == asn1_NOVALUE,
+       is_record(TS, 'TimeNotation') orelse TS == asn1_NOVALUE ->
     F = fun(A) -> 
 		(A == asn1_NOVALUE) orelse 
 				      (is_tuple(A) 
@@ -2177,15 +2169,15 @@ cre_ServiceChangeProfile(N) ->
     cre_ServiceChangeProfile(N, 1).
 
 cre_ServiceChangeProfile(N, V) 
-  when is_list(N) and is_integer(V) and (0 =< V) and (V =< 99) ->
+  when is_list(N), is_integer(V), 0 =< V, V =< 99 ->
     #'ServiceChangeProfile'{profileName = N, version = V}.
     
 cre_PackagesDescriptor([H|_] = D) when is_record(H, 'PackagesItem') ->
     D.
 
 cre_PackagesItem(N, Ver) 
-  when is_list(N) and 
-       is_integer(Ver) and (0 =< Ver) and (Ver =< 99) ->
+  when is_list(N),
+       is_integer(Ver), 0 =< Ver, Ver =< 99 ->
     #'PackagesItem'{packageName    = N, 
 		    packageVersion = Ver}.
 
@@ -2196,7 +2188,7 @@ cre_StatisticsDescriptor(D) ->
 cre_StatisticsParameter(N) when is_list(N) ->
     #'StatisticsParameter'{statName = N}.
 
-cre_StatisticsParameter(N, V) when is_list(N) and is_list(V) ->
+cre_StatisticsParameter(N, V) when is_list(N), is_list(V) ->
     #'StatisticsParameter'{statName = N, statValue = V}.
 
 %% cre_NonStandardData({Tag, _} = Id, Data) when atom(Tag), list(Data) ->
@@ -2220,8 +2212,8 @@ cre_StatisticsParameter(N, V) when is_list(N) and is_list(V) ->
 %% 		       manufacturerCode = MC}.
        
 cre_TimeNotation(D, T) 
-  when is_list(D) and (length(D) == 8) and 
-       is_list(T) and (length(T) == 8) ->
+  when length(D) == 8,
+       length(T) == 8 ->
     #'TimeNotation'{date = D, time = T}.
     
 cre_Value([H|_] = V) when is_list(H) ->
@@ -2566,9 +2558,9 @@ chk_Transaction({Tag, Val} = Trans, Trans) ->
     end;
 chk_Transaction({Tag, Val1} = Trans1, {Tag, Val2} = Trans2) ->
     d("chk_Transaction -> entry (2)"),
-    case (is_Transaction_tag(Tag) and
-	  is_Transaction_val(Tag, Val1) and
-	  is_Transaction_val(Tag, Val2)) of
+    case is_Transaction_tag(Tag) andalso
+        is_Transaction_val(Tag, Val1) andalso
+        is_Transaction_val(Tag, Val2) of
 	true ->
 	    chk_Transaction_val(Tag, Val1, Val2);
 	false ->
@@ -2743,20 +2735,20 @@ chk_TransactionReply_transactionResult(Res, Res) ->
 	     'TransactionReply_transactionResult', Res);
 chk_TransactionReply_transactionResult({Tag, Val1} = Res1, 
 				       {Tag, Val2} = Res2) ->
-    case (is_TransactionReply_transactionResult_tag(Tag) and
-	  is_TransactionReply_transactionResult_val(Tag, Val1) and
-	  is_TransactionReply_transactionResult_val(Tag, Val2)) of
+    case is_TransactionReply_transactionResult_tag(Tag) andalso
+        is_TransactionReply_transactionResult_val(Tag, Val1) andalso
+        is_TransactionReply_transactionResult_val(Tag, Val2) of
 	true ->
 	    chk_TransactionReply_transactionResult_val(Tag, Val1, Val2);
 	false ->
 	    wrong_type('TransactionReply_transactionResult', Res1, Res2)
     end;
-chk_TransactionReply_transactionResult({Tag1, Val1} = Res1, 
+chk_TransactionReply_transactionResult({Tag1, Val1} = Res1,
 				       {Tag2, Val2} = Res2) ->
-    case ((is_TransactionReply_transactionResult_tag(Tag1) and
-	   is_TransactionReply_transactionResult_val(Tag1, Val1)) and
-	  (is_TransactionReply_transactionResult_tag(Tag2) and
-	   is_TransactionReply_transactionResult_val(Tag2, Val2))) of
+    case is_TransactionReply_transactionResult_tag(Tag1) andalso
+        is_TransactionReply_transactionResult_val(Tag1, Val1) andalso
+        is_TransactionReply_transactionResult_tag(Tag2) andalso
+        is_TransactionReply_transactionResult_val(Tag2, Val2) of
 	true ->
 	    not_equal('TransactionReply_transactionResult', Res1, Res2);
 	false ->
@@ -3222,17 +3214,17 @@ chk_ContextRequest_iepscallind(E, E) ->
     chk_type(fun is_ContextRequest_iepscallind/1, 
 	     'ContextRequest_iepscallind', E);
 chk_ContextRequest_iepscallind(E1, E2) ->
-    case (is_ContextRequest_iepscallind(E1) andalso 
+    case (is_ContextRequest_iepscallind(E1) andalso
 	  is_ContextRequest_iepscallind(E2)) of
 	true ->
-	    case (((E1 == false)        and (E2 == asn1_NOVALUE)) or
-		  ((E1 == asn1_NOVALUE) and (E2 == false))) of
+            case E1 == false andalso E2 == asn1_NOVALUE orelse
+                E1 == asn1_NOVALUE andalso E2 == false of
 		true ->
 		    ok;
 		false ->
 		    not_equal('ContextRequest_iepscallind', E1, E2)
 	    end;
-		
+
 	false ->
 	    wrong_type('ContextRequest_iepscallind', E1, E2)
     end.
@@ -6113,19 +6105,19 @@ chk_PropertyParm_value(V1, V2) ->
 chk_PropertyParm_extraInfo(EI, EI) ->
     chk_type(fun is_PropertyParm_extraInfo/1, 'PropertyParm_extraInfo', EI);
 chk_PropertyParm_extraInfo({Tag, Val1} = EI1, {Tag, Val2} = EI2) ->
-    case (is_PropertyParm_extraInfo_tag(Tag) and
-	  is_PropertyParm_extraInfo_val(Tag, Val1) and
-	  is_PropertyParm_extraInfo_val(Tag, Val2)) of
+    case is_PropertyParm_extraInfo_tag(Tag) andalso
+        is_PropertyParm_extraInfo_val(Tag, Val1) andalso
+        is_PropertyParm_extraInfo_val(Tag, Val2) of
 	true ->
 	    chk_PropertyParm_extraInfo_val(Tag, Val1, Val2);
 	false ->
 	    wrong_type('PropertyParm_extraInfo', EI1, EI2)
     end;
 chk_PropertyParm_extraInfo({Tag1, Val1} = EI1, {Tag2, Val2} = EI2) ->
-    case ((is_PropertyParm_extraInfo_tag(Tag1) and
-	   is_PropertyParm_extraInfo_val(Tag1, Val1)) and
-	  (is_PropertyParm_extraInfo_tag(Tag2) and
-	   is_PropertyParm_extraInfo_val(Tag2, Val2))) of
+    case is_PropertyParm_extraInfo_tag(Tag1) andalso
+        is_PropertyParm_extraInfo_val(Tag1, Val1) andalso
+        is_PropertyParm_extraInfo_tag(Tag2) andalso
+        is_PropertyParm_extraInfo_val(Tag2, Val2) of
 	true ->
 	    not_equal('PropertyParm_extraInfo', EI1, EI2);
 	false ->
@@ -6153,9 +6145,9 @@ is_Name(N) ->
 	    false
     end.
 
-is_NAME([H|T]) when (H =< $z) and ($a =< H) ->
+is_NAME([H|T]) when $a =< H, H =< $z ->
     is_NAME2(T);
-is_NAME([H|T]) when (H =< $Z) and ($A =< H) ->
+is_NAME([H|T]) when $A =< H, H =< $Z ->
     is_NAME2(T);
 is_NAME(_) ->
     false.
@@ -6164,11 +6156,11 @@ is_NAME2([]) ->
     true;
 is_NAME2([$_|T]) ->
     is_NAME2(T);
-is_NAME2([H|T]) when (H =< $z) and ($a =< H) ->
+is_NAME2([H|T]) when $a =< H, H =< $z ->
     is_NAME2(T);
-is_NAME2([H|T]) when (H =< $Z) and ($A =< H) ->
+is_NAME2([H|T]) when $A =< H, H =< $Z ->
     is_NAME2(T);
-is_NAME2([H|T]) when (H =< $9) and ($0 =< H) ->
+is_NAME2([H|T]) when $0 =< H, H =< $9 ->
     is_NAME2(T);
 is_NAME2(_) ->
     false.
@@ -7509,19 +7501,19 @@ chk_SigParameter(P1, P2) ->
 chk_SigParameter_extraInfo(EI, EI) ->
     chk_type(fun is_SigParameter_extraInfo/1, 'SigParameter_extraInfo', EI);
 chk_SigParameter_extraInfo({Tag, Val1} = EI1, {Tag, Val2} = EI2) ->
-    case (is_SigParameter_extraInfo_tag(Tag) and
-	  is_SigParameter_extraInfo_val(Tag, Val1) and
-	  is_SigParameter_extraInfo_val(Tag, Val2)) of
+    case is_SigParameter_extraInfo_tag(Tag) andalso
+        is_SigParameter_extraInfo_val(Tag, Val1) andalso
+        is_SigParameter_extraInfo_val(Tag, Val2) of
 	true ->
 	    chk_SigParameter_extraInfo_val(Tag, Val1, Val2);
 	false ->
 	    wrong_type('SigParameter_extraInfo', EI1, EI2)
     end;
 chk_SigParameter_extraInfo({Tag1, Val1} = EI1, {Tag2, Val2} = EI2) ->
-    case ((is_SigParameter_extraInfo_tag(Tag1) and
-	   is_SigParameter_extraInfo_val(Tag1, Val1)) and
-	  (is_SigParameter_extraInfo_tag(Tag2) and
-	   is_SigParameter_extraInfo_val(Tag2, Val2))) of
+    case is_SigParameter_extraInfo_tag(Tag1) andalso
+        is_SigParameter_extraInfo_val(Tag1, Val1) andalso
+        is_SigParameter_extraInfo_tag(Tag2) andalso
+        is_SigParameter_extraInfo_val(Tag2, Val2) of
 	true ->
 	    not_equal('SigParameter_extraInfo', EI1, EI2);
 	false ->
@@ -8440,14 +8432,14 @@ is_OCTET_STRING(L) -> is_OCTET_STRING(L, any).
 
 is_OCTET_STRING(L, any) when is_list(L) ->
     true;
-is_OCTET_STRING(L, {exact, Len}) when is_list(L) and (length(L) == Len) ->
+is_OCTET_STRING(L, {exact, Len}) when length(L) == Len ->
     true;
-is_OCTET_STRING(L, {atleast, Len}) when is_list(L) and (Len =< length(L)) ->
+is_OCTET_STRING(L, {atleast, Len}) when Len =< length(L) ->
     true;
-is_OCTET_STRING(L, {atmost, Len}) when is_list(L) and (length(L) =< Len) ->
+is_OCTET_STRING(L, {atmost, Len}) when length(L) =< Len ->
     true;
-is_OCTET_STRING(L, {range, Min, Max}) 
-  when is_list(L) and (Min =< length(L)) and (length(L) =< Max) ->
+is_OCTET_STRING(L, {range, Min, Max})
+  when Min =< length(L), length(L) =< Max ->
     true;
 is_OCTET_STRING(_, _) ->
     false.
@@ -8507,16 +8499,16 @@ is_INTEGER(I, any) when is_integer(I) ->
     true;
 is_INTEGER(I, {exact, I}) when is_integer(I) ->
     true;
-is_INTEGER(I, {atleast, Min}) when 
-  is_integer(I) and is_integer(Min) and (Min =< I) ->
+is_INTEGER(I, {atleast, Min}) when
+  is_integer(I), is_integer(Min), Min =< I ->
     true;
-is_INTEGER(I, {atmost, Max}) 
-  when is_integer(I) and is_integer(Max) and (I =< Max) ->
+is_INTEGER(I, {atmost, Max})
+  when is_integer(I), is_integer(Max), I =< Max ->
     true;
-is_INTEGER(I, {range, Min, Max}) 
-  when is_integer(I) and 
-       is_integer(Min) and (Min =< I) and 
-       is_integer(Max) and (I =< Max) ->
+is_INTEGER(I, {range, Min, Max})
+  when is_integer(I),
+       is_integer(Min), Min =< I,
+       is_integer(Max), I =< Max ->
     true;
 is_INTEGER(_, _) ->
     false.
@@ -8542,7 +8534,7 @@ chk_INTEGER(I1, I2, R) ->
 %% ----------------------------------------------------------------------
 
 
-to_lower([C|Cs]) when (C >= $A) and (C =< $Z) ->
+to_lower([C|Cs]) when $A =< C, C =< $Z ->
     [C+($a-$A)|to_lower(Cs)];
 to_lower([C|Cs]) ->
     [C|to_lower(Cs)];
@@ -8559,7 +8551,7 @@ validate(F, Type) when is_function(F) ->
     end.
 
 	    
-chk_type(F, T, V) when is_function(F) and is_atom(T) ->
+chk_type(F, T, V) when is_function(F, 1), is_atom(T) ->
     case F(V) of
 	true ->
 	    ok;
@@ -8567,7 +8559,7 @@ chk_type(F, T, V) when is_function(F) and is_atom(T) ->
 	    wrong_type(T, V)
     end.
 
-chk_type(F, T, V1, V2) when is_function(F) and is_atom(T) ->
+chk_type(F, T, V1, V2) when is_function(F, 2), is_atom(T) ->
     case F(V1, V2) of
 	true ->
 	    ok;
@@ -8620,7 +8612,7 @@ is_CHOICE_val(Tag, Val, Tags) ->
     IsVal(Val).
 
 
-chk_CHOICE(V1, V2, Type, Tags) when is_atom(Type) and is_list(Tags) ->
+chk_CHOICE(V1, V2, Type, Tags) when is_atom(Type), is_list(Tags) ->
     IsTag  = fun(Tag) -> is_CHOICE_tag(Tag, Tags) end,
     IsVal  = fun(Tag, Val) -> is_CHOICE_val(Tag, Val, Tags) end,
     ChkVal = fun(Tag, Val1, Val2) ->

--- a/lib/megaco/test/megaco_timer_SUITE.erl
+++ b/lib/megaco/test/megaco_timer_SUITE.erl
@@ -197,15 +197,15 @@ do_simple_init() ->
     Init = 
 	fun(Tmr) ->
 		case (catch megaco_timer:init(Tmr)) of
-		    {WaitFor, {NewTmr, _}} when 
-		        (((WaitFor == infinity) or is_integer(WaitFor)) andalso 
-			 is_record(NewTmr, megaco_incr_timer) andalso
-			 (is_record(Tmr, megaco_incr_timer) andalso 
-			  (Tmr#megaco_incr_timer.max_retries == infinity_restartable))) ->
+                    {WaitFor, {NewTmr, _}} when
+                          WaitFor == infinity orelse is_integer(WaitFor),
+                          is_record(NewTmr, megaco_incr_timer),
+                          is_record(Tmr, megaco_incr_timer),
+                          Tmr#megaco_incr_timer.max_retries == infinity_restartable ->
 			ok;
-		    {WaitFor, NewTmr} when 
-			 (((WaitFor == infinity) or is_integer(WaitFor)) andalso 
-			  ((NewTmr == timeout) or is_record(NewTmr, megaco_incr_timer))) ->
+                    {WaitFor, NewTmr} when
+                          WaitFor == infinity orelse is_integer(WaitFor),
+                          NewTmr == timeout orelse is_record(NewTmr, megaco_incr_timer) ->
 			ok;
 		    X ->
 			d("initiation of timer failed: "

--- a/lib/mnesia/examples/bench/bench_trans.erl
+++ b/lib/mnesia/examples/bench/bench_trans.erl
@@ -83,7 +83,7 @@ read_session_details(Wlock, SubscrId, ServerBit, ServerId) ->
 
     IsAllowed     = ((Group#group.allow_read band ServerBit) == ServerBit),
     IsActive      = ((Subscr#subscriber.active_sessions band ServerBit) == ServerBit),    
-    ExecuteBranch = (IsAllowed and IsActive),
+    ExecuteBranch = IsAllowed andalso IsActive,
 
     case ExecuteBranch of
         true ->
@@ -111,7 +111,7 @@ create_session_to_server(Wlock, SubscrId, ServerBit, ServerId, Details, DoRollba
 
     IsAllowed     = ((Group#group.allow_insert band ServerBit) == ServerBit),
     IsInactive    = ((Subscr#subscriber.active_sessions band ServerBit) == 0),
-    ExecuteBranch = (IsAllowed and IsInactive),
+    ExecuteBranch = IsAllowed andalso IsInactive,
     case ExecuteBranch of
         true ->
             SessionKey = {SubscrId, ServerId},
@@ -149,7 +149,7 @@ delete_session_from_server(Wlock, SubscrId, ServerBit, ServerId, DoRollback) ->
 
     IsAllowed     = ((Group#group.allow_delete band ServerBit) == ServerBit),
     IsActive      = ((Subscr#subscriber.active_sessions band ServerBit) == ServerBit),    
-    ExecuteBranch = (IsAllowed and IsActive),
+    ExecuteBranch = IsAllowed andalso IsActive,
     case ExecuteBranch of
         true ->
             SessionKey = {SubscrId, ServerId},

--- a/lib/odbc/test/odbc_query_SUITE.erl
+++ b/lib/odbc/test/odbc_query_SUITE.erl
@@ -1075,8 +1075,8 @@ param_insert_float(Config) when is_list(Config) ->
 
     ["FIELD"] = odbc_test_lib:to_upper(Fileds),
 
-    case (odbc_test_lib:match_float(Float1, 1.3, 0.000001) and 
-	  odbc_test_lib:match_float(Float2, 1.2, 0.000001)) of
+    case odbc_test_lib:match_float(Float1, 1.3, 0.000001) andalso
+        odbc_test_lib:match_float(Float2, 1.2, 0.000001) of
 	true ->
 	    ok;
 	false ->
@@ -1114,8 +1114,8 @@ param_insert_real(Config) when is_list(Config) ->
 
     ["FIELD"] = odbc_test_lib:to_upper(Fileds),
 
-    case (odbc_test_lib:match_float(Real1, 1.3, 0.000001) and 
-	  odbc_test_lib:match_float(Real2, 1.2, 0.000001)) of
+    case odbc_test_lib:match_float(Real1, 1.3, 0.000001) andalso
+        odbc_test_lib:match_float(Real2, 1.2, 0.000001) of
 	true ->
 	    ok;
 	false ->
@@ -1151,8 +1151,8 @@ param_insert_double(Config) when is_list(Config) ->
 
     ["FIELD"] = odbc_test_lib:to_upper(Fileds),
 
-    case (odbc_test_lib:match_float(Double1, 1.3, 0.000001) and 
-	  odbc_test_lib:match_float(Double2, 1.2, 0.000001)) of
+    case odbc_test_lib:match_float(Double1, 1.3, 0.000001) andalso
+        odbc_test_lib:match_float(Double2, 1.2, 0.000001) of
 	true ->
 	    ok;
 	false ->

--- a/lib/odbc/test/odbc_test_lib.erl
+++ b/lib/odbc/test/odbc_test_lib.erl
@@ -37,7 +37,7 @@ unique_table_name() ->
 			      [], atom_to_list(node()))).
 
 match_float(Float, Match, Delta) ->
-    (Float < Match + Delta) and (Float > Match - Delta).
+    Float < Match + Delta andalso Float > Match - Delta.
 
 odbc_check() ->
     case os:type() of

--- a/lib/runtime_tools/test/instrument_SUITE.erl
+++ b/lib/runtime_tools/test/instrument_SUITE.erl
@@ -137,7 +137,7 @@ verify_allocations_output(#{ histogram_start := HistStart,
     PerPort = lists:any(fun(K) -> is_port(K) end, Origins),
 
     true = lists:all(fun(K) ->
-                             is_pid(K) or is_port(K) or is_atom(K)
+                             is_pid(K) orelse is_port(K) orelse is_atom(K)
                      end, Origins),
 
     %% Do the histograms look alright?

--- a/lib/runtime_tools/test/scheduler_SUITE.erl
+++ b/lib/runtime_tools/test/scheduler_SUITE.erl
@@ -93,7 +93,7 @@ check([{total, Tf, Ts} | List]=U) ->
                        List
                end,
 
-    lists:foreach(fun({Type, Id, F, S}) when ((Type =:= normal) or (Type =:= cpu) or (Type =:= io)),
+    lists:foreach(fun({Type, Id, F, S}) when Type =:= normal orelse Type =:= cpu orelse Type =:= io,
                                              is_integer(Id) ->
                           check_values(F, S, true)
                   end,

--- a/lib/ssl/test/ssl_cert_tests.erl
+++ b/lib/ssl/test/ssl_cert_tests.erl
@@ -1012,7 +1012,7 @@ supported_groups(Group) ->
 
 
 choose_custom_key(#'RSAPrivateKey'{} = Key, Version)
-  when (Version == 'dtlsv1') or (Version == 'tlsv1') or (Version == 'tlsv1.1') ->
+  when Version == 'dtlsv1' orelse Version == 'tlsv1' orelse Version == 'tlsv1.1' ->
     EFun = fun (PlainText, Options) ->
                    public_key:encrypt_private(PlainText, Key, Options)
           end,

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -7279,14 +7279,14 @@ manpage(Config) when is_list(Config) ->
     [2,3,4] = qlc:eval(QH),
 
     %% ets(3)
-    MS = ets:fun2ms(fun({X,Y}) when (X > 1) or (X < 5) -> {Y} end),
+    MS = ets:fun2ms(fun({X,Y}) when X > 1 andalso X < 5 -> {Y} end),
     ETs = [
         [<<"Tab = ets:new(t, []),
             true = ets:insert(Tab,[{1,a},{2,b},{3,c},{4,d}]),
             MS = ">>, io_lib:format("~w", [MS]), <<",
             QH1 = ets:table(Tab, [{traverse, {select, MS}}]),
 
-            QH2 = qlc:q([{Y} || {X,Y} <- ets:table(Tab), (X > 1) or (X < 5)]),
+            QH2 = qlc:q([{Y} || {X,Y} <- ets:table(Tab), X > 1 andalso X < 5]),
 
             true = qlc:info(QH1) =:= qlc:info(QH2),
             true = ets:delete(Tab)">>]],
@@ -7299,7 +7299,7 @@ manpage(Config) when is_list(Config) ->
             MS = ">>, io_lib:format("~w", [MS]), <<",
             QH1 = dets:table(T, [{traverse, {select, MS}}]),
 
-            QH2 = qlc:q([{Y} || {X,Y} <- dets:table(t), (X > 1) or (X < 5)]),
+            QH2 = qlc:q([{Y} || {X,Y} <- dets:table(t), X > 1 andalso X < 5]),
 
             true = qlc:info(QH1) =:= qlc:info(QH2),
             ok = dets:close(T)">>]],
@@ -7700,7 +7700,7 @@ i(H, Option) ->
 has_format({format,_}) ->
     true;
 has_format([E | Es]) ->
-    has_format(E) or has_format(Es);
+    has_format(E) orelse has_format(Es);
 has_format(_) ->
     false.
 


### PR DESCRIPTION
This PR removes all remaining usages of the old boolean operators `and` and `or` and replaces them with `andalso` and `orelse`, or `,` and `;` where applicable. Almost all of them were in tests. (Disclaimer: this was done with the help of AI, I could never have done it manually).

I didn't touch some suites in `compiler` and `debugger` which seem to explicitly test the behavior of `and` and `or`. I also didn't go into `snmp` since this is currently handled in #10730.

Along the way, I also simplified some things (like in `megaco` suites for example, some of which seem _very_ old: for instance, there were guards like `(X == true) or (X == false)`, which seems to be something that predates `is_boolean/1`).

There were also a small number of bugs (like `(X == true) and (X == false)` or something in one instance) which I fixed along the way as I encountered them. There may be more of those, but I didn't explicitly look out for them.

This has turned out much bigger than I had initially expected, and I reckon any reviewers will have a hard time. If you want, I can break this down into smaller commits or even individual PRs, just let me know.