### PR TITLE
syntax_tools: Support all native record syntaxes in syntax tools

### DIFF
--- a/lib/syntax_tools/src/erl_prettypr.erl
+++ b/lib/syntax_tools/src/erl_prettypr.erl
@@ -978,14 +978,15 @@ lay_2(Node, Ctxt) ->
 		       set_prec(Ctxt, PrecR))),
 	    T = erl_syntax:record_access_type(Node),
 	    D3 = beside(beside(floating(text("#")),
-                               lay(T, reset_prec(Ctxt))),
-                        D2),
+                               lay_native_record_name(T, reset_prec(Ctxt))),
+                               D2),
 	    maybe_parentheses(beside(D1, D3), Prec, Ctxt);
 
 	record_expr ->
 	    {PrecL, Prec, _} = inop_prec('#'),
 	    Ctxt1 = reset_prec(Ctxt),
-	    D1 = lay(erl_syntax:record_expr_type(Node), Ctxt1),
+            D1 = lay_native_record_name(erl_syntax:record_expr_type(Node),
+                                        Ctxt1),
 	    D2 = par(seq(erl_syntax:record_expr_fields(Node),
 			 floating(text(",")), Ctxt1,
 			 fun lay/2)),
@@ -1501,6 +1502,15 @@ lay_type_application(Name, Arguments, Ctxt) ->
                           beside(par(As),
                                  floating(text(")"))))),
     maybe_parentheses(D, Prec, Ctxt).
+
+lay_native_record_name(Node, Ctxt) ->
+    case erl_syntax:type(Node) of
+        list ->
+            [Mod, Name] = erl_syntax:list_elements(Node),
+            beside(lay(Mod, Ctxt), beside(text(":"), lay(Name, Ctxt)));
+        _ ->
+            lay(Node, Ctxt)
+    end.
 
 seq([H | T], Separator, Ctxt, Fun) ->
     case T of

--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -3293,11 +3293,11 @@ revert_attribute_1(record, [A, Tuple], Pos, Node) ->
     end;
 revert_attribute_1(native_record, [Name, Fields], Pos, Node) ->
     case type(Name) of
-	atom ->
-	    Fs = fold_record_fields(tuple_elements(Fields)),
-	    {attribute, Pos, record, {concrete(Name), Fs}};
-	_ ->
-	    Node
+        atom ->
+            Fs = fold_record_fields(tuple_elements(Fields)),
+            {attribute, Pos, native_record, {concrete(Name), Fs}};
+        _ ->
+            Node
     end;
 revert_attribute_1(import_record, [M, List], Pos, Node) ->
     case revert_module_name(M) of
@@ -4374,7 +4374,15 @@ revert_record_access(Node) ->
     Field = record_access_field(Node),
     case type(Type) of
         atom ->
-            {record_field, Pos, Argument, concrete(Type), Field};
+            case concrete(Type) of
+                '_' ->
+                    {record_field, Pos, Argument, [], Field};
+                T ->
+                    {record_field, Pos, Argument, T, Field}
+            end;
+        list ->
+            [Mod, Name] = list_elements(Type),
+            {record_field, Pos, Argument, {concrete(Mod), concrete(Name)}, Field};
         _ ->
             Node
     end.
@@ -4405,12 +4413,14 @@ _See also: _`record_access/3`.
 
 record_access_type(Node) ->
     case unwrap(Node) of
-	{record_field, Pos, _, {Mod, Name}, _} ->
-	    list([set_pos(atom(Mod), Pos), set_pos(atom(Name), Pos)]);
-	{record_field, Pos, _, Type, _} ->
-	    set_pos(atom(Type), Pos);
-	Node1 ->
-	    (data(Node1))#record_access.type
+        {record_field, Pos, _, {Mod, Name}, _} ->
+            list([set_pos(atom(Mod), Pos), set_pos(atom(Name), Pos)]);
+        {record_field, Pos, _, [], _} ->
+            set_pos(atom('_'), Pos);
+        {record_field, Pos, _, Type, _} ->
+            set_pos(atom(Type), Pos);
+        Node1 ->
+            (data(Node1))#record_access.type
     end.
 
 
@@ -4487,26 +4497,28 @@ revert_record_expr(Node) ->
     Fields = record_expr_fields(Node),
     Fs = fold_record_fields(Fields),
     case type(Type) of
-	atom ->
-	    T = concrete(Type),
-	    case Argument of
-		none ->
-		    {record, Pos, T, Fs};
-		_ ->
-		    {record, Pos, Argument, T, Fs}
-	    end;
-	list ->
-	    [Mod, Name] = list_elements(Type),
-	    case Argument of
-		none ->
-		    {record, Pos, {concrete(Mod), concrete(Name)}, Fs};
-		_ ->
-		    {record, Pos, Argument, {concrete(Mod), concrete(Name)}, Fs}
-	    end;
-	_ ->
-	    Node
+        atom ->
+            T = case concrete(Type) of
+                    '_' -> [];
+                    Res -> Res
+                end,
+            case Argument of
+                none ->
+                    {record, Pos, T, Fs};
+                _ ->
+                    {record, Pos, Argument, T, Fs}
+            end;
+        list ->
+            [Mod, Name] = list_elements(Type),
+            case Argument of
+                none ->
+                    {record, Pos, {concrete(Mod), concrete(Name)}, Fs};
+                _ ->
+                    {record, Pos, Argument, {concrete(Mod), concrete(Name)}, Fs}
+            end;
+        _ ->
+            Node
     end.
-
 
 -doc """
 Returns the argument subtree of a `record_expr` node, if any.
@@ -4539,18 +4551,22 @@ _See also: _`record_expr/3`.
 
 record_expr_type(Node) ->
     case unwrap(Node) of
-	{record, Pos, {Mod, Name}, _} ->
-	    list([set_pos(atom(Mod), Pos), set_pos(atom(Name), Pos)]);
-	{record_field, Pos, _, Name, _} ->
-	   set_pos(atom(Name), Pos);
-	{record, Pos, Type, _} ->
-	    set_pos(atom(Type), Pos);
-	{record, Pos, _, {Mod, Name}, _} ->
-	    list([set_pos(atom(Mod), Pos), set_pos(atom(Name), Pos)]);
-	{record, Pos, _, Type, _} ->
-	    set_pos(atom(Type), Pos);
-	Node1 ->
-	    (data(Node1))#record_expr.type
+        {record, Pos, {Mod, Name}, _} ->
+            list([set_pos(atom(Mod), Pos), set_pos(atom(Name), Pos)]);
+        {record, Pos, [], _} ->
+            set_pos(atom('_'), Pos);
+        {record_field, Pos, _, Name, _} ->
+           set_pos(atom(Name), Pos);
+        {record, Pos, Type, _} ->
+            set_pos(atom(Type), Pos);
+        {record, Pos, _, {Mod, Name}, _} ->
+            list([set_pos(atom(Mod), Pos), set_pos(atom(Name), Pos)]);
+        {record, Pos, _, [], _} ->
+            set_pos(atom('_'), Pos);
+        {record, Pos, _, Type, _} ->
+            set_pos(atom(Type), Pos);
+        Node1 ->
+            (data(Node1))#record_expr.type
     end.
 
 

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_SUITE_test_module.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/syntax_tools_SUITE_test_module.erl
@@ -44,6 +44,7 @@
 -type some_type() :: map().
 -type some_other_type() :: {'a', #{ list() => term()} }.
 
+-export_record([a, b]).
 -record #a{x, y}.
 -record #b{x=none, y=none, z=none}.
 
@@ -645,13 +646,24 @@ eep78() ->
     ok.
 
 native_record() ->
+    %% Creation.
     ARec = #a{x=1, y=2},
-    #a{x=1} = ARec,
+    ARec = #?MODULE:a{x=1, y=2},
 
+    %% Update.
     R0 = #b{},
     R0 = R0#b{},
     R1 = R0#b{x=foo},
-    #b{x=foo, y=none, z=none} = R1,
-    % foo = R1#_.x,
-    foo = R1#b.x.
+    R1 = R0#?MODULE:b{x=foo},
+    R1 = R0#_{x=foo},
 
+    %% Pattern matching.
+    #a{x=1} = ARec,
+    #?MODULE:a{x=1, y=2} = ARec,
+    #_{x=1, y=2} = ARec,
+
+    %% Field access.
+    #b{x=foo, y=none, z=none} = R1,
+    foo = R1#b.x,
+    foo = R1#?MODULE:b.x,
+    foo = R1#_.x.


### PR DESCRIPTION
Additionally, add more test cases for native records in syntax tools. This commit should be enough to make everything work, but I am not an expert on how syntax tools can be used. If there are more use cases that we need to support for native records, please tell us.