### PR TITLE
emacs: Initialize erlang-compilation-parsing-end in erlang-shell-mode

### DIFF
--- a/lib/tools/emacs/erlang.el
+++ b/lib/tools/emacs/erlang.el
@@ -5267,6 +5267,7 @@ Also see the description of `ielm-prompt-read-only'."
 The following special commands are available:
 \\{erlang-shell-mode-map}"
   (erlang-mode-variables)
+  (setq-local erlang-compilation-parsing-end (make-marker))
   (kill-local-variable 'indent-line-function)
   ;; Needed when compiling directly from the Erlang shell.
   (setq next-error-last-buffer (current-buffer))


### PR DESCRIPTION
When compiling directly from the Erlang shell, the variable `erlang-compilation-parsing-end` must be a marker to track the end of compilation output. If it is not initialized, `set-marker` fails with a `wrong-type-argument` error.

Fixes #10612