### PR TITLE
lib/erl_interface: add proper prototypes in ei_runner.c for GCC 15

### DIFF
--- a/lib/erl_interface/test/all_SUITE_data/ei_runner.c
+++ b/lib/erl_interface/test/all_SUITE_data/ei_runner.c
@@ -47,9 +47,9 @@ static int fd_to_erl;		/* File descriptor to Erlang. */
 
 static int packet_loop();
 static void ensure_buf_big_enough();
-static int readn();
+static int readn(int fd, unsigned char *buf, int len);
 static void reply(char* buf, unsigned size);
-static void dump();
+static void dump(unsigned char* buf, int sz, int max);
 
 void
 run_tests(char* argv0, TestCase test_cases[], unsigned number)


### PR DESCRIPTION
GCC 15 rejects calls through empty-parameter declarations like

    static int readn();
    static void dump();

in its default C mode, reporting errors such as "too many arguments to function". GCC 13 and GCC 14 still accept this code in default mode, but GCC 15 follows newer C2x/C23 semantics here.

Fix this by replacing the non-prototype declarations in ei_runner.c with proper prototypes matching the existing definitions.