### PR TITLE
otp: fixes windows powershell

### DIFF
--- a/.github/workflows/upload-windows-zip.yaml
+++ b/.github/workflows/upload-windows-zip.yaml
@@ -78,19 +78,18 @@ jobs:
         shell: pwsh
         run: |
           $root = Get-Location
-          $basename = $env:BASENAME
 
-          cd $basename
+          cd "$env:BASENAME"
           Get-ChildItem -Recurse -Filter erl.ini | Remove-Item
           rm Install.exe,Install.ini,Uninstall.exe
           $sha256 = Get-FileHash $root\otp.exe -Algorithm SHA256
           $sha256.Hash.ToLower() | Out-File -FilePath installer.sha256
           cp $root/vc_redist.exe .
           cp $root/erts/etc/win32/INSTALL.txt .
-          Compress-Archive -Path * -DestinationPath $root\$basename.zip
+          Compress-Archive -Path * -DestinationPath $root\"$env:BASENAME.zip"
 
           cd $root
-          Expand-Archive -Path $basename.zip -DestinationPath .\otp_test
+          Expand-Archive -Path "$env:BASENAME.zip" -DestinationPath .\otp_test
           .\otp_test\bin\erl.exe +V
 
       - name: Upload
@@ -99,5 +98,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          $basename = $env:BASENAME
-          gh release upload -R $env:GITHUB_REPOSITORY --clobber OTP-$env:INPUTS_VERSION $basename.zip
+          gh release upload -R "$env:GITHUB_REPOSITORY" --clobber "OTP-$env:INPUTS_VERSION" "$env:BASENAME.zip"

--- a/.github/workflows/upload-windows-zip.yaml
+++ b/.github/workflows/upload-windows-zip.yaml
@@ -78,18 +78,19 @@ jobs:
         shell: pwsh
         run: |
           $root = Get-Location
+          $basename = $env:BASENAME
 
-          cd $env:BASENAME
+          cd $basename
           Get-ChildItem -Recurse -Filter erl.ini | Remove-Item
           rm Install.exe,Install.ini,Uninstall.exe
           $sha256 = Get-FileHash $root\otp.exe -Algorithm SHA256
           $sha256.Hash.ToLower() | Out-File -FilePath installer.sha256
           cp $root/vc_redist.exe .
           cp $root/erts/etc/win32/INSTALL.txt .
-          Compress-Archive -Path * -DestinationPath $root\$env:BASENAME.zip
+          Compress-Archive -Path * -DestinationPath $root\$basename.zip
 
           cd $root
-          Expand-Archive -Path $env:BASENAME.zip -DestinationPath .\otp_test
+          Expand-Archive -Path $basename.zip -DestinationPath .\otp_test
           .\otp_test\bin\erl.exe +V
 
       - name: Upload
@@ -98,4 +99,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUTS_VERSION: ${{ inputs.version }}
         run: |
-          gh release upload -R $env:GITHUB_REPOSITORY --clobber OTP-$env:INPUTS_VERSION $env:BASENAME.zip
+          $basename = $env:BASENAME
+          gh release upload -R $env:GITHUB_REPOSITORY --clobber OTP-$env:INPUTS_VERSION $basename.zip


### PR DESCRIPTION
powershell parses `$env:BASENAME.zip` as accessing the property `.zip` on `$env:BASENAME`. this property does not exist and it was not the intention.

this commit assigns the env variable to powershell variable, so any other `$basename.zip` is interpreted as expanding the variable, and not as accessing a property

Fixes broken powershell variable expansion from https://github.com/erlang/otp/pull/11000
