### PR TITLE
Fix register_node and port_please arities in alt_disco guide

### DIFF
--- a/erts/doc/guides/alt_disco.md
+++ b/erts/doc/guides/alt_disco.md
@@ -54,10 +54,10 @@ erlang. The discovery module must implement the following callbacks:
 - **[names/1](`erl_epmd:names/1`)** - Return node names held by the registrar
   for the given host.
 
-- **[register_node/2](`erl_epmd:register_node/2`)** - Register the given node
+- **[register_node/3](`erl_epmd:register_node/3`)** - Register the given node
   name with the registrar.
 
-- **[port_please/3](`erl_epmd:port_please/3`)** - Return the distribution port
+- **[port_please/2](`erl_epmd:port_please/2`)** - Return the distribution port
   used by the given node.
 
 The discovery module may implement the following callback:


### PR DESCRIPTION
[The guide](https://www.erlang.org/doc/apps/erts/alt_disco.html) lists `register_node/2` and `port_please/3` as required callbacks, but the built-in distribution drivers call `register_node/3` and `port_please/2` directly. So a discovery module implemented per the guide fails with `undef` when the driver invokes it.