### PR TITLE
Deprecate erlang:exit/2 and erlang:exit/3

### DIFF
--- a/erts/preloaded/src/erl_prim_loader.erl
+++ b/erts/preloaded/src/erl_prim_loader.erl
@@ -69,7 +69,8 @@ The `erl_prim_loader` module interprets the following command-line flags:
 `m:init`, `m:erl_boot_server`
 """.
 
--compile([{nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}}]).
+-compile([{nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 %% If the macro DEBUG is defined during compilation, 
 %% debug printouts are done through erlang:display/1.

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -81,6 +81,8 @@ in the description of each individual BIF.
               "see the \"Time and Time Correction in Erlang\" "
               "chapter of the ERTS User's Guide for more information"}]).
 -deprecated([{phash,2, "use erlang:phash2/2 instead"}]).
+-deprecated([{exit,2,"use erlang:exit_signal/2 instead"}]).
+-deprecated([{exit,3,"use erlang:exit_signal/3 instead"}]).
 -removed([{hash,2,"use erlang:phash2/2 instead"}]).
 -removed([{get_stacktrace,0,
            "use the new try/catch syntax for retrieving the "
@@ -2556,7 +2558,7 @@ exit_signal(_Pid, _Reason) ->
 
 %% exit/2
 -doc """
-Old form of `exit_signal/2`, with a quirk when sender and receiver are the same.
+Deprecated form of `exit_signal/2`, with a quirk when sender and receiver are the same.
 
 > #### Note {: .info }
 >

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -81,6 +81,8 @@ in the description of each individual BIF.
               "see the \"Time and Time Correction in Erlang\" "
               "chapter of the ERTS User's Guide for more information"}]).
 -deprecated([{phash,2, "use erlang:phash2/2 instead"}]).
+-deprecated([{exit,2,"use erlang:exit_signal/2 instead"}]).
+-deprecated([{exit,3,"use erlang:exit_signal/3 instead"}]).
 -removed([{hash,2,"use erlang:phash2/2 instead"}]).
 -removed([{get_stacktrace,0,
            "use the new try/catch syntax for retrieving the "
@@ -2557,7 +2559,7 @@ exit_signal(_Pid, _Reason) ->
 
 %% exit/2
 -doc """
-Old form of `exit_signal/2`, with a quirk when sender and receiver are the same.
+Deprecated form of `exit_signal/2`, with a quirk when sender and receiver are the same.
 
 > #### Note {: .info }
 >

--- a/erts/preloaded/src/erts_code_purger.erl
+++ b/erts/preloaded/src/erts_code_purger.erl
@@ -22,6 +22,8 @@
 -module(erts_code_purger).
 -moduledoc false.
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 %% Purpose : Implement system process erts_code_purger
 %%           to handle code module purging.
 

--- a/erts/preloaded/src/init.erl
+++ b/erts/preloaded/src/init.erl
@@ -255,7 +255,8 @@ error
 """.
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
-          {nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}}]).
+          {nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 -export([restart/1,restart/0,reboot/0,stop/0,stop/1,
 	 get_status/0,boot/1,get_arguments/0,get_plain_arguments/0,

--- a/lib/eunit/src/eunit_data.erl
+++ b/lib/eunit/src/eunit_data.erl
@@ -839,7 +839,7 @@ ping(P) ->
 
 data_test_() ->
     Setup = fun () -> spawn(fun echo_proc/0) end,
-    Cleanup = fun (Pid) -> exit(Pid, kill) end,
+    Cleanup = fun (Pid) -> erlang:exit_signal(Pid, kill) end,
     Fail = ?_test(throw(eunit)),
     T = ?_test(ok),
     Tests = [T,T,T],

--- a/lib/kernel/src/application_controller.erl
+++ b/lib/kernel/src/application_controller.erl
@@ -23,6 +23,7 @@
 -moduledoc false.
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]},
           nowarn_deprecated_catch]).
 
 %% External exports

--- a/lib/kernel/src/application_master.erl
+++ b/lib/kernel/src/application_master.erl
@@ -23,6 +23,7 @@
 -moduledoc false.
 
 -compile(nowarn_deprecated_catch).
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 %% External exports
 -export([start_link/2, start_type/0, stop/1]).

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -42,6 +42,8 @@
 
 -import(error_logger,[error_msg/2, warning_msg/2]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -include("dist_util.hrl").
 -include("dist.hrl").
 

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -42,6 +42,8 @@
 
 -import(error_logger,[error_msg/2]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -include("dist_util.hrl").
 -include("dist.hrl").
 

--- a/lib/kernel/src/erl_boot_server.erl
+++ b/lib/kernel/src/erl_boot_server.erl
@@ -76,6 +76,8 @@ and `m:erl_prim_loader` in ERTS.
 -export([code_change/3]).
 -export([boot_init/1, boot_accept/3]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -record(state, 
 	{
 	  priority = 0,  %% priority of this server

--- a/lib/kernel/src/global.erl
+++ b/lib/kernel/src/global.erl
@@ -145,6 +145,8 @@ network problem.
 
 -export([info/0]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -include_lib("stdlib/include/ms_transform.hrl").
 
 %% Set this variable to 'allow' to allow several names of a process.

--- a/lib/kernel/src/group.erl
+++ b/lib/kernel/src/group.erl
@@ -23,6 +23,7 @@
 -moduledoc false.
 
 -compile([nowarn_deprecated_catch,
+          {nowarn_deprecated_function, [{erlang,exit,2}]},
           {nowarn_unsafe_function, {os, cmd, 1}}]).
 
 -include_lib("kernel/include/logger.hrl").

--- a/lib/kernel/src/heart.erl
+++ b/lib/kernel/src/heart.erl
@@ -107,6 +107,7 @@ In the following descriptions, all functions fail with reason `badarg` if
 """.
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]},
           nowarn_deprecated_catch]).
 
 %%%--------------------------------------------------------------------

--- a/lib/kernel/src/inet_gethost_native.erl
+++ b/lib/kernel/src/inet_gethost_native.erl
@@ -24,6 +24,7 @@
 -behaviour(supervisor_bridge).
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]},
           nowarn_deprecated_catch]).
 
 %% Supervisor bridge exports

--- a/lib/kernel/src/logger_olp.erl
+++ b/lib/kernel/src/logger_olp.erl
@@ -28,6 +28,8 @@
 -include("logger_olp.hrl").
 -include("logger_internal.hrl").
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 %% API
 -export([start_link/4, load/2, info/1, reset/1, stop/1, restart/1,
          set_opts/2, get_opts/1, get_default_opts/0, get_pid/1,

--- a/lib/kernel/src/logger_simple_h.erl
+++ b/lib/kernel/src/logger_simple_h.erl
@@ -22,6 +22,8 @@
 -module(logger_simple_h).
 -moduledoc false.
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -export([adding_handler/1, removing_handler/1, log/2]).
 
 -behaviour(logger_handler).

--- a/lib/kernel/src/logger_std_h.erl
+++ b/lib/kernel/src/logger_std_h.erl
@@ -191,6 +191,8 @@ startup is found in the `m:logger_disk_log_h` manual.
 -export([log/2, adding_handler/1, removing_handler/1, changing_config/3,
          filter_config/1]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -define(DEFAULT_CALL_TIMEOUT, 5000).
 
 %%%===================================================================

--- a/lib/kernel/src/net_kernel.erl
+++ b/lib/kernel/src/net_kernel.erl
@@ -71,6 +71,7 @@ in the Erlang Reference Manual.
 """.
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]},
           nowarn_deprecated_catch]).
 
 -behaviour(gen_server).

--- a/lib/kernel/src/prim_tty.erl
+++ b/lib/kernel/src/prim_tty.erl
@@ -109,6 +109,8 @@
 %%      * Same problem as insert mode, it only deleted current line, and does not move
 %%        to previous line automatically.
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -export([load/0, init/1, init_ssh/3, reinit/2, isatty/1, handles/1, unicode/1, unicode/2,
          handle_signal/2, window_size/1, update_geometry/3, handle_request/2,
          write/2, write/3,

--- a/lib/kernel/src/rpc.erl
+++ b/lib/kernel/src/rpc.erl
@@ -71,6 +71,7 @@ some specific side effects on the remote node.
 -behaviour(gen_server).
 
 -compile(nowarn_deprecated_catch).
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 -export([start/0, start_link/0, stop/0,
 	 call/4, call/5,

--- a/lib/kernel/src/standard_error.erl
+++ b/lib/kernel/src/standard_error.erl
@@ -24,6 +24,7 @@
 -behaviour(supervisor_bridge).
 
 -compile(nowarn_deprecated_catch).
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 -include_lib("kernel/include/logger.hrl").
 

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -101,6 +101,8 @@
 -export_type([message/0, request/0]).
 -export([start/0, start/1, start_shell/0, start_shell/1, whereis_group/0, flush/0]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 %% gen_statem state callbacks
 -behaviour(gen_statem).
 -export([init/3,server/3,switch_loop/3]).

--- a/lib/kernel/src/user_drv.erl
+++ b/lib/kernel/src/user_drv.erl
@@ -101,6 +101,8 @@
 -export_type([message/0, request/0]).
 -export([start/0, start/1, start_shell/0, start_shell/1, whereis_group/0]).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 %% gen_statem state callbacks
 -behaviour(gen_statem).
 -export([init/3,server/3,switch_loop/3]).

--- a/lib/kernel/src/user_sup.erl
+++ b/lib/kernel/src/user_sup.erl
@@ -31,6 +31,8 @@
 
 -behaviour(supervisor_bridge).
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -export([start/0]).
 
 %% Internal exports.

--- a/lib/stdlib/src/otp_internal.erl
+++ b/lib/stdlib/src/otp_internal.erl
@@ -72,6 +72,10 @@ obsolete(erlang, now, 0) ->
     {deprecated, "see the \"Time and Time Correction in Erlang\" chapter of the ERTS User's Guide for more information"};
 obsolete(erlang, phash, 2) ->
     {deprecated, "use erlang:phash2/2 instead"};
+obsolete(erlang, exit, 2) ->
+    {deprecated, "use erlang:exit_signal/2 instead"};
+obsolete(erlang, exit, 3) ->
+    {deprecated, "use erlang:exit_signal/3 instead"};
 obsolete(http_uri, decode, 1) ->
     {deprecated, "use uri_string:unquote function instead"};
 obsolete(http_uri, encode, 1) ->

--- a/lib/stdlib/src/proc_lib.erl
+++ b/lib/stdlib/src/proc_lib.erl
@@ -62,7 +62,8 @@ processes that terminate as a result of this process terminating.
 `m:logger`
 """.
 
--compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}}]).
+-compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 %% This module is used to set some initial information
 %% in each created process. 

--- a/lib/stdlib/src/shell.erl
+++ b/lib/stdlib/src/shell.erl
@@ -24,6 +24,7 @@
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
           {nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}},
+          {nowarn_deprecated_function, [{erlang,exit,2}]},
           nowarn_deprecated_catch]).
 
 -export([start/0, start/1, start/2, server/1, server/2, history/1, results/1]).

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -292,6 +292,8 @@ but the map is preferred.
 `m:gen_event`, `m:gen_statem`, `m:gen_server`, `m:sys`
 """.
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -behaviour(gen_server).
 
 %% External exports

--- a/lib/stdlib/src/timer.erl
+++ b/lib/stdlib/src/timer.erl
@@ -141,6 +141,8 @@ done
 ```
 """.
 
+-compile([{nowarn_deprecated_function, [{erlang,exit,2}]}]).
+
 -export([apply_after/2, apply_after/3, apply_after/4,
          send_after/3, send_after/2,
          exit_after/3, exit_after/2, kill_after/2, kill_after/1,

--- a/lib/stdlib/src/win32reg.erl
+++ b/lib/stdlib/src/win32reg.erl
@@ -95,7 +95,8 @@ Reference.
 Programmer's Reference (from Microsoft)
 """.
 
--compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}}]).
+-compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
+         {nowarn_deprecated_function, [{erlang,exit,2}]}]).
 
 -export([open/1, close/1,
 	 current_key/1, change_key/2, change_key_create/2,

--- a/system/doc/general_info/DEPRECATIONS
+++ b/system/doc/general_info/DEPRECATIONS
@@ -37,6 +37,12 @@
 #
 
 #
+# Added in OTP 30.
+#
+erlang:exit/2 since=30
+erlang:exit/3 since=30
+
+#
 # Added in OTP 29.
 #
 crypto:private_decrypt/4 unsafe=29


### PR DESCRIPTION
This is a followup based on https://github.com/erlang/otp/pull/10801 and intended for OTP 30.