### PR TITLE
ssh: max_auth_tries option for server role

### DIFF
--- a/lib/ssh/doc/guides/hardening.md
+++ b/lib/ssh/doc/guides/hardening.md
@@ -71,6 +71,11 @@ increase the resilence. The options to use are:
   true, the number of simultaneous login attempts are limited by the value of
   the [max_sessions](`m:ssh#hardening_daemon_options-max_sessions`) option.
 
+- **[max_auth_tries](`m:ssh#hardening_daemon_options-max_auth_tries`)** - The
+  maximum number of authentication attempts permitted per connection. When a
+  client exceeds this number of failed attempts, the daemon disconnects it. The
+  default is 6.
+
 ### Timeouts
 
 - **[hello_timeout](`t:ssh:hello_timeout_daemon_option/0`)** - If the client

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -1288,6 +1288,12 @@ in the User's Guide chapter.
   is the maximum allowed packet size, 262144 bytes,
   which is the same as no check being made,
   since maximum allowed packet size check is performed earlier.
+
+- **`max_auth_tries`{: #hardening_daemon_options-max_auth_tries }** - The
+  maximum number of authentication attempts permitted per connection. When a
+  client exceeds this number of failed attempts, the daemon disconnects it.
+  Accepted values are a positive integer or the atom `infinity` to disable the
+  limit. The default value is `6`.
 """.
 -doc(#{group => <<"Daemon Options">>}).
 -type hardening_daemon_options() ::
@@ -1295,7 +1301,8 @@ in the User's Guide chapter.
       | {max_channels, pos_integer()}
       | {parallel_login, boolean()}
       | {minimal_remote_max_packet_size, pos_integer()}
-      | {max_auth_request_size, pos_integer()}.
+      | {max_auth_request_size, pos_integer()}
+      | {max_auth_tries, pos_integer() | infinity}.
 
 -doc """
 - **`connectfun`** - Provides a fun to implement your own logging when a user
@@ -1406,7 +1413,8 @@ Experimental options that should not to be used in products.
 	  userauth_methods,                 %  list( string() )  eg ["keyboard-interactive", "password"]
 	  userauth_supported_methods,       %  string() eg "keyboard-interactive,password"
           userauth_pubkeys,
-	  kb_tries_left = 0,                %  integer(), num tries left for "keyboard-interactive"
+          auth_tries_left = 0,              %  integer()|infinity, auth tries left (max_auth_tries)
+          auth_attempts = 0,                %  non_neg_integer(), userauth requests seen (OpenSSH "attempt")
 	  userauth_preference,
 	  available_host_keys,
 	  pwdfun_user_state,

--- a/lib/ssh/src/ssh_auth.erl
+++ b/lib/ssh/src/ssh_auth.erl
@@ -235,72 +235,68 @@ handle_userauth_request(#ssh_msg_service_request{name = Name = "ssh-userauth"},
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
-						  method = "password",
+                                                  method = "password" = Method,
 						  data = <<?FALSE, ?UINT32(Sz), Password:Sz/binary>>}, _, 
-			#ssh{userauth_supported_methods = Methods} = Ssh) ->
+                        Ssh) ->
     case check_password(User, Password, Ssh) of
 	{true,Ssh1} ->
 	    {authorized, User,
 	     {#ssh_msg_userauth_success{}, Ssh1}
             };
 	{false,Ssh1}  ->
-	    {not_authorized, {User, {error,"Bad user or password"}}, 
-	     {#ssh_msg_userauth_failure{authentications = Methods,
-                                        partial_success = false}, Ssh1}
-            }
+            userauth_failure(User, Method, {error,"Bad user or password"}, Ssh1)
     end;
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
-						  method = "password",
+                                                  method = "password" = Method,
 						  data = <<?TRUE,
 							   _/binary
 							   %% ?UINT32(Sz1), OldBinPwd:Sz1/binary,
 							   %% ?UINT32(Sz2), NewBinPwd:Sz2/binary
 							 >>
-						 }, _, 
-			#ssh{userauth_supported_methods = Methods} = Ssh) ->
+                                                 }, _, Ssh) ->
     %% Password change without us having sent SSH_MSG_USERAUTH_PASSWD_CHANGEREQ (because we never do)
     %% RFC 4252 says:
     %%   SSH_MSG_USERAUTH_FAILURE without partial success - The password
     %%   has not been changed.  Either password changing was not supported,
     %%   or the old password was bad. 
 
-    {not_authorized, {User, {error,"Password change not supported"}}, 
-     {#ssh_msg_userauth_failure{authentications = Methods,
-                                partial_success = false}, Ssh}
-    };
+    userauth_failure(User, Method, {error, "Password change not supported"}, Ssh);
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
 						  method = "none"}, _,
 			#ssh{userauth_supported_methods = Methods,
+                             auth_attempts = Attempts,
                              opts = Opts} = Ssh) ->
     case ?GET_OPT(no_auth_needed, Opts) of
-        false ->
-            %% The normal case
-            {not_authorized, {User, undefined},
-             {#ssh_msg_userauth_failure{authentications = Methods,
-                                        partial_success = false}, Ssh}
-            };
         true ->
             %% RFC 4252  5.2
 	    {authorized, User,
              {#ssh_msg_userauth_success{}, Ssh}
-            }
+            };
+        false when Attempts =< 1 ->
+            %% RFC 4252 5.4: the client's first "none" request is used to query
+            %% the available methods; like OpenSSH this first attempt is free.
+            {not_authorized, {User, undefined},
+             {#ssh_msg_userauth_failure{authentications = Methods,
+                                        partial_success = false}, Ssh}
+            };
+        false ->
+            %% Any subsequent "none" counts as a failed attempt.
+            userauth_failure(User, "none", undefined, Ssh)
     end;
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
-						  method = "publickey",
+                                                  method = "publickey" = Method,
 						  data = <<?BYTE(?FALSE),
 							   ?UINT32(ALen), BAlg:ALen/binary,
 							   ?UINT32(KLen), KeyBlob:KLen/binary,
 							   _/binary
 							 >>
-						 }, 
-			_SessionId, 
-			#ssh{userauth_supported_methods = Methods} = Ssh0) ->
+                                                 }, _SessionId, Ssh0) ->
     Ssh =
         case check_user(User, Ssh0) of
             {true,Ssh01} -> Ssh01#ssh{user=User};
@@ -313,26 +309,21 @@ handle_userauth_request(#ssh_msg_userauth_request{user = User,
 	true ->
 	    {not_authorized, {User, undefined},
              {#ssh_msg_userauth_pk_ok{algorithm_name = binary_to_list(BAlg),
-                                     key_blob = KeyBlob}, Ssh}
+                                      key_blob = KeyBlob}, Ssh}
             };
 	false ->
-	    {not_authorized, {User, undefined}, 
-	     {#ssh_msg_userauth_failure{authentications = Methods,
-                                        partial_success = false}, Ssh}
-            }
+            userauth_failure(User, Method, undefined, Ssh)
     end;
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
-						  method = "publickey",
+                                                  method = "publickey" = Method,
 						  data = <<?BYTE(?TRUE),
 							   ?UINT32(ALen), BAlg:ALen/binary,
 							   ?UINT32(KLen), KeyBlob:KLen/binary,
 							   SigWLen/binary>>
 						 }, 
-			SessionId, 
-			#ssh{user = PreVerifyUser,
-                             userauth_supported_methods = Methods} = Ssh0) ->
+                        SessionId, #ssh{user = PreVerifyUser} = Ssh0) ->
     
     {UserOk,Ssh} = check_user(User, Ssh0),
     case
@@ -345,81 +336,63 @@ handle_userauth_request(#ssh_msg_userauth_request{user = User,
              {#ssh_msg_userauth_success{}, Ssh}
             };
 	false ->
-	    {not_authorized, {User, undefined}, 
-	     {#ssh_msg_userauth_failure{authentications = Methods,
-                                        partial_success = false}, Ssh}
-            }
+            userauth_failure(User, Method, undefined, Ssh)
     end;
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
 						  method = "keyboard-interactive",
 						  data = _},
-			_, #ssh{opts = Opts,
-				kb_tries_left = KbTriesLeft,
-				userauth_supported_methods = Methods} = Ssh) ->
-    case KbTriesLeft of
-	N when N<1 ->
-	    {not_authorized, {User, {authmethod, "keyboard-interactive"}}, 
-             {#ssh_msg_userauth_failure{authentications = Methods,
-                                        partial_success = false}, Ssh}
-            };
+                        _, #ssh{opts = Opts} = Ssh) ->
+    %% RFC4256
+    %% The data field contains:
+    %%   - language tag (deprecated). If =/=[] SHOULD use it however. We skip
+    %%                                it for simplicity.
+    %%   - submethods. "... the user can give a hint of which actual methods
+    %%                  he wants to use. ...".  It's a "MAY use" so we skip
+    %%                  it. It also needs an understanding between the client
+    %%                  and the server.
+    %%
+    %% "The server MUST reply with an SSH_MSG_USERAUTH_SUCCESS,
+    %%  SSH_MSG_USERAUTH_FAILURE, or SSH_MSG_USERAUTH_INFO_REQUEST message."
+    Default = {"SSH server",
+               "Enter password for \""++User++"\"",
+               "password: ",
+               false},
 
-	_ ->
-	    %% RFC4256
-	    %% The data field contains:
-	    %%   - language tag (deprecated). If =/=[] SHOULD use it however. We skip
-	    %%                                it for simplicity.
-	    %%   - submethods. "... the user can give a hint of which actual methods
-	    %%                  he wants to use. ...".  It's a "MAY use" so we skip
-	    %%                  it. It also needs an understanding between the client
-	    %%                  and the server.
-	    %%                  
-	    %% "The server MUST reply with an SSH_MSG_USERAUTH_SUCCESS,
-	    %%  SSH_MSG_USERAUTH_FAILURE, or SSH_MSG_USERAUTH_INFO_REQUEST message."
-	    Default = {"SSH server",
-		       "Enter password for \""++User++"\"",
-		       "password: ",
-		       false},
-
-	    {Name, Instruction, Prompt, Echo} =
-		case ?GET_OPT(auth_method_kb_interactive_data, Opts) of
-		    undefined -> 
-			Default;
-		    {_,_,_,_}=V -> 
-			V;
-                    F when is_function(F, 4) ->
-			{_,PeerName} = Ssh#ssh.peer,
-			F(PeerName, User, "ssh-connection", Ssh#ssh.pwdfun_user_state);
-		    F when is_function(F) ->
-			{_,PeerName} = Ssh#ssh.peer,
-			F(PeerName, User, "ssh-connection")
-		end,
-	    EchoEnc = case Echo of
-			  true -> <<?TRUE>>;
-			  false -> <<?FALSE>>
-		      end,
-	    Msg = #ssh_msg_userauth_info_request{name = unicode:characters_to_list(Name),
-						 instruction = unicode:characters_to_list(Instruction),
-						 language_tag = "",
-						 num_prompts = 1,
-						 data = <<?STRING(unicode:characters_to_binary(Prompt)),
-							  EchoEnc/binary
-							>>
-						},
-	    {not_authorized, {User, undefined}, 
-	     {Msg, Ssh#ssh{user = User}}
-            }
-    end;
+    {Name, Instruction, Prompt, Echo} =
+        case ?GET_OPT(auth_method_kb_interactive_data, Opts) of
+            undefined ->
+                Default;
+            {_,_,_,_}=V ->
+                V;
+            F when is_function(F, 4) ->
+                {_,PeerName} = Ssh#ssh.peer,
+                F(PeerName, User, "ssh-connection", Ssh#ssh.pwdfun_user_state);
+            F when is_function(F) ->
+                {_,PeerName} = Ssh#ssh.peer,
+                F(PeerName, User, "ssh-connection")
+        end,
+    EchoEnc = case Echo of
+                  true -> <<?TRUE>>;
+                  false -> <<?FALSE>>
+              end,
+    Msg = #ssh_msg_userauth_info_request{name = unicode:characters_to_list(Name),
+                                         instruction = unicode:characters_to_list(Instruction),
+                                         language_tag = "",
+                                         num_prompts = 1,
+                                         data = <<?STRING(unicode:characters_to_binary(Prompt)),
+                                                  EchoEnc/binary
+                                                >>
+                                        },
+    {not_authorized, {User, undefined},
+     {Msg, Ssh#ssh{user = User}}
+    };
 
 handle_userauth_request(#ssh_msg_userauth_request{user = User,
 						  service = "ssh-connection",
-						  method = Other}, _,
-			#ssh{userauth_supported_methods = Methods} = Ssh) ->
-    {not_authorized, {User, {authmethod, Other}}, 
-     {#ssh_msg_userauth_failure{authentications = Methods,
-                                partial_success = false}, Ssh}
-    }.
+                                                  method = Other}, _, Ssh) ->
+    userauth_failure(User, Other, {authmethod, Other}, Ssh).
 
 
 %%%----------------------------------------------------------------
@@ -445,9 +418,7 @@ handle_userauth_info_request(#ssh_msg_userauth_info_request{name = Name,
 handle_userauth_info_response(#ssh_msg_userauth_info_response{num_responses = 1,
 							      data = <<?UINT32(Sz), Password:Sz/binary>>},
 			      #ssh{opts = Opts,
-				   kb_tries_left = KbTriesLeft,
-				   user = User,
-				   userauth_supported_methods = Methods} = Ssh) ->
+                                   user = User} = Ssh) ->
     SendOneEmpty =
 	(?GET_OPT(tstflg,Opts) == one_empty)
 	orelse 
@@ -469,10 +440,8 @@ handle_userauth_info_response(#ssh_msg_userauth_info_response{num_responses = 1,
 	     {#ssh_msg_userauth_success{}, Ssh1}};
 
 	{false,Ssh1} ->
-	    {not_authorized, {User, {error,"Bad user or password"}}, 
-	     {#ssh_msg_userauth_failure{authentications = Methods,
-                                        partial_success = false}, 
-              Ssh1#ssh{kb_tries_left = max(KbTriesLeft-1, 0)}}}
+            Method = "keyboard-interactive",
+            userauth_failure(User, Method, {error,"Bad user or password"}, Ssh1)
     end;
 
 handle_userauth_info_response({extra,#ssh_msg_userauth_info_response{}},
@@ -668,6 +637,20 @@ write_if_nonempty(_, "") -> ok;
 write_if_nonempty(_, <<>>) -> ok;
 write_if_nonempty(IoCb, Text) -> IoCb:format("~s~n",[Text]).
 
+userauth_failure(User, _Method, Error, #ssh{auth_tries_left = Tries} = Ssh)
+  when Tries =/= infinity, Tries =< 1 ->
+    {auth_tries_exceeded, {User, Error}, Ssh};
+userauth_failure(User, _Method, Error,
+                 #ssh{auth_tries_left = Tries, userauth_supported_methods = Methods} = Ssh) ->
+    AuthTriesLeft = reduce_tries_count(Tries),
+    {not_authorized, {User, Error},
+     {#ssh_msg_userauth_failure{authentications = Methods,
+                                partial_success = false},
+      Ssh#ssh{auth_tries_left = AuthTriesLeft}}}.
+
+reduce_tries_count(infinity) -> infinity;
+reduce_tries_count(N) -> N - 1.
+
 %%%----------------------------------------------------------------
 %%% Called just for the tracer ssh_dbg
 ssh_msg_userauth_result(_R) -> ok.
@@ -832,7 +815,7 @@ fmt_req(#ssh_msg_userauth_request{user = User,
                                   service = "ssh-connection",
                                   method = Method,
                                   data = Data}, 
-        #ssh{kb_tries_left = KbTriesLeft,
+        #ssh{auth_tries_left = AuthTriesLeft,
              userauth_supported_methods = Methods}) ->
     [io_lib:format("req user = ~p~n"
                    "req method = ~p~n"
@@ -841,18 +824,21 @@ fmt_req(#ssh_msg_userauth_request{user = User,
      case Method of
          "none" -> "";
          "password" -> fmt_bool(Data);
-         "keyboard-interactive" -> fmt_kb_tries_left(KbTriesLeft);
-         "publickey" -> [case Data of
-                             <<?BYTE(_), ?UINT32(ALen), Alg:ALen/binary, _/binary>> ->
-                                 io_lib:format("~nkey-type = ~p", [Alg]);
-                             _ ->
-                                 ""
-                         end];
+         "keyboard-interactive" -> "";
+         "publickey" -> case Data of
+                            <<?BYTE(_), ?UINT32(ALen), Alg:ALen/binary, _/binary>> ->
+                                io_lib:format("~nkey-type = ~p", [Alg]);
+                            _ ->
+                                ""
+                        end;
          _ -> ""
-     end].
+     end,
+     fmt_auth_tries_left(AuthTriesLeft)].
 
 
-fmt_kb_tries_left(N) when is_integer(N)->
+fmt_auth_tries_left(infinity) ->
+    "";
+fmt_auth_tries_left(N) when is_integer(N) ->
     io_lib:format("~ntries left = ~p", [N-1]).
 
 
@@ -865,6 +851,5 @@ fmt_bool(<<?BYTE(Bool),_/binary>>) ->
                    end]);
 fmt_bool(<<>>) ->
     "".
-
 
 

--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -486,11 +486,18 @@ init_ssh_record(Role, Socket, PeerAddr, Opts) ->
 	    S0#ssh{s_vsn = Vsn,
 		   s_version = Version,
 		   userauth_methods = string:tokens(AuthMethods, ","),
-		   kb_tries_left = 3,
+                   auth_tries_left = get_max_auth_tries(Opts),
 		   peer = {undefined, PeerAddr},
                    local = LocalName
 		  }
     end.
+
+get_max_auth_tries(Opts) ->
+    case ?GET_OPT(max_auth_tries, Opts) of
+        infinity -> infinity;
+        N when is_integer(N) -> N
+    end.
+
 
 handshake(ConnPid, server, Ref, Timeout) ->
     receive

--- a/lib/ssh/src/ssh_fsm_userauth_server.erl
+++ b/lib/ssh/src/ssh_fsm_userauth_server.erl
@@ -64,8 +64,10 @@ handle_event(internal,
                                              user = User},
 	     StateName = {userauth,server},
 	     D0) ->
-    D1 = maybe_send_banner(D0, User),
-    #data{ssh_params=Ssh0} = D1,
+    %% Count every userauth request (OpenSSH's "attempt"); used to grant the
+    %% first "none" request a free pass (ssh_auth:handle_userauth_request/3).
+    D1 = increment_auth_attempts(maybe_send_banner(D0, User)),
+    #data{ssh_params = Ssh0} = D1,
     case {ServiceName, Ssh0#ssh.service, Method} of
 	{"ssh-connection", "ssh-connection", "none"} ->
 	    %% Probably the very first userauth_request but we deny unauthorized login
@@ -79,7 +81,13 @@ handle_event(internal,
                     {next_state, {connected,server}, D,
                      [set_alive_timeout(D), set_max_initial_idle_timeout(D),
                       {change_callback_module,ssh_connection_handler}
-                     ]}
+                     ]};
+                {auth_tries_exceeded, _, Ssh = #ssh{}} ->
+                    {Shutdown, D} = ?send_disconnect(
+                        ?SSH_DISCONNECT_PROTOCOL_ERROR,
+                        "Too many authentication failures", StateName,
+                        D0#data{ssh_params = Ssh}),
+                    {stop, Shutdown, D}
             end;
 	
 	{"ssh-connection", "ssh-connection", Method} ->
@@ -94,6 +102,13 @@ handle_event(internal,
                              [set_alive_timeout(D), set_max_initial_idle_timeout(D),
                               {change_callback_module,ssh_connection_handler}
                              ]};
+                        {auth_tries_exceeded, {User, Error}, Ssh = #ssh{}} ->
+                            retry_fun(User, Error, D0),
+                            {Shutdown, D} = ?send_disconnect(
+                                ?SSH_DISCONNECT_PROTOCOL_ERROR,
+                                "Too many authentication failures", StateName,
+                                D0#data{ssh_params = Ssh}),
+                            {stop, Shutdown, D};
 			{not_authorized, {User, Reason}, {Reply, Ssh}} when Method == "keyboard-interactive" ->
 			    retry_fun(User, Reason, D1),
                             D = ssh_connection_handler:send_msg(Reply, D1#data{ssh_params = Ssh}),
@@ -104,9 +119,10 @@ handle_event(internal,
 			    {keep_state, D}
 		    end;
 		false ->
-		    %% No we do not support this method (=/= none)
-		    %% At least one non-erlang client does like this. Retry as the next event
-		    {keep_state_and_data,
+                    %% No we do not support this method (=/= none)
+                    %% At least one non-erlang client does like this. Retry as the next event.
+                    %% Keep the bumped auth_attempts so the retried "none" is not free.
+                    {keep_state, D1,
 		     [{next_event, internal, Msg#ssh_msg_userauth_request{method="none"}}]
 		    }
 	    end;
@@ -122,7 +138,8 @@ handle_event(internal,
             {stop, Shutdown, D}
     end;
 
-handle_event(internal, #ssh_msg_userauth_info_response{} = Msg, {userauth_keyboard_interactive, server}, D0) ->
+handle_event(internal, #ssh_msg_userauth_info_response{} = Msg,
+             {userauth_keyboard_interactive, server} = StateName, D0) ->
     case ssh_auth:handle_userauth_info_response(Msg, D0#data.ssh_params) of
 	{authorized, User, {Reply, Ssh1}} ->
             D = connected_state(Reply, Ssh1, User, "keyboard-interactive", D0),
@@ -134,7 +151,13 @@ handle_event(internal, #ssh_msg_userauth_info_response{} = Msg, {userauth_keyboa
 	    retry_fun(User, Reason, D0),
             D = ssh_connection_handler:send_msg(Reply, D0#data{ssh_params = Ssh}),
 	    {next_state, {userauth,server}, D};
-
+        {auth_tries_exceeded, {User, Error}, Ssh = #ssh{}} ->
+            retry_fun(User, Error, D0),
+            {Shutdown, D} = ?send_disconnect(
+                               ?SSH_DISCONNECT_PROTOCOL_ERROR,
+                               "Too many authentication failures", StateName,
+                               D0#data{ssh_params = Ssh}),
+            {stop, Shutdown, D};
 	{authorized_but_one_more, _User,  {Reply, Ssh}} ->
             D = ssh_connection_handler:send_msg(Reply, D0#data{ssh_params = Ssh}),
 	    {next_state, {userauth_keyboard_interactive_extra,server}, D}
@@ -230,3 +253,6 @@ maybe_send_banner(D0 = #data{ssh_params = #ssh{userauth_banner_sent = false} = S
     end;
 maybe_send_banner(D, _) ->
     D.
+
+increment_auth_attempts(D = #data{ssh_params = Ssh}) ->
+    D#data{ssh_params = Ssh#ssh{auth_attempts = Ssh#ssh.auth_attempts + 1}}.

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -643,6 +643,14 @@ default(server) ->
             class => user_option
            },
 
+      max_auth_tries =>
+          #{default => 6,
+            chk => fun(V) ->
+                           check_pos_integer(V) orelse V =:= infinity
+                   end,
+            class => user_option
+           },
+
 %%%%% Undocumented
       infofun =>
           #{default => fun(_,_,_) -> void end,

--- a/lib/ssh/test/ssh_basic_SUITE.erl
+++ b/lib/ssh/test/ssh_basic_SUITE.erl
@@ -172,7 +172,8 @@ init_per_suite(Config) ->
                       Config
                   end).
 
-end_per_suite(_Config) ->
+end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     ssh:stop().
 
 %%--------------------------------------------------------------------

--- a/lib/ssh/test/ssh_dbg_SUITE.erl
+++ b/lib/ssh/test/ssh_dbg_SUITE.erl
@@ -86,7 +86,8 @@ init_per_suite(Config) ->
                       setup_dirs(Config)
                   end).
 
-end_per_suite(_Config) ->
+end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     ssh:stop().
 
 %%--------------------------------------------------------------------

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -101,7 +101,8 @@
          pwdfun_lockout_ets/1,
          max_auth_request_size_large_enough/1,
          max_auth_request_size_too_small/1,
-         max_auth_request_size_invalid_option/1
+         max_auth_request_size_invalid_option/1,
+         max_auth_tries_option/1
 	]).
 
 %%% Common test callbacks
@@ -177,7 +178,8 @@ all() ->
      daemon_replace_options_algs_conf_file,
      daemon_replace_options_not_found,
      {group, hardening_tests},
-     {group, max_auth_request_size}
+     {group, max_auth_request_size},
+     {group, max_auth_tries}
     ].
 
 groups() ->
@@ -199,7 +201,8 @@ groups() ->
                         system_dir_option]},
      {max_auth_request_size, [], [max_auth_request_size_large_enough,
                                   max_auth_request_size_too_small,
-                                  max_auth_request_size_invalid_option]}
+                                  max_auth_request_size_invalid_option]},
+     {max_auth_tries, [], [max_auth_tries_option]}
     ].
 
 
@@ -207,7 +210,8 @@ groups() ->
 init_per_suite(Config) ->
     ?CHECK_CRYPTO(Config).
 
-end_per_suite(_Config) ->
+end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     ssh:stop().
 
 %%--------------------------------------------------------------------
@@ -2290,6 +2294,20 @@ pwdfun_lockout_ets(Config) ->
     ?CT_LOG("Account lockout verified", []),
     ets:delete(Tab),
     ssh:stop_daemon(Pid).
+
+%%--------------------------------------------------------------------
+max_auth_tries_option(_Config) ->
+    %% Valid values accepted
+    #{max_auth_tries := 3} = ssh_options:handle_options(server, [{max_auth_tries, 3}]),
+    #{max_auth_tries := 1} = ssh_options:handle_options(server, [{max_auth_tries, 1}]),
+    %% infinity disables the limit
+    #{max_auth_tries := infinity} = ssh_options:handle_options(server, [{max_auth_tries, infinity}]),
+    %% Default value is 6
+    #{max_auth_tries := 6} = ssh_options:handle_options(server, []),
+    %% Bad values rejected
+    {error, {eoptions, _}} = ssh_options:handle_options(server, [{max_auth_tries, 0}]),
+    {error, {eoptions, _}} = ssh_options:handle_options(server, [{max_auth_tries, -1}]),
+    {error, {eoptions, _}} = ssh_options:handle_options(server, [{max_auth_tries, foo}]).
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -31,6 +31,7 @@
 -include("ssh_connect.hrl").
 -include("ssh_auth.hrl").
 -include("ssh_test_lib.hrl").
+-include_lib("public_key/include/public_key.hrl"). % #'ECPoint'{}, ?'id-Ed25519'
 
 %% RFC 3526 Group 14 — 2048-bit MODP prime (generator = 2).
 -define(RFC3526_GROUP14_PRIME,
@@ -114,7 +115,18 @@
          channel_close_timeout/1,
          extra_ssh_msg_service_request/1,
          client_guesses_correctly/1,
-         client_guesses_incorrectly/1
+         client_guesses_incorrectly/1,
+         max_auth_tries_exceeded/1,
+         max_auth_tries_exceeded_none/1,
+         max_auth_tries_almost_exceeded/1,
+         max_auth_tries_exceeded_kb/1,
+         max_auth_tries_exceeded_pubkey/1,
+         max_auth_tries_exceeded_unsupported/1,
+         max_auth_tries_pubkey_probe_free/1,
+         max_auth_tries_none_after_pubkey_probe/1,
+         max_auth_tries_signed_pubkey_failure/1,
+         max_auth_tries_password_change/1,
+         max_auth_tries_infinity/1
         ]).
 
 -define(DEFAULT_KEX, 'diffie-hellman-group14-sha256').
@@ -182,6 +194,10 @@ suite() ->
                 ok;
            (extra_ssh_msg_service_request, 1) ->
                 ok;
+           (max_auth_tries_almost_exceeded, 1) ->
+                ok;
+           (max_auth_tries_infinity, 10) ->
+                ok;
            (_, EventNumber) ->
                 {fail, lists:flatten(
                          io_lib:format("unexpected event cnt: ~s",
@@ -212,7 +228,8 @@ all() ->
      {group,alive},
      {group,dh},
      {group,ecdh},
-     {group,hybrid}
+     {group,hybrid},
+     {group,max_auth_tries}
     ].
 
 groups() ->
@@ -298,7 +315,18 @@ groups() ->
      {aead, [], [packet_length_too_short,
                 packet_length_too_large,
                 packet_length_longer_than_max,
-                bad_mac]}
+                bad_mac]},
+     {max_auth_tries, [], [max_auth_tries_exceeded,
+                           max_auth_tries_exceeded_none,
+                           max_auth_tries_almost_exceeded,
+                           max_auth_tries_exceeded_kb,
+                           max_auth_tries_exceeded_pubkey,
+                           max_auth_tries_exceeded_unsupported,
+                           max_auth_tries_pubkey_probe_free,
+                           max_auth_tries_none_after_pubkey_probe,
+                           max_auth_tries_signed_pubkey_failure,
+                           max_auth_tries_password_change,
+                           max_auth_tries_infinity]}
     ].
 
 
@@ -306,6 +334,7 @@ init_per_suite(Config) ->
     ?CHECK_CRYPTO(start_std_daemon( setup_dirs( start_apps(Config)))).
 
 end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     stop_apps(Config).
 
 init_per_group(guess, Config) ->
@@ -2205,9 +2234,518 @@ client_guesses_incorrectly(Config) ->
      || Helper <- Helpers, K <- ServerKexAlgs, P <- ServerPubKeyAlgs,
         K /= KexAlgs orelse P /= PubKeyAlgs].
 
+
+%%--------------------------------------------------------------------
+%% Macros for max_auth_tries tests
+-define(MATCH_FAILURE, {match, #ssh_msg_userauth_failure{_='_'}, receive_msg}).
+-define(MATCH_DISCONNECT,
+        {match, #ssh_msg_disconnect{code = 2,
+                                    description = "Protocol error",
+                                    _='_'}, receive_msg}).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded(Config) ->
+    %% Test that the server disconnects once max_auth_tries is exceeded.
+    %% We set max_auth_tries to 3. The client's first "none" request is a
+    %% free method-discovery probe (RFC 4252, like OpenSSH), a second "none"
+    %% and every real method count against the limit. So: none#1 (free),
+    %% none#2 (try 1), password#1 (try 2), password#2 -> disconnect.
+    Parent = self(),
+    Ref = make_ref(),
+    DisconnectRef = make_ref(),
+    with_max_auth_daemon(
+      Config, 3,
+      [{failfun, test_failfun(Parent, Ref)},
+       {disconnectfun, test_disconnectfun(Parent, DisconnectRef)}],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              %% The first "none" is a free method-discovery probe; the second
+              %% counts as a failed attempt (MaxTries=3 -> 2 tries left).
+              {ok, State2} =
+                  user_auth_method_failed("none", User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+
+              %% One more failure is answered with a failure message, the next
+              %% one disconnects.
+              BadPwd = "wrong_password",
+              {ok, State4} =
+                  user_auth_password_failed(BadPwd, User, State3, ?MATCH_FAILURE),
+              {ok, _State5} =
+                  user_auth_password_failed(BadPwd, User, State4,
+                                            ?MATCH_DISCONNECT),
+              assert_callbacks(
+                Ref, User, ["Bad user or password", "Bad user or password"]),
+              assert_disconnect_callback(
+                DisconnectRef,
+                "Disconnects with code = 2 [RFC4253 11.1]: Protocol error")
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded_none(Config) ->
+    %% Repeated "none" requests eventually exhaust max_auth_tries, just like
+    %% OpenSSH. Only the very first "none" is free, so with max_auth_tries
+    %% set to 3: none#1 (free), none#2 (try 1), none#3 (try 2), none#4 ->
+    %% disconnect.
+    with_max_auth_daemon(
+      Config, 3, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_method_failed("none", User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+              {ok, State4} =
+                  user_auth_method_failed("none", User, State3, ?MATCH_FAILURE),
+              {ok, _State5} =
+                  user_auth_method_failed("none", User, State4,
+                                          ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_almost_exceeded(Config) ->
+    %% Test that the server rejects password authentication
+    %% allows the authentication to succeed even at the last
+    %% attempt
+    with_max_auth_daemon(
+      Config, 2, [{failfun, fun ssh_test_lib:failfun/2}],
+      fun(Host, Port, UserDir, Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              %% One failure
+              BadPwd = "wrong_password",
+              {ok, State2} =
+                  user_auth_password_failed(BadPwd, User, State1, ?MATCH_FAILURE),
+              %% Success at the last attempt
+              {ok, _State3} =
+                  ssh_trpt_test_lib:exec(
+                    [{send, #ssh_msg_userauth_request{
+                               user = User,
+                               service = "ssh-connection",
+                               method = "password",
+                               data = <<?BOOLEAN(?FALSE),
+                                        ?STRING(unicode:characters_to_binary(Pwd))>>}},
+                     {match, #ssh_msg_userauth_success{_='_'}, receive_msg}
+                    ], State2)
+      end).
+
+max_auth_tries_exceeded_kb(Config) ->
+    %% Same as max_auth_tries_exceeded but with keyboard-interactive as the
+    %% real method and max_auth_tries set to 6. none#1 is free, none#2 uses
+    %% try 1, then four kb failures use tries 2-5 and the sixth disconnects.
+    Parent = self(),
+    Ref = make_ref(),
+    with_max_auth_daemon(
+      Config, 6, [{failfun, test_failfun(Parent, Ref)}],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              %% The first "none" is free; the second counts (MaxTries=6 ->
+              %% 5 left).
+              {ok, State2} =
+                  user_auth_method_failed("none", User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+
+              %% Four more failures are answered with a failure message, the
+              %% fifth disconnects.
+              BadPwd = "wrong_password",
+              {ok, State4} =
+                  user_auth_kb_int_failed(BadPwd, User, State3, ?MATCH_FAILURE),
+              {ok, State5} =
+                  user_auth_kb_int_failed(BadPwd, User, State4, ?MATCH_FAILURE),
+              {ok, State6} =
+                  user_auth_kb_int_failed(BadPwd, User, State5, ?MATCH_FAILURE),
+              {ok, State7} =
+                  user_auth_kb_int_failed(BadPwd, User, State6, ?MATCH_FAILURE),
+              {ok, _State8} =
+                  user_auth_kb_int_failed(BadPwd, User, State7,
+                                          ?MATCH_DISCONNECT),
+              assert_callbacks(
+                Ref, User, lists:duplicate(5, "Bad user or password"))
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded_pubkey(Config) ->
+    %% Test that publickey "query" requests (the RFC 4252 section 7 message
+    %% with the has-signature boolean set to FALSE) count against
+    %% max_auth_tries when the offered key would not be accepted by the
+    %% server. We set max_auth_tries to 3 and send 3 probes with a valid but
+    %% unauthorized key. The third probe leads to the connection being
+    %% disconnected with a protocol error.
+    with_max_auth_daemon(
+      Config, 3, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              %% A valid but (for user "foo") unauthorized key: every probe
+              %% is rejected.
+              {KeyBlob, KeyAlg} = unauthorized_pubkey(),
+              {ok, State2} =
+                  user_auth_pubkey_probe_failed(KeyBlob, KeyAlg, User, State1,
+                                                ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_pubkey_probe_failed(KeyBlob, KeyAlg, User, State2,
+                                                ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_pubkey_probe_failed(KeyBlob, KeyAlg, User, State3,
+                                                ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded_unsupported(Config) ->
+    %% A userauth request with a method the server does not support (i.e. not
+    %% in userauth_methods and not "none") counts against max_auth_tries, like
+    %% OpenSSH. We set max_auth_tries to 3 and send 3 requests with an
+    %% unsupported method; each is answered with a failure listing the
+    %% supported methods, and the third leads to a disconnect.
+    with_max_auth_daemon(
+      Config, 3, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              Method = "hostbased",
+              {ok, State2} =
+                  user_auth_method_failed(Method, User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed(Method, User, State2, ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_method_failed(Method, User, State3,
+                                          ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_pubkey_probe_free(Config) ->
+    %% An accepted unsigned public-key probe does not consume the failure
+    %% budget. With a limit of two, two subsequent bad passwords are therefore
+    %% needed to disconnect the client.
+    with_max_auth_daemon(
+      Config, 2, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {KeyBlob, KeyAlg} = authorized_pubkey(UserDir),
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_pubkey_probe_accepted(KeyBlob, KeyAlg, User, State1),
+              {ok, State3} =
+                  user_auth_password_failed("wrong_password", User, State2,
+                                            ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_password_failed("wrong_password", User, State3,
+                                            ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_none_after_pubkey_probe(Config) ->
+    %% Only an initial "none" request is free. Once an accepted public-key
+    %% probe has been sent, "none" consumes one try and the following bad
+    %% password reaches a limit of two.
+    with_max_auth_daemon(
+      Config, 2, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {KeyBlob, KeyAlg} = authorized_pubkey(UserDir),
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_pubkey_probe_accepted(KeyBlob, KeyAlg, User, State1),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_password_failed("wrong_password", User, State3,
+                                            ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_signed_pubkey_failure(Config) ->
+    %% A signed public-key request with an invalid signature consumes a try.
+    %% A subsequent bad password therefore reaches a limit of two.
+    with_max_auth_daemon(
+      Config, 2, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {KeyBlob, KeyAlg} = authorized_pubkey(UserDir),
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_signed_pubkey_failed(KeyBlob, KeyAlg, User, State1,
+                                                ?MATCH_FAILURE),
+              {ok, _State3} =
+                  user_auth_password_failed("wrong_password", User, State2,
+                                            ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_password_change(Config) ->
+    %% Rejecting a valid unsolicited password-change request consumes one try
+    %% and is reported through failfun. The following bad password therefore
+    %% reaches a limit of two.
+    Parent = self(),
+    Ref = make_ref(),
+    with_max_auth_daemon(
+      Config, 2, [{failfun, test_failfun(Parent, Ref)}],
+      fun(Host, Port, UserDir, Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_password_change_failed(Pwd, "new_password", User,
+                                                   State1, ?MATCH_FAILURE),
+              {ok, _State3} =
+                  user_auth_password_failed("wrong_password", User, State2,
+                                            ?MATCH_DISCONNECT),
+              assert_callbacks(Ref, User,
+                               ["Password change not supported",
+                                "Bad user or password"])
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_infinity(Config) ->
+    %% With max_auth_tries set to infinity the server never disconnects due
+    %% to failed attempts. We send 10 failed password attempts (well above
+    %% the default of 6), each answered with a failure, and then a correct
+    %% password which is accepted.
+    with_max_auth_daemon(
+      Config, infinity, [{failfun, fun ssh_test_lib:failfun/2}],
+      fun(Host, Port, UserDir, Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              BadPwd = "wrong_password",
+              {ok, StateN} =
+                  lists:foldl(
+                    fun(_, {ok, StateAcc}) ->
+                            user_auth_password_failed(BadPwd, User, StateAcc,
+                                                      ?MATCH_FAILURE)
+                    end, {ok, State1}, lists:seq(1, 10)),
+
+              {ok, _StateOk} =
+                  ssh_trpt_test_lib:exec(
+                    [{send, #ssh_msg_userauth_request{
+                               user = User,
+                               service = "ssh-connection",
+                               method = "password",
+                               data = <<?BOOLEAN(?FALSE),
+                                        ?STRING(unicode:characters_to_binary(Pwd))>>}},
+                     {match, #ssh_msg_userauth_success{_='_'}, receive_msg}
+                    ], StateN)
+      end).
+
 %%%================================================================
 %%%==== Internal functions ========================================
 %%%================================================================
+
+%% Connect, run key exchange and request the ssh-userauth service.
+connect_and_request_userauth(Host, Port, UserDir) ->
+    {ok, InitState} =
+        ssh_trpt_test_lib:exec(
+          [{set_options, [print_ops, print_messages]},
+           {connect,Host,Port,
+            [{preferred_algorithms,[{kex,[?DEFAULT_KEX]},
+                                    {cipher,?DEFAULT_CIPHERS}
+                                   ]},
+             {silently_accept_hosts, true},
+             {recv_ext_info, false},
+             {user_dir, UserDir},
+             {user_interaction, false}
+            ]},
+           receive_hello,
+           {send, hello},
+           {send, ssh_msg_kexinit},
+           {match, #ssh_msg_kexinit{_='_'}, receive_msg},
+           {send, ssh_msg_kexdh_init},
+           {match,# ssh_msg_kexdh_reply{_='_'}, receive_msg},
+           {send, #ssh_msg_newkeys{}},
+           {match, #ssh_msg_newkeys{_='_'}, receive_msg}
+          ]),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_service_request{name = "ssh-userauth"}},
+       {match, #ssh_msg_service_accept{name = "ssh-userauth"}, receive_msg}
+      ], InitState).
+
+%% Run a test with a daemon configured for a specific authentication limit and
+%% guarantee that the daemon is stopped when an assertion fails.
+with_max_auth_daemon(Config, MaxTries, ExtraOptions, TestFun) ->
+    UserDir = ssh_test_lib:user_dir(Config),
+    Pwd = "bar",
+    {Pid, Host, Port} =
+        ssh_test_lib:daemon([{system_dir, ssh_test_lib:system_dir(Config)},
+                             {user_dir, UserDir},
+                             {password, Pwd},
+                             {max_auth_tries, MaxTries}
+                             | ExtraOptions]),
+    try
+        TestFun(Host, Port, UserDir, Pwd)
+    after
+        try ssh:stop_daemon(Pid)
+        catch
+            _:_ -> ok
+        end
+    end.
+
+%% Read one of the suite's generated authorized keys. Deriving the algorithm
+%% from the key keeps the tests portable across crypto/FIPS configurations.
+authorized_pubkey(UserDir) ->
+    {ok, AuthorizedKeys} =
+        file:read_file(filename:join(UserDir, "authorized_keys")),
+    DefaultAlgs = ssh_transport:default_algorithms(public_key),
+    [{Key, KeyAlg} | _] =
+        [{CandidateKey, CandidateAlg}
+         || {CandidateKey, _Attributes} <- ssh_file:decode(AuthorizedKeys,
+                                                           auth_keys),
+            {ok, CandidateAlg} <-
+                [authorized_key_algorithm(CandidateKey, DefaultAlgs)]],
+    KeyBlob = ssh_message:ssh2_pubkey_encode(Key),
+    {KeyBlob, atom_to_binary(KeyAlg, latin1)}.
+
+authorized_key_algorithm(Key, DefaultAlgs) ->
+    Candidates =
+        case ssh_transport:public_algo(Key) of
+            'ssh-rsa' -> ['rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa'];
+            PublicAlg -> [PublicAlg]
+        end,
+    case [Alg || Alg <- Candidates, lists:member(Alg, DefaultAlgs)] of
+        [SelectedAlg | _] -> {ok, SelectedAlg};
+        [] -> error
+    end.
+
+%% Build a valid but (for the test user) unauthorized public key blob.
+unauthorized_pubkey() ->
+    {PubBin, _PrivBin} = crypto:generate_key(ecdh, secp256r1),
+    PubKey = {#'ECPoint'{point = PubBin}, {namedCurve, ?'secp256r1'}},
+    {ssh_message:ssh2_pubkey_encode(PubKey), <<"ecdsa-sha2-nistp256">>}.
+
+user_auth_pubkey_probe_accepted(KeyBlob, Alg, User, State) ->
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "publickey",
+                                        data = <<?BYTE(?FALSE),
+                                                 ?STRING(Alg),
+                                                 ?STRING(KeyBlob)>>}},
+       %% SSH_MSG_USERAUTH_PK_OK and SSH_MSG_USERAUTH_PASSWD_CHANGEREQ share
+       %% message number 60. The transport test decoder represents that number
+       %% with the latter record, whose prompt field contains the algorithm.
+       {match, #ssh_msg_userauth_passwd_changereq{prompt = Alg,
+                                                  language = KeyBlob},
+        receive_msg}
+      ], State).
+
+user_auth_pubkey_probe_failed(KeyBlob, Alg, User, State, Match) ->
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "publickey",
+                                        data = <<?BYTE(?FALSE),
+                                                 ?STRING(Alg),
+                                                 ?STRING(KeyBlob)>>}},
+       Match
+      ], State).
+
+user_auth_signed_pubkey_failed(KeyBlob, Alg, User, State, Match) ->
+    %% An empty SSH signature blob is well-formed at the request level but can
+    %% never verify, which reliably exercises the signed-public-key path.
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "publickey",
+                                        data = <<?BYTE(?TRUE),
+                                                 ?STRING(Alg),
+                                                 ?STRING(KeyBlob),
+                                                 ?STRING(<<>>)>>}},
+       Match
+      ], State).
+
+user_auth_method_failed(Method, User, State, Match) ->
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = Method}},
+       Match
+      ], State).
+
+user_auth_kb_int_failed(Pwd0, User, State, Match) ->
+    Pwd = unicode:characters_to_binary(Pwd0),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "keyboard-interactive",
+                                        data = <<0,0,0,0,0,0,0,0>>}},
+       {match, #ssh_msg_userauth_info_request{_='_'}, receive_msg},
+       {send, #ssh_msg_userauth_info_response{num_responses = 1,
+                                              data = [Pwd]}},
+       Match
+      ], State).
+
+user_auth_password_change_failed(OldPwd0, NewPwd0, User, State, Match) ->
+    OldPwd = unicode:characters_to_binary(OldPwd0),
+    NewPwd = unicode:characters_to_binary(NewPwd0),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "password",
+                                        data = <<?BOOLEAN(?TRUE),
+                                                 ?STRING(OldPwd),
+                                                 ?STRING(NewPwd)>>}},
+       Match
+      ], State).
+
+user_auth_password_failed(Pwd0, User, State, Match) ->
+    Pwd = unicode:characters_to_binary(Pwd0),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "password",
+                                        data = <<?BOOLEAN(?FALSE),
+                                                 ?STRING(Pwd)>>}},
+       Match
+      ], State).
+
+test_failfun(Parent, Ref) ->
+    fun(User, _Peer, Reason) ->
+            Parent ! {Ref, failfun, User, Reason}
+    end.
+
+test_disconnectfun(Parent, Ref) ->
+    fun(Reason) ->
+            Parent ! {Ref, disconnectfun, lists:flatten(Reason)}
+    end.
+
+assert_disconnect_callback(Ref, ExpectedReason) ->
+    receive
+        {Ref, disconnectfun, ExpectedReason} ->
+            ok;
+        {Ref, disconnectfun, ActualReason} ->
+            ct:fail("Unexpected disconnect callback: expected ~p, got ~p",
+                    [ExpectedReason, ActualReason])
+    after 2000 ->
+            ct:fail("Missing disconnect callback: ~p", [ExpectedReason])
+    end.
+
+assert_callbacks(Ref, User, ExpectedReasons) ->
+    assert_callbacks(Ref, User, ExpectedReasons, ExpectedReasons).
+
+assert_callbacks(Ref, User, [ExpectedReason | Rest], AllExpected) ->
+    receive
+        {Ref, failfun, User, ExpectedReason} ->
+            assert_callbacks(Ref, User, Rest, AllExpected);
+        {Ref, Tag, ActualUser, Reason} ->
+            ct:fail("Unexpected authentication callback: expected ~p, got ~p",
+                    [{failfun, User, ExpectedReason},
+                     {Tag, ActualUser, Reason}])
+    after 2000 ->
+            ct:fail("Missing authentication callbacks: ~p", [AllExpected])
+    end;
+assert_callbacks(Ref, _User, [], _AllExpected) ->
+    receive
+        {Ref, Tag, User, Reason} ->
+            ct:fail("Unexpected extra authentication callback: ~p",
+                    [{Tag, User, Reason}])
+    after 0 ->
+            ok
+    end.
 
 chk_pref_algs(Config,
               ExpectedKex,

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -31,6 +31,7 @@
 -include("ssh_connect.hrl").
 -include("ssh_auth.hrl").
 -include("ssh_test_lib.hrl").
+-include_lib("public_key/include/public_key.hrl"). % #'ECPoint'{}, ?'id-Ed25519'
 
 %% RFC 3526 Group 14 — 2048-bit MODP prime (generator = 2).
 -define(RFC3526_GROUP14_PRIME,
@@ -114,7 +115,18 @@
          channel_close_timeout/1,
          extra_ssh_msg_service_request/1,
          client_guesses_correctly/1,
-         client_guesses_incorrectly/1
+         client_guesses_incorrectly/1,
+         max_auth_tries_exceeded/1,
+         max_auth_tries_exceeded_none/1,
+         max_auth_tries_almost_exceeded/1,
+         max_auth_tries_exceeded_kb/1,
+         max_auth_tries_exceeded_pubkey/1,
+         max_auth_tries_exceeded_unsupported/1,
+         max_auth_tries_pubkey_probe_free/1,
+         max_auth_tries_none_after_pubkey_probe/1,
+         max_auth_tries_signed_pubkey_failure/1,
+         max_auth_tries_password_change/1,
+         max_auth_tries_infinity/1
         ]).
 
 -define(DEFAULT_KEX, 'diffie-hellman-group14-sha256').
@@ -182,6 +194,10 @@ suite() ->
                 ok;
            (extra_ssh_msg_service_request, 1) ->
                 ok;
+           (max_auth_tries_almost_exceeded, 1) ->
+                ok;
+           (max_auth_tries_infinity, 10) ->
+                ok;
            (_, EventNumber) ->
                 {fail, lists:flatten(
                          io_lib:format("unexpected event cnt: ~s",
@@ -212,7 +228,8 @@ all() ->
      {group,alive},
      {group,dh},
      {group,ecdh},
-     {group,hybrid}
+     {group,hybrid},
+     {group,max_auth_tries}
     ].
 
 groups() ->
@@ -298,7 +315,18 @@ groups() ->
      {aead, [], [packet_length_too_short,
                 packet_length_too_large,
                 packet_length_longer_than_max,
-                bad_mac]}
+                bad_mac]},
+     {max_auth_tries, [], [max_auth_tries_exceeded,
+                           max_auth_tries_exceeded_none,
+                           max_auth_tries_almost_exceeded,
+                           max_auth_tries_exceeded_kb,
+                           max_auth_tries_exceeded_pubkey,
+                           max_auth_tries_exceeded_unsupported,
+                           max_auth_tries_pubkey_probe_free,
+                           max_auth_tries_none_after_pubkey_probe,
+                           max_auth_tries_signed_pubkey_failure,
+                           max_auth_tries_password_change,
+                           max_auth_tries_infinity]}
     ].
 
 
@@ -306,6 +334,7 @@ init_per_suite(Config) ->
     ?CHECK_CRYPTO(start_std_daemon( setup_dirs( start_apps(Config)))).
 
 end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     stop_apps(Config).
 
 init_per_group(guess, Config) ->
@@ -2205,9 +2234,515 @@ client_guesses_incorrectly(Config) ->
      || Helper <- Helpers, K <- ServerKexAlgs, P <- ServerPubKeyAlgs,
         K /= KexAlgs orelse P /= PubKeyAlgs].
 
+
+%%--------------------------------------------------------------------
+%% Macros for max_auth_tries tests
+-define(MATCH_FAILURE, {match, #ssh_msg_userauth_failure{_='_'}, receive_msg}).
+-define(MATCH_DISCONNECT, {match, disconnect(2), receive_msg}).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded(Config) ->
+    %% Test that the server disconnects once max_auth_tries is exceeded.
+    %% We set max_auth_tries to 3. The client's first "none" request is a
+    %% free method-discovery probe (RFC 4252, like OpenSSH), a second "none"
+    %% and every real method count against the limit. So: none#1 (free),
+    %% none#2 (try 1), password#1 (try 2), password#2 -> disconnect.
+    Parent = self(),
+    Ref = make_ref(),
+    DisconnectRef = make_ref(),
+    with_max_auth_daemon(
+      Config, 3,
+      [{failfun, test_failfun(Parent, Ref)},
+       {disconnectfun, test_disconnectfun(Parent, DisconnectRef)}],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              %% The first "none" is a free method-discovery probe; the second
+              %% counts as a failed attempt (MaxTries=3 -> 2 tries left).
+              {ok, State2} =
+                  user_auth_method_failed("none", User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+
+              %% One more failure is answered with a failure message, the next
+              %% one disconnects.
+              BadPwd = "wrong_password",
+              {ok, State4} =
+                  user_auth_password_failed(BadPwd, User, State3, ?MATCH_FAILURE),
+              {ok, _State5} =
+                  user_auth_password_failed(BadPwd, User, State4,
+                                            ?MATCH_DISCONNECT),
+              assert_callbacks(
+                Ref, User, ["Bad user or password", "Bad user or password"]),
+              assert_disconnect_callback(
+                DisconnectRef,
+                "Disconnects with code = 2 [RFC4253 11.1]: Protocol error")
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded_none(Config) ->
+    %% Repeated "none" requests eventually exhaust max_auth_tries, just like
+    %% OpenSSH. Only the very first "none" is free, so with max_auth_tries
+    %% set to 3: none#1 (free), none#2 (try 1), none#3 (try 2), none#4 ->
+    %% disconnect.
+    with_max_auth_daemon(
+      Config, 3, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_method_failed("none", User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+              {ok, State4} =
+                  user_auth_method_failed("none", User, State3, ?MATCH_FAILURE),
+              {ok, _State5} =
+                  user_auth_method_failed("none", User, State4,
+                                          ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_almost_exceeded(Config) ->
+    %% Test that the server rejects password authentication
+    %% allows the authentication to succeed even at the last
+    %% attempt
+    with_max_auth_daemon(
+      Config, 2, [{failfun, fun ssh_test_lib:failfun/2}],
+      fun(Host, Port, UserDir, Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              %% One failure
+              BadPwd = "wrong_password",
+              {ok, State2} =
+                  user_auth_password_failed(BadPwd, User, State1, ?MATCH_FAILURE),
+              %% Success at the last attempt
+              {ok, _State3} =
+                  ssh_trpt_test_lib:exec(
+                    [{send, #ssh_msg_userauth_request{
+                               user = User,
+                               service = "ssh-connection",
+                               method = "password",
+                               data = <<?BOOLEAN(?FALSE),
+                                        ?STRING(unicode:characters_to_binary(Pwd))>>}},
+                     {match, #ssh_msg_userauth_success{_='_'}, receive_msg}
+                    ], State2)
+      end).
+
+max_auth_tries_exceeded_kb(Config) ->
+    %% Same as max_auth_tries_exceeded but with keyboard-interactive as the
+    %% real method and max_auth_tries set to 6. none#1 is free, none#2 uses
+    %% try 1, then four kb failures use tries 2-5 and the sixth disconnects.
+    Parent = self(),
+    Ref = make_ref(),
+    with_max_auth_daemon(
+      Config, 6, [{failfun, test_failfun(Parent, Ref)}],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              %% The first "none" is free; the second counts (MaxTries=6 ->
+              %% 5 left).
+              {ok, State2} =
+                  user_auth_method_failed("none", User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+
+              %% Four more failures are answered with a failure message, the
+              %% fifth disconnects.
+              BadPwd = "wrong_password",
+              {ok, State4} =
+                  user_auth_kb_int_failed(BadPwd, User, State3, ?MATCH_FAILURE),
+              {ok, State5} =
+                  user_auth_kb_int_failed(BadPwd, User, State4, ?MATCH_FAILURE),
+              {ok, State6} =
+                  user_auth_kb_int_failed(BadPwd, User, State5, ?MATCH_FAILURE),
+              {ok, State7} =
+                  user_auth_kb_int_failed(BadPwd, User, State6, ?MATCH_FAILURE),
+              {ok, _State8} =
+                  user_auth_kb_int_failed(BadPwd, User, State7,
+                                          ?MATCH_DISCONNECT),
+              assert_callbacks(
+                Ref, User, lists:duplicate(5, "Bad user or password"))
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded_pubkey(Config) ->
+    %% Test that publickey "query" requests (the RFC 4252 section 7 message
+    %% with the has-signature boolean set to FALSE) count against
+    %% max_auth_tries when the offered key would not be accepted by the
+    %% server. We set max_auth_tries to 3 and send 3 probes with a valid but
+    %% unauthorized key. The third probe leads to the connection being
+    %% disconnected with a protocol error.
+    with_max_auth_daemon(
+      Config, 3, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              %% A valid but (for user "foo") unauthorized key: every probe
+              %% is rejected.
+              {KeyBlob, KeyAlg} = unauthorized_pubkey(),
+              {ok, State2} =
+                  user_auth_pubkey_probe_failed(KeyBlob, KeyAlg, User, State1,
+                                                ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_pubkey_probe_failed(KeyBlob, KeyAlg, User, State2,
+                                                ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_pubkey_probe_failed(KeyBlob, KeyAlg, User, State3,
+                                                ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_exceeded_unsupported(Config) ->
+    %% A userauth request with a method the server does not support (i.e. not
+    %% in userauth_methods and not "none") counts against max_auth_tries, like
+    %% OpenSSH. We set max_auth_tries to 3 and send 3 requests with an
+    %% unsupported method; each is answered with a failure listing the
+    %% supported methods, and the third leads to a disconnect.
+    with_max_auth_daemon(
+      Config, 3, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              Method = "hostbased",
+              {ok, State2} =
+                  user_auth_method_failed(Method, User, State1, ?MATCH_FAILURE),
+              {ok, State3} =
+                  user_auth_method_failed(Method, User, State2, ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_method_failed(Method, User, State3,
+                                          ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_pubkey_probe_free(Config) ->
+    %% An accepted unsigned public-key probe does not consume the failure
+    %% budget. With a limit of two, two subsequent bad passwords are therefore
+    %% needed to disconnect the client.
+    with_max_auth_daemon(
+      Config, 2, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {KeyBlob, KeyAlg} = authorized_pubkey(UserDir),
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_pubkey_probe_accepted(KeyBlob, KeyAlg, User, State1),
+              {ok, State3} =
+                  user_auth_password_failed("wrong_password", User, State2,
+                                            ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_password_failed("wrong_password", User, State3,
+                                            ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_none_after_pubkey_probe(Config) ->
+    %% Only an initial "none" request is free. Once an accepted public-key
+    %% probe has been sent, "none" consumes one try and the following bad
+    %% password reaches a limit of two.
+    with_max_auth_daemon(
+      Config, 2, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {KeyBlob, KeyAlg} = authorized_pubkey(UserDir),
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_pubkey_probe_accepted(KeyBlob, KeyAlg, User, State1),
+              {ok, State3} =
+                  user_auth_method_failed("none", User, State2, ?MATCH_FAILURE),
+              {ok, _State4} =
+                  user_auth_password_failed("wrong_password", User, State3,
+                                            ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_signed_pubkey_failure(Config) ->
+    %% A signed public-key request with an invalid signature consumes a try.
+    %% A subsequent bad password therefore reaches a limit of two.
+    with_max_auth_daemon(
+      Config, 2, [],
+      fun(Host, Port, UserDir, _Pwd) ->
+              User = "foo",
+              {KeyBlob, KeyAlg} = authorized_pubkey(UserDir),
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_signed_pubkey_failed(KeyBlob, KeyAlg, User, State1,
+                                                ?MATCH_FAILURE),
+              {ok, _State3} =
+                  user_auth_password_failed("wrong_password", User, State2,
+                                            ?MATCH_DISCONNECT)
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_password_change(Config) ->
+    %% Rejecting a valid unsolicited password-change request consumes one try
+    %% and is reported through failfun. The following bad password therefore
+    %% reaches a limit of two.
+    Parent = self(),
+    Ref = make_ref(),
+    with_max_auth_daemon(
+      Config, 2, [{failfun, test_failfun(Parent, Ref)}],
+      fun(Host, Port, UserDir, Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+              {ok, State2} =
+                  user_auth_password_change_failed(Pwd, "new_password", User,
+                                                   State1, ?MATCH_FAILURE),
+              {ok, _State3} =
+                  user_auth_password_failed("wrong_password", User, State2,
+                                            ?MATCH_DISCONNECT),
+              assert_callbacks(Ref, User,
+                               ["Password change not supported",
+                                "Bad user or password"])
+      end).
+
+%%--------------------------------------------------------------------
+max_auth_tries_infinity(Config) ->
+    %% With max_auth_tries set to infinity the server never disconnects due
+    %% to failed attempts. We send 10 failed password attempts (well above
+    %% the default of 6), each answered with a failure, and then a correct
+    %% password which is accepted.
+    with_max_auth_daemon(
+      Config, infinity, [{failfun, fun ssh_test_lib:failfun/2}],
+      fun(Host, Port, UserDir, Pwd) ->
+              User = "foo",
+              {ok, State1} = connect_and_request_userauth(Host, Port, UserDir),
+
+              BadPwd = "wrong_password",
+              {ok, StateN} =
+                  lists:foldl(
+                    fun(_, {ok, StateAcc}) ->
+                            user_auth_password_failed(BadPwd, User, StateAcc,
+                                                      ?MATCH_FAILURE)
+                    end, {ok, State1}, lists:seq(1, 10)),
+
+              {ok, _StateOk} =
+                  ssh_trpt_test_lib:exec(
+                    [{send, #ssh_msg_userauth_request{
+                               user = User,
+                               service = "ssh-connection",
+                               method = "password",
+                               data = <<?BOOLEAN(?FALSE),
+                                        ?STRING(unicode:characters_to_binary(Pwd))>>}},
+                     {match, #ssh_msg_userauth_success{_='_'}, receive_msg}
+                    ], StateN)
+      end).
+
 %%%================================================================
 %%%==== Internal functions ========================================
 %%%================================================================
+
+%% Connect, run key exchange and request the ssh-userauth service.
+connect_and_request_userauth(Host, Port, UserDir) ->
+    {ok, InitState} =
+        ssh_trpt_test_lib:exec(
+          [{set_options, [print_ops, print_messages]},
+           {connect,Host,Port,
+            [{preferred_algorithms,[{kex,[?DEFAULT_KEX]},
+                                    {cipher,?DEFAULT_CIPHERS}
+                                   ]},
+             {silently_accept_hosts, true},
+             {recv_ext_info, false},
+             {user_dir, UserDir},
+             {user_interaction, false}
+            ]},
+           receive_hello,
+           {send, hello},
+           {send, ssh_msg_kexinit},
+           {match, #ssh_msg_kexinit{_='_'}, receive_msg},
+           {send, ssh_msg_kexdh_init},
+           {match,# ssh_msg_kexdh_reply{_='_'}, receive_msg},
+           {send, #ssh_msg_newkeys{}},
+           {match, #ssh_msg_newkeys{_='_'}, receive_msg}
+          ]),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_service_request{name = "ssh-userauth"}},
+       {match, #ssh_msg_service_accept{name = "ssh-userauth"}, receive_msg}
+      ], InitState).
+
+%% Run a test with a daemon configured for a specific authentication limit and
+%% guarantee that the daemon is stopped when an assertion fails.
+with_max_auth_daemon(Config, MaxTries, ExtraOptions, TestFun) ->
+    UserDir = ssh_test_lib:user_dir(Config),
+    Pwd = "bar",
+    {Pid, Host, Port} =
+        ssh_test_lib:daemon([{system_dir, ssh_test_lib:system_dir(Config)},
+                             {user_dir, UserDir},
+                             {password, Pwd},
+                             {max_auth_tries, MaxTries}
+                             | ExtraOptions]),
+    try
+        TestFun(Host, Port, UserDir, Pwd)
+    after
+        try ssh:stop_daemon(Pid)
+        catch
+            _:_ -> ok
+        end
+    end.
+
+%% Read one of the suite's generated authorized keys. Deriving the algorithm
+%% from the key keeps the tests portable across crypto/FIPS configurations.
+authorized_pubkey(UserDir) ->
+    {ok, AuthorizedKeys} =
+        file:read_file(filename:join(UserDir, "authorized_keys")),
+    DefaultAlgs = ssh_transport:default_algorithms(public_key),
+    [{Key, KeyAlg} | _] =
+        [{CandidateKey, CandidateAlg}
+         || {CandidateKey, _Attributes} <- ssh_file:decode(AuthorizedKeys,
+                                                           auth_keys),
+            {ok, CandidateAlg} <-
+                [authorized_key_algorithm(CandidateKey, DefaultAlgs)]],
+    KeyBlob = ssh_message:ssh2_pubkey_encode(Key),
+    {KeyBlob, atom_to_binary(KeyAlg, latin1)}.
+
+authorized_key_algorithm(Key, DefaultAlgs) ->
+    Candidates =
+        case ssh_transport:public_algo(Key) of
+            'ssh-rsa' -> ['rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa'];
+            PublicAlg -> [PublicAlg]
+        end,
+    case [Alg || Alg <- Candidates, lists:member(Alg, DefaultAlgs)] of
+        [SelectedAlg | _] -> {ok, SelectedAlg};
+        [] -> error
+    end.
+
+%% Build a valid but (for the test user) unauthorized public key blob.
+unauthorized_pubkey() ->
+    {PubBin, _PrivBin} = crypto:generate_key(ecdh, secp256r1),
+    PubKey = {#'ECPoint'{point = PubBin}, {namedCurve, ?'secp256r1'}},
+    {ssh_message:ssh2_pubkey_encode(PubKey), <<"ecdsa-sha2-nistp256">>}.
+
+user_auth_pubkey_probe_accepted(KeyBlob, Alg, User, State) ->
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "publickey",
+                                        data = <<?BYTE(?FALSE),
+                                                 ?STRING(Alg),
+                                                 ?STRING(KeyBlob)>>}},
+       %% SSH_MSG_USERAUTH_PK_OK and SSH_MSG_USERAUTH_PASSWD_CHANGEREQ share
+       %% message number 60. The transport test decoder represents that number
+       %% with the latter record, whose prompt field contains the algorithm.
+       {match, #ssh_msg_userauth_passwd_changereq{prompt = Alg,
+                                                  language = KeyBlob},
+        receive_msg}
+      ], State).
+
+user_auth_pubkey_probe_failed(KeyBlob, Alg, User, State, Match) ->
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "publickey",
+                                        data = <<?BYTE(?FALSE),
+                                                 ?STRING(Alg),
+                                                 ?STRING(KeyBlob)>>}},
+       Match
+      ], State).
+
+user_auth_signed_pubkey_failed(KeyBlob, Alg, User, State, Match) ->
+    %% An empty SSH signature blob is well-formed at the request level but can
+    %% never verify, which reliably exercises the signed-public-key path.
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "publickey",
+                                        data = <<?BYTE(?TRUE),
+                                                 ?STRING(Alg),
+                                                 ?STRING(KeyBlob),
+                                                 ?STRING(<<>>)>>}},
+       Match
+      ], State).
+
+user_auth_method_failed(Method, User, State, Match) ->
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = Method}},
+       Match
+      ], State).
+
+user_auth_kb_int_failed(Pwd0, User, State, Match) ->
+    Pwd = unicode:characters_to_binary(Pwd0),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "keyboard-interactive",
+                                        data = <<0,0,0,0,0,0,0,0>>}},
+       {match, #ssh_msg_userauth_info_request{_='_'}, receive_msg},
+       {send, #ssh_msg_userauth_info_response{num_responses = 1,
+                                              data = [Pwd]}},
+       Match
+      ], State).
+
+user_auth_password_change_failed(OldPwd0, NewPwd0, User, State, Match) ->
+    OldPwd = unicode:characters_to_binary(OldPwd0),
+    NewPwd = unicode:characters_to_binary(NewPwd0),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "password",
+                                        data = <<?BOOLEAN(?TRUE),
+                                                 ?STRING(OldPwd),
+                                                 ?STRING(NewPwd)>>}},
+       Match
+      ], State).
+
+user_auth_password_failed(Pwd0, User, State, Match) ->
+    Pwd = unicode:characters_to_binary(Pwd0),
+    ssh_trpt_test_lib:exec(
+      [{send, #ssh_msg_userauth_request{user = User,
+                                        service = "ssh-connection",
+                                        method = "password",
+                                        data = <<?BOOLEAN(?FALSE),
+                                                 ?STRING(Pwd)>>}},
+       Match
+      ], State).
+
+test_failfun(Parent, Ref) ->
+    fun(User, _Peer, Reason) ->
+            Parent ! {Ref, failfun, User, Reason}
+    end.
+
+test_disconnectfun(Parent, Ref) ->
+    fun(Reason) ->
+            Parent ! {Ref, disconnectfun, lists:flatten(Reason)}
+    end.
+
+assert_disconnect_callback(Ref, ExpectedReason) ->
+    receive
+        {Ref, disconnectfun, ExpectedReason} ->
+            ok;
+        {Ref, disconnectfun, ActualReason} ->
+            ct:fail("Unexpected disconnect callback: expected ~p, got ~p",
+                    [ExpectedReason, ActualReason])
+    after 2000 ->
+            ct:fail("Missing disconnect callback: ~p", [ExpectedReason])
+    end.
+
+assert_callbacks(Ref, User, ExpectedReasons) ->
+    assert_callbacks(Ref, User, ExpectedReasons, ExpectedReasons).
+
+assert_callbacks(Ref, User, [ExpectedReason | Rest], AllExpected) ->
+    receive
+        {Ref, failfun, User, ExpectedReason} ->
+            assert_callbacks(Ref, User, Rest, AllExpected);
+        {Ref, Tag, ActualUser, Reason} ->
+            ct:fail("Unexpected authentication callback: expected ~p, got ~p",
+                    [{failfun, User, ExpectedReason},
+                     {Tag, ActualUser, Reason}])
+    after 2000 ->
+            ct:fail("Missing authentication callbacks: ~p", [AllExpected])
+    end;
+assert_callbacks(Ref, _User, [], _AllExpected) ->
+    receive
+        {Ref, Tag, User, Reason} ->
+            ct:fail("Unexpected extra authentication callback: ~p",
+                    [{Tag, User, Reason}])
+    after 0 ->
+            ok
+    end.
 
 chk_pref_algs(Config,
               ExpectedKex,

--- a/lib/ssh/test/ssh_renegotiate_SUITE.erl
+++ b/lib/ssh/test/ssh_renegotiate_SUITE.erl
@@ -104,8 +104,13 @@ groups() ->
 init_per_suite(Config) ->
     ?CHECK_CRYPTO(begin
                       ssh:start(),
-                      ct:log("Pub keys setup for: ~p",
-                             [ssh_test_lib:setup_all_user_host_keys(Config)]),
+                      %% All test cases in this suite authenticate with a
+                      %% password (see ssh_test_lib:std_daemon/std_connect).
+                      %% The client user_dir is the suite priv_dir, so it must
+                      %% be kept free of private keys: otherwise the client
+                      %% would offer them as publickey "queries" that the
+                      %% password-only daemon rejects, exhausting the default
+                      %% max_auth_tries (6) before the password method is tried.
                       [{preferred_algorithms,ssh_transport:supported_algorithms()}
                        | Config]
                   end).

--- a/lib/ssh/test/ssh_sftpd_SUITE.erl
+++ b/lib/ssh/test/ssh_sftpd_SUITE.erl
@@ -150,6 +150,7 @@ init_per_suite(Config) ->
        end).
 
 end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     UserDir = filename:join(proplists:get_value(priv_dir, Config), nopubkey),
     file:del_dir(UserDir),
     ssh:stop().

--- a/lib/ssh/test/ssh_sftpd_erlclient_SUITE.erl
+++ b/lib/ssh/test/ssh_sftpd_erlclient_SUITE.erl
@@ -89,7 +89,8 @@ init_per_suite(Config) ->
 	   Config
        end).
 
-end_per_suite(_Config) -> 
+end_per_suite(Config) ->
+    ssh_test_lib:clean_all_user_host_keys(Config),
     ok.
 
 %%--------------------------------------------------------------------

--- a/lib/ssh/test/ssh_test_lib.erl
+++ b/lib/ssh/test/ssh_test_lib.erl
@@ -118,6 +118,7 @@ mk_dir_path/1,
 setup_all_user_host_keys/1,
 setup_all_user_host_keys/2,
 setup_all_user_host_keys/3,
+clean_all_user_host_keys/1,
 setup_all_host_keys/1,
 setup_all_host_keys/2,
 setup_all_user_keys/2,
@@ -1236,6 +1237,19 @@ setup_all_user_host_keys(DataDir, UserDir, SysDir) ->
                         end
                 end, [], ssh_transport:supported_algorithms(public_key)).
 
+clean_all_user_host_keys(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    clean_all_user_host_keys(PrivDir, filename:join(PrivDir, "system")).
+
+clean_all_user_host_keys(UserDir, SysDir) ->
+    lists:foreach(
+      fun(Alg) ->
+              file:delete(filename:join(UserDir, file_base_name(user, Alg))),
+              file:delete(filename:join(SysDir, file_base_name(system, Alg)))
+      end, ssh_transport:supported_algorithms(public_key)),
+    file:delete(filename:join(UserDir, "authorized_keys")),
+    file:del_dir(SysDir),
+    ok.
 
 setup_all_host_keys(Config) ->
     DataDir = proplists:get_value(data_dir, Config),


### PR DESCRIPTION
This change implementes the openssh daemon option MaxAuthTries (https://man7.org/linux/man-pages/man5/sshd_config.5.html).