### PR TITLE
jinterface: Remove from prebuilt

### DIFF
--- a/lib/jinterface/prebuild.keep
+++ b/lib/jinterface/prebuild.keep
@@ -1,2 +1,1 @@
 doc
-priv


### PR DESCRIPTION
Partial revert of #8960

It causes problems with incompatible Java versions in OTP test lab:

> GenericTransportFactoryTest.java:21: cannot access com.ericsson.otp.erlang.OtpGenericTransportFactory
> bad class file: ZipFileIndexFileObject[../29_master-opu_c_x_cross.2026-03-22_21/otp_src_29/lib/jinterface/priv/OtpErlang.jar(com/ericsson/otp/erlang/OtpGenericTransportFactory.class)]
> class file has wrong version 52.0, should be 50.0