### PR TITLE
crypto: Remove untested engine support on Windows

### DIFF
--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -384,7 +384,7 @@
 /* If OPENSSL_NO_EC is set, there will be an error in ec.h included from engine.h
    So if EC is disabled, you can't use Engine either....
 */
-#if !defined(OPENSSL_NO_ENGINE)
+#if !defined(OPENSSL_NO_ENGINE) && !defined(__WIN32__)
 # define HAS_ENGINE_SUPPORT
 #endif
 #endif


### PR DESCRIPTION
* Got crashes on Windows in ssl_engine_SUITE:private_key
* crypto engine_SUITE skipped for Windows since 2018
* Hopefully no one using engine on Windows