### PR TITLE
ssl: Preserve inet option order in emulated_options

### DIFF
--- a/lib/ssl/src/dtls_socket.erl
+++ b/lib/ssl/src/dtls_socket.erl
@@ -233,7 +233,8 @@ emulated_options() ->
     [mode, active,  packet, packet_size].
 
 emulated_options(Opts) ->
-      emulated_options(Opts, internal_inet_values(), default_inet_values()).
+      {Inet, Emulated} = emulated_options(Opts, [], default_inet_values()),
+      {Inet ++ internal_inet_values(), Emulated}.
 
 internal_inet_values() ->
     [{active, false}, {mode,binary}].
@@ -280,7 +281,7 @@ emulated_options([{packet_size, _} = Opt | _], _, _) ->
 emulated_options([Opt|Opts], Inet, Emulated) ->
     emulated_options(Opts, [Opt|Inet], Emulated);
 emulated_options([], Inet,Emulated) ->
-    {Inet, Emulated}.
+    {lists:reverse(Inet), Emulated}.
 
 validate_inet_option(mode, Value)
   when Value =/= list, Value =/= binary ->

--- a/lib/ssl/src/tls_socket.erl
+++ b/lib/ssl/src/tls_socket.erl
@@ -561,7 +561,7 @@ emulated_options([{low_watermark, Value} = Opt | Opts], Inet, Emulated) ->
 emulated_options([Opt|Opts], Inet, Emulated) ->
     emulated_options(Opts, [Opt|Inet], Emulated);
 emulated_options([], Inet,Emulated) ->
-    {Inet, Emulated}.
+    {lists:reverse(Inet), Emulated}.
 
 validate_inet_option(mode, Value)
   when Value =/= list, Value =/= binary ->

--- a/lib/ssl/test/ssl_api_SUITE.erl
+++ b/lib/ssl/test/ssl_api_SUITE.erl
@@ -61,6 +61,8 @@
          select_best_cert/1,
          select_sha1_cert/0,
          select_sha1_cert/1,
+         inet_backend_option_order/0,
+         inet_backend_option_order/1,
          root_any_sign/0,
          root_any_sign/1,
          connection_information/0,
@@ -302,6 +304,7 @@ gen_api_tests() ->
      peercert,
      peercert_with_client_cert,
      select_sha1_cert,
+     inet_backend_option_order,
      connection_information,
      secret_connection_info,
      keylog_connection_info,
@@ -645,6 +648,30 @@ root_any_sign(Config) when is_list(Config) ->
     %% Intermediate cert signatures are validated, so sha1 signatures will fail connection                             
     ssl_test_lib:basic_alert(CFail, [{verify, verify_peer}, {signature_algs, SigAlgs} | SFail],
                              Config, unsupported_certificate).
+
+%%--------------------------------------------------------------------
+inet_backend_option_order() ->
+    [{doc,"Test that inet_backend option is preserved as first option "
+      "when passed to gen_tcp:connect"}].
+inet_backend_option_order(Config) when is_list(Config) ->
+    ClientOpts = ssl_test_lib:ssl_options(client_rsa_verify_opts, Config),
+    ServerOpts = ssl_test_lib:ssl_options(server_rsa_opts, Config),
+    {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                        {from, self()},
+                                        {mfa, {ssl_test_lib, send_recv_result_active, []}},
+                                        {options, [{inet_backend, socket} | ServerOpts]}]),
+    Port = ssl_test_lib:inet_port(Server),
+    Client = ssl_test_lib:start_client([{node, ClientNode}, {port, Port},
+                                        {host, Hostname},
+                                        {from, self()},
+                                        {mfa, {ssl_test_lib, send_recv_result_active, []}},
+                                        {options, [{inet_backend, socket} | ClientOpts]}]),
+
+    ssl_test_lib:check_result(Server, ok, Client, ok),
+
+    ssl_test_lib:close(Server),
+    ssl_test_lib:close(Client).
 
 %%--------------------------------------------------------------------
 connection_information() ->

--- a/lib/ssl/test/ssl_test_lib.erl
+++ b/lib/ssl/test/ssl_test_lib.erl
@@ -1472,7 +1472,15 @@ patch_dtls_options(Options0) ->
     case proplists:get_value(protocol, Options0) of
         dtls ->
             case proplists:get_value(recbuf, Options0, undefined) of
-                undefined -> [{recbuf, ?DTLS_RECBUF}|Options0];
+                undefined ->
+                    %% inet_backend must be the first option in the list
+                    %% for gen_tcp/gen_udp, so insert recbuf after it
+                    case Options0 of
+                        [{inet_backend, _} = InetBackend | Rest] ->
+                            [InetBackend, {recbuf, ?DTLS_RECBUF} | Rest];
+                        _ ->
+                            [{recbuf, ?DTLS_RECBUF} | Options0]
+                    end;
                 _ -> Options0
             end;
         _ ->    Options0


### PR DESCRIPTION
The `emulated_options/3` function in `tls_socket` and `dtls_socket` used a prepend accumulator pattern without reversing the result, causing inet options to be reversed when passed to `gen_tcp:connect`/`gen_udp:open`.

This broke the `inet_backend` option which must be the first option in the list according to `gen_tcp` and `gen_udp` documentation.

Fix by reversing the Inet accumulator before returning.

### Before

```
Erlang/OTP 28 [erts-16.1.2] [source] [64-bit] [smp:14:14] [ds:14:14:10] [async-threads:1] [jit] [dtrace]

Eshell V16.1.2 (press Ctrl+G to abort, type help(). for help)
1> application:ensure_all_started(ssl).
{ok,[crypto,asn1,public_key,ssl]}
2> ssl:connect("127.0.0.1", 12345, [{inet_backend, socket}, {recbuf, 32768}, {verify, verify_none}]).
{error,{badarg,"gen_tcp:connect(\"127.0.0.1\", 12345, [{recbuf,32768},{inet_backend,socket}], infinity)"}}
3> ssl:connect("127.0.0.1", 12345, [{inet_backend, socket}, {recbuf, 32768}, {protocol, dtls}, {verify, verify_none}], 1000).
** exception exit: badarg
     in function  inet_udp:open/2 (inet_udp.erl:56)
     in call from dtls_socket:connect/4 (dtls_socket.erl:92)
     in call from ssl:connect/4 (ssl.erl:2269)
```

### After

```
Erlang/OTP 29 [RELEASE CANDIDATE 2] [erts-16.3] [source-c77b8b0c89] [64-bit] [smp:14:14] [ds:14:14:10] [async-threads:1] [jit]

Eshell V16.3 (press Ctrl+G to abort, type help(). for help)
1> application:ensure_all_started(ssl).
{ok,[crypto,asn1,public_key,ssl]}
2> ssl:connect("127.0.0.1", 12345, [{inet_backend, socket}, {recbuf, 32768}, {verify, verify_none}]).
{error,econnrefused}
3> ssl:connect("127.0.0.1", 12345, [{inet_backend, socket}, {recbuf, 32768}, {protocol, dtls}, {verify, verify_none}], 1000).
{error,timeout}
```
