### PR TITLE
Add support for SO_TIMESTAMPNS socket option

### DIFF
--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -2591,6 +2591,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(tcp);                             \
     GLOBAL_ATOM_DECL(throughput);                      \
     GLOBAL_ATOM_DECL(timestamp);                       \
+    GLOBAL_ATOM_DECL(timestampns);                     \
     GLOBAL_ATOM_DECL(tos);                             \
     GLOBAL_ATOM_DECL(transparent);                     \
     GLOBAL_ATOM_DECL(timeout);                         \
@@ -2617,6 +2618,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(update_accept_context);           \
     GLOBAL_ATOM_DECL(update_connect_context);          \
     GLOBAL_ATOM_DECL(usec);                            \
+    GLOBAL_ATOM_DECL(nsec);                            \
     GLOBAL_ATOM_DECL(user);                            \
     GLOBAL_ATOM_DECL(user_timeout);                    \
     GLOBAL_ATOM_DECL(use_ext_recvinfo);                \
@@ -3384,13 +3386,22 @@ static struct ESockOpt optLevelSocket[] =
             &esock_atom_timestamp},
 
         {
+#ifdef SO_TIMESTAMPNS
+            SO_TIMESTAMPNS,
+            esock_setopt_bool_opt, esock_getopt_bool_opt,
+#else
+            0, NULL, NULL,
+#endif
+            &esock_atom_timestampns},
+
+        {
 #ifdef SO_TYPE
             SO_TYPE,
             NULL, esock_getopt_sock_type,
 #else
             0, NULL, NULL,
 #endif
-            &esock_atom_type}
+            &esock_atom_type},
     };
 
 
@@ -14198,6 +14209,40 @@ static BOOLEAN_T esock_cmsg_decode_timeval(ErlNifEnv *env,
 }
 #endif
 
+#ifdef SCM_TIMESTAMPNS
+static
+BOOLEAN_T esock_cmsg_encode_timespec(ErlNifEnv     *env,
+                                     unsigned char *data,
+                                     size_t         dataLen,
+                                     ERL_NIF_TERM  *eResult) {
+    struct timespec* timeP = (struct timespec *) data;
+
+    if (dataLen < sizeof(*timeP))
+        return FALSE;
+
+    esock_encode_timespec(env, timeP, eResult);
+    return TRUE;
+}
+
+static BOOLEAN_T esock_cmsg_decode_timespec(ErlNifEnv *env,
+                                           ERL_NIF_TERM eValue,
+                                           struct cmsghdr *cmsgP,
+                                           size_t rem,
+                                           size_t *usedP)
+{
+    struct timespec time, *timeP;
+
+    if (! esock_decode_timespec(env, eValue, &time))
+        return FALSE;
+
+    if ((timeP = esock_init_cmsghdr(cmsgP, rem, sizeof(*timeP), usedP)) == NULL)
+        return FALSE;
+
+    *timeP = time;
+    return TRUE;
+}
+#endif
+
 
 #if defined(IP_TOS) || defined(IP_RECVTOS)
 static
@@ -15504,8 +15549,8 @@ static int cmpESockCmsgSpec(const void *vpa, const void *vpb) {
     return COMPARE(*(a->nameP), *(b->nameP));
 }
 
-
-#if defined(SCM_CREDENTIALS) || defined(SCM_RIGHTS) || defined(SCM_TIMESTAMP)
+#if defined(SCM_CREDENTIALS) || defined(SCM_RIGHTS) ||                         \
+    defined(SCM_TIMESTAMP) || defined(SCM_TIMESTAMPNS)
 #define HAVE_ESOCK_CMSG_SOCKET
 #endif
 
@@ -15530,6 +15575,12 @@ static ESockCmsgSpec cmsgLevelSocket[] =
         {SCM_TIMESTAMP,
          &esock_cmsg_encode_timeval, esock_cmsg_decode_timeval,
          &esock_atom_timestamp},
+#endif
+
+#if defined(SCM_TIMESTAMPNS)
+        {SCM_TIMESTAMPNS,
+         &esock_cmsg_encode_timespec, esock_cmsg_decode_timespec,
+         &esock_atom_timestampns},
 #endif
     };
 #endif

--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -705,6 +705,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(tcp);                      \
     GLOBAL_ATOM_DEF(throughput);               \
     GLOBAL_ATOM_DEF(timestamp);                \
+    GLOBAL_ATOM_DEF(timestampns);              \
     GLOBAL_ATOM_DEF(tos);                      \
     GLOBAL_ATOM_DEF(transparent);              \
     GLOBAL_ATOM_DEF(timeout);                  \
@@ -729,6 +730,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(unspec);                   \
     GLOBAL_ATOM_DEF(up);                       \
     GLOBAL_ATOM_DEF(usec);                     \
+    GLOBAL_ATOM_DEF(nsec);                     \
     GLOBAL_ATOM_DEF(user);                     \
     GLOBAL_ATOM_DEF(user_timeout);             \
     GLOBAL_ATOM_DEF(use_ext_recvinfo);         \

--- a/erts/emulator/nifs/common/socket_util.h
+++ b/erts/emulator/nifs/common/socket_util.h
@@ -221,6 +221,12 @@ extern void esock_encode_timeval(ErlNifEnv*      env,
 extern BOOLEAN_T esock_decode_timeval(ErlNifEnv*      env,
                                       ERL_NIF_TERM    eTime,
                                       struct timeval* timeP);
+extern void esock_encode_timespec(ErlNifEnv*       env,
+                                  struct timespec* timeP,
+                                  ERL_NIF_TERM*    eTime);
+extern BOOLEAN_T esock_decode_timespec(ErlNifEnv*       env,
+                                       ERL_NIF_TERM     eTime,
+                                       struct timespec* timeP);
 
 extern
 char* esock_domain_to_string(int domain);

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -362,6 +362,7 @@ server(Addr, Port) ->
               %% Option values' types
               linger/0,
               timeval/0,
+              timespec/0,
               ip_mreq/0,
               ip_mreq_source/0,
               ip_msfilter/0,
@@ -609,6 +610,17 @@ microseconds.
 -type timeval() ::
         #{sec  := integer(),
           usec := integer()}.
+
+-doc """
+C: `struct timespec`
+
+Corresponds to the C `struct timespec`. The field `sec` holds seconds, and `nsec`
+nanoseconds.
+""".
+-type timespec() ::
+        #{sec  := integer(),
+          nsec := integer()}.
+
 
 -doc """
 C: `struct ip_mreq`
@@ -1193,6 +1205,15 @@ _Options for protocol level_ [_`socket`_:](`t:level/0`)
 
 - **`{socket, timestamp}`** - `Value = boolean()`
 
+  Enable or disable the `SO_TIMESTAMP` socket option. When enabled, the socket
+  will receive timestamps in control messages for received packets.
+
+- **`{socket, timestampns}`** - `Value = boolean()`
+
+  Enable or disable the `SO_TIMESTAMPNS` socket option. When enabled, the socket
+  will receive nanosecond-precision timestamps in control messages for received
+  packets.
+
 - **`{socket, type}`** - `Value =` `t:type/0`
 
   Only valid to _get_.
@@ -1459,6 +1480,7 @@ _Options for protocol level_ [_`udp`:_](`t:level/0`)
            sndlowat |
            sndtimeo |
            timestamp |
+           timestampns |
            type} |
         {Level :: ip,
          Opt ::
@@ -2032,6 +2054,8 @@ successfully decoded the data.
 -type cmsg_recv() ::
         #{level := socket,  type := timestamp,    data := binary(),
           value => timeval()}                                       |
+        #{level := socket,  type := timestampns,  data := binary(),
+          value => timespec()}                                      |
         #{level := socket,  type := rights,       data := binary()} |
         #{level := socket,  type := credentials,  data := binary()} |
         #{level := ip,      type := tos,          data := binary(),

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -232,6 +232,7 @@
          api_opt_sock_sndtimeo_udp4/1,
          api_opt_sock_timestamp_udp4/1,
          api_opt_sock_timestamp_tcp4/1,
+         api_opt_sock_timestampns_udp4/1,
          api_opt_ip_add_drop_membership/0, api_opt_ip_add_drop_membership/1,
          api_opt_ip_pktinfo_udp4/1,
          api_opt_ip_recvopts_udp4/1,
@@ -353,6 +354,7 @@ groups() ->
      {option_sock_lowat,       [], api_option_sock_lowat_cases()},
      {option_sock_timeo,       [], api_option_sock_timeo_cases()},
      {option_sock_timestamp,   [], api_option_sock_timestamp_cases()},
+     {option_sock_timestampns, [], api_option_sock_timestampns_cases()},
      {options_ip,              [], api_options_ip_cases()},
      {options_ipv6,            [], api_options_ipv6_cases()},
      {options_tcp,             [], api_options_tcp_cases()},
@@ -535,6 +537,7 @@ api_options_socket_cases() ->
      {group, option_sock_lowat},
      {group, option_sock_timeo},
      {group, option_sock_timestamp},
+     {group, option_sock_timestampns},
      api_opt_sock_reuseaddr,
      api_opt_sock_exclusiveaddruse,
      api_opt_sock_bsp_state
@@ -583,6 +586,11 @@ api_option_sock_timestamp_cases() ->
     [
      api_opt_sock_timestamp_udp4,
      api_opt_sock_timestamp_tcp4
+    ].
+
+api_option_sock_timestampns_cases() ->
+    [
+     api_opt_sock_timestampns_udp4
     ].
 
 api_options_ip_cases() ->
@@ -27172,6 +27180,284 @@ has_support_sock_sndtimeo() ->
 
 has_support_sock_timestamp() ->
     has_support_socket_option_sock(timestamp).
+
+has_support_sock_timestampns() ->
+    has_support_socket_option_sock(timestampns).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%
+%% SO_TIMESTAMPNS tests
+%%
+
+%% Tests that the timestampns control message header is received when
+%% setting the socket 'socket' option true when using sendmsg/recvmsg
+%% on an IPv4 UDP (dgram) socket.
+%% So, this is done on the receiving side: 
+%%
+%%               socket:setopt(Sock, socket, timestampns, boolean()).
+%%
+%% All subsequent *received* messages will be timestamped with nanosecond precision.
+
+api_opt_sock_timestampns_udp4(_Config) when is_list(_Config) ->
+    ?TT(?SECS(5)),
+    tc_try(api_opt_sock_timestampns_udp4,
+           fun() -> has_support_ipv4(), has_support_sock_timestampns() end,
+           fun() ->
+                   Set  = fun(Sock, Value) ->
+                                  socket:setopt(Sock, socket, timestampns, Value)
+                          end,
+                   Get  = fun(Sock) ->
+                                  socket:getopt(Sock, socket, timestampns)
+                          end,
+                   Send = fun(Sock, Data, Dest) ->
+                                  Msg = #{addr => Dest, iov => [Data]},
+                                  socket:sendmsg(Sock, Msg)
+                          end,
+                   Recv = fun(Sock) ->
+                                  case socket:recvmsg(Sock) of
+                                      {ok, #{addr := Source,
+                                             ctrl := CMsgs,
+                                             iov  := [Data]}} ->
+                                          {ok, {Source, CMsgs, Data}};
+                                      {error, _} = ERROR ->
+                                          ERROR
+                                  end
+                          end,
+                   InitState = #{domain => inet,
+                                 proto  => udp,
+                                 send   => Send,
+                                 recv   => Recv,
+                                 set    => Set,
+                                 get    => Get},
+                   ok = api_opt_sock_timestampns_udp(InitState)
+           end).
+
+api_opt_sock_timestampns_udp(InitState) ->
+    Seq =
+        [
+         #{desc => "local address",
+           cmd  => fun(#{domain := Domain} = State) ->
+                           LSA = which_local_socket_addr(Domain),
+                           {ok, State#{lsa_src => LSA,
+                                       lsa_dst => LSA}}
+                   end},
+         #{desc => "open src socket",
+           cmd  => fun(#{domain := Domain,
+                         proto  := Proto} = State) ->
+                           Sock = sock_open(Domain, dgram, Proto),
+                           {ok, State#{sock_src => Sock}}
+                   end},
+         #{desc => "bind src",
+           cmd  => fun(#{sock_src := Sock, lsa_src := LSA}) ->
+                           case sock_bind(Sock, LSA) of
+                               ok ->
+                                   ?SEV_IPRINT("src bound"),
+                                   ok;
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("src bind failed: ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "sockname src socket",
+           cmd  => fun(#{sock_src := Sock} = State) ->
+                           SASrc = sock_sockname(Sock),
+                           ?SEV_IPRINT("src sockaddr: "
+                                       "~n   ~p", [SASrc]),
+                           {ok, State#{sa_src => SASrc}}
+                   end},
+         #{desc => "get current (default) timestampns for src socket",
+           cmd  => fun(#{sock_src := Sock, get := Get} = _State) ->
+                           case Get(Sock) of
+                               {ok, false = Value} ->
+                                   ?SEV_IPRINT("src timestampns: ~p", [Value]),
+                                   ok;
+                               {ok, Unexpected} ->
+                                   ?SEV_EPRINT("Unexpected src timestampns: ~p",
+                                               [Unexpected]),
+                                   {error, {unexpected, Unexpected}};
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed getting (default) timestampns:"
+                                               "   ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "open dst socket",
+           cmd  => fun(#{domain := Domain,
+                         proto  := Proto} = State) ->
+                           Sock = sock_open(Domain, dgram, Proto),
+                           {ok, State#{sock_dst => Sock}}
+                   end},
+         #{desc => "bind dst",
+           cmd  => fun(#{sock_dst := Sock, lsa_dst := LSA}) ->
+                           case sock_bind(Sock, LSA) of
+                               ok ->
+                                   ?SEV_IPRINT("dst bound"),
+                                   ok;
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("dst bind failed: ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "sockname dst socket",
+           cmd  => fun(#{sock_dst := Sock} = State) ->
+                           SADst = sock_sockname(Sock),
+                           ?SEV_IPRINT("dst sockaddr: "
+                                       "~n   ~p", [SADst]),
+                           {ok, State#{sa_dst => SADst}}
+                   end},
+         #{desc => "send req (to dst) (WO TIMESTAMPNS)",
+           cmd  => fun(#{sock_src := Sock, sa_dst := Dst, send := Send}) ->
+                           Send(Sock, ?BASIC_REQ, Dst)
+                   end},
+         #{desc => "recv req (from src)",
+           cmd  => fun(#{sock_dst := Sock, sa_src := Src, recv := Recv}) ->
+                           case Recv(Sock) of
+                               {ok, {Src, [], ?BASIC_REQ}} ->
+                                   ok;
+                               {ok, {BadSrc, BadCHdrs, BadReq} = UnexpData} ->
+                                   ?SEV_EPRINT("Unexpected msg: "
+                                               "~n   Expect Source: ~p"
+                                               "~n   Recv Source:   ~p"
+                                               "~n   Expect CHdrs:  ~p"
+                                               "~n   Recv CHdrs:    ~p"
+                                               "~n   Expect Msg:    ~p"
+                                               "~n   Recv Msg:      ~p",
+                                               [Src, BadSrc,
+                                                [], BadCHdrs,
+                                                ?BASIC_REQ, BadReq]),
+                                   {error, {unexpected_data, UnexpData}};
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed recv: ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "enable timestampns on dst socket",
+           cmd  => fun(#{sock_dst := Sock, set := Set}) ->
+                           case Set(Sock, true) of
+                               ok ->
+                                   ?SEV_IPRINT("dst timestampns enabled"),
+                                   ok;
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed setting timestampns:"
+                                               "   ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "send req 1 (to dst) (W TIMESTAMPNS)",
+           cmd  => fun(#{sock_src := Sock, sa_dst := Dst, send := Send}) ->
+                           Send(Sock, ?BASIC_REQ, Dst)
+                   end},
+         #{desc => "recv req 1 (from src) (W TIMESTAMPNS)",
+           cmd  => fun(#{sock_dst := Sock, sa_src := Src, recv := Recv}) ->
+                           case Recv(Sock) of
+                               {ok, {Src, [#{level := socket,
+                                             type  := timestampns,
+                                             value  := #{sec := Sec, nsec := NSec}}], ?BASIC_REQ}} ->
+                                   ?SEV_IPRINT("received req *with* timestampns: "
+                                               "~n   sec:  ~p"
+                                               "~n   nsec: ~p",
+                                               [Sec, NSec]),
+                                   ok;
+                               {ok, {BadSrc, BadCHdrs, BadReq} = UnexpData} ->
+                                   ?SEV_EPRINT("Unexpected msg (expected timestampns): "
+                                               "~n   Expect Source: ~p"
+                                               "~n   Recv Source:   ~p"
+                                               "~n   Expect CHdrs:  [timestampns]"
+                                               "~n   Recv CHdrs:    ~p"
+                                               "~n   Expect Msg:    ~p"
+                                               "~n   Recv Msg:      ~p",
+                                               [Src, BadSrc,
+                                                BadCHdrs,
+                                                ?BASIC_REQ, BadReq]),
+                                   {error, {unexpected_data, UnexpData}};
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed recv: ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "send req 2 (to dst) (W TIMESTAMPNS)",
+           cmd  => fun(#{sock_src := Sock, sa_dst := Dst, send := Send}) ->
+                           Send(Sock, ?BASIC_REQ, Dst)
+                   end},
+         #{desc => "recv req 2 (from src) (W TIMESTAMPNS)",
+           cmd  => fun(#{sock_dst := Sock, sa_src := Src, recv := Recv}) ->
+                           case Recv(Sock) of
+                               {ok, {Src, [#{level := socket,
+                                             type  := timestampns,
+                                             value  := #{sec := Sec, nsec := NSec}}], ?BASIC_REQ}} ->
+                                   ?SEV_IPRINT("received req *with* timestampns: "
+                                               "~n   sec:  ~p"
+                                               "~n   nsec: ~p",
+                                               [Sec, NSec]),
+                                   ok;
+                               {ok, {BadSrc, BadCHdrs, BadReq} = UnexpData} ->
+                                   ?SEV_EPRINT("Unexpected msg (expected timestampns): "
+                                               "~n   Expect Source: ~p"
+                                               "~n   Recv Source:   ~p"
+                                               "~n   Expect CHdrs:  [timestampns]"
+                                               "~n   Recv CHdrs:    ~p"
+                                               "~n   Expect Msg:    ~p"
+                                               "~n   Recv Msg:      ~p",
+                                               [Src, BadSrc,
+                                                BadCHdrs,
+                                                ?BASIC_REQ, BadReq]),
+                                   {error, {unexpected_data, UnexpData}};
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed recv: ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "disable timestampns on dst socket",
+           cmd  => fun(#{sock_dst := Sock, set := Set}) ->
+                           case Set(Sock, false) of
+                               ok ->
+                                   ?SEV_IPRINT("dst timestampns disabled"),
+                                   ok;
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed setting timestampns:"
+                                               "   ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "send req (to dst) (WO TIMESTAMPNS)",
+           cmd  => fun(#{sock_src := Sock, sa_dst := Dst, send := Send}) ->
+                           Send(Sock, ?BASIC_REQ, Dst)
+                   end},
+         #{desc => "recv req (from src) (WO TIMESTAMPNS)",
+           cmd  => fun(#{sock_dst := Sock, sa_src := Src, recv := Recv}) ->
+                           case Recv(Sock) of
+                               {ok, {Src, [], ?BASIC_REQ}} ->
+                                   ?SEV_IPRINT("received req *without* timestampns"),
+                                   ok;
+                               {ok, {BadSrc, BadCHdrs, BadReq} = UnexpData} ->
+                                   ?SEV_EPRINT("Unexpected msg (expected no timestampns): "
+                                               "~n   Expect Source: ~p"
+                                               "~n   Recv Source:   ~p"
+                                               "~n   Expect CHdrs:  []"
+                                               "~n   Recv CHdrs:    ~p"
+                                               "~n   Expect Msg:    ~p"
+                                               "~n   Recv Msg:      ~p",
+                                               [Src, BadSrc,
+                                                BadCHdrs,
+                                                ?BASIC_REQ, BadReq]),
+                                   {error, {unexpected_data, UnexpData}};
+                               {error, Reason} = ERROR ->
+                                   ?SEV_EPRINT("Failed recv: ~p", [Reason]),
+                                   ERROR
+                           end
+                   end},
+         #{desc => "close sockets",
+           cmd  => fun(#{sock_src := Src, sock_dst := Dst}) ->
+                           (catch socket:close(Src)),
+                           (catch socket:close(Dst)),
+                           ok
+                   end},
+         ?SEV_FINISH_NORMAL
+        ],
+    Evaluator = ?SEV_START("tester", Seq, InitState),
+    ok = ?SEV_AWAIT_FINISH([Evaluator]).
+
 
 
 %% --- IP socket option test functions ---


### PR DESCRIPTION
I've tried to pretty much replicate existing code as much as possible.

This commit adds support for two additional timestamp-related socket options that provide enhanced timestamping capabilities:

- SO_TIMESTAMPNS: Similar to SO_TIMESTAMP but provides nanosecond precision timestamps using timespec instead of timeval. This is useful for applications requiring higher precision timing information.

Platform compatibility:
- Linux: Full support for both options
- BSD/macOS: Code compiles but options unavailable (guarded by #ifdef)
- Windows: Code compiles but options unavailable

These options are particularly useful for network performance monitoring, packet capture tools, and applications requiring precise timing information.

Splits from https://github.com/erlang/otp/pull/10509