### PR TITLE
Log warnings of each missed sub-tick before a complete net_tick_timeout

### DIFF
--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -282,6 +282,15 @@ For more information about configuration parameters, see file
   rather each individual network operation during the connection setup and
   handshake.
 
+- **`log_missed_net_ticks = true | false`{: #log_missed_net_ticks }** - Controls
+  whether a warning is logged for each missed sub-tick on a distribution
+  connection. A sub-tick is missed when no data has been received from a
+  connected node during one tick interval. A warning is emitted on every
+  subsequent missed sub-tick until the node is declared down after
+  [`net_tickintensity`](kernel_app.md#net_tickintensity) consecutive missed
+  sub-ticks, at which point a final timeout warning is always logged regardless
+  of this setting. Defaults to `false`.
+
 - **`net_ticker_spawn_options = Opts`{: #net_ticker_spawn_options }** - Defines
   a list of extra spawn options for net ticker processes. There exist one such
   process for each connection to another node. A net ticker process is

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -1185,10 +1185,10 @@ send_tick(#state{handle = DHandle, socket = Socket,
     LogMissed = application:get_env(kernel, log_missed_net_ticks, false),
     case getstat(DHandle, Socket, MFGetstat) of
 	{ok, Read, _, _} when Ticked0 =:= T ->
-	    LogMissed andalso
-	        warning_msg("** Node ~p: ~w consecutive net ticks missed "
-                           "(tick ~w/~w) — net_tick_timeout **~n",
-                           [Node, TickIntensity, T, TickIntensity]),
+        LogMissed andalso
+            warning_msg("** Node ~p: ~w consecutive net ticks missed "
+                        "(tick ~w/~w) — net_tick_timeout **~n",
+                        [Node, TickIntensity, T, TickIntensity]),
 	    {error, not_responding};
 
         {ok, R, W1, Pend} ->

--- a/lib/kernel/src/dist_util.erl
+++ b/lib/kernel/src/dist_util.erl
@@ -40,7 +40,7 @@
 	 shutdown/3, shutdown/4,
          net_ticker_spawn_options/0]).
 
--import(error_logger,[error_msg/2]).
+-import(error_logger,[error_msg/2, warning_msg/2]).
 
 -include("dist_util.hrl").
 -include("dist.hrl").
@@ -1174,6 +1174,7 @@ to_port(FSend, Socket, Data) ->
 send_tick(#state{handle = DHandle, socket = Socket,
                  tick_intensity = TickIntensity,
                  publish_type = Type, f_tick = MFTick,
+                 node = Node,
                  f_getstat = MFGetstat}, Tick) ->
     #tick{tick = T0,
 	  read = Read,
@@ -1181,12 +1182,30 @@ send_tick(#state{handle = DHandle, socket = Socket,
 	  ticked = Ticked0} = Tick,
     T = T0 + 1,
     T1 = T rem TickIntensity,
+    LogMissed = application:get_env(kernel, log_missed_net_ticks, false),
     case getstat(DHandle, Socket, MFGetstat) of
 	{ok, Read, _, _} when Ticked0 =:= T ->
+	    LogMissed andalso
+	        warning_msg("** Node ~p: ~w consecutive net ticks missed "
+                           "(tick ~w/~w) — net_tick_timeout **~n",
+                           [Node, TickIntensity, T, TickIntensity]),
 	    {error, not_responding};
 
         {ok, R, W1, Pend} ->
             RDiff = R - Read,
+            case RDiff of
+                0 when LogMissed ->
+                    MissedCount = case T - Ticked0 of
+                                      D when D > 0 -> D;
+                                      D -> TickIntensity + D
+                                  end,
+                    warning_msg("** Node ~p: net tick ~w/~w missed "
+                                "(~w consecutive, ~w until timeout) **~n",
+                                [Node, T, TickIntensity,
+                                 MissedCount, TickIntensity - MissedCount]);
+                _ ->
+                    ok
+            end,
             W2 = case need_to_tick(Type, RDiff, W1-Write, Pend) of
                      true ->
                          MFTick(Socket),


### PR DESCRIPTION
Hello

We'd like to have a way of optionally logging each missed tick (if `kernel.log_missed_net_ticks = true`) in runtime before an inter-node connection is marked down with reason `net_tick_timeout`. We have a problem where, when our cluster nodes partition due to `net_tick_timeout`, we dont have enough verbose visibility from the erlang node/cluster side regarding the failing tick activity, which we'd want to relate with our network activity metrics. 

We hope by logging these warnings this can help (optionally, via `kernel.log_missed_net_ticks` seeing this verbosity might not always be needed and can constitute to more log entries).

For example, when enabled, we'd see the following warning logs for such a timing out node connection:

```
=WARNING REPORT=... ** Node node@host55: net tick 1/4 missed (1 consecutive, 3 until timeout) **
=WARNING REPORT=... ** Node node@host55: net tick 2/4 missed (2 consecutive, 2 until timeout) **
=WARNING REPORT=... ** Node node@host55: net tick 3/4 missed (3 consecutive, 1 until timeout) **
=WARNING REPORT=... ** Node node@host55: 4 consecutive net ticks missed (tick 4/4) — net_tick_timeout **
=ERROR REPORT=... ** Node node@host55 not responding ** Removing (timedout) connection **

```
