### PR TITLE
Fix an unsafe optimization of list comprehensions

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -2241,7 +2241,7 @@ opt_lc_body_1(Apply, #c_var{name=Name}, Fun0) ->
     maybe
         %% Look for a letrec body that constructs a list
         %% with a single element.
-        #c_apply{op=#c_var{name=Name},args=[Arg|_]} ?= Apply,
+        #c_apply{op=#c_var{name=Name},args=[Arg]} ?= Apply,
         true ?= cerl:is_c_list(Arg) andalso cerl:list_length(Arg) =:= 1,
 
         %% Now we know that the letrec body is suitable. Try to
@@ -2261,11 +2261,11 @@ opt_lc_definition(#c_fun{body=Case}=Fun, Name) ->
     maybe
         %% Match the case used in a list comprehension generator.
         #c_case{clauses=Cs0} ?= Case,
-        [#c_clause{pats=[#c_cons{tl=Tail}|_],body=C1Body0}=C1,
-         #c_clause{pats=[#c_cons{tl=Tail}|_],guard=#c_literal{val=true},
+        [#c_clause{pats=[#c_cons{tl=Tail}],body=C1Body0}=C1,
+         #c_clause{pats=[#c_cons{tl=Tail}],guard=#c_literal{val=true},
                    body=#c_apply{op=#c_var{name=Name},
                                  args=[Tail|_]}}=C2,
-         #c_clause{pats=[#c_literal{val=[]}|_],body=Iterate}|_] ?= Cs0,
+         #c_clause{pats=[#c_literal{val=[]}],body=Iterate}|_] ?= Cs0,
 
         %% Replace self-recursion with the body of the clause matching
         %% the empty list.

--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -135,7 +135,7 @@ mixed(Config) when is_list(Config) ->
     %% OTP-16899: Nested binary comprehensions would fail to load.
     <<0,1,0,2,0,3,99>> = mixed_nested([1,2,3]),
 
-    <<1>> = cs(<< <<X>> || L <- [[1]], X <- L >>),
+    <<1>> = cs_default(<< <<X>> || L <- [[1]], X <- L >>),
     <<1,2>> = cs_default(<< <<X>> || L <- [[1,2]], X <- L >>),
 
     %% The compiler would crash in v3_kernel.

--- a/lib/compiler/test/zlc_SUITE.erl
+++ b/lib/compiler/test/zlc_SUITE.erl
@@ -418,6 +418,7 @@ bad_generators(Config) when is_list(Config) ->
     {'EXIT',{{bad_generator,a},_}} = catch [X || X := X <- a && _Y <- [1]],
     {'EXIT',{{bad_generators,{[d],[]}},_}} =
         catch #{X => Y || X <- [a,b,c,d] && Y <- [1,2,3], Y > 1},
+    ?assertError({bad_generator,gen}, [ok || 0 <:- [a] && _ := true <- gen]),
 
     %% Make sure that line numbers point out the generator.
     case ?MODULE of


### PR DESCRIPTION
An optimization that was introduced in 8f38c125c286919 is potentially unsafe for zip generators.