### PR TITLE
configure: use a floating-point argument in isfinite checks

### DIFF
--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -2389,7 +2389,7 @@ else
 fi
 
 AC_MSG_CHECKING([for isfinite])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[isfinite(0);]])],[have_isfinite=yes],[have_isfinite=no])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[isfinite(0.0);]])],[have_isfinite=yes],[have_isfinite=no])
 
 if test $have_isfinite = yes; then
     AC_DEFINE(HAVE_ISFINITE,[1],

--- a/lib/common_test/test_server/configure.ac
+++ b/lib/common_test/test_server/configure.ac
@@ -353,7 +353,7 @@ AC_CHECK_LIB(resolv, res_gethostbyname,[AC_DEFINE(HAVE_RES_GETHOSTBYNAME,1)])
 #--------------------------------------------------------------------
 
 AC_MSG_CHECKING([for isfinite])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[isfinite(0);]])],[have_isfinite=yes],[have_isfinite=no])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]], [[isfinite(0.0);]])],[have_isfinite=yes],[have_isfinite=no])
 
 if test $have_isfinite = yes; then
     AC_DEFINE(HAVE_ISFINITE,1)


### PR DESCRIPTION
The configure probes in erts and common_test/test_server currently call isfinite(0). On platforms where isfinite is provided as a macro, this can fail to compile because the argument is not a floating-point value.

Use isfinite(0.0) instead. This matches the expected API usage and fixes the configure checks on Solaris.