### PR TITLE
Silence dialyzer for megaco on win

### DIFF
--- a/lib/megaco/src/flex/megaco_flex_scanner.erl
+++ b/lib/megaco/src/flex/megaco_flex_scanner.erl
@@ -190,11 +190,17 @@ load_driver(Path) ->
     end.
 
 
+%% Flex scanner driver not built on Windows.
+%% This is to suppress Dialyzer warnings.
+-dialyzer({nowarn_function, open_drv_port/1}).
 open_drv_port(true) ->
     open_drv_ports(?NUM_SCHED(), []);
 open_drv_port(_) ->
     open_drv_port().
 
+%% Flex scanner driver not built on Windows.
+%% This is to suppress Dialyzer warnings.
+-dialyzer({nowarn_function, open_drv_ports/2}).
 open_drv_ports(0, Acc) ->
     list_to_tuple(Acc);
 open_drv_ports(N, Acc) when is_integer(N) andalso (N > 0) ->

--- a/scripts/run-dialyzer
+++ b/scripts/run-dialyzer
@@ -62,6 +62,8 @@ DIALYZER=dialyzer
 
 if [ -f $ERL_TOP/bin/dialyzer ]; then
     DIALYZER=$ERL_TOP/bin/dialyzer
+elif [ -f $ERL_TOP/bin/win32/dialyzer.exe ]; then
+    DIALYZER=$ERL_TOP/bin/win32/dialyzer.exe
 fi
 
 PLT="$(mktemp).plt"


### PR DESCRIPTION
The flex scanner is not built on Windows.
 So, when running Dialyzer in (the erlang-) repo, make dialyzer,
 some functions in the megaco flex scanner front-end module,
 megaco_flex_scanner, will generate dialyzer errors.
 As a workaround, we add "ignore" (nowarn) directives to this module
 to silence dialyzer.

Note that this PR is based on another PR, which attempts to 
make it possible to run dialyzer ('make dialyzer') in an erlang repo.