### PR TITLE
`sys`: Remove deprecated `catch`

### DIFF
--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -1074,10 +1074,11 @@ do_change_code(Mod, Module, Vsn, Extra, Misc) ->
     try
         Mod:system_code_change(Misc, Module, Vsn, Extra)
     of
-	{ok, _} = Res -> Res;
+        {ok, _} = Res -> Res;
         Else -> {{error, Else}, Misc}
     catch
         throw:{ok, _} = Res -> Res;
+        throw:Else -> {{error, Else}, Misc};
         error:Reason:Stack -> {{error, {'EXIT', {Reason, Stack}}}, Misc};
         exit:Exit -> {{error, {'EXIT', Exit}}, Misc}
     end.

--- a/lib/stdlib/test/sys_SUITE.erl
+++ b/lib/stdlib/test/sys_SUITE.erl
@@ -218,37 +218,37 @@ spec_proc(Mod) ->
     ok = try
              sys:get_state(Mod)
          of
-	     [] ->
-		 ok
+             [] ->
+                 ok
          catch
              error:{callback_failed, {Mod, system_get_state}, {throw, fail}} ->
                  ok
-	 end,
+         end,
     ok = sync_terminate(Mod),
     {ok,_} = Mod:start_link(4),
     ok = try
              sys:replace_state(Mod, fun(_) -> {} end)
          of
-	     {} ->
-		 ok
+             {} ->
+                 ok
          catch
-	     error:{callback_failed, {Mod, system_replace_state}, {throw, fail}} ->
-		 ok
-	 end,
+             error:{callback_failed, {Mod, system_replace_state}, {throw, fail}} ->
+                 ok
+         end,
     ok = sync_terminate(Mod),
     {ok,_} = Mod:start_link(4),
     StateFun = fun(_) -> error(fail) end,
     ok = try
              sys:replace_state(Mod, StateFun)
          of
-	     {} ->
-		 ok
+             {} ->
+                 ok
          catch
              error:{callback_failed, {Mod, system_replace_state}, {error, fail}} ->
-		 ok;
+                 ok;
              error:{callback_failed, StateFun, {error, fail}} ->
-		 ok
-	 end,
+                 ok
+         end,
     ok = sync_terminate(Mod).
 
 sync_terminate(Mod) ->


### PR DESCRIPTION
This PR removes all deprecated old-style `catch`es from the `sys` module and its test suite.