### PR TITLE
Replace fixed sleep with flush in user_drv shutdown

### DIFF
--- a/erts/test/run_erl_SUITE.erl
+++ b/erts/test/run_erl_SUITE.erl
@@ -104,7 +104,7 @@ count_new_lines(P, N) ->
     receive
 	{P,{data,S}} ->
 	    count_new_lines(P, count_new_lines_1(S, N))
-    after 0 ->
+    after 1000 ->
 	    N
     end.
 

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -1032,7 +1032,7 @@ handle_req(next, TTYState, {false, IOQ} = IOQueue) ->
                 {Reply, MonitorRef, NewTTYState} ->
                     {NewTTYState, {{Origin, MonitorRef, Reply}, ExecQ}};
                 {Reply, {error, Reason}} ->
-                    reply_to_origin(Origin, Reply, {error, Reason}),
+                    _ = reply_to_origin(Origin, Reply, {error, Reason}),
                     handle_req(next, TTYState, {false, ExecQ})
             end
     end;
@@ -1045,7 +1045,7 @@ handle_req(Msg, TTYState, {false, IOQ} = IOQueue) ->
         {Reply, MonitorRef, NewTTYState} ->
             {NewTTYState, {{Origin, MonitorRef, Reply}, IOQ}};
         {Reply, {error, Reason}} ->
-            reply_to_origin(Origin, Reply, {error, Reason}),
+            _ = reply_to_origin(Origin, Reply, {error, Reason}),
             {TTYState, IOQueue}
     end;
 handle_req(Msg,TTYState,{Resp, IOQ}) ->

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -94,7 +94,7 @@
         new_prompt.
 
 -export_type([message/0, request/0]).
--export([start/0, start/1, start_shell/0, start_shell/1, whereis_group/0]).
+-export([start/0, start/1, start_shell/0, start_shell/1, whereis_group/0, flush/0]).
 
 %% gen_statem state callbacks
 -behaviour(gen_statem).
@@ -141,6 +141,14 @@ start_shell() ->
 -spec start_shell(arguments()) -> ok | {error, already_started}.
 start_shell(Args) ->
     gen_statem:call(?MODULE, {start_shell, Args}).
+
+-spec flush() -> ok | {error, term()}.
+flush() ->
+    try
+        gen_statem:call(?MODULE, flush, 1000)
+    catch
+        _:_ -> ok
+    end.
 
 -spec whereis_group() -> pid() | undefined.
 whereis_group() ->
@@ -453,6 +461,10 @@ server({call, From}, {start_shell, Args},
 server({call, From}, {start_shell, _Args}, _State) ->
     gen_statem:reply(From, {error, already_started}),
     keep_state_and_data;
+server({call, From}, flush, #state{ tty = TTYState, queue = Queue } = State) ->
+    Msg = {{statem_reply, From}, {put_chars_sync, unicode, <<>>, noreply}},
+    {NewTTYState, NewQueue} = handle_req(Msg, TTYState, Queue),
+    {keep_state, State#state{ tty = NewTTYState, queue = NewQueue }};
 server(info, {ReadHandle,{data,UTF8Binary}}, State = #state{ read = ReadHandle })
   when State#state.current_group =:= State#state.user ->
     State#state.current_group ! {self(), {data,UTF8Binary}},
@@ -529,6 +541,12 @@ server(info, Req, State = #state{ user = User, current_group = Curr, editor = un
     {NewTTYState, NewQueue} = handle_req(Req, State#state.tty, State#state.queue),
     {keep_state, State#state{ tty = NewTTYState, queue = NewQueue }};
 server(info, {WriteRef, ok}, State = #state{ write = WriteRef,
+                                             queue = {{{statem_reply, From}, MonitorRef, _Reply}, IOQ} }) ->
+    gen_statem:reply(From, ok),
+    erlang:demonitor(MonitorRef, [flush]),
+    {NewTTYState, NewQueue} = handle_req(next, State#state.tty, {false, IOQ}),
+    {keep_state, State#state{ tty = NewTTYState, queue = NewQueue }};
+server(info, {WriteRef, ok}, State = #state{ write = WriteRef,
                                              queue = {{Origin, MonitorRef, Reply}, IOQ} }) ->
     %% We get this ok from the user_drv_writer, in io_request we store
     %% info about where to send reply at head of queue
@@ -536,6 +554,11 @@ server(info, {WriteRef, ok}, State = #state{ write = WriteRef,
     erlang:demonitor(MonitorRef, [flush]),
     {NewTTYState, NewQueue} = handle_req(next, State#state.tty, {false, IOQ}),
     {keep_state, State#state{ tty = NewTTYState, queue = NewQueue }};
+server(info, {'DOWN', MonitorRef, _, _, Reason},
+       #state{ queue = {{{statem_reply, From}, MonitorRef, _Reply}, _IOQ} }) ->
+    gen_statem:reply(From, {error, Reason}),
+    ?LOG_INFO("Failed to write to standard out (~p)", [Reason]),
+    stop;
 server(info, {'DOWN', MonitorRef, _, _, Reason},
        #state{ queue = {{Origin, MonitorRef, Reply}, _IOQ} }) ->
     %% The writer process died, we send the correct error to the caller and
@@ -745,6 +768,10 @@ switch_loop(info, {Requester, tty_geometry}, {_Cont, #state{ tty = TTYState }}) 
 switch_loop(timeout, _, {_Cont, State}) ->
     {keep_state_and_data,
      {next_event, info, {State#state.read,{data,[]}}}};
+switch_loop({call, From}, flush, {Cont, State = #state{ tty = TTYState, queue = Queue }}) ->
+    Msg = {{statem_reply, From}, {put_chars_sync, unicode, <<>>, noreply}},
+    {NewTTYState, NewQueue} = handle_req(Msg, TTYState, Queue),
+    {keep_state, {Cont, State#state{ tty = NewTTYState, queue = NewQueue }}};
 switch_loop(info, _Unknown, _State) ->
     {keep_state_and_data, postpone}.
 
@@ -1005,7 +1032,7 @@ handle_req(next, TTYState, {false, IOQ} = IOQueue) ->
                 {Reply, MonitorRef, NewTTYState} ->
                     {NewTTYState, {{Origin, MonitorRef, Reply}, ExecQ}};
                 {Reply, {error, Reason}} ->
-                    Origin ! {reply, Reply, {error, Reason}},
+                    reply_to_origin(Origin, Reply, {error, Reason}),
                     handle_req(next, TTYState, {false, ExecQ})
             end
     end;
@@ -1018,12 +1045,17 @@ handle_req(Msg, TTYState, {false, IOQ} = IOQueue) ->
         {Reply, MonitorRef, NewTTYState} ->
             {NewTTYState, {{Origin, MonitorRef, Reply}, IOQ}};
         {Reply, {error, Reason}} ->
-            Origin ! {reply, Reply, {error, Reason}},
+            reply_to_origin(Origin, Reply, {error, Reason}),
             {TTYState, IOQueue}
     end;
 handle_req(Msg,TTYState,{Resp, IOQ}) ->
     %% All requests are queued when we have outstanding sync put_chars
     {TTYState, {Resp, queue:in(Msg,IOQ)}}.
+
+reply_to_origin({statem_reply, From}, _Reply, Resp) ->
+    gen_statem:reply(From, Resp);
+reply_to_origin(Origin, Reply, Resp) ->
+    Origin ! {reply, Reply, Resp}.
 
 %% gr_new()
 %% gr_get_num(Group, Index)

--- a/lib/kernel/src/user_sup.erl
+++ b/lib/kernel/src/user_sup.erl
@@ -84,14 +84,13 @@ relay1(Pid) ->
 
 
 %%-----------------------------------------------------------------
-%% Sleep a while in order to let user write all (some) buffered 
-%% information before termination.
+%% Wait for user_drv to flush buffered output before termination.
 %%-----------------------------------------------------------------
 
 -spec terminate(term(), pid()) -> 'ok'.
 
 terminate(_Reason, UserPid) ->
-    receive after 1000 -> ok end,
+    user_drv:flush(),
     exit(UserPid, kill),
     ok.
 

--- a/lib/kernel/src/user_sup.erl
+++ b/lib/kernel/src/user_sup.erl
@@ -90,7 +90,7 @@ relay1(Pid) ->
 -spec terminate(term(), pid()) -> 'ok'.
 
 terminate(_Reason, UserPid) ->
-    user_drv:flush(),
+    _ = user_drv:flush(),
     exit(UserPid, kill),
     ok.
 

--- a/lib/kernel/test/init_SUITE.erl
+++ b/lib/kernel/test/init_SUITE.erl
@@ -33,7 +33,8 @@
 	 reboot/1, stop_status/1, stop/1, get_status/1, script_id/1,
          dot_erlang/1, unknown_module/1, dash_S/1, dash_extra/1,
          dash_run/1, dash_s/1,
-	 find_system_processes/0
+	 find_system_processes/0,
+         stop_flush/1
          ]).
 -export([boot1/1, boot2/1]).
 -export([test_dash_S/1, test_dash_s/1, test_dash_extra/0,
@@ -50,11 +51,11 @@ suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{minutes,2}}].
 
-all() -> 
+all() ->
     [get_arguments, get_argument, boot_var,
      many_restarts, restart_with_mode,
      get_plain_arguments, init_group_history_deadlock,
-     restart, stop_status, get_status, script_id,
+     restart, stop_status, stop_flush, get_status, script_id,
      dot_erlang, unknown_module, {group, boot},
      dash_S, dash_extra, dash_run, dash_s].
 
@@ -648,7 +649,30 @@ stop(Config) when is_list(Config) ->
     ok.
 
 %% ------------------------------------------------
-%% 
+%% Verify that init:stop() does not sleep for a fixed
+%% duration when flushing user_drv output. Shutdown
+%% should complete well under 1 second for an idle node.
+%% ------------------------------------------------
+stop_flush(Config) when is_list(Config) ->
+    {ok, Peer, Node} = ?CT_PEER(#{connection => standard_io}),
+    erlang:monitor_node(Node, true),
+    T0 = erlang:monotonic_time(millisecond),
+    ok = rpc:call(Node, init, stop, []),
+    receive
+        {nodedown, Node} ->
+            Elapsed = erlang:monotonic_time(millisecond) - T0,
+            ct:pal("Shutdown took ~b ms", [Elapsed]),
+            ?assert(Elapsed < 900,
+                    lists:flatten(
+                      io_lib:format("Shutdown took ~b ms, expected < 900 ms",
+                                    [Elapsed])))
+    after 10000 ->
+        peer:stop(Peer),
+        ct:fail(not_stopping)
+    end.
+
+%% ------------------------------------------------
+%%
 %% ------------------------------------------------
 get_status(Config) when is_list(Config) ->
     {Start, _} = init:get_status(),


### PR DESCRIPTION
When `init:stop()` is called, `user_sup:terminate/2` needs to give pending I/O a chance to reach the terminal before it kills the user process. The current implementation does this with `receive after 1000 -> ok end`, an unconditional one-second sleep. This works, but it means every shutdown pays a full second of latency, whether or not there is actually output in flight. On an idle node, the delay is pure waste.

This change introduces `user_drv:flush/0`, which enqueues a synchronous `put_chars_sync` request carrying an empty binary into the existing I/O queue. Because the queue is processed in order, the call returns only after every preceding write has been acknowledged by the writer process. `user_sup:terminate/2` now calls `flush()` instead of sleeping, so shutdown completes as soon as the queue drains rather than always waiting the full second. The `flush` call uses a one-second timeout and catches all failures, so it degrades gracefully if `user_drv` is already gone or unresponsive. The worst case is the same one-second delay as before.