### PR TITLE
dialyzer: Implement type-checking for native records

### DIFF
--- a/lib/compiler/src/cerl.erl
+++ b/lib/compiler/src/cerl.erl
@@ -1699,7 +1699,7 @@ _See also: _`c_record/2`.
 """.
 -doc(#{since => <<"OTP @OTP-19785@">>}).
 
--spec record_arg(Node :: c_record()) -> c_record() | c_literal().
+-spec record_arg(Node :: c_record()) -> c_var() | c_literal().
 
 record_arg(#c_record{arg = M}) ->
     M.

--- a/lib/compiler/test/native_record_SUITE.erl
+++ b/lib/compiler/test/native_record_SUITE.erl
@@ -31,7 +31,7 @@
 %% Unexported records.
 -record #empty{}.
 -record #a{x, y}.
--record #c{x::integer, y=0::integer, z=[]}.
+-record #c{x::integer(), y=0::integer(), z=[]}.
 -record #d{f=3.1416, l=[a,b,c], t={a,b,c},
            m=#{a => 1}}.
 

--- a/lib/dialyzer/src/cerl_prettypr.erl
+++ b/lib/dialyzer/src/cerl_prettypr.erl
@@ -625,10 +625,13 @@ lay_map_pair(Node, Ctxt) ->
 lay_record(Node, Ctxt) ->
     Arg = record_arg(Node),
     Id = record_id(Node),
-    N = beside(lay(Arg, Ctxt), beside(floating(text("#")), lay(Id, Ctxt))),
-    beside(N, beside(floating(text("~{")),
+    N = case cerl:concrete(Arg) of
+	ok -> beside(floating(text("#")), lay(Id, Ctxt));
+	_ -> beside(lay(Arg, Ctxt), beside(floating(text("#")), lay(Id, Ctxt)))
+        end,
+    beside(N, beside(floating(text("{")),
             beside(par(seq(record_es(Node), floating(text(",")), Ctxt, fun lay/2)),
-	        floating(text("}~"))))).
+	        floating(text("}"))))).
 
 lay_record_pair(Node, Ctxt) ->
     K = record_pair_key(Node),

--- a/lib/dialyzer/src/dialyzer.erl
+++ b/lib/dialyzer/src/dialyzer.erl
@@ -854,6 +854,9 @@ message_to_string({record_constr, [Name, Field, Type]}, I, _E) ->
 message_to_string({record_matching, [String, Name]}, I, _E) ->
   io_lib:format("The ~ts violates the"
 		" declared type for #~tw{}\n", [rec_type(String, I), Name]);
+message_to_string({record_update, [Arg, {M, N}]}, _I, _E) ->
+  io_lib:format("The record update cannot succeed because ~tw is not"
+    " a native record of type #~tw:~tw{}\n", [Arg, M, N]);
 message_to_string({record_match, [Pat, Type]}, I, _E) ->
   io_lib:format("Matching of ~ts tagged with a record name violates"
                 " the declared type of ~ts\n", [ps(Pat, I), t(Type, I)]);

--- a/lib/dialyzer/src/dialyzer_dataflow.erl
+++ b/lib/dialyzer/src/dialyzer_dataflow.erl
@@ -60,7 +60,8 @@
 	 t_limit/2, t_list/0, t_list_elements/1,
 	 t_maybe_improper_list/0, t_module/0,
 	 t_none/0, t_non_neg_integer/0, t_number/0, t_number_vals/1,
-	 t_pid/0, t_port/0, t_product/1, t_record/0, t_record/1, t_reference/0,
+	 t_pid/0, t_port/0, t_product/1, t_record/1, t_record/2,
+	 t_record_get/2, t_record_replace/2, t_reference/0,
          t_to_string/2, t_to_tlist/1,
 	 t_tuple/0, t_tuple/1, t_tuple_args/1,
          t_tuple_subtypes/1,
@@ -1122,32 +1123,56 @@ handle_tuple(Tree, Map, State) ->
 
 %%----------------------------------------
 
-handle_native_record(Tree, Map, State) ->
-  Id = cerl:concrete(cerl:record_id(Tree)),
+handle_native_record(Tree, Map, State=#state{module=Module}) ->
+  Id = case cerl:concrete(cerl:record_id(Tree)) of
+         [] -> [];
+         {M, N} -> {M, N};
+         N -> {Module, N}
+       end,
   Arg = cerl:record_arg(Tree),
   Es = cerl:record_es(Tree),
-  {State1, Map1, ArgType} = traverse(Arg, Map, State),
-  {State2, Map2, _EsType} = traverse_record_pairs(Es, Map1, State1, []),
-  RecordType = t_record(Id),
-  ArgType1 = t_inf(RecordType, ArgType),
-  case t_is_impossible(ArgType1) of
+  {State1, Map1, EsType} = traverse_record_pairs(Es, Map, State, []),
+  RecordType = t_record(Id, EsType),
+  case cerl:is_literal(Arg) of
     true ->
-      {State2, Map2, ArgType1};
+      %% Creation
+      handle_native_record_inf(Tree, Map1, Id, RecordType, State);
     false ->
-      case state__lookup_record(Id, 0, State2) of
-        error -> {State2, Map2, RecordType};
-        {ok, RecType, _FieldNames} ->
-          InfRecType = t_inf(RecType, RecordType),
+      %% Update
+      {State2, Map2, ArgType} = traverse(Arg, Map1, State1),
+      ArgType1 = t_inf(t_record(Id), ArgType),
+      case t_is_impossible(ArgType1) of
+        true ->
+          Msg = {record_update, [cerl:var_name(Arg), Id]},
+          State3 = state__add_warning(State1, ?WARN_MATCHING,
+                                      Tree, Msg),
+          {State3, Map2, ArgType1};
+        false ->
+          RecordType1 = t_record_replace(EsType, ArgType1),
+          handle_native_record_inf(Tree, Map2, Id, RecordType1, State2)
+      end
+  end.
+
+handle_native_record_inf(Tree, Map1, Id, RecordType, State1) ->
+  case Id of
+    [] ->
+      {State1, Map1, t_record([])};
+    _ ->
+      case state__lookup_record(Id, 0, State1) of
+        error ->
+          {State1, Map1, RecordType};
+        {ok, Prototype, _FieldNames} ->
+          InfRecType = t_inf(Prototype, RecordType),
           case t_is_none(InfRecType) of
             true ->
-              RecC = format_type(RecordType, State2),
-              Msg = {record_constr, [RecC]},
-              LocTree = 2,
-              State3 = state__add_warning(State2, ?WARN_MATCHING,
-                                          LocTree, Msg),
-              {State3, Map2, t_none()};
+              RecC = format_type(RecordType, State1),
+              FieldDiffs = erl_types:native_record_field_diffs(Prototype, RecordType),
+              Msg = {record_constr, [RecC, FieldDiffs]},
+              State2 = state__add_warning(State1, ?WARN_MATCHING,
+                                          Tree, Msg),
+              {State2, Map1, t_none()};
             false ->
-              {State2, Map2, t_record(Id)}
+              {State1, Map1, RecordType}
           end
       end
   end.
@@ -1155,11 +1180,11 @@ handle_native_record(Tree, Map, State) ->
 traverse_record_pairs([], Map, State, PairAcc) ->
   {State, Map, lists:reverse(PairAcc)};
 traverse_record_pairs([Pair|Pairs], Map, State, PairAcc) ->
-  Key = cerl:record_pair_key(Pair),
+  Key = cerl:concrete(cerl:record_pair_key(Pair)),
   Val = cerl:record_pair_val(Pair),
   {State1, Map1, V} = traverse(Val,Map,State),
   traverse_record_pairs(Pairs, Map1, State1,
-		     [{{Key,V},Pair}|PairAcc]).
+		     [{Key,V}|PairAcc]).
 
 %%----------------------------------------
 %% Clauses
@@ -1619,14 +1644,41 @@ bind_tuple(Pat, Type, Map, State, Rev) ->
       {Map1, TupleType, State2}
   end.
 
-bind_record(Pat, Type, Map, State, _Rev) ->
-  _Es = cerl:record_es(Pat),
-  Prototype = t_record(),
-  {_Record, State1} = bind_checked_inf(Pat, Prototype, Type, State),
-  _MapJ = join_maps_begin(Map),
-  %% Need to call the top function to get the try-catch wrapper.
-  {_Results, State2} = {t_record(), State1},
-  {Map, t_record(), State2}.
+bind_record(Pat, Type, Map, State=#state{module=Module}, Rev) ->
+  case cerl:concrete(cerl:record_id(Pat)) of
+    [] ->
+      {Map, t_record([]), State};
+    _ ->
+      Es = cerl:record_es(Pat),
+      {Id, Pat1} =
+        case cerl:concrete(cerl:record_id(Pat)) of
+          [] -> {[], Pat};
+          {M, N} -> {{M, N}, Pat};
+          N -> {{Module, N}, cerl:c_record(cerl:abstract({Module, N}), Es)}
+        end,
+      Prototype = case state__lookup_record(Id, 0, State) of
+                    error ->
+                      t_record(Id);
+                    {ok, R, _FieldNames} ->
+                      R
+                  end,
+      {Record, State1} = bind_checked_inf(Pat1, Prototype, Type, State),
+      try bind_record_pairs(Es, Record, Map, State1, Rev) of
+        Result -> Result
+      catch
+        _ -> throw({error, record, [Pat], Prototype})
+      end
+  end.
+
+bind_record_pairs([], Record, Map, State, _Rev) ->
+  {Map, Record, State};
+bind_record_pairs([Pair|Pairs], Record, Map, State, Rev) ->
+  Key = cerl:concrete(cerl:record_pair_key(Pair)),
+  Val = cerl:record_pair_val(Pair),
+  Bind = t_record_get(Key, Record),
+  {Map1, [ValType], State1} = do_bind_pat_vars([Val], [Bind], Map, State, Rev, []),
+  Record1 = t_record_replace({Key, ValType}, Record),
+  bind_record_pairs(Pairs, Record1, Map1, State1, Rev).
 
 bind_bin_segs(BinSegs, BinType, Map, State) ->
   bind_bin_segs(BinSegs, BinType, [], Map, State).
@@ -2111,60 +2163,96 @@ handle_guard_is_function(Guard, Map, Env, Eval, State0) ->
   end.
 
 handle_guard_is_record(Guard, Map, Env, Eval, State0) ->
+  Args = cerl:call_args(Guard),
+  [_Rec, _Tag0, Arity0] = Args,
+  case cerl:is_c_int(Arity0) of
+    true ->
+      handle_guard_is_tuple_record(Guard, Map, Env, Eval, State0);
+    false ->
+      handle_guard_is_native_record(Guard, Map, Env, Eval, State0)
+  end.
+
+handle_guard_is_tuple_record(Guard, Map, Env, Eval, State0) ->
   MFA = {erlang, is_record, 3},
   Args = cerl:call_args(Guard),
   [Rec, Tag0, Arity0] = Args,
-  case cerl:is_c_int(Arity0) of
+  Tag = cerl:atom_val(Tag0),
+  Arity = cerl:int_val(Arity0),
+  {Map1, RecType, State1} = bind_guard(Rec, Map, Env, dont_know, State0),
+  State2 = handle_opaque_guard_warnings(MFA, Guard, [Rec], [RecType], State1),
+  ArityMin1 = Arity - 1,
+  Tuple = t_tuple([t_atom(Tag)|lists:duplicate(ArityMin1, t_any())]),
+  Inf = t_inf(Tuple, RecType),
+  State3 = case erl_types:t_opacity_conflict(RecType,
+                                             Tuple,
+                                             State2#state.module) of
+             none ->
+               State2;
+             _ ->
+               Msg = failed_msg(State2, opaque, Guard, Tuple, [Guard], Inf),
+               state__add_warning(State2, ?WARN_OPAQUE, Guard, Msg)
+           end,
+  case t_is_none(Inf) of
     true ->
-      Tag = cerl:atom_val(Tag0),
-      Arity = cerl:int_val(Arity0),
-      {Map1, RecType, State1} = bind_guard(Rec, Map, Env, dont_know, State0),
-      State2 = handle_opaque_guard_warnings(MFA, Guard, [Rec], [RecType], State1),
-      ArityMin1 = Arity - 1,
-      Tuple = t_tuple([t_atom(Tag)|lists:duplicate(ArityMin1, t_any())]),
-      Inf = t_inf(Tuple, RecType),
-      State3 = case erl_types:t_opacity_conflict(RecType,
-                                                Tuple,
-                                                State2#state.module) of
-                none ->
-                  State2;
-                _ ->
-                  Msg = failed_msg(State2, opaque, Guard, Tuple, [Guard], Inf),
-                  state__add_warning(State2, ?WARN_OPAQUE, Guard, Msg)
-              end,
-      case t_is_none(Inf) of
-        true ->
-            case Eval of
-              pos -> signal_guard_fail(Eval, Guard,
-                                      [RecType, t_from_term(Tag),
-                                        t_from_term(Arity)],
-                                      State3);
-              neg -> {Map1, t_atom(false), State3};
-              dont_know -> {Map1, t_atom(false), State3}
-            end;
-        false ->
-          TupleType =
-            case state__lookup_record(Tag, ArityMin1, State3) of
-              error -> Tuple;
-              {ok, Prototype, _FieldNames} -> Prototype
-            end,
-          Type = t_inf(TupleType, RecType),
-          case t_is_none(Type) of
-            true ->
-              %% No special handling of opaque errors.
-              FArgs = "record " ++ format_type(RecType, State3),
-              throw({fail, {Guard, {record_matching, [FArgs, Tag]}}});
-            false ->
-              case Eval of
-                pos -> {enter_type(Rec, Type, Map1), t_atom(true), State3};
-                neg -> {Map1, t_atom(false), State3};
-                dont_know -> {Map1, t_boolean(), State3}
-              end
-          end
+      case Eval of
+        pos -> signal_guard_fail(Eval, Guard,
+                                 [RecType, t_from_term(Tag),
+                                  t_from_term(Arity)],
+                                 State3);
+        neg -> {Map1, t_atom(false), State3};
+        dont_know -> {Map1, t_atom(false), State3}
       end;
     false ->
-      %% TODO: is_record/3 for native records
-      {Map, t_boolean(), State0}
+      TupleType =
+        case state__lookup_record(Tag, ArityMin1, State3) of
+          error -> Tuple;
+          {ok, Prototype, _FieldNames} -> Prototype
+        end,
+      Type = t_inf(TupleType, RecType),
+      case t_is_none(Type) of
+        true ->
+          %% No special handling of opaque errors.
+          FArgs = "record " ++ format_type(RecType, State3),
+          throw({fail, {Guard, {record_matching, [FArgs, Tag]}}});
+        false ->
+          case Eval of
+            pos -> {enter_type(Rec, Type, Map1), t_atom(true), State3};
+            neg -> {Map1, t_atom(false), State3};
+            dont_know -> {Map1, t_boolean(), State3}
+          end
+      end
+  end.
+
+handle_guard_is_native_record(Guard, Map, Env, Eval, State0) ->
+  Args = cerl:call_args(Guard),
+  [Rec, Tag0, Arity0] = Args,
+  {Map1, RecType, State1} = bind_guard(Rec, Map, Env, dont_know, State0),
+  Mod = cerl:atom_val(Tag0),
+  Name = cerl:atom_val(Arity0),
+  Prototype = t_record({Mod, Name}),
+  Inf = t_inf(RecType, Prototype),
+  case t_is_none(Inf) of
+    true ->
+      case Eval of
+        pos ->
+          signal_guard_fail(Eval, Guard,
+                            [RecType, t_from_term(Mod),
+                             t_from_term(Name)],
+                            State1);
+        neg ->
+          {Map1, t_atom(false), State1};
+        dont_know ->
+          {Map1, t_atom(false), State1}
+      end;
+    false ->
+      case Eval of
+        pos ->
+          {enter_type(Rec, RecType, Map1), t_atom(true), State1};
+        neg ->
+          {Map1, t_atom(false), State1};
+        dont_know ->
+          {Map1, t_boolean(), State1}
+      end
   end.
 
 handle_guard_eq(Guard, Map, Env, Eval, State) ->
@@ -3132,8 +3220,17 @@ state__lookup_record(Tag, Arity, #state{records = Records}) ->
   case erl_types:lookup_record(Tag, Arity, Records) of
     {ok, Fields} ->
       RecType =
-        t_tuple([t_from_term(Tag)|
-                 [FieldType || {_FieldName, _Abstr, FieldType} <- Fields]]),
+        case Arity =:= 0 andalso is_tuple(Tag) of
+          true ->
+            %% Native record
+            Fields1 = [{FieldName, FieldType} ||
+                        {FieldName, _, FieldType} <- Fields],
+            t_record(Tag, Fields1);
+          false ->
+            %% Tuple record
+            t_tuple([t_from_term(Tag)|
+                     [FieldType || {_FieldName, _Abstr, FieldType} <- Fields]])
+        end,
       FieldNames = [FieldName || {FieldName, _Abstr, _FieldType} <- Fields],
       {ok, RecType, FieldNames};
     error ->

--- a/lib/dialyzer/src/dialyzer_typesig.erl
+++ b/lib/dialyzer/src/dialyzer_typesig.erl
@@ -58,7 +58,7 @@
 	 t_list_elements/1, t_nonempty_list/1, t_maybe_improper_list/0,
 	 t_module/0, t_number/0, t_number_vals/1,
 	 t_pid/0, t_port/0, t_product/1, t_reference/0,
-	 t_record/1, t_subst/2,
+	 t_record/0, t_subst/2,
 	 t_timeout/0, t_tuple/0, t_tuple/1,
          t_var/1, t_var_name/1,
 	 t_none/0, t_unit/0,
@@ -614,35 +614,7 @@ traverse(Tree, DefinedVars, State) ->
 	end,
       {state__store_conj(MapVar, sub, MapType, State4), MapVar};
     record ->
-      Id = cerl:concrete(cerl:record_id(Tree)),
-      RecordFoldFun = fun(Entry, AccState) ->
-                          AccState1 = state__set_in_match(AccState, false),
-                          {AccState2, KeyVar} = traverse(cerl:record_pair_key(Entry),
-                                                         DefinedVars, AccState1),
-                          AccState3 = state__set_in_match(
-                                        AccState2, state__is_in_match(AccState)),
-                          {AccState4, ValVar} = traverse(cerl:record_pair_val(Entry),
-                                                         DefinedVars, AccState3),
-                          {{KeyVar, ValVar}, AccState4}
-                      end,
-      Entries = cerl:record_es(Tree),
-      {_EVars, State1} = lists:mapfoldl(RecordFoldFun, State, Entries),
-      {State2, _ArgVar} = case cerl:record_arg(Tree) of
-                            {c_literal,[],empty} ->
-                              {State1, t_record(Id)};
-                            {c_literal,[],ok} ->
-                              {State1, t_record(Id)};
-                            _ ->
-                              traverse(cerl:record_arg(Tree), DefinedVars, State1)
-                          end,
-      RecordVar = mk_var(Tree),
-      RecordType = t_record(Id),
-      case lookup_record(State2, Id, 0) of
-        {error, State3} -> {State3, RecordType};
-        {ok, RecordType1, State3} ->
-          State4 = state__store_conj(RecordVar, sub, RecordType1, State3),
-          {State4, RecordType}
-        end;
+      {State, t_any()};
     values ->
       %% We can get into trouble when unifying products that have the
       %% same element appearing several times. Handle these cases by
@@ -1078,8 +1050,6 @@ get_type_test({erlang, is_map, 1}) ->       {ok, t_map()};
 get_type_test({erlang, is_number, 1}) ->    {ok, t_number()};
 get_type_test({erlang, is_pid, 1}) ->       {ok, t_pid()};
 get_type_test({erlang, is_port, 1}) ->      {ok, t_port()};
-%% get_type_test({erlang, is_record, 2}) ->    {ok, t_tuple()};
-%% get_type_test({erlang, is_record, 3}) ->    {ok, t_tuple()};
 get_type_test({erlang, is_reference, 1}) -> {ok, t_reference()};
 get_type_test({erlang, is_tuple, 1}) ->     {ok, t_tuple()};
 get_type_test({M, F, A}) when is_atom(M), is_atom(F), is_integer(A) -> error.
@@ -1462,7 +1432,6 @@ get_bif_constr({erlang, is_record, 2}, Dst, [Var, Tag] = Args, _State) ->
 			   mk_constraint(Tag, sub, t_atom()),
 			   mk_constraint(Var, sub, ArgV)]);
 get_bif_constr({erlang, is_record, 3}, Dst, [Var, Tag, Arity] = Args, State) ->
-  %% TODO: Revise this to make it precise for Tag and Arity.
   ArgFun =
     fun(Map) ->
 	case t_is_any_atom(true, lookup_type(Dst, Map)) of
@@ -1490,7 +1459,7 @@ get_bif_constr({erlang, is_record, 3}, Dst, [Var, Tag, Arity] = Args, State) ->
 		    end;
 		  _ -> t_tuple()
 		end;
-	      false -> t_tuple()
+	      false -> t_sup(t_tuple(), t_record())
 	    end;
 	  false -> t_any()
 	end
@@ -1502,10 +1471,20 @@ get_bif_constr({erlang, is_record, 3}, Dst, [Var, Tag, Arity] = Args, State) ->
 	       bif_return(erlang, is_record, 3, TmpArgTypes)
 	   end,
   DstV = ?mk_fun_var(DstFun, Args),
-  mk_conj_constraint_list([mk_constraint(Dst, sub, DstV),
-			   mk_constraint(Arity, sub, t_integer()),
-			   mk_constraint(Tag, sub, t_atom()),
-			   mk_constraint(Var, sub, ArgV)]);
+  case {t_is_atom(Arity),t_is_integer(Arity)} of
+    {false, true} ->
+      %% Tuple record
+      mk_conj_constraint_list([mk_constraint(Dst, sub, DstV),
+                               mk_constraint(Arity, sub, t_integer()),
+                               mk_constraint(Tag, sub, t_atom()),
+                               mk_constraint(Var, sub, ArgV)]);
+    {true, false} ->
+      %% Native record
+      mk_conj_constraint_list([mk_constraint(Var, sub, t_record()),
+                               mk_constraint(Tag, sub, t_atom())]);
+    {_, _} ->
+      mk_constraint_any(sub)
+  end;
 get_bif_constr({erlang, is_tuple, 1}, Dst, [Arg], State) ->
   get_bif_test_constr(Dst, Arg, t_tuple(), State);
 get_bif_constr({erlang, 'and', 2}, Dst, [Arg1, Arg2] = Args, _State) ->
@@ -3143,9 +3122,8 @@ lookup_record(State, Tag, Arity) ->
     end,
   case erl_types:lookup_record(Tag, Arity, Rec) of
     {ok, Fields} ->
-      RecType =
-        t_tuple([t_from_term(Tag)|
-                 [FieldType || {_FieldName, _Abstr, FieldType} <- Fields]]),
+      RecType = t_tuple([t_from_term(Tag)|
+                            [FieldType || {_FieldName, _Abstr, FieldType} <- Fields]]),
       {ok, RecType, State1};
     error ->
       {error, State1}

--- a/lib/dialyzer/src/dialyzer_utils.erl
+++ b/lib/dialyzer/src/dialyzer_utils.erl
@@ -171,9 +171,8 @@ get_record_and_type_info(Core) ->
 get_record_and_type_info([{native_record, Location, [{Name, Fields0}]}|Left],
 			 Module, RecDict, File) ->
   {ok, Fields} = get_record_fields(Fields0, RecDict),
-  Arity = length(Fields),
   FN = {File, Location},
-  NewRecDict = maps:put({native_record, Name}, {FN, [{Arity,Fields}]}, RecDict),
+  NewRecDict = maps:put({native_record, {Module,Name}}, {FN, Fields}, RecDict),
   get_record_and_type_info(Left, Module, NewRecDict, File);
 get_record_and_type_info([{record, Location, [{Name, Fields0}]}|Left],
 			 Module, RecDict, File) ->
@@ -307,26 +306,19 @@ process_record_remote_types_module(Module, CServer) ->
           {native_record, Name} ->
             {FileLocation, Fields} = Value,
             {File, _Location} = FileLocation,
+            Site = {native_record, Name, File},
             FieldFun =
-              fun({Arity, Fields0}, C4) ->
-                  MRA = {Module, Name, Arity},
-                  Site = {native_record, MRA, File},
-                  {Fields1, C7} =
-                    lists:mapfoldl(fun({FieldName, Field, _}, C5) ->
-                                       check_remote(Field, ExpTypes, MRA,
-                                                    File, RecordTable),
-                                       {FieldT, C6} =
-                                         erl_types:t_from_form
-                                           (Field, ExpTypes, Site,
-                                            RecordTable, VarTable,
-                                            C5),
-                                       {{FieldName, Field, FieldT}, C6}
-                                   end, C4, Fields0),
-                  {{Arity, Fields1}, C7}
+              fun({FieldName, Field, _}, C5) ->
+                {FieldT, C6} =
+                  erl_types:t_from_form
+                    (Field, ExpTypes, Site,
+                    RecordTable, VarTable,
+                    C5),
+                {{FieldName, Field, FieldT}, C6}
               end,
             {FieldsList, C3} =
-              lists:mapfoldl(FieldFun, C2, orddict:to_list(Fields)),
-            {{{native_record, {Module,Name}}, {FileLocation, orddict:from_list(FieldsList)}}, C3};
+              lists:mapfoldl(FieldFun, C2, Fields),
+            {{Key, {FileLocation, FieldsList}}, C3};
           {record, Name} ->
             {FileLocation, Fields} = Value,
             {File, _Location} = FileLocation,
@@ -460,12 +452,10 @@ check_record_fields(AllModules, CServer, TempExpTypes) ->
                 {native_record, Name} ->
                   {FileLocation, Fields} = Value,
                   {File, _Location} = FileLocation,
+                  Site = {native_record, Name, File},
                   FieldFun =
-                    fun({Arity, Fields0}, C3) ->
-                        Site = {native_record, {Module, Name, Arity}, File},
-                        lists:foldl(fun({_, Field, _}, C4) ->
-                                        CheckForm(Field, Site, C4)
-                                    end, C3, Fields0)
+                    fun({_, Field, _}, C4) ->
+                      CheckForm(Field, Site, C4)
                     end,
                   Fun = fun() -> lists:foldl(FieldFun, C2, Fields) end,
                   msg_with_position(Fun, FileLocation);

--- a/lib/dialyzer/src/erl_bif_types.erl
+++ b/lib/dialyzer/src/erl_bif_types.erl
@@ -82,6 +82,8 @@
 		    t_is_port/1,
 		    t_is_maybe_improper_list/1,
 		    t_is_record/1,
+		    t_is_record/2,
+		    t_is_record/3,
 		    t_is_reference/1,
 		    t_is_subtype/2,
 		    t_is_tuple/1,
@@ -692,9 +694,10 @@ type(erlang, is_record, 1, Xs) ->
   strict(erlang, is_record, 1, Xs, Fun);
 type(erlang, is_record, 2, Xs) ->
   Fun = fun ([X, Y]) ->
-	    case {t_is_tuple(X), t_is_record(X)} of
+	    case {t_is_tuple(X), t_is_record(X, Y)} of
 	      {false, true} ->
-		%% TODO: We must handle native records here.
+		t_atom('true');
+	      {false, unknown} ->
 		t_boolean();
 	      {true, false} ->
 		case t_tuple_subtypes(X) of
@@ -721,7 +724,7 @@ type(erlang, is_record, 3, Xs) ->
                       true -> t_number_vals(Z);
                       false -> -1
 	            end,
-	    case {t_is_tuple(X), t_is_record(X)} of
+	    case {t_is_tuple(X), t_is_record(X, Y, Z)} of
 	      {false, false} when length(Arity) =:= 1 ->
 		[RealArity] = Arity,
 		case t_is_none(t_inf(t_tuple(RealArity), X)) of
@@ -739,7 +742,6 @@ type(erlang, is_record, 3, Xs) ->
 		  unknown -> t_boolean();
 		  [Tuple] ->
 		    case t_tuple_args(Tuple) of
-		      %% any -> t_boolean();
 		      Args when length(Args) =:= RealArity ->
                         check_record_tag(hd(Args), Y);
 		      Args when length(Args) =/= RealArity ->
@@ -751,7 +753,8 @@ type(erlang, is_record, 3, Xs) ->
 	      {true, false} ->
 		t_boolean();
 	      {false, true} ->
-		%% TODO: We must handle native records here.
+		t_atom('true');
+	      {false, unknown} ->
 		t_boolean()
 	    end
 	end,

--- a/lib/dialyzer/src/erl_types.erl
+++ b/lib/dialyzer/src/erl_types.erl
@@ -126,7 +126,9 @@
 	 t_is_pid/1,
 	 t_is_port/1,
 	 t_is_maybe_improper_list/1,
-         t_is_record/1,
+	 t_is_record/1,
+	 t_is_record/2,
+	 t_is_record/3,
 	 t_is_reference/1,
          t_is_same_opaque/2,
 	 t_is_singleton/1,
@@ -172,9 +174,11 @@
 	 t_port/0,
 	 t_maybe_improper_list/0,
 	 t_product/1,
-         t_record/0,
-         t_record/1,
-         t_record_put/2,
+	 t_record/0,
+	 t_record/1,
+	 t_record/2,
+	 t_record_replace/2,
+	 t_record_get/2,
 	 t_reference/0,
 	 t_string/0,
 	 t_subst/2,
@@ -200,6 +204,7 @@
          t_widen_to_number/1,
 	 type_is_defined/4,
 	 record_field_diffs_to_string/2,
+	 native_record_field_diffs/2,
 	 subst_all_vars_to_any/1,
          lift_list_to_pos_empty/1,
 	 is_erl_type/1,
@@ -264,6 +269,7 @@
 -define(number_tag,     number).
 -define(product_tag,    product).
 -define(record_tag,     record).
+-define(record_set_tag, record_set).
 -define(tuple_set_tag,  tuple_set).
 -define(tuple_tag,      tuple).
 -define(union_tag,      union).
@@ -272,7 +278,7 @@
 -type tag()  :: ?atom_tag | ?binary_tag | ?function_tag | ?identifier_tag
               | ?list_tag | ?map_tag | ?nil_tag | ?number_tag
               | ?nominal_tag | ?nominal_set_tag
-              | ?product_tag
+              | ?product_tag | ?record_tag | ?record_set_tag
               | ?tuple_tag | ?tuple_set_tag | ?union_tag | ?var_tag.
 
 -define(float_qual,     float).
@@ -345,6 +351,7 @@
 	#c{tag=?map_tag, elements={Pairs,DefKey,DefVal}}).
 -define(product(Types),            #c{tag=?product_tag, elements=Types}).
 -define(record(Name, Types),       #c{tag=?record_tag, elements={Name, Types}}).
+-define(record_set(Types),          #c{tag=?record_set_tag, elements=Types}).
 -define(tuple(Types, Arity, Qual), #c{tag=?tuple_tag, elements=Types,
                                       qualifier={Arity, Qual}}).
 -define(tuple_set(Tuples),         #c{tag=?tuple_set_tag, elements=Tuples}).
@@ -376,19 +383,20 @@
 %%
 
 -define(union(List), #c{tag=?union_tag, elements=List}).
--define(untagged_union(A, B, F, I, L, N, T, Map), [A,B,F,I,L,N,T,Map]).
+-define(untagged_union(A, B, F, I, L, N, T, Map, R), [A,B,F,I,L,N,T,Map,R]).
 
 -define(num_types_in_union, length(?untagged_union(?any, ?any, ?any, ?any, ?any,
-                                                   ?any, ?any, ?any))).
+                                                   ?any, ?any, ?any, ?any))).
 
--define(atom_union(T),       ?union([T,?none,?none,?none,?none,?none,?none,?none])).
--define(bitstr_union(T),     ?union([?none,T,?none,?none,?none,?none,?none,?none])).
--define(function_union(T),   ?union([?none,?none,T,?none,?none,?none,?none,?none])).
--define(identifier_union(T), ?union([?none,?none,?none,T,?none,?none,?none,?none])).
--define(list_union(T),       ?union([?none,?none,?none,?none,T,?none,?none,?none])).
--define(number_union(T),     ?union([?none,?none,?none,?none,?none,T,?none,?none])).
--define(tuple_union(T),      ?union([?none,?none,?none,?none,?none,?none,T,?none])).
--define(map_union(T),        ?union([?none,?none,?none,?none,?none,?none,?none,T])).
+-define(atom_union(T),       ?union([T,?none,?none,?none,?none,?none,?none,?none,?none])).
+-define(bitstr_union(T),     ?union([?none,T,?none,?none,?none,?none,?none,?none,?none])).
+-define(function_union(T),   ?union([?none,?none,T,?none,?none,?none,?none,?none,?none])).
+-define(identifier_union(T), ?union([?none,?none,?none,T,?none,?none,?none,?none,?none])).
+-define(list_union(T),       ?union([?none,?none,?none,?none,T,?none,?none,?none,?none])).
+-define(number_union(T),     ?union([?none,?none,?none,?none,?none,T,?none,?none,?none])).
+-define(tuple_union(T),      ?union([?none,?none,?none,?none,?none,?none,T,?none,?none])).
+-define(map_union(T),        ?union([?none,?none,?none,?none,?none,?none,?none,T,?none])).
+-define(record_union(T),     ?union([?none,?none,?none,?none,?none,?none,?none,?none,T])).
 -define(integer_union(T),    ?number_union(T)).
 -define(float_union(T),      ?number_union(T)).
 -define(nil_union(T),        ?list_union(T)).
@@ -765,27 +773,57 @@ is_fun(_) -> false.
 -spec t_record() -> erl_type().
 
 t_record() ->
-  ?record(?any, ?any).
+  ?record(nil, #{}).
 
 -spec t_record(any()) -> erl_type().
 
+t_record([]) ->
+  ?record(nil, #{});
 t_record(Name) ->
-  ?record(Name, ?any).
+  ?record(Name, #{}).
+
+-spec t_record(any(), any()) -> erl_type().
+
+t_record([], Fields) ->
+  ?record(nil, #{K => {present, V} || {K, V} <- Fields});
+t_record(Name, Fields) ->
+  ?record(Name, #{K => {present, V} || {K, V} <- Fields}).
 
 -spec t_is_record(erl_type()) -> boolean().
 
-t_is_record(Type) ->
-  structural(Type, fun is_record1/1).
+t_is_record(?record(_, _)) -> true;
+t_is_record(_) -> false.
 
-is_record1(?record(_, _)) -> true;
-is_record1(_) -> false.
+-spec t_is_record(erl_type(), any()) -> atom().
+t_is_record(?record({_,Name}, _), Name) -> true;
+t_is_record(?record(_, _), Name) when is_atom(Name) -> unknown;
+t_is_record(_, _) -> false.
 
--spec t_record_put({atom(), erl_type()}, erl_type()) -> erl_type().
-t_record_put({K, V}, ?record(Name, Fields)) ->
+-spec t_is_record(erl_type(), any(), any()) -> atom().
+t_is_record(?record({Mod, Name}, _), Mod, Name) ->
+  true;
+t_is_record(?record({_, _}, _), Mod, Name) when is_atom(Mod), is_atom(Name) ->
+  unknown;
+t_is_record(_, _, _) ->
+  false.
+
+-spec t_record_get(atom(), erl_type()) -> erl_type().
+t_record_get(K, ?record(_, Fields)) ->
+  case Fields of
+    #{K := {present, V}} -> V;
+    #{K := _} -> ?none;
+    #{} -> ?any
+  end.
+
+-spec t_record_replace(any(), erl_type()) -> erl_type().
+t_record_replace([KV|KVs], Record) ->
+  t_record_replace(KVs, t_record_replace(KV, Record));
+t_record_replace([], Record) ->
+  Record;
+t_record_replace({K, V}, ?record(Name, Fields)) ->
   NewFields = case Fields of
-                #{K := OldV} -> Fields#{K => t_sup(OldV, V)};
-                #{} -> Fields#{K => V};
-                _ -> #{K => V}
+                #{K := _OldV} -> Fields#{K => {present, V}};
+                #{} -> Fields#{K => {present, V}}
               end,
   ?record(Name, NewFields).
 
@@ -1865,6 +1903,8 @@ t_has_var(?tuple_set(_) = T) ->
 t_has_var(?map(_, DefK, _)= Map) ->
   t_has_var_list(map_all_values(Map)) orelse
     t_has_var(DefK);
+t_has_var(?record(_,Type)) ->
+  t_has_var_list(maps:to_list(Type));
 t_has_var(?union(List)) ->
   t_has_var_list(List);
 t_has_var(_) -> false.
@@ -1949,6 +1989,7 @@ t_from_term(T) when is_map(T) ->
 t_from_term(T) when is_pid(T) ->       t_pid();
 t_from_term(T) when is_port(T) ->      t_port();
 t_from_term(T) when is_reference(T) -> t_reference();
+t_from_term(T) when is_record(T) ->    t_record();
 t_from_term(T) when is_tuple(T) ->
   t_tuple([t_from_term(E) || E <- tuple_to_list(T)]).
 
@@ -2107,8 +2148,6 @@ t_sup_aux(?opaque, T) -> T;
 t_sup_aux(T, ?opaque) -> T;
 t_sup_aux(?var(_), _) -> ?any;
 t_sup_aux(_, ?var(_)) -> ?any;
-t_sup_aux(?record(_,_), _) -> ?any;
-t_sup_aux(_, ?record(_,_)) -> ?any;
 t_sup_aux(?atom(Set1), ?atom(Set2)) ->
   ?atom(set_union(Set1, Set2));
 t_sup_aux(?bitstr(U1, B1), ?bitstr(U2, B2)) ->
@@ -2163,6 +2202,27 @@ t_sup_aux(?product(_), _) ->
   ?any;
 t_sup_aux(_, ?product(_)) ->
   ?any;
+t_sup_aux(?record(nil, Es1), ?record(nil, Es2)) ->
+  ?record(nil, sup_record_fields(Es1, Es2));
+t_sup_aux(?record(_, Es1), ?record(nil, Es2)) ->
+  ?record(nil, sup_record_fields(Es1, Es2));
+t_sup_aux(?record(nil, Es1), ?record(_, Es2)) ->
+  ?record(nil, sup_record_fields(Es1, Es2));
+t_sup_aux(?record(N, Es1), ?record(N, Es2)) ->
+  ?record(N, sup_record_fields(Es1, Es2));
+t_sup_aux(?record(N1, _)=A, ?record(N2, _)=B) ->
+  case N1 < N2 of
+    true ->
+      ?record_set([A, B]);
+    false ->
+      ?record_set([B, A])
+  end;
+t_sup_aux(?record(_,_)=Record, ?record_set(Records)) ->
+  record_set_merge(Records, [Record], []);
+t_sup_aux(?record_set(Records), ?record(_,_)=Record) ->
+  record_set_merge(Records, [Record], []);
+t_sup_aux(?record_set(RecordsA), ?record_set(RecordsB)) ->
+  record_set_merge(RecordsA, RecordsB, []);
 t_sup_aux(?tuple(?any, ?any, ?any) = T, ?tuple(_, _, _)) -> T;
 t_sup_aux(?tuple(_, _, _), ?tuple(?any, ?any, ?any) = T) -> T;
 t_sup_aux(?tuple(?any, ?any, ?any) = T, ?tuple_set(_)) -> T;
@@ -2283,6 +2343,86 @@ t_sup_aux(T1, T2) ->
 
 t_sup_lists(Ts1, Ts2) ->
   [t_sup(T1, T2) || T1 <- Ts1 && T2 <- Ts2].
+
+
+sup_record_fields(Es1, Es2) ->
+  Keys = if
+            map_size(Es1) =< map_size(Es2) -> maps:keys(Es1);
+            map_size(Es1) > map_size(Es2) -> maps:keys(Es2)
+          end,
+  sup_record_fields(Keys, Es1, Es2, #{}).
+
+sup_record_fields([Key | Keys], Es1, Es2, Acc0) ->
+  case {Es1, Es2} of
+    {#{ Key := {present, Type1 }}, #{ Key := {present, Type2} }} ->
+      Acc = set_record_field(Key, t_sup_aux(Type1, Type2), Acc0),
+      sup_record_fields(Keys, Es1, Es2, Acc);
+    {#{ Key := missing }, #{ Key := missing }} ->
+      sup_record_fields(Keys, Es1, Es2, Acc0#{ Key => missing });
+    {#{ Key := {present, _ }}, #{ Key := missing }} ->
+      Acc = maps:remove(Key, Acc0),
+      sup_record_fields(Keys, Es1, Es2, Acc);
+    {#{ Key := missing }, #{ Key := {present, _} }} ->
+      Acc = maps:remove(Key, Acc0),
+      sup_record_fields(Keys, Es1, Es2, Acc);
+    {#{}, #{}} ->
+      sup_record_fields(Keys, Es1, Es2, Acc0)
+  end;
+sup_record_fields([], _Es1, _Es2, Acc) ->
+  Acc.
+
+set_record_field(_Index, none, Es) ->
+  Es;
+set_record_field(Index, Type, Es) ->
+  Es#{ Index => {present, Type} }.
+
+record_set_merge([], [], [Record]) ->
+  Record;
+record_set_merge([], [], Acc) ->
+  ?record_set(lists:reverse(Acc));
+record_set_merge([?record(N1,_)=A | _]=RsA, [?record(N2,_)=B | _]=RsB, [?record(nil,_)=Acc]) ->
+  case N1 < N2 of
+    true ->
+      ?record(_,_) = t_sup_aux(A, Acc), %Assertion.
+      record_set_merge(tl(RsA), RsB, [t_sup_aux(A, Acc)]);
+    false ->
+      ?record(_,_) = t_sup_aux(B, Acc), %Assertion.
+      record_set_merge(RsA, tl(RsB), [t_sup_aux(B, Acc)])
+  end;
+record_set_merge([?record(N1,_)=A | TsA]=RsA, [?record(N2,_)=B | TsB]=RsB, Acc) ->
+  case {N1, N2} of
+    {nil, _} ->
+      T = t_sup_aux(A, B),
+      ?record(_,_) = T, %Assertion.
+      record_set_merge(Acc ++ TsA, TsB, [T]);
+    {_, nil} ->
+      T = t_sup_aux(B, A),
+      ?record(_,_) = T, %Assertion.
+      record_set_merge(Acc ++ TsA, TsB, [T]);
+    {Same, Same} ->
+      T = t_sup_aux(A, B),
+      ?record(_,_) = T, %Assertion.
+      record_set_merge(TsA, TsB, [T | Acc]);
+    _ ->
+      case N1 < N2 of
+        true ->
+          record_set_merge(TsA, RsB, [A | Acc]);
+        false ->
+          record_set_merge(RsA, TsB, [B | Acc])
+      end
+  end;
+record_set_merge([A | RsA], [], [?record(nil,_)=Acc]) ->
+  record_set_merge(RsA, [], [t_sup_aux(A, Acc)]);
+record_set_merge([?record(nil,_)=A], [], Acc) ->
+  record_set_merge(Acc, [], [A]);
+record_set_merge([A | RsA], [], Acc) ->
+  record_set_merge(RsA, [], [A | Acc]);
+record_set_merge([], [B | RsB], [?record(nil,_)=Acc]) ->
+  record_set_merge([], RsB, [t_sup_aux(B, Acc)]);
+record_set_merge([], [?record(nil,_)=B], Acc) ->
+  record_set_merge(Acc, [], [B]);
+record_set_merge([], [B | RsB], Acc) ->
+  record_set_merge([], RsB, [B | Acc]).
 
 %% Adds the new nominal `Sup` into the set of nominals `Ns0`. Note that it does
 %% not handle structurals; the caller is expected to normalize the result
@@ -2448,6 +2588,8 @@ force_union(T = ?number(_, _)) ->     ?number_union(T);
 force_union(T = ?map(_,_,_)) ->       ?map_union(T);
 force_union(T = ?tuple(_, _, _)) ->   ?tuple_union(T);
 force_union(T = ?tuple_set(_)) ->     ?tuple_union(T);
+force_union(T = ?record(_,_)) ->      ?record_union(T);
+force_union(T = ?record_set(_)) ->    ?record_union(T);
 force_union(T = ?union(_)) ->         T.
 
 %%-----------------------------------------------------------------------------
@@ -2734,6 +2876,26 @@ t_inf_aux(?product(_), _) ->
   ?none;
 t_inf_aux(_, ?product(_)) ->
   ?none;
+t_inf_aux(?record(N1, Es1), ?record(N2, Es2)) ->
+  maybe
+    {ok, Name} ?=
+      case {N1, N2} of
+        {Same, Same} -> {ok, Same};
+        {nil, N} -> {ok, N};
+        {N, nil} -> {ok, N};
+        {_, _} -> error
+      end,
+    #{} ?= Es = inf_record_elements(Es1, Es2),
+    ?record(Name, Es)
+  else
+    _ -> ?none
+  end;
+t_inf_aux(?record(_, _)=Record, ?record_set(Records)) ->
+    inf_record_sets(Records, [Record], []);
+t_inf_aux(?record_set(_)=Records, ?record(_, _)=Record) ->
+    inf_record_sets(Records, [Record], []);
+t_inf_aux(?record_set(RecordsA), ?record_set(RecordsB)) ->
+    inf_record_sets(RecordsA, RecordsB, []);
 t_inf_aux(?tuple(?any, ?any, ?any), ?tuple(_, _, _) = T) ->
   T;
 t_inf_aux(?tuple(_, _, _) = T, ?tuple(?any, ?any, ?any)) ->
@@ -2763,10 +2925,6 @@ t_inf_aux(?union(U1), T) ->
 t_inf_aux(T, ?union(U2)) ->
   ?union(U1) = force_union(T),
   inf_union(U1, U2);
-t_inf_aux(?record(_,_)=T, _) ->
-  T;
-t_inf_aux(_, ?record(_,_)=T) ->
-  T;
 t_inf_aux(#c{}, #c{}) ->
   ?none.
 
@@ -2790,6 +2948,56 @@ t_inf_lists_strict([T1|Left1], [T2|Left2], Acc) ->
   end;
 t_inf_lists_strict([], [], Acc) ->
   lists:reverse(Acc).
+
+inf_record_elements(Es1, Es2) ->
+  Keys = lists:usort(maps:keys(Es1) ++ maps:keys(Es2)),
+  inf_record_elements(Keys, Es1, Es2, #{}).
+
+inf_record_elements([Key | Keys], Es1, Es2, Acc) ->
+  case {Es1, Es2} of
+    {#{ Key := {present, Type1} }, #{ Key := {present, Type2} }} ->
+      case t_inf_aux(Type1, Type2) of
+        ?none -> ?none;
+        Type -> inf_record_elements(Keys, Es1, Es2, Acc#{ Key => {present, Type} })
+      end;
+    {#{ Key := {present, _ }}, #{ Key := missing}} ->
+      ?none;
+    {#{ Key := missing}, #{ Key := {present, _}}} ->
+      ?none;
+    {#{ Key := Type1 }, _} ->
+      inf_record_elements(Keys, Es1, Es2, Acc#{ Key => Type1 });
+    {_, #{ Key := Type2 }} ->
+      inf_record_elements(Keys, Es1, Es2, Acc#{ Key => Type2 })
+  end;
+inf_record_elements([], _Es1, _Es2, Acc) ->
+  Acc.
+
+inf_record_sets([?record(N1, _) | _]=RsA,
+                [?record(N2, _) | _]=RsB, Acc) when N1 =/= N2 andalso N1 =/= nil andalso N2 =/= nil ->
+  case N1 < N2 of
+    true ->
+      inf_record_sets(tl(RsA), RsB, Acc);
+    false ->
+      inf_record_sets(RsA, tl(RsB), Acc)
+  end;
+inf_record_sets([A | RsA], [B | RsB], Acc) ->
+  maybe
+    ?record(_,_)=T ?= t_inf_aux(A, B),
+    case T of
+      ?record(nil, _) -> T; 
+      _ -> inf_record_sets(RsA, RsB, [T | Acc])
+    end
+  else
+    _ -> ?none
+  end;
+inf_record_sets(_RsA, [], [_,_|_]=Acc) ->
+  ?record_set(lists:reverse(Acc));
+inf_record_sets([], _RsB, [_,_|_]=Acc) ->
+  ?record_set(lists:reverse(Acc));
+inf_record_sets(_RsA, _RsB, [Record]) ->
+  Record;
+inf_record_sets(_RsA, _RsB, []) ->
+  ?none.
 
 inf_nominal_sets([_|_]=LHS, [_|_]=RHS) ->
   %% Because a nominal in LHS_Ns can be a subtype of another in RHS_Ns or of
@@ -2866,9 +3074,9 @@ inf_tuples_in_sets2(_, [], Acc) -> lists:reverse(Acc).
 inf_union(U1, U2) ->
   OpaqueFun =
     fun(Union1, Union2, InfFun) ->
-        ?untagged_union(_,_,_,_,_,_,_,_) = Union1,
-        ?untagged_union(A,B,F,I,L,N,T,Map) = Union2,
-        List = [A,B,F,I,L,N,T,Map],
+        ?untagged_union(_,_,_,_,_,_,_,_,_) = Union1,
+        ?untagged_union(A,B,F,I,L,N,T,Map,R) = Union2,
+        List = [A,B,F,I,L,N,T,Map,R],
         %% FIXME: Faking ?none opaque -- remove argument.
         inf_union_collect(List, InfFun, [], [])
     end,
@@ -2998,6 +3206,11 @@ t_subst_aux(?tuple_set(_) = TS, Map) ->
 t_subst_aux(?map(Pairs, DefK, DefV), Map) ->
   t_map([{K, MNess, t_subst_aux(V, Map)} || {K, MNess, V} <- Pairs],
 	t_subst_aux(DefK, Map), t_subst_aux(DefV, Map));
+t_subst_aux(?record(Name, Type), Map) ->
+  Type1 = #{K => {present, t_subst_aux(V, Map)} || K := {present, V} <- Type},
+  ?record(Name, Type1);
+t_subst_aux(?record_set(Rs), Map) ->
+  ?record_set([t_subst_aux(R, Map) || R <- Rs]);
 t_subst_aux(?union(List), Map) ->
   ?union([t_subst_aux(E, Map) || E <- List]);
 t_subst_aux(T, _Map) ->
@@ -3391,6 +3604,13 @@ t_subtract_aux(T, ?product(_)) ->
   T;
 t_subtract_aux(?record(_,_) = T, _) ->
   T;
+t_subtract_aux(?record_set([_|_]=Records0), ?record(_, _)=B) ->
+  %% Filter out all records that are more specific than B.
+  case [T || T <:- Records0, t_inf_aux(T, B) =/= T] of
+    [_,_|_]=Records -> ?record_set(Records);
+    [Record] -> Record;
+    [] -> ?none
+  end;
 t_subtract_aux(?union(U1), ?union(U2)) ->
   subtract_union(U1, U2);
 t_subtract_aux(T1, T2) ->
@@ -3406,10 +3626,10 @@ t_subtract_lists(L1, L2) ->
 -spec subtract_union([erl_type(),...], [erl_type(),...]) -> erl_type().
 
 subtract_union(U1, U2) ->
-  ?untagged_union(A1,B1,F1,I1,L1,N1,T1,Map1) = U1,
-  ?untagged_union(A2,B2,F2,I2,L2,N2,T2,Map2) = U2,
-  List1 = ?untagged_union(A1,B1,F1,I1,L1,N1,T1,Map1),
-  List2 = ?untagged_union(A2,B2,F2,I2,L2,N2,T2,Map2),
+  ?untagged_union(A1,B1,F1,I1,L1,N1,T1,Map1,R1) = U1,
+  ?untagged_union(A2,B2,F2,I2,L2,N2,T2,Map2,R2) = U2,
+  List1 = ?untagged_union(A1,B1,F1,I1,L1,N1,T1,Map1,R1),
+  List2 = ?untagged_union(A2,B2,F2,I2,L2,N2,T2,Map2,R2),
   subtract_union(List1, List2, ?none, []).
 
 subtract_union([T1|Left1], [T2|Left2], Type, Acc) ->
@@ -3520,12 +3740,12 @@ t_structural(?product(Types)) ->
   ?product([t_structural(T) || T <- Types]);
 t_structural(?function(Domain, Range)) ->
   ?function(t_structural(Domain), t_structural(Range));
-t_structural(?union(?untagged_union(A,B,F,I,L,N,T,Map))) ->
+t_structural(?union(?untagged_union(A,B,F,I,L,N,T,Map,R))) ->
   UL = t_structural(L),
   UT = t_structural(T),
   UF = t_structural(F),
   UMap = t_structural(Map),
-  t_sup([A,B,UF,I,UL,N,UT,UMap]);
+  t_sup([A,B,UF,I,UL,N,UT,UMap,R]);
 t_structural(?map(Pairs,DefK,DefV)) ->
   t_map([{t_structural(K), MNess, t_structural(V)}
          || {K, MNess, V} <- Pairs],
@@ -3714,6 +3934,11 @@ t_abstract_records(?tuple(Elements, _Arity, _Tag), RecDict) ->
   t_tuple([t_abstract_records(E, RecDict) || E <- Elements]);
 t_abstract_records(?tuple_set(_) = Tuples, RecDict) ->
   t_sup([t_abstract_records(T, RecDict) || T <- t_tuple_subtypes(Tuples)]);
+t_abstract_records(?record(Name, Type), RecDict) ->
+  Type1 = #{K => {present, t_abstract_records(V, RecDict)} || K := {present, V} <- Type},
+  ?record(Name, Type1);
+t_abstract_records(?record_set(Rs), RecDict) ->
+  ?record_set([t_abstract_records(R, RecDict) || R <- Rs]);
 t_abstract_records(T, _RecDict) ->
   T.
 
@@ -3881,17 +4106,19 @@ t_to_string(?map(Pairs0,DefK,DefV), RecDict) ->
   "#{" ++ flat_join([K ++ ":=" ++ V||{K,V}<-StrMand]
                     ++ [K ++ "=>" ++ V||{K,V}<-StrOpt]
                     ++ ExtraEl, ", ") ++ "}";
-t_to_string(?record(?any, ?any), _RecDict) ->
+t_to_string(?record(nil, Pairs), _RecDict) when map_size(Pairs) =:= 0 ->
   "record()";
-t_to_string(?record({Module, Name}, ?any), _RecDict) ->
-  ModName = flat_format("~w:~tw", [Module, Name]),
-  ModName ++ "#{any()}";
+t_to_string(?record(nil, Pairs), RecDict) ->
+  "_#{" ++ record_fields_to_ordered(Pairs, RecDict);
 t_to_string(?record({Module, Name}, Pairs), RecDict) ->
   ModName = flat_format("~w:~tw", [Module, Name]),
-  ModName ++ "#{" ++
-  flat_join([t_to_string(K, RecDict) ++ "=" ++ t_to_string(V, RecDict)
-             || K := V <:- Pairs], ", ")
-  ++ "}";
+  "#" ++ ModName ++ "{" ++
+  record_fields_to_ordered(Pairs, RecDict);
+t_to_string(?record(Name, Pairs), RecDict) ->
+  "#" ++ atom_to_string(Name) ++ "{" ++
+  record_fields_to_ordered(Pairs, RecDict);
+t_to_string(?record_set(Ts), RecDict) ->
+  union_sequence([T || T <- Ts], RecDict);
 t_to_string(?tuple(?any, ?any, ?any), _RecDict) -> "tuple()";
 t_to_string(?tuple(Elements, _Arity, ?any), RecDict) ->
   "{" ++ comma_sequence(Elements, RecDict) ++ "}";
@@ -3911,6 +4138,11 @@ t_to_string(?var(Id), _RecDict) when is_atom(Id) ->
 t_to_string(?var(Id), _RecDict) when is_integer(Id) ->
   flat_format("var(~w)", [Id]).
 
+record_fields_to_ordered(Pairs, RecDict) ->
+  Pairs1 = lists:keysort(1, maps:to_list(Pairs)),
+  flat_join([atom_to_string(K) ++ "=" ++ t_to_string(V, RecDict)
+             || {K, {present, V}} <- Pairs1], ", ")
+  ++ "}".
 
 record_to_string(Tag, [_|Fields], FieldNames, RecDict) ->
   FieldStrings = record_fields_to_string(Fields, FieldNames, RecDict, []),
@@ -3957,6 +4189,33 @@ field_diffs([F|Fs], [{FName, _Abstr, DefType}|FDefs], Pos, RecDict, Acc) ->
 field_diffs([], [], _, _, Acc) ->
   lists:reverse(Acc).
 
+-spec native_record_field_diffs(erl_type(), erl_type()) -> string().
+native_record_field_diffs(?record(Name1, Fields1), ?record(Name2, Fields2)) ->
+  case Name1 =:= Name2 of
+    true ->
+      Keys = lists:sort(maps:keys(Fields2)),
+      native_record_field_diffs_1(Keys, Fields1, Fields2, []);
+    false ->
+      {M, N} = Name1,
+      ["#", atom_to_string(M), ":", atom_to_string(N), "{}"]
+  end.
+
+native_record_field_diffs_1([K|Keys], Fields1, Fields2, Acc) ->
+  %% Fields1 are in the definition. Fields2 are in the instance.
+  %% Only warn about type conflicts for keys in the instance.
+  case {Fields1, Fields2} of
+    {#{K := {present, V1}}, #{K := {present, V2}}} ->
+      case t_inf_aux(V1, V2) of
+        none -> native_record_field_diffs_1(Keys, Fields1, Fields2, [{K, V1}|Acc]);
+        _ -> native_record_field_diffs_1(Keys, Fields1, Fields2, Acc)
+      end;
+    _ ->
+      native_record_field_diffs_1(Keys, Fields1, Fields2, Acc)
+  end;
+native_record_field_diffs_1([], _, _, Acc) ->
+    lists:flatten([lists:join(", ", [atom_to_string(K) ++ "::" ++
+                                     t_to_string(V1, #{}) || {K, V1} <- Acc])]).
+
 comma_sequence(Types, RecDict) ->
   List = [case T =:= ?any of
 	    true -> "_";
@@ -3982,7 +4241,7 @@ union_sequence(Types, RecDict) ->
                | {'spec', mfa(), file:filename()}
                | {'record', mra(), file:filename()}
                | {'check', mta(), file:filename()}
-               | {'native_record', mra(), file:filename()}.
+               | {'native_record', any(), file:filename()}.
 -type cache_key() :: {module(), atom(), expand_depth(),
                       [erl_type()], type_names()}.
 -type mod_type_table() :: ets:tid().
@@ -4459,7 +4718,45 @@ remote_from_form1(RemMod, Name, Args, ArgsLen, RemDict, RemType, TypeNames,
   end.
 
 
-
+record_from_form({tuple, _, [{atom, _, M}, {atom, _, N}]}, ModFields, S, D0, L0, C) ->
+  #from_form{site = Site, mrecs = MR, tnames = TypeNames} = S,
+  RecName = {M, N},
+  RecordType = {native_record, {M, N}},
+  case can_unfold_more(RecordType, TypeNames) of
+    true ->
+      {R, C1} = case lookup_module_types(M, MR, C) of
+                  error -> throw({error, io_lib:format("Unknown record #~tw:~tw{}\n", [M, N])});
+                  Res -> Res
+                end,
+      case lookup_record(RecName, R) of
+        {ok, DeclFields} ->
+          NewTypeNames = [RecordType|TypeNames],
+          Site1 = {native_record, RecName, site_file(Site)},
+          S1 = S#from_form{site = Site1, tnames = NewTypeNames},
+          Fun = fun(D, L) ->
+                    {GetModRec, L1, C2} =
+                      get_mod_record(ModFields, DeclFields, S1, D, L, C1),
+                    case GetModRec of
+                      {error, FieldName} ->
+                        throw({error,
+                                io_lib:format("Illegal declaration of #~tw:~tw{~tw}\n",
+                                              [M, N, FieldName])});
+                      {ok, NewFields} ->
+                        S2 = S1#from_form{vtab = var_table__new()},
+                        {NewFields1, L2, C3} =
+                          fields_from_form(NewFields, S2, D, L1, C2),
+                        Rec = t_record(RecName,
+                                [{FieldName, Type} || {FieldName, Type} <- NewFields1]),
+                        {Rec, L2, C3}
+                    end
+                end,
+          recur_limit(Fun, D0, L0, RecordType, TypeNames);
+        error ->
+          throw({error, io_lib:format("Unknown record #~tw:~tw{}\n", [M, N])})
+      end;
+    false ->
+      {t_any(), L0, C}
+  end;
 record_from_form({atom, _, Name}, ModFields, S, D0, L0, C) ->
   #from_form{site = Site, mrecs = MR, tnames = TypeNames} = S,
   RecordType = {record, Name},
@@ -4494,7 +4791,11 @@ record_from_form({atom, _, Name}, ModFields, S, D0, L0, C) ->
                 end,
           recur_limit(Fun, D0, L0, RecordType, TypeNames);
         error ->
-          throw({error, io_lib:format("Unknown record #~tw{}\n", [Name])})
+          RecName = case Name of
+                      {M1, N1} -> {tuple, 0, [{atom, 0, M1}, {atom, 0, N1}]};
+                      _ -> {tuple, 0, [{atom, 0, M}, {atom, 0, Name}]}
+                    end,
+          record_from_form(RecName, ModFields, S, D0, L0, C)
       end;
     false ->
        {t_any(), L0, C}
@@ -4686,18 +4987,53 @@ check_record_fields({type, _Anno, _, Args}, S, C) ->
 check_record_fields({user_type, _Anno, _Name, Args}, S, C) ->
   list_check_record_fields(Args, S, C).
 
+
+check_record({tuple, _, [{atom, _, M}, {atom, _, N}]}, ModFields, S, C) ->
+  %% Remote native record with syntax #Mod:Name{}.
+  #from_form{site = Site, mrecs = MR} = S,
+  M = site_module(Site),
+  {R, C1} = case lookup_module_types(M, MR, C) of
+              error ->
+                throw({error, io_lib:format("Unknown record #~tw:~tw{}\n", [M, N])});
+              Res ->
+                Res
+            end,
+  {RecName, DeclFields} = lookup_record({M, N}, R),
+  case check_fields(RecName, ModFields, DeclFields, S, C1) of
+    {error, FieldName} ->
+      throw({error, io_lib:format("Illegal declaration of #~tw:~tw{~tw}\n",
+                                  [M, N, FieldName])});
+    C2 -> C2
+  end;
 check_record({atom, _, Name}, ModFields, S, C) ->
   #from_form{site = Site, mrecs = MR} = S,
   M = site_module(Site),
   {R, C1} = lookup_module_types(M, MR, C),
-  {ok, DeclFields} = lookup_record(Name, R),
-  case check_fields(Name, ModFields, DeclFields, S, C1) of
+  {RecName, DeclFields} = case lookup_record(Name, R) of
+                            {ok, Fields} ->
+                              {Name, Fields};
+                            error ->
+                              {ok, Fields} = lookup_record({M, Name}, R),
+                              {{M, Name}, Fields}
+                          end,
+  case check_fields(RecName, ModFields, DeclFields, S, C1) of
     {error, FieldName} ->
       throw({error, io_lib:format("Illegal declaration of #~tw{~tw}\n",
                                   [Name, FieldName])});
     C2 -> C2
   end.
 
+check_fields({M, RecName}, [{type, _, field_type, [{atom, _, Name}, Abstr]}|Left],
+             DeclFields, S, C) ->
+  #from_form{site = Site0, xtypes = ET, mrecs = MR, vtab = V} = S,
+  Site = {native_record, {M, RecName}, site_file(Site0)},
+  {Type, C1} = t_from_form(Abstr, ET, Site, MR, V, C),
+  {Name, _, DeclType} = lists:keyfind(Name, 1, DeclFields),
+  TypeNoVars = subst_all_vars_to_any(Type),
+  case t_is_impossible(t_inf(TypeNoVars, DeclType)) of
+    true -> {error, Name};
+    false -> check_fields(RecName, Left, DeclFields, S, C1)
+  end;
 check_fields(RecName, [{type, _, field_type, [{atom, _, Name}, Abstr]}|Left],
              DeclFields, S, C) ->
   #from_form{site = Site0, xtypes = ET, mrecs = MR, vtab = V} = S,
@@ -4719,6 +5055,8 @@ list_check_record_fields([H|Tail], S, C) ->
   C1 = check_record_fields(H, S, C),
   list_check_record_fields(Tail, S, C1).
 
+site_module({_, {Module, _}, _}) ->
+  Module;
 site_module({_, {Module, _, _}, _}) ->
   Module.
 
@@ -4848,6 +5186,8 @@ t_form_to_string({type, _Anno, range, [From, To]} = Type) ->
       flat_format("~w..~w", [FromVal, ToVal]);
     _ -> flat_format("Badly formed type ~w",[Type])
   end;
+t_form_to_string({type, _Anno, record, []}) ->
+  "record()";
 t_form_to_string({type, _Anno, record, [{atom, _, Name}]}) ->
   flat_format("#~tw{}", [Name]);
 t_form_to_string({type, _Anno, record, [{atom, _, Name}|Fields]}) ->
@@ -4965,13 +5305,11 @@ lookup_record(Tag, Table) when is_atom(Tag) ->
     #{} ->
       error
   end;
-lookup_record(Tag, Table) ->
+lookup_record(Tag, Table) when is_tuple(Tag) ->
   Key = {native_record, Tag},
   case Table of
-    #{Key := {_FileLocation, [{_Arity, Fields}]}} ->
+    #{Key := {_FileLocation, Fields}} ->
       {ok, Fields};
-    #{Key := {_FileLocation, List}} when is_list(List) ->
-      error;
     #{} ->
       error
   end.
@@ -4989,13 +5327,11 @@ lookup_record(Tag, Arity, Table) when is_atom(Tag) ->
     #{} ->
       error
   end;
-lookup_record(Tag, 0, Table) ->
+lookup_record(Tag, 0, Table) when is_tuple(Tag) ->
   Key = {native_record, Tag},
   case Table of
-    #{Key := {_FileLocation, [{_Arity, Fields}]}} ->
+    #{Key := {_FileLocation, Fields}} ->
       {ok, Fields};
-    #{Key := _OrdDict} ->
-      error;
     #{} ->
       error
   end.
@@ -5281,6 +5617,8 @@ get_modules_mentioned({char, _L, _Char}, _D, L, Acc) ->
 get_modules_mentioned({op, _L, _Op, _Arg}, _D, L, Acc) ->
   {L, Acc};
 get_modules_mentioned({op, _L, _Op, _Arg1, _Arg2}, _D, L, Acc) ->
+  {L, Acc};
+get_modules_mentioned({tuple, _, _}, _D, L, Acc) ->
   {L, Acc};
 get_modules_mentioned({type, _L, 'fun', [{type, _, any}, Range]}, D, L, Acc) ->
   get_modules_mentioned(Range, D - 1, L - 1, Acc);

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_construct
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_construct
@@ -1,9 +1,36 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
 record_construct.erl:16:3: Record construction 
           #r_opa{b :: gb_sets:set(_), c :: 42, e :: 'false'} violates the declared type of field c ::
           boolean()
 record_construct.erl:21:3: Record construction 
           #r_rem{a :: 'gazonk'} violates the declared type of field a ::
+          string()
+record_construct.erl:26:3: Record construction 
+          #record_construct:n_loc{a = gazonk, b = 42} violates the declared type of field b ::atom(), a::integer()
+record_construct.erl:28:16: Record construction 
+          #record_construct:n_opa{a = atom, c = 42, d = 0, e = false} violates the declared type of field c ::
+          boolean()
+record_construct.erl:39:3: Record construction 
+          #n_rem{a :: 'gazonk'} violates the declared type of field a ::
           string()
 record_construct.erl:7:3: Record construction 
           #r_loc{a :: 'gazonk', b :: 42} violates the declared type of field a ::

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_creation_diffs
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_creation_diffs
@@ -1,4 +1,27 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
 record_creation_diffs.erl:11:41: Record construction 
           #bar{some_list :: {'this', 'is', 'a', 'tuple'}} violates the declared type of field some_list ::
+          [any()]
+record_creation_diffs.erl:13:12: Record construction 
+          #record_creation_diffs:n{some_atom = any(),
+                                   some_list = {this, is, a, tuple}} violates the declared type of field some_list ::
           [any()]

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_match
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_match
@@ -1,3 +1,22 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
 record_match.erl:17:5: Matching of pattern 
           {'b_literal', 'undefined'} tagged with a record name violates the declared type of 

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_pat
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_pat
@@ -1,4 +1,26 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
 record_pat.erl:14:1: Matching of pattern 
           {'foo', 'baz'} tagged with a record name violates the declared type of 
           #foo{bar :: integer()}
+record_pat.erl:19:1: Matching of pattern 
+          #n_foo{bar = baz} tagged with a record name violates the declared type of 
+          #record_pat:n_foo{bar = integer()}

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_send_test
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_send_test
@@ -1,6 +1,29 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
 record_send_test.erl:30:7: The call erlang:'!'
          (Rec1 :: #rec1{a :: 'a', b :: 'b', c :: 'c'},
           'hello_again') will never return since it differs in the 1st argument from the success typing arguments: 
+         (atom() | pid() | port() | reference() | {atom(), atom()},
+          any())
+
+record_send_test.erl:46:7: The call erlang:'!'(Rec1::#record_send_test:n_rec1{a='a', b='b', c='c'},'hello_again') will never return since it differs in the 1st argument from the success typing arguments: 
          (atom() | pid() | port() | reference() | {atom(), atom()},
           any())

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_test
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_test
@@ -1,6 +1,30 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
 record_test.erl:19:5: Matching of pattern 
           {'foo', _} tagged with a record name violates the declared type of 
           'foo'
 record_test.erl:21:5: The variable _ can never match since previous clauses completely covered the type 
           'foo'
+record_test.erl:31:5: The pattern 
+          #n_foo{} can never match the type 
+          'n_foo'
+record_test.erl:33:5: The variable _ can never match since previous clauses completely covered the type 
+          'n_foo'

--- a/lib/dialyzer/test/indent_SUITE_data/results/record_update
+++ b/lib/dialyzer/test/indent_SUITE_data/results/record_update
@@ -1,4 +1,26 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
 
+record_update.erl:15:3: Record construction 
+          #record_update:n_foo{bar = 1} violates the declared type of field bar ::
+          atom()
 record_update.erl:7:2: Invalid type specification for function record_update:quux/2.
  The success typing is record_update:quux
           (#foo{bar :: atom()}, atom()) -> #foo{bar :: atom()}

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_construct.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_construct.erl
@@ -1,5 +1,5 @@
 -module(record_construct).
--export([t_loc/0, t_opa/0, t_rem/0]).
+-export([t_loc/0, t_opa/0, t_rem/0, n_loc/0, n_opa/0, n_rem/0, foo2/1]).
 
 -record(r_loc, {a = gazonk :: integer(), b = 42 :: atom()}).
 
@@ -19,3 +19,46 @@ t_opa() ->
 
 t_rem() ->
   #r_rem{}.
+
+-record #n_loc{a = gazonk :: integer(), b = 42 :: atom()}.
+
+n_loc() ->
+  #n_loc{}.
+
+-record #n_opa{a                 :: atom(),
+		c = 42            :: boolean(),
+		d,	% untyped on purpose
+		e = false         :: boolean()}.
+
+n_opa() ->
+  #n_opa{a=atom,d=0}.
+
+-record(n_rem, {a = gazonk :: string()}).
+
+n_rem() ->
+  #n_rem{}.
+
+-import_record(record_creation_diffs, [n]).
+
+foo2(Input) ->
+    #n{some_atom = Input, some_list = {this,is,a,tuple}}.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_creation_diffs.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_creation_diffs.erl
@@ -1,6 +1,6 @@
 -module(record_creation_diffs).
 
--export([foo/1]).
+-export([foo/1, foo2/1]).
 
 -record(bar, {
           some_atom :: atom(),
@@ -9,3 +9,28 @@
 
 foo(Input) ->
     #bar{some_atom = Input, some_list = {this,is,a,tuple}}.
+
+-record #n{some_atom :: atom(), some_list :: list()}.
+
+foo2(Input) ->
+    #n{some_atom = Input, some_list = {this,is,a,tuple}}.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_match.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_match.erl
@@ -1,6 +1,6 @@
 -module(record_match).
 
--export([select/0]).
+-export([select/0, n_select/0]).
 
 -record(b_literal, {val}).
 -record(b_remote, {mod,name,arity}).
@@ -15,3 +15,37 @@
 
 select() ->
     #b_set{args=[#b_remote{},#b_literal{}]}.
+
+-record #n_literal{val=0}.
+-record #n_remote{mod=m,name=n,arity=0}.
+-record #n_local{name,arity}.
+
+-type n_remote()   :: #n_remote{}.
+-type n_local()    :: #n_local{}.
+
+-type n_argument()   :: n_remote() | n_local().
+
+-record #n_set{args=[] :: [n_argument()]}.
+
+n_select() ->
+    #n_set{args=[#n_remote{},#n_literal{}]}.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_pat.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_pat.erl
@@ -7,9 +7,34 @@
 %%%-------------------------------------------------------------------
 -module(record_pat).
 
--export([t/1]).
+-export([t/1, n_t/1]).
 
 -record(foo, {bar :: integer()}).
 
 t(#foo{bar=baz}) -> no_way;
 t(#foo{bar=1}) -> ok.
+
+-record #n_foo{bar :: integer()}.
+
+n_t(#n_foo{bar=baz}) -> no_way;
+n_t(#n_foo{bar=1}) -> ok.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_send_test.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_send_test.erl
@@ -13,7 +13,7 @@
 %%-------------------------------------------------------------------
 -module(record_send_test).
 
--export([t/0]).
+-export([t/0, n_t/0]).
 
 -record(rec1, {a=a, b=b, c=c}).
 -record(rec2, {a}).
@@ -30,3 +30,39 @@ t(Rec1 = #rec1{b=B}) ->
       Rec1 ! hello_again
   end,
   B.
+
+-record #n_rec1{a=a, b=b, c=c}.
+-record #n_rec2{a}.
+
+n_t() ->
+  n_t(#n_rec1{}).
+
+n_t(Rec1 = #n_rec1{b=B}) ->
+  Rec2 = some_mod:some_function(),
+  if
+    is_record(Rec2, n_rec2) ->
+      Rec2 ! hello;	%% currently this one is not found
+    true ->
+      Rec1 ! hello_again
+  end,
+  B.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_test.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_test.erl
@@ -7,7 +7,7 @@
 %%%-------------------------------------------------------------------
 -module(record_test).
 
--export([t/0]).
+-export([t/0, n_t/0]).
 
 -record(foo, {bar}).
 
@@ -20,3 +20,35 @@ doit(X) ->
     foo -> ok;
     _ -> error2
   end.
+
+-record #n_foo{bar}.
+
+n_t() ->
+  do(n_foo).
+
+do(X) ->
+  case X of
+    #n_foo{} -> error1;
+    n_foo -> ok;
+    _ -> error2
+  end.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/dialyzer/test/indent_SUITE_data/src/record_update.erl
+++ b/lib/dialyzer/test/indent_SUITE_data/src/record_update.erl
@@ -1,6 +1,6 @@
 -module(record_update).
 
--export([quux/2]).
+-export([quux/2, n_quux/2, update/1]).
 
 -record(foo, {bar :: atom()}).
 
@@ -8,3 +8,33 @@
 
 quux(Foo, NotBar) ->
   Foo#foo{ bar = NotBar }.
+
+-record #n_foo{bar :: atom()}.
+
+update(NFoo) ->
+  NFoo#n_foo{bar = 1}.
+
+-spec n_quux(#n_foo{}, string()) -> #n_foo{}.
+
+n_quux(NFoo, NotBar) ->
+  NFoo#n_foo{bar = NotBar}.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%

--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -52,6 +52,9 @@ Section [The Abstract Format](`e:erts:absform.md`) in ERTS User's Guide.
                  %% Compiler option 'dialyzer'.
                  dialyzer=false :: boolean(),
 
+                 %% Option 'expand_inits'.
+                 expand_inits=false :: boolean(),
+
                  %% Whether the size of the tuple should be tested.
                  strict_rec_tests=true :: boolean(),
 
@@ -85,6 +88,7 @@ module(Fs0, Opts0) ->
     put(erl_expand_records_in_guard, false),
     Opts = Opts0 ++ compiler_options(Fs0),
     St0 = #exprec{dialyzer = lists:member(dialyzer, Opts),
+                  expand_inits = lists:member(expand_inits, Opts),
                   calltype = init_calltype(Fs0),
                   rec_mod = init_rec_mod(Fs0),
                   strict_rec_tests = strict_record_tests(Opts)},
@@ -423,14 +427,12 @@ expr({record,Anno,{M,N},Inits}, St0) ->
 expr({record,Anno0,Name,Is}, St0) when is_atom(Name) ->
     case St0#exprec.rec_mod of
         #{Name := {local, Inits}} ->
-            M = St0#exprec.module,
-            case M of
-                shell_default ->
-                    Fs = native_record_inits(Anno0, Inits, Is),
-                    expr({record,Anno0,{M,Name},Fs}, St0);
-                _ ->
+            case maybe_expand_inits(Anno0, Name, Inits, Is, St0) of
+                no ->
                     {Es1, St1} = expr_list(Is, St0),
-                    {{record,Anno0,Name,Es1},St1}
+                    {{record,Anno0,Name,Es1},St1};
+                {yes,Record} ->
+                    expr(Record, St0)
             end;
         #{Name := {imported, M}} ->
             expr({record,Anno0,{M,Name},Is}, St0);
@@ -683,6 +685,21 @@ strict_record_access(E0, St0) ->
     St1 = St0#exprec{check_needed=[], checked_access=NRC},
     expr(E1, St1).
 
+maybe_expand_inits(Anno0, Name, Inits, Is, St) ->
+    M = St#exprec.module,
+    case St of
+        #exprec{dialyzer=true} when is_list(Inits) ->
+            Fs0 = native_record_inits(Anno0, Inits, Is),
+            Fs1 = [F|| {record_field, _, _, V} =F <- Fs0,
+                       V =/= {nil,novalue} andalso V =/= {nil,badfield}],
+            {yes, {record,Anno0,{M,Name},Fs1}};
+        #exprec{expand_inits=true} ->
+            Fs = native_record_inits(Anno0, Inits, Is),
+            {yes, {record,Anno0,{M,Name},Fs}};
+        #exprec{} ->
+            no
+    end.
+
 %% Make it look nice (?) when compiled with the 'E' flag
 %% ('and'/2 is left recursive).
 conj([], __E) ->
@@ -931,27 +948,35 @@ record_inits(Fs, Is) ->
 	end, Fs).
 
 native_record_inits(Anno0, Inits0, Is) ->
-    Inits1 = native_record_inits_1(Anno0, Inits0, []),
-    WildcardInit = record_wildcard_init(Is),
+    Inits1 = native_record_no_type(Inits0, []),
+    Inits2 = native_record_inits_1(Anno0, Inits1, []),
     IsKeys = [F || {record_field,_,{atom,_,F},_} <- Is],
-    InitKeys = [F || {record_field,_,{atom,_,F},_} <- Inits0] ++
-        [F || {record_field,_,{atom,_,F}} <- Inits0],
+    InitKeys = [F || {record_field,_,{atom,_,F},_} <- Inits1] ++
+        [F || {record_field,_,{atom,_,F}} <- Inits1],
     NoDef = ordsets:subtract(ordsets:from_list(IsKeys),
                              ordsets:from_list(InitKeys)),
     [{record_field,Anno0,{atom,Anno0,F},{nil,badfield}} || F <- NoDef] ++
         map(fun ({record_field,A1,{atom,A2,F},D}) ->
                     case find_field(F, Is) of
                         {ok,Init} -> {record_field,A1,{atom,A2,F},Init};
-                        error when WildcardInit =:= none ->
-                            {record_field,A1,{atom,A2,F},D};
-                        error -> {record_field,A1,{atom,A2,F},WildcardInit}
+                        error ->
+                            {record_field,A1,{atom,A2,F},D}
                     end;
                 ({record_field,A1,{atom,A2,F}}) ->
                     case find_field(F, Is) of
                         {ok,Init} -> {record_field,A1,{atom,A2,F},Init};
                         error -> {record_field,A1,{atom,A2,F},{nil,novalue}}
                     end
-            end, Inits1).
+            end, Inits2).
+
+native_record_no_type([{typed_record_field,Field,_Type} | Fs], Acc) ->
+    native_record_no_type([Field | Fs], Acc);
+native_record_no_type([{record_field,_,_,_}=F|Fs], Acc) ->
+    native_record_no_type(Fs, [F|Acc]);
+native_record_no_type([{record_field,_,_}=F|Fs], Acc) ->
+    native_record_no_type(Fs, [F|Acc]);
+native_record_no_type([], Acc) ->
+    reverse(Acc).
 
 native_record_inits_1(Anno0, [{record_field,_,{atom,_,F},Di}|Fs], Acc) ->
     native_record_inits_1(Anno0, Fs,

--- a/lib/stdlib/src/records.erl
+++ b/lib/stdlib/src/records.erl
@@ -123,7 +123,7 @@ a
 """.
 -doc #{since => ~"OTP @OTP-19785@"}.
 -spec get_name(Record) -> Name when
-      Record :: record,
+      Record :: record(),
       Name :: atom().
 get_name(_Record) ->
     erlang:nif_error(undefined).

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -1229,7 +1229,8 @@ expand_records(UsedRecords, E0) ->
     RecordDefs = [{attribute,A,module,shell_default}] ++
                  [Def || {_Name,Def} <- UsedRecords],
     Forms0 = RecordDefs ++ [{function,A,foo,0,[{clause,A,[],[],[E]}]}],
-    Forms = erl_expand_records:module(Forms0, [strict_record_tests]),
+    Forms = erl_expand_records:module(Forms0, [strict_record_tests,
+                                               expand_inits]),
     {function,A,foo,0,[{clause,A,[],[],[NE]}]} = lists:last(Forms),
     prep_rec(NE).
 


### PR DESCRIPTION
Native record definitions are now stored in Dialyzer's record table. When a native record is created, updated, or be part of a pattern, the native record type will be type-checked against its definition.

There is one feature missing. It will be added later: When an external native record is imported using `-import_record` and used without a module name, Dialyzer will not emit type errors and warnings.