### PR TITLE
stdlib: add helper for old array format

### DIFF
--- a/lib/stdlib/src/array.erl
+++ b/lib/stdlib/src/array.erl
@@ -110,6 +110,8 @@ beyond the last set entry:
          fix/1, relax/1, is_fix/1,
 	 resize/1, resize/2, shift/2, slice/3, prepend/2, append/2]).
 
+-export([upgrade/1]).
+
 -export_type([array/0, array/1]).
 
 -moduledoc(#{ authors => [~"Richard Carlsson <carlsson.richard@gmail.com>",
@@ -2249,3 +2251,40 @@ sparse_mapfoldr_3_1(Low, High, Ix, [E|Es], D, F, A, Es1) when Low =< High ->
     end;
 sparse_mapfoldr_3_1(_Low, _High, _Ix, Es, _D, _F, A, Es1) ->
     {list_to_tuple(lists:reverse(Es, Es1)), A}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Be nice if someone did not read the docs and stored old format to disk.
+%%
+-doc false.
+-spec upgrade(OldArray::tuple() | array()) -> array().
+upgrade(A = #array{}) ->
+    A;
+upgrade({array, Size, Max, Def, Es}) ->
+    A = old_sparse_foldl_1(Size-1, Es, new({default, Def}), 0, fun set/3, Def),
+    case Max == 0 of
+        true -> fix(A);
+        false -> A
+    end;
+upgrade(A) ->
+    error({badarg, A}).
+
+old_sparse_foldl_1(N, E={_,_,_,_,_, _,_,_,_,_,S}, A, Ix, F, D) ->
+    old_sparse_foldl_2(1, E, A, Ix, F, D, N div S + 1, N rem S, S);
+old_sparse_foldl_1(_N, E, A, _Ix, _F, _D) when is_integer(E) ->
+    A;
+old_sparse_foldl_1(N, E, A, Ix, F, D) ->
+    old_sparse_foldl_3(1, E, A, Ix, F, D, N+1).
+
+old_sparse_foldl_2(I, E, A, Ix, F, D, I, R, _S) ->
+    old_sparse_foldl_1(R, element(I, E), A, Ix, F, D);
+old_sparse_foldl_2(I, E, A, Ix, F, D, N, R, S) ->
+    old_sparse_foldl_2(I+1, E, old_sparse_foldl_1(S-1, element(I, E), A, Ix, F, D),
+                       Ix + S, F, D, N, R, S).
+
+old_sparse_foldl_3(I, T, A, Ix, F, D, N) when I =< N ->
+    case element(I, T) of
+        D -> old_sparse_foldl_3(I+1, T, A, Ix+1, F, D, N);
+        E -> old_sparse_foldl_3(I+1, T, F(Ix, E, A), Ix+1, F, D, N)
+    end;
+old_sparse_foldl_3(_I, _T, A, _Ix, _F, _D, _N) ->
+    A.

--- a/lib/stdlib/test/array_SUITE.erl
+++ b/lib/stdlib/test/array_SUITE.erl
@@ -56,6 +56,7 @@
          sparse_foldr_test/1,
          mapfoldl_test/1,
          import_export/1,
+         old_format/1,
          doctests/1,
          %% Property tests
          prop_new/1, prop_is_array/1, prop_set_get/1, prop_size/1,
@@ -96,7 +97,7 @@ all() ->
      from_orddict_test, map_test, sparse_map_test,
      foldl_test, sparse_foldl_test, foldr_test, sparse_foldr_test,
      mapfoldl_test,
-     import_export, doctests,
+     import_export, old_format, doctests,
      {group, property}].
 
 groups() ->
@@ -975,6 +976,28 @@ import_export(_Config) ->
     ?assert(RGBBin =:= array:foldl(RGB2Bin, <<>>, array:from(Bin2RGB, RGBBin))),
 
     ok.
+
+old_format(_Config) ->
+    %% array:fix(array:from_orddict([{3,a}, {42,b}, {43,c}, {44,d}, {45,e}, {500,x}], foo)).
+    List = [{3,a}, {42,b}, {43,c}, {44,d}, {45,e}, {500,x}],
+    Old = {array,501,0,foo,
+           {{{foo,foo,foo,a,foo,foo,foo,foo,foo,foo},
+             10,10,10,
+             {foo,foo,b,c,d,e,foo,foo,foo,foo},
+             10,10,10,10,10,10},
+            100,100,100,100,
+            {{x,foo,foo,foo,foo,foo,foo,foo,foo,foo},
+             10,10,10,10,10,10,10,10,10,10},
+            100,100,100,100,100}},
+    A = array:upgrade(Old),
+    ?assert(List =:= array:sparse_to_orddict(A)),
+    ?assert(true =:= array:is_fix(A)),
+    ?assert(foo =:= array:default(A)),
+    ?assert(x =:= array:get(500, A)),
+    ?assert(foo =:= array:get(499, A)),
+    ?assert(A =:= array:upgrade(A)),
+    ok.
+
 
 doctests(Config) when is_list(Config) ->
     shell_docs:test(array, []).


### PR DESCRIPTION
Even if it should NOT have been stored to disk or sent over distribution, be nice and provide a undocumented converter function.