### PR TITLE
erts: Fix tty_tinfo_make_map function arguments

### DIFF
--- a/erts/emulator/nifs/common/prim_tty_nif.c
+++ b/erts/emulator/nifs/common/prim_tty_nif.c
@@ -785,10 +785,11 @@ static ERL_NIF_TERM tty_setupterm_nif(ErlNifEnv* env, int argc, const ERL_NIF_TE
 #endif
 }
 
+#ifdef HAVE_TERMCAP
 static ERL_NIF_TERM tty_tinfo_make_map(ErlNifEnv* env,
-                                       const char * const* names,
-                                       const char * const* codes,
-                                       const char * const* fnames) {
+                                       NCURSES_CONST char * const* names,
+                                       NCURSES_CONST char * const* codes,
+                                       NCURSES_CONST char * const* fnames) {
     ERL_NIF_TERM res = enif_make_list(env, 0);
     ERL_NIF_TERM ks[3] = {
         enif_make_atom(env, "name"),
@@ -807,6 +808,7 @@ static ERL_NIF_TERM tty_tinfo_make_map(ErlNifEnv* env,
     }
     return res;
 }
+#endif
 
 static ERL_NIF_TERM tty_tinfo_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
 #ifdef HAVE_TERMCAP


### PR DESCRIPTION
According to [1], term_variables: bool*, num*, std* are `NCURSES_CONST char * const`. Where NCURSES_CONST is defined by ncurses configuration scripts [2].

1: https://man7.org/linux/man-pages/man3/term_variables.3x.html
2: https://github.com/mirror/ncurses/blob/master/configure.in#L1228

----

Without this fix gcc 15.2 is saying:

```
nifs/common/prim_tty_nif.c: In function ‘tty_tinfo_nif’:                                                                                                                                                                                   
nifs/common/prim_tty_nif.c:820:33: error: passing argument 2 of ‘tty_tinfo_make_map’ from incompatible pointer type [-Wincompatible-pointer-types]                                                                                         
  820 |         tty_tinfo_make_map(env, boolnames, boolcodes, boolfnames),
      |                                ^~~~~~~~~
      |                                 |
      |                                 char * const*
nifs/common/prim_tty_nif.c:789:60: note: expected ‘const char * const*’ but argument is of type ‘char * const*’
  789 |                                        const char * const* names,
      | ~~~~~~~~~~~~~~~~~~~~^~~~~
nifs/common/prim_tty_nif.c:820:44: error: passing argument 3 of ‘tty_tinfo_make_map’ from incompatible pointer type [-Wincompatible-pointer-types]
  820 |         tty_tinfo_make_map(env, boolnames, boolcodes, boolfnames),
      |                                            ^~~~~~~~~
      |                                             |
      |                                            char * const*
```