### PR TITLE
otp: system-test depends on pack

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -711,8 +711,8 @@ jobs:
   system-test:
     name: Test Erlang/OTP (system)
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() }} # Run even if the need has failed
-    needs: test
+    if: ${{ !cancelled() && needs.pack.result == 'success' }} # Run even if the need has failed
+    needs: [pack, test]     # it makes no sense to run this if there is no build image (pack job)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/build-base-image


### PR DESCRIPTION
the github job (in `main.yaml`) `system-test` depends only on `test`.
this is not quite correct as `system-test` cannot run unless there is a
docker image ready. this change makes `system-test` to depend on `pack`,
which is the job that creates a docker image. `system-test` will only
run when the `pack` job is successful, and will run even if `test`
fails.

as an example:

https://github.com/erlang/otp/actions/runs/24440673940

this job fails in `pack` and also in `system-test`. but there is no need
to fail on `system-test` because it is impossible for it to run.
