### PR TITLE
document httpc autoretry since tag

### DIFF
--- a/lib/inets/src/http_client/httpc.erl
+++ b/lib/inets/src/http_client/httpc.erl
@@ -305,6 +305,8 @@ HTTP options:
 
   Default is atom `infinity`.
 
+  Since OTP 28.4
+
 - **`proxy_auth`** - A proxy-authorization header using a tuple where the first
   element is the `username` and the second element of the tuple is the
   `password` added to the request.


### PR DESCRIPTION
Autoretry option added in https://github.com/erlang/otp/pull/10469

Based on: https://github.com/erlang/otp/pull/10942/changes

@Whaileee can you check the version so we're sure it's correct.