### PR TITLE
Add alternative to ryu

### DIFF
--- a/HOWTO/INSTALL.md
+++ b/HOWTO/INSTALL.md
@@ -372,7 +372,6 @@ Some of the available `configure` options are:
 *   `--with-javac=JAVAC` - Specify Java compiler to use
 *   `--{with,without}-javac` - Java compiler (without implies that the
     `jinterface` application won't be built)
-*   `--{enable,disable}-builtin-zlib` - Use the built-in source for zlib.
 *   `--{enable,disable}-dynamic-ssl-lib` - Enable or disable dynamic OpenSSL
     libraries when linking the crypto NIF. By default dynamic linking is
     done unless it does not work or is if it is a Windows system.
@@ -455,6 +454,22 @@ Some of the available `configure` options are:
     flags when compiling Erlang/OTP. This can be useful in some scenarios
     when the flags either causes Erlang/OTP not to build, or unacceptable
     performance degradations.
+*   `--enable-use-embedded-3pp-alternatives` - Use all available alternatives
+    instead of embedded 3pps. Implies all `--disable-builtin-*` options. Can
+    be overridden by individual `--enable-builtin-*` options.
+*   `--disable-use-embedded-3pp-alternatives` - Do not use any alternatives
+    to embedded 3pps. Implies all `--enable-builtin-*` options. Can be overridden
+    by individual `--disable-builtin-*` options.
+*   `--enable-builtin-ryu` - Use our own built-in ryu for float to short string.
+*   `--disable-builtin-ryu` - Use C++17 as an alternative for built-in ryu. May
+    cause slightly different results when converting floating point values to
+    strings using `float_to_list(F,[short])`, `float_to_binary(F,[short])` or
+    `io:format` with control sequences `~p` or `~w`.
+*   `--enable-builtin-zstd` - Force use of our own built-in zstd.
+*   `--disable-builtin-zstd` - Find a static libzstd on the system to use.
+*   `--enable-builtin-zlib` - Force use of our own built-in zlib.
+*   `--disable-builtin-zlib` - Find a zlib on the system to use.
+
 
 If you or your system has special requirements please read the `Makefile` for
 additional configuration information.

--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -78,6 +78,9 @@
    64-bit alignment will be forced. */
 #undef ERTS_STRUCTURE_ALIGNED_ALLOC
 
+/* Define if builtin ryu should be used */
+#undef ERTS_USE_BUILTIN_RYU
+
 /* Define if builtin zlib should be used */
 #undef ERTS_USE_BUILTIN_ZLIB
 

--- a/erts/configure
+++ b/erts/configure
@@ -663,6 +663,7 @@ PRIMARY_FLAVOR
 JIT_ARCH
 JIT_ENABLED
 EMU_LDFLAGS
+ERTS_USE_BUILTIN_RYU
 M4
 LIBRT
 BITS64
@@ -853,6 +854,7 @@ with_with_sparc_memory_order
 enable_ppc_lwsync_instruction
 with_threadnames
 enable_use_embedded_3pp_alternatives
+enable_builtin_ryu
 enable_builtin_zstd
 enable_builtin_zlib
 enable_esock
@@ -1601,13 +1603,22 @@ Optional Features:
                           disable use of powerpc lwsync instruction
   --enable-use-embedded-3pp-alternatives
                           use all available alternatives instead of embedded
-                          3pps
+                          3pps. Implies all --disable-builtin-* options. Can
+                          be overridden by individual --enable-builtin-*
+                          options.
   --disable-use-embedded-3pp-alternatives
-                          do not use any alternatives to embedded 3pps
+                          do not use any alternatives to embedded 3pps.
+                          Implies all --enable-builtin-* options. Can be
+                          overridden by individual --disable-builtin-*
+                          options.
+  --enable-builtin-ryu    use our own built-in ryu for float to short string
+                          (default)
+  --disable-builtin-ryu   use C++17 as an alternative for built-in ryu
   --enable-builtin-zstd   force use of our own built-in zstd
   --disable-builtin-zstd  try to find a static libzstd on the system to use
+                          (default)
   --enable-builtin-zlib   force use of our own built-in zlib
-  --disable-builtin-zlib  try to find a zlib on the system to use
+  --disable-builtin-zlib  try to find a zlib on the system to use (default)
   --enable-esock          enable builtin socket (as a nif) support (default)
   --disable-esock         disable builtin socket (as a nif) support
   --enable-esock-rcvsndtimeo
@@ -16670,21 +16681,28 @@ if test ${enable_use_embedded_3pp_alternatives+y}
 then :
   enableval=$enable_use_embedded_3pp_alternatives;  case "$enableval" in
     no)
+      builtin_ryu=yes
       builtin_zstd=yes
       builtin_zlib=yes
       ;;
     *)
+      builtin_ryu=no
       builtin_zstd=no
       builtin_zlib=no
       ;;
   esac
 
-else case e in #(
-  e)
-  builtin_zstd=no
-  builtin_zlib=no
- ;;
-esac
+fi
+
+
+
+# Check whether --enable-builtin-ryu was given.
+if test ${enable_builtin_ryu+y}
+then :
+  enableval=$enable_builtin_ryu; case "$enableval" in
+      no) builtin_ryu=no ;;
+      *)  builtin_ryu=yes ;;
+   esac
 fi
 
 
@@ -16701,7 +16719,7 @@ fi
 
 LIBZSTD=
 
-if test "$builtin_zstd" = "no"
+if test "$builtin_zstd" != "yes"
 then :
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for static libzstd of version 1.5.6 or higher" >&5
@@ -16740,8 +16758,14 @@ printf "%s\n" "yes" >&6; }
 
 else case e in #(
   e)
- { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, using builtin zstd instead" >&5
-printf "%s\n" "no, using builtin zstd instead" >&6; }
+ if test "$builtin_zstd" = "no"
+then :
+  as_fn_error $? "libzstd not found" "$LINENO" 5
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, using builtin zstd instead" >&5
+printf "%s\n" "no, using builtin zstd instead" >&6; } ;;
+esac
+fi
  ;;
 esac
 fi
@@ -16777,17 +16801,9 @@ fi
 
 Z_LIB=
 
-if test "x$builtin_zlib" = "xyes"
+if test "$builtin_zlib" != "yes"
 then :
 
-
-printf "%s\n" "#define HAVE_ZLIB_INFLATEGETDICTIONARY 1" >>confdefs.h
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Using our own built-in zlib source" >&5
-printf "%s\n" "$as_me: Using our own built-in zlib source" >&6;}
-
-else case e in #(
-  e)
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for zlib 1.2.5 or higher" >&5
 printf %s "checking for zlib 1.2.5 or higher... " >&6; }
 zlib_save_LIBS=$LIBS
@@ -16826,8 +16842,14 @@ printf "%s\n" "yes" >&6; }
 
 else case e in #(
   e)
- { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+ if test "$builtin_zlib" = "no"
+then :
+  as_fn_error $? "zlib not found" "$LINENO" 5
+else case e in #(
+  e) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, using builtin zlib instead" >&5
+printf "%s\n" "no, using builtin zlib instead" >&6; } ;;
+esac
+fi
  ;;
 esac
 fi
@@ -16911,15 +16933,19 @@ fi
 
 LIBS=$zlib_save_LIBS
 
-  ;;
-esac
+
 fi
 
 if test "$Z_LIB" = ""
 then :
 
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Using our own built-in zlib source" >&5
+printf "%s\n" "$as_me: Using our own built-in zlib source" >&6;}
 
 printf "%s\n" "#define ERTS_USE_BUILTIN_ZLIB 1" >>confdefs.h
+
+
+printf "%s\n" "#define HAVE_ZLIB_INFLATEGETDICTIONARY 1" >>confdefs.h
 
 
 fi
@@ -26278,7 +26304,6 @@ fi
 
 
 JIT_ARCH=
-
 if test ${enable_jit} != no
 then :
 
@@ -26345,7 +26370,10 @@ printf "%s\n" "$as_me: WARNING: JIT disabled due to lack to support on $ARCH-$OP
            ;;
    esac
 
-   if test ${enable_jit} != no
+fi
+
+
+if test ${enable_jit} != no -o "$builtin_ryu" = "no"
 then :
 
        if test "$CXX" != false
@@ -26384,6 +26412,7 @@ else case e in #(
 printf %s "checking for C++17 support... " >&6; }
                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
+               CXXFLAGS=$old_CXXFLAGS
                HAVE_CXX17=false ;;
 esac
 fi
@@ -26397,9 +26426,16 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 fi
        if test "$CXX" = false -o "$HAVE_CXX17" = false; then
+         # C++17 not found
+         if test "$builtin_ryu" = "no"; then
+           as_fn_error $? "Alternative to builtin ryu needs C++17 support" "$LINENO" 5
+         else
+           builtin_ryu=yes
+         fi
          if test ${enable_jit} = yes; then
            as_fn_error $? "JIT needs a C++ compiler with C++17 support" "$LINENO" 5
-         else
+         fi
+         if test ${enable_jit} != no; then
            enable_jit=no
            cat >> $ERL_TOP/erts/CONF_INFO <<EOF
 
@@ -26407,16 +26443,32 @@ fi
 EOF
            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: JIT disable due to lack of C++ compiler with C++17 support" >&5
 printf "%s\n" "$as_me: WARNING: JIT disable due to lack of C++ compiler with C++17 support" >&2;}
-        fi
-     fi
+         fi
+       else
+         # C++17 found
+         if test ${enable_jit} != no; then
+           enable_jit=yes
+         fi
+       fi
 
 fi
 
-   if test ${enable_jit} != no; then
-     enable_jit=yes
-   fi
+if test "$builtin_ryu" = "no"
+then :
 
+        ERTS_USE_BUILTIN_RYU=no
+
+else case e in #(
+  e)
+
+printf "%s\n" "#define ERTS_USE_BUILTIN_RYU 1" >>confdefs.h
+
+        ERTS_USE_BUILTIN_RYU=yes
+       ;;
+esac
 fi
+
+
 
 if test ${enable_jit} != no
 then :

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -1255,24 +1255,40 @@ AS_IF([test "X$host" != "Xwin32"],
 
 AC_ARG_ENABLE(use-embedded-3pp-alternatives,
 AS_HELP_STRING([--enable-use-embedded-3pp-alternatives],
-               [use all available alternatives instead of embedded 3pps])
+               [use all available alternatives instead of embedded 3pps.
+                Implies all --disable-builtin-* options. Can be overridden
+                by individual --enable-builtin-* options.])
 AS_HELP_STRING([--disable-use-embedded-3pp-alternatives],
-               [do not use any alternatives to embedded 3pps]),
+               [do not use any alternatives to embedded 3pps.
+                Implies all --enable-builtin-* options. Can be overridden
+                by individual --disable-builtin-* options.]),
 [ case "$enableval" in
     no)
+      builtin_ryu=yes
       builtin_zstd=yes
       builtin_zlib=yes
       ;;
     *)
+      builtin_ryu=no
       builtin_zstd=no
       builtin_zlib=no
       ;;
   esac
-],
-[
-  builtin_zstd=no
-  builtin_zlib=no
 ])
+
+dnl -------------
+dnl ryu (float to short string)
+dnl -------------
+
+AC_ARG_ENABLE(builtin-ryu,
+AS_HELP_STRING([--enable-builtin-ryu],
+               [use our own built-in ryu for float to short string (default)])
+AS_HELP_STRING([--disable-builtin-ryu],
+               [use C++17 as an alternative for built-in ryu]),
+  [case "$enableval" in
+      no) builtin_ryu=no ;;
+      *)  builtin_ryu=yes ;;
+   esac])
 
 dnl -------------
 dnl zstd
@@ -1282,7 +1298,7 @@ AC_ARG_ENABLE(builtin-zstd,
 AS_HELP_STRING([--enable-builtin-zstd],
                [force use of our own built-in zstd])
 AS_HELP_STRING([--disable-builtin-zstd],
-               [try to find a static libzstd on the system to use]),
+               [try to find a static libzstd on the system to use (default)]),
   [ case "$enableval" in
       no) builtin_zstd=no ;;
       *)  builtin_zstd=yes ;;
@@ -1290,7 +1306,7 @@ AS_HELP_STRING([--disable-builtin-zstd],
 
 LIBZSTD=
 
-AS_IF([test "$builtin_zstd" = "no"],
+AS_IF([test "$builtin_zstd" != "yes"],
  [
   AC_MSG_CHECKING(for static libzstd of version 1.5.6 or higher)
   zstd_save_LIBS=$LIBS
@@ -1313,7 +1329,9 @@ error
  LIBZSTD="-l:libzstd.a"
  AC_MSG_RESULT(yes)
 ],[
- AC_MSG_RESULT([no, using builtin zstd instead])
+ AS_IF([test "$builtin_zstd" = "no"],
+       [AC_MSG_ERROR([libzstd not found])],
+       [AC_MSG_RESULT([no, using builtin zstd instead])])
 ])
 
 LIBS="$zstd_save_LIBS"
@@ -1335,7 +1353,7 @@ AC_ARG_ENABLE(builtin-zlib,
 AS_HELP_STRING([--enable-builtin-zlib],
                [force use of our own built-in zlib])
 AS_HELP_STRING([--disable-builtin-zlib],
-               [try to find a zlib on the system to use]),
+               [try to find a zlib on the system to use (default)]),
   [ case "$enableval" in
       no) builtin_zlib=no ;;
       *)  builtin_zlib=yes ;;
@@ -1343,12 +1361,7 @@ AS_HELP_STRING([--disable-builtin-zlib],
 
 Z_LIB=
 
-AS_IF([test "x$builtin_zlib" = "xyes"],
- [
-  AC_DEFINE(HAVE_ZLIB_INFLATEGETDICTIONARY, 1,
-            [Define if your zlib version defines inflateGetDictionary.])
-  AC_MSG_NOTICE([Using our own built-in zlib source])
- ],
+AS_IF([test "$builtin_zlib" != "yes"],
  [
 AC_MSG_CHECKING(for zlib 1.2.5 or higher)
 zlib_save_LIBS=$LIBS
@@ -1371,7 +1384,9 @@ error
  AC_DEFINE(HAVE_LIBZ, 1, [Define to 1 if you have the `z' library (-lz).])
  AC_MSG_RESULT(yes)
 ],[
- AC_MSG_RESULT(no)
+ AS_IF([test "$builtin_zlib" = "no"],
+       [AC_MSG_ERROR([zlib not found])],
+       [AC_MSG_RESULT([no, using builtin zlib instead])])
 ])
 
 AS_IF([test "$Z_LIB" != ""],
@@ -1387,7 +1402,10 @@ LIBS=$zlib_save_LIBS
 
 AS_IF([test "$Z_LIB" = ""],
       [
+        AC_MSG_NOTICE([Using our own built-in zlib source])
         AC_DEFINE(ERTS_USE_BUILTIN_ZLIB, [1], [Define if builtin zlib should be used])
+        AC_DEFINE(HAVE_ZLIB_INFLATEGETDICTIONARY, 1,
+            [Define if your zlib version defines inflateGetDictionary.])
       ])
 
 AC_SUBST(Z_LIB)
@@ -3070,9 +3088,11 @@ AS_IF([test ${enable_jit} != no],
            fi
            ;;
    esac
+  ])
 
-   AS_IF([test ${enable_jit} != no],
-     [
+dnl Test for C++17
+AS_IF([test ${enable_jit} != no -o "$builtin_ryu" = "no"],
+  [
        AS_IF([test "$CXX" != false],
          [
           AC_LANG_PUSH(C++)
@@ -3088,27 +3108,46 @@ AS_IF([test ${enable_jit} != no],
                HAVE_CXX17=true],
               [AC_MSG_CHECKING([for C++17 support])
                AC_MSG_RESULT([no])
+               CXXFLAGS=$old_CXXFLAGS
                HAVE_CXX17=false])
           AC_LANG_POP()
          ])
        if test "$CXX" = false -o "$HAVE_CXX17" = false; then
+         # C++17 not found
+         if test "$builtin_ryu" = "no"; then
+           AC_MSG_ERROR([Alternative to builtin ryu needs C++17 support])
+         else
+           builtin_ryu=yes
+         fi
          if test ${enable_jit} = yes; then
            AC_MSG_ERROR([JIT needs a C++ compiler with C++17 support])
-         else
+         fi
+         if test ${enable_jit} != no; then
            enable_jit=no
            cat >> $ERL_TOP/erts/CONF_INFO <<EOF
 
                  JIT disabled due to lack of compiler with C++17 support
 EOF
            AC_MSG_WARN([JIT disable due to lack of C++ compiler with C++17 support])
-        fi
-     fi
-    ])
-
-   if test ${enable_jit} != no; then
-     enable_jit=yes
-   fi
+         fi
+       else
+         # C++17 found
+         if test ${enable_jit} != no; then
+           enable_jit=yes
+         fi
+       fi
   ])
+
+AS_IF([test "$builtin_ryu" = "no"],
+      [
+        ERTS_USE_BUILTIN_RYU=no
+      ],
+      [
+        AC_DEFINE(ERTS_USE_BUILTIN_RYU, [1], [Define if builtin ryu should be used])
+        ERTS_USE_BUILTIN_RYU=yes
+      ])
+AC_SUBST(ERTS_USE_BUILTIN_RYU)
+
 
 dnl Test if we can use the native stack for Erlang code
 AS_IF([test ${enable_jit} != no],

--- a/erts/emulator/Makefile.in
+++ b/erts/emulator/Makefile.in
@@ -37,6 +37,7 @@ Z_LIB=@Z_LIB@
 CROSS_COMPILING = @CROSS_COMPILING@
 NO_INLINE_FUNCTIONS=false
 USING_VC=@MIXED_VC@
+ERTS_USE_BUILTIN_RYU=@ERTS_USE_BUILTIN_RYU@
 
 OPCODE_TABLES = \
     $(ERL_TOP)/lib/compiler/src/genop.tab \
@@ -386,12 +387,14 @@ endif
 EPCRE_LIB = $(ERL_TOP)/erts/emulator/pcre/obj/$(TARGET)/$(TYPE)/$(LIB_PREFIX)epcre$(LIB_SUFFIX)
 DEPLIBS += $(EPCRE_LIB)
 
+ifeq ($(ERTS_USE_BUILTIN_RYU),yes)
 DEPLIBS += $(RYU_LIBRARY)
 ifeq ($(TARGET),win32)
 LIBS += -L$(RYU_OBJDIR) -lryu
 else
 # Build on darwin fails if -lryu is used
 LIBS += $(RYU_LIBRARY)
+endif
 endif
 
 ifdef LIBZSTD
@@ -530,7 +533,9 @@ endif
 
 include zlib/zlib.mk
 include pcre/pcre.mk
+ifeq ($(ERTS_USE_BUILTIN_RYU),yes)
 include ryu/ryu.mk
+endif
 include zstd/zstd.mk
 
 $(ERTS_LIB):
@@ -848,7 +853,10 @@ endif
 ifndef LIBZSTD
 COMMON_INCLUDES += -Izstd
 endif
-COMMON_INCLUDES += -Ipcre -Iryu
+ifeq ($(ERTS_USE_BUILTIN_RYU),yes)
+COMMON_INCLUDES += -Iryu
+endif
+COMMON_INCLUDES += -Ipcre
 COMMON_INCLUDES += -I../include -I../include/$(TARGET)
 COMMON_INCLUDES += -I../include/internal -I../include/internal/$(TARGET)
 
@@ -957,6 +965,9 @@ $(OBJDIR)/%.o: sys/$(ERLANG_OSTYPE)/%.c
 
 $(OBJDIR)/%.o: sys/common/%.c
 	$(V_CC) $(subst $(space)-O2$(space), $(GEN_OPT_FLGS) , $(CFLAGS)) $(INCLUDES) -c $< -o $@
+
+$(OBJDIR)/%.o: sys/common/%.cpp
+	$(V_CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 $(OBJDIR)/%.o: drivers/common/%.c
 	$(V_CC) $(CFLAGS) -DLIBSCTP=$(LIBSCTP) $(INCLUDES) -Idrivers/common -Idrivers/$(ERLANG_OSTYPE) -c $< -o $@
@@ -1279,6 +1290,9 @@ OS_OBJS +=	$(OBJDIR)/erl_poll.o \
 ifeq ($(ERTS_BUILD_FALLBACK_POLL),yes)
 OS_OBJS += 	$(OBJDIR)/erl_poll.flbk.o
 endif
+ifneq ($(ERTS_USE_BUILTIN_RYU),yes)
+OS_OBJS += 	$(OBJDIR)/erl_float_short.o
+endif
 
 ifeq ($(JIT_ENABLED),yes)
 BASE_OBJS = $(JIT_OBJS)
@@ -1459,7 +1473,10 @@ $(TARGET)/gen_git_version.mk:
 # rebuild.
 	$(V_at)if utils/gen_git_version $@; then touch beam/erl_bif_info.c; fi
 
-DEPEND_DEPS=jit src drv nif sys target zlib ryu zstd
+DEPEND_DEPS=jit src drv nif sys target zlib zstd
+ifeq ($(ERTS_USE_BUILTIN_RYU),yes)
+DEPEND_DEPS += ryu
+endif
 
 $(TTF_DIR)/src.depend.mk: $(TTF_DIR)/GENERATED $(PRELOAD_SRC)
 	$(gen_verbose)

--- a/erts/emulator/beam/bif.c
+++ b/erts/emulator/beam/bif.c
@@ -52,7 +52,9 @@
 #include "erl_msacc.h"
 #include "erl_proc_sig_queue.h"
 #include "erl_fun.h"
-#include "ryu.h"
+#ifdef ERTS_USE_BUILTIN_RYU
+#  include "ryu.h"
+#endif
 #include "jit/beam_asm.h"
 #include "erl_global_literals.h"
 #include "beam_load.h"
@@ -3414,11 +3416,15 @@ static int do_float_to_charbuf(Process *p, Eterm efloat, Eterm list,
     GET_DOUBLE(efloat, f);
 
     if (fmt_type == FMT_SHORT) {
+#ifdef ERTS_USE_BUILTIN_RYU
         const int index = d2s_buffered_n(f.fd, fbuf);
 
         /* Terminate the string. */
         fbuf[index] = '\0';
         return index;
+#else
+        return sys_double_to_chars_short(f.fd, fbuf, sizeof_fbuf);
+#endif
     } else if (fmt_type == FMT_FIXED) {
         return sys_double_to_chars_fast(f.fd, fbuf, sizeof_fbuf,
                 decimals, compact);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -3595,13 +3595,15 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 #endif
         xtra -= 2;
 
-        hp = erts_produce_heap(&hfact, 2, xtra);
+        hp = erts_produce_heap(&hfact, 4, xtra);
+#ifdef ERTS_USE_BUILTIN_RYU
         included = CONS(hp, AM_STL, included);
-        xtra -= 2;
-
-        hp = erts_produce_heap(&hfact, 2, xtra);
-        included = CONS(hp, AM_ryu, included);
-        xtra -= 2;
+        included = CONS(hp+2, AM_ryu, included);
+#else
+        excluded = CONS(hp, AM_STL, excluded);
+        excluded = CONS(hp+2, AM_ryu, excluded);
+#endif
+        xtra -= 4;
 
         hp = erts_produce_heap(&hfact, 2, xtra);
         included = CONS(hp, AM_pcre2, included);

--- a/erts/emulator/beam/sys.h
+++ b/erts/emulator/beam/sys.h
@@ -893,6 +893,7 @@ int sys_chars_to_double(char*, double*);
 int sys_double_to_chars(double, char*, size_t);
 int sys_double_to_chars_ext(double, char*, size_t, size_t);
 int sys_double_to_chars_fast(double, char*, int, int, int);
+int sys_double_to_chars_short(double, char*, int);
 void sys_get_pid(char *, size_t);
 int sys_get_hostname(char *buf, size_t size);
 

--- a/erts/emulator/sys/common/erl_float_short.cpp
+++ b/erts/emulator/sys/common/erl_float_short.cpp
@@ -1,0 +1,94 @@
+/*
+ * %CopyrightBegin%
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright Ericsson AB 2026. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#ifdef ERTS_USE_BUILTIN_RYU
+# error "ERTS_USE_BUILTIN_RYU should not be defined here"
+#endif
+
+#include <charconv>
+#include <string.h>
+#include <math.h>
+
+extern "C"
+int sys_double_to_chars_short(double f, char* fbuf, int sizeof_fbuf)
+{
+    std::to_chars_result tcr;
+
+    if (fabs(f) < 9007199254740992.0) {
+        tcr = std::to_chars(fbuf, fbuf + sizeof_fbuf -1, f);
+    }
+    else {
+        tcr = std::to_chars(fbuf, fbuf + sizeof_fbuf -1, f,
+                            std::chars_format::scientific);
+    }
+
+    if (tcr.ec != std::errc()) {
+        return 0;
+    }
+
+    char* end = tcr.ptr;
+    bool add_dot0 = true;
+
+    for (char *p = fbuf+1; p < end; p++) {
+        if (*p == '.') {
+            add_dot0 = false;
+        }
+        else if (*p == 'e') {
+            if (add_dot0) {
+                memmove(p+2, p, end - p);
+                *p++ = '.';
+                *p++ = '0';
+                end += 2;
+                add_dot0 = false;
+            }
+            p++;
+            char* exp_dst = p;
+            if (*p == '+') {
+                p++;
+            }
+            else if (*p == '-') {
+                p++;
+                exp_dst++;
+            }
+            if (*p == '0') {
+                p++;
+            }
+            if (p != exp_dst) {
+                memmove(exp_dst, p, end - p);
+                end -= p - exp_dst;
+            }
+            break;
+        }
+    }
+
+    if (add_dot0) {
+        *end++ = '.';
+        *end++ = '0';
+    }
+
+    *end = '\0';
+    return end - fbuf;
+}

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -222,21 +222,21 @@ t_float_to_string(Config) when is_list(Config) ->
     % test switching logic between decimal and scientific
     test_fts("1.0e-6", 1.0e-6, [short]),
     test_fts("1.0e-5", 1.0e-5, [short]),
-    test_fts("0.0001", 1.0e-4, [short]),
+    test_fts_2x("0.0001", "1.0e-4", 1.0e-4, [short]),
     test_fts("0.001", 1.0e-3, [short]),
     test_fts("0.01", 1.0e-2, [short]),
     test_fts("0.1", 1.0e-1, [short]),
     test_fts("1.0", 1.0e0, [short]),
     test_fts("10.0", 1.0e1, [short]),
     test_fts("100.0", 1.0e2, [short]),
-    test_fts("1.0e3", 1.0e3, [short]),
-    test_fts("1.0e4", 1.0e4, [short]),
+    test_fts_2x("1.0e3", "1000.0", 1.0e3, [short]),
+    test_fts_2x("1.0e4", "10000.0", 1.0e4, [short]),
     test_fts("1.0e5", 1.0e5, [short]),
     test_fts("1.0e6", 1.0e6, [short]),
     test_fts("1.0e7", 1.0e7, [short]),
     test_fts("1.234e-6", 1.234e-6, [short]),
     test_fts("1.234e-5", 1.234e-5, [short]),
-    test_fts("1.234e-4", 1.234e-4, [short]),
+    test_fts_2x("1.234e-4", "0.0001234", 1.234e-4, [short]),
     test_fts("0.001234", 1.234e-3, [short]),
     test_fts("0.01234", 1.234e-2, [short]),
     test_fts("0.1234", 1.234e-1, [short]),
@@ -245,8 +245,8 @@ t_float_to_string(Config) when is_list(Config) ->
     test_fts("123.4", 1.234e2, [short]),
     test_fts("1234.0", 1.234e3, [short]),
     test_fts("12340.0", 1.234e4, [short]),
-    test_fts("1.234e5", 1.234e5, [short]),
-    test_fts("1.234e6", 1.234e6, [short]),
+    test_fts_2x("1.234e5", "123400.0", 1.234e5, [short]),
+    test_fts_2x("1.234e6", "1234000.0", 1.234e6, [short]),
 
     % test the switch to subnormals
     test_fts("2.2250738585072014e-308", 2.2250738585072014e-308, [short]),
@@ -275,6 +275,14 @@ test_fts(Expect, Float, Args) ->
     BinExpect = list_to_binary(Expect),
     ?assertEqual(BinExpect, float_to_binary(Float,Args)).
 
+%% When ryu and our own impl differ
+test_fts_2x(ExpRyu, ExpSTL, Float, Args) ->
+    #{included := Included} = erlang:system_info(embedded_3pps),
+    Expect = case lists:member(ryu, Included) of
+                 true -> ExpRyu;
+                 false -> ExpSTL
+             end,
+    test_fts(Expect, Float, Args).
 
 rand_float_reasonable() ->
     F = rand_float(),

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -23,6 +23,7 @@
 -module(num_bif_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 %% Tests the BIFs:
 %% 	abs/1
@@ -265,14 +266,14 @@ t_float_to_string(Config) when is_list(Config) ->
     ok.
 
 test_fts(Expect, Float) ->
-    Expect = float_to_list(Float),
+    ?assertEqual(Expect, float_to_list(Float)),
     BinExpect = list_to_binary(Expect),
-    BinExpect = float_to_binary(Float).
+    ?assertEqual(BinExpect, float_to_binary(Float)).
 
 test_fts(Expect, Float, Args) ->
-    Expect = float_to_list(Float,Args),
+    ?assertEqual(Expect, float_to_list(Float,Args)),
     BinExpect = list_to_binary(Expect),
-    BinExpect = float_to_binary(Float,Args).
+    ?assertEqual(BinExpect, float_to_binary(Float,Args)).
 
 
 rand_float_reasonable() ->


### PR DESCRIPTION
### What?
The implementation of `float_to_list/binary(_, [short])`.

### Why?
To optionally avoid yet another embedded 3PP.

### Limitations
- Needs C++17
- Currently not totally backward compatible with ryu's output format.