### PR TITLE
fix(mnesia): load ram_copies table from 'better' copy when start

### DIFF
--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -1485,11 +1485,14 @@ orphan_tables([Tab | Tabs], Node, Ns, Local, Remote) ->
 		    orphan_tables(Tabs, Node, Ns, Local, Remote)
 	    end;
 	false when Active == [], DiscCopyHolders == [],
-               RamCopyHolders =/= [], not (LocalContent == true) ->
-	    %% RAM-only table. This must be handled before the discless
-	    %% special case below, otherwise a fully disc-less cluster
-	    %% (where RamCopyHoldersOnDiscNodes is always []) would load
-	    %% an empty local copy instead of a better remote copy.
+               RamCopyHolders =/= [], not (LocalContent == true),
+               (RamCopyHoldersOnDiscNodes =/= [] orelse DiscNodes == []) ->
+	    %% RAM-only table whose copies live on disc nodes, OR a fully
+	    %% disc-less cluster (DiscNodes == []). In both cases a remote
+	    %% holder may have a better copy, so don't blindly load an empty
+	    %% local copy. Handled before the disc-less special case below;
+	    %% the mixed case (ram copies only on ram nodes while a disc node
+	    %% exists) falls through to that clause and keeps loading directly.
 	    case RamCopyHolders -- Ns of
 		[] ->
 		    %% We're last up and the other nodes have not

--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -1487,6 +1487,33 @@ orphan_tables([Tab | Tabs], Node, Ns, Local, Remote) ->
 	false when Active == [], DiscCopyHolders == [], RamCopyHoldersOnDiscNodes == [] ->
 	    %% Special case when all replicas resides on disc less nodes
 	    orphan_tables(Tabs, Node, Ns, [Tab | Local], Remote);
+	false when Active == [], DiscCopyHolders == [], 
+               RamCopyHolders =/= [], not (LocalContent == true) ->
+	    case RamCopyHolders -- Ns of
+		[] ->
+		    %% We're last up and the other nodes have not
+		    %% loaded the table. Lets load it if we are
+		    %% the smallest node.
+		    case lists:min(RamCopyHolders) of
+			Min when Min == node() ->
+                %% This is safe for ram copies because if all nodes are 
+                %% waiting that means the table is empty on all nodes.
+                %% here we just need to elect a bootstrap node to break
+                %% the waiting loop.
+			    case mnesia_recover:get_master_nodes(Tab) of
+				[] ->
+				    L = [Tab | Local],
+				    orphan_tables(Tabs, Node, Ns, L, Remote);
+				Masters ->
+				    R = [{Tab, Masters} | Remote],
+				    orphan_tables(Tabs, Node, Ns, Local, R)
+			    end;
+			_ ->
+			    orphan_tables(Tabs, Node, Ns, Local, Remote)
+		    end;
+		_ ->
+		    orphan_tables(Tabs, Node, Ns, Local, Remote)
+	    end;
 	_ when LocalContent == true ->
 	    orphan_tables(Tabs, Node, Ns, [Tab | Local], Remote);
 	_ ->
@@ -1595,21 +1622,11 @@ update_whereabouts(Tab, Node, State) ->
     end.
 
 initial_safe_loads() ->
-    case val({schema, storage_type}) of
-	ram_copies ->
-	    Downs = [],
-	    Tabs = val({schema, local_tables}) -- [schema],
-	    LastC = fun(T) -> last_consistent_replica(T, Downs) end,
-	    lists:zf(LastC, Tabs);
-
-	disc_copies ->
-	    Downs = mnesia_recover:get_mnesia_downs(),
-	    dbg_out("mnesia_downs = ~p~n", [Downs]),
-
-	    Tabs = val({schema, local_tables}) -- [schema],
-	    LastC = fun(T) -> last_consistent_replica(T, Downs) end,
-	    lists:zf(LastC, Tabs)
-    end.
+	Downs = mnesia_recover:get_mnesia_downs(),
+	dbg_out("mnesia_downs = ~p~n", [Downs]),
+	Tabs = val({schema, local_tables}) -- [schema],
+	LastC = fun(T) -> last_consistent_replica(T, Downs) end,
+	lists:zf(LastC, Tabs).
 
 last_consistent_replica(Tab, Downs) ->
     case ?catch_val({Tab, cstruct}) of
@@ -1656,12 +1673,14 @@ last_consistent_replica(Cs, Tab, Downs) ->
 	    %% Wait for remote master copy
 	    false;
 	Storage == ram_copies ->
-	    if
-		Disc == [], DiscOnly == [], Ext == [] ->
-		    %% Nobody has copy on disc
+        if
+		Disc == [], DiscOnly == [], Ext == [], BetterCopies0 == [] ->
+		    %% RAM-only table and no non-down remote copy holder.
+		    %% Safe to load locally.
 		    {true, {Tab, ram_only}};
 		true ->
-		    %% Some other node has copy on disc
+		    %% Either a disc-resident copy exists or a non-down
+		    %% remote copy holder may have a better copy.
 		    false
 	    end;
 	AccessMode == read_only ->

--- a/lib/mnesia/src/mnesia_controller.erl
+++ b/lib/mnesia/src/mnesia_controller.erl
@@ -1484,11 +1484,12 @@ orphan_tables([Tab | Tabs], Node, Ns, Local, Remote) ->
 		_ ->
 		    orphan_tables(Tabs, Node, Ns, Local, Remote)
 	    end;
-	false when Active == [], DiscCopyHolders == [], RamCopyHoldersOnDiscNodes == [] ->
-	    %% Special case when all replicas resides on disc less nodes
-	    orphan_tables(Tabs, Node, Ns, [Tab | Local], Remote);
-	false when Active == [], DiscCopyHolders == [], 
+	false when Active == [], DiscCopyHolders == [],
                RamCopyHolders =/= [], not (LocalContent == true) ->
+	    %% RAM-only table. This must be handled before the discless
+	    %% special case below, otherwise a fully disc-less cluster
+	    %% (where RamCopyHoldersOnDiscNodes is always []) would load
+	    %% an empty local copy instead of a better remote copy.
 	    case RamCopyHolders -- Ns of
 		[] ->
 		    %% We're last up and the other nodes have not
@@ -1512,8 +1513,14 @@ orphan_tables([Tab | Tabs], Node, Ns, Local, Remote) ->
 			    orphan_tables(Tabs, Node, Ns, Local, Remote)
 		    end;
 		_ ->
+		    %% A non-down remote copy holder may have a better
+		    %% copy. Stay 'nowhere' and net_load it once that
+		    %% holder connects.
 		    orphan_tables(Tabs, Node, Ns, Local, Remote)
 	    end;
+	false when Active == [], DiscCopyHolders == [], RamCopyHoldersOnDiscNodes == [] ->
+	    %% Special case when all replicas resides on disc less nodes
+	    orphan_tables(Tabs, Node, Ns, [Tab | Local], Remote);
 	_ when LocalContent == true ->
 	    orphan_tables(Tabs, Node, Ns, [Tab | Local], Remote);
 	_ ->

--- a/lib/mnesia/test/mnesia_consistency_test.erl
+++ b/lib/mnesia/test/mnesia_consistency_test.erl
@@ -35,6 +35,8 @@
          consistency_after_restart_2_ram/1,
          consistency_after_restart_2_disc/1,
          consistency_after_restart_2_disc_only/1,
+         consistency_after_isolated_restart_2_nodes/1,
+         consistency_after_isolated_restart_3_nodes/1,
          consistency_after_dump_tables_1_ram/1,
          consistency_after_dump_tables_2_ram/1,
          consistency_after_add_replica_2_ram/1,
@@ -106,6 +108,7 @@ end_per_testcase(Func, Conf) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 all() -> 
     [{group, consistency_after_restart},
+     {group, consistency_after_isolated_restart},
      {group, consistency_after_dump_tables},
      {group, consistency_after_add_replica},
      {group, consistency_after_del_replica},
@@ -124,6 +127,9 @@ groups() ->
        consistency_after_restart_2_ram,
        consistency_after_restart_2_disc,
        consistency_after_restart_2_disc_only]},
+     {consistency_after_isolated_restart, [],
+      [consistency_after_isolated_restart_2_nodes,
+       consistency_after_isolated_restart_3_nodes]},
      {consistency_after_dump_tables, [],
       [consistency_after_dump_tables_1_ram,
        consistency_after_dump_tables_2_ram]},
@@ -389,6 +395,171 @@ consistency_after_restart(ReplicaType, NodeConfig, Config) ->
     mnesia_tpcb:stop(),
     ?match(ok, mnesia_tpcb:verify_tabs()),
     ?verify_mnesia(Nodes, []).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+consistency_after_isolated_restart_2_nodes(suite) -> [];
+consistency_after_isolated_restart_2_nodes(Config) when is_list(Config) ->
+    [Node1, Node2] = Nodes = ?acquire_nodes(2, Config),
+
+    N = 10,
+
+    ?match({atomic, ok}, mnesia:create_table(ram, [{ram_copies, Nodes}])),
+    ?match(ok, mnesia:sync_dirty(fun() ->
+        [mnesia:write({ram, K, K}) || K <- lists:seq(1, N)], ok end)),
+
+    case mnesia_test_lib:diskless(Config) of
+        true ->
+            ok;
+        false ->
+            ?match({atomic, ok}, mnesia:create_table(disc, [{disc_copies, Nodes}])),
+            ?match(ok, mnesia:sync_dirty(fun() ->
+                [mnesia:write({disc, K, K}) || K <- lists:seq(1, N)], ok end)),
+            ?match({atomic, ok}, mnesia:create_table(disc_only, [{disc_only_copies, Nodes}])),
+            ?match(ok, mnesia:sync_dirty(fun() ->
+                [mnesia:write({disc_only, K, K}) || K <- lists:seq(1, N)], ok end))
+    end,
+
+    ?match([], mnesia_test_lib:kill_mnesia([Node1])),
+
+    OldCookie = erlang:get_cookie(),
+    P2 = mnesia_test_lib:get_peer_ref(Node2),
+    ?match(true, peer:call(P2, erlang, set_cookie, [invalid_cookie])),
+    try
+        ?match(true, peer:call(P2, net_kernel, disconnect, [Node1])),
+
+        case mnesia_test_lib:diskless(Config) of
+            true ->
+                ?match(ok, mnesia:start([{extra_db_nodes, [Node2]}])),
+                ?match({timeout, [ram]}, mnesia:wait_for_tables([ram], 5000));
+            false ->
+                ?match(ok, mnesia:start()),
+                ?match({timeout, [ram, disc, disc_only]}, mnesia:wait_for_tables([ram, disc, disc_only], 5000))
+        end,
+
+        ?match(true, peer:call(P2, erlang, set_cookie, [OldCookie])),
+        ?match(pong, peer:call(P2, net_adm, ping, [Node1])),
+
+        ?match({ok, _}, mnesia_controller:connect_nodes(Nodes)),
+        case mnesia_test_lib:diskless(Config) of
+            true ->
+                ?match({[ok, ok], []}, rpc:multicall(Nodes, mnesia, wait_for_tables, [[ram], 5000]));
+            false ->
+                ?match({[ok, ok], []}, rpc:multicall(Nodes, mnesia, wait_for_tables, [[ram, disc, disc_only], 5000]))
+        end,
+
+        RamPat = [{{ram, '_', '_'}, [], ['$_']}],
+        ExpectedRam = sets:from_list([{ram, K, K} || K <- lists:seq(1, N)]),
+        {[ActualRamN1, ActualRamN2], []} = rpc:multicall(Nodes, mnesia, dirty_select, [ram, RamPat]),
+        ?match(ExpectedRam, sets:from_list(ActualRamN1)),
+        ?match(ExpectedRam, sets:from_list(ActualRamN2)),
+
+        case mnesia_test_lib:diskless(Config) of
+            true ->
+                ok;
+            false ->
+                DiscPat = [{{disc, '_', '_'}, [], ['$_']}],
+                ExpectedDisc = sets:from_list([{disc, K, K} || K <- lists:seq(1, N)]),
+                {[ActualDiscN1, ActualDiscN2], []} = rpc:multicall(Nodes, mnesia, dirty_select, [disc, DiscPat]),
+                ?match(ExpectedDisc, sets:from_list(ActualDiscN1)),
+                ?match(ExpectedDisc, sets:from_list(ActualDiscN2)),
+
+                DiscOnlyPat = [{{disc_only, '_', '_'}, [], ['$_']}],
+                ExpectedDiscOnly = sets:from_list([{disc_only, K, K} || K <- lists:seq(1, N)]),
+                {[ActualDiscOnlyN1, ActualDiscOnlyN2], []} = rpc:multicall(Nodes, mnesia, dirty_select, [disc_only, DiscOnlyPat]),
+                ?match(ExpectedDiscOnly, sets:from_list(ActualDiscOnlyN1)),
+                ?match(ExpectedDiscOnly, sets:from_list(ActualDiscOnlyN2))
+        end
+    after
+        ?match(true, peer:call(P2, erlang, set_cookie, [OldCookie]))
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+consistency_after_isolated_restart_3_nodes(suite) -> [];
+consistency_after_isolated_restart_3_nodes(Config) when is_list(Config) ->
+    [Node1, Node2, Node3] = Nodes = ?acquire_nodes(3, Config),
+
+    TableNodes = [Node2, Node3],
+    N = 10,
+
+    ?match({atomic, ok}, mnesia:create_table(ram, [{ram_copies, TableNodes}])),
+    ?match(ok, mnesia:sync_dirty(fun() ->
+        [mnesia:write({ram, K, K}) || K <- lists:seq(1, N)], ok end)),
+
+    case mnesia_test_lib:diskless(Config) of
+        true ->
+            ok;
+        false ->
+            ?match({atomic, ok}, mnesia:create_table(disc, [{disc_copies, TableNodes}])),
+            ?match(ok, mnesia:sync_dirty(fun() ->
+                [mnesia:write({disc, K, K}) || K <- lists:seq(1, N)], ok end)),
+            ?match({atomic, ok}, mnesia:create_table(disc_only, [{disc_only_copies, TableNodes}])),
+            ?match(ok, mnesia:sync_dirty(fun() ->
+                [mnesia:write({disc_only, K, K}) || K <- lists:seq(1, N)], ok end))
+    end,
+
+    ?match([], mnesia_test_lib:kill_mnesia([Node2])),
+
+    OldCookie = erlang:get_cookie(),
+    P2 = mnesia_test_lib:get_peer_ref(Node2),
+    P3 = mnesia_test_lib:get_peer_ref(Node3),
+    ?match(true, peer:call(P2, erlang, set_cookie, [invalid_cookie1])),
+    ?match(true, peer:call(P3, erlang, set_cookie, [invalid_cookie2])),
+    try
+        ?match(true, peer:call(P3, net_kernel, disconnect, [Node2])),
+        %% Global could already have disconnected, ignore return value
+        peer:call(P3, net_kernel, disconnect, [Node1]),
+
+        ?match(true, peer:call(P2, erlang, set_cookie, [OldCookie])),
+        ?match(pong, net_adm:ping(Node2)),
+        case mnesia_test_lib:diskless(Config) of
+            true ->
+                ?match(ok, rpc:call(Node2, mnesia, start, [[{extra_db_nodes, [Node1, Node3]}]])),
+                ?match({timeout, [ram]}, rpc:call(Node2, mnesia, wait_for_tables, [[ram], 5000]));
+            false ->
+                ?match(ok, rpc:call(Node2, mnesia, start, [])),
+                ?match({timeout, [ram, disc, disc_only]}, rpc:call(Node2, mnesia, wait_for_tables, [[ram, disc, disc_only], 5000]))
+        end,
+
+        ?match(true, peer:call(P3, erlang, set_cookie, [OldCookie])),
+        ?match(pong, peer:call(P3, net_adm, ping, [Node1])),
+        ?match(pong, peer:call(P3, net_adm, ping, [Node2])),
+
+        ?match({ok, _}, mnesia_controller:connect_nodes(Nodes)),
+        case mnesia_test_lib:diskless(Config) of
+            true ->
+                ?match({[ok, ok], []}, rpc:multicall(TableNodes, mnesia, wait_for_tables, [[ram], 5000]));
+            false ->
+                ?match({[ok, ok], []}, rpc:multicall(TableNodes, mnesia, wait_for_tables, [[ram, disc, disc_only], 5000]))
+        end,
+
+        RamPat = [{{ram, '_', '_'}, [], ['$_']}],
+        ExpectedRam = sets:from_list([{ram, K, K} || K <- lists:seq(1, N)]),
+        {[ActualRamN2, ActualRamN3], []} = rpc:multicall(TableNodes, mnesia, dirty_select, [ram, RamPat]),
+        ?match(ExpectedRam, sets:from_list(ActualRamN2)),
+        ?match(ExpectedRam, sets:from_list(ActualRamN3)),
+
+        case mnesia_test_lib:diskless(Config) of
+            true ->
+                ok;
+            false ->
+                DiscPat = [{{disc, '_', '_'}, [], ['$_']}],
+                ExpectedDisc = sets:from_list([{disc, K, K} || K <- lists:seq(1, N)]),
+                {[ActualDiscN2, ActualDiscN3], []} = rpc:multicall(TableNodes, mnesia, dirty_select, [disc, DiscPat]),
+                ?match(ExpectedDisc, sets:from_list(ActualDiscN2)),
+                ?match(ExpectedDisc, sets:from_list(ActualDiscN3)),
+
+                DiscOnlyPat = [{{disc_only, '_', '_'}, [], ['$_']}],
+                ExpectedDiscOnly = sets:from_list([{disc_only, K, K} || K <- lists:seq(1, N)]),
+                {[ActualDiscOnlyN2, ActualDiscOnlyN3], []} = rpc:multicall(TableNodes, mnesia, dirty_select, [disc_only, DiscOnlyPat]),
+                ?match(ExpectedDiscOnly, sets:from_list(ActualDiscOnlyN2)),
+                ?match(ExpectedDiscOnly, sets:from_list(ActualDiscOnlyN3))
+        end
+    after
+        ?match(true, peer:call(P2, erlang, set_cookie, [OldCookie])),
+        ?match(true, peer:call(P3, erlang, set_cookie, [OldCookie]))
+    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/lib/mnesia/test/mnesia_consistency_test.erl
+++ b/lib/mnesia/test/mnesia_consistency_test.erl
@@ -37,6 +37,8 @@
          consistency_after_restart_2_disc_only/1,
          consistency_after_isolated_restart_2_nodes/1,
          consistency_after_isolated_restart_3_nodes/1,
+         consistency_after_isolated_restart_local_master_3_nodes/1,
+         consistency_after_isolated_restart_remote_master_3_nodes/1,
          consistency_after_dump_tables_1_ram/1,
          consistency_after_dump_tables_2_ram/1,
          consistency_after_add_replica_2_ram/1,
@@ -129,7 +131,9 @@ groups() ->
        consistency_after_restart_2_disc_only]},
      {consistency_after_isolated_restart, [],
       [consistency_after_isolated_restart_2_nodes,
-       consistency_after_isolated_restart_3_nodes]},
+       consistency_after_isolated_restart_3_nodes,
+       consistency_after_isolated_restart_local_master_3_nodes,
+       consistency_after_isolated_restart_remote_master_3_nodes]},
      {consistency_after_dump_tables, [],
       [consistency_after_dump_tables_1_ram,
        consistency_after_dump_tables_2_ram]},
@@ -560,6 +564,180 @@ consistency_after_isolated_restart_3_nodes(Config) when is_list(Config) ->
         ?match(true, peer:call(P2, erlang, set_cookie, [OldCookie])),
         ?match(true, peer:call(P3, erlang, set_cookie, [OldCookie]))
     end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+consistency_after_isolated_restart_local_master_3_nodes(suite) -> [];
+consistency_after_isolated_restart_local_master_3_nodes(Config) when is_list(Config) ->
+    case mnesia_test_lib:diskless(Config) of
+        true ->
+            ?skip("Master node settings do not survive a diskless restart", []);
+        false ->
+            consistency_after_isolated_restart_local_master_3_nodes_do(Config)
+    end.
+
+consistency_after_isolated_restart_local_master_3_nodes_do(Config) ->
+    [Coordinator, Node2, Node3] = Nodes = ?acquire_nodes(3, Config),
+    TableNodes = [Node2, Node3],
+    LocalMaster = lists:min(TableNodes),
+    [RemoteNode] = TableNodes -- [LocalMaster],
+
+    %% GIVEN three tables replicated across two storage nodes, where one node
+    %% is configured as its own master and a third node coordinates the test.
+    Tabs = create_isolated_restart_tables(TableNodes),
+    [?match(ok, rpc:call(LocalMaster, mnesia, set_master_nodes,
+                         [Tab, [LocalMaster]])) || Tab <- Tabs],
+
+    %% WHEN the local master is stopped, isolated from the other storage node,
+    %% and restarted while remaining connected to the coordinator.
+    ?match([], mnesia_test_lib:kill_mnesia([LocalMaster])),
+    OldCookie = erlang:get_cookie(),
+    PLocalMaster = mnesia_test_lib:get_peer_ref(LocalMaster),
+    PRemote = mnesia_test_lib:get_peer_ref(RemoteNode),
+    ?match(true, peer:call(PLocalMaster, erlang, set_cookie, [invalid_cookie1])),
+    ?match(true, peer:call(PRemote, erlang, set_cookie, [invalid_cookie2])),
+    try
+        ?match(true, peer:call(PRemote, net_kernel, disconnect, [LocalMaster])),
+        %% Global could already have disconnected, ignore the return value.
+        peer:call(PRemote, net_kernel, disconnect, [Coordinator]),
+        ?match(true, peer:call(PLocalMaster, erlang, set_cookie, [OldCookie])),
+        ?match(pong, net_adm:ping(LocalMaster)),
+        ?match(ok, rpc:call(LocalMaster, mnesia, start, [])),
+
+        %% THEN it loads all local copies because it is the configured master:
+        %% RAM is empty after restart and disk-backed copies retain their data.
+        ?match(ok, rpc:call(LocalMaster, mnesia, wait_for_tables, [Tabs, 5000])),
+        [?match(local_master,
+                rpc:call(LocalMaster, mnesia, table_info,
+                         [Tab, load_reason])) || Tab <- Tabs],
+        assert_table_records(LocalMaster, ram, []),
+        assert_table_records(LocalMaster, disc, expected_table_records(disc)),
+        assert_table_records(LocalMaster, disc_only,
+                             expected_table_records(disc_only)),
+
+        %% WHEN the partition is healed.
+        ?match(true, peer:call(PRemote, erlang, set_cookie, [OldCookie])),
+        ?match(pong, peer:call(PRemote, net_adm, ping, [Coordinator])),
+        ?match(pong, peer:call(PRemote, net_adm, ping, [LocalMaster])),
+        ?match({ok, _}, mnesia_controller:connect_nodes(Nodes)),
+        ?match({[ok, ok], []},
+               rpc:multicall(TableNodes, mnesia, wait_for_tables,
+                             [Tabs, 5000])),
+
+        %% THEN both storage nodes converge. Clear RAM through the local master
+        %% so its empty restart state is replicated to the other storage node.
+        ?match({atomic, ok}, rpc:call(LocalMaster, mnesia, clear_table, [ram])),
+        [assert_table_records(Node, ram, []) || Node <- TableNodes],
+        [assert_table_records(Node, disc, expected_table_records(disc)) ||
+            Node <- TableNodes],
+        [assert_table_records(Node, disc_only,
+                              expected_table_records(disc_only)) ||
+            Node <- TableNodes],
+        ?verify_mnesia(Nodes, [])
+    after
+        ?match(true, peer:call(PLocalMaster, erlang, set_cookie, [OldCookie])),
+        ?match(true, peer:call(PRemote, erlang, set_cookie, [OldCookie]))
+    end.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+consistency_after_isolated_restart_remote_master_3_nodes(suite) -> [];
+consistency_after_isolated_restart_remote_master_3_nodes(Config) when is_list(Config) ->
+    case mnesia_test_lib:diskless(Config) of
+        true ->
+            ?skip("Master node settings do not survive a diskless restart", []);
+        false ->
+            consistency_after_isolated_restart_remote_master_3_nodes_do(Config)
+    end.
+
+consistency_after_isolated_restart_remote_master_3_nodes_do(Config) ->
+    [Coordinator, Node2, Node3] = Nodes = ?acquire_nodes(3, Config),
+    TableNodes = [Node2, Node3],
+    ElectionNode = lists:min(TableNodes),
+    [MasterNode] = TableNodes -- [ElectionNode],
+
+    %% GIVEN three tables replicated across two storage nodes, where only
+    %% ElectionNode has the other storage node configured as its master. A
+    %% third node coordinates the test without holding any table copies.
+    Tabs = create_isolated_restart_tables(TableNodes),
+    [?match(ok, rpc:call(ElectionNode, mnesia, set_master_nodes,
+                         [Tab, [MasterNode]])) || Tab <- Tabs],
+
+    %% Stopping MasterNode first prevents it from recording ElectionNode as
+    %% down, so each storage node will wait for the other after restart.
+    ?match([], mnesia_test_lib:kill_mnesia([MasterNode])),
+    ?match([], mnesia_test_lib:kill_mnesia([ElectionNode])),
+
+    OldCookie = erlang:get_cookie(),
+    PElection = mnesia_test_lib:get_peer_ref(ElectionNode),
+    PMaster = mnesia_test_lib:get_peer_ref(MasterNode),
+    ?match(true, peer:call(PElection, erlang, set_cookie, [invalid_cookie1])),
+    ?match(true, peer:call(PMaster, erlang, set_cookie, [invalid_cookie2])),
+    try
+        %% WHEN both storage nodes restart while isolated from each other.
+        ?match(true, peer:call(PMaster, net_kernel, disconnect,
+                               [ElectionNode])),
+        %% Global could already have disconnected, ignore the return value.
+        peer:call(PMaster, net_kernel, disconnect, [Coordinator]),
+        ?match(true, peer:call(PElection, erlang, set_cookie, [OldCookie])),
+        ?match(pong, net_adm:ping(ElectionNode)),
+        ?match(ok, rpc:call(ElectionNode, mnesia, start, [])),
+        ?match(ok, peer:call(PMaster, mnesia, start, [])),
+
+        %% THEN MasterNode waits for ElectionNode's better copy, while
+        %% ElectionNode waits for its configured remote master.
+        ?match({timeout, Tabs},
+               rpc:call(ElectionNode, mnesia, wait_for_tables,
+                        [Tabs, 1000])),
+        ?match({timeout, Tabs},
+               peer:call(PMaster, mnesia, wait_for_tables,
+                         [Tabs, 1000])),
+
+        %% WHEN the partition is healed.
+        ?match(true, peer:call(PMaster, erlang, set_cookie, [OldCookie])),
+        ?match(pong, peer:call(PMaster, net_adm, ping, [Coordinator])),
+        ?match(pong, peer:call(PMaster, net_adm, ping, [ElectionNode])),
+        ?match({ok, _}, mnesia_controller:connect_nodes(Nodes)),
+        ?match({[ok, ok], []},
+               rpc:multicall(TableNodes, mnesia, wait_for_tables,
+                             [Tabs, 5000])),
+
+        %% THEN ElectionNode asks its configured master to load the orphan
+        %% tables, and both storage nodes converge on the expected contents.
+        [?match({adopt_orphan, ElectionNode},
+                rpc:call(MasterNode, mnesia, table_info,
+                         [Tab, load_reason])) || Tab <- Tabs],
+        [assert_table_records(Node, ram, []) || Node <- TableNodes],
+        [assert_table_records(Node, disc, expected_table_records(disc)) ||
+            Node <- TableNodes],
+        [assert_table_records(Node, disc_only,
+                              expected_table_records(disc_only)) ||
+            Node <- TableNodes],
+        ?verify_mnesia(Nodes, [])
+    after
+        ?match(true, peer:call(PElection, erlang, set_cookie, [OldCookie])),
+        ?match(true, peer:call(PMaster, erlang, set_cookie, [OldCookie]))
+    end.
+
+create_isolated_restart_tables(Nodes) ->
+    Tabs = [{ram, ram_copies},
+            {disc, disc_copies},
+            {disc_only, disc_only_copies}],
+    [?match({atomic, ok}, mnesia:create_table(Tab, [{Storage, Nodes}])) ||
+        {Tab, Storage} <- Tabs],
+    [?match(ok, mnesia:sync_dirty(fun() ->
+        [mnesia:write(Record) || Record <- expected_table_records(Tab)], ok
+    end)) || {Tab, _} <- Tabs],
+    [Tab || {Tab, _} <- Tabs].
+
+expected_table_records(Tab) ->
+    [{Tab, K, K} || K <- lists:seq(1, 10)].
+
+assert_table_records(Node, Tab, Expected) ->
+    Pattern = [{{Tab, '_', '_'}, [], ['$_']}],
+    Actual = rpc:call(Node, mnesia, dirty_select, [Tab, Pattern]),
+    ExpectedSet = sets:from_list(Expected),
+    ?match(ExpectedSet, sets:from_list(Actual)).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/lib/mnesia/test/mnesia_consistency_test.erl
+++ b/lib/mnesia/test/mnesia_consistency_test.erl
@@ -39,6 +39,15 @@
          consistency_after_isolated_restart_3_nodes/1,
          consistency_after_isolated_restart_local_master_3_nodes/1,
          consistency_after_isolated_restart_remote_master_3_nodes/1,
+         master_nodes_ignores_active_non_master_3_nodes/1,
+         master_nodes_multiple_remote_masters_3_nodes/1,
+         master_nodes_clear_while_waiting_3_nodes/1,
+         master_nodes_expand_while_waiting_3_nodes/1,
+         master_nodes_mutual_remote_masters_3_nodes/1,
+         master_nodes_remote_master_loads_locally_3_nodes/1,
+         master_nodes_mixed_storage_orphan_master_3_nodes/1,
+         master_nodes_local_member_precedence_3_nodes/1,
+         master_nodes_two_local_masters_partitioned_3_nodes/1,
          consistency_after_dump_tables_1_ram/1,
          consistency_after_dump_tables_2_ram/1,
          consistency_after_add_replica_2_ram/1,
@@ -99,7 +108,33 @@
 
 -export([change_tab/3]).
 
+-import(mnesia_test_lib,
+        [mnesia_node_call/2,
+         mnesia_node_set_masters/3,
+         mnesia_node_assert_master_policies/2,
+         mnesia_node_stop/2,
+         mnesia_node_assert_down_logged/2,
+         mnesia_node_kill/2,
+         mnesia_node_start/1,
+         mnesia_node_set_partitions/1,
+         mnesia_node_set_connected_groups/1,
+         mnesia_node_assert_topology/1,
+         mnesia_node_assert_running/1,
+         mnesia_node_connect/1,
+         mnesia_node_assert_active_replica/3,
+         mnesia_node_assert_waiting/2,
+         mnesia_node_assert_locally_readable/2,
+         mnesia_node_assert_loaded_from/4,
+         mnesia_node_assert_load_reason/3,
+         mnesia_node_assert_local_records/3,
+         mnesia_node_assert_eventually/2,
+         mnesia_node_with_observer/4,
+         mnesia_node_get_observed_events/2,
+         mnesia_node_get_orphan_load_requests/3,
+         mnesia_node_has_inconsistency_event/3]).
+
 -include("mnesia_test_lib.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 init_per_testcase(Func, Conf) ->
     mnesia_test_lib:init_per_testcase(Func, Conf).
@@ -133,7 +168,16 @@ groups() ->
       [consistency_after_isolated_restart_2_nodes,
        consistency_after_isolated_restart_3_nodes,
        consistency_after_isolated_restart_local_master_3_nodes,
-       consistency_after_isolated_restart_remote_master_3_nodes]},
+       consistency_after_isolated_restart_remote_master_3_nodes,
+       master_nodes_ignores_active_non_master_3_nodes,
+       master_nodes_multiple_remote_masters_3_nodes,
+       master_nodes_clear_while_waiting_3_nodes,
+       master_nodes_expand_while_waiting_3_nodes,
+       master_nodes_mutual_remote_masters_3_nodes,
+       master_nodes_remote_master_loads_locally_3_nodes,
+       master_nodes_mixed_storage_orphan_master_3_nodes,
+       master_nodes_local_member_precedence_3_nodes,
+       master_nodes_two_local_masters_partitioned_3_nodes]},
      {consistency_after_dump_tables, [],
       [consistency_after_dump_tables_1_ram,
        consistency_after_dump_tables_2_ram]},
@@ -569,175 +613,302 @@ consistency_after_isolated_restart_3_nodes(Config) when is_list(Config) ->
 
 consistency_after_isolated_restart_local_master_3_nodes(suite) -> [];
 consistency_after_isolated_restart_local_master_3_nodes(Config) when is_list(Config) ->
-    case mnesia_test_lib:diskless(Config) of
-        true ->
-            ?skip("Master node settings do not survive a diskless restart", []);
-        false ->
-            consistency_after_isolated_restart_local_master_3_nodes_do(Config)
-    end.
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN A < B, two replicas of each storage type, and coordinator C
+        %% without table copies. A trusts only itself; B has no masters.
+        Tabs = create_tables([A, B]),
+        mnesia_node_set_masters(A, Tabs, [A]),
+        mnesia_node_assert_master_policies(Tabs, [{A, [A]}, {B, []}, {C, []}]),
 
-consistency_after_isolated_restart_local_master_3_nodes_do(Config) ->
-    [Coordinator, Node2, Node3] = Nodes = ?acquire_nodes(3, Config),
-    TableNodes = [Node2, Node3],
-    LocalMaster = lists:min(TableNodes),
-    [RemoteNode] = TableNodes -- [LocalMaster],
+        %% WHEN A's Mnesia is abruptly killed, then restarted in {A,C} | {B}.
+        %% Keep crash recovery distinct from the graceful-stop master cases.
+        mnesia_node_kill(A, [B, C]),
+        mnesia_node_set_partitions([[A, C], [B]]),
+        mnesia_node_start(A),
+        mnesia_node_assert_master_policies(Tabs, [{A, [A]}, {B, []}, {C, []}]),
+        ?assertEqual(false, mnesia_node_call(A, fun() ->
+            mnesia_recover:has_mnesia_down(B)
+        end)),
 
-    %% GIVEN three tables replicated across two storage nodes, where one node
-    %% is configured as its own master and a third node coordinates the test.
-    Tabs = create_isolated_restart_tables(TableNodes),
-    [?match(ok, rpc:call(LocalMaster, mnesia, set_master_nodes,
-                         [Tab, [LocalMaster]])) || Tab <- Tabs],
+        %% THEN A loads locally despite the potentially better live B.
+        %% Without a RAM dump, A's RAM is empty; its disk data survives.
+        mnesia_node_assert_loaded_from(A, Tabs, A, fun restart_records/1),
+        mnesia_node_assert_load_reason(A, Tabs, local_master),
+        mnesia_node_assert_locally_readable(B, Tabs),
+        mnesia_node_assert_local_records(B, Tabs, fun expected_records/1),
 
-    %% WHEN the local master is stopped, isolated from the other storage node,
-    %% and restarted while remaining connected to the coordinator.
-    ?match([], mnesia_test_lib:kill_mnesia([LocalMaster])),
-    OldCookie = erlang:get_cookie(),
-    PLocalMaster = mnesia_test_lib:get_peer_ref(LocalMaster),
-    PRemote = mnesia_test_lib:get_peer_ref(RemoteNode),
-    ?match(true, peer:call(PLocalMaster, erlang, set_cookie, [invalid_cookie1])),
-    ?match(true, peer:call(PRemote, erlang, set_cookie, [invalid_cookie2])),
-    try
-        ?match(true, peer:call(PRemote, net_kernel, disconnect, [LocalMaster])),
-        %% Global could already have disconnected, ignore the return value.
-        peer:call(PRemote, net_kernel, disconnect, [Coordinator]),
-        ?match(true, peer:call(PLocalMaster, erlang, set_cookie, [OldCookie])),
-        ?match(pong, net_adm:ping(LocalMaster)),
-        ?match(ok, rpc:call(LocalMaster, mnesia, start, [])),
+        %% WHEN the partition heals, THEN already-loaded copies are retained:
+        %% A still has empty RAM, while B still has the original RAM records.
+        mnesia_node_set_connected_groups([[A, B, C]]),
+        mnesia_node_connect([A, B, C]),
+        mnesia_node_assert_loaded_from(A, Tabs, A, fun restart_records/1),
+        mnesia_node_assert_locally_readable(B, Tabs),
+        mnesia_node_assert_local_records(B, Tabs, fun expected_records/1),
 
-        %% THEN it loads all local copies because it is the configured master:
-        %% RAM is empty after restart and disk-backed copies retain their data.
-        ?match(ok, rpc:call(LocalMaster, mnesia, wait_for_tables, [Tabs, 5000])),
-        [?match(local_master,
-                rpc:call(LocalMaster, mnesia, table_info,
-                         [Tab, load_reason])) || Tab <- Tabs],
-        assert_table_records(LocalMaster, ram, []),
-        assert_table_records(LocalMaster, disc, expected_table_records(disc)),
-        assert_table_records(LocalMaster, disc_only,
-                             expected_table_records(disc_only)),
-
-        %% WHEN the partition is healed.
-        ?match(true, peer:call(PRemote, erlang, set_cookie, [OldCookie])),
-        ?match(pong, peer:call(PRemote, net_adm, ping, [Coordinator])),
-        ?match(pong, peer:call(PRemote, net_adm, ping, [LocalMaster])),
-        ?match({ok, _}, mnesia_controller:connect_nodes(Nodes)),
-        ?match({[ok, ok], []},
-               rpc:multicall(TableNodes, mnesia, wait_for_tables,
-                             [Tabs, 5000])),
-
-        %% THEN both storage nodes converge. Clear RAM through the local master
-        %% so its empty restart state is replicated to the other storage node.
-        ?match({atomic, ok}, rpc:call(LocalMaster, mnesia, clear_table, [ram])),
-        [assert_table_records(Node, ram, []) || Node <- TableNodes],
-        [assert_table_records(Node, disc, expected_table_records(disc)) ||
-            Node <- TableNodes],
-        [assert_table_records(Node, disc_only,
-                              expected_table_records(disc_only)) ||
-            Node <- TableNodes],
-        ?verify_mnesia(Nodes, [])
-    after
-        ?match(true, peer:call(PLocalMaster, erlang, set_cookie, [OldCookie])),
-        ?match(true, peer:call(PRemote, erlang, set_cookie, [OldCookie]))
-    end.
+        %% Cleanup: clearing RAM replicates the empty state. This does not
+        %% assert automatic convergence with the live replica on reconnection.
+        ?assertEqual({atomic, ok}, mnesia_node_call(A, fun() ->
+            mnesia:clear_table(ram)
+        end)),
+        [mnesia_node_assert_local_records(N, Tabs, fun restart_records/1)
+         || N <- [A, B]]
+    end).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 consistency_after_isolated_restart_remote_master_3_nodes(suite) -> [];
 consistency_after_isolated_restart_remote_master_3_nodes(Config) when is_list(Config) ->
-    case mnesia_test_lib:diskless(Config) of
-        true ->
-            ?skip("Master node settings do not survive a diskless restart", []);
-        false ->
-            consistency_after_isolated_restart_remote_master_3_nodes_do(Config)
-    end.
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN A < B, two replicas of each storage type, and coordinator C
+        %% without table copies. Only A names B as its remote master.
+        Tabs = create_tables([A, B]),
+        mnesia_node_set_masters(A, Tabs, [B]),
+        mnesia_node_assert_master_policies(Tabs, [{A, [B]}, {B, []}, {C, []}]),
 
-consistency_after_isolated_restart_remote_master_3_nodes_do(Config) ->
-    [Coordinator, Node2, Node3] = Nodes = ?acquire_nodes(3, Config),
-    TableNodes = [Node2, Node3],
-    ElectionNode = lists:min(TableNodes),
-    [MasterNode] = TableNodes -- [ElectionNode],
+        %% WHEN B's Mnesia is abruptly killed before A's, then both restart
+        %% in {A,C} | {B}. B cannot have recorded A as down before its crash.
+        mnesia_node_kill(B, [A, C]),
+        mnesia_node_kill(A, [C]),
+        mnesia_node_set_partitions([[A, C], [B]]),
+        mnesia_node_start(A),
+        mnesia_node_start(B),
+        mnesia_node_assert_master_policies(Tabs, [{A, [B]}, {B, []}, {C, []}]),
+        ?assertEqual(false, mnesia_node_call(B, fun() ->
+            mnesia_recover:has_mnesia_down(A)
+        end)),
 
-    %% GIVEN three tables replicated across two storage nodes, where only
-    %% ElectionNode has the other storage node configured as its master. A
-    %% third node coordinates the test without holding any table copies.
-    Tabs = create_isolated_restart_tables(TableNodes),
-    [?match(ok, rpc:call(ElectionNode, mnesia, set_master_nodes,
-                         [Tab, [MasterNode]])) || Tab <- Tabs],
+        %% THEN B waits for A's potentially better copy, while A waits for B
+        %% under its master policy. Neither replica has loaded locally.
+        [mnesia_node_assert_waiting(N, Tabs) || N <- [A, B]],
 
-    %% Stopping MasterNode first prevents it from recording ElectionNode as
-    %% down, so each storage node will wait for the other after restart.
-    ?match([], mnesia_test_lib:kill_mnesia([MasterNode])),
-    ?match([], mnesia_test_lib:kill_mnesia([ElectionNode])),
+        %% WHEN the partition heals, THEN A delegates orphan loading to B.
+        %% B bootstraps locally and supplies A, including the RAM-only table.
+        mnesia_node_set_connected_groups([[A, B, C]]),
+        mnesia_node_connect([A, B, C]),
+        mnesia_node_assert_loaded_from(B, Tabs, B, fun restart_records/1),
+        mnesia_node_assert_load_reason(B, Tabs, {adopt_orphan, A}),
+        mnesia_node_assert_loaded_from(A, Tabs, B, fun restart_records/1),
+        mnesia_node_assert_master_policies(Tabs, [{A, [B]}, {B, []}, {C, []}])
+    end).
 
-    OldCookie = erlang:get_cookie(),
-    PElection = mnesia_test_lib:get_peer_ref(ElectionNode),
-    PMaster = mnesia_test_lib:get_peer_ref(MasterNode),
-    ?match(true, peer:call(PElection, erlang, set_cookie, [invalid_cookie1])),
-    ?match(true, peer:call(PMaster, erlang, set_cookie, [invalid_cookie2])),
-    try
-        %% WHEN both storage nodes restart while isolated from each other.
-        ?match(true, peer:call(PMaster, net_kernel, disconnect,
-                               [ElectionNode])),
-        %% Global could already have disconnected, ignore the return value.
-        peer:call(PMaster, net_kernel, disconnect, [Coordinator]),
-        ?match(true, peer:call(PElection, erlang, set_cookie, [OldCookie])),
-        ?match(pong, net_adm:ping(ElectionNode)),
-        ?match(ok, rpc:call(ElectionNode, mnesia, start, [])),
-        ?match(ok, peer:call(PMaster, mnesia, start, [])),
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-        %% THEN MasterNode waits for ElectionNode's better copy, while
-        %% ElectionNode waits for its configured remote master.
-        ?match({timeout, Tabs},
-               rpc:call(ElectionNode, mnesia, wait_for_tables,
-                        [Tabs, 1000])),
-        ?match({timeout, Tabs},
-               peer:call(PMaster, mnesia, wait_for_tables,
-                         [Tabs, 1000])),
+master_nodes_ignores_active_non_master_3_nodes(suite) -> [];
+master_nodes_ignores_active_non_master_3_nodes(Config) when is_list(Config) ->
+    run_active_source_case(Config, chain).
 
-        %% WHEN the partition is healed.
-        ?match(true, peer:call(PMaster, erlang, set_cookie, [OldCookie])),
-        ?match(pong, peer:call(PMaster, net_adm, ping, [Coordinator])),
-        ?match(pong, peer:call(PMaster, net_adm, ping, [ElectionNode])),
-        ?match({ok, _}, mnesia_controller:connect_nodes(Nodes)),
-        ?match({[ok, ok], []},
-               rpc:multicall(TableNodes, mnesia, wait_for_tables,
-                             [Tabs, 5000])),
+master_nodes_multiple_remote_masters_3_nodes(suite) -> [];
+master_nodes_multiple_remote_masters_3_nodes(Config) when is_list(Config) ->
+    run_active_source_case(Config, multiple).
 
-        %% THEN ElectionNode asks its configured master to load the orphan
-        %% tables, and both storage nodes converge on the expected contents.
-        [?match({adopt_orphan, ElectionNode},
-                rpc:call(MasterNode, mnesia, table_info,
-                         [Tab, load_reason])) || Tab <- Tabs],
-        [assert_table_records(Node, ram, []) || Node <- TableNodes],
-        [assert_table_records(Node, disc, expected_table_records(disc)) ||
-            Node <- TableNodes],
-        [assert_table_records(Node, disc_only,
-                              expected_table_records(disc_only)) ||
-            Node <- TableNodes],
-        ?verify_mnesia(Nodes, [])
-    after
-        ?match(true, peer:call(PElection, erlang, set_cookie, [OldCookie])),
-        ?match(true, peer:call(PMaster, erlang, set_cookie, [OldCookie]))
-    end.
+master_nodes_clear_while_waiting_3_nodes(suite) -> [];
+master_nodes_clear_while_waiting_3_nodes(Config) when is_list(Config) ->
+    run_active_source_case(Config, clear).
 
-create_isolated_restart_tables(Nodes) ->
-    Tabs = [{ram, ram_copies},
-            {disc, disc_copies},
-            {disc_only, disc_only_copies}],
-    [?match({atomic, ok}, mnesia:create_table(Tab, [{Storage, Nodes}])) ||
-        {Tab, Storage} <- Tabs],
-    [?match(ok, mnesia:sync_dirty(fun() ->
-        [mnesia:write(Record) || Record <- expected_table_records(Tab)], ok
-    end)) || {Tab, _} <- Tabs],
-    [Tab || {Tab, _} <- Tabs].
+master_nodes_expand_while_waiting_3_nodes(suite) -> [];
+master_nodes_expand_while_waiting_3_nodes(Config) when is_list(Config) ->
+    run_active_source_case(Config, expand).
 
-expected_table_records(Tab) ->
-    [{Tab, K, K} || K <- lists:seq(1, 10)].
+master_nodes_mutual_remote_masters_3_nodes(suite) -> [];
+master_nodes_mutual_remote_masters_3_nodes(Config) when is_list(Config) ->
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN A < B, two replicas that each trust only the other, and a
+        %% coordinator without table copies. Neither may bootstrap locally.
+        Tabs = create_tables([A, B]),
+        mnesia_node_set_masters(A, Tabs, [B]),
+        mnesia_node_set_masters(B, Tabs, [A]),
+        mnesia_node_stop(B, [A, C]),
+        mnesia_node_stop(A, [C]),
+        mnesia_node_set_partitions([[A, C], [B]]),
+        mnesia_node_start(A),
+        mnesia_node_start(B),
+        mnesia_node_assert_master_policies(Tabs, [{A, [B]}, {B, [A]}, {C, []}]),
+        [mnesia_node_assert_waiting(N, Tabs) || N <- [A, B]],
+        mnesia_node_with_observer(A, [{mnesia_late_loader, maybe_async_late_disc_load, 3}],
+                                  false, fun(TraceA) ->
+            mnesia_node_with_observer(B, [{mnesia_controller, schedule_late_disc_load, 2}],
+                                      false, fun(TraceB) ->
+                %% WHEN all nodes reconnect, A asks B to adopt the orphans.
+                mnesia_node_set_connected_groups([[A, B, C]]),
+                mnesia_node_connect([A, B, C]),
+                mnesia_node_assert_running([A, B, C]),
+                mnesia_node_assert_eventually(fun() ->
+                    Requests = mnesia_node_get_orphan_load_requests(A, TraceA, A),
+                    lists:all(fun(Tab) -> lists:member({B, Tab}, Requests) end,
+                              Tabs)
+                end, {orphan_requests, A, B}),
+                %% THEN B processes the request but schedules no tables:
+                %% its own master list excludes itself.
+                mnesia_node_assert_eventually(fun() ->
+                    lists:any(fun
+                        ({trace, _, call,
+                          {mnesia_controller, schedule_late_disc_load,
+                           [[], {adopt_orphan, Origin}]}}) -> Origin == A;
+                        (_) -> false
+                    end, mnesia_node_get_observed_events(B, TraceB))
+                end, {rejected_orphans, B}),
+                [mnesia_node_assert_waiting(N, Tabs) || N <- [A, B]]
+            end)
+        end),
+        %% Cleanup: WHEN B is explicitly made an authority and restarted,
+        %% THEN it bootstraps locally and supplies the waiting A.
+        mnesia_node_stop(B, [A, C]),
+        mnesia_node_set_masters(B, Tabs, [B]),
+        mnesia_node_start(B),
+        mnesia_node_assert_loaded_from(B, Tabs, B, fun restart_records/1),
+        mnesia_node_assert_load_reason(B, Tabs, local_master),
+        mnesia_node_assert_loaded_from(A, Tabs, B, fun restart_records/1)
+    end).
 
-assert_table_records(Node, Tab, Expected) ->
-    Pattern = [{{Tab, '_', '_'}, [], ['$_']}],
-    Actual = rpc:call(Node, mnesia, dirty_select, [Tab, Pattern]),
-    ExpectedSet = sets:from_list(Expected),
-    ?match(ExpectedSet, sets:from_list(Actual)).
+master_nodes_remote_master_loads_locally_3_nodes(suite) -> [];
+master_nodes_remote_master_loads_locally_3_nodes(Config) when is_list(Config) ->
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN A trusts B and B trusts itself, with two replicas and a
+        %% neutral coordinator. The policy is local to each node.
+        Tabs = create_tables([A, B]),
+        mnesia_node_set_masters(A, Tabs, [B]),
+        mnesia_node_set_masters(B, Tabs, [B]),
+        mnesia_node_stop(B, [A, C]),
+        mnesia_node_stop(A, [C]),
+        mnesia_node_set_partitions([[A, C], [B]]),
+        %% WHEN both replicas restart on opposite sides of the partition.
+        mnesia_node_start(A),
+        mnesia_node_start(B),
+        mnesia_node_assert_master_policies(Tabs, [{A, [B]}, {B, [B]}, {C, []}]),
+        %% THEN B loads locally while A waits for its remote master.
+        mnesia_node_assert_waiting(A, Tabs),
+        mnesia_node_assert_loaded_from(B, Tabs, B, fun restart_records/1),
+        mnesia_node_assert_load_reason(B, Tabs, local_master),
+        %% WHEN the partition heals, THEN A loads from the already-active B.
+        mnesia_node_set_connected_groups([[A, B, C]]),
+        mnesia_node_connect([A, B, C]),
+        mnesia_node_assert_loaded_from(A, Tabs, B, fun restart_records/1),
+        mnesia_node_assert_local_records(B, Tabs, fun restart_records/1)
+    end).
+
+master_nodes_mixed_storage_orphan_master_3_nodes(suite) -> [];
+master_nodes_mixed_storage_orphan_master_3_nodes(Config) when is_list(Config) ->
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN A < B with disk copies on A/B and RAM on C. Both disk
+        %% storage variants exercise exclusion of the RAM master from adoption.
+        Tabs = create_tables(
+                 [{mixed_disc, [{disc_copies, [A, B]}, {ram_copies, [C]}]},
+                  {mixed_disc_only,
+                   [{disc_only_copies, [A, B]}, {ram_copies, [C]}]}], [A, B, C]),
+        mnesia_node_set_masters(A, Tabs, [B, C]),
+        mnesia_node_stop(B, [A, C]),
+        mnesia_node_stop(C, [A]),
+        mnesia_node_stop(A, []),
+        mnesia_node_set_partitions([[A], [B], [C]]),
+        [mnesia_node_start(N) || N <- [A, B, C]],
+        mnesia_node_assert_master_policies(Tabs, [{A, [B, C]}, {B, []}, {C, []}]),
+        [mnesia_node_assert_waiting(N, Tabs) || N <- [A, B, C]],
+        ?assertEqual(false, mnesia_node_call(B, fun() ->
+            mnesia_recover:has_mnesia_down(A)
+        end)),
+        ?assertEqual(false, mnesia_node_call(C, fun() ->
+            mnesia_recover:has_mnesia_down(A)
+        end)),
+        mnesia_node_with_observer(A, [{mnesia_late_loader, maybe_async_late_disc_load, 3}],
+                                  false, fun(Trace) ->
+            %% WHEN the partition heals, observe the entire adoption pass.
+            mnesia_node_set_connected_groups([[A, B, C]]),
+            mnesia_node_connect([A, B, C]),
+            mnesia_node_assert_running([A, B, C]),
+            mnesia_node_assert_loaded_from(B, Tabs, B, fun expected_records/1),
+            mnesia_node_assert_load_reason(B, Tabs, {adopt_orphan, A}),
+            mnesia_node_assert_loaded_from(A, Tabs, B, fun expected_records/1),
+            mnesia_node_assert_locally_readable(C, Tabs),
+            [begin
+                 Source = mnesia_node_call(C, fun() -> mnesia:table_info(Tab, load_node) end),
+                 ?assert(lists:member(Source, [A, B]))
+             end || Tab <- Tabs],
+            mnesia_node_assert_local_records(C, Tabs, fun expected_records/1),
+            %% THEN B received every orphan, but C received none. A controller
+            %% barrier plus trace delivery covers all targets, not just the
+            %% first request that happened to produce a successful load.
+            mnesia_node_call(A, fun() ->
+                %% SYNC Barrier.
+                _ = sys:get_status(mnesia_controller),
+                Ref = erlang:trace_delivered(whereis(mnesia_controller)),
+                receive {trace_delivered, _, Ref} -> ok after 5000 -> error(trace_timeout) end
+            end),
+            Requests = mnesia_node_get_orphan_load_requests(A, Trace, A),
+            ?assertEqual(lists:sort([{B, Tab} || Tab <- Tabs]),
+                         lists:usort(Requests))
+        end)
+    end).
+
+master_nodes_local_member_precedence_3_nodes(suite) -> [];
+master_nodes_local_member_precedence_3_nodes(Config) when is_list(Config) ->
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN A trusts [B,A], not just [A], and stops while B is still live.
+        Tabs = create_tables([A, B]),
+        mnesia_node_set_masters(A, Tabs, [B, A]),
+        mnesia_node_stop(A, [B, C]),
+        mnesia_node_set_partitions([[A, C], [B]]),
+        %% WHEN A restarts without access to the potentially better B.
+        mnesia_node_start(A),
+        ?assertEqual(false, mnesia_node_call(A, fun() ->
+            mnesia_recover:has_mnesia_down(B)
+        end)),
+        mnesia_node_assert_master_policies(Tabs, [{A, [B, A]}, {B, []}, {C, []}]),
+        %% THEN local membership wins regardless of list order. RAM is empty
+        %% on A while the still-live B retains old data; disk data remains intact.
+        mnesia_node_assert_loaded_from(A, Tabs, A, fun restart_records/1),
+        mnesia_node_assert_load_reason(A, Tabs, local_master),
+        mnesia_node_assert_local_records(B, Tabs, fun expected_records/1),
+        %% Cleanup explicitly selects A; reconnection alone is not a merge.
+        recover_follower(A, B, C, Tabs, fun restart_records/1)
+    end).
+
+master_nodes_two_local_masters_partitioned_3_nodes(suite) -> [];
+master_nodes_two_local_masters_partitioned_3_nodes(Config) when is_list(Config) ->
+    run_restart_case(Config, fun(A, B, C) ->
+        %% GIVEN self masters and no schema masters. Partition while both
+        %% replicas run, so both durably record the other as down.
+        Tabs = create_tables([A, B]),
+        mnesia_node_set_masters(A, Tabs, [A]),
+        mnesia_node_set_masters(B, Tabs, [B]),
+        mnesia_node_set_partitions([[A, C], [B]]),
+        mnesia_node_assert_down_logged(A, B),
+        mnesia_node_assert_down_logged(B, A),
+        mnesia_node_stop(B, []),
+        mnesia_node_stop(A, [C]),
+        %% WHEN both replicas restart in isolation and receive different writes.
+        mnesia_node_start(A),
+        mnesia_node_start(B),
+        mnesia_node_assert_master_policies(Tabs, [{A, [A]}, {B, [B]}, {C, []}]),
+        [begin
+             mnesia_node_assert_loaded_from(N, Tabs, N, fun restart_records/1),
+             mnesia_node_assert_load_reason(N, Tabs, local_master)
+         end || N <- [A, B]],
+        mnesia_node_assert_down_logged(A, B),
+        mnesia_node_assert_down_logged(B, A),
+        write_marker(A, Tabs, side_a),
+        write_marker(B, Tabs, side_b),
+        RecordsA = fun(Tab) -> restart_records(Tab) ++ [{Tab, marker, side_a}] end,
+        RecordsB = fun(Tab) -> restart_records(Tab) ++ [{Tab, marker, side_b}] end,
+        mnesia_node_assert_local_records(A, Tabs, RecordsA),
+        mnesia_node_assert_local_records(B, Tabs, RecordsB),
+        mnesia_node_with_observer(A, [], true, fun(EventsA) ->
+            mnesia_node_with_observer(B, [], true, fun(EventsB) ->
+                %% WHEN connectivity returns with subscriptions already active.
+                mnesia_node_set_connected_groups([[A, B, C]]),
+                %% THEN report the inconsistent pair (either event context or
+                %% direction), and keep both already-loaded contents unchanged.
+                mnesia_node_assert_eventually(fun() ->
+                    mnesia_node_has_inconsistency_event(A, EventsA, B) orelse
+                        mnesia_node_has_inconsistency_event(B, EventsB, A)
+                end, {inconsistent_database, A, B}),
+                mnesia_node_connect([A, B, C]),
+                mnesia_node_assert_local_records(A, Tabs, RecordsA),
+                mnesia_node_assert_local_records(B, Tabs, RecordsB)
+            end)
+        end),
+        %% Cleanup: THEN restarting B with A as sole authority replaces RB by RA.
+        recover_follower(A, B, C, Tabs, RecordsA)
+    end).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1965,4 +2136,188 @@ cross_check_tables([Pid|Rest],Tab,{Val1,Val2,Val3}) ->
               {R1,R2,R3}
             end,
     ?match_receive({ Pid, {Val1, Val2, Val3 } }),
-    cross_check_tables(Rest,Tab,{Val1,Val2,Val3} ).   
+    cross_check_tables(Rest,Tab,{Val1,Val2,Val3} ).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% BEGIN: Helpers for restart/set-master-node scenarios.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Exercise A's choice of load source under different table master policies.
+%% C stays active while B and A stop. A restarts in isolation, then reconnects
+%% to C while B remains stopped. B and C have no master restrictions.
+%%
+%% chain: A trusts only [B] and cannot load directly from C. Its policy stays
+%%        unchanged. B rejoins and starts, loads from C, then supplies A.
+%%        The chain is the data transfer C -> B -> A, not a chain of policies.
+%% multiple: A trusts [B, C] from the outset. Connecting to the active C is
+%%           enough to load A, even though the unavailable B is listed first.
+%% clear: A initially trusts [B] and waits despite C being connected. Clearing
+%%        its masters to [] removes the restriction, allowing C -> A.
+%% expand: A initially trusts [B] and waits despite C being connected. Setting
+%%         its masters to [B, C] makes C eligible, allowing C -> A.
+%%
+%% clear and expand release A's wait by changing its policy while B is still
+%% stopped, without restarting A or reconnecting C. Unlike multiple, expand
+%% tests making an already-connected, initially forbidden source eligible.
+-spec run_active_source_case(Config :: proplists:proplist(),
+                             Mode :: chain | multiple | clear | expand) -> ok.
+run_active_source_case(Config, Mode) ->
+    run_restart_case(Config, fun(A, B, C) ->
+        Nodes = [A, B, C],
+        %% GIVEN three replicas, with a remote-only master policy on A.
+        Tabs = create_tables(Nodes),
+        Masters = case Mode of multiple -> [B, C]; _ -> [B] end,
+        mnesia_node_set_masters(A, Tabs, Masters),
+        mnesia_node_assert_master_policies(Tabs, [{A, Masters}, {B, []}, {C, []}]),
+        %% C stays active. B must remember C as a potentially better copy.
+        mnesia_node_stop(B, [A, C]),
+        mnesia_node_stop(A, [C]),
+        write_marker(C, Tabs, source_c),
+        mnesia_node_assert_local_records(C, Tabs,
+                                         fun(Tab) -> marked_records(Tab, source_c) end),
+        mnesia_node_set_partitions([[A], [B], [C]]),
+        mnesia_node_start(A),
+        mnesia_node_assert_master_policies(Tabs, [{A, Masters}]),
+        ?assertEqual(false, mnesia_node_call(A, fun() ->
+            mnesia_recover:has_mnesia_down(C)
+        end)),
+        mnesia_node_assert_waiting(A, Tabs),
+
+        %% WHEN A reconnects to C, while B remains stopped and isolated.
+        mnesia_node_set_connected_groups([[A, C], [B]]),
+        mnesia_node_connect([A, C]),
+        mnesia_node_assert_active_replica(A, Tabs, C),
+        case Mode of
+            multiple ->
+                %% THEN an available member is enough, even with B first.
+                mnesia_node_assert_loaded_from(
+                    A, Tabs, C, fun(Tab) -> marked_records(Tab, source_c) end);
+            _ ->
+                %% THEN C is registered but cannot supply A's local copy.
+                mnesia_node_assert_waiting(A, Tabs)
+        end,
+        case Mode of
+            chain ->
+                %% WHEN B rejoins and starts normally, it first loads from C.
+                mnesia_node_set_connected_groups([Nodes]),
+                mnesia_node_start(B),
+                ?assertEqual(false, mnesia_node_call(B, fun() ->
+                    mnesia_recover:has_mnesia_down(C)
+                end)),
+                mnesia_node_assert_loaded_from(
+                    B, Tabs, C, fun(Tab) -> marked_records(Tab, source_c) end),
+                %% THEN A obtains that data from B, never directly from C.
+                mnesia_node_assert_loaded_from(
+                    A, Tabs, B, fun(Tab) -> marked_records(Tab, source_c) end);
+            _ ->
+                NewMasters = case Mode of
+                                 clear -> [];
+                                 expand -> [B, C];
+                                 multiple -> Masters
+                             end,
+                %% WHEN a waiting node clears/expands its policy, there is no
+                %% restart, reconnection, or new announcement from C.
+                Controller = mnesia_node_call(A, fun() -> whereis(mnesia_controller) end),
+                mnesia_node_set_masters(A, Tabs, NewMasters),
+                mnesia_node_assert_loaded_from(
+                    A, Tabs, C, fun(Tab) -> marked_records(Tab, source_c) end),
+                ?assertEqual(Controller, mnesia_node_call(A, fun() ->
+                    whereis(mnesia_controller)
+                end)),
+                mnesia_node_assert_topology([[A, C], [B]]),
+                mnesia_node_assert_master_policies(Tabs, [{A, NewMasters}, {C, []}]),
+                mnesia_node_set_connected_groups([Nodes]),
+                mnesia_node_start(B)
+        end,
+        %% THEN all local copies contain the marker written while A/B were down.
+        [mnesia_node_assert_locally_readable(N, Tabs) || N <- Nodes],
+        [mnesia_node_assert_local_records(N, Tabs,
+                                         fun(Tab) -> marked_records(Tab, source_c) end)
+         || N <- Nodes],
+        mnesia_node_assert_master_policies(Tabs, [{B, []}, {C, []}])
+    end).
+
+run_restart_case(Config, Test) ->
+    case mnesia_test_lib:diskless(Config) of
+        true -> ?skip("Master node settings do not survive a diskless restart", []);
+        false -> ok
+    end,
+    [C | Peers] = Nodes = ?acquire_nodes(3, Config),
+    [A, B] = lists:sort(Peers),
+    Cookies = [{N, mnesia_node_call(N, fun erlang:get_cookie/0)} || N <- Nodes],
+    try
+        [begin
+             ?assertEqual(disc_copies, mnesia_node_call(N, fun() ->
+                 mnesia:table_info(schema, storage_type)
+             end)),
+             ?assertEqual([], mnesia_node_call(N, fun() ->
+                 mnesia_recover:get_master_nodes(schema)
+             end))
+         end || N <- Nodes],
+        Test(A, B, C),
+        mnesia_node_assert_running(Nodes)
+    after
+        %% Even on assertion failure, remove policies and stop Mnesia before
+        %% healing. The next acquire_nodes rebuilds fresh schemas. Intentional
+        %% waiting/divergence is recovered and checked in each successful case.
+        Cleanup = [catch mnesia_node_call(N, fun() ->
+             stopped = mnesia:stop(),
+             mnesia:set_master_nodes([])
+         end) || N <- Nodes],
+        [?assertEqual(true, mnesia_node_call(N, fun() -> erlang:set_cookie(Cookie) end))
+         || {N, Cookie} <- Cookies],
+        mnesia_node_set_connected_groups([Nodes]),
+        ?assertEqual([ok || _ <- Nodes], Cleanup)
+    end.
+
+create_tables(Nodes) ->
+    create_tables([{ram, [{ram_copies, Nodes}]},
+                           {disc, [{disc_copies, Nodes}]}, %% Why both disc_only and disc copy?
+                           {disc_only, [{disc_only_copies, Nodes}]}], Nodes).
+
+create_tables(Definitions, Nodes) ->
+    Tabs = [Tab || {Tab, _} <- Definitions],
+    [begin
+         ?assertEqual({atomic, ok}, mnesia:create_table(Tab, Copies)),
+         ?assertEqual(false, mnesia:table_info(Tab, local_content)),
+         ?assertEqual(false, mnesia:table_info(Tab, majority)),
+         ?assertEqual(read_write, mnesia:table_info(Tab, access_mode)),
+         ok = mnesia:sync_dirty(fun() ->
+             [mnesia:write(Record) || Record <- expected_records(Tab)], ok
+         end)
+     end || {Tab, Copies} <- Definitions],
+    [begin
+         mnesia_node_assert_locally_readable(N, Tabs),
+         mnesia_node_assert_local_records(N, Tabs, fun expected_records/1),
+         ?assertEqual(ok, mnesia_node_call(N, fun mnesia:sync_log/0))
+     end || N <- Nodes],
+    mnesia_node_assert_master_policies(Tabs, [{N, []} || N <- lists:usort([node() | Nodes])]),
+    Tabs.
+
+write_marker(Node, Tabs, Value) ->
+    ?assertEqual(ok, mnesia_node_call(Node, fun() ->
+        mnesia:sync_dirty(fun() ->
+            [mnesia:write({Tab, marker, Value}) || Tab <- Tabs], ok
+        end)
+    end)).
+
+expected_records(Tab) ->
+    [{Tab, K, K} || K <- lists:seq(1, 10)].
+
+marked_records(Tab, Marker) ->
+    expected_records(Tab) ++ [{Tab, marker, Marker}].
+
+restart_records(ram) -> [];
+restart_records(Tab) -> expected_records(Tab).
+
+recover_follower(Authority, Follower, C, Tabs, Records) ->
+    mnesia_node_stop(Follower, []),
+    mnesia_node_set_masters(Follower, Tabs, [Authority]),
+    mnesia_node_set_connected_groups([[Authority, Follower, C]]),
+    mnesia_node_start(Follower),
+    mnesia_node_assert_loaded_from(Follower, Tabs, Authority, Records),
+    mnesia_node_assert_local_records(Authority, Tabs, Records),
+    mnesia_node_assert_master_policies(Tabs, [{Follower, [Authority]}]).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% END: Helpers for restart/set-master-node scenarios.
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/mnesia/test/mnesia_durability_test.erl
+++ b/lib/mnesia/test/mnesia_durability_test.erl
@@ -221,10 +221,10 @@ load_local_contents_directly(Config) when is_list(Config) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 load_directly_when_all_are_ram_copiesA(doc) ->
-    ["Tables that are RAM copies only shall also be loaded directly. ",
+    ["Tables that are RAM copies only shall NOT be loaded directly. ",
      "1. N1 and N2 has RAM copies of a table, stop N1 before N2. ",
-     "2. When N1 starts he shall have access to the table ",
-     "   without having to start N2" ];
+     "2. When N1 starts he shall NOT have access to the table ",
+     "   without loading the better copy from N2" ];
 load_directly_when_all_are_ram_copiesA(suite) -> [];
 load_directly_when_all_are_ram_copiesA(Config) when is_list(Config) ->
     [N1, N2] = Nodes = ?acquire_nodes(2, Config),
@@ -251,20 +251,21 @@ load_directly_when_all_are_ram_copiesA(Config) when is_list(Config) ->
            rpc:call(N2,mnesia,transaction,[Read_one]) ),
     %%Stop Mnesia on N2
     ?match([], mnesia_test_lib:kill_mnesia([N2])),
-    %%Restart Mnesia on N1 verify that we can access test_rec from
-    %%N1 without starting Mnesia on N2.
+    %%Restart Mnesia on N1 verify that we CANNOT access test_rec from
+    %%N1 without starting Mnesia on N2 because N2 is not in down_nodes of N1 node.
     ?match(ok, rpc:call(N1, mnesia, start, [])),
-    ?match(ok, rpc:call(N1, mnesia, wait_for_tables, [[test_rec], 30000])),
-    ?match({atomic,[]}, rpc:call(N1,mnesia,transaction,[Read_one])),
-    ?match({atomic,ok}, rpc:call(N1,mnesia,transaction,[Write_one,[33]])),
-    ?match({atomic,[#test_rec{key=2,val=33}]},
+    ?match({timeout, [test_rec]}, rpc:call(N1, mnesia, wait_for_tables, [[test_rec], 30000])),
+    ?match({aborted, {no_exists, test_rec}}, rpc:call(N1,mnesia,transaction,[Read_one])),
+    ?match({aborted, {no_exists, test_rec}}, rpc:call(N1,mnesia,transaction,[Write_one,[33]])),
+    ?match({aborted,{no_exists,test_rec}},
            rpc:call(N1,mnesia,transaction,[Read_one])),
     %%Restart Mnesia on N2 and verify the contents there.
     ?match([], mnesia_test_lib:start_mnesia([N2], [test_rec])),
-    ?match( {atomic,[#test_rec{key=2,val=33}]},
+    ?match({atomic, ok}, rpc:call(N1,mnesia,transaction,[Write_one,[44]])),
+    ?match( {atomic,[#test_rec{key=2,val=44}]},
            rpc:call(N2, mnesia, transaction, [Read_one] ) ),
     %%Check that the start of Mnesai on N2 did not affect the contents on N1
-    ?match( {atomic,[#test_rec{key=2,val=33}]},
+    ?match( {atomic,[#test_rec{key=2,val=44}]},
            rpc:call(N1, mnesia, transaction, [Read_one] ) ),
     ?verify_mnesia(Nodes, []).
 
@@ -1350,15 +1351,27 @@ dump_ram_copies(Config) when is_list(Config)  ->
     %% test_lib:mnesia_start doesn't work, because it waits
     %% for the schema on all nodes ... ???
     ?match(ok,rpc:call(Node3,mnesia,start,[]) ),
-    ?match(ok,rpc:call(Node3,mnesia,wait_for_tables,
-		       [[Tab],timer:seconds(30)]   ) ),
     
-    %% node3  shall have the contents of the dump
-    cross_check_tables([C],Tab,{[{Tab,1,4711}],[{Tab,2,42}],[{Tab,3,256}]}),
-    
-    %% start Mnesia on the other 2 nodes, too
+    %% node3 is the first-killed node, thus it should wait for better copy
+    %% from late-killed node to ensure consistency in the cluster
+    %% to get the better copy, node3 needs to contact the node which has better copy.
+    ?match({timeout, [Tab]}, 
+           rpc:call(Node3, mnesia,wait_for_tables,
+                    [[Tab],timer:seconds(3)])),
+
+    %% node3 shall NOT serve for this table before it get connected to the better copy.
+    ?match({badrpc,{'EXIT',{aborted,{no_exists,[Tab,1]}}}}, 
+           rpc:call(Node3, mnesia, dirty_read, [Tab,1])),
+
+    %% start Mnesia on the other 2 nodes now
     mnesia_test_lib:start_mnesia([Node1,Node2],[Tab]),
+
+
+    %% node3 should load the better copy and ready to serve.
+    ?match(ok, rpc:call(Node3, mnesia,wait_for_tables, 
+                        [[Tab],timer:seconds(30)])),
     
+    %% Since all nodes are up
     cross_check_tables([A,B,C],Tab,
 		       {[{Tab,1,4711}],[{Tab,2,42}],[{Tab,3,256}]}),
     ?verify_mnesia(Nodes, []).

--- a/lib/mnesia/test/mnesia_test_lib.erl
+++ b/lib/mnesia/test/mnesia_test_lib.erl
@@ -135,7 +135,8 @@
 	 init_per_testcase/2,
 	 end_per_testcase/2,
 	 kill_tc/2,
-	 get_ext_test_server_name/0
+	 get_ext_test_server_name/0,
+	 get_peer_ref/1
 	]).
 
 -include("mnesia_test_lib.hrl").
@@ -306,7 +307,8 @@ node_start_link(Host, Name, Retries) ->
     end.
 
 starter(Host, Name, Args) ->
-    {ok, _, Node} = peer:start(#{host => Host, name => Name, args => Args}),
+    {ok, Peer, Node} = peer:start(#{host => Host, name => Name, args => Args, connection => 0}),
+    ok = persistent_term:put_new({peer, Node}, Peer),
     {ok, Node}.
 
 node_sup() ->
@@ -1135,3 +1137,6 @@ sort(W) ->
 
 get_ext_test_server_name() ->
     list_to_atom("ext_test_server_" ++ atom_to_list(node())).
+
+get_peer_ref(Node) ->
+    persistent_term:get({peer, Node}).

--- a/lib/mnesia/test/mnesia_test_lib.erl
+++ b/lib/mnesia/test/mnesia_test_lib.erl
@@ -308,7 +308,7 @@ node_start_link(Host, Name, Retries) ->
 
 starter(Host, Name, Args) ->
     {ok, Peer, Node} = peer:start(#{host => Host, name => Name, args => Args, connection => 0}),
-    ok = persistent_term:put_new({peer, Node}, Peer),
+    ok = persistent_term:put({peer, Node}, Peer),
     {ok, Node}.
 
 node_sup() ->

--- a/lib/mnesia/test/mnesia_test_lib.erl
+++ b/lib/mnesia/test/mnesia_test_lib.erl
@@ -139,7 +139,33 @@
 	 get_peer_ref/1
 	]).
 
+%% helpers for mnesia_consistency_test
+-export([mnesia_node_call/2,
+         mnesia_node_set_masters/3,
+         mnesia_node_assert_master_policies/2,
+         mnesia_node_stop/2,
+         mnesia_node_assert_down_logged/2,
+         mnesia_node_kill/2,
+         mnesia_node_start/1,
+         mnesia_node_set_partitions/1,
+         mnesia_node_set_connected_groups/1,
+         mnesia_node_assert_topology/1,
+         mnesia_node_assert_running/1,
+         mnesia_node_connect/1,
+         mnesia_node_assert_active_replica/3,
+         mnesia_node_assert_waiting/2,
+         mnesia_node_assert_locally_readable/2,
+         mnesia_node_assert_loaded_from/4,
+         mnesia_node_assert_load_reason/3,
+         mnesia_node_assert_local_records/3,
+         mnesia_node_assert_eventually/2,
+         mnesia_node_with_observer/4,
+         mnesia_node_get_observed_events/2,
+         mnesia_node_get_orphan_load_requests/3,
+         mnesia_node_has_inconsistency_event/3]).
+
 -include("mnesia_test_lib.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -1140,3 +1166,263 @@ get_ext_test_server_name() ->
 
 get_peer_ref(Node) ->
     persistent_term:get({peer, Node}).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Partition-safe node control, local table assertions, and scoped observers.
+%% Remote nodes must have a peer control handle and this module available.
+
+%% The peer control channel does not reconnect Erlang distribution. Anonymous
+%% functions also let local ETS/DETS assertions run on fully isolated peers.
+mnesia_node_call(Node, Fun) when Node == node() -> Fun();
+mnesia_node_call(Node, Fun) ->
+    peer:call(get_peer_ref(Node), erlang, apply, [Fun, []], 30000).
+
+mnesia_node_set_masters(Node, Tabs, Masters) ->
+    [ ?assertEqual(ok, mnesia_node_call(Node, fun() ->
+          mnesia:set_master_nodes(Tab, Masters)
+      end)) || Tab <- Tabs],
+    ok.
+
+mnesia_node_assert_master_policies(Tabs, Policies) ->
+    [ ?assertEqual(lists:sort(Masters), mnesia_node_call(N, fun() ->
+          lists:sort(mnesia_recover:get_master_nodes(Tab))
+      end)) || {N, Masters} <- Policies, Tab <- Tabs],
+    ok.
+
+mnesia_node_stop(Node, Survivors) ->
+    ?assertEqual(stopped, mnesia_node_call(Node, fun mnesia:stop/0)),
+    ?assertEqual(no, mnesia_node_call(Node, fun() -> mnesia:system_info(is_running) end)),
+    [mnesia_node_assert_down_logged(N, Node) || N <- Survivors],
+    ok.
+
+%% Abruptly kill Mnesia without taking down Erlang or the peer control channel.
+%% Check the crash completed and survivors durably observed it before proceeding.
+mnesia_node_kill(Node, Survivors) ->
+    ?assertEqual(yes, mnesia_node_call(Node, fun() -> mnesia:system_info(is_running) end)),
+    ?assertEqual(ok, mnesia_node_call(Node, fun mnesia:lkill/0)),
+    ?assertEqual(no, mnesia_node_call(Node, fun() -> mnesia:system_info(is_running) end)),
+    [mnesia_node_assert_down_logged(N, Node) || N <- Survivors],
+    ok.
+
+mnesia_node_assert_down_logged(Node, Down) ->
+    mnesia_node_assert_eventually(
+      fun() -> 
+              mnesia_node_call(Node, 
+                               fun() ->
+                                       mnesia_recover:has_mnesia_down(Down)
+                               end) 
+      end, 
+      {mnesia_down, Node, Down}),
+    ?assertEqual(ok, mnesia_node_call(Node, fun mnesia:sync_log/0)).
+
+mnesia_node_start(Node) ->
+    ?assertEqual(ok, mnesia_node_call(Node, fun mnesia:start/0)),
+    ?assertEqual(yes, mnesia_node_call(Node, fun() -> mnesia:system_info(is_running) end)).
+
+%% First block every new cross-peer connection, then disconnect every edge.
+%% Restore group cookies only after the full isolation is observable.
+mnesia_node_set_partitions(Groups) ->
+    Nodes = lists:append(Groups),
+    [mnesia_node_call(N, fun() -> erlang:set_cookie(Cookie) end)
+     || {N, Cookie} <- lists:zip(Nodes, [mnesia_node_cookie_a, 
+                                         mnesia_node_cookie_b,
+                                         mnesia_node_cookie_c])],
+    [mnesia_node_call(N, fun() -> erlang:disconnect_node(Other) end)
+     || N <- Nodes, Other <- Nodes -- [N]],
+    mnesia_node_assert_topology([[N] || N <- Nodes]),
+    mnesia_node_set_connected_groups(Groups).
+
+%% Set group cookies and connect within each group. Existing cross-group edges
+%% must already be disconnected; use set_partitions when splitting a group.
+mnesia_node_set_connected_groups(Groups) ->
+    %% Keep the coordinator's cookie, including when it is itself isolated.
+    Cookie = erlang:get_cookie(),
+    [begin
+         GroupCookie = case lists:member(node(), Group) of
+                           true -> Cookie;
+                           false -> element(Index, {mnesia_node_group_a,
+                                                    mnesia_node_group_b,
+                                                    mnesia_node_group_c})
+                       end,
+         [mnesia_node_call(N, fun() -> erlang:set_cookie(GroupCookie) end) || N <- Group]
+     end || {Group, Index} <- lists:zip(Groups, lists:seq(1, length(Groups)))],
+    mnesia_node_assert_eventually(fun() ->
+        [mnesia_node_call(N, fun() -> net_kernel:connect_node(Other) end)
+         || Group <- Groups, N <- Group, Other <- Group -- [N]],
+        mnesia_node_matches_topology(Groups)
+    end, {connectivity, Groups}),
+    mnesia_node_assert_topology(Groups).
+
+mnesia_node_assert_topology(Groups) ->
+    mnesia_node_assert_eventually(
+      fun() -> mnesia_node_matches_topology(Groups) end,
+      {topology, Groups}).
+
+mnesia_node_matches_topology(Groups) ->
+    All = lists:append(Groups),
+    lists:all(fun(Group) ->
+        lists:all(fun(N) ->
+            lists:sort(Group -- [N]) == mnesia_node_call(N, fun() ->
+                lists:sort([Peer || Peer <- nodes(), lists:member(Peer, All)])
+            end)
+        end, Group)
+    end, Groups).
+
+mnesia_node_assert_running(Nodes) ->
+    mnesia_node_assert_eventually(fun() ->
+        lists:all(fun(N) -> mnesia_node_call(N, fun() ->
+            mnesia:system_info(is_running) == yes andalso
+                lists:sort(mnesia:system_info(running_db_nodes)) == lists:sort(Nodes)
+        end) end, Nodes)
+    end, {running_db_nodes, Nodes}).
+
+mnesia_node_connect([Node | _] = Nodes) ->
+    ?assertMatch({ok, _}, mnesia_node_call(Node, fun() ->
+        mnesia_controller:connect_nodes(Nodes)
+    end)),
+    mnesia_node_assert_running(Nodes).
+
+mnesia_node_assert_active_replica(Node, Tabs, Source) ->
+    IsReplica = fun(Tab) ->
+                        lists:member(Source, mnesia_lib:val({Tab, active_replicas}))
+                end,
+    IsReplicaForTabs = fun() -> lists:all(IsReplica, Tabs) end,
+    mnesia_node_assert_eventually(
+      fun() ->
+              mnesia_node_call(Node, IsReplicaForTabs)
+      end, {active_replica, Node, Source}).
+
+mnesia_node_assert_waiting(Node, Tabs) ->
+    mnesia_node_call(Node, fun() ->
+        ?assertEqual(yes, mnesia:system_info(is_running)),
+        [?assertEqual(nowhere, mnesia:table_info(Tab, where_to_read)) || Tab <- Tabs],
+        ?assertEqual({timeout, lists:sort(Tabs)},
+                     case mnesia:wait_for_tables(Tabs, 500) of
+                         {timeout, Missing} -> {timeout, lists:sort(Missing)};
+                         Other -> Other
+                     end),
+        [?assertEqual(nowhere, mnesia:table_info(Tab, where_to_read)) || Tab <- Tabs]
+    end).
+
+mnesia_node_assert_locally_readable(Node, Tabs) ->
+    mnesia_node_call(Node, fun() ->
+        ?assertEqual(ok, mnesia:wait_for_tables(Tabs, 10000)),
+        [?assertEqual(node(), mnesia:table_info(Tab, where_to_read)) || Tab <- Tabs]
+    end).
+
+mnesia_node_assert_loaded_from(Node, Tabs, Source, Records) ->
+    mnesia_node_assert_locally_readable(Node, Tabs),
+    mnesia_node_call(Node, fun() ->
+        [?assertEqual(Source, mnesia:table_info(Tab, load_node)) || Tab <- Tabs]
+    end),
+    mnesia_node_assert_local_records(Node, Tabs, Records).
+
+mnesia_node_assert_load_reason(Node, Tabs, Reason) ->
+    mnesia_node_call(Node, fun() ->
+        [?assertEqual(Reason, mnesia:table_info(Tab, load_reason)) || Tab <- Tabs]
+    end).
+
+mnesia_node_assert_local_records(Node, Tabs, Records) ->
+    mnesia_node_call(Node, fun() ->
+        [begin
+             %% Read the actual local storage, never a remotely routed query.
+             Actual = case mnesia:table_info(Tab, storage_type) of
+                          disc_only_copies -> dets:match_object(Tab, '_');
+                          _ -> ets:tab2list(Tab)
+                      end,
+             ?assertEqual(lists:sort(Records(Tab)), lists:sort(Actual))
+         end || Tab <- Tabs]
+    end).
+
+mnesia_node_assert_eventually(Check, Context) ->
+    Deadline = erlang:monotonic_time(millisecond) + 10000,
+    mnesia_node_assert_eventually(Check, Context, Deadline).
+
+mnesia_node_assert_eventually(Check, Context, Deadline) ->
+    case Check() of
+        true -> ok;
+        Actual ->
+            case erlang:monotonic_time(millisecond) < Deadline of
+                true ->
+                    timer:sleep(100),
+                    mnesia_node_assert_eventually(Check, Context, Deadline);
+                false -> error({mnesia_node_timeout, Context, Actual})
+            end
+    end.
+
+%% Each observer owns its trace session/subscription on the observed node.
+%% Nothing is sent over distribution while partitioned. Destroying the session
+%% leaves other test/debug trace sessions untouched, including on failures.
+mnesia_node_with_observer(Node, Functions, Subscribe, Test) ->
+    Observer = mnesia_node_call(Node, fun() ->
+        spawn(fun() -> mnesia_node_run_observer(Functions, Subscribe) end)
+    end),
+    try
+        %% Ready barrier, before the test action.
+        mnesia_node_get_observed_events(Node, Observer),
+        Test(Observer)
+    after
+        mnesia_node_call(Node, fun() ->
+            Ref = monitor(process, Observer),
+            Observer ! stop,
+            receive {'DOWN', Ref, process, Observer, _} -> ok
+            after 5000 -> error(observer_stop_timeout)
+            end
+        end)
+    end.
+
+mnesia_node_run_observer(Functions, IsSubscribe) ->
+    Session = trace:session_create(mnesia_node_test, self(), []),
+    try
+        [trace:function(Session, MFA, [], [local]) || MFA <- Functions],
+        [trace:process(Session, whereis(Name), true, [call])
+         || Name <- [mnesia_controller, mnesia_late_loader]],
+        case IsSubscribe of 
+            true -> {ok, _} = mnesia:subscribe(system); 
+            false -> ok 
+        end,
+        mnesia_node_collect_observer_events([])
+    after
+        trace:session_destroy(Session),
+        case IsSubscribe of
+            true -> mnesia:unsubscribe(system); 
+            false -> ok 
+        end
+    end.
+
+mnesia_node_collect_observer_events(Events) ->
+    receive
+        {events, From, Ref} ->
+            From ! {Ref, lists:reverse(Events)},
+            mnesia_node_collect_observer_events(Events);
+        stop -> ok;
+        Event -> mnesia_node_collect_observer_events([Event | Events])
+    end.
+
+mnesia_node_get_observed_events(Node, Observer) ->
+    mnesia_node_call(Node, fun() ->
+        Ref = monitor(process, Observer),
+        Observer ! {events, self(), Ref},
+        receive
+            {Ref, Events} -> demonitor(Ref, [flush]), Events;
+            {'DOWN', Ref, process, Observer, Reason} -> error({observer_down, Reason})
+        after 5000 -> 
+                demonitor(Ref, [flush]), error(observer_timeout)
+        end
+    end).
+
+mnesia_node_get_orphan_load_requests(Node, Observer, Origin) ->
+    [{Target, Tab} ||
+        {trace, _, call, {mnesia_late_loader, maybe_async_late_disc_load,
+                         [Target, Tabs, {adopt_orphan, From}]}}
+            <- mnesia_node_get_observed_events(Node, Observer),
+        From == Origin, Tab <- Tabs].
+
+mnesia_node_has_inconsistency_event(Node, Observer, Other) ->
+    lists:any(fun
+        ({mnesia_system_event, {inconsistent_database, Context, N}}) ->
+            N == Other andalso
+                (Context == running_partitioned_network orelse
+                 Context == starting_partitioned_network);
+        (_) -> false
+    end, mnesia_node_get_observed_events(Node, Observer)).

--- a/lib/mnesia/test/mt
+++ b/lib/mnesia/test/mt
@@ -26,16 +26,19 @@
 #    
 # Usage: mt <args to erlang startup script>
 
-#top=".."
 top="$ERL_TOP/lib/mnesia"
 h=`hostname`
 p="-pa $top/examples -pa $top/ebin -pa $top/test -mnesia_test_verbose true"
 log=test_log$$
 latest=test_log_latest
 args=${1+"$@"}
-erlcmd="erl -sname a@localhost $p $args -mnesia_test_timeout"
-erlcmd1="erl -sname a1@localhost $p $args"
-erlcmd2="erl -sname a2@localhost $p $args"
+tmp=$(mktemp -d)
+if [ "$?" != "0" ]; then
+    echo "Failed to create temp directory" >&2
+    exit 1
+fi
+trap "rm -rf $tmp" EXIT
+erlcmd="erl -sname a@localhost $p $args -mnesia_test_timeout -s mt start_peers a1 a2 $tmp"
 
 if test z"$MT_TERM" = z ; then
     MT_TERM=xterm
@@ -77,8 +80,9 @@ echo ""
 
 $MT_TERM $geom0 $title a $exec script -c "$erlcmd" -f $log &
 
-$MT_TERM $geom1 $title a1 $exec $erlcmd1 &
-$MT_TERM $geom2 $title a2 $exec $erlcmd2 &
+sleep 1
+$MT_TERM $geom1 $title a1 $exec to_erl $tmp/a1/ &
+$MT_TERM $geom2 $title a2 $exec to_erl $tmp/a2/ &
 
 echo "Give the following command in order to see the outcome from node a@$h"":"
 echo ""

--- a/lib/mnesia/test/mt.erl
+++ b/lib/mnesia/test/mt.erl
@@ -38,6 +38,7 @@
 	 doc/0, doc/1,                      % Generate test case doc
 	 struct/0, struct/1,                % View test suite struct
 	 shutdown/0, ping/0, start_nodes/0, % Node admin
+	 start_peers/1,                     % Peers for mt script
 	 read_config/0, write_config/1      % Config admin
 	]).
 
@@ -278,3 +279,44 @@ ok_result([{_T,{TC,List}}|R]) when is_tuple(TC), is_list(List) ->
     ok_result(List) andalso ok_result(R);
 ok_result([]) -> true;
 ok_result(_) -> error.
+
+%% Peer nodes for mt script
+start_peers(Args) ->
+    [Name2, Name3, TmpDirA | ExtraArgs0] = Args,
+    CodePaths = lists:append([["-pa", P] || P <- code:get_path(), P /= "."]),
+    ExtraArgs =
+    case ExtraArgs0 of
+        [] -> CodePaths;
+        ExtraArgs0 -> CodePaths ++ " " ++ ExtraArgs0
+    end,
+    TmpDir = atom_to_list(TmpDirA),
+    {Name2, P2, N2} = start_peer(Name2, TmpDir, ExtraArgs),
+    {Name3, P3, N3} = start_peer(Name3, TmpDir, ExtraArgs),
+    ok = persistent_term:put_new({peer, N2}, P2),
+    ok = persistent_term:put_new({peer, N3}, P3).
+
+start_peer(Name, TmpDir, ExtraArgs) ->
+    Dir = TmpDir ++ "/" ++ atom_to_list(Name) ++ "/",
+    ok = filelib:ensure_dir(Dir),
+    Erl = case init:get_argument(progname) of
+              {ok, [[Prog]]} ->
+                  case os:find_executable(Prog) of
+                      false -> "erl";
+                      Found -> Found
+                  end;
+              _ -> "erl"
+          end,
+    RunErl = os:find_executable("run_erl"),
+    {ok, Peer, Node} = peer:start(#{
+        name => Name,
+        host => "localhost",
+        connection => 0,
+        detached => false,
+        exec => {RunErl, ["-daemon"]},
+        post_process_args => fun(Args) ->
+            Cmd = lists:flatten([Erl, " ", lists:join(" ", Args)]),
+            [Dir, Dir, "exec " ++ Cmd]
+        end,
+        args => ExtraArgs
+    }),
+    {Name, Peer, Node}.


### PR DESCRIPTION
fix #11021

Without this fix, ram_copies is 'safe loaded' locally when remote nodes have not been connected (yet). This makes the table accessible by application becasue 'where_to_read' is set to local node().

```
mnesia:dirty_read(emqx_route_filters,1).
[]
```

Also when remote node is connected afterwards, ram_copies table will not load the 'better' copy, this makes the data inconsistent within the cluster.

This commit fix that during mnesia start, ram_copy table should NOT do local safe load when there is a better copy from the remote. the where_to_read will stay in 'nowhere' and table access won't be served.

```
mnesia:dirty_read(emqx_route_filters,1).
** exception exit: {aborted,{no_exists,[emqx_route_filters,1]}}
```

After remote node is connected, local node will do `net_load_table` from the remote.

Resue `adopt_orphans` function to resolve the conflicts when there is a deadlock of deciding the better copy, that is the same behaviour for disc_copies tables.

note1: BetterCopies0 = mnesia_lib:remote_copy_holders(Cs) -- Downs

note2: disc copy table has no such issue.

note3: if there is no better copy (when other nodes are down before current one), it is correct to load from local.