### PR TITLE
Rename the gen module to gen_gen and make it a behaviour

### DIFF
--- a/erts/test/erlc_SUITE_data/src/start_ok.script
+++ b/erts/test/erlc_SUITE_data/src/start_ok.script
@@ -1,3 +1,24 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2009-2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
 {script,{"OTP  APN 181 01","NT"},
  [{preLoaded,[init,erl_prim_loader]},
   {progress,preloaded},
@@ -27,7 +48,7 @@
 	     file,
 	     filename,
 	     os,
-	     gen,
+	     gen_gen,
 	     gen_event,
 	     gen_server,
 	     global,

--- a/lib/kernel/src/net_adm.erl
+++ b/lib/kernel/src/net_adm.erl
@@ -99,7 +99,7 @@ Sets up a connection to `Node`. Returns `pong` if it is successful, otherwise
       Node :: atom().
 
 ping(Node) when is_atom(Node) ->
-    case catch gen:call({net_kernel, Node},
+    case catch gen_gen:call({net_kernel, Node},
 			'$gen_call',
 			{is_auth, node()},
 			infinity) of

--- a/lib/kernel/test/pg_SUITE.erl
+++ b/lib/kernel/test/pg_SUITE.erl
@@ -756,7 +756,7 @@ second_monitor(Scope, Group, Control, SecondMonitor) ->
 second_monitor(Msgs) ->
     receive
         {'$gen_call', Reply, flush} ->
-            gen:reply(Reply, lists:reverse(Msgs));
+            gen_gen:reply(Reply, lists:reverse(Msgs));
         Msg ->
             second_monitor([Msg | Msgs])
     end.

--- a/lib/sasl/src/release_handler_1.erl
+++ b/lib/sasl/src/release_handler_1.erl
@@ -571,7 +571,7 @@ start(Procs) ->
 %%
 %%       A second case where this can occur is if a child spec is
 %%       incorrect and get_modules is called against a process that
-%%       can't respond to the gen:call. Again an error is logged,
+%%       can't respond to the gen_gen:call. Again an error is logged,
 %%       an error returned and a VM restart is issued.
 %%
 %% Returns: [{SuperPid, ChildName, ChildPid, Mods}]
@@ -676,7 +676,7 @@ get_proc_state(Proc) ->
     end.
 
 maybe_get_dynamic_mods(Name, Pid) ->
-    try gen:call(Pid, self(), get_modules) of
+    try gen_gen:call(Pid, self(), get_modules) of
         {ok, Res} ->
             Res
     catch

--- a/lib/sasl/src/systools_make.erl
+++ b/lib/sasl/src/systools_make.erl
@@ -1560,7 +1560,7 @@ mandatory_modules() ->
      filename,
      file_server,
      file_io_server,
-     gen,
+     gen_gen,
      gen_event,
      gen_server,
      heart,

--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -91,7 +91,7 @@ MODULES= \
 	filename \
 	gb_trees \
 	gb_sets \
-	gen \
+	gen_gen \
 	gen_event \
 	gen_fsm \
 	gen_server \

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -127,7 +127,7 @@ or if bad arguments are specified.
 
 %%%
 %%% NOTE: If init_ack() return values are modified, see comment
-%%%       above monitor_return() in gen.erl!
+%%%       above monitor_return() in gen_gen.erl!
 %%%
 
 -compile(nowarn_deprecated_catch).
@@ -146,8 +146,8 @@ or if bad arguments are specified.
          reqids_add/3, reqids_to_list/1,
          wake_hib/5]).
 
--export([init_it/6,
-	 system_continue/3,
+%% sys callbacks
+-export([system_continue/3,
 	 system_terminate/4,
 	 system_code_change/4,
 	 system_get_state/1,
@@ -155,6 +155,11 @@ or if bad arguments are specified.
 	 format_status/2]).
 
 -behaviour(sys).
+
+%% gen_gen callbacks
+-export([init_it/6]).
+
+%-behaviour(gen_gen).
 
 %% logger callback
 -export([format_log/1, format_log/2]).
@@ -577,7 +582,7 @@ The reference can be any of the following:
 -type start_mon_ret() :: {'ok', {pid(),reference()}} | {'error', term()}.
 
 -doc "An opaque request identifier. See `send_request/3` for details.".
--opaque request_id() :: gen:request_id().
+-opaque request_id() :: gen_gen:request_id().
 
 -doc """
 An opaque collection of request identifiers (`t:request_id/0`).
@@ -585,7 +590,7 @@ An opaque collection of request identifiers (`t:request_id/0`).
 Each request identifier can be associated with a label
 chosen by the user.  For more information see `reqids_new/0`.
 """.
--opaque request_id_collection() :: gen:request_id_collection().
+-opaque request_id_collection() :: gen_gen:request_id_collection().
 
 -doc """
 Response time-out for an asynchronous call.
@@ -639,7 +644,7 @@ Currently valid values:
 -doc(#{equiv => start([])}).
 -spec start() -> start_ret().
 start() ->
-    gen:start(?MODULE, nolink, ?NO_CALLBACK, [], []).
+    gen_gen:start(?MODULE, nolink, ?NO_CALLBACK, [], []).
 
 -doc """
 Create a stand-alone event manager process, possibly nameless.
@@ -655,9 +660,9 @@ For a description of the arguments and return values, see `start_link/2`.
 -spec start(EventMgrName :: emgr_name()) -> start_ret();
            (Options :: options()) -> start_ret().
 start(Name) when is_tuple(Name) ->
-    gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], []);
+    gen_gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], []);
 start(Options) when is_list(Options) ->
-    gen:start(?MODULE, nolink, ?NO_CALLBACK, [], Options);
+    gen_gen:start(?MODULE, nolink, ?NO_CALLBACK, [], Options);
 start(Arg) ->
     error(badarg, [Arg]).
 
@@ -672,14 +677,14 @@ For a description of the arguments and return values, see `start_link/2`.
 -doc(#{since => <<"OTP 20.0">>}).
 -spec start(EventMgrName :: emgr_name(), Options :: options()) -> start_ret().
 start(Name, Options) when is_tuple(Name), is_list(Options) ->
-    gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], Options);
+    gen_gen:start(?MODULE, nolink, Name, ?NO_CALLBACK, [], Options);
 start(Name, Options) ->
     error(badarg, [Name, Options]).
 
 -doc(#{equiv => start_link([])}).
 -spec start_link() -> start_ret().
 start_link() ->
-    gen:start(?MODULE, link, ?NO_CALLBACK, [], []).
+    gen_gen:start(?MODULE, link, ?NO_CALLBACK, [], []).
 
 -doc """
 Create an event manager process as part of a supervision tree,
@@ -696,9 +701,9 @@ For a description of the arguments and return values, see `start_link/2`.
 -spec start_link(EventMgrName :: emgr_name()) -> start_ret();
                 (Options :: options()) -> start_ret().
 start_link(Name) when is_tuple(Name) ->
-    gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], []);
+    gen_gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], []);
 start_link(Options) when is_list(Options) ->
-    gen:start(?MODULE, link, ?NO_CALLBACK, [], Options);
+    gen_gen:start(?MODULE, link, ?NO_CALLBACK, [], Options);
 start_link(Arg) ->
     error(badarg, [Arg]).
 
@@ -755,7 +760,7 @@ has been consumed.
 -doc(#{since => <<"OTP 20.0">>}).
 -spec start_link(EventMgrName :: emgr_name(), Options :: options()) -> start_ret().
 start_link(Name, Options) when is_tuple(Name), is_list(Options) ->
-    gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], Options);
+    gen_gen:start(?MODULE, link, Name, ?NO_CALLBACK, [], Options);
 start_link(Name, Options) ->
     error(badarg, [Name, Options]).
 
@@ -763,7 +768,7 @@ start_link(Name, Options) ->
 -doc(#{since => <<"OTP 23.0">>}).
 -spec start_monitor() -> start_mon_ret().
 start_monitor() ->
-    gen:start(?MODULE, monitor, ?NO_CALLBACK, [], []).
+    gen_gen:start(?MODULE, monitor, ?NO_CALLBACK, [], []).
 
 -doc """
 Creates a stand-alone event manager process,
@@ -781,9 +786,9 @@ see `start_monitor/2` and `start_link/1`.
 -doc(#{since => <<"OTP 23.0">>}).
 -spec start_monitor(EventMgrNameOrOptions :: emgr_name() | options()) -> start_mon_ret().
 start_monitor(Name) when is_tuple(Name) ->
-    gen:start(?MODULE, monitor, Name, ?NO_CALLBACK, [], []);
+    gen_gen:start(?MODULE, monitor, Name, ?NO_CALLBACK, [], []);
 start_monitor(Options) when is_list(Options) ->
-    gen:start(?MODULE, monitor, ?NO_CALLBACK, [], Options);
+    gen_gen:start(?MODULE, monitor, ?NO_CALLBACK, [], Options);
 start_monitor(Arg) ->
     error(badarg, [Arg]).
 
@@ -807,7 +812,7 @@ from the message queue.
 -doc(#{since => <<"OTP 23.0">>}).
 -spec start_monitor(EventMgtName :: emgr_name(), Options :: options()) -> start_mon_ret().
 start_monitor(Name, Options) when is_tuple(Name), is_list(Options) ->
-    gen:start(?MODULE, monitor, Name, ?NO_CALLBACK, [], Options);
+    gen_gen:start(?MODULE, monitor, Name, ?NO_CALLBACK, [], Options);
 start_monitor(Name, Options) ->
     error(badarg, [Name, Options]).
 
@@ -817,9 +822,9 @@ init_it(Starter, self, Name, Mod, Args, Options) ->
     init_it(Starter, self(), Name, Mod, Args, Options);
 init_it(Starter, Parent, Name0, _, _, Options) ->
     process_flag(trap_exit, true),
-    Name = gen:name(Name0),
-    Debug = gen:debug_options(Name, Options),
-	HibernateAfterTimeout = gen:hibernate_after(Options),
+    Name = gen_gen:name(Name0),
+    Debug = gen_gen:debug_options(Name, Options),
+    HibernateAfterTimeout = gen_gen:hibernate_after(Options),
     proc_lib:init_ack(Starter, {ok, self()}),
     loop(Parent, Name, [], HibernateAfterTimeout, Debug, false).
 
@@ -986,7 +991,7 @@ to handle the request.
           ReqId::request_id().
 send_request(M, Handler, Request) ->
     try
-        gen:send_request(M, self(), {call, Handler, Request})
+        gen_gen:send_request(M, self(), {call, Handler, Request})
     catch
         error:badarg ->
             error(badarg, [M, Handler, Request])
@@ -1020,7 +1025,7 @@ but slightly more efficient.
           NewReqIdCollection::request_id_collection().
 send_request(M, Handler, Request, Label, ReqIdCol) ->
     try
-        gen:send_request(M, self(), {call, Handler, Request}, Label, ReqIdCol)
+        gen_gen:send_request(M, self(), {call, Handler, Request}, Label, ReqIdCol)
     catch
         error:badarg ->
             error(badarg, [M, Handler, Request, Label, ReqIdCol])
@@ -1062,7 +1067,7 @@ while [`wait_response/2`](`wait_response/2`) does not.
       Result :: Response | 'timeout'.
 
 wait_response(ReqId, WaitTime) ->
-    try gen:wait_response(ReqId, WaitTime) of
+    try gen_gen:wait_response(ReqId, WaitTime) of
         {reply, {error, _} = Err} -> Err;
         Return -> Return
     catch
@@ -1137,7 +1142,7 @@ and then return `timeout`.
                 'timeout'.
 
 wait_response(ReqIdCol, WaitTime, Delete) ->
-    try gen:wait_response(ReqIdCol, WaitTime, Delete) of
+    try gen_gen:wait_response(ReqIdCol, WaitTime, Delete) of
         {{reply, {error, _} = Err}, Label, NewReqIdCol} ->
             {Err, Label, NewReqIdCol};
         Return ->
@@ -1186,7 +1191,7 @@ while [`wait_response/2`](`wait_response/2`) does not.
       Result :: Response | 'timeout'.
 
 receive_response(ReqId, Timeout) ->
-    try gen:receive_response(ReqId, Timeout) of
+    try gen_gen:receive_response(ReqId, Timeout) of
         {reply, {error, _} = Err} -> Err;
         Return -> Return
     catch
@@ -1263,7 +1268,7 @@ and then return `timeout`.
                 'timeout'.
 
 receive_response(ReqIdCol, Timeout, Delete) ->
-    try gen:receive_response(ReqIdCol, Timeout, Delete) of
+    try gen_gen:receive_response(ReqIdCol, Timeout, Delete) of
         {{reply, {error, _} = Err}, Label, NewReqIdCol} ->
             {Err, Label, NewReqIdCol};
         Return ->
@@ -1302,7 +1307,7 @@ that is; `Msg` reports the server's death, this function returns
       Result :: Response | 'no_reply'.
 
 check_response(Msg, ReqId) ->
-    try gen:check_response(Msg, ReqId) of
+    try gen_gen:check_response(Msg, ReqId) of
         {reply, {error, _} = Err} -> Err;
         Return -> Return
     catch
@@ -1369,7 +1374,7 @@ it will always return `no_reply`.
                 'no_reply'.
 
 check_response(Msg, ReqIdCol, Delete) ->
-    try gen:check_response(Msg, ReqIdCol, Delete) of
+    try gen_gen:check_response(Msg, ReqIdCol, Delete) of
         {{reply, {error, _} = Err}, Label, NewReqIdCol} ->
             {Err, Label, NewReqIdCol};
         Return ->
@@ -1401,7 +1406,7 @@ request identifiers in a collection.
           NewReqIdCollection::request_id_collection().
 
 reqids_new() ->
-    gen:reqids_new().
+    gen_gen:reqids_new().
 
 -doc "Returns the number of request identifiers in `ReqIdCollection`.".
 -doc(#{since => <<"OTP 25.0">>}).
@@ -1410,7 +1415,7 @@ reqids_new() ->
 
 reqids_size(ReqIdCollection) ->
     try
-        gen:reqids_size(ReqIdCollection)
+        gen_gen:reqids_size(ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqIdCollection])
     end.
@@ -1429,7 +1434,7 @@ the resulting request identifier collection.
 
 reqids_add(ReqId, Label, ReqIdCollection) ->
     try
-        gen:reqids_add(ReqId, Label, ReqIdCollection)
+        gen_gen:reqids_add(ReqId, Label, ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqId, Label, ReqIdCollection])
     end.
@@ -1447,7 +1452,7 @@ in [`ReqIdCollection`](`t:request_id_collection/0`).
 
 reqids_to_list(ReqIdCollection) ->
     try
-        gen:reqids_to_list(ReqIdCollection)
+        gen_gen:reqids_to_list(ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqIdCollection])
     end.
@@ -1541,7 +1546,7 @@ which_handlers(M) -> rpc(M, which_handlers).
 -doc(#{equiv => stop(EventMgrRef, normal, infinity)}).
 -spec stop(EventMgrRef :: emgr_ref()) -> 'ok'.
 stop(M) ->
-    gen:stop(M).
+    gen_gen:stop(M).
 
 -doc """
 Stop an event manager.
@@ -1570,15 +1575,15 @@ to the remote `Node` where the server runs.
 -doc(#{since => <<"OTP 18.0">>}).
 -spec stop(EventMgrRef :: emgr_ref(), Reason :: term(), Timeout :: timeout()) -> 'ok'.
 stop(M, Reason, Timeout) ->
-    gen:stop(M, Reason, Timeout).
+    gen_gen:stop(M, Reason, Timeout).
 
 rpc(M, Cmd) ->
-    {ok, Reply} = gen:call(M, self(), Cmd, infinity),
+    {ok, Reply} = gen_gen:call(M, self(), Cmd, infinity),
     Reply.
 
 call1(M, Handler, Query) ->
     Cmd = {call, Handler, Query},
-    try gen:call(M, self(), Cmd) of
+    try gen_gen:call(M, self(), Cmd) of
 	{ok, Res} ->
 	    Res
     catch
@@ -1588,7 +1593,7 @@ call1(M, Handler, Query) ->
 
 call1(M, Handler, Query, Timeout) ->
     Cmd = {call, Handler, Query},
-    try gen:call(M, self(), Cmd, Timeout) of
+    try gen_gen:call(M, self(), Cmd, Timeout) of
 	{ok, Res} ->
 	    Res
     catch
@@ -1698,7 +1703,7 @@ terminate_server(Reason, Parent, MSL, ServerName) ->
     exit(Reason).
 
 reply(From, Reply) ->
-    gen:reply(From, Reply).
+    gen_gen:reply(From, Reply).
 
 %% unlink the supervisor process of all supervised handlers.
 %% We do not want a handler supervisor to EXIT due to the
@@ -2109,7 +2114,7 @@ report_error(Handler, Exit, State, LastIn, SName) ->
             R ->
                 {R, fun(Reason) -> Reason end}
         end,
-    Status = gen:format_status(
+    Status = gen_gen:format_status(
                Handler#handler.module,
                terminate,
                #{ state => State,
@@ -2348,11 +2353,11 @@ get_modules(MSL) ->
 -doc false.
 format_status(Opt, StatusData) ->
     [PDict, SysState, Parent, Debug, [ServerName, MSL, _HibernateAfterTimeout, _Hib]] = StatusData,
-    Header = gen:format_status_header("Status for event handler", ServerName),
+    Header = gen_gen:format_status_header("Status for event handler", ServerName),
     {FmtMSL, Logs} =
         lists:mapfoldl(
           fun(#handler{module = Mod, state = State} = MS, Logs) ->
-                  Status = gen:format_status(
+                  Status = gen_gen:format_status(
                              Mod, Opt, #{ log => Logs, state => State },
                              [PDict, State]),
                   {MS#handler{state=maps:get('$status',Status,maps:get(state,Status))},

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -373,14 +373,20 @@ that implements the state machine.
 	 start_timer/2,send_event_after/2,cancel_timer/1,
 	 enter_loop/4, enter_loop/5, enter_loop/6, wake_hib/7]).
 
-%% Internal exports
--export([init_it/6,
-	 system_continue/3,
+%% sys callbacks
+-export([system_continue/3,
 	 system_terminate/4,
 	 system_code_change/4,
 	 system_get_state/1,
 	 system_replace_state/2,
 	 format_status/2]).
+
+-behaviour(sys).
+
+%% gen_gen callbacks
+-export([init_it/6]).
+
+%-behaviour(gen_gen).
 
 %% logger callback
 -export([format_log/1, format_log/2]).
@@ -769,7 +775,7 @@ that large state terms are printed in log files.
 
 To be used when starting a `gen_fsm`. See `start_link/4`.
 """.
--type fsm_name() :: % Duplicate of gen:emgr_name()
+-type fsm_name() :: % Duplicate of gen_gen:emgr_name()
         {'local', LocalName :: atom()}
       | {'global', GlobalName :: term()}
       | {'via', RegMod :: module(), ViaName :: term()}.
@@ -779,7 +785,7 @@ To be used when starting a `gen_fsm`. See `start_link/4`.
 
 To be used in for example `send_event/2` to specify the server.
 """.
--type fsm_ref() :: % What gen:call/3,4 and gen:stop/1,3 accepts
+-type fsm_ref() :: % What gen_gen:call/3,4 and gen_gen:stop/1,3 accepts
         pid()
       | (LocalName :: atom())
       | {Name :: atom(), Node :: atom()}
@@ -793,7 +799,7 @@ and [`start_link/3,4`](`start_link/3`) functions.
 
 See `start_link/4`.
 """.
--type start_opt() :: % Duplicate of gen:option()
+-type start_opt() :: % Duplicate of gen_gen:option()
         {'timeout', Time :: timeout()}
       | {'spawn_opt', [proc_lib:start_spawn_option()]}
       | enter_loop_opt().
@@ -806,7 +812,7 @@ and [`start_link/3,4`](`start_link/3`) functions.
 
 See `start_link/4`.
 """.
--type enter_loop_opt() :: % Some gen:option()s works for enter_loop/*
+-type enter_loop_opt() :: % Some gen_gen:option()s works for enter_loop/*
       {'debug', Dbgs :: [sys:debug_option()]}.
 
 
@@ -844,7 +850,7 @@ see [`start_link/3,4`](`start_link/3`).
       Pid     :: pid(),
       Reason  :: term().
 start(Mod, Args, Options) ->
-    gen:start(?MODULE, nolink, Mod, Args, Options).
+    gen_gen:start(?MODULE, nolink, Mod, Args, Options).
 
 -doc """
 Create a standalone `gen_fsm` process.
@@ -864,7 +870,7 @@ see [`start_link/3,4`](`start_link/4`).
       Pid     :: pid(),
       Reason  :: {'already_started', Pid} | term().
 start(Name, Mod, Args, Options) ->
-    gen:start(?MODULE, nolink, Name, Mod, Args, Options).
+    gen_gen:start(?MODULE, nolink, Name, Mod, Args, Options).
 
 -doc """
 Create a `gen_fsm` process in a supervision tree, not registered.
@@ -880,7 +886,7 @@ without registering a `Name`.
       Pid     :: pid(),
       Reason  :: term().
 start_link(Mod, Args, Options) ->
-    gen:start(?MODULE, link, Mod, Args, Options).
+    gen_gen:start(?MODULE, link, Mod, Args, Options).
 
 -doc """
 Create a `gen_fsm` process in a supervision tree.
@@ -952,13 +958,13 @@ or `ignore`, the process is terminated and the function returns
       Pid     :: pid(),
       Reason  :: {'already_started', Pid} | term().
 start_link(Name, Mod, Args, Options) ->
-    gen:start(?MODULE, link, Name, Mod, Args, Options).
+    gen_gen:start(?MODULE, link, Name, Mod, Args, Options).
 
 -doc #{ equiv => stop(FsmRef, normal, infinity) }.
 -spec stop(FsmRef) -> ok when
       FsmRef :: fsm_ref().
 stop(Name) ->
-    gen:stop(Name).
+    gen_gen:stop(Name).
 
 -doc """
 Synchronously stop a generic FSM.
@@ -985,7 +991,7 @@ If the process does not exist, a `noproc` exception is raised.
       Reason :: term(),
       Timeout :: timeout().
 stop(Name, Reason, Timeout) ->
-    gen:stop(Name, Reason, Timeout).
+    gen_gen:stop(Name, Reason, Timeout).
 
 -doc """
 Send an event asynchronously to a generic FSM.
@@ -1029,7 +1035,7 @@ send_event(Name, Event) ->
       Event  :: term(),
       Reply  :: term().
 sync_send_event(Name, Event) ->
-    case catch gen:call(Name, '$gen_sync_event', Event) of
+    case catch gen_gen:call(Name, '$gen_sync_event', Event) of
 	{ok,Res} ->
 	    Res;
 	{'EXIT',Reason} ->
@@ -1066,7 +1072,7 @@ Return value `Reply` is defined in the return value of
       Timeout :: timeout(),
       Reply   :: term().
 sync_send_event(Name, Event, Timeout) ->
-    case catch gen:call(Name, '$gen_sync_event', Event, Timeout) of
+    case catch gen_gen:call(Name, '$gen_sync_event', Event, Timeout) of
 	{ok,Res} ->
 	    Res;
 	{'EXIT',Reason} ->
@@ -1108,7 +1114,7 @@ send_all_state_event(Name, Event) ->
       Event  :: term(),
       Reply  :: term().
 sync_send_all_state_event(Name, Event) ->
-    case catch gen:call(Name, '$gen_sync_all_state_event', Event) of
+    case catch gen_gen:call(Name, '$gen_sync_all_state_event', Event) of
 	{ok,Res} ->
 	    Res;
 	{'EXIT',Reason} ->
@@ -1135,7 +1141,7 @@ and `sync_send_all_state_event`, see `send_all_state_event/2`.
       Timeout :: timeout(),
       Reply   :: term().
 sync_send_all_state_event(Name, Event, Timeout) ->
-    case catch gen:call(Name, '$gen_sync_all_state_event', Event, Timeout) of
+    case catch gen_gen:call(Name, '$gen_sync_all_state_event', Event, Timeout) of
 	{ok,Res} ->
 	    Res;
 	{'EXIT',Reason} ->
@@ -1320,10 +1326,10 @@ according to `FsmName`.
       FsmName   :: fsm_name() | pid(),
       Timeout   :: timeout().
 enter_loop(Mod, Options, StateName, StateData, ServerName, Timeout) ->
-    Name = gen:get_proc_name(ServerName),
-    Parent = gen:get_parent(),
-    Debug = gen:debug_options(Name, Options),
-	HibernateAfterTimeout = gen:hibernate_after(Options),
+    Name = gen_gen:get_proc_name(ServerName),
+    Parent = gen_gen:get_parent(),
+    Debug = gen_gen:debug_options(Name, Options),
+    HibernateAfterTimeout = gen_gen:hibernate_after(Options),
     loop(Parent, Name, StateName, StateData, Mod, Timeout, HibernateAfterTimeout, Debug).
 
 %%% ---------------------------------------------------
@@ -1337,9 +1343,9 @@ enter_loop(Mod, Options, StateName, StateData, ServerName, Timeout) ->
 init_it(Starter, self, Name, Mod, Args, Options) ->
     init_it(Starter, self(), Name, Mod, Args, Options);
 init_it(Starter, Parent, Name0, Mod, Args, Options) ->
-    Name = gen:name(Name0),
-    Debug = gen:debug_options(Name, Options),
-    HibernateAfterTimeout = gen:hibernate_after(Options),
+    Name = gen_gen:name(Name0),
+    Debug = gen_gen:debug_options(Name, Options),
+    HibernateAfterTimeout = gen_gen:hibernate_after(Options),
     case catch Mod:init(Args) of
 	{ok, StateName, StateData} ->
 	    proc_lib:init_ack(Starter, {ok, self()}),
@@ -1348,13 +1354,13 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	    proc_lib:init_ack(Starter, {ok, self()}),
 	    loop(Parent, Name, StateName, StateData, Mod, Timeout, HibernateAfterTimeout, Debug);
 	{stop, Reason} ->
-            gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
             exit(Reason);
 	ignore ->
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
 	    proc_lib:init_fail(Starter, ignore, {exit, normal});
 	{'EXIT', Reason} ->
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
             exit(Reason);
 	Else ->
 	    Reason = {bad_return_value, Else},
@@ -1599,7 +1605,7 @@ Return value `Result` is not further defined, and is always to be ignored.
       Reply  :: term(),
       Result :: term().
 reply(From, Reply) ->
-    gen:reply(From, Reply).
+    gen_gen:reply(From, Reply).
 
 reply(Name, From, Reply, Debug, StateName) ->
     reply(From, Reply),
@@ -1955,7 +1961,7 @@ mod(_) -> "t".
 format_status(Opt, StatusData) ->
     [PDict, SysState, Parent, Debug, [Name, StateName, StateData, Mod, _Time, _HibernateAfterTimeout]] =
 	StatusData,
-    Header = gen:format_status_header("Status for state machine",
+    Header = gen_gen:format_status_header("Status for state machine",
                                       Name),
     Log = sys:get_log(Debug),
     Specific =

--- a/lib/stdlib/src/gen_gen.erl
+++ b/lib/stdlib/src/gen_gen.erl
@@ -19,7 +19,7 @@
 %%
 %% %CopyrightEnd%
 %%
--module(gen).
+-module(gen_gen).
 -moduledoc false.
 -compile({inline,[get_node/1]}).
 
@@ -49,6 +49,15 @@
 -define(default_timeout, 5000).
 
 -include("logger.hrl").
+
+-doc "Initialization callback for the gen_gen behaviour.".
+-callback init_it(Starter, Parent, Name, Module, Args, Options) -> ok when
+      Starter :: pid(),
+      Parent :: pid() | 'self',
+      Name :: term(),
+      Module :: module(),
+      Args :: term(),
+      Options :: [option()].
 
 %%-----------------------------------------------------------------
 

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -114,7 +114,7 @@ using exit signals.
 
 %%%
 %%% NOTE: If init_ack() return values are modified, see comment
-%%%       above monitor_return() in gen.erl!
+%%%       above monitor_return() in gen_gen.erl!
 %%%
 
 %%% ---------------------------------------------------
@@ -202,7 +202,7 @@ using exit signals.
 	 multi_call/2, multi_call/3, multi_call/4,
 	 enter_loop/3, enter_loop/4, enter_loop/5]).
 
-%% System exports
+%% sys callbacks
 -export([system_continue/3,
 	 system_terminate/4,
 	 system_code_change/4,
@@ -212,11 +212,13 @@ using exit signals.
 
 -behaviour(sys).
 
+%% gen_gen callbacks
+-export([init_it/6]).
+
+%-behaviour(gen_gen).
+
 %% logger callback
 -export([format_log/1, format_log/2]).
-
-%% Internal exports
--export([init_it/6]).
 
 -include("logger.hrl").
 
@@ -756,10 +758,10 @@ that has called the `gen_server` using [`call/2,3`](`call/2`).
 -type from() ::	{Client :: pid(), Tag :: reply_tag()}.
 
 -doc "A handle that associates a reply to the corresponding request.".
--opaque reply_tag() :: gen:reply_tag().
+-opaque reply_tag() :: gen_gen:reply_tag().
 
 -doc "An opaque request identifier. See `send_request/2` for details.".
--opaque request_id() :: gen:request_id().
+-opaque request_id() :: gen_gen:request_id().
 
 -doc """
 An opaque collection of request identifiers (`t:request_id/0`).
@@ -767,7 +769,7 @@ An opaque collection of request identifiers (`t:request_id/0`).
 Each request identifier can be associated with a label
 chosen by the user.  For more information see `reqids_new/0`.
 """.
--opaque request_id_collection() :: gen:request_id_collection().
+-opaque request_id_collection() :: gen_gen:request_id_collection().
 
 -doc """
 Response time-out for an asynchronous call.
@@ -838,7 +840,7 @@ To be used when starting a `gen_server`.  See functions
   Thus, `{via, global, GlobalName}` is a valid reference
   equivalent to `{global, GlobalName}`.
 """.
--type server_name() :: % Duplicate of gen:emgr_name()
+-type server_name() :: % Duplicate of gen_gen:emgr_name()
         {'local', LocalName :: atom()}
       | {'global', GlobalName :: term()}
       | {'via', RegMod :: module(), ViaName :: term()}.
@@ -867,7 +869,7 @@ It can be:
   in an alternative process registry.  See the same term
   described for `t:server_name/0`.
 """.
--type server_ref() :: % What gen:call/3,4 and gen:stop/1,3 accepts
+-type server_ref() :: % What gen_gen:call/3,4 and gen_gen:stop/1,3 accepts
         pid()
       | (LocalName :: atom())
       | {Name :: atom(), Node :: atom()}
@@ -897,7 +899,7 @@ for example, [`start_link/3,4`](`start_link/4`).
   below for more start options that are also allowed
   by [`enter_loop/3,4,5`](`enter_loop/3`).
 """.
--type start_opt() :: % Duplicate of gen:option()
+-type start_opt() :: % Duplicate of gen_gen:option()
         {'timeout', Timeout :: timeout()}
       | {'spawn_opt', SpawnOptions :: [proc_lib:start_spawn_option()]}
       | enter_loop_opt().
@@ -918,7 +920,7 @@ Options that can be used when starting a `gen_server` server through
 - **`{debug, Dbgs}`** - For every entry in `Dbgs`,
   the corresponding function in `m:sys` is called.
 """.
--type enter_loop_opt() :: % Some gen:option()s works for enter_loop/*
+-type enter_loop_opt() :: % Some gen_gen:option()s works for enter_loop/*
 	{'hibernate_after', HibernateAfterTimeout :: timeout()}
       | {'debug', Dbgs :: [sys:debug_option()]}.
 
@@ -949,7 +951,7 @@ Return value from the [`start/3,4`](`start/3`) and
 See [`Module:init/1`](`c:init/1`) about the exit reason
 for the `gen_server` process when it fails to initialize.
 """.
--type start_ret() :: % gen:start_ret() without monitor return
+-type start_ret() :: % gen_gen:start_ret() without monitor return
         {'ok', Pid :: pid()}
       | 'ignore'
       | {'error', Reason :: term()}.
@@ -961,7 +963,7 @@ The same as type `t:start_ret/0` except that for a succesful start
 it returns both the process identifier `Pid`
 and a [`monitor/2,3`](`erlang:monitor/2`) [`MonRef`](`t:reference/0`).
 """.
--type start_mon_ret() :: % gen:start_ret() with only monitor return
+-type start_mon_ret() :: % gen_gen:start_ret() with only monitor return
         {'ok', {Pid :: pid(), MonRef :: reference()}}
       | 'ignore'
       | {'error', Reason :: term()}.
@@ -983,7 +985,7 @@ registered with any [name service](`t:server_name/0`).
 %%
 start(Module, Args, Options)
   when is_atom(Module), is_list(Options) ->
-    gen:start(?MODULE, nolink, Module, Args, Options);
+    gen_gen:start(?MODULE, nolink, Module, Args, Options);
 start(Module, Args, Options) ->
     error(badarg, [Module, Args, Options]).
 
@@ -1006,7 +1008,7 @@ Other than that see `start_link/4`.
 %%
 start(ServerName, Module, Args, Options)
   when is_tuple(ServerName), is_atom(Module), is_list(Options) ->
-    gen:start(?MODULE, nolink, ServerName, Module, Args, Options);
+    gen_gen:start(?MODULE, nolink, ServerName, Module, Args, Options);
 start(ServerName, Module, Args, Options) ->
     error(badarg, [ServerName, Module, Args, Options]).
 
@@ -1025,7 +1027,7 @@ not registered with any [name service](`t:server_name/0`).
 %%
 start_link(Module, Args, Options)
   when is_atom(Module), is_list(Options) ->
-    gen:start(?MODULE, link, Module, Args, Options);
+    gen_gen:start(?MODULE, link, Module, Args, Options);
 start_link(Module, Args, Options) ->
     error(badarg, [Module, Args, Options]).
 
@@ -1095,7 +1097,7 @@ with reason `normal`.
 %%
 start_link(ServerName, Module, Args, Options)
   when is_tuple(ServerName), is_atom(Module), is_list(Options) ->
-    gen:start(?MODULE, link, ServerName, Module, Args, Options);
+    gen_gen:start(?MODULE, link, ServerName, Module, Args, Options);
 start_link(ServerName, Module, Args, Options) ->
     error(badarg, [ServerName, Module, Args, Options]).
 
@@ -1115,7 +1117,7 @@ is not registered with any [name service](`t:server_name/0`).
 %%
 start_monitor(Module, Args, Options)
   when is_atom(Module), is_list(Options) ->
-    gen:start(?MODULE, monitor, Module, Args, Options);
+    gen_gen:start(?MODULE, monitor, Module, Args, Options);
 start_monitor(Module, Args, Options) ->
     error(badarg, [Module, Args, Options]).
 
@@ -1146,7 +1148,7 @@ and removed from the message queue.
 %%
 start_monitor(ServerName, Module, Args, Options)
   when is_tuple(ServerName), is_atom(Module), is_list(Options) ->
-    gen:start(?MODULE, monitor, ServerName, Module, Args, Options);
+    gen_gen:start(?MODULE, monitor, ServerName, Module, Args, Options);
 start_monitor(ServerName, Module, Args, Options) ->
     error(badarg, [ServerName, Module, Args, Options]).
 
@@ -1164,7 +1166,7 @@ start_monitor(ServerName, Module, Args, Options) ->
        ) -> ok.
 %%
 stop(ServerRef) ->
-    gen:stop(ServerRef).
+    gen_gen:stop(ServerRef).
 
 -doc """
 Stop a server.
@@ -1196,7 +1198,7 @@ if the connection fails to the remote `Node` where the server runs.
        ) -> ok.
 %%
 stop(ServerRef, Reason, Timeout) ->
-    gen:stop(ServerRef, Reason, Timeout).
+    gen_gen:stop(ServerRef, Reason, Timeout).
 
 %% -----------------------------------------------------------------
 %% Make a call to a generic server.
@@ -1214,7 +1216,7 @@ stop(ServerRef, Reason, Timeout) ->
                   Reply :: term().
 %%
 call(ServerRef, Request) ->
-    case catch gen:call(ServerRef, '$gen_call', Request) of
+    case catch gen_gen:call(ServerRef, '$gen_call', Request) of
 	{ok,Res} ->
 	    Res;
 	{'EXIT',Reason} ->
@@ -1294,7 +1296,7 @@ and `Reason` can be (at least) one of:
                   Reply :: term().
 %%
 call(ServerRef, Request, Timeout) ->
-    case catch gen:call(ServerRef, '$gen_call', Request, Timeout) of
+    case catch gen_gen:call(ServerRef, '$gen_call', Request, Timeout) of
 	{ok,Res} ->
 	    Res;
 	{'EXIT',Reason} ->
@@ -1344,7 +1346,7 @@ See the type `t:server_ref/0` for the possible values for `ServerRef`.
 
 send_request(ServerRef, Request) ->
     try
-        gen:send_request(ServerRef, '$gen_call', Request)
+        gen_gen:send_request(ServerRef, '$gen_call', Request)
     catch
         error:badarg ->
             error(badarg, [ServerRef, Request])
@@ -1375,7 +1377,7 @@ but slightly more efficient.
 
 send_request(ServerRef, Request, Label, ReqIdCol) ->
     try
-        gen:send_request(ServerRef, '$gen_call', Request, Label, ReqIdCol)
+        gen_gen:send_request(ServerRef, '$gen_call', Request, Label, ReqIdCol)
     catch
         error:badarg ->
             error(badarg, [ServerRef, Request, Label, ReqIdCol])
@@ -1414,7 +1416,7 @@ while [`wait_response/2`](`wait_response/2`) does not.
 
 wait_response(ReqId, WaitTime) ->
     try
-        gen:wait_response(ReqId, WaitTime)
+        gen_gen:wait_response(ReqId, WaitTime)
     catch
         error:badarg ->
             error(badarg, [ReqId, WaitTime])
@@ -1488,7 +1490,7 @@ and then return `timeout`.
 
 wait_response(ReqIdCol, WaitTime, Delete) ->
     try
-        gen:wait_response(ReqIdCol, WaitTime, Delete)
+        gen_gen:wait_response(ReqIdCol, WaitTime, Delete)
     catch
         error:badarg ->
             error(badarg, [ReqIdCol, WaitTime, Delete])
@@ -1530,7 +1532,7 @@ while `wait_response/2` does not.
 
 receive_response(ReqId, Timeout) ->
     try
-        gen:receive_response(ReqId, Timeout)
+        gen_gen:receive_response(ReqId, Timeout)
     catch
         error:badarg ->
             error(badarg, [ReqId, Timeout])
@@ -1606,7 +1608,7 @@ and then return `timeout`.
 
 receive_response(ReqIdCol, Timeout, Delete) ->
     try
-        gen:receive_response(ReqIdCol, Timeout, Delete)
+        gen_gen:receive_response(ReqIdCol, Timeout, Delete)
     catch
         error:badarg ->
             error(badarg, [ReqIdCol, Timeout, Delete])
@@ -1641,7 +1643,7 @@ this function returns an `error` return with the exit `Reason`.
 
 check_response(Msg, ReqId) ->
     try
-        gen:check_response(Msg, ReqId)
+        gen_gen:check_response(Msg, ReqId)
     catch
         error:badarg ->
             error(badarg, [Msg, ReqId])
@@ -1706,7 +1708,7 @@ this function, it will always return `no_reply`.
 
 check_response(Msg, ReqIdCol, Delete) ->
     try
-        gen:check_response(Msg, ReqIdCol, Delete)
+        gen_gen:check_response(Msg, ReqIdCol, Delete)
     catch
         error:badarg ->
             error(badarg, [Msg, ReqIdCol, Delete])
@@ -1734,7 +1736,7 @@ request identifiers in a collection.
           NewReqIdCollection::request_id_collection().
 
 reqids_new() ->
-    gen:reqids_new().
+    gen_gen:reqids_new().
 
 -doc "Returns the number of request identifiers in `ReqIdCollection`.".
 -doc(#{since => <<"OTP 25.0">>}).
@@ -1743,7 +1745,7 @@ reqids_new() ->
 
 reqids_size(ReqIdCollection) ->
     try
-        gen:reqids_size(ReqIdCollection)
+        gen_gen:reqids_size(ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqIdCollection])
     end.
@@ -1762,7 +1764,7 @@ the resulting request identifier collection.
 
 reqids_add(ReqId, Label, ReqIdCollection) ->
     try
-        gen:reqids_add(ReqId, Label, ReqIdCollection)
+        gen_gen:reqids_add(ReqId, Label, ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqId, Label, ReqIdCollection])
     end.
@@ -1780,7 +1782,7 @@ in [`ReqIdCollection`](`t:request_id_collection/0`).
 
 reqids_to_list(ReqIdCollection) ->
     try
-        gen:reqids_to_list(ReqIdCollection)
+        gen_gen:reqids_to_list(ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqIdCollection])
     end.
@@ -1848,7 +1850,7 @@ as the return value of `call/2,3` or `multi_call/2,3,4`.
                    ok.
 %%
 reply(Client, Reply) ->
-    gen:reply(Client, Reply).
+    gen_gen:reply(Client, Reply).
 
 %% -----------------------------------------------------------------
 %% Asynchronous broadcast, returns nothing, it's just send 'n' pray
@@ -2205,14 +2207,14 @@ according to `ServerName`.
 %%
 enter_loop(Mod, Options, State, ServerName, Action)
   when is_atom(Mod), is_list(Options) ->
-    Name = gen:get_proc_name(ServerName),
-    ServerData = server_data(gen:get_parent(), Name, Mod, gen:hibernate_after(Options)),
+    Name = gen_gen:get_proc_name(ServerName),
+    ServerData = server_data(gen_gen:get_parent(), Name, Mod, gen_gen:hibernate_after(Options)),
     case handle_action(ServerData, Action) of
         error ->
-            gen:unregister_name(Name),
+            gen_gen:unregister_name(Name),
             exit({bad_action, Action});
         LoopAction ->
-            loop(ServerData, State, LoopAction, gen:debug_options(Name, Options))
+            loop(ServerData, State, LoopAction, gen_gen:debug_options(Name, Options))
     end.
 
 %%%========================================================================
@@ -2230,9 +2232,9 @@ enter_loop(Mod, Options, State, ServerName, Action)
 init_it(Starter, self, Name, Mod, Args, Options) ->
     init_it(Starter, self(), Name, Mod, Args, Options);
 init_it(Starter, Parent, Name0, Mod, Args, Options) ->
-    Name = gen:name(Name0),
-    ServerData = server_data(Parent, Name, Mod, gen:hibernate_after(Options)),
-    Debug = gen:debug_options(Name, Options),
+    Name = gen_gen:name(Name0),
+    ServerData = server_data(Parent, Name, Mod, gen_gen:hibernate_after(Options)),
+    Debug = gen_gen:debug_options(Name, Options),
     case init_it(Mod, Args) of
 	{ok, {ok, State}} ->
 	    proc_lib:init_ack(Starter, {ok, self()}),
@@ -2240,7 +2242,7 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	{ok, {ok, State, Action} = Return} ->
             case handle_action(ServerData, Action) of
 		error ->
-		    gen:unregister_name(Name0),
+                    gen_gen:unregister_name(Name0),
 		    exit({bad_return_value, Return});
                 LoopAction ->
                     proc_lib:init_ack(Starter, {ok, self()}),
@@ -2253,22 +2255,22 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
 	    %% (Otherwise, the parent process could get
 	    %% an 'already_started' error if it immediately
 	    %% tried starting the process again.)
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
             exit(Reason);
 	{ok, {error, _Reason} = ERROR} ->
             %% The point of this clause is that we shall have a silent/graceful
             %% termination. The error reason will be returned to the
             %% 'Starter' ({error, Reason}), but *no* crash report.
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
 	    proc_lib:init_fail(Starter, ERROR, {exit, normal});
 	{ok, ignore} ->
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
             proc_lib:init_fail(Starter, ignore, {exit, normal});
 	{ok, Else} ->
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
             exit({bad_return_value, Else});
 	{'EXIT', Class, Reason, Stacktrace} ->
-	    gen:unregister_name(Name0),
+            gen_gen:unregister_name(Name0),
             erlang:raise(Class, Reason, Stacktrace)
     end.
 init_it(Mod, Args) ->
@@ -2765,7 +2767,7 @@ error_info(#server_data{name = application_controller}, _State, _Msg, _From, _Re
 error_info(#server_data{name = Name, module = Mod}, State, Msg, From, Reason, ST, Debug) ->
     Log = sys:get_log(Debug),
     Status =
-        gen:format_status(Mod, terminate,
+        gen_gen:format_status(Mod, terminate,
                           #{ reason => Reason,
                              state => State,
                              message => Msg,
@@ -3080,9 +3082,9 @@ mod(_) -> "t".
 -doc false.
 format_status(Opt, StatusData) ->
     [PDict, SysState, Parent, Debug, [#server_data{parent=Parent, name=Name, module=Mod}, State, _Timer, _Hib]] = StatusData,
-    Header = gen:format_status_header("Status for generic server", Name),
+    Header = gen_gen:format_status_header("Status for generic server", Name),
     Status =
-        case gen:format_status(Mod, Opt, #{ state => State, log => sys:get_log(Debug) },
+        case gen_gen:format_status(Mod, Opt, #{ state => State, log => sys:get_log(Debug) },
                                [PDict, State]) of
             #{ 'EXIT' := R } = M ->
                 M#{ '$status' => [{data,[{"State",R}]}] };
@@ -3106,12 +3108,12 @@ format_log_state(Mod, Log) ->
         false ->
             [case Event of
                  {out,Msg,From,State} ->
-                     Status = gen:format_status(
+                     Status = gen_gen:format_status(
                                 Mod, terminate, #{ state => State },
                                 [get(), State]),
                      {out, Msg, From, maps:get(state, Status) };
                  {noreply,State} ->
-                     Status = gen:format_status(
+                     Status = gen_gen:format_status(
                                 Mod, terminate, #{ state => State },
                                 [get(), State]),
                      {noreply, maps:get(state, Status)};

--- a/lib/stdlib/src/gen_statem.erl
+++ b/lib/stdlib/src/gen_statem.erl
@@ -393,7 +393,7 @@ off
 ok
 8> pushbutton:push().
 ** exception exit: {noproc,{gen_statem,call,[pushbutton_statem,push,infinity]}}
-     in function  gen:do_for_proc/2 (gen.erl, line 261)
+     in function gen_gen:do_for_proc/2 (gen.erl, line 261)
      in call from gen_statem:call/3 (gen_statem.erl, line 386)
 ```
 
@@ -486,9 +486,10 @@ handle_event(_, _, State, Data) ->
     enter_loop/4,enter_loop/5,enter_loop/6,
     reply/1,reply/2]).
 
-%% gen callbacks
--export(
-   [init_it/6]).
+%% gen_gen callbacks
+-export([init_it/6]).
+
+%-behaviour(gen_gen).
 
 %% sys callbacks
 -export(
@@ -560,7 +561,7 @@ using [`call/2,3`](`call/3`).
 
 %%----------------------
 -doc "A handle that associates a reply to the corresponding request.".
--opaque reply_tag() :: gen:reply_tag().
+-opaque reply_tag() :: gen_gen:reply_tag().
 
 %%----------------------
 -doc """
@@ -1429,7 +1430,7 @@ in all future versions of `gen_statem`.
 
 %%----------------------
 -doc "An opaque request identifier. See `send_request/2` for details.".
--opaque request_id() :: gen:request_id().
+-opaque request_id() :: gen_gen:request_id().
 
 %%----------------------
 -doc """
@@ -1438,7 +1439,7 @@ An opaque collection of request identifiers (`t:request_id/0`).
 Each request identifier can be associated with
 a label chosen by the user.  For more information see `reqids_new/0`.
 """.
--opaque request_id_collection() :: gen:request_id_collection().
+-opaque request_id_collection() :: gen_gen:request_id_collection().
 
 %%----------------------
 -doc """
@@ -2126,7 +2127,7 @@ Server name specification: `local`, `global`, or `via` registered.
 Name specification to use when starting a `gen_statem` server.
 See `start_link/3` and `t:server_ref/0` below.
 """.
--type server_name() :: % Duplicate of gen:emgr_name()
+-type server_name() :: % Duplicate of gen_gen:emgr_name()
         {'local', atom()}
       | {'global', GlobalName :: term()}
       | {'via', RegMod :: module(), Name :: term()}.
@@ -2154,7 +2155,7 @@ It can be:
   the corresponding functions in `m:global`.
   Thus, `{via, global, GlobalName}` is the same as `{global, GlobalName}`.
 """.
--type server_ref() :: % What gen:call/3,4 and gen:stop/1,3 accepts
+-type server_ref() :: % What gen_gen:call/3,4 and gen_gen:stop/1,3 accepts
         pid()
       | (LocalName :: atom())
       | {Name :: atom(), Node :: atom()}
@@ -2169,7 +2170,7 @@ and [`start_monitor/3,4`](`start_monitor/3`) functions.
 
 See [`start_link/4`](#start-options).
 """.
--type start_opt() :: % Duplicate of gen:option()
+-type start_opt() :: % Duplicate of gen_gen:option()
         {'timeout', Time :: timeout()}
       | {'spawn_opt', [proc_lib:start_spawn_option()]}
       | enter_loop_opt().
@@ -2183,7 +2184,7 @@ and [`start_monitor/3,4`](`start_monitor/3`), functions.
 
 See [`start_link/4`](#start-options).
 """.
--type enter_loop_opt() :: % Some gen:option()s works for enter_loop/*
+-type enter_loop_opt() :: % Some gen_gen:option()s works for enter_loop/*
 	{'hibernate_after', HibernateAfterTimeout :: timeout()}
       | {'debug', Dbgs :: [sys:debug_option()]}.
 
@@ -2194,7 +2195,7 @@ and [`start_link/3,4`](`start_link/3`) functions.
 
 See [`start_link/4`](#start-return-values).
 """.
--type start_ret() :: % gen:start_ret() without monitor return
+-type start_ret() :: % gen_gen:start_ret() without monitor return
         {'ok', pid()}
       | 'ignore'
       | {'error', term()}.
@@ -2208,7 +2209,7 @@ wraps the process ID and the [monitor reference](`erlang:monitor/2`) in a
 `{ok, {`[`pid()`](`t:pid/0`)`, `[`reference()`](`t:reference/0`)`}}`
 tuple.
 """.
--type start_mon_ret() :: % gen:start_ret() with only monitor return
+-type start_mon_ret() :: % gen_gen:start_ret() with only monitor return
         {'ok', {pid(),reference()}}
       | 'ignore'
       | {'error', term()}.
@@ -2230,7 +2231,7 @@ is not registered with any [name service](`t:server_name/0`).
 		   start_ret().
 start(Module, Args, Opts)
   when is_atom(Module), is_list(Opts) ->
-    gen:start(?MODULE, nolink, Module, Args, Opts);
+    gen_gen:start(?MODULE, nolink, Module, Args, Opts);
 start(Module, Args, Opts) ->
     error(badarg, [Module, Args, Opts]).
 %%
@@ -2253,7 +2254,7 @@ see [`start_link/4`](`start_link/4`).
 		   start_ret().
 start(ServerName, Module, Args, Opts)
   when is_tuple(ServerName), is_atom(Module), is_list(Opts) ->
-    gen:start(?MODULE, nolink, ServerName, Module, Args, Opts);
+    gen_gen:start(?MODULE, nolink, ServerName, Module, Args, Opts);
 start(ServerName, Module, Args, Opts) ->
     error(badarg, [ServerName, Module, Args, Opts]).
 
@@ -2271,7 +2272,7 @@ is not registered with any [name service](`t:server_name/0`).
 		   start_ret().
 start_link(Module, Args, Opts)
   when is_atom(Module), is_list(Opts) ->
-    gen:start(?MODULE, link, Module, Args, Opts);
+    gen_gen:start(?MODULE, link, Module, Args, Opts);
 start_link(Module, Args, Opts) ->
     error(badarg, [Module, Args, Opts]).
 %%
@@ -2394,7 +2395,7 @@ that message has been consumed.
 		   start_ret().
 start_link(ServerName, Module, Args, Opts)
   when is_tuple(ServerName), is_atom(Module), is_list(Opts) ->
-    gen:start(?MODULE, link, ServerName, Module, Args, Opts);
+    gen_gen:start(?MODULE, link, ServerName, Module, Args, Opts);
 start_link(ServerName, Module, Args, Opts) ->
     error(badarg, [ServerName, Module, Args, Opts]).
 
@@ -2412,7 +2413,7 @@ process is not registered with any [name service](`t:server_name/0`).
 		   start_mon_ret().
 start_monitor(Module, Args, Opts)
   when is_atom(Module), is_list(Opts) ->
-    gen:start(?MODULE, monitor, Module, Args, Opts);
+    gen_gen:start(?MODULE, monitor, Module, Args, Opts);
 start_monitor(Module, Args, Opts) ->
     error(badarg, [Module, Args, Opts]).
 %%
@@ -2443,7 +2444,7 @@ and removed from the caller's message queue.
 		   start_mon_ret().
 start_monitor(ServerName, Module, Args, Opts)
   when is_tuple(ServerName), is_atom(Module), is_list(Opts) ->
-    gen:start(?MODULE, monitor, ServerName, Module, Args, Opts);
+    gen_gen:start(?MODULE, monitor, ServerName, Module, Args, Opts);
 start_monitor(ServerName, Module, Args, Opts) ->
     error(badarg, [ServerName, Module, Args, Opts]).
 
@@ -2453,7 +2454,7 @@ start_monitor(ServerName, Module, Args, Opts) ->
 -doc #{ since => <<"OTP 19.0">> }.
 -spec stop(ServerRef :: server_ref()) -> ok.
 stop(ServerRef) ->
-    gen:stop(ServerRef).
+    gen_gen:stop(ServerRef).
 %%
 %%----------------------
 -doc """
@@ -2485,7 +2486,7 @@ if the connection fails to the remote `Node` where the server runs.
 	Reason :: term(),
 	Timeout :: timeout()) -> ok.
 stop(ServerRef, Reason, Timeout) ->
-    gen:stop(ServerRef, Reason, Timeout).
+    gen_gen:stop(ServerRef, Reason, Timeout).
 
 %% Send an event to a state machine that arrives with type 'event'
 %%----------------------
@@ -2628,7 +2629,7 @@ or `check_response/2` functions.
         ReqId::request_id().
 send_request(ServerRef, Request) ->
     try
-        gen:send_request(ServerRef, '$gen_call', Request)
+        gen_gen:send_request(ServerRef, '$gen_call', Request)
     catch
         error:badarg ->
             error(badarg, [ServerRef, Request])
@@ -2661,7 +2662,7 @@ but slightly more efficient.
 
 send_request(ServerRef, Request, Label, ReqIdCol) ->
     try
-        gen:send_request(ServerRef, '$gen_call', Request, Label, ReqIdCol)
+        gen_gen:send_request(ServerRef, '$gen_call', Request, Label, ReqIdCol)
     catch
         error:badarg ->
             error(badarg, [ServerRef, Request, Label, ReqIdCol])
@@ -2716,7 +2717,7 @@ while `wait_response/2` does not.
 
 wait_response(ReqId, WaitTime) ->
     try
-        gen:wait_response(ReqId, WaitTime)
+        gen_gen:wait_response(ReqId, WaitTime)
     catch
         error:badarg ->
             error(badarg, [ReqId, WaitTime])
@@ -2791,7 +2792,7 @@ and then return `timeout`.
 
 wait_response(ReqIdCol, WaitTime, Delete) ->
     try
-        gen:wait_response(ReqIdCol, WaitTime, Delete)
+        gen_gen:wait_response(ReqIdCol, WaitTime, Delete)
     catch
         error:badarg ->
             error(badarg, [ReqIdCol, WaitTime, Delete])
@@ -2848,7 +2849,7 @@ while `wait_response/2` does not.
 
 receive_response(ReqId, Timeout) ->
     try
-        gen:receive_response(ReqId, Timeout)
+        gen_gen:receive_response(ReqId, Timeout)
     catch
         error:badarg ->
             error(badarg, [ReqId, Timeout])
@@ -2925,7 +2926,7 @@ and then return `timeout`.
 
 receive_response(ReqIdCol, Timeout, Delete) ->
     try
-        gen:receive_response(ReqIdCol, Timeout, Delete)
+        gen_gen:receive_response(ReqIdCol, Timeout, Delete)
     catch
         error:badarg ->
             error(badarg, [ReqIdCol, Timeout, Delete])
@@ -2961,7 +2962,7 @@ this function returns an `error` return with the exit `Reason`.
 
 check_response(Msg, ReqId) ->
     try
-        gen:check_response(Msg, ReqId)
+        gen_gen:check_response(Msg, ReqId)
     catch
         error:badarg ->
             error(badarg, [Msg, ReqId])
@@ -3027,7 +3028,7 @@ this function, it will always return `no_reply`.
 
 check_response(Msg, ReqIdCol, Delete) ->
     try
-        gen:check_response(Msg, ReqIdCol, Delete)
+        gen_gen:check_response(Msg, ReqIdCol, Delete)
     catch
         error:badarg ->
             error(badarg, [Msg, ReqIdCol, Delete])
@@ -3056,7 +3057,7 @@ request identifiers in a collection.
           NewReqIdCollection::request_id_collection().
 
 reqids_new() ->
-    gen:reqids_new().
+    gen_gen:reqids_new().
 
 %%----------------------
 -doc "Return the number of request identifiers in `ReqIdCollection`.".
@@ -3066,7 +3067,7 @@ reqids_new() ->
 
 reqids_size(ReqIdCollection) ->
     try
-        gen:reqids_size(ReqIdCollection)
+        gen_gen:reqids_size(ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqIdCollection])
     end.
@@ -3086,7 +3087,7 @@ the resulting request identifier collection.
 
 reqids_add(ReqId, Label, ReqIdCollection) ->
     try
-        gen:reqids_add(ReqId, Label, ReqIdCollection)
+        gen_gen:reqids_add(ReqId, Label, ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqId, Label, ReqIdCollection])
     end.
@@ -3105,7 +3106,7 @@ in [`ReqIdCollection`](`t:request_id_collection/0`).
 
 reqids_to_list(ReqIdCollection) ->
     try
-        gen:reqids_to_list(ReqIdCollection)
+        gen_gen:reqids_to_list(ReqIdCollection)
     catch
         error:badarg -> error(badarg, [ReqIdCollection])
     end.
@@ -3148,7 +3149,7 @@ from a [_state callback_](#state-callback).
 -doc #{ since => <<"OTP 19.0">> }.
 -spec reply(From :: from(), Reply :: term()) -> ok.
 reply(From, Reply) ->
-    gen:reply(From, Reply).
+    gen_gen:reply(From, Reply).
 
 %% Instead of starting the state machine through start/3,4
 %% or start_link/3,4 turn the current process presumably
@@ -3234,10 +3235,10 @@ according to `t:server_name/0`.
 			no_return().
 enter_loop(Module, Opts, State, Data, Server, Actions) ->
     is_atom(Module) orelse error({atom,Module}),
-    Parent = gen:get_parent(),
-    Name = gen:get_proc_name(Server),
-    Debug = gen:debug_options(Name, Opts),
-    HibernateAfterTimeout = gen:hibernate_after(Opts),
+    Parent = gen_gen:get_parent(),
+    Name = gen_gen:get_proc_name(Server),
+    Debug = gen_gen:debug_options(Name, Opts),
+    HibernateAfterTimeout = gen_gen:hibernate_after(Opts),
     enter(
       Parent, Debug, Module, Name, HibernateAfterTimeout,
       State, Data, Actions).
@@ -3251,7 +3252,7 @@ wrap_cast(Event) ->
 
 -compile({inline, [call/4]}).
 call(ServerRef, Request, Timeout, T) ->
-    try gen:call(ServerRef, '$gen_call', Request, T) of
+    try gen_gen:call(ServerRef, '$gen_call', Request, T) of
         {ok,Reply} ->
             Reply
     catch
@@ -3310,9 +3311,9 @@ enter(
 init_it(Starter, self, ServerRef, Module, Args, Opts) ->
     init_it(Starter, self(), ServerRef, Module, Args, Opts);
 init_it(Starter, Parent, ServerRef, Module, Args, Opts) ->
-    Name = gen:get_proc_name(ServerRef),
-    Debug = gen:debug_options(Name, Opts),
-    HibernateAfterTimeout = gen:hibernate_after(Opts),
+    Name = gen_gen:get_proc_name(ServerRef),
+    Debug = gen_gen:debug_options(Name, Opts),
+    HibernateAfterTimeout = gen_gen:hibernate_after(Opts),
     try Module:init(Args) of
 	Result ->
 	    init_result(
@@ -3324,7 +3325,7 @@ init_it(Starter, Parent, ServerRef, Module, Args, Opts) ->
               Starter, Parent, ServerRef, Module, Result,
               Name, Debug, HibernateAfterTimeout);
 	Class:Reason:Stacktrace ->
-	    gen:unregister_name(ServerRef),
+            gen_gen:unregister_name(ServerRef),
 	    error_info(
 	      Class, Reason, Stacktrace, Debug,
               #params{parent = Parent, name = Name, modules = [Module]},
@@ -3338,7 +3339,7 @@ init_it(Starter, Parent, ServerRef, Module, Args, Opts) ->
 
 %%%
 %%% NOTE: If init_ack() return values are modified, see comment
-%%%       above monitor_return() in gen.erl!
+%%%       above monitor_return() in gen_gen.erl!
 %%%
 
 init_result(
@@ -3356,19 +3357,19 @@ init_result(
               Parent, Debug, Module, Name, HibernateAfterTimeout,
               State, Data, Actions);
 	{stop,Reason} ->
-	    gen:unregister_name(ServerRef),
+            gen_gen:unregister_name(ServerRef),
             exit(Reason);
 	{error, _Reason} = ERROR ->
             %% The point of this clause is that we shall have a *silent*
             %% termination. The error reason will be returned to the
             %% 'Starter' ({error, Reason}), but *no* crash report.
-	    gen:unregister_name(ServerRef),
+            gen_gen:unregister_name(ServerRef),
 	    proc_lib:init_fail(Starter, ERROR, {exit,normal});
 	ignore ->
-	    gen:unregister_name(ServerRef),
+            gen_gen:unregister_name(ServerRef),
             proc_lib:init_fail(Starter, ignore, {exit,normal});
 	_ ->
-	    gen:unregister_name(ServerRef),
+            gen_gen:unregister_name(ServerRef),
 	    Reason = {bad_return_from_init,Result},
 	    error_info(
 	      error, Reason, ?STACKTRACE(), Debug,
@@ -3438,7 +3439,7 @@ format_status(
    {#params{name = Name, modules = [Mod | _] = Modules},
     #state{postponed = Postponed, timers = Timers,
            state_data = {State,Data}}}]) ->
-    Header = gen:format_status_header("Status for state machine", Name),
+    Header = gen_gen:format_status_header("Status for state machine", Name),
 
     Timeouts = list_timeouts(Timers),
     StatusMap = #{ state => State, data => Data,
@@ -3447,7 +3448,7 @@ format_status(
                  },
 
     NewStatusMap =
-        case gen:format_status(Mod, Opt, StatusMap, [PDict,State,Data]) of
+        case gen_gen:format_status(Mod, Opt, StatusMap, [PDict,State,Data]) of
             #{ 'EXIT' := R } ->
                 Crashed = [{data,[{"State",{State,R}}]}],
                 StatusMap#{ '$status' => Crashed };
@@ -4965,7 +4966,7 @@ error_info(
     Timeouts = list_timeouts(Timers),
 
     Status =
-        gen:format_status(Mod, terminate,
+        gen_gen:format_status(Mod, terminate,
                           #{ reason => Reason,
                              state => State,
                              data => Data,

--- a/lib/stdlib/src/peer.erl
+++ b/lib/stdlib/src/peer.erl
@@ -553,7 +553,7 @@ send(Dest, To, Message) ->
                      stdio = <<>> :: binary(),
                      %% peer state
                      peer_state = booting :: peer_state(),
-                     %% pid/ref saved for gen:reply() when node is booted, or false
+                     %% pid/ref saved for gen_gen:reply() when node is booted, or false
                      notify = false :: false | {pid(), reference()},
                      %% counter (reference) for calls.
                      %% it is not possible to use erlang reference, or pid,
@@ -992,7 +992,7 @@ handle_alternative_data(_Kind, {message, To, Content}, State) ->
     State;
 handle_alternative_data(_Kind, {reply, Seq, Class, Result}, #peer_state{outstanding = Out} = State) ->
     {From, NewOut} = maps:take(Seq, Out),
-    gen:reply(From, {Class, Result}),
+    gen_gen:reply(From, {Class, Result}),
     State#peer_state{outstanding = NewOut};
 handle_alternative_data(_Kind, {started, NodeName}, State)->
     boot_complete(NodeName, started, State).

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -926,19 +926,19 @@ raw_initial_call(ProcInfo) when is_list(ProcInfo) ->
 %% Translate the initial call to some useful information.
 %% -----------------------------------------------------
 
-trans_init(gen,init_it,[gen_server,_,_,supervisor,{_,Module,_},_]) ->
+trans_init(gen_gen,init_it,[gen_server,_,_,supervisor,{_,Module,_},_]) ->
     {supervisor,Module,1};
-trans_init(gen,init_it,[gen_server,_,_,_,supervisor,{_,Module,_},_]) ->
+trans_init(gen_gen,init_it,[gen_server,_,_,_,supervisor,{_,Module,_},_]) ->
     {supervisor,Module,1};
-trans_init(gen,init_it,[gen_server,_,_,supervisor_bridge,[Module|_],_]) ->
+trans_init(gen_gen,init_it,[gen_server,_,_,supervisor_bridge,[Module|_],_]) ->
     {supervisor_bridge,Module,1};
-trans_init(gen,init_it,[gen_server,_,_,_,supervisor_bridge,[Module|_],_]) ->
+trans_init(gen_gen,init_it,[gen_server,_,_,_,supervisor_bridge,[Module|_],_]) ->
     {supervisor_bridge,Module,1};
-trans_init(gen,init_it,[gen_event|_]) ->
+trans_init(gen_gen,init_it,[gen_event|_]) ->
     {gen_event,init_it,6};
-trans_init(gen,init_it,[_GenMod,_,_,Module,_,_]) when is_atom(Module) ->
+trans_init(gen_gen,init_it,[_GenMod,_,_,Module,_,_]) when is_atom(Module) ->
     {Module,init,1};
-trans_init(gen,init_it,[_GenMod,_,_,_,Module|_]) when is_atom(Module) ->
+trans_init(gen_gen,init_it,[_GenMod,_,_,_,Module|_]) when is_atom(Module) ->
     {Module,init,1};
 trans_init(M, F, A) when is_atom(M), is_atom(F) ->
     {M,F,length(A)}.

--- a/lib/stdlib/src/stdlib.app.src
+++ b/lib/stdlib/src/stdlib.app.src
@@ -70,7 +70,7 @@
 	     filename,
 	     gb_trees,
 	     gb_sets,
-	     gen,
+	     gen_gen,
 	     gen_event,
 	     gen_fsm,
 	     gen_server,

--- a/lib/stdlib/src/sys.erl
+++ b/lib/stdlib/src/sys.erl
@@ -746,7 +746,7 @@ remove(Name, FuncOrFuncId, Timeout) ->
 %% The receiving side should send Msg to handle_system_msg/5.
 %%-----------------------------------------------------------------
 send_system_msg(Name, Request) ->
-    try gen:call(Name, system, Request) of
+    try gen_gen:call(Name, system, Request) of
         {ok, Res} ->
             Res
     catch exit : Reason ->
@@ -754,7 +754,7 @@ send_system_msg(Name, Request) ->
     end.
 
 send_system_msg(Name, Request, Timeout) ->
-    try gen:call(Name, system, Request, Timeout) of
+    try gen_gen:call(Name, system, Request, Timeout) of
         {ok, Res} ->
             Res
     catch exit : Reason ->
@@ -830,13 +830,13 @@ handle_system_msg(Msg, From, Parent, Mod, Debug, Misc, Hib) ->
 handle_system_msg(SysState, Msg, From, Parent, Mod, Debug, Misc, Hib) ->
     case do_cmd(SysState, Msg, Parent, Mod, Debug, Misc) of
 	{suspended, Reply, NDebug, NMisc} ->
-	    _ = gen:reply(From, Reply),
+            _ = gen_gen:reply(From, Reply),
 	    suspend_loop(suspended, Parent, Mod, NDebug, NMisc, Hib);
 	{running, Reply, NDebug, NMisc} ->
-	    _ = gen:reply(From, Reply),
+            _ = gen_gen:reply(From, Reply),
             Mod:system_continue(Parent, NDebug, NMisc);
 	{{terminating, Reason}, Reply, NDebug, NMisc} ->
-	    _ = gen:reply(From, Reply),
+            _ = gen_gen:reply(From, Reply),
 	    Mod:system_terminate(Reason, Parent, NDebug, NMisc)
     end.
 

--- a/lib/stdlib/test/gen_server_SUITE.erl
+++ b/lib/stdlib/test/gen_server_SUITE.erl
@@ -3105,12 +3105,12 @@ reply_by_alias_with_payload(Config) when is_list(Config) ->
         {[[alias|Alias]|_] = Tag, Reply} ->
             ok
     end,
-    %% Check gen:reply/2 as well...
+    %% Check gen_gen:reply/2 as well...
     Reply2 = make_ref(),
     Alias2 = alias(),
     Tag2 = [[alias|Alias2], "payload"],
     spawn_link(fun () ->
-                       gen:reply({undefined, Tag2},
+                       gen_gen:reply({undefined, Tag2},
                                  Reply2)
                end),
     receive

--- a/lib/stdlib/test/gen_statem_SUITE.erl
+++ b/lib/stdlib/test/gen_statem_SUITE.erl
@@ -2972,7 +2972,7 @@ init([]) ->
 %% just to not leak resources (process, name, ETS table, etc...)
 %%
 init_sup(Result) ->
-    Parent = gen:get_parent(),
+    Parent = gen_gen:get_parent(),
     Statem = self(),
     _Supervisor =
         spawn(

--- a/lib/stdlib/test/gen_statem_SUITE_data/oc_statem.erl
+++ b/lib/stdlib/test/gen_statem_SUITE_data/oc_statem.erl
@@ -37,7 +37,7 @@ init([]) ->
     %% (fails due to some reason), kill the state machine,
     %% just to not leak resources (process, name, ETS table, etc...)
     %%
-    Parent = gen:get_parent(),
+    Parent = gen_gen:get_parent(),
     Statem = self(),
     _Supervisor =
         spawn(

--- a/lib/wx/src/wx_object.erl
+++ b/lib/wx/src/wx_object.erl
@@ -290,7 +290,7 @@ Example:
       Options::[{timeout, timeout()} | {debug, [Flag]}].
 start(Mod, Args, Options)
   when is_atom(Mod), is_list(Options) ->
-    gen_response(gen:start(?MODULE, nolink, Mod, Args, [get(?WXE_IDENTIFIER)|Options]));
+    gen_response(gen_gen:start(?MODULE, nolink, Mod, Args, [get(?WXE_IDENTIFIER)|Options]));
 start(Mod, Args, Options) ->
     error(badarg, [Mod, Args, Options]).
 
@@ -307,7 +307,7 @@ Starts a generic wx_object server and invokes Mod:init(Args) in the new process.
       Options::[{timeout, timeout()} | {debug, [Flag]}].
 start(Name, Mod, Args, Options)
   when is_tuple(Name), is_atom(Mod), is_list(Options) ->
-    gen_response(gen:start(?MODULE, nolink, Name, Mod, Args, [get(?WXE_IDENTIFIER)|Options]));
+    gen_response(gen_gen:start(?MODULE, nolink, Name, Mod, Args, [get(?WXE_IDENTIFIER)|Options]));
 start(Name, Mod, Args, Options) ->
     error(badarg, [Name, Mod, Args, Options]).
 
@@ -323,7 +323,7 @@ Starts a generic wx_object server and invokes Mod:init(Args) in the new process.
       Options::[{timeout, timeout()} | {debug, [Flag]}].
 start_link(Mod, Args, Options)
   when is_atom(Mod), is_list(Options) ->
-    gen_response(gen:start(?MODULE, link, Mod, Args, [get(?WXE_IDENTIFIER)|Options]));
+    gen_response(gen_gen:start(?MODULE, link, Mod, Args, [get(?WXE_IDENTIFIER)|Options]));
 start_link(Mod, Args, Options) ->
     error(badarg, [Mod, Args, Options]).
 


### PR DESCRIPTION
Because of the name, it has always been quite difficult to debug code that revolves around the `gen` module, in particular when its module name is passed around as an atom. It is also surprising and somewhat confusing to newcomers playing around with Erlang that the name `gen.erl` is already taken by the standard libraries (but not documented).

This renames the module to `gen_gen` which does not already occur as a substring anywhere in the codebase, and also turns it into a behaviour whose callbacks can be checked against the uses in `gen_server`, `gen_event`, etc. 