### PR TITLE
otp: remove non-existing report in release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1203,7 +1203,6 @@ jobs:
             artifacts/*.tar.gz \
             artifacts/*.txt \
             attestations/*.sigstore \
-            scan-report-web-app.html \
             bom.*
       - name: Deploy on erlang.org
         env:


### PR DESCRIPTION
during the release workflow, the GH Action was trying to upload `scan-report-web-app.html`. However, this report does not exists and the `gh` crashes when a file does not exist.

This PR simply removes the upload of the non-existing `scan-report-web-app.html`

https://github.com/erlang/otp/pull/11000 changed the action to use directly `gh`, which fails when an uploaded file is missing.
