### PR TITLE
Teach `erl_syntax:is_literal/1` to recognize utf8 binaries

### DIFF
--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -7513,16 +7513,26 @@ is_literal(T) ->
     end.
 
 is_literal_binary_field(F) ->
+    case is_literal_binary_field_type(F) of
+        true ->
+            B = binary_field_body(F),
+            case type(B) of
+                size_qualifier ->
+                    is_literal(size_qualifier_body(B)) andalso
+                        is_literal(size_qualifier_argument(B));
+                _ ->
+                    is_literal(B)
+            end;
+        false ->
+            false
+    end.
+
+is_literal_binary_field_type(F) ->
     case binary_field_types(F) of
-	[] -> B = binary_field_body(F),
-              case type(B) of
-                  size_qualifier ->
-                      is_literal(size_qualifier_body(B)) andalso
-                          is_literal(size_qualifier_argument(B));
-                  _ ->
-                      is_literal(B)
-              end;
-	_  -> false
+        [] ->
+            true;
+        [Type] ->
+            is_literal(Type) andalso concrete(Type) =:= utf8
     end.
 
 is_literal_map_field(F) ->

--- a/lib/syntax_tools/test/merl_SUITE.erl
+++ b/lib/syntax_tools/test/merl_SUITE.erl
@@ -92,6 +92,11 @@ merl_smoke_test(Config) when is_list(Config) ->
                            ?Q("{foo, _@Bar, '@Baz'}") -> ?Q("{_@Bar, _@Baz}")
                        end
                    end)),
+    ?assertEqual("42",
+                 f(begin
+                       Answer = 42,
+                       ?Q(~"_@Answer@")
+                   end)),
     ok.
 
 transform_parse_error_test(_Config) ->

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -43,7 +43,8 @@
          t_abstract_type/1,t_erl_parse_type/1,t_type/1,
          t_epp_dodger/1,t_epp_dodger_clever/1,
          t_comment_scan/1,t_prettypr/1,test_named_fun_bind_ann/1,
-         test_maybe_expr_ann/1,test_mc_ann/1,test_zip_ann/1]).
+         test_maybe_expr_ann/1,test_mc_ann/1,test_zip_ann/1,
+         is_literal/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -54,7 +55,8 @@ all() ->
      t_abstract_type,t_erl_parse_type,t_type,
      t_epp_dodger,t_epp_dodger_clever,
      t_comment_scan,t_prettypr,test_named_fun_bind_ann,
-     test_maybe_expr_ann,test_mc_ann,test_zip_ann].
+     test_maybe_expr_ann,test_mc_ann,test_zip_ann,
+     is_literal].
 
 groups() ->
     [].
@@ -754,6 +756,16 @@ validate_special_type(list,Node) ->
 	    ok
     end;
 validate_special_type(_,_) ->
+    ok.
+
+is_literal(_Config) ->
+    true = erl_syntax:is_literal(string_to_expr(~s'<<"abc">>')),
+    true = erl_syntax:is_literal(string_to_expr(~s'<<"abc"/utf8>>')),
+    true = erl_syntax:is_literal(string_to_expr(~s'~"abc"')),
+    true = erl_syntax:is_literal(string_to_expr(
+                                   ~s'~"""
+                                      abc
+                                      """')),
     ok.
 
 %%% scan_and_parse


### PR DESCRIPTION
A literal binary encoded as UTF8 would not be recognized as a literal by `erl_syntax:is_literal/1`:

    1> Tree = fun(S) -> {ok,Toks,_} = erl_scan:string(S),
       {ok,[Tree]} = erl_parse:parse_exprs(Toks),
       Tree end.
    #Fun<erl_eval.42.113135111>
    2> erl_syntax:is_literal(Tree(~s'<<"abc">>.')).
    true
    3> erl_syntax:is_literal(Tree(~s'<<"abc"/utf8>>.')).
    false
    4> erl_syntax:is_literal(Tree(~s'~"abc".')).
    false

This had consequences for `merl`. Consider the following module:

    -module(merl_example).
    -export([f/0]).
    -include_lib("syntax_tools/include/merl.hrl").

    f() ->
        Mod = some_module,
        Tree = ?Q([~"""
                   -module('@Mod@').
                   """]),
        merl:print(Tree).

Since the triple-quoted binary is encoded in UTF8, which is not recognized by `erl_syntax:is_literal/1` as a literal, the `merl` parse transform will not do the expected substitution of `@Mod@`:

    c(merl_example).
    merl_example.erl:6:5: Warning: variable 'Mod' is unused
    %    6|     Mod = some_module,
    %     |     ^

    {ok,merl_example}
    2> merl_example:f().
    -module('@Mod@').
    ok

After updating `erl_syntax:is_literal/1` to recognize an UTF8-encoded binary, this will work:

    1> c(merl_example).
    {ok,merl_example}
    2> merl_example:f().
    -module(some_module).
    ok