### PR TITLE
Fix reltool on windows

### DIFF
--- a/lib/reltool/src/reltool_target.erl
+++ b/lib/reltool/src/reltool_target.erl
@@ -942,12 +942,11 @@ spec_escripts(#sys{apps = Apps}, ErtsBin, BinFiles) ->
     lists:flatten(lists:filtermap(Filter, Apps)).
 
 do_spec_escript(File, ErtsBin, BinFiles) ->
-    [{copy_file, EscriptExe}] = safe_lookup_spec("escript", BinFiles),
     EscriptExt = ".escript",
     Base = filename:basename(File, EscriptExt),
-    ExeExt = filename:extension(EscriptExe),
-    [{copy_file, Base ++ EscriptExt, File},
-     {copy_file, Base ++ ExeExt, filename:join([ErtsBin, EscriptExe])}].
+    ExeS = [{copy_file, Base ++ filename:extension(BinF), filename:join([ErtsBin, BinF])}
+            || {copy_file, BinF} <- safe_lookup_spec("escript", BinFiles)],
+    [{copy_file, Base ++ EscriptExt, File} | ExeS].
 
 check_sys(Mandatory, SysFiles) ->
     lists:foreach(fun(M) -> do_check_sys(M, SysFiles) end, Mandatory).


### PR DESCRIPTION
Windows now included .pdb for every executable which made the testcases fail.