### PR TITLE
Disallow restriction of native record types

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -483,6 +483,8 @@ format_error_1(native_record_illegal_multi_field_init) ->
     ~"multi-field initialization (assigning to _) is only supported for tuple records";
 format_error_1({native_record_already_exported,N}) ->
     {~"native record ~tw already exported",[N]};
+format_error_1(native_record_field_types) ->
+    ~"native records do not allow special field types";
 format_error_1(tuple_record_export) ->
     ~"tuple records cannot be exported; only native records can";
 format_error_1(bad_multi_field_init) ->
@@ -4035,9 +4037,17 @@ check_record_types(Anno, {Mod, Name}, Fields, SeenVars, St) ->
             {SeenVars, St}
     end;
 check_record_types(Anno, Name, Fields, SeenVars, St) when is_atom(Name) ->
-    case maps:find(Name, St#lint.records) of
-        {ok,{_A,_,DefFields}} ->
-	    case all(fun({type, _, field_type, _}) -> true;
+    case St#lint.records of
+        #{Name := {_A,native,_DefFields}} ->
+            case Fields of
+                [] ->
+                    {SeenVars, St};
+                [Token|_] ->
+                    {SeenVars, add_error(element(2, Token),
+                                         native_record_field_types, St)}
+            end;
+        #{Name := {_A,_,DefFields}} ->
+            case all(fun({type, _, field_type, _}) -> true;
                         (_) -> false
                      end, Fields) of
 		true ->
@@ -4045,7 +4055,7 @@ check_record_types(Anno, Name, Fields, SeenVars, St) when is_atom(Name) ->
 		false ->
 		    {SeenVars, add_error(Anno, {type_syntax, record}, St)}
 	    end;
-        error ->
+        #{} ->
             case St#lint.rec_imports of
                 #{Name := _Mod} ->
                     {SeenVars, St};

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -6029,6 +6029,24 @@ native_records(Config) ->
                      [98,97,100,32,"record",32,100,101,99,108,97,114,97,116,105,111,
                       110]}],
             []}
+          },
+          {illegal_type_restriction,
+           <<"-record #xy{x :: number(), y :: number()}.
+             -type xy() :: #xy{}.
+             -type int_xy() :: #xy{x :: integer(), y :: integer()}.
+
+             -spec mk_int_xy() -> #xy{x :: integer(), y :: integer()}.
+             mk_int_xy() -> #xy{x=0,y=1}.
+
+             -spec int_inc_xy(int_xy()) -> int_xy().
+             int_inc_xy(#xy{x=X,y=Y}) -> #xy{x=X+1, y=Y+1}.
+
+              -spec mk_xy() -> xy().
+              mk_xy() -> #xy{x=42.0,y=100.0}.">>,
+           [],
+           {errors,[{{3,36},erl_lint,native_record_field_types},
+                    {{5,39},erl_lint,native_record_field_types}],
+            []}
           }
          ],
     [] = run(Config, Ts),


### PR DESCRIPTION
The native records accidentally inherited the behavior of types from tuple records. It was not intended that one should be allowed to define a type that overrides the types on a per-field basis, such as in the following example:

    -record #xy{x :: number(), y :: number()}.
    -type int_xy() :: #xy{x :: integer(), y :: integer()}.

The reason is that it vastly complicates type checkers.

It is the intention that a better way to achieve this will be suggested in a new EEP and implemented in Erlang/OTP 30.