### PR TITLE
`gb_sets` and `gb_trees`: Add checks to `from_ordset` and `from_orddict`

### DIFF
--- a/lib/stdlib/src/gb_sets.erl
+++ b/lib/stdlib/src/gb_sets.erl
@@ -329,7 +329,7 @@ insert_1(Key, {Key1, Smaller, Bigger}, S) when Key < Key1 ->
 	    P = ?pow(SS, ?p),
 	    if
 		H > P -> 
-		    balance(T, SS);
+                    balance_unchecked(T, SS);
 		true ->
 		    {T, H, SS}
 	    end;
@@ -346,7 +346,7 @@ insert_1(Key, {Key1, Smaller, Bigger}, S) when Key > Key1 ->
 	    P = ?pow(SS, ?p),
 	    if
 		H > P -> 
-		    balance(T, SS);
+                    balance_unchecked(T, SS);
 		true ->
 		    {T, H, SS}
 	    end;
@@ -393,26 +393,46 @@ does not rebalance the tree.
       Set2 :: set(Element).
 
 balance({S, T}) when is_integer(S), S >= 0 ->
-    {S, balance(T, S)}.
+    {S, balance_unchecked(T, S)}.
 
-balance(T, S) ->
-    balance_list(to_list_1(T), S).
+balance_unchecked(T, S) ->
+    balance_list_unchecked(to_list_1(T), S).
 
-balance_list(L, S) ->
-    {T, _} = balance_list_1(L, S),
+balance_list_unchecked(L, S) ->
+    {T, _} = balance_list_unchecked_1(L, S),
     T.
 
-balance_list_1(L, S) when S > 1 ->
-    Sm = S - 1,
-    S2 = Sm div 2,
-    S1 = Sm - S2,
-    {T1, [K | L1]} = balance_list_1(L, S1),
-    {T2, L2} = balance_list_1(L1, S2),
+balance_list_unchecked_1(L, S) when S > 1 ->
+    {S1, S2} = split_list_size(S),
+    {T1, [K | L1]} = balance_list_unchecked_1(L, S1),
+    {T2, L2} = balance_list_unchecked_1(L1, S2),
     T = {K, T1, T2},
     {T, L2};
-balance_list_1([Key | L], 1) ->
+balance_list_unchecked_1([Key | L], 1) ->
     {{Key, nil, nil}, L};
-balance_list_1(L, 0) ->
+balance_list_unchecked_1(L, 0) ->
+    {nil, L}.
+
+balance_list_checked(L, S) ->
+    {T, _} = balance_list_checked_1(L, S),
+    T.
+
+balance_list_checked_1(L, S) when S > 1 ->
+    {S1, S2} = split_list_size(S),
+    {T1, [K | L1]} = balance_list_checked_1(L, S1),
+    case L1 of
+        [K1 | _] when K >= K1 ->
+            erlang:error({badarg, not_ordset});
+        _ ->
+            {T2, L2} = balance_list_checked_1(L1, S2),
+            T = {K, T1, T2},
+            {T, L2}
+    end;
+balance_list_checked_1([E1, E2 | _], 1) when E1 >= E2 ->
+    erlang:error({badarg, not_ordset});
+balance_list_checked_1([Key | L], 1) ->
+    {{Key, nil, nil}, L};
+balance_list_checked_1(L, 0) ->
     {nil, L}.
 
 -doc """
@@ -470,7 +490,7 @@ contain duplicates.
       Set :: set(Element).
 
 from_list(L) ->
-    from_ordset(ordsets:from_list(L)).
+    from_ordset_unchecked(ordsets:from_list(L)).
 
 -doc """
 Turns an ordered list without duplicates `List` into a set.
@@ -492,7 +512,11 @@ duplicates.
 
 from_ordset(L) ->
     S = length(L),
-    {S, balance_list(L, S)}.
+    {S, balance_list_checked(L, S)}.
+
+from_ordset_unchecked(L) ->
+    S = length(L),
+    {S, balance_list_unchecked(L, S)}.
 
 -doc(#{equiv => delete_any(Element, Set1)}).
 -spec del_element(Element, Set1) -> Set2 when
@@ -1051,9 +1075,7 @@ balance_revlist(L, S) when is_integer(S) ->
     T.
 
 balance_revlist_1(L, S) when S > 1 ->
-    Sm = S - 1,
-    S2 = Sm div 2,
-    S1 = Sm - S2,
+    {S1, S2} = split_list_size(S),
     {T2, [K | L1]} = balance_revlist_1(L, S1),
     {T1, L2} = balance_revlist_1(L1, S2),
     T = {K, T1, T2},
@@ -1435,7 +1457,7 @@ Filters elements in `Set1` using predicate function `Pred`.
       Set2 :: set(Element).
 
 filter(F, S) when is_function(F, 1) ->
-    from_ordset([X || X <- to_list(S), F(X)]).
+    from_ordset_unchecked([X || X <- to_list(S), F(X)]).
 
 -doc """
 Maps elements in `Set1` with mapping function `Fun`.
@@ -1543,3 +1565,11 @@ fold_1(F, Acc0, {Key, Small, Big}) ->
     fold_1(F, Acc, Big);
 fold_1(_, Acc, _) ->
     Acc.
+
+
+-compile({inline, [split_list_size/1]}).
+split_list_size(S) ->
+    Sm = S - 1,
+    S2 = Sm div 2,
+    S1 = Sm - S2,
+    {S1, S2}.

--- a/lib/stdlib/src/gb_trees.erl
+++ b/lib/stdlib/src/gb_trees.erl
@@ -60,8 +60,8 @@ should also be OK.
 
 -export([empty/0, is_empty/1, size/1, lookup/2, get/2, insert/3,
 	 update/3, enter/3, delete/2, delete_any/2, balance/1,
-	 is_defined/2, keys/1, values/1, to_list/1, from_orddict/1,
-	 smallest/1, largest/1, take/2, take_any/2,
+         is_defined/2, keys/1, values/1, to_list/1, from_list/1,
+         from_orddict/1, smallest/1, largest/1, take/2, take_any/2,
          take_smallest/1, take_largest/1, smaller/2, larger/2,
          iterator/1, iterator/2, iterator_from/2, iterator_from/3,
          next/1, map/2]).
@@ -431,24 +431,64 @@ balance({S, T}) when is_integer(S), S >= 0 ->
     {S, balance(T, S)}.
 
 balance(T, S) ->
-    balance_list(to_list_1(T), S).
+    balance_list_unchecked(to_list_1(T), S).
 
-balance_list(L, S) ->
-    {T, []} = balance_list_1(L, S),
+balance_list_unchecked(L, S) ->
+    {T, []} = balance_list_unchecked_1(L, S),
     T.
 
-balance_list_1(L, S) when S > 1 ->
-    Sm = S - 1,
-    S2 = Sm div 2,
-    S1 = Sm - S2,
-    {T1, [{K, V} | L1]} = balance_list_1(L, S1),
-    {T2, L2} = balance_list_1(L1, S2),
+balance_list_unchecked_1(L, S) when S > 1 ->
+    {S1, S2} = split_list_size(S),
+    {T1, [{K, V} | L1]} = balance_list_unchecked_1(L, S1),
+    {T2, L2} = balance_list_unchecked_1(L1, S2),
     T = {K, V, T1, T2},
     {T, L2};
-balance_list_1([{Key, Val} | L], 1) ->
+balance_list_unchecked_1([{Key, Val} | L], 1) ->
     {{Key, Val, nil, nil}, L};
-balance_list_1(L, 0) ->
+balance_list_unchecked_1(L, 0) ->
     {nil, L}.
+
+balance_list_checked(L, S) ->
+    {T, []} = balance_list_checked_1(L, S),
+    T.
+
+balance_list_checked_1(L, S) when S > 1 ->
+    {S1, S2} = split_list_size(S),
+    {T1, [{K, V} | L1]} = balance_list_checked_1(L, S1),
+    case L1 of
+        [{K1, _} | _] when K >= K1 ->
+            erlang:error({badarg, not_orddict});
+        _ ->
+            {T2, L2} = balance_list_checked_1(L1, S2),
+            T = {K, V, T1, T2},
+            {T, L2}
+    end;
+balance_list_checked_1([{K1, _}, {K2, _} | _], 1) when K1 >= K2 ->
+    erlang:error({badarg, not_orddict});
+balance_list_checked_1([{Key, Val} | L], 1) ->
+    {{Key, Val, nil, nil}, L};
+balance_list_checked_1(L, 0) ->
+    {nil, L}.
+
+-doc """
+Returns a tree of the key-value tuples in `List`,
+where `List` can be unordered and contain duplicate keys.
+
+## Examples
+
+```erlang
+1> Unordered = [{x, 1}, {y, 2}, {a, 3}, {x, 4}, {y, 5}, {b, 6}].
+2> gb_trees:to_list(gb_trees:from_list(Unordered)).
+[{a,3},{b,6},{x,4},{y,5}]
+```
+""".
+-doc #{since => ~"OTP @OTP-20061@"}.
+-spec from_list(List) -> Tree when
+      List :: [{Key, Value}],
+      Tree :: tree(Key, Value).
+
+from_list(L) ->
+    from_orddict_unchecked(orddict:from_list(L)).
 
 -doc """
 Turns an ordered list `List` of key-value tuples into a tree.
@@ -469,7 +509,11 @@ The list must not contain duplicate keys.
 
 from_orddict(L) ->
     S = length(L),
-    {S, balance_list(L, S)}.
+    {S, balance_list_checked(L, S)}.
+
+from_orddict_unchecked(L) ->
+    S = length(L),
+    {S, balance_list_unchecked(L, S)}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1092,3 +1136,11 @@ map(F, {Size, Tree}) when is_function(F, 2) ->
 map_1(_, nil) -> nil;
 map_1(F, {K, V, Smaller, Larger}) ->
     {K, F(K, V), map_1(F, Smaller), map_1(F, Larger)}.
+
+
+-compile({inline, [split_list_size/1]}).
+split_list_size(S) ->
+    Sm = S - 1,
+    S2 = Sm div 2,
+    S1 = Sm - S2,
+    {S1, S2}.

--- a/lib/stdlib/test/qlc_SUITE.erl
+++ b/lib/stdlib/test/qlc_SUITE.erl
@@ -6835,7 +6835,7 @@ otp_6674(Config) when is_list(Config) ->
                 false = lookup_keys(Q)
          end, [{{1}}, {{2}}])">>,
 
-    <<"T = gb_trees:from_orddict([{foo,{1}}, {bar,{2}}]),
+    <<"T = gb_trees:from_orddict([{bar,{2}}, {foo,{1}}]),
        Q = qlc:q([{X,Y} || {_,X} <- gb_table:table(T), 
                        {Y} <- [{{1}},{{2}},{{1.0}},{{2.0}}],
                          (X =:= {1}) or (X == {2}), 

--- a/lib/stdlib/test/sets_SUITE.erl
+++ b/lib/stdlib/test/sets_SUITE.erl
@@ -35,6 +35,7 @@
          doctests_gb_sets/1, doctests_ordsets/1, doctests_sets/1]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -import(lists, [foldl/3,reverse/1]).
 
@@ -195,7 +196,7 @@ intersection_1(List, M) ->
     true = M(is_equal, {Empty,M(intersection, [S0,Empty,S0,Empty])}),
 
     %% The intersection of no sets is undefined.
-    {'EXIT',_} = (catch M(intersection, [])),
+    ?assertError(_, M(intersection, [])),
 
     %% Disjoint sets.
     Disjoint = [{El} || El <- List],


### PR DESCRIPTION
I recently had the pleasure to debug some code where, ultimately, an unordered list and/or with duplicates, was given to `gb_sets:from_ordset/1`. The implementation does not complain, but silently turns the list into an invalid gb_set, resulting in misbehaviors like elements that _are_ in the set not being found, and elements that have been _deleted_ from the set still being reported as being in the set. Adding or deleting elements from the set may also result in elements appearing and disappearing. And so on :woman_shrugging:

This is a mistake easily made. Until recently, the documentation kinda _encouraged_ the use of `from_ordset` in multiple places, with the assumption that the list given to it is sorted and free of duplicates only mentioned in the _prose_ of _`from_ordset`_. It is also a mistake ***very hard to find*** once made, more so when you're not the person who wrote that code, and the person who _did_ left years ago. (😡)

Anyway. This PR adds checks to the functions which turn lists-that-may-be-ordsets-or-not. Internal uses bypass the check in order to not impose a penalty when not necessary.

This also applies to `gb_trees:from_orddict/1`, which is likewise changed by this PR.

On the way, we also added `gb_trees:from_list/1`, and removed the one remaining old-style `catch` in `sets_SUITE`.

There are no tests yet, we would like to hear if this addition is really wanted or not before putting more work into it :wink:

This change _may_ break some existing code, but if so, IMO for the better, as it would clearly be a bug.