### PR TITLE
erts: Fix tty_tinfo_make_map call

### DIFF
--- a/erts/emulator/nifs/common/prim_tty_nif.c
+++ b/erts/emulator/nifs/common/prim_tty_nif.c
@@ -824,9 +824,9 @@ static ERL_NIF_TERM tty_tinfo_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     };
 
     ERL_NIF_TERM vs[3] = {
-        tty_tinfo_make_map(env, (const char * const*)boolnames, (const char * const*)boolcodes, (const char * const*)boolfnames),
-        tty_tinfo_make_map(env, (const char * const*)numnames, (const char * const*)numcodes, (const char * const*)numfnames),
-        tty_tinfo_make_map(env, (const char * const*)strnames, (const char * const*)strcodes, (const char * const*)strfnames)
+        tty_tinfo_make_map(env, (NCURSES_CONST char * const*)boolnames, (NCURSES_CONST char * const*)boolcodes, (NCURSES_CONST char * const*)boolfnames),
+        tty_tinfo_make_map(env, (NCURSES_CONST char * const*)numnames, (NCURSES_CONST char * const*)numcodes, (NCURSES_CONST char * const*)numfnames),
+        tty_tinfo_make_map(env, (NCURSES_CONST char * const*)strnames, (NCURSES_CONST char * const*)strcodes, (NCURSES_CONST char * const*)strfnames)
     };
     ERL_NIF_TERM res;
     


### PR DESCRIPTION
According to [1], term_variables: bool*, num*, std* are `NCURSES_CONST char * const`. Where NCURSES_CONST is defined by ncurses configuration scripts [2].

1: https://man7.org/linux/man-pages/man3/term_variables.3x.html
2: https://github.com/mirror/ncurses/blob/master/configure.in#L1228