### PR TITLE
stdlib: Add warning for native record defs in headers

### DIFF
--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -852,6 +852,11 @@ value are listed.
   record. It can also be emitted when creating a record if the module
   name for the record is explicitly given as the current module.
 
+- **`nowarn_native_record_header`** - By default, a warning is emitted
+  when a native record is defined in a header file. You can replace a
+  native record definition in a header file with an `-import_record()`
+  directive. Use this option to turn off this kind of warning.
+
 - **`nowarn_unsafe_function`** - Turns off warnings for calls to unsafe
   functions. Default is to emit warnings for every call to a function known by
   the compiler to be unsafe. Notice that the compiler does not know about

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -523,6 +523,8 @@ format_error_1({unused_record,T}) ->
     {~"record ~tw is unused", [T]};
 format_error_1({untyped_record,T}) ->
     {~"record ~tw has field(s) without type information", [T]};
+format_error_1({native_record_header,T}) ->
+    {~"record ~tw is defined in a header file", [T]};
 %% --- variables ----
 format_error_1({unbound_var,V}) ->
     {~"variable ~w is unbound", [V]};
@@ -977,7 +979,8 @@ bool_options() ->
      {novalue,true},
      {undefined_field,true},
      {unsafe_function,true},
-     {possibly_unsafe_function,false}].
+     {possibly_unsafe_function,false},
+     {native_record_header,true}].
 
 %% is_warn_enabled(Category, St) -> boolean().
 %%  Check whether a warning of category Category is enabled.
@@ -1401,13 +1404,14 @@ post_traversal_check(Forms, St0) ->
     StD = check_on_load(StC),
     StE = check_export_record(Forms, StD),
     StF = check_unused_records(Forms, StE),
-    StG = check_local_opaque_types(StF),
-    StH = check_dialyzer_attribute(Forms, StG),
-    StI = check_callback_information(StH),
-    StJ = check_nifs(Forms, StI),
-    StK = check_unexported_functions(StJ),
-    StL = check_removed(Forms, StK),
-    check_unsafe(Forms, StL).
+    StG = check_native_records_header(Forms, StF),
+    StH = check_local_opaque_types(StG),
+    StI = check_dialyzer_attribute(Forms, StH),
+    StJ = check_callback_information(StI),
+    StK = check_nifs(Forms, StJ),
+    StL = check_unexported_functions(StK),
+    StM = check_removed(Forms, StL),
+    check_unsafe(Forms, StM).
 
 %% check_behaviour(State0) -> State
 %% Check that the behaviour attribute is valid.
@@ -1963,6 +1967,20 @@ check_unused_records(Forms, St0) ->
             foldl(fun ({N,Anno}, St) ->
                           add_warning(Anno, {unused_record, N}, St)
                   end, St1, Unused);
+        _ ->
+            St0
+    end.
+
+check_native_records_header(Forms, #lint{records = Records}=St0) ->
+    AttrFiles = [File || {attribute,_A,file,{File,_Line}} <- Forms],
+    case {is_warn_enabled(native_record_header, St0),AttrFiles} of
+        {true,[FirstFile|_]} ->
+            InHeader = [{Name,Anno} ||
+                Name := {Anno,native,_Fields} <- Records,
+                element(1, loc(Anno, St0)) =/= FirstFile],
+            foldl(fun ({N,Anno}, St) ->
+                          add_warning(Anno, {native_record_header, N}, St)
+                  end, St0, InHeader);
         _ ->
             St0
     end.

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -5759,7 +5759,8 @@ do_coverage() ->
     io:format("~p\n", [Res]),
     ok.
 
-native_records(Config) ->
+native_records(Conf) ->
+    DataDir = ?datadir,
     Ts = [{basic,
            ~"""
            -record #r{x=42::integer(), y::integer()}.
@@ -6047,9 +6048,17 @@ native_records(Config) ->
            {errors,[{{3,36},erl_lint,native_record_field_types},
                     {{5,39},erl_lint,native_record_field_types}],
             []}
+          },
+          {native_record_header,
+           ~"""
+           -include("native_record_header.hrl").
+               id() -> ok.
+           """,
+           [{i,DataDir}, {keep_all_warnings,true}],
+           {warnings, [{{1,2},erl_lint,{native_record_header,a}}]}
           }
          ],
-    [] = run(Config, Ts),
+    [] = run(Conf, Ts),
     ok.
 
 %%%
@@ -6130,7 +6139,8 @@ run_test2(Conf, Test, Warnings0) ->
 
     case compile:file(File, [binary|Opts]) of
         {ok, _M, Code, Ws} when is_binary(Code) ->
-            warnings(File, Ws, Test);
+            KeepAllWarnings = proplists:get_bool(keep_all_warnings, Opts),
+            warnings(File, Ws, Test, KeepAllWarnings);
         {error, [{File,Es}], []} ->
             print_diagnostics(Es, Test),
 	    {errors, call_format_error(Es), []};
@@ -6144,8 +6154,9 @@ run_test2(Conf, Test, Warnings0) ->
 	    {errors2, Es1, Es2}
     end.
 
-warnings(File, Ws, Source) ->
-    case lists:append([W || {F, W} <- Ws, F =:= File]) of
+warnings(File, Ws, Source, KeepAllWarnings) ->
+    case lists:append([W || {F, W} <- Ws,
+                            KeepAllWarnings orelse F =:= File]) of
         [] ->
 	    [];
         L ->

--- a/lib/stdlib/test/erl_lint_SUITE_data/native_record_header.hrl
+++ b/lib/stdlib/test/erl_lint_SUITE_data/native_record_header.hrl
@@ -1,0 +1,21 @@
+-record #a{x}.
+
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%


### PR DESCRIPTION
Add warning `native_record_header` to the linter. This warning is emitted when a native record is defined in a header file. It is turned on by default. Use `nowarn_native_record_header` to turn it off.