### PR TITLE
Ingela/ssl/backwards inet compat/otp 20018

### DIFF
--- a/lib/ssl/src/ssl.erl
+++ b/lib/ssl/src/ssl.erl
@@ -3221,7 +3221,19 @@ getopts(#sslsocket{}, OptionTags) ->
 
 %%--------------------------------------------------------------------
 -doc(#{group => <<"Client and Server API">>}).
--doc "Sets options according to `Options` for socket `SslSocket`.".
+-doc """
+Sets options according to `Options` for socket `SslSocket`.
+
+> #### Note {: .info }
+Note that setting low level transport protocol specific options
+may or may not work in a TLS-environment. And even if they work it
+may make your code platform specific, or stop working in later
+version of this application. Such options could make sense for
+some special corner cases although it is not a general viable option.
+Such trade-offs must be carefully considered by the user that need
+to fully understand the consequences of setting such options.
+""".
+%%--------------------------------------------------------------------
 -spec setopts(SslSocket, Options) -> ok | {error, reason()} when
       SslSocket :: sslsocket(),
       Options :: [gen_tcp:option()].

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -590,6 +590,12 @@ send_or_buffer(Transport, Socket, Msgs, From, #data{buff = undefined} = StateDat
             send_reply(From, ok),
             {ok, StateData0};
         {error, timeout} = Error ->
+            %% This clause is to retain some backwards compatibility with
+            %% inet-driver behavior for gen_tcp:send timeout. That
+            %% happened to work before OTP-28, due to the fact that
+            %% the inet-driver always buffers and will not return rest data.
+            %% Buy time for people that might have relied on this behavior
+            %% for better solutions to be crated.
             send_reply(From, Error),
             {ok, StateData0};
         {error, _Err} = Error ->


### PR DESCRIPTION
Document that setting transport protocol specific socket options is not generally expected to work for TLS and if it happens to work it comes with consequences that should be understood an accepted by the user. Also retain some backwards compatibility with such an option that happened to work to buy time for people to come up with better solutions.