### PR TITLE
ssl: Save supervisor memory

### DIFF
--- a/lib/ssl/src/dtls_connection_sup.erl
+++ b/lib/ssl/src/dtls_connection_sup.erl
@@ -45,12 +45,22 @@ start_link() ->
 start_link_dist() ->
     supervisor:start_link({local, dtls_connection_sup_dist}, ?MODULE, []).
 
-start_child(Args) ->
-    supervisor:start_child(?MODULE, Args).
-        
-start_child_dist(Args) ->
-    supervisor:start_child(dtls_connection_sup_dist, Args).
-    
+start_child([_Role, _Host, _Port, _Socket, {SslOpts, _, _}, _User, _CbInfo] = Args) ->
+    start_child(?MODULE, SslOpts, Args).
+
+start_child_dist([_Role, _Host, _Port, _Socket, {SslOpts, _, _}, _User, _CbInfo] = Args) ->
+    start_child(dtls_connection_sup_dist, SslOpts, Args).
+
+start_child(Module, SslOpts, Args) ->
+    ReceiverSpawnOpts = maps:get(receiver_spawn_opts, SslOpts, []),
+    case supervisor:start_child(Module, [self(), ReceiverSpawnOpts]) of
+        {ok, Pid} ->
+            Pid ! {self(), options, Args},
+            {ok, Pid};
+        Error ->
+            Error
+    end.
+
 %%%=========================================================================
 %%%  Supervisor callback
 %%%=========================================================================

--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -36,8 +36,8 @@
 -include("tls_connection.hrl").
 
 %% Initial Erlang process setup
--export([tls_start_link/7,
-         dtls_start_link/7,
+-export([tls_start_link/2,
+         dtls_start_link/2,
          init/1]).
 
 %% TLS connection setup
@@ -110,37 +110,43 @@
 %%% Initial Erlang process setup
 %%--------------------------------------------------------------------
 %%--------------------------------------------------------------------
--spec tls_start_link(client | server, ssl:host(), inet:port_number(), port(), tuple(), pid(), tuple()) ->
+-spec tls_start_link(pid(), list()) ->
     {ok, pid()} | ignore |  {error, ssl:reason()}.
 %%
 %% Description: Creates a process which calls Module:init/1 to
-%% choose appropriat gen_statem and initialize.
+%% choose appropriate gen_statem and initialize.
 %%--------------------------------------------------------------------
-tls_start_link(Role, Host, Port, Socket, {SslOpts, _, _} = Options, User, CbInfo) ->
-    ReceiverOpts = maps:get(receiver_spawn_opts, SslOpts, []),
-    Opts = [link | proplists:delete(link, ReceiverOpts)],
-    Pid = proc_lib:spawn_opt(?MODULE, init, [[Role, self(), Host, Port, Socket, Options, User, CbInfo]], Opts),
+tls_start_link(ConnSupv, ReceiverSpawnOpts) ->
+    Opts = [link | proplists:delete(link, ReceiverSpawnOpts)],
+    Pid = proc_lib:spawn_opt(?MODULE, init, [ConnSupv], Opts),
     {ok, Pid}.
 
 %%--------------------------------------------------------------------
--spec dtls_start_link(client | server, ssl:host(), inet:port_number(), port(), tuple(), pid(), tuple()) ->
+-spec dtls_start_link(pid(), list()) ->
 			{ok, pid()} | ignore |  {error, ssl:reason()}.
 %%
 %% Description: Creates a gen_statem process which calls Module:init/1 to
 %% initialize.
 %%--------------------------------------------------------------------
-dtls_start_link(Role, Host, Port, Socket, {SslOpts, _, _} = Options, User, CbInfo) ->
-    ReceiverOpts = maps:get(receiver_spawn_opts, SslOpts, []),
-    Opts = [link | proplists:delete(link, ReceiverOpts)],
-    Pid = proc_lib:spawn_opt(?MODULE, init, [[Role, Host, Port, Socket, Options, User, CbInfo]], Opts),
+dtls_start_link(ConnSupv, ReceiverSpawnOpts) ->
+    Opts = [link | proplists:delete(link, ReceiverSpawnOpts)],
+    Pid = proc_lib:spawn_opt(?MODULE, init, [ConnSupv], Opts),
     {ok, Pid}.
 
 
 %%--------------------------------------------------------------------
--spec init(list()) -> no_return().
+-spec init(pid()) -> no_return().
 %% Description: Initialization
+%%   We are linked through the supervisors here so either we die or get
+%%   the message from the supervisor.
 %%--------------------------------------------------------------------
-init([Role, Sup, Host, Port, Socket, {TLSOpts, EmOpts, Trackers}, User, CbInfo]) ->
+init(ConnSupv) ->
+    receive
+        {ConnSupv, options, Args} ->
+            init_statem(Args)
+    end.
+
+init_statem([Role, Sup, Host, Port, Socket, {TLSOpts, EmOpts, Trackers}, User, CbInfo]) ->
     process_flag(trap_exit, true),
 
     {ok, {_, Sender,_,_}} = supervisor:which_child(Sup, sender),
@@ -176,7 +182,7 @@ init([Role, Sup, Host, Port, Socket, {TLSOpts, EmOpts, Trackers}, User, CbInfo])
                     tls_server_connection:init([Role, Sender, Tab|InitArgs])
             end
     end;
-init([Role, Host, Port, Socket, {DTLSOpts,EmOpts,Trackers}, User, CbInfo]) ->
+init_statem([Role, Host, Port, Socket, {DTLSOpts,EmOpts,Trackers}, User, CbInfo]) ->
     process_flag(trap_exit, true),
 
     init_label(Role, Host, Port, DTLSOpts),

--- a/lib/ssl/src/tls_dyn_connection_sup.erl
+++ b/lib/ssl/src/tls_dyn_connection_sup.erl
@@ -42,19 +42,28 @@
 %%%=========================================================================
 %%%  API
 %%%=========================================================================
-start_link(SenderArgs, ReciverArgs) ->
-    supervisor:start_link(?MODULE, [SenderArgs, ReciverArgs]).
+start_link(SenderArgs, ReceiverArgs) ->
+    [Role, _Host, _Port, _Socket, {SslOpts, _, _}, _User, _CbInfo] = ReceiverArgs,
+    ReceiverSpawnOpts = maps:get(receiver_spawn_opts, SslOpts, []),
+    case supervisor:start_link(?MODULE, [self(), SenderArgs, ReceiverSpawnOpts]) of
+        {ok, Sup} ->
+            {ok, {_, Receiver, _, _}} = supervisor:which_child(Sup, receiver),
+            Receiver ! {self(), options, [Role, Sup | tl(ReceiverArgs)]},
+            {ok, Sup};
+        Error ->
+            Error
+    end.
 
 %%%=========================================================================
 %%%  Supervisor callback
 %%%=========================================================================
-init([SenderArgs, ReciverArgs]) ->
+init([Parent, SenderArgs, ReceiverSpawnOpts]) ->
     SupFlags = #{strategy      => one_for_all,
                  auto_shutdown => any_significant,
                  intensity     =>    0,
                  period        => 3600
                 },
-    ChildSpecs = [sender(SenderArgs), receiver(ReciverArgs)],
+    ChildSpecs = [sender(SenderArgs), receiver(Parent, ReceiverSpawnOpts)],
     {ok, {SupFlags, ChildSpecs}}.
 
 sender(Args) ->
@@ -65,12 +74,12 @@ sender(Args) ->
       modules     => [tls_sender]
      }.
 
-receiver(Args) ->
+receiver(Parent, SpawnOpts) ->
     #{id          => receiver,
       restart     => temporary,
       type        => worker,
       significant => true,
-      start       => {ssl_gen_statem, tls_start_link, Args},
+      start       => {ssl_gen_statem, tls_start_link, [Parent, SpawnOpts]},
       modules     => [ssl_gen_statem,
                       tls_client_connection,
                       tls_server_connection,


### PR DESCRIPTION
Do not start the socket handling processes with the args including the user options, send them to the process afterwards.

Otherwise the supervisor will store the "unused" options in its state, which can be quite large, which may include a lot of certs and keys.