### PR TITLE
[erts] Actual errno value in erl_errno_id() result if unknown

### DIFF
--- a/erts/doc/references/erl_driver.md
+++ b/erts/doc/references/erl_driver.md
@@ -2782,12 +2782,19 @@ This function is thread-safe.
 ## erl_errno_id()
 
 ```c
-char * erl_errno_id(int error);
+char * erl_errno_id(int eno);
 ```
 
-Returns the atom name of the Erlang error, given the error number in `error`.
-The error atoms are `einval`, `enoent`, and so on. It can be used to make error
-terms from the driver.
+Returns a string corresponding to the lowercase `errno` name for the integer
+value of `eno`. For example, `erl_errno_id(ENOTSUP)` will return the string
+`"enotsup"`. Note that multiple `errno` names can share the same integer
+value, so for example `erl_errno_id(EOPNOTSUPP)` might not return
+`"eopnotsupp"`, but might instead return `"enotsup"`. The resulting string can
+be used to make error terms to propagate from the driver.
+
+If no corresponding `errno` name can be determined, the string
+`"errno_<ERRNO-INTEGER>"` will, as of the OTP 29 release, be returned. In
+releases prior to to OTP 29, the string `"unknown"` was returned.
 
 ## remove_driver_entry()
 

--- a/erts/emulator/beam/erl_errno_str.c
+++ b/erts/emulator/beam/erl_errno_str.c
@@ -27,16 +27,18 @@
 #include "erl_errno.h"
 #include "sys.h"
 
-#if !defined(ERTS_USE_BUILTIN_ERRNO_ID)
-
 #include <string.h>
 #include "hash.h"
 #include "erl_driver.h"
 #include "erl_alloc.h"
 
-static char *unknown = "unknown";
+#define ERTS_UNKNOWN_ERRNO_FORMAT "errno_%d"
+#define ERTS_UNKNOWN_ERRNO_BUF_SZ 30 /* Big enough even if errno should be 64-bit integer */
+
+#if !defined(ERTS_USE_BUILTIN_ERRNO_ID)
 static char **errno_map;
 static int max_errno = 0;
+#endif
 static erts_rwmtx_t errno_rwmtx;
 static int hash_initialized = 0;
 static Hash *errno_table = NULL;
@@ -187,6 +189,15 @@ init_hash_table(void)
     }
 }
 
+static void
+write_unknown_errno(char *buf, size_t buf_sz, int eno)
+{
+    erts_snprintf(&buf[0], buf_sz, ERTS_UNKNOWN_ERRNO_FORMAT, eno);
+}
+
+
+#if !defined(ERTS_USE_BUILTIN_ERRNO_ID)
+
 static const char *errno_name(int eno)
 {
 #define ERTS_ERRNO_CASE(ENO) case ENO: return #ENO
@@ -329,19 +340,31 @@ static const char *errno_name(int eno)
 #undef ERTS_ERRNO_CASE
 }
 
+#endif /* !defined(ERTS_USE_BUILTIN_ERRNO_ID) */
+
 void
 erts_errno_init(void)
 {
     /* Allocators have been initialized... */
+#if !defined(ERTS_USE_BUILTIN_ERRNO_ID)
     int eno;
-    size_t tot_sz = 0, arr_sz;
+    size_t tot_sz = 0, unknown_sz, arr_sz;
     char *ptr, *end_ptr;
+    char unknown_buf[ERTS_UNKNOWN_ERRNO_BUF_SZ];
 
-    for (eno = 0; eno < ERTS_MAX_CACHED_ERRNO; eno++) {
+    write_unknown_errno(&unknown_buf[0], sizeof(unknown_buf), 0);
+    unknown_sz = strlen(&unknown_buf[0]) + 1;
+
+    for (eno = 1; eno < ERTS_MAX_CACHED_ERRNO; eno++) {
         const char *str = errno_name(eno);
         if (str) {
             max_errno = eno;
-            tot_sz += strlen(str) + 1;
+            tot_sz += unknown_sz + strlen(str) + 1;
+            unknown_sz = 0;
+        }
+        else {
+            write_unknown_errno(&unknown_buf[0], sizeof(unknown_buf), eno);
+            unknown_sz += strlen(&unknown_buf[0]) + 1;
         }
     }
 
@@ -354,17 +377,27 @@ erts_errno_init(void)
 
     ptr += arr_sz;
 
-    errno_map[0] = unknown;
+    errno_map[0] = ptr;
+    write_unknown_errno(ptr, end_ptr - ptr, 0);
+    ptr += strlen(ptr) + 1;
+
     for (eno = 1; eno <= max_errno; eno++) {
         const char *str = errno_name(eno);
-        if (!str) {
-            errno_map[eno] = unknown;
-        }
-        else {
-            errno_map[eno] = ptr;
+        errno_map[eno] = ptr;
+        if (str) {
             ptr = tolower_copy_estring(ptr, end_ptr, str);
         }
+        else {
+            write_unknown_errno(ptr, end_ptr - ptr, eno);
+            ptr += strlen(ptr) + 1;
+        }
     }
+
+#if 0
+    for (eno = 0; eno <= max_errno; eno++)
+        fprintf(stderr, "%d - %s\r\n", eno, errno_map[eno]);
+#endif
+#endif /* !defined(ERTS_USE_BUILTIN_ERRNO_ID) */
 
     init_done = !0;
 }
@@ -404,12 +437,15 @@ static void rwlock(void)
         erts_rwmtx_rwlock(&errno_rwmtx);
     }
 }
+
 static void rwunlock(void)
 {
     if (late_init_done) {
         erts_rwmtx_rwunlock(&errno_rwmtx);
     }
 }
+
+#if !defined(ERTS_USE_BUILTIN_ERRNO_ID)
 
 char *
 erl_errno_id(int eno)
@@ -418,7 +454,31 @@ erl_errno_id(int eno)
      * Note! Returned strings must not move or be deallocated
      * during the runtime systems lifetime.
      */
-    char *res, *str;
+    if (!init_done) {
+        /*
+         * Alloc-util allocators have not yet been initialized so we will go
+         * for malloc/free instead of erts_alloc/erts_free from now on.
+         *
+         * This scenario is very unlikely, but might happen on a fatal error
+         * during initialization of the emulator.
+         */
+        used_before_init = !0;
+        erts_errno_init();
+    }
+
+    if (0 <= eno && eno <= max_errno) {
+        return errno_map[eno];
+    }
+
+    return erl_errno_id_unknown((char *) errno_name(eno), eno);
+}
+
+#endif /* !defined(ERTS_USE_BUILTIN_ERRNO_ID) */
+
+char *
+erl_errno_id_unknown(char *str, int eno)
+{
+    char *res;
     ErtsErrnoEntry *hash_res;
     ErtsErrnoEntry tmpl;
 
@@ -431,15 +491,7 @@ erl_errno_id(int eno)
          * during initialization of the emulator.
          */
         used_before_init = !0;
-    }
-
-    if (0 <= eno && eno <= max_errno) {
-        return errno_map[eno];
-    }
-
-    str = (char *) errno_name(eno);
-    if (!str) {
-        return unknown;
+        erts_errno_init();
     }
 
     rlock();
@@ -463,7 +515,16 @@ erl_errno_id(int eno)
         res = &hash_res->str[0];
     }
     else {
-        ErtsErrnoEntry *entry = make_errno_entry(eno, str);
+        ErtsErrnoEntry *entry;
+        char buf[ERTS_UNKNOWN_ERRNO_BUF_SZ];
+
+        if (!str) {
+            write_unknown_errno(&buf[0], sizeof(buf), eno);
+            str = &buf[0];
+        }
+
+        entry = make_errno_entry(eno, str);
+
         rwlock();
         hash_res = hash_put(errno_table, entry);
         if (hash_res != entry) {
@@ -481,5 +542,3 @@ erl_errno_id(int eno)
 
     return res;
 }
-
-#endif /* !defined(ERTS_USE_BUILTIN_ERRNO_ID) */

--- a/erts/emulator/beam/erl_posix_str.c
+++ b/erts/emulator/beam/erl_posix_str.c
@@ -78,20 +78,6 @@ terms specified in this license.
 
 #include "erl_driver.h"
 
-void
-erts_errno_init(void)
-{
-    /* Allocators have been initialized... */
-}
-
-void
-erts_errno_late_init(void)
-{
-    /*
-     * We are still single threaded and now the thread lib has been
-     * initialized...
-     */
-}
 /*
  *----------------------------------------------------------------------
  *
@@ -717,7 +703,7 @@ erl_errno_id(int error /* Posix error number (as from errno). */)
     case WSA_E_CANCELLED: return "e_cancelled";
 #endif
     }
-    return "unknown";
+    return erl_errno_id_unknown(NULL, error);
 }
 
 #endif /* ERTS_USE_BUILTIN_ERRNO_ID */

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -691,6 +691,7 @@ Uint erts_sys_misc_mem_sz(void);
 /* erl_errno_str.c & erl_posix_str.c */
 
 /* char *erl_errno_id(int eno); */ /* Prototype in erl_driver.h */
+char *erl_errno_id_unknown(char *str, int eno);
 void erts_errno_init(void);
 void erts_errno_late_init(void);
 

--- a/erts/emulator/test/driver_SUITE_data/erl_errno_id_drv.c
+++ b/erts/emulator/test/driver_SUITE_data/erl_errno_id_drv.c
@@ -120,10 +120,18 @@ send_error(ErlDrvData drv_data,
     }
 }
 
+#if 0
+#define DEBUG_PRINT(ENO, ENOSTR, STR) \
+    fprintf(stderr, "%d | %s | %s\r\n", ENO, ENOSTR, STR)
+#else
+#define DEBUG_PRINT(ENO, ENOSTR, STR)
+#endif
+
 #define TEST_ERRNO_IMPL(Eno, EnoStr, Alt1, Alt2, Alt3)                  \
     do {                                                                \
         char *res = erl_errno_id(Eno);                                  \
         char *exp = to_lower_str(EnoStr);                               \
+        DEBUG_PRINT(Eno, EnoStr, res);                                  \
         if (!exp) {                                                     \
             driver_failure_posix((ErlDrvPort) drv_data, ENOMEM);        \
             return;                                                     \
@@ -151,8 +159,19 @@ send_error(ErlDrvData drv_data,
 #define TEST_ERRNO_ALT2(Eno, Alt1, Alt2) TEST_ERRNO_IMPL(Eno, #Eno, Alt1, Alt2, NULL)
 #define TEST_ERRNO_ALT3(Eno, Alt1, Alt2, Alt3) TEST_ERRNO_IMPL(Eno, #Eno, Alt1, Alt2, Alt3)
 
+#define TEST_ERRNO_UNKNOWN(RES, INT)                            \
+    do {                                                        \
+        RES = erl_errno_id(INT);                                \
+        DEBUG_PRINT(INT, #INT, RES);                            \
+        if (strcmp(RES, "errno_" #INT) != 0) {                  \
+            send_error(drv_data, #INT, "errno_" #INT, RES);     \
+            return;                                             \
+        }                                                       \
+    } while (0)
+
 static void output(ErlDrvData drv_data, char *buf, ErlDrvSizeT len)
 {
+    char *neg_4711_res, *res;
     /* Test all POSIX.1-2017 errno names... */
 #ifdef E2BIG
     TEST_ERRNO(E2BIG);
@@ -398,12 +417,16 @@ static void output(ErlDrvData drv_data, char *buf, ErlDrvSizeT len)
     TEST_ERRNO(EXDEV);
 #endif
 
-    {
-        char *res = erl_errno_id(-1);
-        if (strcmp(res, "unknown") != 0) {
-            send_error(drv_data, "unknown", "unknown", res);
-            return;
-        }
+    TEST_ERRNO_UNKNOWN(res, -4711);
+    neg_4711_res = res;
+    TEST_ERRNO_UNKNOWN(res, -1);
+    TEST_ERRNO_UNKNOWN(res, 0);
+    TEST_ERRNO_UNKNOWN(res, 4711);
+
+    if (neg_4711_res != erl_errno_id(-4711)) {
+        driver_failure_atom((ErlDrvPort) drv_data,
+                            "result for -4711 moved");
+        return;
     }
 
     send_ok(drv_data);


### PR DESCRIPTION
Include the actual integer `errno` value in the result from `erl_errno_id()`, instead of just the result `"unknown"`, when the `errno` name is unknown. The string returned when the name is unknown will now be `"errno_<INT-VALUE>"`.