### PR TITLE
doc tests: Use simple pids, ports, and refs

### DIFF
--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -4173,8 +4173,8 @@ identifier.
 ## Examples
 
 ```erlang
-1> list_to_pid("<0.4.1>").
-<0.4.1>
+1> list_to_pid("<0.1.0>").
+<0.1.0>
 ```
 """.
 -doc #{ category => terms }.
@@ -4197,8 +4197,8 @@ identifier.
 ## Examples
 
 ```erlang
-1> list_to_port("#Port<0.4>").
-#Port<0.4>
+1> list_to_port("#Port<0.0>").
+#Port<0.0>
 ```
 
 """.
@@ -4222,8 +4222,8 @@ Failure: `badarg` if `String` contains a bad representation of a reference.
 ## Examples
 
 ```erlang
-1> list_to_ref("#Ref<0.4192537678.4073193475.71181>").
-#Ref<0.4192537678.4073193475.71181>
+1> list_to_ref("#Ref<0.0.0.0>").
+#Ref<0.0.0.0>
 ```
 """.
 -doc(#{since => <<"OTP 20.0">>}).
@@ -5023,8 +5023,8 @@ Returns a string corresponding to the text representation of `Pid`.
 ## Examples
 
 ```erlang
-1> erlang:pid_to_list(<0.85.0>).
-"<0.85.0>"
+1> erlang:pid_to_list(<0.1.0>).
+"<0.1.0>"
 ```
 """.
 -doc #{ category => terms }.
@@ -5040,8 +5040,8 @@ Returns a string corresponding to the text representation of the port identifier
 ## Examples
 
 ```erlang
-1> erlang:port_to_list(#Port<0.85>).
-"#Port<0.85>"
+1> erlang:port_to_list(#Port<0.0>).
+"#Port<0.0>"
 ```
 """.
 -doc #{ category => terms }.
@@ -5836,8 +5836,8 @@ Returns a string corresponding to the text representation of `Ref`.
 ## Examples
 
 ```erlang
-1> ref_to_list(#Ref<0.4192537678.4073193475.71181>).
-"#Ref<0.4192537678.4073193475.71181>"
+1> ref_to_list(#Ref<0.0.0.0>).
+"#Ref<0.0.0.0>"
 ```
 """.
 -doc #{ category => terms }.


### PR DESCRIPTION
In our daily builds, `bif_SUITE:doctests/1` would fail on some of the platforms every day while attempting to parse a pid or a reference. While `ct_doctest` supports parsing literal pids such a `<0.4.1>`, parsing will fail if no such pid currently exists, and similar for references and ports. It turns out that the sample pids and references used in the examples exist on most platforms but not all of them all of the time.

To eliminate the failing test cases, ~don't test the examples for `list_to_pid/1` and friends.~ change all of the sample pid, ports, and refs to be the lowest numbered item of each kind. That should guarantee that they always exist.

