### PR TITLE
feat: upgrade mermaid to 11.14.0

### DIFF
--- a/make/ex_doc.exs
+++ b/make/ex_doc.exs
@@ -252,7 +252,7 @@ config =
     before_closing_body_tag: fn
       :html ->
         """
-          <script defer src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+          <script defer src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
           <script>
           let initialized = false;
 


### PR DESCRIPTION
[Here](https://www.erlang.org/doc/system/sup_princ.html#one_for_all) and [also here](https://www.erlang.org/doc/system/sup_princ.html#rest_for_one) are 2 partially rendered graphs ("Note" is not rendered due to empty line in the note ("unsupported markdown code" error").

If that empty line is removed, graph renders correctly. However, this might be a bug because it works even with empty lines with mermaid `11.14.0` so I think this is a better solution because this situation might exist in other graphs too (tried that locally on the same graph).

NOTE: I didn't try building whole docs locally, but hopefully I can inspect them in CI artifacts afterwards.
