### PR TITLE
Do not install wx demos to examples dir

### DIFF
--- a/lib/wx/examples/demo/Makefile
+++ b/lib/wx/examples/demo/Makefile
@@ -83,15 +83,11 @@ include $(ERL_TOP)/make/otp_release_targets.mk
 docs:
 
 release_spec: opt
-	$(INSTALL_DIR) "$(RELSYSDIR)/examples/demo"
-	$(INSTALL_DATA) $(TESTSRC)  "$(RELSYSDIR)/examples/demo"
-	$(INSTALL_DATA) $(TESTTARGETS) "$(RELSYSDIR)/examples/demo"
-	$(INSTALL_DATA) image.jpg erlang.png ex_htmlWindow.html "$(RELSYSDIR)/examples/demo"
-
-release_tests_spec:
-
-release_docs_spec:
 	$(INSTALL_DIR) $(EXRELSYSDIR)
 	$(INSTALL_DATA) $(TESTSRC)  $(EXRELSYSDIR)
 	$(INSTALL_DATA) $(TESTTARGETS) $(EXRELSYSDIR)
 	$(INSTALL_DATA) image.jpg erlang.png ex_htmlWindow.html $(EXRELSYSDIR)
+
+release_tests_spec:
+
+release_docs_spec:

--- a/lib/wx/examples/simple/Makefile
+++ b/lib/wx/examples/simple/Makefile
@@ -46,7 +46,7 @@ docs:
 run: opt
 	erl -smp -detached -pa $(TOPDIR)/ebin -s hello
 
-EXRELSYSDIR = "$(RELSYSDIR)/examples/simple"
+EXRELSYSDIR = "$(RELSYSDIR)/doc/examples/simple"
 include $(ERL_TOP)/make/otp_release_targets.mk
 
 docs:

--- a/lib/wx/examples/sudoku/Makefile
+++ b/lib/wx/examples/sudoku/Makefile
@@ -46,7 +46,7 @@ docs:
 run: opt
 	erl -smp -detached -pa $(TOPDIR)/ebin -s sudoku
 
-EXRELSYSDIR = "$(RELSYSDIR)/examples/sudoku"
+EXRELSYSDIR = "$(RELSYSDIR)/doc/examples/sudoku"
 include $(ERL_TOP)/make/otp_release_targets.mk
 
 docs:

--- a/lib/wx/src/wx.erl
+++ b/lib/wx/src/wx.erl
@@ -579,9 +579,14 @@ Starts a Wx demo if examples directory exists and is compiled
 -spec demo() -> 'ok' | {'error', atom()}.
 demo() ->
     Priv = code:priv_dir(wx),
-    Demo = filename:join([filename:dirname(Priv),examples,demo]),
-    Mod  = list_to_atom("demo"), %% Fool xref tests
-    case file:set_cwd(Demo) of
+    DemoSrc = filename:join([filename:dirname(Priv),examples,demo]),
+    DemoDoc = filename:join([filename:dirname(Priv),doc,examples,demo]),
+    Mod  = list_to_existing_atom("demo"), %% Fool xref tests
+    DemoDir = case filelib:is_dir(DemoSrc) of
+                  true  -> DemoSrc;
+                  false -> DemoDoc
+              end,
+    case file:set_cwd(DemoDir) of
 	ok ->
 	    apply(Mod, start, []),
 	    ok;


### PR DESCRIPTION
Only install to "doc/examples/[demo]".

Having the demo files installed to two directories caused problems for dialyzer, if dialyzer was started with: 'dialyzer make_plt -r lib/*'