### PR TITLE
Handle invalid record access in the loader

### DIFF
--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -1663,6 +1663,9 @@ is_record_accessible Fail=f Src=xy a =>
 i_is_record_accessible f? xy
 i_is_wildcard_record_accessible f? xy a
 
+get_record_field Fail BadRecord=c Mod Name Dst =>
+    move BadRecord x | get_record_field Fail x Mod Name Dst
+
 get_record_field Fail Src Id=a Field Dst =>
     i_get_local_record_field Fail Src Id Field Dst
 get_record_field Fail Src Id Field Dst =>

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -1428,4 +1428,7 @@ i_update_native_record s d t I *
 
 is_record_accessible f xy a
 
+get_record_field Fail BadRecord=c Mod Name Dst =>
+    move BadRecord x | get_record_field Fail x Mod Name Dst
+
 get_record_field j xy c a d

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -1350,4 +1350,7 @@ i_update_native_record s d t I *
 
 is_record_accessible f xy a
 
+get_record_field Fail BadRecord=c Mod Name Dst =>
+    move BadRecord x | get_record_field Fail x Mod Name Dst
+
 get_record_field j xy c a d

--- a/lib/compiler/test/native_record_SUITE.erl
+++ b/lib/compiler/test/native_record_SUITE.erl
@@ -122,11 +122,19 @@ local_basic(_Config) ->
     ?assertError({badfield,{{?MODULE,b},bad_field}},
                  BRec#b{bad_field = some_value}),
 
-    %% Test errors when accessing native records
+    %% Test errors when accessing native records.
     ?assertError({badfield,{{?MODULE,b},zoo}}, BRec#b.zoo),
     ?assertError({badfield,{{?MODULE,b},zoo}}, BRec#?MODULE:b.zoo),
     ?assertError({badrecord,ARec}, ARec#b.x),
     ?assertError({badrecord,ARec}, ARec#non_existing_module:rec.x),
+
+    %% Test errors when accessing literal native records.
+    ?assertError({badrecord,not_a_record}, not_a_record#a.x),
+    ?assertError({badrecord,not_a_record},
+                 not_a_record#non_existing_module:rec.x),
+    ?assertError({badrecord,not_a_record}, not_a_record#a.x),
+    ?assertError({badrecord,42}, (42)#non_existing_module:rec.x),
+    ?assertError({badrecord,{a,b,c}}, {a,b,c}#a.x),
 
     true = is_int_ax(ARec),
     false = is_int_ax(id(#a{x=a,y=b})),


### PR DESCRIPTION
The following invalid record access should cause an error at runtime, not at load time:

    not_a_record#rec.x