### PR TITLE
Support kitty keyboard protocol in the shell

### DIFF
--- a/erts/emulator/nifs/common/prim_tty_nif.c
+++ b/erts/emulator/nifs/common/prim_tty_nif.c
@@ -116,6 +116,8 @@ typedef struct {
 #endif
 } TTYResource;
 
+static void tty_set_kitty_keyboard(TTYResource *tty, int enable);
+
 // #define HARD_DEBUG
 #ifdef HARD_DEBUG
 static FILE *logFile = NULL;
@@ -957,6 +959,7 @@ static ERL_NIF_TERM tty_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
 
     ERL_NIF_TERM input;
     TTYResource *tty;
+    enum TTYState previous_tty;
 
     debug("tty_init_nif(%T,%T)\r\n", argv[0], argv[1]);
 
@@ -978,6 +981,7 @@ static ERL_NIF_TERM tty_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
 
 #if defined(HAVE_TERMCAP) || defined(__WIN32__)
 
+    previous_tty = tty->tty;
     tty->tty = enif_is_identical(input, atom_raw) ? enabled : disabled;
 
 #ifndef __WIN32__
@@ -1040,6 +1044,12 @@ static ERL_NIF_TERM tty_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
     }
 
 #endif /* __WIN32__ */
+
+    if (previous_tty != enabled && tty->tty == enabled) {
+        tty_set_kitty_keyboard(tty, 1);
+    } else if (previous_tty == enabled && tty->tty != enabled) {
+        tty_set_kitty_keyboard(tty, 0);
+    }
 
     enif_self(env, &tty->self);
     enif_monitor_process(env, tty, &tty->self, NULL);
@@ -1116,11 +1126,19 @@ static ERL_NIF_TERM tty_select_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM 
 
 static void tty_monitor_down(ErlNifEnv* caller_env, void* obj, ErlNifPid* pid, ErlNifMonitor* mon) {
     TTYResource *tty = obj;
-#ifdef HAVE_TERMCAP
     if (enif_compare_pids(pid, &tty->self) == 0) {
+        tty_set_kitty_keyboard(tty, 0);
+#ifdef HAVE_TERMCAP
         tcsetattr(tty->ifd, TCSANOW, &tty->tty_rmode);
-    }
+#elif defined(__WIN32__)
+        if (tty->ifd != INVALID_HANDLE_VALUE) {
+            SetConsoleMode(tty->ifd, tty->dwOriginalInMode);
+        }
+        if (tty->ofd != INVALID_HANDLE_VALUE) {
+            SetConsoleMode(tty->ofd, tty->dwOriginalOutMode);
+        }
 #endif
+    }
     if (enif_compare_pids(pid, &tty->reader) == 0) {
         enif_select(caller_env, tty->ifd, ERL_NIF_SELECT_STOP, tty, NULL, atom_undefined);
     }
@@ -1131,6 +1149,45 @@ static void tty_select_stop(ErlNifEnv* caller_env, void* obj, ErlNifEvent event,
 #ifndef __WIN32__
     if (event != 0)
         close(event);
+#endif
+}
+
+static void tty_set_kitty_keyboard(TTYResource *tty, int enable) {
+    static const char kitty_enable[] = "\x1b[>1u";
+    static const char kitty_disable[] = "\x1b[<u";
+    const char *seq = enable ? kitty_enable : kitty_disable;
+    size_t len = enable ? sizeof(kitty_enable) - 1 : sizeof(kitty_disable) - 1;
+
+#ifdef __WIN32__
+    if (tty->ofd == INVALID_HANDLE_VALUE) {
+        return;
+    }
+    while (len > 0) {
+        DWORD written = 0;
+        if (!WriteFile(tty->ofd, seq, (DWORD)len, &written, NULL) || written == 0) {
+            return;
+        }
+        seq += written;
+        len -= written;
+    }
+#else
+    if (tty->ofd < 0) {
+        return;
+    }
+    while (len > 0) {
+        ssize_t written = write(tty->ofd, seq, len);
+        if (written < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return;
+        }
+        if (written == 0) {
+            return;
+        }
+        seq += written;
+        len -= written;
+    }
 #endif
 }
 

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -460,6 +460,9 @@ server(info, {ReadHandle,{data,UTF8Binary}}, State = #state{ read = ReadHandle }
 server(info, {ReadHandle,{data,UTF8Binary}}, State = #state{ read = ReadHandle }) ->
     case contains_ctrl_g_or_ctrl_c(UTF8Binary) of
         ctrl_g -> {next_state, switch_loop, State, {next_event, internal, init}};
+        kitty_ctrl_c ->
+            send_break(State),
+            keep_state_and_data;
         ctrl_c ->
             case gr_get_info(State#state.groups, State#state.current_group) of
                 undefined -> ok;
@@ -639,10 +642,103 @@ contains_ctrl_g_or_ctrl_c(<<$\^G,_/binary>>) ->
     ctrl_g;
 contains_ctrl_g_or_ctrl_c(<<$\^C,_/binary>>) ->
     ctrl_c;
+contains_ctrl_g_or_ctrl_c(<<$\e,$[,Rest/binary>>) ->
+    case contains_kitty_ctrl_g_or_ctrl_c(Rest) of
+        none ->
+            contains_ctrl_g_or_ctrl_c(Rest);
+        Ctrl ->
+            Ctrl
+    end;
 contains_ctrl_g_or_ctrl_c(<<_/utf8,T/binary>>) ->
     contains_ctrl_g_or_ctrl_c(T);
 contains_ctrl_g_or_ctrl_c(<<>>) ->
     none.
+
+send_break(#state{terminal_mode = raw, tty = TTYState, write = WriteRef}) ->
+    case os:type() of
+        {unix, _} ->
+            %% Kitty keyboard protocol turns Ctrl+C into input data, so emulate
+            %% the terminal-generated SIGINT that would normally trigger BREAK.
+            %% Disable kitty keyboard protocol while the BREAK handler is active,
+            %% since the emulator break menu reads stdin directly and does not
+            %% understand CSI-u sequences.
+            ok = tty_write_sync(TTYState, WriteRef, <<"\e[<u">>),
+            _ = os:cmd("kill -INT " ++ os:getpid()),
+            ok = tty_write_sync(TTYState, WriteRef, <<"\e[>1u">>),
+            ok;
+        _ ->
+            ok
+    end;
+send_break(_) ->
+    ok.
+
+tty_write_sync(TTYState, WriteRef, Chars) ->
+    {ok, MonitorRef} = prim_tty:write(TTYState, Chars, self()),
+    receive
+        {WriteRef, ok} ->
+            erlang:demonitor(MonitorRef, [flush]),
+            ok;
+        {'DOWN', MonitorRef, _, _, Reason} ->
+            exit(Reason)
+    end.
+
+contains_kitty_ctrl_g_or_ctrl_c(Bin) ->
+    case take_kitty_decimal(Bin) of
+        {ok, Codepoint, Rest} ->
+            case take_kitty_modifiers(Rest) of
+                {ok, Modifiers} when (Modifiers band 4) =/= 0 ->
+                    case Codepoint of
+                        $c -> kitty_ctrl_c;
+                        $C -> kitty_ctrl_c;
+                        $g -> ctrl_g;
+                        $G -> ctrl_g;
+                        _ -> none
+                    end;
+                _ ->
+                    none
+            end;
+        error ->
+            none
+    end.
+
+take_kitty_modifiers(<<$u>>) ->
+    {ok, 0};
+take_kitty_modifiers(<<$:, Rest/binary>>) ->
+    take_kitty_modifiers(skip_kitty_decimal(Rest));
+take_kitty_modifiers(<<$;, Rest/binary>>) ->
+    case take_kitty_decimal(Rest) of
+        {ok, Modifiers, Rest1} ->
+            case skip_kitty_suffix(Rest1) of
+                ok -> {ok, Modifiers - 1};
+                error -> error
+            end;
+        error ->
+            error
+    end;
+take_kitty_modifiers(_) ->
+    error.
+
+skip_kitty_suffix(<<$u>>) ->
+    ok;
+skip_kitty_suffix(<<$:, Rest/binary>>) ->
+    skip_kitty_suffix(skip_kitty_decimal(Rest));
+skip_kitty_suffix(_) ->
+    error.
+
+take_kitty_decimal(<<C, Rest/binary>>) when $0 =< C, C =< $9 ->
+    take_kitty_decimal(Rest, C - $0);
+take_kitty_decimal(_) ->
+    error.
+
+take_kitty_decimal(<<C, Rest/binary>>, Acc) when $0 =< C, C =< $9 ->
+    take_kitty_decimal(Rest, Acc * 10 + C - $0);
+take_kitty_decimal(Rest, Acc) ->
+    {ok, Acc, Rest}.
+
+skip_kitty_decimal(<<C, Rest/binary>>) when $0 =< C, C =< $9 ->
+    skip_kitty_decimal(Rest);
+skip_kitty_decimal(Rest) ->
+    Rest.
 
 switch_loop(internal, init, State) ->
     case application:get_env(stdlib, shell_esc, jcl) of

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -50,6 +50,7 @@
          shell_history_custom/1, shell_history_custom_errors/1,
          shell_history_toggle/1,
 	 job_control_remote_noshell/1,ctrl_keys/1,
+         kitty_keyboard_protocol/1, kitty_keyboard_normalization/1,
          get_columns_and_rows_escript/1,
          shell_get_password/1,
          shell_navigation/1, shell_multiline_navigation/1, shell_multiline_prompt/1, shell_multiline_prompt_ssh/1,
@@ -174,6 +175,8 @@ groups() ->
        shell_xnfix, shell_delete, shell_format,
        shell_combining_unicode,
        shell_transpose, shell_search, shell_insert,
+       kitty_keyboard_normalization,
+       kitty_keyboard_protocol,
        shell_update_window, shell_small_window_multiline_navigation, shell_huge_input,
        shell_support_ansi_input,
        shell_receive_standard_out,
@@ -1539,6 +1542,53 @@ test_invalid_keymap(Config) when is_list(Config) ->
         shell_test_lib:stop_tty(Term1),
         ok
     end.
+
+kitty_keyboard_protocol(Config) ->
+    Term = start_tty(Config),
+    try
+        shell_test_lib:send_tty(Term, "1+23"),
+        shell_test_lib:send_tty(Term, "\e[127u"),
+        shell_test_lib:send_tty(Term, "."),
+        shell_test_lib:send_tty(Term, "Enter"),
+        shell_test_lib:check_content(Term, "1\\+2\\.\\n3\\n"),
+
+        shell_test_lib:send_tty(Term, "123"),
+        shell_test_lib:send_tty(Term, "\e[7~"),
+        shell_test_lib:send_tty(Term, "a"),
+        shell_test_lib:send_tty(Term, "\e[8~"),
+        shell_test_lib:send_tty(Term, "b"),
+        shell_test_lib:send_tty(Term, "Enter"),
+        shell_test_lib:check_content(Term, "a123b\\n"),
+
+        shell_test_lib:send_tty(Term, "\e[99;5u"),
+        timer:sleep(250),
+        shell_test_lib:send_tty(Term, "4+4"),
+        shell_test_lib:send_tty(Term, "Enter"),
+        shell_test_lib:check_content(Term, "4\\+4\\n8\\n"),
+
+        shell_test_lib:send_tty(Term, "123+456"),
+        shell_test_lib:send_tty(Term, "\e[98;3:98u"),
+        shell_test_lib:send_tty(Term, "7"),
+        shell_test_lib:send_tty(Term, "Enter"),
+        shell_test_lib:check_content(Term, "123\\+7456\\n7579\\n"),
+
+        shell_test_lib:send_tty(Term, "\e[99;5u"),
+        shell_test_lib:check_content(Term, "BREAK: \\(a\\)bort"),
+        shell_test_lib:send_tty(Term, "c"),
+        shell_test_lib:check_content(Term, "4> $"),
+        ok
+    after
+        shell_test_lib:stop_tty(Term),
+        ok
+    end.
+
+kitty_keyboard_normalization(_Config) ->
+    "\^[b" = edlin_key:normalize_kitty_key("\e[98;3u"),
+    "\^[b" = edlin_key:normalize_kitty_key("\e[98;3;98u"),
+    "\^[B" = edlin_key:normalize_kitty_key("\e[66:98;3u"),
+    "\^G" = edlin_key:normalize_kitty_key("\e[71:103;5u"),
+    {key, "\e[98;3:98u", []} = edlin_key:get_valid_escape_key("\e[98;3:98u", none),
+    ok.
 external_editor(Config) ->
     case os:find_executable("nano") of
         false -> {skip, "nano is not installed"};

--- a/lib/stdlib/src/edlin.erl
+++ b/lib/stdlib/src/edlin.erl
@@ -352,10 +352,16 @@ edit(Buf, P, {LB, {Bef,Aft}, LA}=MultiLine, {ShellMode1, EscapePrefix}, Rs0) ->
             KeyMap = get(key_map),
             Value = case maps:find(Key, maps:get(ShellMode, KeyMap)) of
                 error ->
-                    %% Default handling for shell modes
-                    case maps:find(default, maps:get(ShellMode, KeyMap)) of
-                        error -> none;
-                        {ok, Value0} -> Value0
+                    NormalizedKey = edlin_key:normalize_kitty_key(Key),
+                    case maps:find(NormalizedKey, maps:get(ShellMode, KeyMap)) of
+                        error ->
+                            %% Default handling for shell modes
+                            case maps:find(default, maps:get(ShellMode, KeyMap)) of
+                                error -> none;
+                                {ok, Value0} -> Value0
+                            end;
+                        {ok, Value0} ->
+                            Value0
                     end;
                 {ok, Value0} -> Value0
             end,

--- a/lib/stdlib/src/edlin_key.erl
+++ b/lib/stdlib/src/edlin_key.erl
@@ -21,7 +21,7 @@
 %%
 -module(edlin_key).
 -moduledoc false.
--export([get_key_map/0, get_valid_escape_key/2]).
+-export([get_key_map/0, get_valid_escape_key/2, normalize_kitty_key/1]).
 -import(lists, [reverse/1, reverse/2]).
 get_key_map() ->
     KeyMap = application:get_env(stdlib, shell_keymap, none),
@@ -92,6 +92,11 @@ get_valid_escape_key([C|Rest], meta_left_sq_bracket) ->
         _ when $a =< C, C =< $z; $A =< C, C =< $Z -> get_valid_escape_key(Rest, {finished, "\e["++[C]});
         _ -> get_valid_escape_key(Rest, {invalid, "\e["++[C]})
     end;
+get_valid_escape_key([C|Rest], {csi, [$:|Acc]}) ->
+    case C of
+        _ when $0 =< C, C =< $9 -> get_valid_escape_key(Rest, {csi, [C,$:|Acc]});
+        _ -> get_valid_escape_key(Rest, {invalid, "\e["++reverse([$:|Acc])++[C]})
+    end;
 get_valid_escape_key([C|Rest], {csi, [$;|Acc]}) ->
     case C of
         _ when $0 =< C, C =< $9 -> get_valid_escape_key(Rest, {csi, [C,$;|Acc]});
@@ -100,6 +105,7 @@ get_valid_escape_key([C|Rest], {csi, [$;|Acc]}) ->
 get_valid_escape_key([C|Rest], {csi, Acc}) ->
     case C of
         $~ -> get_valid_escape_key(Rest, {finished, "\e["++reverse([$~|Acc])});
+        $: -> get_valid_escape_key(Rest, {csi, [$:|Acc]});
         $; -> get_valid_escape_key(Rest, {csi, [$;|Acc]});
         _ when $0 =< C, C =< $9 -> get_valid_escape_key(Rest, {csi, [C|Acc]});
         $m -> {invalid, "\e["++reverse([$m|Acc]), [$m|Rest]};
@@ -114,6 +120,186 @@ get_valid_escape_key(Rest, {invalid, Acc}) ->
     {invalid, Acc, Rest};
 get_valid_escape_key(Rest, Acc) ->
     {invalid, Acc, Rest}.
+
+normalize_kitty_key("\e[" ++ _ = Key) ->
+    case parse_kitty_key(Key) of
+        {ok, Codepoint, Modifiers} ->
+            kitty_to_legacy_key(Codepoint, Modifiers, Key);
+        error ->
+            case normalize_kitty_function_key(Key) of
+                undefined -> Key;
+                Normalized -> Normalized
+            end
+    end;
+normalize_kitty_key(Key) ->
+    Key.
+
+parse_kitty_key("\e[" ++ Rest) ->
+    case take_decimal(Rest) of
+        error ->
+            error;
+        {Codepoint, Rest1} ->
+            parse_kitty_key_tail(Codepoint, Rest1)
+    end;
+parse_kitty_key(_) ->
+    error.
+
+parse_kitty_key_tail(Codepoint, ":" ++ Rest) ->
+    parse_kitty_key_tail(Codepoint, skip_decimal(Rest));
+parse_kitty_key_tail(Codepoint, "u") ->
+    {ok, Codepoint, 1};
+parse_kitty_key_tail(Codepoint, ";" ++ Rest) ->
+    case take_decimal(Rest) of
+        error ->
+            error;
+        {Modifiers, Rest1} ->
+            case skip_kitty_key_suffix(Codepoint, Rest1) of
+                {ok, Codepoint, _} ->
+                    {ok, Codepoint, Modifiers};
+                error ->
+                    error
+            end
+    end;
+parse_kitty_key_tail(_, _) ->
+    error.
+
+skip_kitty_key_suffix(Codepoint, ":" ++ Rest) ->
+    skip_kitty_key_suffix(Codepoint, skip_decimal(Rest));
+skip_kitty_key_suffix(Codepoint, ";" ++ Rest) ->
+    skip_kitty_key_suffix(Codepoint, skip_decimal(Rest));
+skip_kitty_key_suffix(Codepoint, "u") ->
+    {ok, Codepoint, 1};
+skip_kitty_key_suffix(_, _) ->
+    error.
+
+take_decimal([C | Rest]) when $0 =< C, C =< $9 ->
+    take_decimal(Rest, C - $0);
+take_decimal(_) ->
+    error.
+
+take_decimal([C | Rest], Acc) when $0 =< C, C =< $9 ->
+    take_decimal(Rest, Acc * 10 + C - $0);
+take_decimal(Rest, Acc) ->
+    {Acc, Rest}.
+
+skip_decimal([C | Rest]) when $0 =< C, C =< $9 ->
+    skip_decimal(Rest);
+skip_decimal(Rest) ->
+    Rest.
+
+kitty_to_legacy_key(Codepoint, Modifiers, Fallback) ->
+    Flags = Modifiers - 1,
+    Alt = (Flags band 2) =/= 0,
+    Ctrl = (Flags band 4) =/= 0,
+    case kitty_base_key(Codepoint) of
+        undefined ->
+            case kitty_ctrl_key(Codepoint, Ctrl) of
+                undefined ->
+                    case kitty_alt_key(Codepoint, Alt, Ctrl) of
+                        undefined -> Fallback;
+                        Key when Alt -> "\e" ++ Key;
+                        Key -> Key
+                    end;
+                Key ->
+                    case Alt of
+                        true -> "\e" ++ Key;
+                        false -> Key
+                    end
+            end;
+        Key when Alt ->
+            "\e" ++ Key;
+        Key ->
+            Key
+    end.
+
+kitty_base_key(8) -> "\^H";
+kitty_base_key(9) -> "\t";
+kitty_base_key(13) -> "\r";
+kitty_base_key(27) -> "\e";
+kitty_base_key(127) -> "\^?";
+kitty_base_key(_) -> undefined.
+
+kitty_ctrl_key(127, true) ->
+    "\^?";
+kitty_ctrl_key(Codepoint, true) when $a =< Codepoint, Codepoint =< $z ->
+    [Codepoint band 31];
+kitty_ctrl_key(Codepoint, true) when $A =< Codepoint, Codepoint =< $Z ->
+    [Codepoint band 31];
+kitty_ctrl_key($@, true) -> [0];
+kitty_ctrl_key($[, true) -> [27];
+kitty_ctrl_key($\\, true) -> [28];
+kitty_ctrl_key($], true) -> [29];
+kitty_ctrl_key($^, true) -> [30];
+kitty_ctrl_key($_, true) -> [31];
+kitty_ctrl_key($?, true) -> [127];
+kitty_ctrl_key(_, _) -> undefined.
+
+kitty_alt_key(Codepoint, true, _Ctrl) when 32 =< Codepoint, Codepoint =< 126 ->
+    [Codepoint];
+kitty_alt_key(_, _, _) ->
+    undefined.
+
+normalize_kitty_function_key("\e[" ++ Rest) ->
+    case parse_kitty_function_key(Rest) of
+        {ok, Sequence} -> "\e[" ++ Sequence;
+        error -> undefined
+    end;
+normalize_kitty_function_key(_) ->
+    undefined.
+
+parse_kitty_function_key("1~") ->
+    {ok, "H"};
+parse_kitty_function_key("4~") ->
+    {ok, "F"};
+parse_kitty_function_key("7~") ->
+    {ok, "H"};
+parse_kitty_function_key("8~") ->
+    {ok, "F"};
+parse_kitty_function_key(Rest) ->
+    case take_decimal(Rest) of
+        error ->
+            error;
+        {1, ";" ++ Rest1} ->
+            parse_kitty_function_suffix(Rest1);
+        {Codepoint, ";" ++ Rest1} when Codepoint =:= 2;
+                                        Codepoint =:= 3;
+                                        Codepoint =:= 5;
+                                        Codepoint =:= 6;
+                                        Codepoint =:= 7;
+                                        Codepoint =:= 8;
+                                        11 =< Codepoint, Codepoint =< 24 ->
+            parse_kitty_function_tilde(Codepoint, Rest1);
+        _ ->
+            error
+    end.
+
+parse_kitty_function_suffix(Rest) ->
+    case take_decimal(Rest) of
+        error ->
+            error;
+        {Modifiers, [Suffix]} when Suffix =:= $A;
+                                   Suffix =:= $B;
+                                   Suffix =:= $C;
+                                   Suffix =:= $D;
+                                   Suffix =:= $F;
+                                   Suffix =:= $H;
+                                   Suffix =:= $P;
+                                   Suffix =:= $Q;
+                                   Suffix =:= $S ->
+            {ok, "1;" ++ integer_to_list(Modifiers) ++ [Suffix]};
+        _ ->
+            error
+    end.
+
+parse_kitty_function_tilde(Codepoint, Rest) ->
+    case take_decimal(Rest) of
+        error ->
+            error;
+        {Modifiers, "~"} ->
+            {ok, integer_to_list(Codepoint) ++ ";" ++ integer_to_list(Modifiers) ++ "~"};
+        _ ->
+            error
+    end.
 
 merge(KeyMap) ->
     merge(KeyMap, [normal, search, tab_expand, help], key_map()).


### PR DESCRIPTION
## Summary
- enable kitty keyboard protocol when prim_tty enters raw mode
- normalize kitty CSI-u key sequences in edlin and recognize kitty Ctrl+G/Ctrl+C in user_drv
- preserve legacy BREAK behavior by disabling kitty protocol while the emulator break menu reads stdin directly
- add interactive shell coverage for kitty normalization and BREAK handling

## Verification
- `make ERL_TOP=/Users/jechol/dev/otp opt` in `lib/stdlib`
- `make ERL_TOP=/Users/jechol/dev/otp opt` in `lib/kernel`
- `make ERL_TOP=/Users/jechol/dev/otp -C /Users/jechol/dev/otp/erts local_setup`
- manual check with `bin/erl` for kitty `Ctrl+C` -> BREAK menu and second `Ctrl+C` abort behavior