### PR TITLE
erts: Add distribution capability flag DFLAG_NATIVE_RECORDS

### DIFF
--- a/erts/doc/guides/erl_dist_protocol.md
+++ b/erts/doc/guides/erl_dist_protocol.md
@@ -833,6 +833,11 @@ following capability flags are defined:
   [`ALTACT_SIG_SEND`](erl_dist_protocol.md#ALTACT_SIG_SEND) control messages.
   Introduced in OTP 28.
 
+- **`-define(DFLAG_NATIVE_RECORDS, (1 bsl 38)).`{: #DFLAG_NATIVE_RECORDS }** -
+  The node supports native record terms encoded with the
+  [`RECORD_EXT`](erl_ext_dist.md#record_ext) tag.
+  Introduced in OTP 29.
+
 There is also function `dist_util:strict_order_flags/0` returning all flags
 (bitwise or:ed together) corresponding to features that require strict ordering
 of data over distribution channels.

--- a/erts/emulator/beam/dist.h
+++ b/erts/emulator/beam/dist.h
@@ -67,6 +67,7 @@
 #define DFLAG_ALIAS            (((Uint64)0x8) << 32)
 #define DFLAG_LOCAL_EXT        (((Uint64)0x10) << 32) /* internal */
 #define DFLAG_ALTACT_SIG       (((Uint64)0x20) << 32)
+#define DFLAG_NATIVE_RECORDS   (((Uint64)0x40) << 32)
 
 /*
  * In term_to_binary/2, we will use DFLAG_ATOM_CACHE to mean
@@ -105,7 +106,8 @@
                               | DFLAG_DIST_MONITOR_NAME         \
                               | DFLAG_SPAWN                     \
                               | DFLAG_ALTACT_SIG                \
-			      | DFLAG_ALIAS)
+                              | DFLAG_ALIAS                     \
+                              | DFLAG_NATIVE_RECORDS)
 
 /* Our preferred set of flags. Used for connection setup handshake */
 #define DFLAG_DIST_DEFAULT (DFLAG_DIST_MANDATORY | DFLAG_DIST_HOPEFULLY \

--- a/lib/kernel/include/dist.hrl
+++ b/lib/kernel/include/dist.hrl
@@ -59,6 +59,7 @@
 -define(DFLAG_ALIAS,        (16#08 bsl 32)).
 -define(DFLAG_LOCAL_EXT,    (16#10 bsl 32)). %% only used internally
 -define(DFLAG_ALTACT_SIG,   (16#20 bsl 32)).
+-define(DFLAG_NATIVE_RECORDS, (16#40 bsl 32)).
 
 %% The following flags are mandatory in OTP 25. OTP 25 and higher
 %% will accept ?DFLAG_MANDATORY_25_DIGEST as a shorthand for all those

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -133,6 +133,8 @@ dflag2str(?DFLAG_LOCAL_EXT) ->
     "LOCAL_EXT";
 dflag2str(?DFLAG_ALTACT_SIG) ->
     "ALTACT_SIG";
+dflag2str(?DFLAG_NATIVE_RECORDS) ->
+    "NATIVE_RECORDS";
 dflag2str(Other) ->
     lists:flatten(io_lib:format("UNKNOWN<~.16.0B>", [Other])).
 


### PR DESCRIPTION
Currently unused.

Could be used to disconnect from sending side if trying to send native records to someone without that capability.
