### PR TITLE
feat: Add supervisor:get_tree/1 for full supervision tree introspection

### DIFF
--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -301,6 +301,7 @@ but the map is preferred.
 	 which_children/1, which_child/2,
 	 count_children/1, check_childspecs/1,
 	 check_childspecs/2, get_childspec/2,
+	 get_tree/1,
 	 stop/1, stop/3]).
 
 %% Internal exports
@@ -333,7 +334,7 @@ but the map is preferred.
 -export_type([sup_flags/0, child_spec/0, strategy/0,
               startchild_ret/0, startchild_err/0,
               startlink_ret/0, startlink_err/0,
-              sup_name/0, sup_ref/0]).
+              sup_name/0, sup_ref/0, supervision_tree/0]).
 
 %%--------------------------------------------------------------------------
 
@@ -437,6 +438,21 @@ see more details [above](`m:supervisor#sup_flags`).
                       Intensity :: non_neg_integer(),
                       Period :: pos_integer()}.
 -type children() :: {Ids :: [child_id()], Db :: #{child_id() => child_rec()}}.
+-doc """
+A hierarchical representation of the supervision tree rooted at a supervisor.
+The tuple contains the supervisor's PID and a list of its child nodes, each
+containing the child ID, child PID (or 'restarting'/'undefined'), child type,
+modules, and the subtree of child supervisors (if any). Workers have empty
+subtrees.
+""".
+-type supervision_tree() :: {Pid :: pid(),
+                             [supervision_tree_node()]} |
+                            {error, no_supervision_info}.
+-type supervision_tree_node() :: {Id :: child_id(),
+                                   Child :: pid() | restarting | undefined,
+                                   Type :: worker | supervisor,
+                                   Modules :: modules(),
+                                   Subtree :: supervision_tree() | []}.
 
 %%--------------------------------------------------------------------------
 %% Defaults
@@ -828,6 +844,49 @@ processes:
              | {workers, ChildWorkerCount :: non_neg_integer()}.
 count_children(Supervisor) ->
     call(Supervisor, count_children).
+
+-doc """
+Returns a nested structure representing the entire supervision tree rooted at
+the given supervisor. This includes all child processes (direct and indirect)
+organized hierarchically.
+
+Each node in the tree contains:
+- `Id` - The child ID as specified in the child specification
+- `Child` - The child process PID, or `restarting` if being restarted, or
+  `undefined` if not running
+- `Type` - Either `worker` or `supervisor`
+- `Modules` - The modules implementing the child process
+- `Subtree` - For supervisor children, the supervision tree below that supervisor,
+  or an empty list for worker children
+
+If the supervisor process does not exist or is not a valid supervisor,
+returns `{error, no_supervision_info}`.
+
+This function is useful for debugging and visualization of the supervision
+structure of an application at runtime.
+
+#### Example
+
+```erlang
+% Get the supervision tree for the root supervisor
+{RootSupPid, Children} = supervisor:get_tree(my_app_sup),
+
+% Each child has the form:
+% {child_id, ChildPid, supervisor, [Modules], ChildrenList}
+```
+""".
+-doc(#{since => <<"OTP 28.0">>}).
+-spec get_tree(SupRef) -> supervision_tree() when
+      SupRef :: sup_ref().
+get_tree(Supervisor) ->
+    try
+        Children = which_children(Supervisor),
+        SupPid = get_sup_pid(Supervisor),
+        {SupPid, [build_tree_node(Id, Child, Type, Modules) ||
+                  {Id, Child, Type, Modules} <- Children]}
+    catch
+        _:_ -> {error, no_supervision_info}
+    end.
 
 -doc(#{equiv => stop(SupRef, normal, infinity)}).
 -doc(#{since => <<"OTP 29.0">>}).
@@ -2537,3 +2596,40 @@ dyn_init(Child,State) when ?is_temporary(Child) ->
     State#state{dynamics={mapsets,maps:new()}};
 dyn_init(_Child,State) ->
     State#state{dynamics={maps,maps:new()}}.
+
+%% Helper function to extract supervisor PID from various reference types
+get_sup_pid(Pid) when is_pid(Pid) ->
+    Pid;
+get_sup_pid(Name) when is_atom(Name) ->
+    case whereis(Name) of
+        Pid when is_pid(Pid) -> Pid;
+        undefined -> error({nonexistent_process, Name})
+    end;
+get_sup_pid({global, Name}) ->
+    case global:whereis_name(Name) of
+        Pid when is_pid(Pid) -> Pid;
+        undefined -> error({nonexistent_process, {global, Name}})
+    end;
+get_sup_pid({via, Module, Name}) ->
+    case Module:whereis_name(Name) of
+        Pid when is_pid(Pid) -> Pid;
+        undefined -> error({nonexistent_process, {via, Module, Name}})
+    end.
+
+%% Helper function to build a tree node for a single child
+build_tree_node(Id, Child, Type, Modules) ->
+    Subtree = case Type of
+        supervisor when is_pid(Child), Child =/= undefined ->
+            try which_children(Child) of
+                Children ->
+                    [build_tree_node(CId, CPid, CType, CMods) ||
+                     {CId, CPid, CType, CMods} <- Children]
+            catch
+                _:_ -> []
+            end;
+        supervisor ->
+            [];
+        worker ->
+            []
+    end,
+    {Id, Child, Type, Modules, Subtree}.

--- a/lib/stdlib/src/supervisor.erl
+++ b/lib/stdlib/src/supervisor.erl
@@ -880,8 +880,8 @@ structure of an application at runtime.
       SupRef :: sup_ref().
 get_tree(Supervisor) ->
     try
-        Children = which_children(Supervisor),
-        SupPid = get_sup_pid(Supervisor),
+        SupPid = resolve_supervisor_reference(Supervisor),
+        Children = which_children(SupPid),
         {SupPid, [build_tree_node(Id, Child, Type, Modules) ||
                   {Id, Child, Type, Modules} <- Children]}
     catch
@@ -2597,20 +2597,23 @@ dyn_init(Child,State) when ?is_temporary(Child) ->
 dyn_init(_Child,State) ->
     State#state{dynamics={maps,maps:new()}}.
 
-%% Helper function to extract supervisor PID from various reference types
-get_sup_pid(Pid) when is_pid(Pid) ->
+%% Resolve a supervisor reference (pid | atom | {global,Name} | {via,Mod,Name})
+%% to a concrete PID. Called once before any gen_server operations to avoid
+%% races where a registered name could be re-bound between two separate lookups.
+-spec resolve_supervisor_reference(sup_ref()) -> pid().
+resolve_supervisor_reference(Pid) when is_pid(Pid) ->
     Pid;
-get_sup_pid(Name) when is_atom(Name) ->
+resolve_supervisor_reference(Name) when is_atom(Name) ->
     case whereis(Name) of
         Pid when is_pid(Pid) -> Pid;
         undefined -> error({nonexistent_process, Name})
     end;
-get_sup_pid({global, Name}) ->
+resolve_supervisor_reference({global, Name}) ->
     case global:whereis_name(Name) of
         Pid when is_pid(Pid) -> Pid;
         undefined -> error({nonexistent_process, {global, Name}})
     end;
-get_sup_pid({via, Module, Name}) ->
+resolve_supervisor_reference({via, Module, Name}) ->
     case Module:whereis_name(Name) of
         Pid when is_pid(Pid) -> Pid;
         undefined -> error({nonexistent_process, {via, Module, Name}})
@@ -2619,7 +2622,7 @@ get_sup_pid({via, Module, Name}) ->
 %% Helper function to build a tree node for a single child
 build_tree_node(Id, Child, Type, Modules) ->
     Subtree = case Type of
-        supervisor when is_pid(Child), Child =/= undefined ->
+        supervisor when is_pid(Child) ->
             try which_children(Child) of
                 Children ->
                     [build_tree_node(CId, CPid, CType, CMods) ||

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -96,7 +96,12 @@
          order_of_children/1, scale_start_stop_many_children/1,
          format_log_1/1, format_log_2/1, already_started_outside_supervisor/1,
 	 which_children/1, which_children_simple_one_for_one/1,
-	 get_tree/1, get_tree_error/1]).
+	 get_tree/1, get_tree_error/1,
+	 get_tree_with_local_name/1,
+	 get_tree_with_global_name/1,
+	 get_tree_with_undefined_children/1,
+	 get_tree_nested_supervisors/1,
+	 get_tree_mixed_child_states/1]).
 
 %%-------------------------------------------------------------------------
 
@@ -126,7 +131,8 @@ all() ->
      code_change, code_change_map, code_change_simple, code_change_simple_map,
      order_of_children, scale_start_stop_many_children,
      format_log_1, format_log_2, already_started_outside_supervisor,
-     which_children, which_children_simple_one_for_one].
+     which_children, which_children_simple_one_for_one,
+     {group, get_tree}].
 
 groups() -> 
     [{sup_start, [],
@@ -174,7 +180,14 @@ groups() ->
        significant_upgrade_never_any, significant_upgrade_any_never,
        significant_upgrade_never_all, significant_upgrade_all_never,
        significant_upgrade_any_all, significant_upgrade_all_any,
-       significant_upgrade_child]}].
+       significant_upgrade_child]},
+     {get_tree, [],
+      [get_tree, get_tree_error,
+       get_tree_with_local_name,
+       get_tree_with_global_name,
+       get_tree_with_undefined_children,
+       get_tree_nested_supervisors,
+       get_tree_mixed_child_states]}].
 
 init_per_suite(Config) ->
     Config.
@@ -3939,6 +3952,104 @@ get_tree_error(Config) when is_list(Config) ->
     {error, no_supervision_info} = supervisor:get_tree(Pid),
     exit(Pid, kill),
 
+    ok.
+
+get_tree_with_local_name(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, SupPid} = supervisor:start_link({local, sup_test}, ?MODULE,
+                                         {ok, {#{strategy => one_for_one,
+                                                 intensity => 2,
+                                                 period => 3600}, []}}),
+    {ok, CPid} = supervisor:start_child(sup_test,
+                                        #{id => child1,
+                                          start => {supervisor_1, start_child, []}}),
+
+    %% Atom name reference should resolve to the same PID
+    {SupPid, [{child1, CPid, worker, [supervisor_1], []}]} =
+        supervisor:get_tree(sup_test),
+
+    true = is_pid(SupPid),
+    terminate(SupPid, shutdown),
+    ok.
+
+get_tree_with_global_name(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, SupPid} = supervisor:start_link({global, global_sup_tree}, ?MODULE,
+                                         {ok, {#{strategy => one_for_one,
+                                                 intensity => 2,
+                                                 period => 3600}, []}}),
+    {ok, CPid} = supervisor:start_child(SupPid,
+                                        #{id => child1,
+                                          start => {supervisor_1, start_child, []}}),
+
+    %% Global reference should resolve correctly
+    {SupPid, [{child1, CPid, worker, [supervisor_1], []}]} =
+        supervisor:get_tree({global, global_sup_tree}),
+
+    terminate(SupPid, shutdown),
+    check_exit([SupPid]),
+    ok.
+
+get_tree_with_undefined_children(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, SupPid} = start_link({ok, {#{strategy => one_for_one,
+                                      intensity => 2,
+                                      period => 3600}, []}}),
+    {ok, _CPid} = supervisor:start_child(SupPid,
+                                         #{id => child1,
+                                           start => {supervisor_1, start_child, []}}),
+
+    %% Terminate child (becomes undefined, not deleted)
+    ok = supervisor:terminate_child(SupPid, child1),
+
+    {SupPid, [{child1, undefined, worker, [supervisor_1], []}]} =
+        supervisor:get_tree(SupPid),
+    ok.
+
+get_tree_nested_supervisors(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, SupPid} = start_link({ok, {#{strategy => one_for_one,
+                                      intensity => 2,
+                                      period => 3600}, []}}),
+    ChildSupSpec = #{id => child_sup,
+                     start => {supervisor, start_link,
+                                [?MODULE, {ok, {#{strategy => one_for_one,
+                                                  intensity => 2,
+                                                  period => 3600}, []}}]},
+                     type => supervisor,
+                     shutdown => infinity},
+    {ok, ChildSupPid} = supervisor:start_child(SupPid, ChildSupSpec),
+
+    {ok, WorkerPid} = supervisor:start_child(ChildSupPid,
+                                             #{id => worker1,
+                                               start => {supervisor_1, start_child, []}}),
+
+    {SupPid, [{child_sup, ChildSupPid, supervisor, _, Subtree}]} =
+        supervisor:get_tree(SupPid),
+
+    [{worker1, WorkerPid, worker, [supervisor_1], []}] = Subtree,
+    ok.
+
+get_tree_mixed_child_states(Config) when is_list(Config) ->
+    process_flag(trap_exit, true),
+    {ok, SupPid} = start_link({ok, {#{strategy => one_for_one,
+                                      intensity => 2,
+                                      period => 3600}, []}}),
+    {ok, CPid1} = supervisor:start_child(SupPid,
+                                         #{id => child1,
+                                           start => {supervisor_1, start_child, []}}),
+    {ok, CPid2} = supervisor:start_child(SupPid,
+                                         #{id => child2,
+                                           start => {supervisor_1, start_child, []}}),
+
+    %% Terminate child1 only; child2 keeps running
+    ok = supervisor:terminate_child(SupPid, child1),
+
+    {SupPid, Children} = supervisor:get_tree(SupPid),
+    2 = length(Children),
+
+    [{child2, CPid2, worker, [supervisor_1], []},
+     {child1, undefined, worker, [supervisor_1], []}] = Children,
     ok.
 
 %%-------------------------------------------------------------------------

--- a/lib/stdlib/test/supervisor_SUITE.erl
+++ b/lib/stdlib/test/supervisor_SUITE.erl
@@ -95,7 +95,8 @@
 	 code_change_simple/1, code_change_simple_map/1,
          order_of_children/1, scale_start_stop_many_children/1,
          format_log_1/1, format_log_2/1, already_started_outside_supervisor/1,
-	 which_children/1, which_children_simple_one_for_one/1]).
+	 which_children/1, which_children_simple_one_for_one/1,
+	 get_tree/1, get_tree_error/1]).
 
 %%-------------------------------------------------------------------------
 
@@ -3897,6 +3898,46 @@ which_children_simple_one_for_one(Config) when is_list(Config) ->
     {error, not_found} = supervisor:which_child(SupPid, self()),
 
     {error, simple_one_for_one} = supervisor:which_child(SupPid, not_a_pid),
+
+    ok.
+
+get_tree(Config) when is_list(Config) ->
+    {ok, SupPid} = start_link({ok, {#{}, []}}),
+
+    %% Empty tree initially
+    {SupPid, []} = supervisor:get_tree(SupPid),
+
+    %% Add a worker child
+    {ok, Child1} = supervisor:start_child(SupPid, #{id => child1,
+						    start => {supervisor_1, start_child, []}}),
+    {SupPid, [{child1, Child1, worker, [supervisor_1], []}]} = supervisor:get_tree(SupPid),
+
+    %% Add another worker child
+    {ok, Child2} = supervisor:start_child(SupPid, #{id => child2,
+						    start => {supervisor_1, start_child, []}}),
+    Tree = supervisor:get_tree(SupPid),
+    {SupPid, Children} = Tree,
+    ?assertEqual(2, length(Children)),
+
+    %% Verify structure of returned tree
+    [{child2, Child2, worker, [supervisor_1], []},
+     {child1, Child1, worker, [supervisor_1], []}] = Children,
+
+    %% Terminate a child and verify tree updates
+    ok = supervisor:terminate_child(SupPid, child1),
+    {SupPid, [{child2, Child2, worker, [supervisor_1], []},
+              {child1, undefined, worker, [supervisor_1], []}]} = supervisor:get_tree(SupPid),
+
+    ok.
+
+get_tree_error(Config) when is_list(Config) ->
+    %% Test with nonexistent process
+    {error, no_supervision_info} = supervisor:get_tree(nonexistent_supervisor),
+
+    %% Test with non-supervisor pid
+    {ok, Pid} = supervisor_1:start_child(),
+    {error, no_supervision_info} = supervisor:get_tree(Pid),
+    exit(Pid, kill),
 
     ok.
 


### PR DESCRIPTION
Operators debugging distributed Erlang applications often need to understand the complete supervision structure at runtime. Previously, this required manually walking the supervision tree by repeatedly calling supervisor:which_children/1 on each supervisor found.

This commit introduces supervisor:get_tree/1, which returns a complete hierarchical representation of the supervision tree rooted at a given supervisor. The function recursively builds a nested structure containing:
- Child ID, PID, type (worker/supervisor), and modules
- Full subtrees for child supervisors
- Empty subtrees for worker processes

The feature enables:
- Better debugging of supervision hierarchies
- Improved application visualization tools
- Runtime introspection for operational monitoring
- Automation of cluster topology discovery

The implementation:
- Uses existing supervisor:which_children/1 as its foundation
- Handles all supervisor reference types (pid, atom, global, via)
- Gracefully handles errors and nonexistent supervisors
- Returns structured data suitable for JSON serialization or display

Added comprehensive tests for:
- Basic tree building with multiple children
- Supervisor and worker process types
- Terminated and undefined child processes
- Error handling for invalid references