### PR TITLE
`base64`: Remove deprecated `catch` in test suite

### DIFF
--- a/lib/stdlib/test/base64_SUITE.erl
+++ b/lib/stdlib/test/base64_SUITE.erl
@@ -23,6 +23,7 @@
 -module(base64_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 %% Test server specific exports
 -export([all/0, suite/0, groups/0, group/1]).
@@ -126,19 +127,15 @@ base64_decode(Config) when is_list(Config) ->
         base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>, #{padding => false}),
     <<"Aladdin:open sesame">> =
         base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ", #{padding => false}),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ"),
+    ?assertError(missing_padding, base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>)),
+    ?assertError(missing_padding, base64:decode("QWxhZGRpbjpvcGVuIHNlc2FtZQ")),
     %% One pad
     <<"Hello World">> = base64:decode(<<"SGVsbG8gV29ybGQ=">>),
     <<"Hello World">> = base64:decode("SGVsbG8gV29ybGQ="),
     <<"Hello World">> = base64:decode(<<"SGVsbG8gV29ybGQ">>, #{padding => false}),
     <<"Hello World">> = base64:decode("SGVsbG8gV29ybGQ", #{padding => false}),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode_to_string("SGVsbG8gV29ybGQ"),
+    ?assertError(missing_padding, base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>)),
+    ?assertError(missing_padding, base64:decode_to_string("SGVsbG8gV29ybGQ")),
     %% No pad
     <<"Aladdin:open sesam">> =
         base64:decode(<<"QWxhZGRpbjpvcGVuIHNlc2Ft">>),
@@ -175,19 +172,15 @@ base64_decode_to_string(Config) when is_list(Config) ->
         base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>, #{padding => false}),
     "Aladdin:open sesame" =
         base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2FtZQ", #{padding => false}),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2FtZQ"),
+    ?assertError(missing_padding, base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2FtZQ">>)),
+    ?assertError(missing_padding, base64:decode_to_string("QWxhZGRpbjpvcGVuIHNlc2FtZQ")),
     %% One pad
     "Hello World" = base64:decode_to_string(<<"SGVsbG8gV29ybGQ=">>),
     "Hello World" = base64:decode_to_string("SGVsbG8gV29ybGQ="),
     "Hello World" = base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>, #{padding => false}),
     "Hello World" = base64:decode_to_string("SGVsbG8gV29ybGQ", #{padding => false}),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>),
-    {'EXIT', {'missing_padding', _}} =
-        catch base64:decode_to_string("SGVsbG8gV29ybGQ"),
+    ?assertError(missing_padding, base64:decode_to_string(<<"SGVsbG8gV29ybGQ">>)),
+    ?assertError(missing_padding, base64:decode_to_string("SGVsbG8gV29ybGQ")),
     %% No pad
     "Aladdin:open sesam" =
         base64:decode_to_string(<<"QWxhZGRpbjpvcGVuIHNlc2Ft">>),
@@ -220,13 +213,13 @@ base64_decode_modes(Config) when is_list(Config) ->
 
     DataBin = base64:decode("F+o/o++B/a+r", #{mode => standard}),
     DataBin = base64:decode("F-o_o--B_a-r", #{mode => urlsafe}),
-    {'EXIT', _} = catch base64:decode("F-o_o--B_a-r", #{mode => standard}),
-    {'EXIT', _} = catch base64:decode("F+o/o++B/a+r", #{mode => urlsafe}),
+    ?assertError(_, base64:decode("F-o_o--B_a-r", #{mode => standard})),
+    ?assertError(_, base64:decode("F+o/o++B/a+r", #{mode => urlsafe})),
 
     DataStr = base64:decode_to_string("F+o/o++B/a+r", #{mode => standard}),
     DataStr = base64:decode_to_string("F-o_o--B_a-r", #{mode => urlsafe}),
-    {'EXIT', _} = catch base64:decode_to_string("F-o_o--B_a-r", #{mode => standard}),
-    {'EXIT', _} = catch base64:decode_to_string("F+o/o++B/a+r", #{mode => urlsafe}),
+    ?assertError(_, base64:decode_to_string("F-o_o--B_a-r", #{mode => standard})),
+    ?assertError(_, base64:decode_to_string("F+o/o++B/a+r", #{mode => urlsafe})),
 
     ok.
 
@@ -238,7 +231,7 @@ base64_otp_5635(Config) when is_list(Config) ->
 %%-------------------------------------------------------------------------
 %% OTP-6279: Make sure illegal characters are rejected when decoding.
 base64_otp_6279(Config) when is_list(Config) ->
-    {'EXIT',_} = (catch base64:decode("dGVzda==a")),
+    ?assertError(_, base64:decode("dGVzda==a")),
     ok.
 %%-------------------------------------------------------------------------
 %% Encode and decode big binaries.
@@ -255,11 +248,11 @@ big(Config) when is_list(Config) ->
 illegal(Config) when is_list(Config) ->
     %% A few samples with different error reasons. Nothing can be
     %% assumed about the reason for the crash.
-    {'EXIT',_} = (catch base64:decode("()")),
-    {'EXIT',_} = (catch base64:decode(<<19:8,20:8,21:8,22:8>>)),
-    {'EXIT',_} = (catch base64:decode([19,20,21,22])),
-    {'EXIT',_} = (catch base64:decode_to_string(<<19:8,20:8,21:8,22:8>>)),
-    {'EXIT',_} = (catch base64:decode_to_string([19,20,21,22])),
+    ?assertError(_, base64:decode("()")),
+    ?assertError(_, base64:decode(<<19:8,20:8,21:8,22:8>>)),
+    ?assertError(_, base64:decode([19,20,21,22])),
+    ?assertError(_, base64:decode_to_string(<<19:8,20:8,21:8,22:8>>)),
+    ?assertError(_, base64:decode_to_string([19,20,21,22])),
     ok.
 %%-------------------------------------------------------------------------
 %% mime_decode and mime_decode_to_string have different implementations


### PR DESCRIPTION
This PR removes all deprecated old-style `catch`es from the test suite of the `base64` module.