### PR TITLE
crypto: Auto-load application from on_load

### DIFF
--- a/lib/crypto/doc/crypto_app.md
+++ b/lib/crypto/doc/crypto_app.md
@@ -69,6 +69,21 @@ parameters.
   rounded up to an integral number of words of the size these seed functions
   use.
 
+> #### Change {: .info }
+>
+> From Erlang/OTP 29, in [interactive mode](`e:system:system_principles.md#code_loading`),
+> application `crypto` will be automatically loaded if needed when module
+> `crypto` is loaded. In [embedded mode](`e:system:system_principles.md#code_loading`),
+> module `crypto` will fail to load if application `crypto` has not been
+> loaded by the boot script. This is all done to make sure `crypto` is not
+> initialized with incorrect configuration parameters.
+>
+> In Erlang/OTP 28 and earlier, no automatic loading of the application is done.
+> If module `crypto` is then loaded (by a first call for example) before the
+> application has been loaded, it will initialize with possibly incorrect
+> configuration parameters. In particular, `fips_mode` will then default to
+> `false` even if configured to be `true`.
+
 ## SEE ALSO
 
 application(3)

--- a/lib/crypto/doc/guides/fips.md
+++ b/lib/crypto/doc/guides/fips.md
@@ -64,8 +64,8 @@ $ make
 If `FIPS_mode_set` returns `no` the OpenSSL library is not FIPS enabled and
 crypto won't support FIPS mode either.
 
-1. Set the `fips_mode` configuration setting of the crypto application to `true`
-   _before loading the crypto module_.
+1. Set the [`fips_mode`](crypto_app.md#fips_mode) configuration setting of the
+   crypto application to `true` _before loading the crypto module_.
 
 The best place is in the `sys.config` system configuration file of the release.
 

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -4121,6 +4121,17 @@ ensure_engine_unloaded(Engine, _EngineMethods) ->
 %%% On load
 %%--------------------------------------------------------------------
 on_load() ->
+    %% Make sure crypto app is loaded in order to do get_env below.
+    case {code:get_mode(),application:load(crypto)} of
+        {_, {error,{already_loaded,crypto}}} -> ok;
+        {interactive, ok} -> ok;
+        {embedded, ok} ->
+            %% Application not already loaded by boot script. Why?
+            %% Could happen if application start type was 'none' in .rel file.
+            erlang:error({on_load, "Module 'crypto' cannot be loaded in embedded"
+                          " mode without application 'crypto' being loaded"})
+    end,
+
     LibBaseName = "crypto",
     PrivDir = code:priv_dir(crypto),
     LibName = case erlang:system_info(build_type) of
@@ -4147,14 +4158,14 @@ on_load() ->
 	      end,
     Lib = filename:join([PrivDir, "lib", LibName]),
     LibBin   = path2bin(Lib),
-    {FipsMode,AppLoaded} =
+    FipsMode =
         case application:get_env(crypto, fips_mode) of
-            {ok, true} -> {true, loaded};
-            {ok, _} -> {false, loaded};
+            {ok, true} -> true;
+            {ok, false} -> false;
+            {ok, Other} ->
+                erlang:error({"crypto fips_mode must be true or false, not",Other});
             undefined ->
-                %% We assume application crypto has a default value for fips_mode.
-                %% If undefined the application has not been loaded.
-                {false, unloaded}
+                erlang:error({"crypto fips_mode is undefined"})
         end,
     Status = case erlang:load_nif(Lib, {?CRYPTO_NIF_VSN,LibBin,FipsMode}) of
 		 ok -> ok;
@@ -4182,7 +4193,6 @@ on_load() ->
 	     end,
     case Status of
 	ok ->
-            warn_app_not_loaded_maybe(AppLoaded),
             ok;
 	{error, {E, Str}} ->
             Fmt = "Unable to load crypto library. Failed with error:~n\"~p, ~s\"~n~s",
@@ -4193,19 +4203,6 @@ on_load() ->
                     end,
 	    error_logger:error_msg(Fmt, [E,Str,Extra]),
 	    Status
-    end.
-
-warn_app_not_loaded_maybe(loaded) ->
-    ok;
-warn_app_not_loaded_maybe(unloaded) ->
-    %% For backward compatible reasons we allow application crypto
-    %% not being loaded.
-    case info_fips() of
-        not_enabled ->
-            logger:warning("Module 'crypto' loaded without application 'crypto' being loaded.\n"
-                           "Without application config 'fips_mode' loaded, FIPS mode is disabled by default.");
-        _ ->
-            ok
     end.
 
 path2bin(Path) when is_list(Path) ->


### PR DESCRIPTION
To ensure we pass correct `fips_mode` configuration parameter to NIF initialization.

- In `interactive` mode; auto load `crypto` _application_ if not already loaded.
- In `embedded` mode; check that boot script has loaded the _application._ If not, fail to boot.