### PR TITLE
`string`: Remove deprecated `catch` in test suite

### DIFF
--- a/lib/stdlib/test/string_SUITE.erl
+++ b/lib/stdlib/test/string_SUITE.erl
@@ -24,6 +24,7 @@
 %%%-----------------------------------------------------------------
 -module(string_SUITE).
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 %% Test server specific exports
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
@@ -108,16 +109,6 @@ debug() ->
         test(?LINE,?FUNCTION_NAME,B,C,D, false),
         test(?LINE,?FUNCTION_NAME,hd(C),[B|tl(C)],D, false)).
 
--define(TRY(Exp),
-        fun() ->
-                try Exp
-                catch _E:Reason:_ST ->
-                        %% io:format("~p:~w: ~p: ~.0p ~p~n",
-                        %%           [?FUNCTION_NAME, ?LINE,_E,Reason, hd(_ST)]),
-                        {'EXIT', Reason}
-                end
-        end()).
-
 is_empty(_) ->
     ?TEST("", [], true),
     ?TEST([""|<<>>], [], true),
@@ -128,8 +119,8 @@ is_empty(_) ->
 
 length(_) ->
     %% invalid arg type
-    {'EXIT',_} = (catch string:length({})),
-    {'EXIT',_} = (catch string:length(foo)),
+    ?assertError(_, string:length({})),
+    ?assertError(_, string:length(foo)),
     %% Valid signs
     ?TEST("", [], 0),
     ?TEST([""|<<>>], [], 0),
@@ -142,15 +133,15 @@ length(_) ->
     ?TEST([<<97/utf8, 778/utf8, 98/utf8>>, [776,111,776]], [], 3), %% åäö in nfd
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:length(InvalidUTF8)),
-    {'EXIT', {badarg, _}} = ?TRY(string:length(<<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:length(InvalidUTF8)),
+    ?assertError({badarg, _}, string:length(<<$a, InvalidUTF8/binary, $z>>)),
     ok.
 
 equal(_) ->
     %% invalid arg type
-    {'EXIT',_} = (catch string:equal(1, 2)),
-    {'EXIT',_} = (catch string:equal(1, 2, foo)),
-    {'EXIT',_} = (catch string:equal(1, 2, true, foo)),
+    ?assertError(_, string:equal(1, 2)),
+    ?assertError(_, string:equal(1, 2, foo)),
+    ?assertError(_, string:equal(1, 2, true, foo)),
 
     ?TEST("", [<<"">>], true),
     ?TEST("Hello", ["Hello"], true),
@@ -234,7 +225,7 @@ equal(_) ->
 
 to_graphemes(_) ->
     %% More tests are in unicode_util_SUITE.erl
-    {'EXIT', _} = (catch unicode:characters_to_nfd_binary(["asdåäö", an_atom])),
+    ?assertError(_, unicode:characters_to_nfd_binary(["asdåäö", an_atom])),
     String = ["abc..åäö", $e, 788, <<"Ωµe`è"/utf8>>, "œŒþæÆħ§ß"],
     NFD = unicode:characters_to_nfd_list(String),
     [] = string:to_graphemes([]),
@@ -245,11 +236,11 @@ to_graphemes(_) ->
     true = erlang:length(GCs) =:=
         erlang:length(string:to_graphemes(unicode:characters_to_nfc_list(String))),
 
-    {'EXIT', {badarg, _}} = ?TRY(string:to_graphemes(<<$a,192,192,$z>>)),
+    ?assertError({badarg, _}, string:to_graphemes(<<$a,192,192,$z>>)),
     ok.
 
 reverse(_) ->
-    {'EXIT',_} = (catch string:reverse(2)),
+    ?assertError(_, string:reverse(2)),
     Str1 = "Hello ",
     Str2 = "Ω ßð",
     Str3 = "åäö",
@@ -260,15 +251,15 @@ reverse(_) ->
     true = string:reverse(Str3) =:= lists:reverse(string:to_graphemes(Str3)),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:reverse(InvalidUTF8)),
-    {'EXIT', {badarg, _}} = ?TRY(string:reverse(<<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:reverse(InvalidUTF8)),
+    ?assertError({badarg, _}, string:reverse(<<$a, InvalidUTF8/binary, $z>>)),
 
     ok.
 
 slice(_) ->
-    {'EXIT',_} = (catch string:slice(2, 2, 2)),
-    {'EXIT',_} = (catch string:slice("asd", foo, 2)),
-    {'EXIT',_} = (catch string:slice("asd", 2, -1)),
+    ?assertError(_, string:slice(2, 2, 2)),
+    ?assertError(_, string:slice("asd", foo, 2)),
+    ?assertError(_, string:slice("asd", 2, -1)),
     ?TEST("", [3], ""),
     ?TEST("aåä", [1, 0], ""),
     ?TEST("aåä", [3], ""),
@@ -286,11 +277,11 @@ slice(_) ->
     InvalidUTF8 = <<192,192>>,
     [$b, $c|InvalidUTF8] = string:slice(["abc", InvalidUTF8], 1),
     InvalidUTF8 = string:slice(["abc", InvalidUTF8], 3),
-    {'EXIT', {badarg, _}} = ?TRY(string:slice(["abc", InvalidUTF8], 1, 5)),
+    ?assertError({badarg, _}, string:slice(["abc", InvalidUTF8], 1, 5)),
     BadUtf8 = <<$a, InvalidUTF8/binary, "teststring">>,
-    {'EXIT', {badarg, _}} = ?TRY(string:slice(BadUtf8, 2)),
-    {'EXIT', {badarg, _}} = ?TRY(string:slice(BadUtf8, 1, 5)),
-    {'EXIT', {badarg, _}} = ?TRY(string:slice(BadUtf8, 0, 5)),
+    ?assertError({badarg, _}, string:slice(BadUtf8, 2)),
+    ?assertError({badarg, _}, string:slice(BadUtf8, 1, 5)),
+    ?assertError({badarg, _}, string:slice(BadUtf8, 0, 5)),
     ok.
 
 pad(_) ->
@@ -305,8 +296,8 @@ pad(_) ->
     ?TEST(Str++[" flåwer"], [10, trailing, $.], "Hallå flåwer"),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:pad(InvalidUTF8, 10, both, $.)),
-    {'EXIT', {badarg, _}} = ?TRY(string:pad(<<$a, InvalidUTF8/binary, $z>>, 10, both, $.)),
+    ?assertError({badarg, _}, string:pad(InvalidUTF8, 10, both, $.)),
+    ?assertError({badarg, _}, string:pad(<<$a, InvalidUTF8/binary, $z>>, 10, both, $.)),
     ok.
 
 trim(_) ->
@@ -339,9 +330,9 @@ trim(_) ->
     ?TEST([<<"vv">>|<<204,128,118,204,128>>], [trailing, [[118,768]]], "v"),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:trim(InvalidUTF8, both, "az")),
+    ?assertError({badarg, _}, string:trim(InvalidUTF8, both, "az")),
     %% Not checked  (using binary search)
-    %% {'EXIT', {badarg, _}} = ?TRY(string:trim(<<$a, $b, InvalidUTF8/binary, $z>>, both, "az")),
+    %% ?assertError({badarg, _}, string:trim(<<$a, $b, InvalidUTF8/binary, $z>>, both, "az")),
     ok.
 
 chomp(_) ->
@@ -443,11 +434,11 @@ take(_) ->
           {[$e,778]++"åäöe"++[778], [$e,779]}),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:take(InvalidUTF8, [$.], false, leading)),
+    ?assertError({badarg, _}, string:take(InvalidUTF8, [$.], false, leading)),
     %% Not checked  (using binary search)
-    %% {'EXIT', {badarg, _}} = ?TRY(string:take(InvalidUTF8, [$.], true, leading)),
-    %% {'EXIT', {badarg, _}} = ?TRY(string:take(InvalidUTF8, [$.], false, trailing)),
-    {'EXIT', {badarg, _}} = ?TRY(string:take(InvalidUTF8, [$.], true, trailing)),
+    %% ?assertError({badarg, _}, string:take(InvalidUTF8, [$.], true, leading)),
+    %% ?assertError({badarg, _}, string:take(InvalidUTF8, [$.], false, trailing)),
+    ?assertError({badarg, _}, string:take(InvalidUTF8, [$.], true, trailing)),
 
     ok.
 
@@ -467,8 +458,8 @@ uppercase(_) ->
     ?TEST("ß sharp s", [], "SS SHARP S"),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:uppercase(InvalidUTF8)),
-    {'EXIT', {badarg, _}} = ?TRY(string:uppercase(<<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:uppercase(InvalidUTF8)),
+    ?assertError({badarg, _}, string:uppercase(<<$a, InvalidUTF8/binary, $z>>)),
 
     ok.
 
@@ -485,8 +476,8 @@ lowercase(_) ->
     ?TEST("İ I WITH DOT ABOVE", [], "i̇ i with dot above"),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:lowercase(InvalidUTF8)),
-    {'EXIT', {badarg, _}} = ?TRY(string:lowercase(<<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:lowercase(InvalidUTF8)),
+    ?assertError({badarg, _}, string:lowercase(<<$a, InvalidUTF8/binary, $z>>)),
     ok.
 
 titlecase(_) ->
@@ -502,8 +493,8 @@ titlecase(_) ->
     ?TEST("ß sharp s", [], "Ss sharp s"),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:titlecase(InvalidUTF8)),
-    <<$A, _/binary>> = ?TRY(string:titlecase(<<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:titlecase(InvalidUTF8)),
+    <<$A, _/binary>> = string:titlecase(<<$a, InvalidUTF8/binary, $z>>),
     ok.
 
 casefold(_) ->
@@ -520,8 +511,8 @@ casefold(_) ->
     ?TEST("İ I WITH DOT ABOVE", [], "i̇ i with dot above"),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:casefold(InvalidUTF8)),
-    {'EXIT', {badarg, _}} = ?TRY(string:casefold(<<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:casefold(InvalidUTF8)),
+    ?assertError({badarg, _}, string:casefold(<<$a, InvalidUTF8/binary, $z>>)),
     ok.
 
 
@@ -755,8 +746,8 @@ lexemes(_) ->
     ok.
 
 nth_lexeme(_) ->
-    {'EXIT', _} = (catch string:nth_lexeme("test test", 0, [])),
-    {'EXIT', _} = (catch string:nth_lexeme(<<"test test">>, 0, [])),
+    ?assertError(_, string:nth_lexeme("test test", 0, [])),
+    ?assertError(_, string:nth_lexeme(<<"test test">>, 0, [])),
     ?TEST( "", [1, " ,."],  []),
     ?TEST( "Hej san", [1, ""],  "Hej san"),
     ?TEST( "  ,., ", [1, " ,."],  []),
@@ -821,8 +812,8 @@ jaro_similarity(_Config) ->
     ?TEST("caabx", ["caba"], ((4/5+4/4+((4-2/2)/4))/3)),
 
     InvalidUTF8 = <<192,192>>,
-    {'EXIT', {badarg, _}} = ?TRY(string:jaro_similarity("foo", InvalidUTF8)),
-    {'EXIT', {badarg, _}} = ?TRY(string:jaro_similarity("foo", <<$a, InvalidUTF8/binary, $z>>)),
+    ?assertError({badarg, _}, string:jaro_similarity("foo", InvalidUTF8)),
+    ?assertError({badarg, _}, string:jaro_similarity("foo", <<$a, InvalidUTF8/binary, $z>>)),
 
     ok.
 
@@ -1229,7 +1220,7 @@ len(Config) when is_list(Config) ->
     L = tuple_size(list_to_tuple(atom_to_list(?MODULE))),
     L = string:len(atom_to_list(?MODULE)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:len({})),
+    ?assertError(_, string:len({})),
     ok.
 
 old_equal(Config) when is_list(Config) ->
@@ -1245,7 +1236,7 @@ old_concat(Config) when is_list(Config) ->
     "x" = string:concat("x", ""),
     "y" = string:concat("", "y"),
     %% invalid arg type
-    {'EXIT',_} = (catch string:concat(hello, please)),
+    ?assertError(_, string:concat(hello, please)),
     ok.
 
 chr_rchr(Config) when is_list(Config) ->
@@ -1259,13 +1250,13 @@ chr_rchr(Config) when is_list(Config) ->
     3 = string:chr("xyzyx", $z),
     3 = string:rchr("xyzyx", $z),
     %% invalid arg type
-    {'EXIT',_} = (catch string:chr(hello, $h)),
+    ?assertError(_, string:chr(hello, $h)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:chr("hello", h)),
+    ?assertError(_, string:chr("hello", h)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:rchr(hello, $h)),
+    ?assertError(_, string:rchr(hello, $h)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:rchr("hello", h)),
+    ?assertError(_, string:rchr("hello", h)),
     ok.
 
 str_rstr(Config) when is_list(Config) ->
@@ -1282,13 +1273,13 @@ str_rstr(Config) when is_list(Config) ->
     3 = string:rstr("xy z yx", " z"),
     3 = string:str("aaab", "ab"),
     %% invalid arg type
-    {'EXIT',_} = (catch string:str(hello, "he")),
+    ?assertError(_, string:str(hello, "he")),
     %% invalid arg type
-    {'EXIT',_} = (catch string:str("hello", he)),
+    ?assertError(_, string:str("hello", he)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:rstr(hello, "he")),
+    ?assertError(_, string:rstr(hello, "he")),
     %% invalid arg type
-    {'EXIT',_} = (catch string:rstr("hello", he)),
+    ?assertError(_, string:rstr("hello", he)),
     ok.
 
 span_cspan(Config) when is_list(Config) ->
@@ -1303,25 +1294,25 @@ span_cspan(Config) when is_list(Config) ->
     1 = string:cspan("3 ", "12 "),
     6 = string:cspan("1231234", "4"),
     %% invalid arg type
-    {'EXIT',_} = (catch string:span(1234, "1")),
+    ?assertError(_, string:span(1234, "1")),
     %% invalid arg type
-    {'EXIT',_} = (catch string:span(1234, "1")),
+    ?assertError(_, string:span(1234, "1")),
     %% invalid arg type
-    {'EXIT',_} = (catch string:cspan("1234", 1)),
+    ?assertError(_, string:cspan("1234", 1)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:cspan("1234", 4)),
+    ?assertError(_, string:cspan("1234", 4)),
     ok.
 
 
 substr(Config) when is_list(Config) ->
-    {'EXIT',_} = (catch string:substr("", 0)),
+    ?assertError(_, string:substr("", 0)),
     [] = string:substr("", 1),
-    {'EXIT',_} = (catch string:substr("", 2)),
+    ?assertError(_, string:substr("", 2)),
     [] = string:substr("1", 2),
-    {'EXIT',_} = (catch  string:substr("", 0, 1)),
+    ?assertError(_,  string:substr("", 0, 1)),
     [] = string:substr("", 1, 1),
     [] = string:substr("", 1, 2),
-    {'EXIT',_} = (catch string:substr("", 2, 2)),
+    ?assertError(_, string:substr("", 2, 2)),
     "1234" = string:substr("1234", 1),
     "1234" = string:substr("1234", 1, 4),
     "1234" = string:substr("1234", 1, 5),
@@ -1330,9 +1321,9 @@ substr(Config) when is_list(Config) ->
     "" = string:substr("1234", 4, 0),
     "4" = string:substr("1234", 4, 1),
     %% invalid arg type
-    {'EXIT',_} = (catch string:substr(1234, 1)),
+    ?assertError(_, string:substr(1234, 1)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:substr("1234", "1")),
+    ?assertError(_, string:substr("1234", "1")),
     ok.
 
 old_tokens(Config) when is_list(Config) ->
@@ -1342,8 +1333,8 @@ old_tokens(Config) when is_list(Config) ->
     ["1","2 34","45","5","6","7"] = do_tokens("1,2 34,45;5,;6;,7", ";,"),
 
     %% invalid arg type
-    {'EXIT',_} = (catch string:tokens('x,y', ",")),
-    {'EXIT',_} = (catch string:tokens("x,y", ',')),
+    ?assertError(_, string:tokens('x,y', ",")),
+    ?assertError(_, string:tokens("x,y", ',')),
     ok.
 
 do_tokens(S0, Sep0) ->
@@ -1375,7 +1366,7 @@ chars(Config) when is_list(Config) ->
     10 = erlang:length(string:chars(32, 10, [])),
     "aaargh" = string:chars($a, 3, "rgh"),
     %% invalid arg type
-    {'EXIT',_} = (catch string:chars($x, [])),
+    ?assertError(_, string:chars($x, [])),
     ok.
 
 copies(Config) when is_list(Config) ->
@@ -1384,8 +1375,8 @@ copies(Config) when is_list(Config) ->
     "." = string:copies(".", 1),
     30 = erlang:length(string:copies("123", 10)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:copies("hej", -1)),
-    {'EXIT',_} = (catch string:copies("hej", 2.0)),
+    ?assertError(_, string:copies("hej", -1)),
+    ?assertError(_, string:copies("hej", 2.0)),
     ok.
 
 words(Config) when is_list(Config) ->
@@ -1397,9 +1388,9 @@ words(Config) when is_list(Config) ->
     2 = string:words("2.35", $.),
     100 = string:words(string:copies(". ", 100)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:chars(hej, 1)),
+    ?assertError(_, string:chars(hej, 1)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:chars("hej", 1, " ")),
+    ?assertError(_, string:chars("hej", 1, " ")),
     ok.
 
 
@@ -1413,23 +1404,23 @@ strip(Config) when is_list(Config) ->
     "  hej  " = string:strip("  hej  ", right, $.),
     "hej  hopp" = string:strip("  hej  hopp  ", both),
     %% invalid arg type
-    {'EXIT',_} = (catch string:strip(hej)),
+    ?assertError(_, string:strip(hej)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:strip(" hej", up)),
+    ?assertError(_, string:strip(" hej", up)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:strip(" hej", left, " ")),	% not good
+    ?assertError(_, string:strip(" hej", left, " ")),	% not good
     ok.
 
 sub_word(Config) when is_list(Config) ->
     "" = string:sub_word("", 1),
     "" = string:sub_word("", 1, $,),
-    {'EXIT',_} = (catch string:sub_word("1 2 3", 0)),
+    ?assertError(_, string:sub_word("1 2 3", 0)),
     "" = string:sub_word("1 2 3", 4),
     "llo th" = string:sub_word("but hello there", 2, $e),
     %% invalid arg type
-    {'EXIT',_} = (catch string:sub_word('hello there', 1)),
+    ?assertError(_, string:sub_word('hello there', 1)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:sub_word("hello there", 1, "e")),
+    ?assertError(_, string:sub_word("hello there", 1, "e")),
     ok.
 
 left_right(Config) when is_list(Config) ->
@@ -1446,24 +1437,24 @@ left_right(Config) when is_list(Config) ->
     "1" = string:left("123", 1, $.),
     "3" = string:right("123", 1, $.),
     %% invalid arg type
-    {'EXIT',_} = (catch string:left(hello, 5)),
+    ?assertError(_, string:left(hello, 5)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:right(hello, 5)),
+    ?assertError(_, string:right(hello, 5)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:left("hello", 5, ".")),
+    ?assertError(_, string:left("hello", 5, ".")),
     %% invalid arg type
-    {'EXIT',_} = (catch string:right("hello", 5, ".")),
+    ?assertError(_, string:right("hello", 5, ".")),
     ok.
 
 sub_string(Config) when is_list(Config) ->
-    {'EXIT',_} = (catch string:sub_string("", 0)),
+    ?assertError(_, string:sub_string("", 0)),
     [] = string:sub_string("", 1),
-    {'EXIT',_} = (catch string:sub_string("", 2)),
+    ?assertError(_, string:sub_string("", 2)),
     [] = string:sub_string("1", 2),
-    {'EXIT',_} = (catch string:sub_string("", 0, 1)),
+    ?assertError(_, string:sub_string("", 0, 1)),
     [] = string:sub_string("", 1, 1),
     [] = string:sub_string("", 1, 2),
-    {'EXIT',_} = (catch string:sub_string("", 2, 2)),
+    ?assertError(_, string:sub_string("", 2, 2)),
     "1234" = string:sub_string("1234", 1),
     "1234" = string:sub_string("1234", 1, 4),
     "1234" = string:sub_string("1234", 1, 5),
@@ -1472,9 +1463,9 @@ sub_string(Config) when is_list(Config) ->
     "4" = string:sub_string("1234", 4, 4),
     "4" = string:sub_string("1234", 4, 5),
     %% invalid arg type
-    {'EXIT',_} = (catch string:sub_string(1234, 1)),
+    ?assertError(_, string:sub_string(1234, 1)),
     %% invalid arg type
-    {'EXIT',_} = (catch string:sub_string("1234", "1")),
+    ?assertError(_, string:sub_string("1234", "1")),
     ok.
 
 centre(Config) when is_list(Config) ->
@@ -1489,7 +1480,7 @@ centre(Config) when is_list(Config) ->
     "--agda--" = string:centre("agda", 8, $-),
     "agda" = string:centre("agda", 4),
     %% invalid arg type
-    {'EXIT',_} = (catch string:centre(hello, 10)),
+    ?assertError(_, string:centre(hello, 10)),
     ok.
 
 old_to_integer(Config) when is_list(Config) ->
@@ -1534,7 +1525,7 @@ test_to_integer(Str) ->
     %% io:format("Checking ~p~n", [Str]),
     case string:to_integer(Str) of
 	{error,_Reason} = Bad ->
-	    {'EXIT',_} = (catch list_to_integer(Str)),
+            ?assertError(_, list_to_integer(Str)),
 	    Bad;
 	{F,_Rest} = Res ->
 	    _ = integer_to_list(F),
@@ -1579,7 +1570,7 @@ test_to_float(Str) ->
     %% io:format("Checking ~p~n", [Str]),
     case string:to_float(Str) of
 	{error,_Reason} = Bad ->
-	    {'EXIT',_} = (catch list_to_float(Str)),
+            ?assertError(_, list_to_float(Str)),
 	    Bad;
 	{F,_Rest} = Res ->
 	    _ = float_to_list(F),
@@ -1643,5 +1634,5 @@ join(Config) when is_list(Config) ->
     "1234" = string:join(["1", "2", "3", "4"], ""),
     [] = string:join([], ""), % OTP-7231
     %% invalid arg type
-    {'EXIT',_} = (catch string:join([apa], "")),
+    ?assertError(_, string:join([apa], "")),
     ok.


### PR DESCRIPTION
This PR removes all deprecated old-style `catch`es from the test suite of the `string` module.