### PR TITLE
ssh: update documentation guides for OTP 29

### DIFF
--- a/lib/ssh/doc/guides/configurations.md
+++ b/lib/ssh/doc/guides/configurations.md
@@ -21,9 +21,7 @@ limitations under the License.
 -->
 # Configuration in SSH
 
-## Introduction
-
-The OTP SSH app can be configurated by a large amount of _Options_. This chapter
+The OTP SSH application can be configured by a large number of _Options_. This chapter
 will not go into details of what each of the options does. It will however
 describe and define different ways by which they could be entered.
 
@@ -31,11 +29,11 @@ Options for hardening are described in the [Hardening SSH](hardening.md)
 chapter. How the options for algorithm configuration interact are described in
 the [Configuring algorithms in SSH](configure_algos.md) chapter.
 
-## Options configuration
+## Setting Options
 
-There are from OTP-23.0 two main ways to set an option:
+There are two ways to set an option:
 
-- Like before, in the `Options` parameter in the Erlang code in a call to for
+- In the `Options` parameter in the Erlang code in a call to for
   example `ssh:daemon/3` or `ssh:connect/3` or any of their variants. Example:
 
   ```erlang
@@ -58,10 +56,10 @@ There are from OTP-23.0 two main ways to set an option:
       {vsn, "4.9"},
       {modules, [ssh,
             ...
-    	     ssh_xfer]},
+            ssh_xfer]},
       {registered, []},
       {applications, [kernel, stdlib, crypto, public_key]},
-      {env, [{user, "bar"]}, % <<<<<<<<<<<<<<<<<<<<<<<<<<<<<< HERE
+      {env, [{user, "bar"}]}, % <<<<<<<<<<<<<<<<<<<<<<<<<<<<<< HERE
       {mod, {ssh_app, []}},
            ...
     ```
@@ -75,19 +73,15 @@ There are from OTP-23.0 two main ways to set an option:
     where `ex1.config` contains:
 
     ```erlang
-    [
-    {ssh, [{user, "foo"}]}
-    ].
+    [{ssh, [{user, "foo"}]}].
     ```
 
   If the option is intended only for a server or for a client, it may be set in
   this way:
 
   ```erlang
-  [
-  {ssh, [{server_options,[{user, "foo"}]},
-         {client_options,[{user, "bar"}]}
-  ].
+  [{ssh, [{server_options, [{user, "foo"}]},
+          {client_options, [{user, "bar"}]}]}].
   ```
 
   A server (daemon) will use the user name `foo`, and a client will use the name
@@ -108,10 +102,12 @@ There is an ordering, which is:
 If the same option is set at two different levels, the one at the highest level
 is used.
 
-The only exception is the
-[modify_algorithms](`t:ssh:modify_algorithms_common_option/0`) common option.
-They are all applied in ascending level order on the set of algorithms. So a
-`modify_algorithms` on level one is applied before one of level two and so on.
+> #### Note {: .info }
+>
+> The only exception is the
+> [modify_algorithms](`t:ssh:modify_algorithms_common_option/0`) common option.
+> They are all applied in ascending level order on the set of algorithms. So a
+> `modify_algorithms` on level one is applied before one of level two and so on.
 
 If there is an
 [preferred_algorithms](`t:ssh:preferred_algorithms_common_option/0`) option on
@@ -125,34 +121,32 @@ set without code changes, only by adding an option in a config file. This can be
 used to interoperate with legacy systems that still uses algorithms no longer
 considered secure enough to be supported by default.
 
-### Algorithm configuration
+## Algorithm Configuration
 
-There is a [separate chapter](configure_algos.md#introduction) about how
+There is a [separate chapter](configure_algos.md) about how
 [preferred_algorithms](`t:ssh:preferred_algorithms_common_option/0`) and
 [modify_algorithms](`t:ssh:modify_algorithms_common_option/0`) co-operate. How
 the different configuration levels affect them, is described here in this
 section.
 
-#### The ssh:start/0 function
+### Algorithms Before and After ssh:start/0
 
 If the application SSH is _not_ [started](`ssh:start/0`), the command
 `ssh:default_algorithms/0` delivers the list of default (hardcoded) algorithms
 with respect to the support in the current cryptolib.
 
 If the application SSH _is_ [started](`ssh:start/0`), the command
-`ssh:default_algorithms/0` delvers the list of algorithms after application of
+`ssh:default_algorithms/0` delivers the list of algorithms after application of
 level 0 and level 1 configurations.
 
 Here is an example. The config-file has the following contents:
 
 ```text
 $ cat ex2.config
-[
- {ssh, [{preferred_algorithms, [{cipher, ['aes192-ctr']},
-       			        {public_key, ['ssh-rsa']},
+[{ssh, [{preferred_algorithms, [{cipher, ['aes192-ctr']},
+                                {public_key, ['ssh-rsa']},
                                 {kex, ['ecdh-sha2-nistp384']},
-                                {mac, ['hmac-sha1']}]}]}
-].
+                                {mac, ['hmac-sha1']}]}]}].
 ```
 
 Erlang is started with `ex2.config` as configuration and we check the default
@@ -160,33 +154,37 @@ set of algorithms before starting ssh:
 
 ```text
 $ erl -config ex2
-Erlang/OTP 23 [RELEASE CANDIDATE 1] [erts-10.6.4] [source-96a0823109] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe]
+Erlang/OTP 29 [erts-16.3.1] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [jit:ns]
 
-Eshell V10.6.4  (abort with ^G)
+Eshell V16.3.1 (press Ctrl+G to abort, type help(). for help)
 1> ssh:default_algorithms().
-[{kex,['ecdh-sha2-nistp384','ecdh-sha2-nistp521',
-       'ecdh-sha2-nistp256','diffie-hellman-group-exchange-sha256',
+[{kex,['mlkem768x25519-sha256','curve25519-sha256',
+       'curve25519-sha256@libssh.org','curve448-sha512',
+       'ecdh-sha2-nistp521','ecdh-sha2-nistp384',
+       'ecdh-sha2-nistp256',
+       'diffie-hellman-group-exchange-sha256',
        'diffie-hellman-group16-sha512',
        'diffie-hellman-group18-sha512',
-       'diffie-hellman-group14-sha256','curve25519-sha256',
-       'curve25519-sha256@libssh.org','curve448-sha512',
-       'diffie-hellman-group14-sha1',
-       'diffie-hellman-group-exchange-sha1']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-              'ecdsa-sha2-nistp256','ssh-ed25519','ssh-ed448','ssh-rsa',
-              'rsa-sha2-256','rsa-sha2-512','ssh-dss']},
- {cipher,[{client2server,['chacha20-poly1305@openssh.com',
-                          'aes256-gcm@openssh.com','aes256-ctr','aes192-ctr',
-                          'aes128-gcm@openssh.com','aes128-ctr','aes256-cbc',
-                          'aes192-cbc','aes128-cbc','3des-cbc']},
-          {server2client,['chacha20-poly1305@openssh.com',
-                          'aes256-gcm@openssh.com','aes256-ctr','aes192-ctr',
-                          'aes128-gcm@openssh.com','aes128-ctr','aes256-cbc',
-                          'aes192-cbc','aes128-cbc','3des-cbc']}]},
- {mac,[{client2server,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']},
-       {server2client,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']}]},
+       'diffie-hellman-group14-sha256']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
+ {cipher,[{client2server,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']},
+          {server2client,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
  {compression,[{client2server,[none,'zlib@openssh.com']},
                {server2client,[none,'zlib@openssh.com']}]}]
 ```
@@ -213,7 +211,7 @@ We see that the algorithm set is changed to the one in the `ex2.config`. Since
 `compression` is not specified in the file, the hard-coded default is still used
 for that entry.
 
-#### Establishing a connection (ssh:connect et al) or starting a daemon (ssh:daemon)
+### Options in ssh:connect and ssh:daemon
 
 Both when the client establishes a connection with ssh:connect or other
 functions, or a daemon is started with ssh:daemon, the option lists in the
@@ -235,17 +233,10 @@ algorithm set. We remove the only one (`'ecdh-sha2-nistp384'`) and add
 
 ```erlang
 4> {ok,C} = ssh:connect(loopback, 22,
-                        [{modify_algorithms,
-                                 [{rm,
-                                     [ {kex,['ecdh-sha2-nistp384']} ]
-				  },
-                                  {append,
-			             [ {kex,['curve25519-sha256@libssh.org']} ]
-				  }
-				 ]
-	                 }
-                        ]).
-{ok,>0.118.0>}
+     [{modify_algorithms,
+         [{rm,     [{kex, ['ecdh-sha2-nistp384']}]},
+          {append, [{kex, ['curve25519-sha256@libssh.org']}]}]}]).
+{ok,<0.118.0>}
 ```
 
 We check which algorithms are negotiated by the client and the server, and note
@@ -265,7 +256,7 @@ that the (only) `kex` algorithm `'curve25519-sha256@libssh.org'` was selected:
              {recv_ext_info,true}]}
 ```
 
-#### Example of modify_algorithms handling
+### Example: modify_algorithms Across Levels
 
 We will now check if the
 [modify_algorithms](`t:ssh:modify_algorithms_common_option/0`) on a lower level
@@ -277,11 +268,8 @@ but not in the default set.
 The config file `ex3.config` has the contents:
 
 ```erlang
-[
- {ssh, [{modify_algorithms,
-         [ {prepend, [{public_key, ['ssh-dss']}]} ]
-        }]}
-].
+[{ssh, [{modify_algorithms,
+         [{prepend, [{public_key, ['ssh-dss']}]}]}]}].
 ```
 
 A newly started erlang shell shows that no `'ssh-dss'` is present in the
@@ -289,9 +277,9 @@ A newly started erlang shell shows that no `'ssh-dss'` is present in the
 
 ```erlang
 1> proplists:get_value(public_key, ssh:default_algorithms()).
-['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
- 'ecdsa-sha2-nistp256','ssh-ed25519','ssh-ed448',
- 'rsa-sha2-256','rsa-sha2-512','ssh-rsa']
+['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+ 'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+ 'rsa-sha2-512','rsa-sha2-256']
 2>
 ```
 
@@ -301,14 +289,12 @@ A call to `ssh:connect/3` removes all algorithms but one of each type:
 2> ssh:start().
 ok
 3> {ok,C} = ssh:connect(loopback, 22,
-                        [{preferred_algorithms,
-                         [{public_key, ['ecdsa-sha2-nistp256']},
-			  {kex, ['ecdh-sha2-nistp256']},
-		          {cipher, ['chacha20-poly1305@openssh.com']},
-			  {mac, ['hmac-sha2-256']},
-			  {compression, [none]}
-			  ]}
-			 ]).
+     [{preferred_algorithms,
+         [{public_key, ['ecdsa-sha2-nistp256']},
+          {kex, ['ecdh-sha2-nistp256']},
+          {cipher, ['chacha20-poly1305@openssh.com']},
+          {mac, ['hmac-sha2-256']},
+          {compression, [none]}]}]).
 {ok,<0.101.0>}
 4> ssh:connection_info(C,algorithms).
 {algorithms,[{kex,'ecdh-sha2-nistp256'},
@@ -331,6 +317,6 @@ This example showed that we could augment the set of algorithms with a
 config-file without the need to change the actual call.
 
 For demonstration purposes we used `prepend` instead of `append`. This forces
-the negotiation to select `ssh-dss` since the the full list of public key
+the negotiation to select `ssh-dss` since the full list of public key
 algorithms was `['ssh-dss','ecdsa-sha2-nistp256']`. Normally it is safer to
 append a non-default algorithm.

--- a/lib/ssh/doc/guides/configure_algos.md
+++ b/lib/ssh/doc/guides/configure_algos.md
@@ -21,28 +21,26 @@ limitations under the License.
 -->
 # Configuring algorithms in SSH
 
-## Introduction
-
 To fully understand how to configure the algorithms, it is essential to have a
-basic understanding of the SSH protocol and how OTP SSH app handles the
+basic understanding of the SSH protocol and how OTP SSH application handles the
 corresponding items.
 
-The first subsection will give a short background of the SSH protocol while
-later sections describes the implementation and provides some examples.
+The first section will give a short background of the SSH protocol while
+later sections describe the implementation and provide some examples.
 
-How the different levels of configuration "interfere" with this, see the section
+How the different levels of configuration interact with this, see the section
 [Algorithm Configuration](configurations.md#algorithm-configuration) in the
 chapter [Configuration in SSH](configurations.md).
 
-### Basics of the ssh protocol's algorithms handling
+## Algorithm Negotiation in SSH
 
 SSH uses different sets of algorithms in different phases of a session. Which
 algorithms to use is negotiated by the client and the server at the beginning of
 a session. See [RFC 4253](https://tools.ietf.org/html/rfc4253), "The Secure
 Shell (SSH) Transport Layer Protocol" for details.
 
-The negotiation is simple: both peers sends their list of supported alghorithms
-to the other part. The first algorithm on the client's list that also in on the
+The negotiation is simple: both peers send their list of supported algorithms
+to the other party. The first algorithm on the client's list that is also on the
 server's list is selected. So it is the client's ordering of the list that
 gives the priority for the algorithms.
 
@@ -54,8 +52,8 @@ The lists are (named as in the SSH application's options):
 - **`kex`** - Key exchange
 
   An algorithm is selected for computing a secret encryption key. Among examples
-  are: the old nowadays week `'diffie-hellman-group-exchange-sha1'` and the very
-  strong and modern `'ecdh-sha2-nistp512'`.
+  are: the old and weak `'diffie-hellman-group-exchange-sha1'` and the modern
+  `'mlkem768x25519-sha256'` (a post-quantum hybrid key exchange).
 
 - **`public_key`** - Server host key
 
@@ -65,7 +63,7 @@ The lists are (named as in the SSH application's options):
 
 - **`cipher`** - Symmetric cipher algorithm used for the payload encryption.
   This algorithm will use the key calculated in the kex phase (together with
-  other info) to generate the actual key used. Examples are tripple-DES
+  other info) to generate the actual key used. Examples are triple-DES
   `'3des-cbc'` and one of many AES variants `'aes192-ctr'`.
 
   This list is actually two - one for each direction server-to-client and
@@ -86,17 +84,17 @@ The lists are (named as in the SSH application's options):
 
   This list is also divided into two for the both directions
 
-### The SSH app's mechanism
+## Default Algorithms
 
-The set of algorithms that the SSH app uses by default depends on the algorithms
+The set of algorithms that the SSH application uses by default depends on the algorithms
 supported by the:
 
-- `m:crypto` app,
+- `m:crypto` application,
 - The cryptolib OTP is linked with, usually the one the OS uses, probably
   OpenSSL,
-- and finally what the SSH app implements
+- and finally what the SSH application implements
 
-Due to this, it impossible to list in documentation what algorithms that are
+Due to this, it is impossible to list in documentation what algorithms are
 available in a certain installation.
 
 There is an important command to list the actual algorithms and their ordering:
@@ -104,26 +102,32 @@ There is an important command to list the actual algorithms and their ordering:
 
 ```erlang
 0> ssh:default_algorithms().
-[{kex,['ecdh-sha2-nistp384','ecdh-sha2-nistp521',
-       'ecdh-sha2-nistp256','diffie-hellman-group-exchange-sha256',
+[{kex,['mlkem768x25519-sha256','curve25519-sha256',
+       'curve25519-sha256@libssh.org','curve448-sha512',
+       'ecdh-sha2-nistp521','ecdh-sha2-nistp384','ecdh-sha2-nistp256',
+       'diffie-hellman-group-exchange-sha256',
        'diffie-hellman-group16-sha512',
        'diffie-hellman-group18-sha512',
-       'diffie-hellman-group14-sha256',
-       'diffie-hellman-group14-sha1',
-       'diffie-hellman-group-exchange-sha1']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-              'ecdsa-sha2-nistp256','ssh-rsa','rsa-sha2-256',
-              'rsa-sha2-512','ssh-dss']},
- {cipher,[{client2server,['aes256-gcm@openssh.com',
-                          'aes256-ctr','aes192-ctr','aes128-gcm@openssh.com',
-                          'aes128-ctr','aes128-cbc','3des-cbc']},
+       'diffie-hellman-group14-sha256']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
+ {cipher,[{client2server,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']},
           {server2client,['aes256-gcm@openssh.com','aes256-ctr',
-                          'aes192-ctr','aes128-gcm@openssh.com','aes128-ctr',
-                          'aes128-cbc','3des-cbc']}]},
- {mac,[{client2server,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']},
-       {server2client,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']}]},
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
  {compression,[{client2server,[none,'zlib@openssh.com']},
                {server2client,[none,'zlib@openssh.com']}]}]
 ```
@@ -140,15 +144,15 @@ The options are
 [modify_algorithms](`t:ssh:modify_algorithms_common_option/0`). The first one
 replaces the default set, while the latter modifies the default set.
 
-## Replacing the default set: preferred_algorithms
+## Replacing Defaults: preferred_algorithms
 
 See the [Reference Manual](`t:ssh:preferred_algorithms_common_option/0`) for
 details
 
 Here follows a series of examples ranging from simple to more complex.
 
-To forsee the effect of an option there is an experimental function
-`ssh:chk_algos_opts(Opts)`. It mangles the options `preferred_algorithms` and
+To foresee the effect of an option there is an experimental function
+`ssh:chk_algos_opts(Opts)`. It applies the options `preferred_algorithms` and
 `modify_algorithms` in the same way as `ssh:daemon`, `ssh:connect` and their
 friends does.
 
@@ -159,25 +163,28 @@ Replace the kex algorithms list with the single algorithm
 
 ```erlang
 1> ssh:chk_algos_opts(
-               [{preferred_algorithms,
-                     [{kex, ['diffie-hellman-group14-sha256']}
-                     ]
-                }
-              ]).
+     [{preferred_algorithms,
+         [{kex, ['diffie-hellman-group14-sha256']}]}]).
 [{kex,['diffie-hellman-group14-sha256']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-              'ecdsa-sha2-nistp256','ssh-rsa','rsa-sha2-256',
-              'rsa-sha2-512','ssh-dss']},
- {cipher,[{client2server,['aes256-gcm@openssh.com',
-                          'aes256-ctr','aes192-ctr','aes128-gcm@openssh.com',
-                          'aes128-ctr','aes128-cbc','3des-cbc']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
+ {cipher,[{client2server,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']},
           {server2client,['aes256-gcm@openssh.com','aes256-ctr',
-                          'aes192-ctr','aes128-gcm@openssh.com','aes128-ctr',
-                          'aes128-cbc','3des-cbc']}]},
- {mac,[{client2server,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']},
-       {server2client,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']}]},
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
  {compression,[{client2server,[none,'zlib@openssh.com']},
                {server2client,[none,'zlib@openssh.com']}]}]
 ```
@@ -192,27 +199,28 @@ possible to change both directions at once:
 
 ```erlang
 2> ssh:chk_algos_opts(
-               [{preferred_algorithms,
-                     [{cipher,['aes128-ctr']}
-                     ]
-                }
-              ]).
-[{kex,['ecdh-sha2-nistp384','ecdh-sha2-nistp521',
-       'ecdh-sha2-nistp256','diffie-hellman-group-exchange-sha256',
+     [{preferred_algorithms,
+         [{cipher, ['aes128-ctr']}]}]).
+[{kex,['mlkem768x25519-sha256','curve25519-sha256',
+       'curve25519-sha256@libssh.org','curve448-sha512',
+       'ecdh-sha2-nistp521','ecdh-sha2-nistp384','ecdh-sha2-nistp256',
+       'diffie-hellman-group-exchange-sha256',
        'diffie-hellman-group16-sha512',
        'diffie-hellman-group18-sha512',
-       'diffie-hellman-group14-sha256',
-       'diffie-hellman-group14-sha1',
-       'diffie-hellman-group-exchange-sha1']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-              'ecdsa-sha2-nistp256','ssh-rsa','rsa-sha2-256',
-              'rsa-sha2-512','ssh-dss']},
+       'diffie-hellman-group14-sha256']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
  {cipher,[{client2server,['aes128-ctr']},
           {server2client,['aes128-ctr']}]},
- {mac,[{client2server,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']},
-       {server2client,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
  {compression,[{client2server,[none,'zlib@openssh.com']},
                {server2client,[none,'zlib@openssh.com']}]}]
 ```
@@ -227,29 +235,31 @@ possible to change only one of the directions:
 
 ```erlang
 3> ssh:chk_algos_opts(
-               [{preferred_algorithms,
-                     [{cipher,[{client2server,['aes128-ctr']}]}
-                     ]
-                }
-              ]).
-[{kex,['ecdh-sha2-nistp384','ecdh-sha2-nistp521',
-       'ecdh-sha2-nistp256','diffie-hellman-group-exchange-sha256',
+     [{preferred_algorithms,
+         [{cipher, [{client2server, ['aes128-ctr']}]}]}]).
+[{kex,['mlkem768x25519-sha256','curve25519-sha256',
+       'curve25519-sha256@libssh.org','curve448-sha512',
+       'ecdh-sha2-nistp521','ecdh-sha2-nistp384','ecdh-sha2-nistp256',
+       'diffie-hellman-group-exchange-sha256',
        'diffie-hellman-group16-sha512',
        'diffie-hellman-group18-sha512',
-       'diffie-hellman-group14-sha256',
-       'diffie-hellman-group14-sha1',
-       'diffie-hellman-group-exchange-sha1']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-              'ecdsa-sha2-nistp256','ssh-rsa','rsa-sha2-256',
-              'rsa-sha2-512','ssh-dss']},
+       'diffie-hellman-group14-sha256']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
  {cipher,[{client2server,['aes128-ctr']},
           {server2client,['aes256-gcm@openssh.com','aes256-ctr',
-                          'aes192-ctr','aes128-gcm@openssh.com','aes128-ctr',
-                          'aes128-cbc','3des-cbc']}]},
- {mac,[{client2server,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']},
-       {server2client,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']}]},
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
  {compression,[{client2server,[none,'zlib@openssh.com']},
                {server2client,[none,'zlib@openssh.com']}]}]
 ```
@@ -260,16 +270,13 @@ It is of course possible to change more than one list:
 
 ```erlang
 4> ssh:chk_algos_opts(
-               [{preferred_algorithms,
-                     [{cipher,['aes128-ctr']},
-		      {mac,['hmac-sha2-256']},
-                      {kex,['ecdh-sha2-nistp384']},
-		      {public_key,['ssh-rsa']},
-		      {compression,[{server2client,[none]},
-		                    {client2server,[zlib]}]}
-                     ]
-                }
-              ]).
+     [{preferred_algorithms,
+         [{cipher, ['aes128-ctr']},
+          {mac, ['hmac-sha2-256']},
+          {kex, ['ecdh-sha2-nistp384']},
+          {public_key, ['ssh-rsa']},
+          {compression, [{server2client, [none]},
+                         {client2server, [zlib]}]}]}]).
 [{kex,['ecdh-sha2-nistp384']},
  {public_key,['ssh-rsa']},
  {cipher,[{client2server,['aes128-ctr']},
@@ -282,7 +289,7 @@ It is of course possible to change more than one list:
 
 Note that the order of the tuples in the lists does not matter.
 
-## Modifying the default set: modify_algorithms
+## Modifying Defaults: modify_algorithms
 
 A situation where it might be useful to add an algorithm is when one need to use
 a supported but disabled one. An example is the `'diffie-hellman-group1-sha1'`
@@ -303,8 +310,7 @@ algorithms:
 ```erlang
 {modify_algorithms, [{append,  ...},
                      {prepend, ...},
-		     {rm,      ...}
-		    ]}
+                     {rm,      ...}]}
 ```
 
 Each of the `...` can be a `algs_list()` as the argument to the
@@ -317,34 +323,34 @@ supported according to [Supported algorithms](ssh_app.md#supported_algos).
 
 ```erlang
 5> ssh:chk_algos_opts(
-         [{modify_algorithms,
-	       [{prepend,
-	           [{kex,['diffie-hellman-group1-sha1']}]
-		   }
-	       ]
-          }
-        ]).
-[{kex,['diffie-hellman-group1-sha1','ecdh-sha2-nistp384',
-       'ecdh-sha2-nistp521','ecdh-sha2-nistp256',
-       'diffie-hellman-group-exchange-sha256',
+     [{modify_algorithms,
+         [{prepend, [{kex, ['diffie-hellman-group1-sha1']}]}]}]).
+[{kex,['diffie-hellman-group1-sha1','mlkem768x25519-sha256',
+       'curve25519-sha256','curve25519-sha256@libssh.org',
+       'curve448-sha512','ecdh-sha2-nistp521','ecdh-sha2-nistp384',
+       'ecdh-sha2-nistp256','diffie-hellman-group-exchange-sha256',
        'diffie-hellman-group16-sha512',
        'diffie-hellman-group18-sha512',
-       'diffie-hellman-group14-sha256',
-       'diffie-hellman-group14-sha1',
-       'diffie-hellman-group-exchange-sha1']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-              'ecdsa-sha2-nistp256','ssh-rsa','rsa-sha2-256',
-              'rsa-sha2-512','ssh-dss']},
- {cipher,[{client2server,['aes256-gcm@openssh.com',
-                          'aes256-ctr','aes192-ctr','aes128-gcm@openssh.com',
-                          'aes128-ctr','aes128-cbc','3des-cbc']},
+       'diffie-hellman-group14-sha256']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
+ {cipher,[{client2server,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']},
           {server2client,['aes256-gcm@openssh.com','aes256-ctr',
-                          'aes192-ctr','aes128-gcm@openssh.com','aes128-ctr',
-                          'aes128-cbc','3des-cbc']}]},
- {mac,[{client2server,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']},
-       {server2client,['hmac-sha2-256','hmac-sha2-512',
-                       'hmac-sha1']}]},
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
  {compression,[{client2server,[none,'zlib@openssh.com']},
                {server2client,[none,'zlib@openssh.com']}]}]
 ```
@@ -359,26 +365,37 @@ the `'ecdh-sha2-nistp521'` to the end in the kex list, that is, `append` it.
 
 ```erlang
 6> ssh:chk_algos_opts(
-         [{modify_algorithms,
-	       [{prepend,
-	           [{kex, ['diffie-hellman-group1-sha1']}
-		   ]},
-		{append,
-                   [{kex, ['ecdh-sha2-nistp521']}
-                   ]}
-	       ]
-          }
-        ]).
-[{kex,['diffie-hellman-group1-sha1','ecdh-sha2-nistp384',
-       'ecdh-sha2-nistp256','diffie-hellman-group-exchange-sha256',
+     [{modify_algorithms,
+         [{prepend, [{kex, ['diffie-hellman-group1-sha1']}]},
+          {append,  [{kex, ['ecdh-sha2-nistp521']}]}]}]).
+[{kex,['diffie-hellman-group1-sha1','mlkem768x25519-sha256',
+       'curve25519-sha256','curve25519-sha256@libssh.org',
+       'curve448-sha512','ecdh-sha2-nistp384','ecdh-sha2-nistp256',
+       'diffie-hellman-group-exchange-sha256',
        'diffie-hellman-group16-sha512',
        'diffie-hellman-group18-sha512',
-       'diffie-hellman-group14-sha256',
-       'diffie-hellman-group14-sha1',
-       'diffie-hellman-group-exchange-sha1','ecdh-sha2-nistp521']},
- {public_key,['ecdsa-sha2-nistp384','ecdsa-sha2-nistp521',
-   .....
-]
+       'diffie-hellman-group14-sha256','ecdh-sha2-nistp521']},
+ {public_key,['ssh-ed25519','ssh-ed448','ecdsa-sha2-nistp521',
+              'ecdsa-sha2-nistp384','ecdsa-sha2-nistp256',
+              'rsa-sha2-512','rsa-sha2-256']},
+ {cipher,[{client2server,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']},
+          {server2client,['aes256-gcm@openssh.com','aes256-ctr',
+                          'aes192-ctr','aes128-gcm@openssh.com',
+                          'aes128-ctr',
+                          'chacha20-poly1305@openssh.com']}]},
+ {mac,[{client2server,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']},
+       {server2client,['hmac-sha2-512-etm@openssh.com',
+                       'hmac-sha2-256-etm@openssh.com',
+                       'hmac-sha2-512','hmac-sha2-256',
+                       'hmac-sha1-etm@openssh.com','hmac-sha1']}]},
+ {compression,[{client2server,[none,'zlib@openssh.com']},
+               {server2client,[none,'zlib@openssh.com']}]}]
 ```
 
 Note that the appended algorithm is removed from its original place and then
@@ -392,25 +409,16 @@ unsupported algorithm is quietly removed.
 
 ```erlang
 7> ssh:chk_algos_opts(
-         [{preferred_algorithms,
-               [{cipher,['aes128-ctr']},
-	        {mac,['hmac-sha2-256']},
-                {kex,['ecdh-sha2-nistp384']},
-		{public_key,['ssh-rsa']},
-		{compression,[{server2client,[none]},
-		              {client2server,[zlib]}]}
-               ]
-           },
-          {modify_algorithms,
-	       [{prepend,
-	           [{kex, ['some unsupported algorithm']}
-		   ]},
-		{append,
-                   [{kex, ['diffie-hellman-group1-sha1']}
-                   ]}
-	       ]
-          }
-        ]).
+     [{preferred_algorithms,
+         [{cipher, ['aes128-ctr']},
+          {mac, ['hmac-sha2-256']},
+          {kex, ['ecdh-sha2-nistp384']},
+          {public_key, ['ssh-rsa']},
+          {compression, [{server2client, [none]},
+                         {client2server, [zlib]}]}]},
+      {modify_algorithms,
+         [{prepend, [{kex, ['some unsupported algorithm']}]},
+          {append,  [{kex, ['diffie-hellman-group1-sha1']}]}]}]).
 [{kex,['ecdh-sha2-nistp384','diffie-hellman-group1-sha1']},
  {public_key,['ssh-rsa']},
  {cipher,[{client2server,['aes128-ctr']},

--- a/lib/ssh/doc/guides/hardening.md
+++ b/lib/ssh/doc/guides/hardening.md
@@ -21,8 +21,6 @@ limitations under the License.
 -->
 # Hardening
 
-## Introduction
-
 The Erlang/OTP SSH application is intended to be used in other applications as a
 library.
 
@@ -37,14 +35,16 @@ one may accept many users simultaneously logged in, while the second one wants
 to limit them to only one.
 
 That simple example shows that it is impossible to deliver the SSH application
-with default values on hardening options as well on other options that suites
+with default values on hardening options as well on other options that suit
 every need.
 
 The purpose of this guide is to discuss the different hardening options
 available, as a guide to the reader. Configuration in general is described in
 the [Configuration in SSH](configurations.md) chapter.
 
-## Resilience to DoS attacks
+## DoS Resilience (Server)
+
+[](){: #resilience-to-dos-attacks }
 
 The following applies to daemons (servers).
 
@@ -53,7 +53,7 @@ firewalls and other means needed, but that is out of scope for this guide.
 However, some measures could be taken in the configuration of the SSH server to
 increase the resilence. The options to use are:
 
-### Counters and parallelism
+### Counters and Parallelism
 
 - **[max_sessions](`m:ssh#hardening_daemon_options-max_sessions`)** - The
   maximum number of simultaneous sessions that are accepted at any time for this
@@ -114,7 +114,7 @@ The following table clarifies when a timeout is started and when it triggers:
 | 8 | Channel *x_n* closed (all channels closed) | `idle_time` | |
 | 9 | Connection closed | | `idle_time` |
 
-### Resilience to compression-based attacks
+### Compression
 
 SSH supports compression of the data stream.
 
@@ -135,15 +135,63 @@ compression-based side-channel and traffic-analysis attacks.
 In both algorithms decompression is protected by a size limit that prevents
 excessive memory consumption.
 
-### SFTP Server Resource Limits
+## Reducing Attack Surface
+
+### Shell and Exec Services
+
+A daemon has two services for evaluating tasks on behalf of a remote client. The
+_exec_ server-side service takes a string provided by the client, evaluates it
+and returns the result. The _shell_ function enables the client to open a shell
+in the shell host.
+
+The options [exec](`t:ssh:exec_daemon_option/0`) and
+[shell](`t:ssh:shell_daemon_option/0`) are disabled per default.
+The same options could also install handlers for
+the string(s) passed from the client to the server.
+
+### SFTP Subsystem
+
+The SFTP subsystem is not enabled by default. When enabled, SFTP provides
+access to the file system with the rights of the OS process running the
+Erlang emulator, regardless of the authenticated SSH user. See the
+[Terminology](terminology.md) section for details.
+
+The [subsystems](`t:ssh:subsystem_daemon_option/0`) option controls which
+subsystems are available. To enable SFTP:
+
+```erlang
+ssh:daemon({192, 168, 1, 10}, Port,
+           [{subsystems, [ssh_sftpd:subsystem_spec([])]} | Options]).
+```
+
+**Root directory isolation**
+
+The `root` option (see `m:ssh_sftpd`) restricts SFTP users to a
+specific directory tree, preventing access to files outside that directory.
+
+```erlang
+ssh:daemon(Port, [
+    {subsystems, [ssh_sftpd:subsystem_spec([{root, "/home/sftpuser"}])]},
+    ...
+]).
+```
+
+The `root` option is configured per daemon, not per user. All
+users connecting to the same daemon share the same root directory. For per-user
+isolation, consider running separate daemon instances on different ports or
+using OS-level mechanisms (PAM chroot, containers, file permissions).
+
+For high-security deployments, combine the `root` option
+with OS-level isolation mechanisms such as chroot jails, containers, or
+mandatory access control (SELinux, AppArmor).
+
+**Resource limits**
 
 When enabling the SFTP subsystem via `ssh_sftpd:subsystem_spec/1`, additional
 resource limits can be configured to protect against resource exhaustion attacks:
 
-#### max_handles
-
-Limits the maximum number of file and directory handles that can be opened
-simultaneously per SFTP connection. The default is 1000.
+`max_handles` limits the maximum number of file and directory handles that can
+be opened simultaneously per SFTP connection. The default is 1000.
 
 Recommended values by deployment type:
 
@@ -163,10 +211,8 @@ Recommended values by deployment type:
   - Parallel file operations
   - Monitor actual usage before increasing
 
-#### max_path
-
-Limits the maximum path length accepted from SFTP clients. The default is
-4096 bytes.
+`max_path` limits the maximum path length accepted from SFTP clients. The
+default is 4096 bytes.
 
 Recommended values:
 
@@ -180,10 +226,8 @@ Recommended values:
   - Additional defense layer
   - Verify compatibility first
 
-#### max_files
-
-Limits the number of filenames returned per READDIR request. The default is
-0 (unlimited).
+`max_files` limits the number of filenames returned per READDIR request. The
+default is 0 (unlimited).
 
 This option prevents memory exhaustion from large directory listings. Unlike
 max_handles and max_path, this is primarily a performance/memory protection
@@ -203,7 +247,7 @@ Recommended values:
   - Embedded systems
   - Resource-limited containers
 
-#### Example Configuration
+**Example configuration**
 
 ```erlang
 ssh:daemon(Port, [
@@ -222,124 +266,7 @@ ssh:daemon(Port, [
 
 See `m:ssh_sftpd` for complete documentation of subsystem options.
 
-## Verifying the remote daemon (server) in an SSH client
-
-Every SSH server presents a public key - the _host key_ \- to the client while
-keeping the corresponding private key in relatively safe privacy.
-
-The client checks that the host that presented the public key also possesses the
-private key of the key-pair. That check is part of the SSH protocol.
-
-But how can the client know that the host _really_ is the one that it tried to
-connect to and not an evil one impersonating the expected one using its own
-valid key-pair? There are two alternatives available with the default key
-handling plugin `m:ssh_file`. The alternatives are:
-
-- **Pre-store the host key** - For the default handler ssh_file, store the
-  valid host keys in the file [`known_hosts`](`m:ssh_file#FILE-known_hosts`) and
-  set the option
-  [silently_accept_hosts](`m:ssh#hardening_client_options-silently_accept_hosts`)
-  to `false`. Alternatively, write a specialized key handler using the
-  [SSH client key API](`m:ssh_client_key_api`) that accesses the pre-shared
-  key in some other way.
-
-- **Pre-store the "fingerprint" (checksum) of the host key** - Use
-  [silently_accept_hosts](`m:ssh#hardening_client_options-silently_accept_hosts`)
-  with a callback: [`accept_callback()`](`t:ssh:accept_callback/0`)
-  or [`{HashAlgoSpec, accept_callback()}`](`t:ssh:accept_hosts/0`).
-
-## Verifying the remote client in a daemon (server)
-
-- **Password checking** - The default password checking is with the list in the
-  [user_passwords](`m:ssh#option-user_passwords`) option in the SSH daemon. It
-  could be replaced with a [pwdfun](`m:ssh#option-pwdfun`) plugin. The arity
-  four variant ([`pwdfun_4()`](`t:ssh:pwdfun_4/0`)) can also be used for
-  introducing delays after failed password checking attempts. Here is a simple
-  example of such a pwdfun:
-
-  ```erlang
-  fun(User, Password, _PeerAddress, State) ->
-          case lists:member({User,Password}, my_user_pwds()) of
-              true ->
-                  {true, undefined}; % Reset delay time
-              false when State == undefined ->
-                  timer:sleep(1000),
-                  {false, 2000}; % Next delay is 2000 ms
-              false when is_integer(State) ->
-                  timer:sleep(State),
-                  {false, 2*State} % Double the delay for each failure
-          end
-  end.
-  ```
-
-  If a public key is used for logging in, there is normally no checking of the
-  user name. It could be enabled by setting the option
-  [`pk_check_user`](`m:ssh#option-pk_check_user`) to `true`. In that case the
-  pwdfun will get the atom `pubkey` in the password argument.
-
-## Hardening in the cryptographic area
-
-### Algorithm selection
-
-One of the cornerstones of security in SSH is cryptography. The development in
-crypto analysis is fast, and yesterday's secure algorithms are unsafe today.
-Therefore some algorithms are no longer enabled by default and that group grows
-with time. See the
-[SSH (App)](ssh_app.md#supported-specifications-and-standards) for a list of
-supported and of disabled algorithms. In the User's Guide the chapter
-[Configuring algorithms in SSH](configure_algos.md) describes the options for
-enabling or disabling algorithms -
-[preferred_algorithms](`t:ssh:preferred_algorithms_common_option/0`) and
-[modify_algorithms](`t:ssh:modify_algorithms_common_option/0`).
-
-### Re-keying
-
-In the setup of the SSH connection a secret cipher key is generated by
-co-operation of the client and the server. Keeping this key secret is crucial
-for keeping the communication secret. As time passes and encrypted messages are
-exchanged, the probability that a listener could guess that key increases.
-
-The SSH protocol therefore has a special operation defined - _key
-re-negotiation_ or _re-keying_. Any side (client or server) could initiate the
-re-keying and the result is a new cipher key. The result is that the
-eves-dropper has to restart its evil and dirty craftmanship.
-
-See the option [rekey_limit](`t:ssh:rekey_limit_common_option/0`) for a
-description.
-
-## Hardening of the SSH protocol - both daemons and clients
-
-### Disabling shell and exec in a daemon
-
-A daemon has two services for evaluating tasks on behalf of a remote client. The
-_exec_ server-side service takes a string provided by the client, evaluates it
-and returns the result. The _shell_ function enables the client to open a shell
-in the shell host.
-
-The options [exec](`t:ssh:exec_daemon_option/0`) and
-[shell](`t:ssh:shell_daemon_option/0`) are disabled per default.
-The same options could also install handlers for
-the string(s) passed from the client to the server.
-
-### Enabling the SFTP subsystem
-
-The SFTP subsystem is not enabled by default. When enabled, SFTP provides
-access to the file system with the rights of the OS process running the
-Erlang emulator, regardless of the authenticated SSH user. See the
-[Terminology](terminology.md) section for details.
-
-The [subsystems](`t:ssh:subsystem_daemon_option/0`) option controls which
-subsystems are available. To enable SFTP:
-
-```erlang
-ssh:daemon({192, 168, 1, 10}, Port,
-           [{subsystems, [ssh_sftpd:subsystem_spec([])]} | Options]).
-```
-
-Use the `root` option to restrict SFTP users to a specific directory
-tree (see [Root Directory Isolation](#root-directory-isolation) below).
-
-### The id string
+### The ID String
 
 One way to reduce the risk of intrusion is to not convey which software and
 which version the intruder is connected to. This limits the risk of an intruder
@@ -376,7 +303,100 @@ It is possible to replace the string with one randomly generated for each
 connection attempt. See the reference manual for
 [id_string](`t:ssh:id_string_common_option/0`).
 
-## Client connection options
+## Cryptographic Hardening
+
+### Algorithm Selection
+
+One of the cornerstones of security in SSH is cryptography. The development in
+crypto analysis is fast, and yesterday's secure algorithms are unsafe today.
+Therefore some algorithms are no longer enabled by default and that group grows
+with time. See the
+[SSH (App)](ssh_app.md#supported-specifications-and-standards) for a list of
+supported and disabled algorithms. In the User's Guide the chapter
+[Configuring algorithms in SSH](configure_algos.md) describes the options for
+enabling or disabling algorithms -
+[preferred_algorithms](`t:ssh:preferred_algorithms_common_option/0`) and
+[modify_algorithms](`t:ssh:modify_algorithms_common_option/0`).
+
+### Post-Quantum Key Exchange
+
+The `mlkem768x25519-sha256` algorithm provides quantum-resistant key
+exchange using a hybrid construction that combines ML-KEM-768 (NIST
+FIPS 203) with X25519. When the underlying crypto library supports
+ML-KEM, this algorithm is negotiated by default as the highest-priority
+key exchange method. No configuration is needed to enable it.
+
+### Re-Keying
+
+In the setup of the SSH connection a secret cipher key is generated by
+co-operation of the client and the server. Keeping this key secret is crucial
+for keeping the communication secret. As time passes and encrypted messages are
+exchanged, the probability that a listener could guess that key increases.
+
+The SSH protocol therefore has a special operation defined - _key
+re-negotiation_ or _re-keying_. Any side (client or server) could initiate the
+re-keying and the result is a new cipher key. The result is that the
+eavesdropper has to restart its evil and dirty craftsmanship.
+
+See the option [rekey_limit](`t:ssh:rekey_limit_common_option/0`) for a
+description.
+
+## Verifying the Remote Daemon (Server) in an SSH Client
+
+Every SSH server presents a public key - the _host key_ \- to the client while
+keeping the corresponding private key in relatively safe privacy.
+
+The client checks that the host that presented the public key also possesses the
+private key of the key-pair. That check is part of the SSH protocol.
+
+But how can the client know that the host _really_ is the one that it tried to
+connect to and not an evil one impersonating the expected one using its own
+valid key-pair? There are two alternatives available with the default key
+handling plugin `m:ssh_file`. The alternatives are:
+
+- **Pre-store the host key** - For the default handler ssh_file, store the
+  valid host keys in the file [`known_hosts`](`m:ssh_file#FILE-known_hosts`) and
+  set the option
+  [silently_accept_hosts](`m:ssh#hardening_client_options-silently_accept_hosts`)
+  to `false`. Alternatively, write a specialized key handler using the
+  [SSH client key API](`m:ssh_client_key_api`) that accesses the pre-shared
+  key in some other way.
+
+- **Pre-store the "fingerprint" (checksum) of the host key** - Use
+  [silently_accept_hosts](`m:ssh#hardening_client_options-silently_accept_hosts`)
+  with a callback: [`accept_callback()`](`t:ssh:accept_callback/0`)
+  or [`{HashAlgoSpec, accept_callback()}`](`t:ssh:accept_hosts/0`).
+
+## Verifying the Remote Client in a Daemon (Server)
+
+- **Password checking** - The default password checking is with the list in the
+  [user_passwords](`m:ssh#option-user_passwords`) option in the SSH daemon. It
+  could be replaced with a [pwdfun](`m:ssh#option-pwdfun`) plugin. The arity
+  four variant ([`pwdfun_4()`](`t:ssh:pwdfun_4/0`)) can also be used for
+  introducing delays after failed password checking attempts. Here is a simple
+  example of such a pwdfun:
+
+  ```erlang
+  fun(User, Password, _PeerAddress, State) ->
+          case lists:member({User,Password}, my_user_pwds()) of
+              true ->
+                  {true, undefined}; % Reset delay time
+              false when State == undefined ->
+                  timer:sleep(1000),
+                  {false, 2000}; % Next delay is 2000 ms
+              false when is_integer(State) ->
+                  timer:sleep(State),
+                  {false, 2*State} % Double the delay for each failure
+          end
+  end.
+  ```
+
+  If a public key is used for logging in, there is normally no checking of the
+  user name. It could be enabled by setting the option
+  [`pk_check_user`](`m:ssh#option-pk_check_user`) to `true`. In that case the
+  pwdfun will get the atom `pubkey` in the password argument.
+
+## Client Connection Options
 
 A client could limit the time for the initial tcp connection establishment with
 the option [connect_timeout](`t:ssh:connect_timeout_client_option/0`). The time
@@ -385,35 +405,6 @@ is in milliseconds, and the initial value is infinity.
 The negotiation (session setup time) time can be limited with the _parameter_
 `NegotiationTimeout` in a call establishing an ssh session, for example
 `ssh:connect/3`.
-
-## SFTP Security
-
-Note that the SFTP server runs with the file access rights of the OS
-process running the Erlang emulator, regardless of the authenticated
-SSH user. See the [Terminology](terminology.md) section for details.
-
-### Root Directory Isolation
-
-The `root` option (see `m:ssh_sftpd`) restricts SFTP users to a
-specific directory tree, preventing access to files outside that directory.
-
-**Example:**
-
-```erlang
-ssh:daemon(Port, [
-    {subsystems, [ssh_sftpd:subsystem_spec([{root, "/home/sftpuser"}])]},
-    ...
-]).
-```
-
-**Important:** The `root` option is configured per daemon, not per user. All
-users connecting to the same daemon share the same root directory. For per-user
-isolation, consider running separate daemon instances on different ports or
-using OS-level mechanisms (PAM chroot, containers, file permissions).
-
-**Defense-in-depth:** For high-security deployments, combine the `root` option
-with OS-level isolation mechanisms such as chroot jails, containers, or
-mandatory access control (SELinux, AppArmor).
 
 ## Network-Level Security
 
@@ -492,4 +483,3 @@ lockout_pwdfun(User, Password, _PeerAddr, State) ->
             end
     end.
 ```
-

--- a/lib/ssh/doc/guides/introduction.md
+++ b/lib/ssh/doc/guides/introduction.md
@@ -49,16 +49,17 @@ Conceptually, the SSH protocol can be partitioned into four layers:
 
 ```mermaid
 ---
-title: SSH Protocol Architecture
+title: SSH Protocol Architecture (RFC 4251)
 ---
 
 block-beta
-    columns 2
+    columns 4
 
-    l1["SSH Client/Server Applications"]:2
-    l2a["Connection Protocol"] l2b["Authentication Protocol"]
-    l3["Transport Protocol"]:2
-    l4["TCP/IP Stack"]:2
+    Shell Exec SFTP Custom
+    l1["Connection / Channels\n(RFC 4254)"]:4
+    l2["Authentication\n(RFC 4252)"]:4
+    l3["Transport\n(RFC 4253)"]:4
+    l4["TCP/IP"]:4
 ```
 
 ### Transport Protocol

--- a/lib/ssh/doc/guides/terminology.md
+++ b/lib/ssh/doc/guides/terminology.md
@@ -21,26 +21,17 @@ limitations under the License.
 -->
 # Terminology
 
-## General Information
+This chapter explains terms that may cause confusion.
 
-In the following terms that may cause confusion are explained.
+The term "user" is used differently in [OpenSSH](http://www.openssh.com) and
+SSH in Erlang/OTP. The reason is the different environments and use cases that
+are not immediately obvious. The following sections explain the differences and
+give a rationale for why Erlang/OTP handles "user" as it does.
 
-## The term "user"
-
-A "user" is a term that everyone understands intuitively. However, the
-understandings may differ which can cause confusion.
-
-The term is used differently in [OpenSSH](http://www.openssh.com) and SSH in
-Erlang/OTP. The reason is the different environments and use cases that are not
-immediately obvious.
-
-This chapter aims at explaining the differences and giving a rationale for why
-Erlang/OTP handles "user" as it does.
-
-### In OpenSSH
+## The Term "user" in OpenSSH
 
 Many have been in contact with the command 'ssh' on a Linux machine (or similar)
-to remotly log in on another machine. One types
+to remotely log in on another machine. One types
 
 ```text
 ssh host
@@ -66,7 +57,7 @@ is exactly as that context: The _user_ could read, write and execute programs
 according to the OS rules. In addition, the user has a home directory (`$HOME`)
 and there is a `$HOME/.ssh/` directory with ssh-specific files.
 
-#### SSH password authentication
+### Password Authentication
 
 When SSH tries to log in to a host, the ssh protocol communicates the user name
 (as a string) and a password. The remote ssh server checks that there is such a
@@ -74,7 +65,7 @@ user defined and that the provided password is acceptable.
 
 If so, the user is authorized.
 
-#### SSH public key authentication
+### Public Key Authentication
 
 This is a stronger method where the ssh protocol brings the user name, the
 user's public key and some cryptographic information which we could ignore here.
@@ -88,7 +79,7 @@ The ssh server on the remote host checks:
 
 if so, the user is authorized.
 
-#### The SSH server on UNIX/Linux/etc after a successful authentication
+### After a Successful Authentication
 
 After a successful incoming authentication, a new process runs as the just
 authenticated user.
@@ -100,7 +91,7 @@ arrives from the client (that's "you").
 In case of a sftp request, an sftp server is started in with the user's rights.
 So it could read, write or delete files if allowed for that user.
 
-### In Erlang/OTP SSH
+## The Term "user" in Erlang/OTP SSH
 
 For the Erlang/OTP SSH server the situation is different. The server executes in
 an Erlang process in the Erlang emulator which in turn executes in an OS
@@ -108,7 +99,7 @@ process. The emulator does not try to change its user when authenticated over
 the SSH protocol. So the remote user name is only for authentication purposes in
 the Erlang/OTP SSH application.
 
-#### Password authentication in Erlang SSH
+### Password Authentication
 
 The Erlang/OTP SSH server checks the user name and password in the following
 order:
@@ -119,10 +110,13 @@ order:
    defined and the username and the password matches, the authentication is a
    success.
 1. Else, if the option [`password`](`m:ssh#option-password`) is defined and
-   matches the password the authentication is a success. Note that the use of
-   this option is not recommended in non-test code.
+   matches the password the authentication is a success.
 
-#### Public key authentication in Erlang SSH
+> #### Warning {: .warning }
+>
+> The `password` option is intended for testing only.
+
+### Public Key Authentication
 
 The user name, public key and cryptographic data (a signature) that is sent by
 the client are used as follows (some steps left out for clarity):
@@ -146,7 +140,13 @@ If the provided public key is not found, the authentication fails.
 1. Finally, if the provided public key is found, the signature provided by the
    client is checked with the public key.
 
-#### The Erlang/OTP SSH server after a successful authentication
+### After a Successful Authentication
+
+> #### Note {: .info }
+>
+> Shell, exec, and SFTP are disabled by default. They must be
+> explicitly enabled in the daemon options. See the
+> [Hardening](hardening.md) guide for details.
 
 After a successful authentication an _Erlang process_ is handling the service
 request from the remote ssh client. The rights of that process are those of the
@@ -163,3 +163,18 @@ running the Erlang emulator, regardless of the authenticated SSH user.
 
 So after an authentication, the user name is not used anymore and has no
 influence.
+
+## Authentication vs Authorization
+
+*Authentication* verifies identity ("are you who you claim to be?").
+*Authorization* grants permissions ("are you allowed to do this?").
+
+The OpenSSH file `authorized_keys` is named from a historical
+convention. Checking a key against this file is *authentication*,
+not *authorization*. Erlang/OTP SSH uses the same filename for
+compatibility with OpenSSH.
+
+In Erlang/OTP SSH, after successful authentication all operations
+run with the rights of the OS process running the Erlang emulator,
+regardless of the authenticated SSH user. See the sections above
+for details.

--- a/lib/ssh/doc/guides/using_ssh.md
+++ b/lib/ssh/doc/guides/using_ssh.md
@@ -62,8 +62,8 @@ see Section Configuration in [ssh](ssh_app.md).
 The option [`user_dir`](`t:ssh_file:user_dir_common_option/0`) defaults to
 directory `~/.ssh`.
 
-_Step 1._ To run the example without root privileges, generate new keys and host
-keys:
+_Step 1._ To run the example without root privileges, generate new host keys
+and user keys:
 
 ```text
 $bash> ssh-keygen -t rsa -f /tmp/ssh_daemon/ssh_host_rsa_key
@@ -129,7 +129,7 @@ ok
 
 [](){: #simple-client-example }
 
-### Erlang client contacting OS standard ssh server
+### Erlang Client Contacting OpenSSH Server
 
 In the following example, the Erlang shell is the client process that receives
 the channel replies as Erlang messages.
@@ -173,9 +173,11 @@ To collect the channel messages in a program, use `receive...end` instead of
 6>
 ```
 
-Note that only the exec channel is closed after the one-time execution. The
-connection is still up and can handle previously opened channels. It is also
-possible to open a new channel:
+> #### Note {: .info }
+>
+> Only the exec channel is closed after the one-time execution. The
+> connection is still up and can handle previously opened channels.
+> It is also possible to open a new channel:
 
 ```erlang
 % try to open a new channel to check if the ConnectionRef is still open
@@ -190,7 +192,7 @@ To close the connection, call the function
 connection. This will cause the connection to be closed automatically when there
 are no channels open for the specified time period, in this case 1 ms.
 
-### OS standard client and Erlang daemon (server)
+### OpenSSH and Erlang Clients to Erlang Daemon
 
 An Erlang SSH daemon could be called for one-time execution of a "command". The
 "command" must be as if entered into the erlang shell, that is a sequence of
@@ -234,8 +236,10 @@ ok
 5>
 ```
 
-Note that Erlang shell specific functions and control sequences like for example
-`h().` are not supported.
+> #### Note {: .info }
+>
+> Erlang shell specific functions and control sequences like for example
+> `h().` are not supported.
 
 ### I/O from a function called in an Erlang ssh daemon
 
@@ -331,7 +335,11 @@ ok
 4>
 ```
 
-and call it:
+The `fun()` in the exec option could take up to three arguments (`Cmd`, `User`
+and `ClientAddress`). See the
+[exec_daemon_option()](`t:ssh:exec_daemon_option/0`) for the details.
+
+And call it:
 
 ```text
 $bash> ssh localhost -p 1234 1
@@ -348,8 +356,10 @@ $bash> ssh localhost -p 1234 1+ 2.
 $bash>
 ```
 
-Note that spaces are preserved and that no point (.) is needed at the end - that
-was required by the default evaluator.
+> #### Note {: .info }
+>
+> Spaces are preserved and no `.` is needed at the end — that
+> was required by the default evaluator.
 
 The error return in the Erlang client (The text as data type 1 and exit_status
 255):
@@ -370,17 +380,11 @@ ok
 6>
 ```
 
-The `fun()` in the exec option could take up to three arguments (`Cmd`, `User`
-and `ClientAddress`). See the
-[exec_daemon_option()](`t:ssh:exec_daemon_option/0`) for the details.
-
 > #### Note {: .info }
 >
-> An old, discouraged and undocumented way of installing an alternative
-> evaluator exists.
->
-> It still works, but lacks for example I/O possibility. It is because of that
-> compatibility we need the `{direct,...}` construction.
+> The `{direct, ...}` wrapper is required to distinguish from a legacy
+> evaluator interface that lacks I/O support. The legacy form is
+> undocumented and discouraged.
 
 ## SFTP Server
 
@@ -414,6 +418,11 @@ sftp>
 ```
 
 ## SFTP Client
+
+> #### Note {: .info }
+>
+> This assumes the remote SSH server has the SFTP subsystem enabled.
+> OpenSSH enables it by default.
 
 Fetch a file with the Erlang SFTP client:
 
@@ -507,12 +516,12 @@ following example:
 
 ```erlang
 -module(ssh_echo_server).
--behaviour(ssh_server_channel). % replaces ssh_daemon_channel
+-behaviour(ssh_server_channel).
 -record(state, {
-	  n,
-	  id,
-	  cm
-	 }).
+    n,
+    id,
+    cm
+}).
 -export([init/1, handle_msg/2, handle_ssh_msg/2, terminate/2]).
 
 init([N]) ->
@@ -520,23 +529,23 @@ init([N]) ->
 
 handle_msg({ssh_channel_up, ChannelId, ConnectionManager}, State) ->
     {ok, State#state{id = ChannelId,
-		     cm = ConnectionManager}}.
+                     cm = ConnectionManager}}.
 
 handle_ssh_msg({ssh_cm, CM, {data, ChannelId, 0, Data}}, #state{n = N} = State) ->
-    M = N - size(Data),
+    M = N - byte_size(Data),
     case M > 0 of
-	true ->
-	   ssh_connection:send(CM, ChannelId, Data),
-	   {ok, State#state{n = M}};
-	false ->
-	   <<SendData:N/binary, _/binary>> = Data,
-           ssh_connection:send(CM, ChannelId, SendData),
-           ssh_connection:send_eof(CM, ChannelId),
-	   {stop, ChannelId, State}
+        true ->
+            ssh_connection:send(CM, ChannelId, Data),
+            {ok, State#state{n = M}};
+        false ->
+            <<SendData:N/binary, _/binary>> = Data,
+            ssh_connection:send(CM, ChannelId, SendData),
+            ssh_connection:send_eof(CM, ChannelId),
+            {stop, ChannelId, State}
     end;
 handle_ssh_msg({ssh_cm, _ConnectionManager,
-		{data, _ChannelId, 1, Data}}, State) ->
-    error_logger:format(standard_error, " ~p~n", [binary_to_list(Data)]),
+                {data, _ChannelId, 1, Data}}, State) ->
+    logger:notice(" ~p~n", [binary_to_list(Data)]),
     {ok, State};
 
 handle_ssh_msg({ssh_cm, _ConnectionManager, {eof, _ChannelId}}, State) ->
@@ -547,8 +556,8 @@ handle_ssh_msg({ssh_cm, _, {signal, _, _}}, State) ->
     {ok, State};
 
 handle_ssh_msg({ssh_cm, _, {exit_signal, ChannelId, _, _Error, _}},
-	       State) ->
-    {stop, ChannelId,  State};
+               State) ->
+    {stop, ChannelId, State};
 
 handle_ssh_msg({ssh_cm, _, {exit_status, ChannelId, _Status}}, State) ->
     {stop, ChannelId, State}.
@@ -571,6 +580,8 @@ ok
 3>
 ```
 
+Then connect from an Erlang client:
+
 ```erlang
 1> ssh:start().
 ok
@@ -581,10 +592,10 @@ ok
 4> success = ssh_connection:subsystem(ConnectionRef, ChannelId, "echo_n", infinity).
 5> ok = ssh_connection:send(ConnectionRef, ChannelId, "0123456789", infinity).
 6> flush().
-{ssh_msg, <0.57.0>, {data, 0, 1, "0123456789"}}
-{ssh_msg, <0.57.0>, {eof, 0}}
-{ssh_msg, <0.57.0>, {closed, 0}}
+{ssh_cm, <0.57.0>, {data, 0, 0, <<"0123456789">>}}
+{ssh_cm, <0.57.0>, {eof, 0}}
+{ssh_cm, <0.57.0>, {closed, 0}}
 7> {error, closed} = ssh_connection:send(ConnectionRef, ChannelId, "10", infinity).
 ```
 
-See also `m:ssh_client_channel` (replaces ssh_channel(3)).
+See also `m:ssh_client_channel`.

--- a/lib/ssh/doc/ssh_app.md
+++ b/lib/ssh/doc/ssh_app.md
@@ -141,6 +141,7 @@ Supported algorithms are (in the default order):
 
 **Key exchange algorithms**
 
+- mlkem768x25519-sha256
 - curve25519-sha256
 - curve25519-sha256@libssh.org
 - curve448-sha512
@@ -394,6 +395,11 @@ The following RFCs are supported:
 - [Secure Shell (SSH) Key Exchange Method Using Curve25519 and Curve448](https://tools.ietf.org/html/rfc8731)
 - [RFC 8709](https://tools.ietf.org/html/rfc8709) Ed25519 and Ed448 public key
   algorithms for the Secure Shell (SSH) protocol
+- [draft-kampanakis-curdle-ssh-pq-ke](https://datatracker.ietf.org/doc/draft-kampanakis-curdle-ssh-pq-ke/),
+  Post-Quantum Traditional Hybrid Key Exchange for SSH.
+
+  Comment: Implements mlkem768x25519-sha256. The ML-KEM-768 component is
+  defined by [NIST FIPS 203](https://csrc.nist.gov/pubs/fips/203/final).
 
 ## See Also
 

--- a/lib/ssh/src/ssh.erl
+++ b/lib/ssh/src/ssh.erl
@@ -44,7 +44,7 @@ server-side process. Those process pairs could handle for example file transfers
 (sftp) or remote command execution (shell, exec and/or cli). If a custom shell
 is implemented, the user of the client could execute the special commands
 remotely. Note that the user is not necessarily a human but probably a system
-interfacing the SSH app.
+interfacing the SSH application.
 
 A server-side subssystem (channel) server is requested by the client with
 `ssh_connection:subsystem/4`.

--- a/lib/ssh/src/ssh.hrl
+++ b/lib/ssh/src/ssh.hrl
@@ -354,7 +354,7 @@ compression in both directions. The kex (key exchange) is implicit but
 public_key is set explicitly.
 
 For background and more examples see the
-[User's Guide](configure_algos.md#introduction).
+[User's Guide](configure_algos.md#algorithm-negotiation-in-ssh).
 
 If an algorithm name occurs more than once in a list, the behaviour is
 undefined. The tags in the property lists are also assumed to occur at most one
@@ -415,7 +415,7 @@ The example specifies that:
   enforced
 
 For background and more examples see the
-[User's Guide](configure_algos.md#introduction).
+[User's Guide](configure_algos.md#algorithm-negotiation-in-ssh).
 """.
 -doc(#{group => <<"Common Options">>}).
 -type modify_algs_list()      :: list( {append,algs_list()} | {prepend,algs_list()} | {rm,algs_list()} ) .
@@ -1079,7 +1079,7 @@ supporting ext-info.
   doing public key authentication. It is disabled by default.
 
   The term "user" is used differently in OpenSSH and SSH in Erlang/OTP: see more
-  in the [User's Guide](terminology.md#the-term-user).
+  in the [User's Guide](terminology.md#the-term-user-in-openssh).
 
   If the option is enabled, and no [`pwdfun`](`m:ssh#option-pwdfun`) is present,
   the user name must present in the

--- a/lib/ssh/src/ssh_agent.erl
+++ b/lib/ssh/src/ssh_agent.erl
@@ -55,7 +55,7 @@ option can be set.
 
 > #### Note {: .info }
 >
-> The functions are _Callbacks_ for the SSH app. They are not intended to be
+> The functions are _Callbacks_ for the SSH application. They are not intended to be
 > called from the user's code\!
 """.
 -moduledoc(#{since => "OTP 23.0"}).

--- a/lib/ssh/src/ssh_sftpd.erl
+++ b/lib/ssh/src/ssh_sftpd.erl
@@ -109,7 +109,7 @@ Options:
 
   Note: This provides application-level isolation. For additional security,
   consider using OS-level chroot or similar mechanisms. See the
-  [SFTP Security](hardening.md#sftp-security) section in the Hardening guide
+  [SFTP subsystem](hardening.md#sftp-subsystem) section in the Hardening guide
   for deployment recommendations.
 
 - **`sftpd_vsn`** - Sets the SFTP version to use. Defaults to 5. Version 6 is


### PR DESCRIPTION
Fix stale algorithm examples, typos, and heading structure across all 7 SSH guide files.

- Re-capture all default_algorithms outputs for OTP 29 (mlkem, curve25519, ed25519, etm MACs, chacha20)
- Fix 11 typos/grammar errors in configure_algos.md
- Add mlkem768x25519-sha256 to ssh_app.md algorithm list
- Add PQC section to hardening.md
- Restructure headings in configure_algos.md, configurations.md, hardening.md, terminology.md (remove ## Introduction wrappers, eliminate #### depth)
- Convert plain-text notes to admonitions in using_ssh.md
- Fix "Creating a Subsystem" example (byte_size, logger, ssh_cm)
- Replace tabs with spaces in code blocks
- Note disabled-by-default shell/exec/SFTP in terminology.md