### PR TITLE
erts: Allow erlang:load_nif/2 to load a NIF library from an in-memory binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ JAVADOC-GENERATED
 /erts/emulator/test/*_native_SUITE.erl
 /erts/emulator/test/*_SUITE_data/Makefile
 /erts/emulator/test/*_stripped_types_SUITE.erl
+/erts/emulator/test/nif_SUITE_data/*.so
 /erts/test/install_SUITE_data/install_bin
 /erts/test/autoimport_SUITE_data/erlang.xml
 /erts/emulator/make_test_dir/

--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -311,6 +311,7 @@ atom extra
 atom false
 atom fcgi
 atom fd
+atom filename
 atom first
 atom firstline
 atom flags

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -44,7 +44,6 @@
 #endif
 
 #include "erl_nif.h"
-
 #include "sys.h"
 #include "global.h"
 #include "erl_binary.h"
@@ -69,10 +68,160 @@
 #endif
 #include "jit/beam_asm.h"
 #include "erl_global_literals.h"
+
 #include "erl_iolist.h"
+#include "erl_atom_table.h"
 
 #include <limits.h>
 #include <stddef.h> /* offsetof */
+
+#undef SHMOPEN_USE_LINUX_MEMFD
+#undef SHMOPEN_USE_SHM_ANON
+#undef SHMOPEN_USE_SHM_MKSTEMP
+#undef SHMOPEN_USE_POSIX
+#undef USE_ERTS_DLOPEN_MEM
+
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#if defined(__linux__)
+#  if defined(__linux__)
+#    include <sys/syscall.h>
+#  endif
+#  include <sys/utsname.h>
+#  ifdef SYS_memfd_create
+#    define SHMOPEN_USE_LINUX_MEMFD
+#  else
+#    define SHMOPEN_USE_SHM_POSIX
+#  endif
+#  define USE_ERTS_DLOPEN_MEM
+#elif defined(__FreeBSD__)
+#  define SHMOPEN_USE_SHM_ANON
+#  define USE_ERTS_DLOPEN_MEM
+#elif defined(__OpenBSD__)
+#  define SHMOPEN_USE_SHM_MKSTEMP
+#  define USE_ERTS_DLOPEN_MEM
+#else
+#  if defined(__APPLE__)  || defined(__MACH__)      || defined(__DARWIN__) || \
+      defined(__NetBSD__) || defined(__DragonFly__) || defined(__HAIKU__)  || \
+      defined(__sun)
+#    define SHMOPEN_USE_POSIX
+#    define USE_ERTS_DLOPEN_MEM
+#  endif
+#endif
+
+#define ERTS_NIF_MEM_NAME_MAX 64
+#define ERTS_MIN_KERNEL_VSN   317
+
+#ifdef USE_ERTS_DLOPEN_MEM
+/* Always declare erts_dlopen_mem for all platforms */
+static void *erts_dlopen_mem(const char *filename, const void *mem, size_t size);
+
+static char* erts_shm_name(const char *pfx, const char *sfx, char* buf, size_t buf_len)
+{
+    /* Generate a unique name for the shared memory object. */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    enif_snprintf(buf, buf_len, "%s-%-06ld%s", pfx, (long)tv.tv_usec, sfx);
+    return buf;
+}
+
+/*
+ * Load a shared object from memory using memfd_create (Linux >= 3.17) or
+ * shm_open (other POSIX systems).  Returns a dlopen(3) handle on success,
+ * or NULL on failure.
+ *
+ * filename - a label associated with the in-memory file (may be NULL)
+ * mem      - pointer to the SO image in memory
+ * size     - byte length of the SO image
+ */
+static void *erts_dlopen_mem(const char *filename, const void *mem, size_t size)
+{
+    char path[PATH_MAX];
+    char shm_name[NAME_MAX];
+    int  shm_fd = -1;
+    void *handle = NULL;
+#if defined(SHMOPEN_USE_SHM_MKSTEMP) || defined(SHMOPEN_USE_POSIX)
+    int  need_unlink = 0;
+#endif
+
+    path[0]     = '\0';
+    shm_name[0] = '\0';
+
+#if defined(SHMOPEN_USE_LINUX_MEMFD)
+    if (!filename)
+        filename = erts_shm_name("erl-nif-mem-", ".so", shm_name, sizeof(shm_name));
+    shm_fd = memfd_create(filename, MFD_CLOEXEC);
+    if (shm_fd < 0)
+        return NULL;
+    enif_snprintf(path, sizeof(path), "/proc/self/fd/%d", shm_fd);
+
+#elif defined(SHMOPEN_USE_SHM_ANON)
+    if (filename)
+        return NULL;
+    shm_fd = shm_open(SHM_ANON, O_RDWR, 0);
+    if (shm_fd < 0)
+        return NULL;
+# if defined(__APPLE__)
+    if (fcntl(shm_fd, F_GETPATH, path) < 0)
+        goto err;
+# else
+    enif_snprintf(path, sizeof(path), "/dev/fd/%d", shm_fd);
+# endif
+
+#elif defined(SHMOPEN_USE_SHM_MKSTEMP)
+    enif_snprintf(path, sizeof(path), "/tmp/%s-XXXXXX", filename ? filename : "enif-shm");
+    shm_fd = shm_mkstemp(path);
+    if (shm_fd < 0)
+        return NULL;
+    need_unlink = 1;
+
+#else /* SHMOPEN_USE_POSIX */
+    if (filename) {
+        enif_snprintf(shm_name, sizeof(shm_name), "%s", filename);
+    } else {
+        erts_shm_name("enif-shm-", ".so", shm_name, sizeof(shm_name));
+    }
+    enif_snprintf(path, sizeof(path), "/dev/shm/%s", shm_name);
+    shm_fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (shm_fd < 0)
+        return NULL;
+    need_unlink = 1;
+#endif
+
+    if (ftruncate(shm_fd, size) || write(shm_fd, mem, size) != (ssize_t)size)
+        goto err;
+
+    handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+
+err:
+# if defined(SHMOPEN_USE_SHM_MKSTEMP)
+    if (need_unlink)
+        unlink(path);
+# elif defined(SHMOPEN_USE_POSIX)
+    if (need_unlink)
+        shm_unlink(path);
+# endif
+    if (shm_fd >= 0)
+        close(shm_fd);
+    return handle;
+}
+#endif /* USE_ERTS_DLOPEN_MEM */
 
 #define ERTS_NIF_HALT_INFO_FLAG_BLOCK               (1 << 0)
 #define ERTS_NIF_HALT_INFO_FLAG_HALTING             (1 << 1)
@@ -4721,6 +4870,8 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
     Eterm ret = am_ok;
     int veto;
     int is_static = 0;
+    int load_from_mem = 0;       /* non-zero when loading from in-memory binary */
+    Eterm nif_binary = THE_NON_VALUE;
     struct erl_module_nif* lib = NULL;
     struct erl_module_instance* this_mi;
     struct erl_module_instance* prev_mi;
@@ -4731,13 +4882,49 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
         /* since lib_name is used in error messages */
         encoding = ERL_FILENAME_UTF8;
     }
+
+    /*
+     * Accept either:
+     *   Filename::string()|binary()              -- load from file (existing behaviour)
+     *   #{filename := string()|binary()}         -- load from file (map form, no memory)
+     *   #{memory := NifSO}                       -- load from memory, auto-generated filename
+     *   #{memory := NifSO, filename := Filename} -- load from memory with explicit filename
+     *
+     * If the map contains only 'filename', it falls back to the string|binary filename implementation.
+     */
+    if (is_map(filename)) {
+        const Eterm *fnm_val = erts_maps_get(am_filename, filename);
+        const Eterm *mem_val = erts_maps_get(am_memory,   filename);
+        if (fnm_val == NULL && mem_val == NULL) {
+            return load_nif_error(c_p, "bad_lib",
+                "load_nif/2: map argument must contain a 'memory' or 'filename' key");
+        }
+        if (mem_val) {
+            if (!is_bitstring(*mem_val) || TAIL_BITS(bitstring_size(*mem_val)) != 0) {
+                return load_nif_error(c_p, "bad_lib",
+                    "load_nif/2: 'memory' value must be a list or binary");
+            }
+            nif_binary    = *mem_val;
+            load_from_mem = 1;
+        }
+        if (fnm_val) {
+            filename = *fnm_val;   /* fall through to filename decoding from argument */
+            if (!is_list(filename) && !(is_bitstring(filename) && TAIL_BITS(bitstring_size(filename)) == 0)) {
+                return load_nif_error(c_p, "bad_lib",
+                    "load_nif/2: 'filename' value must be a string or binary");
+            }
+        } else {
+            lib_name = NULL;   /* anonymous: erts_dlopen_mem will generate a name */
+            goto after_lib_name;
+        }
+    }
     lib_name = erts_convert_filename_to_encoding(filename, NULL, 0,
                                                  ERTS_ALC_T_TMP, 1, 0, encoding,
-						 NULL, 0);
-    if (!lib_name) {
+                                                 NULL, 0);
+    if (!lib_name)
         return THE_NON_VALUE;
-    }
 
+after_lib_name:
     /* Find calling module */
     caller = erts_find_function_from_pc(I);
     ASSERT(caller != NULL);
@@ -4756,24 +4943,65 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
     this_mi = &module_p->curr;
     prev_mi = &module_p->old;
     if (in_area(caller, module_p->old.code_hdr, module_p->old.code_length)) {
-	ret = load_nif_error(c_p, "old_code", "Calling load_nif from old "
-			     "module '%T' not allowed", mod_atom);
-	goto error;
+        ret = load_nif_error(c_p, "old_code", "Calling load_nif from old "
+                             "module '%T' not allowed", mod_atom);
+        goto error;
     } else if (module_p->on_load) {
-	ASSERT(((module_p->on_load)->code_hdr)->on_load);
-	if (module_p->curr.code_hdr) {
-	    prev_mi = &module_p->curr;
-	} else {
-	    prev_mi = &module_p->old;
-	}
-	this_mi = module_p->on_load;
+        ASSERT(((module_p->on_load)->code_hdr)->on_load);
+        if (module_p->curr.code_hdr) {
+            prev_mi = &module_p->curr;
+        } else {
+            prev_mi = &module_p->old;
+        }
+        this_mi = module_p->on_load;
+    }
+
+    /* If the caller passed #{memory => NifSO::binary(), filename => Filename},
+     * open the shared object from memory now so that `handle` is ready for
+     * the common else-if chain below (which runs
+     * erts_sys_ddll_load_nif_init / call_nif_init, version checks, and
+     * create_lib for both file and memory loads). */
+    if (!is_static && load_from_mem) {
+#if defined(USE_ERTS_DLOPEN_MEM)
+        const byte *bin_bytes = NULL;
+        Uint  bin_size  = 0;
+        const byte *tmp_alloc = NULL;
+        static const int max_path_len = PATH_MAX - 9; /* space for "/dev/shm/" */
+        if (lib_name != NULL) {
+            int lib_name_len = sys_strlen(lib_name);
+            if (lib_name_len > max_path_len - 1) { /* -1 for null terminator added */
+                ret = load_nif_error(c_p, "load_failed",
+                    "NIF library path too long: %d (max %d bytes)",
+                    lib_name_len, max_path_len);
+                goto error;
+            }
+        }
+        bin_bytes = erts_get_aligned_binary_bytes(nif_binary, &bin_size, &tmp_alloc);
+        if (!bin_bytes) {
+            ret = load_nif_error(c_p, "load_failed",
+                "Failed to access NIF binary data");
+            goto error;
+        }
+        handle = erts_dlopen_mem(lib_name, bin_bytes, (size_t)bin_size);
+        erts_free_aligned_binary_bytes(tmp_alloc);
+        if (!handle) {
+            ret = load_nif_error(c_p, "load_failed",
+                "Failed to load NIF library from memory: '%s'",
+                dlerror());
+            goto error;
+        }
+#else
+        ret = load_nif_error(c_p, "load_failed",
+            "Loading NIF from memory is not supported on this platform");
+        goto error;
+#endif
     }
 
     if (this_mi->nif != NULL) {
         ret = load_nif_error(c_p,"reload","NIF library already loaded"
                              " (reload disallowed since OTP 20).");
     }
-    else if (!is_static &&
+    else if (!is_static && !load_from_mem &&
              (err=erts_sys_ddll_open(lib_name, &handle, &errdesc)) != ERL_DE_NO_ERROR) {
 	const char slogan[] = "Failed to load NIF library";
 	if (strstr(errdesc.str, lib_name) != NULL) {
@@ -4785,14 +5013,14 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
     }
     else if (!is_static &&
 	     erts_sys_ddll_load_nif_init(handle, &init_func, &errdesc) != ERL_DE_NO_ERROR) {
-	ret  = load_nif_error(c_p, bad_lib, "Failed to find library init"
+         ret  = load_nif_error(c_p, bad_lib, "Failed to find library init"
 			      " function: '%s'", errdesc.str);
 	
     }
     else if (!is_static &&
              (erts_add_taint(mod_atom),
               (entry = erts_sys_ddll_call_nif_init(init_func)) == NULL)) {
-	ret = load_nif_error(c_p, bad_lib, "Library init-call unsuccessful");
+        ret = load_nif_error(c_p, bad_lib, "Library init-call unsuccessful");
     }
     else if (entry->major > ERL_NIF_MAJOR_VERSION
              || (entry->major == ERL_NIF_MAJOR_VERSION
@@ -4811,12 +5039,12 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
     }   
     else if (AT_LEAST_VERSION(entry, 2, 1)
 	     && sys_strcmp(entry->vm_variant, ERL_NIF_VM_VARIANT) != 0) {
-	ret = load_nif_error(c_p, bad_lib, "Library (%s) not compiled for "
+        ret = load_nif_error(c_p, bad_lib, "Library (%s) not compiled for "
 			     "this vm variant (%s).",
 			     entry->vm_variant, ERL_NIF_VM_VARIANT);
     }
     else if (!erts_is_atom_str((char*)entry->name, mod_atom, 1)) {
-	ret = load_nif_error(c_p, bad_lib, "Library module name '%s' does not"
+        ret = load_nif_error(c_p, bad_lib, "Library module name '%s' does not"
 			     " match calling module '%T'", entry->name, mod_atom);
     }
     else {
@@ -4941,7 +5169,7 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
     }
 
     if (ret != am_ok) {
-	goto error;
+        goto error;
     }
     ASSERT(lib);
     ASSERT(lib->finish->nstubs_hashed == lib->entry.num_of_funcs);
@@ -5016,22 +5244,23 @@ Eterm erts_load_nif(Process *c_p, ErtsCodePtr I, Eterm filename, Eterm args)
     }
     else {
     error:
-	rollback_opened_resource_types();
-	ASSERT(ret != am_ok);
-        if (lib != NULL) {
-            if (lib->finish != NULL) {
-                erase_hashed_stubs(lib->finish);
-                erts_free(ERTS_ALC_T_NIF, lib->finish);
-            }
-	    erts_free(ERTS_ALC_T_NIF, lib);
-	}
-	if (handle != NULL) {
-	    erts_sys_ddll_close(handle);
-	}
-	erts_sys_ddll_free_error(&errdesc);
+        rollback_opened_resource_types();
+        ASSERT(ret != am_ok);
+            if (lib != NULL) {
+                if (lib->finish != NULL) {
+                    erase_hashed_stubs(lib->finish);
+                    erts_free(ERTS_ALC_T_NIF, lib->finish);
+                }
+            erts_free(ERTS_ALC_T_NIF, lib);
+        }
+        if (handle != NULL) {
+            erts_sys_ddll_close(handle);
+        }
+        erts_sys_ddll_free_error(&errdesc);
     }
 
-    erts_free(ERTS_ALC_T_TMP, lib_name);
+    if (lib_name)
+        erts_free(ERTS_ALC_T_TMP, lib_name);
 
     BIF_RET(ret);
 }

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -34,6 +34,7 @@
          init_per_group/2, end_per_group/2,
 	 init_per_testcase/2, end_per_testcase/2,
          basic/1, reload_error/1, upgrade/1, heap_frag/1,
+         load_nif_from_mem/1,
          t_on_load/1,
          t_nifs_attrib/1,
          t_load_race/1,
@@ -216,11 +217,12 @@
 -define(ERL_NIF_LATIN1,1).
 -define(ERL_NIF_UTF8,2).
 
-suite() -> [{ct_hooks,[ts_install_cth]}].
+suite() -> [{ct_hooks,[]}].
 
 all() ->
     [basic,
-     non_exported_nif]
+     non_exported_nif,
+     load_nif_from_mem]
         ++
     [{group, G} || G <- api_groups()]
         ++
@@ -261,7 +263,9 @@ all() ->
      nif_atom_out_cache_index].
 
 init_per_suite(Config) ->
-    erts_debug:set_internal_state(available_internal_state, true),
+    try erts_debug:set_internal_state(available_internal_state, true) 
+    catch _ -> ok 
+    end,
     Config.
 
 end_per_suite(_Config) ->
@@ -355,6 +359,87 @@ basic(Config) when is_list(Config) ->
 non_exported_nif(Config) when is_list(Config) ->
     ensure_lib_loaded(Config),
     false = lists:member({lib_version,0}, ?MODULE:module_info(exports)),
+    ok.
+
+
+%% Test loading a NIF library from an in-memory binary image via
+%% erlang:load_nif(#{memory := Binary, ...}, LoadInfo).
+load_nif_from_mem(Config) when is_list(Config) ->
+    case os:type() of
+        {unix, _} -> run_load_nif_from_mem(Config);
+        _ ->
+            %% Should fail with load_failed on unsupported platforms
+            {error, {load_failed, _}} =
+                erlang:load_nif(#{memory => <<1,2,3,4>>}, []),
+            ok
+    end.
+
+run_load_nif_from_mem(Config) ->
+    Data = proplists:get_value(data_dir, Config),
+    ModFile = filename:join(Data, "nif_mod"),
+    {ok, nif_mod, ModBin} = compile:file(ModFile, [binary, return_errors]),
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+
+    %% Derive the .so path the same way nif_mod:load_nif_lib/2 does,
+    %% but with the .so extension appended explicitly for file:read_file/1.
+    SoPath = filename:join(Data, "nif_mod.1.so"),
+    {ok, SoBin} = file:read_file(SoPath),
+
+    %% --- happy path: map with filename ---
+    ok = nif_mod:load_nif_lib_from_mem(Config, 1, SoBin),
+    1 = nif_mod:lib_version(),
+
+    %% cleanup: delete + purge so the module can be reloaded for error tests
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
+    %% --- error: 'memory' value is not a binary ---
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+    {error, {bad_lib, _}} = nif_mod:load_nif_lib_from_mem(Config, 1, not_a_binary),
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+    LongPath = lists:duplicate(4096-9, $x),
+    ok = nif_mod:load_nif_mem_path(LongPath, SoBin),
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
+    %% --- anonymous load: map with only 'memory' key ---
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+    ok = nif_mod:load_nif_mem_anon(SoBin),
+    1 = nif_mod:lib_version(),
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
+    %% --- error: both keys present but filename is not string/binary ---
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+    Map1 = #{memory => SoBin, filename => 123},
+    {error, {bad_lib, _}} = erlang:load_nif(Map1, []),
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
+    %% --- error: map with neither memory nor filename ---
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+    Map2 = #{foo => bar},
+    {error, {bad_lib, _}} = erlang:load_nif(Map2, []),
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
+    %% --- error: map with only filename key and non-string/binary value ---
+    {module, nif_mod} = erlang:load_module(nif_mod, ModBin),
+    Map3 = #{filename => 123},
+    {error, {bad_lib, _}} = erlang:load_nif(Map3, []),
+    true = erlang:delete_module(nif_mod),
+    true = erlang:purge_module(nif_mod),
+    receive unloaded -> ok after 1000 -> ok end,
+
     ok.
 
 %% Test old reload feature now always fails

--- a/erts/emulator/test/nif_SUITE_data/nif_mod.erl
+++ b/erts/emulator/test/nif_SUITE_data/nif_mod.erl
@@ -24,7 +24,8 @@
 
 -include_lib("common_test/include/ct.hrl").
 
--export([load_nif_lib/2, load_nif_lib/3, start/0,
+-export([load_nif_lib/2, load_nif_lib/3, load_nif_lib_from_mem/3,
+         load_nif_mem_path/2, load_nif_mem_anon/1, start/0,
          lib_version/0, lib_version_check/0, trace_me/1,
 	 get_priv_data_ptr/0, make_new_resource/2, get_resource/2,
          monitor_process/3]).
@@ -71,6 +72,23 @@ load_nif_lib(Config, Ver, LoadInfo) ->
     API = proplists:get_value(nif_api_version, Config, ""),
     R = erlang:load_nif(filename:join(Path,libname(Ver,API)), LoadInfo),
     check_api_version(R, API).
+
+%% Load the NIF library from an in-memory binary image.
+%% SoBin must be the contents of the .so file.
+load_nif_lib_from_mem(Config, Ver, SoArg) ->
+    Path = proplists:get_value(data_dir, Config),
+    API = proplists:get_value(nif_api_version, Config, ""),
+    LibName = filename:join(Path, libname(Ver, API)),
+    R = erlang:load_nif(#{memory => SoArg, label => LibName}, []),
+    check_api_version(R, API).
+
+%% Load from memory with an explicit label (string or binary).
+load_nif_mem_path(Path, SoBin) ->
+    erlang:load_nif(#{memory => SoBin, label => Path}, []).
+
+%% Load from memory with no label (auto-generated shm name).
+load_nif_mem_anon(SoBin) ->
+    erlang:load_nif(#{memory => SoBin}, []).
 
 libname(no_init,API) -> libname(3,API);
 libname(Ver,API) when is_integer(Ver) ->

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -7528,15 +7528,82 @@ load_module(Mod, Code) ->
     end.
 
 -doc """
+
 Loads and links a dynamic library containing native implemented functions (NIFs)
 for a module.
 
-`Path` is a file path to the shareable object/dynamic library file
-minus the OS-dependent file extension (`.so` for Unix and `.dll` for Windows).
-Notice that on most OSs the library has to have a different name on disc when an
-upgrade of the nif is done. If the name is the same, but the contents differ,
-the old library may be loaded instead. For information on how to implement a NIF
-library, see [`erl_nif(3)`](erl_nif.md).
+`Path` specifies the NIF library to load. It can take one of the following
+forms:
+
+- **`string() | binary()`** - A file path to the shareable object/dynamic
+  library file minus the OS-dependent file extension (`.so` for Unix and `.dll`
+  for Windows). Notice that on most OSs the library has to have a different name
+  on disc when an upgrade of the NIF is done. If the name is the same, but the
+  contents differ, the old library may be loaded instead.
+
+- **`#{filename := string()|binary()}`** - Same as above.
+
+- **`#{memory := NifSO}`** - Load the NIF library directly from the in-memory
+  binary `NifSO` (raw bytes of the shared-object file) without a label. An
+  anonymous name is auto-generated for the shared-memory region. Only supported
+  on Unix platforms that provide `memfd_create(2)` or POSIX shared memory.
+
+- **`#{memory := NifSO, filename := Filename}`** - Same as above, but `Filename`
+  (a `string()` or `binary()`) is used as the label for the shared-memory
+  region and in error messages. `Filename` must be shorter than `PATH_MAX - 9`
+  characters (to allow for the `/dev/shm/` prefix used internally).
+
+> #### Platform Support {: .info }
+>
+> In-memory NIF loading (`#{memory := ...}`) is only supported on Unix systems
+> with either `memfd_create(2)` or POSIX shared memory (`shm_open`,
+> `shm_mkstemp`). Not all Unix platforms support this feature. On unsupported
+> platforms, attempting to load a NIF from memory will return
+> `{error, {load_failed, Reason}}` where `Reason` describes the lack of support.
+
+> #### Resource Cleanup {: .info }
+>
+> The runtime will automatically clean up any temporary files or shared memory
+> objects created for in-memory NIF loading. On platforms using POSIX shared
+> memory, the shared memory object is unlinked immediately after loading.
+
+For information on how to implement a NIF library, see
+[`erl_nif(3)`](erl_nif.md).
+
+`LoadInfo` can be any term. It is passed on to the library as part of the
+initialization. A good practice is to include a module version number to support
+future code upgrade scenarios.
+
+The call to [`load_nif/2`](`load_nif/2`) must be made _directly_ from the Erlang
+code of the module that the NIF library belongs to. It returns either `ok`, or
+`{error,{Reason,Text}}` if loading fails. `Reason` is one of the following atoms
+while `Text` is a human readable string that can give more information about the
+failure:
+
+- **`load_failed`** - The OS failed to load the NIF library (including lack of
+  platform support for in-memory loading).
+
+- **`bad_lib`** - The library did not fulfill the requirements as a NIF library
+  of the calling module.
+
+- **`load | upgrade`** - The corresponding library callback was unsuccessful.
+
+- **`reload`** - A NIF library is already loaded for this module instance. The
+  previously deprecated `reload` feature was removed in OTP 20.
+
+- **`old_code`** - The call to [`load_nif/2`](`load_nif/2`) was made from the
+  old code of a module that has been upgraded; this is not allowed.
+
+If the [`-nifs()`](`e:system:modules.md#nifs_attribute`) attribute is used
+(which is recommended), all NIFs in the dynamic library must be declared as such
+for [`load_nif/2`](`load_nif/2`) to succeed. On the other hand, all functions
+declared with the `-nifs()` attribute do not have to be implemented by the
+dynamic library. This allows a target independent Erlang file to contain
+fallback implementations for functions that may lack NIF support depending on
+target OS/hardware platform.
+
+For information on how to implement a NIF library, see
+[`erl_nif(3)`](erl_nif.md).
 
 `LoadInfo` can be any term. It is passed on to the library as part of the
 initialization. A good practice is to include a module version number to support
@@ -7570,8 +7637,13 @@ fallback implementations for functions that may lack NIF support depending on
 target OS/hardware platform.
 """.
 -doc #{ category => code }.
--spec load_nif(Path, LoadInfo) ->  ok | Error when
-      Path :: string(),
+-spec load_nif(Path, LoadInfo) -> ok | Error when
+      Path :: string() |
+              binary() |
+              #{filename := Filename :: string() | binary()} |
+              #{memory := NifSO :: binary()} |
+              #{memory := NifSO :: binary(),
+                filename := Filename :: string() | binary()},
       LoadInfo :: term(),
       Error :: {error, {Reason, Text :: string()}},
       Reason :: load_failed | bad_lib | load | reload | upgrade | old_code.


### PR DESCRIPTION
Add support for passing `#{memory => NifSO::binary(), filename => Filename::string()}` as the first argument to erlang:load_nif/2. When a map is given, the NIF shared object is loaded directly from the binary image in memory instead of from the file system.

Why is this needed?
-------------------
Presently build tools (i.e. `rebar3`, `mix`) cannot bundle all dependencies into a single executable archive escript (a.k.a. escriptizing) that have dependencies with NIF shared object libraries. This PR addresses that gap, and extends the `erlang:load_nif/2` call with the missing functionality. After it's merged, the build tools will be able to be modified to take advantage of it. See #4476 issue.

Implementation
--------------
* erts_dlopen_mem() — new static helper in erl_nif.c (Linux/POSIX only). On Linux >= 3.17 it uses memfd_create(2) to create an anonymous in-memory file, writes the SO image into it, and calls dlopen(3) via /proc/self/fd/<fd>.  On older Linux kernels and other POSIX systems it falls back to shm_open(3) + /dev/shm/<name>.  The implementation is derived from the https://github.com/saleyn/memfd_create proof of concept.

* erts_load_nif() — extended argument parsing:
  - Plain filename :: string()|binary() continues to work unchanged.
  - #{filename => string()|binary()}: same as passing the filename string
  - #{memory => Binary, filename => string()|binary()} map: Binary is extracted via erts_get_aligned_binary_bytes(), passed to erts_dlopen_mem(), and the resulting dlopen handle is used directly.  The optional filename string serves only as a label inside the memory-backed file descriptor, and is only valid on non-MacOS systems.
  - The open-from-memory step is performed before the existing else-if validation chain (version checks, module-name check, create_lib) so both code paths share the same validation and bookkeeping.
  - erts_sys_ddll_open() is skipped (via !load_from_mem guard) when a handle was already obtained from memory.

* The feature is guarded by #if defined(HAVE_DLOPEN) && defined(__unix__). On unsupported platforms load_nif/2 returns {error,{load_failed,…}}.

Testing
-------
* nif_SUITE: new test case load_nif_from_mem
  - Happy path: reads nif_mod.1.so into a binary, calls erlang:load_nif(#{memory => Binary, filename => Filename}, []) via nif_mod:load_nif_lib_from_mem/3, and asserts lib_version() == 1.
  - Error path: non-binary second element returns {error,{bad_lib,_}}.

* nif_mod.erl: new exported helper load_nif_lib_from_mem/3 so that the load_nif call site lives inside the NIF module (required by the BIF).