### PR TITLE
`os`: Remove deprecated `catch`

### DIFF
--- a/lib/kernel/src/os.erl
+++ b/lib/kernel/src/os.erl
@@ -35,8 +35,6 @@ a program to run on most platforms.
 > Types" section.
 """.
 
--compile(nowarn_deprecated_catch).
-
 %% Provides a common operating system interface.
 
 -export([type/0, version/0, cmd/1, cmd/2, find_executable/1, find_executable/2]).
@@ -728,7 +726,7 @@ get_data(Port, MonRef, Eot, Sofar, Size, Max, ExitStatus) ->
                     get_data(Port, MonRef, Eot, [Sofar, Bytes],
                              Size + byte_size(Bytes), Max, ExitStatus);
                 {Last, Remain} ->
-                    catch port_close(Port),
+                    try port_close(Port) catch _:_ -> true end,
                     flush_until_down(Port, MonRef),
                     Result = [Sofar, Last],
                     case ExitStatus andalso eot(Remain, Eot, byte_size(Remain), Max) of

--- a/lib/kernel/test/os_SUITE.erl
+++ b/lib/kernel/test/os_SUITE.erl
@@ -200,10 +200,10 @@ space_in_name(Config) when is_list(Config) ->
     [] = receive_all(),
     ok.
 
-%% Check that a bad command doesn't crasch the server or the emulator (it used to).
+%% Check that a bad command doesn't crash the server or the emulator (it used to).
 bad_command(Config) when is_list(Config) ->
-    catch os:cmd([a|b]),
-    catch os:cmd({bad, thing}),
+    ok = ?assertError(badarg, os:cmd([a|b])),
+    ok = ?assertError(badarg, os:cmd({bad, thing})),
 
     %% This should at least not crash (on Unix it typically returns
     %% a message from the shell).


### PR DESCRIPTION
This PR removes all deprecated old-style `catch`es from the `os` module and its test suite.