### PR TITLE
SSL: Fix connection problems in RC3

### DIFF
--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -944,94 +944,47 @@ default_signature_algs(_) ->
 legacy_signature_algs_pre_13() ->
     [{sha224, ecdsa}, {sha224, rsa}, {sha, ecdsa}, {sha, rsa}, {sha, dsa}].
 
-signature_schemes(Version, [_|_] =SignatureSchemes) when is_tuple(Version)
-                                                         andalso ?TLS_GTE(Version, ?TLS_1_2) ->
-    Hashes = crypto:supports(hashs),
-    PubKeys = crypto:supports(public_keys),
-    Curves = crypto:supports(curves),
+signature_schemes(Version, [_|_] = SignatureSchemes)
+  when is_tuple(Version) andalso ?TLS_GTE(Version, ?TLS_1_2) ->
+    Hashes  = crypto:supports(hashs),
+    PubKeys = sets:from_list(crypto:supports(public_keys)),
+    Curves  = crypto:supports(curves),
     RSAOpts = crypto:supports(rsa_opts),
     RSAPSSSupported = lists:member(rsa_pkcs1_pss_padding, RSAOpts),
-    Fun = fun(mldsa44 = Scheme, Acc)->
-                  [Scheme | Acc];
-             (mldsa65 = Scheme, Acc)->
-                  [Scheme | Acc];
-             (mldsa87 = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_shake_256f = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_shake_256s = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_shake_192f = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_shake_192s = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_shake_128f = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_shake_128s = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_sha2_256f = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_sha2_256s = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_sha2_192f = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_sha2_192s = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_sha2_128f = Scheme, Acc)->
-                  [Scheme | Acc];
-             (slh_dsa_sha2_128s = Scheme, Acc)->
-                  [Scheme | Acc];
-             (Scheme, Acc) when is_atom(Scheme) ->
-                  {Hash, Sign0, Curve} =
-                      ssl_cipher:scheme_to_components(Scheme),
-                  Sign = case Sign0 of
-                             rsa_pkcs1 ->
-                                 rsa;
-                             rsa_pss_rsae when RSAPSSSupported ->
-                                 rsa;
-                             rsa_pss_pss when RSAPSSSupported ->
-                                 rsa;
-                             S -> S
-                         end,
-                  case proplists:get_bool(Sign, PubKeys)
-                      andalso
-                      (proplists:get_bool(Hash, Hashes)
-                       andalso (Curve =:= undefined orelse
-                                proplists:get_bool(Curve, Curves))
-                       andalso is_pair(Hash, Sign, Hashes)) orelse
-                      ((Sign == eddsa) andalso ((Curve == ed448)
-                                                orelse
-                                                (Curve == ed25519)))
-                  of
-                      true ->
-                          [Scheme | Acc];
-                      false ->
-                          Acc
-                  end;
-              %% Special clause for filtering out the legacy hash-sign tuples.
-              ({Hash, dsa = Sign} = Alg, Acc) ->
-                  case proplists:get_bool(dss, PubKeys)
-                      andalso proplists:get_bool(Hash, Hashes)
-                      andalso is_pair(Hash, Sign, Hashes)
-                  of
-                      true ->
-                          [Alg | Acc];
-                      false ->
-                          Acc
-                  end;
-              ({Hash, Sign} = Alg, Acc) ->
-                  case proplists:get_bool(Sign, PubKeys)
-                      andalso proplists:get_bool(Hash, Hashes)
-                      andalso is_pair(Hash, Sign, Hashes)
-                  of
-                      true ->
-                          [Alg | Acc];
-                      false ->
-                          Acc
-                  end
-          end,
-    Supported = lists:foldl(Fun, [], SignatureSchemes),
-    lists:reverse(Supported);
+
+    CheckComponents =
+        fun(Scheme) ->
+                {Hash, Sign0, Curve} = ssl_cipher:scheme_to_components(Scheme),
+                Sign = case Sign0 of
+                           rsa_pkcs1 ->
+                               rsa;
+                           rsa_pss_rsae when RSAPSSSupported ->
+                               rsa;
+                           rsa_pss_pss when RSAPSSSupported ->
+                               rsa;
+                           S -> S
+                       end,
+                sets:is_element(Sign, PubKeys)
+                    andalso (proplists:get_bool(Hash, Hashes)
+                             andalso (Curve =:= undefined
+                                      orelse proplists:get_bool(Curve, Curves))
+                             andalso is_pair(Hash, Sign, Hashes))
+                    orelse ((Sign == eddsa)
+                            andalso ((Curve == ed448)
+                                     orelse (Curve == ed25519)))
+        end,
+
+    Filter = fun(Scheme) when is_atom(Scheme) ->
+                     sets:is_element(Scheme, PubKeys) orelse CheckComponents(Scheme);
+                ({Hash, Sign0}) ->
+                     Sign = if Sign0 =:= dsa -> dss;
+                               true -> Sign0
+                            end,
+                     sets:is_element(Sign, PubKeys)
+                         andalso proplists:get_bool(Hash, Hashes)
+                         andalso is_pair(Hash, Sign0, Hashes)
+             end,
+    lists:filter(Filter, SignatureSchemes);
 signature_schemes(_, _) ->
     [].
 

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -975,11 +975,11 @@ signature_schemes(_, _) ->
     [].
 
 default_signature_schemes(Version) ->
-    Default = [mldsa87,
-               mldsa65,
-               mldsa44] ++ slh_dsa_schemes() ++
-        [eddsa_ed25519,
-         eddsa_ed448,
+    [GoodSLH|SLH_DSA] = slh_dsa_schemes(),
+    Default =
+        [mldsa87, mldsa65, mldsa44,
+         GoodSLH,
+         eddsa_ed25519, eddsa_ed448,
          ecdsa_secp521r1_sha512,
          ecdsa_secp384r1_sha384,
          ecdsa_secp256r1_sha256,
@@ -992,7 +992,7 @@ default_signature_schemes(Version) ->
          rsa_pss_rsae_sha512,
          rsa_pss_rsae_sha384,
          rsa_pss_rsae_sha256
-        ],
+        | SLH_DSA ],
     signature_schemes(Version, Default).
 
 legacy_signature_schemes(Version) ->
@@ -1025,10 +1025,10 @@ rsa_schemes() ->
     end.
 
 slh_dsa_schemes() ->
-    [slh_dsa_shake_256f,
-     slh_dsa_shake_256s,
-     slh_dsa_sha2_256f,
+    [slh_dsa_sha2_256f,  %% Fastest
      slh_dsa_sha2_256s,
+     slh_dsa_shake_256f,
+     slh_dsa_shake_256s,
      slh_dsa_shake_192f,
      slh_dsa_shake_192s,
      slh_dsa_sha2_192f,

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -920,11 +920,8 @@ signature_algs(?TLS_1_2, HashSigns) ->
 			    end, [], HashSigns),
     lists:reverse(Supported).
 
-default_signature_algs([?TLS_1_3]) ->
+default_signature_algs([?TLS_1_3|_]) ->
     default_signature_schemes(?TLS_1_3) ++ legacy_signature_schemes(?TLS_1_3);
-default_signature_algs([?TLS_1_3, ?TLS_1_2 | _]) ->
-    default_signature_schemes(?TLS_1_3) ++ legacy_signature_schemes(?TLS_1_3)
-        ++ default_pre_1_3_signature_algs_only();
 default_signature_algs([?TLS_1_2 = Version |_]) ->
     Default = [%% SHA2 ++ PSS
                {sha512, ecdsa},
@@ -943,14 +940,6 @@ default_signature_algs([?TLS_1_2 = Version |_]) ->
     signature_algs(Version, Default);
 default_signature_algs(_) ->
     undefined.
-
-default_pre_1_3_signature_algs_only() ->
-    Default = [%% SHA2
-               {sha512, ecdsa},
-               {sha384, ecdsa},
-               {sha256, ecdsa}
-              ],
-    signature_algs(?TLS_1_2, Default).
 
 legacy_signature_algs_pre_13() ->
     [{sha224, ecdsa}, {sha224, rsa}, {sha, ecdsa}, {sha, rsa}, {sha, dsa}].

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -889,36 +889,22 @@ signature_algs(?TLS_1_2, HashSigns) ->
     Hashes = crypto:supports(hashs),
     PubKeys = crypto:supports(public_keys),
     Schemes =  rsa_schemes(),
-    Supported = lists:foldl(fun({Hash, dsa = Sign} = Alg, Acc) ->
-				    case proplists:get_bool(dss, PubKeys)
-					andalso proplists:get_bool(Hash, Hashes)
-					andalso is_pair(Hash, Sign, Hashes)
-				    of
-					true ->
-					    [Alg | Acc];
-					false ->
-					    Acc
-				    end;
-			       ({Hash, Sign} = Alg, Acc) ->
-				    case proplists:get_bool(Sign, PubKeys)
-					andalso proplists:get_bool(Hash, Hashes)
-					andalso is_pair(Hash, Sign, Hashes)
-				    of
-					true ->
-					    [Alg | Acc];
-					false ->
-					    Acc
-				    end;
-                               (Alg, Acc) when is_atom(Alg) ->
-                                    case lists:member(Alg, Schemes) of
-                                        true ->
-                                            [NewAlg] = signature_schemes(?TLS_1_3, [Alg]),
-                                            [NewAlg| Acc];
-					false ->
-					    Acc
-				    end
-			    end, [], HashSigns),
-    lists:reverse(Supported).
+    lists:filtermap(fun({Hash, Sign0}) ->
+                            Sign = if Sign0 =:= dsa -> dss;
+                                      true -> Sign0
+                                   end,
+                            proplists:get_bool(Sign, PubKeys)
+                                andalso proplists:get_bool(Hash, Hashes)
+                                andalso is_pair(Hash, Sign0, Hashes);
+                       (Alg) when is_atom(Alg) ->
+                            case lists:member(Alg, Schemes) of
+                                true ->
+                                    [NewAlg] = signature_schemes(?TLS_1_3, [Alg]),
+                                    {true, NewAlg};
+                                false ->
+                                    false
+                            end
+                    end, HashSigns).
 
 default_signature_algs([?TLS_1_3|_]) ->
     default_signature_schemes(?TLS_1_3) ++ legacy_signature_schemes(?TLS_1_3);


### PR DESCRIPTION
 ssl: Fix default signature_algs causing connection failures                                                                                 
                                                                                                                                              
  The default signature_algorithms extension in the ClientHello had two                                                                       
  issues causing connections to fail with certain servers:                                                                                    
                                                                                                                                              
  1. Duplicate code points: When both TLS 1.3 and 1.2 were configured,                                                                        
     default_signature_algs/1 appended legacy {hash,sign} tuples (e.g.                                                                        
     {sha256,ecdsa}) that encode to the same wire values as the scheme                                                                        
     atoms already in the list (e.g. ecdsa_secp256r1_sha256). Strict                                                                          
     servers such as erlang.org rejected this with a decode error.                                                                            
                                                                                                                                              
  2. Unsupported PQ algorithms: The ML-DSA and SLH-DSA signature schemes                                                                      
     were included unconditionally without checking crypto support,                                                                           
     bloating the extension and causing servers with size limits (e.g.                                                                        
     fastly.com) to close the connection.                                                                                                     
                                                                                                                                              
  Fix by removing the redundant legacy ECDSA tuples from the TLS 1.3+1.2                                                                      
  default, filtering PQ schemes against crypto:supports(public_keys) in                                                                       
  signature_schemes/2, and prioritizing the fastest SLH-DSA variant while                                                                     
  moving the rest to the end of the default list.
  
  Fixes #11018
  