### PR TITLE
use 56-bit SWAR to accelerate binary ASCII traversal

### DIFF
--- a/lib/stdlib/src/Makefile
+++ b/lib/stdlib/src/Makefile
@@ -150,7 +150,7 @@ HRL_FILES= \
 	../include/qlc.hrl \
 	../include/zip.hrl
 
-INTERNAL_HRL_FILES= dets.hrl erl_tar.hrl otp_internal.hrl json.hrl
+INTERNAL_HRL_FILES= dets.hrl erl_tar.hrl otp_internal.hrl json.hrl swar_ascii.hrl
 
 ERL_FILES= $(MODULES:%=%.erl)
 

--- a/lib/stdlib/src/json.hrl
+++ b/lib/stdlib/src/json.hrl
@@ -179,50 +179,7 @@
     Byte =:= 127
 ).
 
-%% SWAR (SIMD Within A Register) check for 7 bytes of plain ASCII at once.
-%%
-%% Instead of matching 8 individual bytes and checking each against
-%% is_ascii_plain/1 (which the JIT compiles to 8 jump table lookups
-%% with indirect branches), we match a single 56-bit integer and use
-%% bitwise arithmetic to validate all 7 bytes in parallel.
-%%
-%% We use 56 bits (7 bytes) because it is the largest value that fits
-%% in a BEAM small integer (59-bit on 64-bit). This ensures all
-%% bitwise and arithmetic guard operations (band, bor, bxor, +, -)
-%% compile to single native instructions with no type checks or
-%% bignum fallback calls. Benchmarks showed 4/6/7-byte variants all
-%% outperform the original, with 7 bytes winning on string-heavy
-%% inputs (up to 55% faster) due to its larger stride.
-%%
-%% The byte-by-byte is_ascii_plain fallback path handles any remaining
-%% bytes (< 7) and is always entered when the SWAR check fails, so
-%% correctness does not depend on the SWAR path.
-
--define(SWAR_MASK80, 16#80808080808080).
--define(SWAR_MASK01, 16#01010101010101).
-
-%% Detect if any byte in a 56-bit word is zero (Mycroft's trick).
-%%
-%% This is a simplified variant that omits the standard (bnot V) term.
-%% The full formula is: ((V - 0x01..01) band (bnot V) band 0x80..80).
-%% The (bnot V) term filters out false positives from bytes >= 0x80,
-%% where subtracting 0x01 does not clear the high bit. This term is
-%% unnecessary here: check 1 in are_all_ascii_plain_swar/1 proves all
-%% bytes of W are < 128 before no_zero_byte is reached (thanks to
-%% andalso short-circuit evaluation), and XOR of two 7-bit values is
-%% still 7-bit, so no byte in V can have bit 7 set.
-%%
-%% We also avoid bnot because the JIT lacks an always_small fast path
-%% for it, emitting runtime type checks and bignum fallback calls even
-%% when the result provably fits in a small.
-%%
-%% Borrow propagation between bytes may cause rare false positives
-%% (a non-zero byte adjacent to a zero byte detected as zero), but
-%% these are harmless: we simply fall through to the byte-by-byte
-%% path which is always correct.
--define(no_zero_byte(V),
-    ((V) - ?SWAR_MASK01) band ?SWAR_MASK80 =:= 0
-).
+-include("swar_ascii.hrl").
 
 %% SWAR check: all 7 bytes (in one 56-bit word) are "plain ASCII"
 %% i.e., in [32, 127] and not $" (0x22) or $\\ (0x5C).

--- a/lib/stdlib/src/string.erl
+++ b/lib/stdlib/src/string.erl
@@ -154,6 +154,7 @@ functions of both packages have been retained.
 -import(lists,[member/2]).
 -compile({no_auto_import,[length/1]}).
 -compile({inline, [btoken/2, rev/1, append/2, stack/2, search_compile/1]}).
+-include("swar_ascii.hrl").
 -define(ASCII_LIST(CP1,CP2),
         is_integer(CP1), 0 =< CP1, CP1 < 256,
         is_integer(CP2), 0 =< CP2, CP2 < 256, CP1 =/= $\r).
@@ -1148,13 +1149,12 @@ length_1(Str, N) ->
         {error, Err} -> error({badarg, Err})
     end.
 
-length_b(<<CP2, CP3, CP4, CP5, CP6, CP7, CP8, CP9, Rest/binary>>,
-         CP1, N)
-  when CP1 =/= $\r,CP2 =/= $\r,CP3 =/= $\r,CP4 =/= $\r,
-       CP5 =/= $\r,CP6 =/= $\r,CP7 =/= $\r,CP8 =/= $\r,
-       ((CP1 bor CP2 bor CP3 bor CP4 bor CP5 bor CP6 bor CP7 bor CP8 bor CP9)
-            band bnot 127) =:= 0 ->
-    length_b(Rest, CP9, N+8);
+%% Binary fast path: 8 single-byte UTF-8 units per step.
+length_b(<<W:56, B, Rest/binary>>, CP1, N)
+  when CP1 =/= $\r, B =/= $\r,
+       CP1 < 128, B < 128,
+       ?are_all_ascii_len_swar(W) ->
+    length_b(Rest, B, N+8);
 length_b(<<CP2/utf8, Rest/binary>>, CP1, N)
   when ?ASCII_LIST(CP1,CP2) ->
     length_b(Rest, CP2, N+1);
@@ -1223,7 +1223,7 @@ reverse_b(Bin0, CP1, Acc) ->
         {error, Err} -> error({badarg, Err})
     end.
 
-slice_l0(<<CP1/utf8, Bin/binary>>, N) when N > 0 ->
+slice_l0(<<CP1/utf8, Bin/binary>>, N) when is_integer(N), N > 0 ->
     slice_lb(Bin, CP1, N);
 slice_l0(L, N) ->
     slice_l(L, N).
@@ -1240,8 +1240,12 @@ slice_l(CD, N) when is_integer(N), N > 0 ->
 slice_l(Cont, 0) ->
     Cont.
 
+slice_lb(<<W:56, B, Bin/binary>>, CP1, N)
+  when CP1 < 128, CP1 =/= $\r, B < 128, B =/= $\r, N > 8,
+       ?are_all_ascii_len_swar(W) ->
+    slice_lb(Bin, B, N-8);
 slice_lb(<<CP2/utf8, Bin/binary>>, CP1, N)
-  when ?ASCII_LIST(CP1,CP2), is_integer(N), N > 1 ->
+  when ?ASCII_LIST(CP1,CP2), N > 1 ->
     slice_lb(Bin, CP2, N-1);
 slice_lb(Bin, CP1, N) ->
     [_|Rest] = unicode_util:gc([CP1|Bin]),
@@ -1281,6 +1285,10 @@ slice_list(CD, N) when N > 0 ->
 slice_list(_, 0) ->
     [].
 
+slice_bin(<<W:56, B, Bin/binary>>, CP1, N)
+  when CP1 < 128, CP1 =/= $\r, B < 128, B =/= $\r, N > 8,
+       ?are_all_ascii_len_swar(W) ->
+    slice_bin(Bin, B, N-8);
 slice_bin(<<CP2/utf8, Bin/binary>>, CP1, N) when ?ASCII_LIST(CP1,CP2), N > 0 ->
     slice_bin(Bin, CP2, N-1);
 slice_bin(CD, CP1, N) when N > 0 ->

--- a/lib/stdlib/src/swar_ascii.hrl
+++ b/lib/stdlib/src/swar_ascii.hrl
@@ -1,0 +1,62 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Nelson Vides 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%% SWAR (SIMD Within A Register) helpers for validating 7 bytes at once.
+%%
+%% We use 56 bits (7 bytes) because it is the largest value that fits
+%% in a BEAM small integer (59-bit on 64-bit). This ensures bitwise and
+%% arithmetic guard operations (band, bor, bxor, +, -) compile to fast
+%% native code without bignum fallback.
+%%
+%% Call sites must provide a byte-by-byte fallback when SWAR checks fail.
+
+-define(SWAR_MASK80, 16#80808080808080).
+-define(SWAR_MASK01, 16#01010101010101).
+
+%% Detect if any byte in a 56-bit word is zero (Mycroft's trick).
+%%
+%% This is a simplified variant that omits the standard (bnot V) term.
+%% The full formula is: ((V - 0x01..01) band (bnot V) band 0x80..80).
+%% The (bnot V) term filters out false positives from bytes >= 0x80,
+%% where subtracting 0x01 does not clear the high bit. This term is
+%% unnecessary when all bytes of the input word are already known to be
+%% < 128 before no_zero_byte is reached (andalso short-circuit), and
+%% XOR of two 7-bit values is still 7-bit, so no byte in V can have bit 7 set.
+%%
+%% We also avoid bnot because the JIT lacks an always_small fast path
+%% for it, emitting runtime type checks and bignum fallback calls even
+%% when the result provably fits in a small.
+%%
+%% Borrow propagation between bytes may cause rare false positives
+%% (a non-zero byte adjacent to a zero byte detected as zero), but
+%% these are harmless: callers fall through to a correct byte-by-byte path.
+-define(no_zero_byte(V),
+    ((V) - ?SWAR_MASK01) band ?SWAR_MASK80 =:= 0
+).
+
+%% SWAR check for `string:length/1` binary fast path: 7 bytes that are
+%% UTF-8 single-byte code units (< 128) and not carriage return ($\r, 0x0D).
+%% Other C0 controls (e.g. $\n, $\t) are allowed.
+-define(are_all_ascii_len_swar(W),
+    (W) band ?SWAR_MASK80 =:= 0 andalso
+        ?no_zero_byte((W) bxor 16#0D0D0D0D0D0D0D)
+).

--- a/lib/stdlib/test/string_SUITE.erl
+++ b/lib/stdlib/test/string_SUITE.erl
@@ -135,6 +135,15 @@ length(_) ->
     InvalidUTF8 = <<192,192>>,
     ?assertError({badarg, _}, string:length(InvalidUTF8)),
     ?assertError({badarg, _}, string:length(<<$a, InvalidUTF8/binary, $z>>)),
+    %% SWAR fast path: long ASCII; controls other than $\r; $\r forces slow path but length is correct
+    LongAscii = list_to_binary(lists:duplicate(200, $a)),
+    200 = string:length(LongAscii),
+    9 = string:length(<<"\t\n\v\f\n", $a, $b, $\r, $c>>),
+    12 = string:length(<<"abcdefg", $\r, "1234">>),
+    %% $\r in the 7-byte SWAR window (inside the 56-bit word after the first byte of an 8-byte step)
+    17 = string:length(<<"1234567", $\r, "123456789">>),
+    %% Non-ASCII after a SWAR-sized ASCII run (8 ASCII bytes then UTF-8 for ß)
+    9 = string:length(<<$a, $b, $c, $d, $e, $f, $g, $h, 195, 159>>),
     ok.
 
 equal(_) ->
@@ -273,6 +282,20 @@ slice(_) ->
     ?TEST("aåäöbcd", [3,2], "öb"),
     ?TEST([<<"aå"/utf8>>,"äöbcd"], [3,3], "öbc"),
     ?TEST([<<"aåä"/utf8>>,"öbcd"], [3,10], "öbcd"),
+
+    %% Ensure binary slice fast/slow paths are exercised:
+    %% - SWAR fast path in slice_lb/slice_bin (long ASCII, N/Length > 8)
+    ?TEST(<<"abcdefghijklmnopqrstuv">>, [9], "jklmnopqrstuv"),
+    ?TEST(<<"abcdefghijklmnopqrstuv">>, [2, 12], "cdefghijklmn"),
+    %% - ASCII fallback path in slice_lb/slice_bin (small N/Length <= 8)
+    ?TEST(<<"abcdefghijkl">>, [3], "defghijkl"),
+    ?TEST(<<"abcdefghijkl">>, [3, 5], "defgh"),
+    %% - SWAR guard rejection by CR (forces fallback path)
+    ?TEST(<<"abc\rdefghijklmnop">>, [2], "c\rdefghijklmnop"),
+    ?TEST(<<"abc\rdefghijklmnop">>, [2, 8], "c\rdefghi"),
+    %% - Non-ASCII fallback path
+    ?TEST(<<"abcdefghßijkl"/utf8>>, [8], [$ß,$i,$j,$k,$l]),
+    ?TEST(<<"abcdefghßijkl"/utf8>>, [7, 3], [$h,$ß,$i]),
 
     InvalidUTF8 = <<192,192>>,
     [$b, $c|InvalidUTF8] = string:slice(["abc", InvalidUTF8], 1),


### PR DESCRIPTION
Follow up on top of #10938, as suggested by Lukas at https://github.com/erlang/otp/pull/10938#issuecomment-4153579878, we can also apply the same optimisations to the string module. I found out we could apply not only to `length`, but also to `slice`, with improvements ranging from 0x to 2x and with no regressions I could find :)

~Marking as draft as it is on top of the JSON branch.~ JSON branch merged, rebased this.