### PR TITLE
Explicitly set RTLD_LOCAL in dlopen()

### DIFF
--- a/erts/emulator/sys/unix/erl_unix_sys_ddll.c
+++ b/erts/emulator/sys/unix/erl_unix_sys_ddll.c
@@ -130,7 +130,7 @@ int erts_sys_ddll_open_noext(char *dlname, void **handle, ErtsSysDdllError* err)
     int ret = ERL_DE_NO_ERROR;
     char *str;
     dlerror();
-    if ((*handle = dlopen(dlname, RTLD_NOW)) == NULL) {
+    if ((*handle = dlopen(dlname, RTLD_NOW | RTLD_LOCAL)) == NULL) {
 	str = dlerror();
 
 	if (err == NULL) {


### PR DESCRIPTION
`RTLD_LOCAL` is already the default on Linux [1], OpenBSD [2], FreeBSD [3], NetBSD [4], and Solaris [5]. However, for whatever strange reason, it is not the default on MacOS [6].

This can lead to unexpected breakage on MacOS when NIF global symbols clash with MacOS's own similarly named library functions. We observed this in practice with jiffy [7] when the `unicode_to_utf8` symbol clashed with MacOS Tahoe's new biometrics library. We fixed it by hiding symbols with the `-fvisibility=hidden` compler flag, however it might be nice to also fix it in Erlang/OTP to have a more uniform NIF loading behavior and prevent surprises on MacOS in the future.

[1] https://linux.die.net/man/3/dlopen
[2] https://man.openbsd.org/dlopen.3
[3] https://man.freebsd.org/cgi/man.cgi?query=dlopen&sektion=3&format=html
[4] https://man.netbsd.org/dlopen.3
[5] https://docs.oracle.com/cd/E86824_01/html/E54766/dlopen-3c.html
[6] https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html
[7] https://github.com/davisp/jiffy/pull/245