### PR TITLE
TOS Format

### DIFF
--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -432,25 +432,6 @@ static void (*esock_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 
 /* *** Misc macros and defines *** */
 
-/* This macro exist on some (linux) platforms */
-#if !defined(IPTOS_TOS_MASK)
-#define IPTOS_TOS_MASK     0x1E
-#endif
-#if !defined(IPTOS_TOS)
-#define IPTOS_TOS(tos)     ((tos)&IPTOS_TOS_MASK)
-#endif
-#define ESOCK_TOS_SHIFT    1
-
-/* This macro exist on some (linux) platforms */
-#if !defined(IPTOS_PREC_MASK)
-#define IPTOS_PREC_MASK    0xe0
-#endif
-#if !defined(IPTOS_PREC)
-#define IPTOS_PREC(tos)    ((tos)&IPTOS_PREC_MASK)
-#endif
-#define ESOCK_TOS_PREC_SHIFT    5
-
-#define ESOCK_DSCP_MASK         0xfc
 #define ESOCK_DSCP_SHIFT        2
 /* https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml */
 /* DSCP Pool 1 */
@@ -480,7 +461,32 @@ static void (*esock_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 #define ESOCK_DSCP_LE           1
 #define ESOCK_DSCP_NQB          45
 
+/* Legacy RFC 1349: Type of Service in the Internet Protocol Suite
+ */
 
+#define ESOCK_TOS_MASK     0x1E
+#define ESOCK_TOS_SHIFT    1
+/**/
+#define ESOCK_TOS_LOWDELAY      8
+#define ESOCK_TOS_THROUGHPUT    4
+#define ESOCK_TOS_RELIABILITY   2
+#define ESOCK_TOS_MINCOST       1
+#define ESOCK_TOS_DEFAULT       0
+
+#define ESOCK_TOS_PREC_MASK     0xe0
+#define ESOCK_TOS_PREC_SHIFT    5
+/**/
+#define ESOCK_TOS_PREC_NETCONTROL       ESOCK_DSCP_CS7
+#define ESOCK_TOS_PREC_INTERNETCONTROL  ESOCK_DSCP_CS6
+#define ESOCK_TOS_PREC_CRITIC_ECP       ESOCK_DSCP_CS5
+#define ESOCK_TOS_PREC_FLASHOVERRIDE    ESOCK_DSCP_CS4
+#define ESOCK_TOS_PREC_FLASH            ESOCK_DSCP_CS3
+#define ESOCK_TOS_PREC_IMMEDIATE        ESOCK_DSCP_CS2
+#define ESOCK_TOS_PREC_PRIORITY         ESOCK_DSCP_CS1
+#define ESOCK_TOS_PREC_ROUTINE          ESOCK_DSCP_CS0
+
+
+#define ESOCK_DSCP_MASK         0xfc
 #if defined(TCP_CA_NAME_MAX)
 #define ESOCK_OPT_TCP_CONGESTION_NAME_MAX TCP_CA_NAME_MAX
 #else
@@ -16105,19 +16111,17 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
 
         /* Take the 'TOS' values first */
         if (COMPARE(eVal, esock_atom_lowdelay) == 0) {
-            *val   = IPTOS_LOWDELAY;
+            *val   = ESOCK_TOS_LOWDELAY << ESOCK_TOS_SHIFT;
             result = TRUE;
         } else if (COMPARE(eVal, esock_atom_throughput) == 0) {
-            *val   = IPTOS_THROUGHPUT;
+            *val   = ESOCK_TOS_THROUGHPUT << ESOCK_TOS_SHIFT;
             result = TRUE;
         } else if (COMPARE(eVal, esock_atom_reliability) == 0) {
-            *val   = IPTOS_RELIABILITY;
+            *val   = ESOCK_TOS_RELIABILITY << ESOCK_TOS_SHIFT;
             result = TRUE;
-#if defined(IPTOS_MINCOST)
         } else if (COMPARE(eVal, esock_atom_mincost) == 0) {
-            *val   = IPTOS_MINCOST;
+            *val   = ESOCK_TOS_MINCOST << ESOCK_TOS_SHIFT;
             result = TRUE;
-#endif
 
             /* DSCP Pool 1 */
         } else if (COMPARE(eVal, esock_atom_cs0) == 0) {
@@ -16232,72 +16236,58 @@ BOOLEAN_T decode_iptos_tos_value(ErlNifEnv* env, ERL_NIF_TERM map, int* val)
     }
 
 
-    /*
-     * PRECEDENCE
-     *
-     * UGLY but will have to do for now...
-     */
+    /* PRECEDENCE */
 
     if (IS_NUM(env, ePREC)) {
 
         if (! GET_UINT(env, ePREC, &tmp)) {
             *val = -1;
-            return FALSE;           
+            return FALSE;
         }
 
-        prec = (unsigned char) IPTOS_PREC(tmp);
-            
+        prec = (unsigned char) tmp;
+
     } else if (IS_ATOM(env, ePREC)) {
 
-#if defined(IPTOS_PREC_NETCONTROL)
         if (IS_IDENTICAL(ePREC, esock_atom_netcontrol)) {
-            prec = IPTOS_PREC_NETCONTROL;
+            prec = ESOCK_TOS_PREC_NETCONTROL;
         }
-#endif
-        
-#if defined(IPTOS_PREC_INTERNETCONTROL)
-        if (IS_IDENTICAL(ePREC, esock_atom_internetcontrol)) {
-            prec = IPTOS_PREC_INTERNETCONTROL;
-        }
-#endif
-        
-#if defined(IPTOS_PREC_CRITIC_ECP)
-        if (IS_IDENTICAL(ePREC, esock_atom_critical_ecp)) {
-            prec = IPTOS_PREC_CRITIC_ECP;
-        }
-#endif
-        
-#if defined(IPTOS_PREC_FLASHOVERRIDE)
-        if (IS_IDENTICAL(ePREC, esock_atom_flashoverride)) {
-            prec = IPTOS_PREC_FLASHOVERRIDE;
-        }
-#endif
-        
-#if defined(IPTOS_PREC_FLASH)
-        if (IS_IDENTICAL(ePREC, esock_atom_flash)) {
-            prec = IPTOS_PREC_FLASH;
-        }
-#endif
 
-#if defined(IPTOS_PREC_IMMEDIATE)
-        if (IS_IDENTICAL(ePREC, esock_atom_immediate)) {
-            prec = IPTOS_PREC_IMMEDIATE;
+        else if (IS_IDENTICAL(ePREC, esock_atom_internetcontrol)) {
+            prec = ESOCK_TOS_PREC_INTERNETCONTROL;
         }
-#endif
-        
-#if defined(IPTOS_PREC_PRIORITY)
-        if (IS_IDENTICAL(ePREC, esock_atom_priority)) {
-            prec = IPTOS_PREC_PRIORITY;
-        }
-#endif
-        
-#if defined(IPTOS_PREC_ROUTINE)
-        if (IS_IDENTICAL(ePREC, esock_atom_routine)) {
-            prec = IPTOS_PREC_ROUTINE;
-        }
-#endif
 
-    } else {
+        else if (IS_IDENTICAL(ePREC, esock_atom_critical_ecp)) {
+            prec = ESOCK_TOS_PREC_CRITIC_ECP;
+        }
+
+        else if (IS_IDENTICAL(ePREC, esock_atom_flashoverride)) {
+            prec = ESOCK_TOS_PREC_FLASHOVERRIDE;
+        }
+
+        else if (IS_IDENTICAL(ePREC, esock_atom_flash)) {
+            prec = ESOCK_TOS_PREC_FLASH;
+        }
+
+        else if (IS_IDENTICAL(ePREC, esock_atom_immediate)) {
+            prec = ESOCK_TOS_PREC_IMMEDIATE;
+        }
+
+        else if (IS_IDENTICAL(ePREC, esock_atom_priority)) {
+            prec = ESOCK_TOS_PREC_PRIORITY;
+        }
+
+        else if (IS_IDENTICAL(ePREC, esock_atom_routine)) {
+            prec = ESOCK_TOS_PREC_ROUTINE;
+        }
+
+        else {
+            *val = -1;
+            return FALSE;
+        }
+
+    }
+    else {
         *val = -1;
         return FALSE;
     }
@@ -16309,52 +16299,50 @@ BOOLEAN_T decode_iptos_tos_value(ErlNifEnv* env, ERL_NIF_TERM map, int* val)
 
         if (! GET_UINT(env, eTOS, &tmp)) {
             *val = -1;
-            return FALSE;           
+            return FALSE;
         }
 
-        tos = (unsigned char) IPTOS_TOS(tmp);
-            
+        tos = (unsigned char) tmp;
+
     } else if (IS_ATOM(env, eTOS)) {
 
-#if defined(IPTOS_LOWDELAY)
         if (IS_IDENTICAL(eTOS, esock_atom_lowdelay)) {
-            tos = IPTOS_LOWDELAY;
-        }
-#endif
-        
-#if defined(IPTOS_THROUGHPUT)
-        if (IS_IDENTICAL(eTOS, esock_atom_throughput)) {
-            tos = IPTOS_THROUGHPUT;
-        }
-#endif
-        
-#if defined(IPTOS_RELIABILITY)
-        if (IS_IDENTICAL(eTOS, esock_atom_reliability)) {
-            tos = IPTOS_RELIABILITY;
-        }
-#endif
-        
-#if defined(IPTOS_MINCOST)
-        if (IS_IDENTICAL(eTOS, esock_atom_mincost)) {
-            tos = IPTOS_MINCOST;
-        }
-#endif
-
-        if (IS_IDENTICAL(eTOS, esock_atom_default)) {
-            tos = 0;
+            tos = ESOCK_TOS_LOWDELAY;
         }
 
-    } else {
+        else if (IS_IDENTICAL(eTOS, esock_atom_throughput)) {
+            tos = ESOCK_TOS_THROUGHPUT;
+        }
+
+        else if (IS_IDENTICAL(eTOS, esock_atom_reliability)) {
+            tos = ESOCK_TOS_RELIABILITY;
+        }
+
+        else if (IS_IDENTICAL(eTOS, esock_atom_mincost)) {
+            tos = ESOCK_TOS_MINCOST;
+        }
+
+        else if (IS_IDENTICAL(eTOS, esock_atom_default)) {
+            tos = ESOCK_TOS_DEFAULT;
+        }
+
+        else {
+            *val = -1;
+            return FALSE;
+        }
+    }
+    else {
         *val = -1;
         return FALSE;
     }
 
     /* And put them together */
-    *val = prec | tos;
+    *val = ((prec << ESOCK_TOS_PREC_SHIFT) & ESOCK_TOS_PREC_MASK)
+        | ((tos << ESOCK_TOS_SHIFT) & ESOCK_TOS_MASK);
     return TRUE;
-    
+
 }
-  
+
 #endif
 
 
@@ -16670,97 +16658,73 @@ static
 ERL_NIF_TERM encode_iptos_tos(ErlNifEnv* env, int val)
 {
     ERL_NIF_TERM tos, prec, result;
-    int          nativeTOS  = IPTOS_TOS(val);
-    int          nativePREC = IPTOS_PREC(val);
+    int nativeTOS  = (val & ESOCK_TOS_MASK) >> ESOCK_TOS_SHIFT;
+    int nativePREC = (val & ESOCK_TOS_PREC_MASK) >> ESOCK_TOS_PREC_SHIFT;
 
     /* *** PRECEDENCE *** */
     switch (nativePREC) {
-#if defined(IPTOS_PREC_NETCONTROL)
-    case IPTOS_PREC_NETCONTROL:
+    case ESOCK_TOS_PREC_NETCONTROL:
         prec = esock_atom_netcontrol;
         break;
-#endif
 
-#if defined(IPTOS_PREC_INTERNETCONTROL)
-    case IPTOS_PREC_INTERNETCONTROL:
+    case ESOCK_TOS_PREC_INTERNETCONTROL:
         prec = esock_atom_internetcontrol;
         break;
-#endif
 
-#if defined(IPTOS_PREC_CRITIC_ECP)
-    case IPTOS_PREC_CRITIC_ECP:
+    case ESOCK_TOS_PREC_CRITIC_ECP:
         prec = esock_atom_critical_ecp;
         break;
-#endif
 
-#if defined(IPTOS_PREC_FLASHOVERRIDE)
-    case IPTOS_PREC_FLASHOVERRIDE:
+    case ESOCK_TOS_PREC_FLASHOVERRIDE:
         prec = esock_atom_flashoverride;
         break;
-#endif
 
-#if defined(IPTOS_PREC_FLASH)
-    case IPTOS_PREC_FLASH:
+    case ESOCK_TOS_PREC_FLASH:
         prec = esock_atom_flash;
         break;
-#endif
 
-#if defined(IPTOS_PREC_IMMEDIATE)
-    case IPTOS_PREC_IMMEDIATE:
+    case ESOCK_TOS_PREC_IMMEDIATE:
         prec = esock_atom_immediate;
         break;
-#endif
 
-#if defined(IPTOS_PREC_PRIORITY)
-    case IPTOS_PREC_PRIORITY:
+    case ESOCK_TOS_PREC_PRIORITY:
         prec = esock_atom_priority;
         break;
-#endif
 
-#if defined(IPTOS_PREC_ROUTINE)
-    case IPTOS_PREC_ROUTINE:
+    case ESOCK_TOS_PREC_ROUTINE:
         prec = esock_atom_routine;
         break;
-#endif
 
     default:
-        prec = MKI(env, nativePREC >> ESOCK_TOS_PREC_SHIFT);
+        prec = MKI(env, nativePREC);
         break;
     }
 
 
     /* *** TOS *** */
     switch (nativeTOS) {
-    case 0:
+    case ESOCK_TOS_LOWDELAY:
+        tos = esock_atom_lowdelay;
+        break;
+
+    case ESOCK_TOS_THROUGHPUT:
+        tos = esock_atom_throughput;
+        break;
+
+    case ESOCK_TOS_RELIABILITY:
+        tos = esock_atom_reliability;
+        break;
+
+    case ESOCK_TOS_MINCOST:
+        tos = esock_atom_mincost;
+        break;
+
+    case ESOCK_TOS_DEFAULT:
         tos = esock_atom_default;
         break;
 
-#if defined(IPTOS_LOWDELAY)
-    case IPTOS_LOWDELAY:
-        tos = esock_atom_lowdelay;
-        break;
-#endif
-
-#if defined(IPTOS_THROUGHPUT)
-    case IPTOS_THROUGHPUT:
-        tos = esock_atom_throughput;
-        break;
-#endif
-
-#if defined(IPTOS_RELIABILITY)
-    case IPTOS_RELIABILITY:
-        tos = esock_atom_reliability;
-        break;
-#endif
-
-#if defined(IPTOS_MINCOST)
-    case IPTOS_MINCOST:
-        tos = esock_atom_mincost;
-        break;
-#endif
-
     default:
-        tos = MKI(env, nativeTOS >> ESOCK_TOS_SHIFT);
+        tos = MKI(env, nativeTOS);
         break;
     }
 

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -439,6 +439,7 @@ static void (*esock_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 #if !defined(IPTOS_TOS)
 #define IPTOS_TOS(tos)     ((tos)&IPTOS_TOS_MASK)
 #endif
+#define ESOCK_TOS_SHIFT    1
 
 /* This macro exist on some (linux) platforms */
 #if !defined(IPTOS_PREC_MASK)
@@ -447,18 +448,37 @@ static void (*esock_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 #if !defined(IPTOS_PREC)
 #define IPTOS_PREC(tos)    ((tos)&IPTOS_PREC_MASK)
 #endif
+#define ESOCK_TOS_PREC_SHIFT    5
 
-/* This macro exist on some (linux) platforms */
-#if !defined(IPTOS_DSCP_MASK)
-#define IPTOS_DSCP_MASK    0xfc
-#endif
-#if !defined(IPTOS_DSCP)
-#define IPTOS_DSCP(x)     ((x)&IPTOS_DSCP_MASK)
-#endif
-
-#define ESOCK_DSCP_LE          0x04
-#define ESOCK_DSCP_VOICE_ADMIT 0xb0
-#define ESOCK_DSCP_NQB         0xb4
+#define ESOCK_DSCP_MASK         0xfc
+#define ESOCK_DSCP_SHIFT        2
+/* https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml */
+/* DSCP Pool 1 */
+#define ESOCK_DSCP_CS0          0
+#define ESOCK_DSCP_CS1          8
+#define ESOCK_DSCP_CS2          16
+#define ESOCK_DSCP_CS3          24
+#define ESOCK_DSCP_CS4          32
+#define ESOCK_DSCP_CS5          40
+#define ESOCK_DSCP_CS6          48
+#define ESOCK_DSCP_CS7          56
+#define ESOCK_DSCP_AF11         10
+#define ESOCK_DSCP_AF12         12
+#define ESOCK_DSCP_AF13         14
+#define ESOCK_DSCP_AF21         18
+#define ESOCK_DSCP_AF22         20
+#define ESOCK_DSCP_AF23         22
+#define ESOCK_DSCP_AF31         26
+#define ESOCK_DSCP_AF32         28
+#define ESOCK_DSCP_AF33         30
+#define ESOCK_DSCP_AF41         34
+#define ESOCK_DSCP_AF42         36
+#define ESOCK_DSCP_AF43         38
+#define ESOCK_DSCP_EF           46
+#define ESOCK_DSCP_VOICE_ADMIT  44
+/* DSCP Pool 3 */
+#define ESOCK_DSCP_LE           1
+#define ESOCK_DSCP_NQB          45
 
 
 #if defined(TCP_CA_NAME_MAX)
@@ -2280,6 +2300,14 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(counters);                        \
     GLOBAL_ATOM_DECL(credentials);                     \
     GLOBAL_ATOM_DECL(critical_ecp);                    \
+    GLOBAL_ATOM_DECL(cs0);                             \
+    GLOBAL_ATOM_DECL(cs1);                             \
+    GLOBAL_ATOM_DECL(cs2);                             \
+    GLOBAL_ATOM_DECL(cs3);                             \
+    GLOBAL_ATOM_DECL(cs4);                             \
+    GLOBAL_ATOM_DECL(cs5);                             \
+    GLOBAL_ATOM_DECL(cs6);                             \
+    GLOBAL_ATOM_DECL(cs7);                             \
     GLOBAL_ATOM_DECL(ctrl);                            \
     GLOBAL_ATOM_DECL(ctrunc);                          \
     GLOBAL_ATOM_DECL(cum_tsn);                         \
@@ -16091,149 +16119,86 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
             result = TRUE;
 #endif
 
-#if defined(IPTOS_DSCP_CS0)
+            /* DSCP Pool 1 */
         } else if (COMPARE(eVal, esock_atom_cs0) == 0) {
-            *val   = IPTOS_DSCP_CS0;
+            *val   = ESOCK_DSCP_CS0 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS1)
         } else if (COMPARE(eVal, esock_atom_cs1) == 0) {
-            *val   = IPTOS_DSCP_CS1;
+            *val   = ESOCK_DSCP_CS1 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF11)
-        } else if (COMPARE(eVal, esock_atom_af11) == 0) {
-            *val   = IPTOS_DSCP_AF11;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF12)
-        } else if (COMPARE(eVal, esock_atom_af12) == 0) {
-            *val   = IPTOS_DSCP_AF12;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF13)
-        } else if (COMPARE(eVal, esock_atom_af13) == 0) {
-            *val   = IPTOS_DSCP_AF13;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS2)
         } else if (COMPARE(eVal, esock_atom_cs2) == 0) {
-            *val   = IPTOS_DSCP_CS2;
+            *val   = ESOCK_DSCP_CS2 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF21)
-        } else if (COMPARE(eVal, esock_atom_af21) == 0) {
-            *val   = IPTOS_DSCP_AF21;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF22)
-        } else if (COMPARE(eVal, esock_atom_af22) == 0) {
-            *val   = IPTOS_DSCP_AF22;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF23)
-        } else if (COMPARE(eVal, esock_atom_af23) == 0) {
-            *val   = IPTOS_DSCP_AF23;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS3)
         } else if (COMPARE(eVal, esock_atom_cs3) == 0) {
-            *val   = IPTOS_DSCP_CS3;
+            *val   = ESOCK_DSCP_CS3 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF31)
-        } else if (COMPARE(eVal, esock_atom_af31) == 0) {
-            *val   = IPTOS_DSCP_AF31;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF32)
-        } else if (COMPARE(eVal, esock_atom_af32) == 0) {
-            *val   = IPTOS_DSCP_AF32;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF33)
-        } else if (COMPARE(eVal, esock_atom_af33) == 0) {
-            *val   = IPTOS_DSCP_AF33;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS4)
         } else if (COMPARE(eVal, esock_atom_cs4) == 0) {
-            *val   = IPTOS_DSCP_CS4;
+            *val   = ESOCK_DSCP_CS4 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF41)
-        } else if (COMPARE(eVal, esock_atom_af41) == 0) {
-            *val   = IPTOS_DSCP_AF41;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF42)
-        } else if (COMPARE(eVal, esock_atom_af42) == 0) {
-            *val   = IPTOS_DSCP_AF42;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_AF43)
-        } else if (COMPARE(eVal, esock_atom_af43) == 0) {
-            *val   = IPTOS_DSCP_AF43;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS5)
         } else if (COMPARE(eVal, esock_atom_cs5) == 0) {
-            *val   = IPTOS_DSCP_CS5;
+            *val   = ESOCK_DSCP_CS5 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_EF)
-        } else if (COMPARE(eVal, esock_atom_ef) == 0) {
-            *val   = IPTOS_DSCP_EF;
-            result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS6)
         } else if (COMPARE(eVal, esock_atom_cs6) == 0) {
-            *val   = IPTOS_DSCP_CS6;
+            *val   = ESOCK_DSCP_CS6 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-#if defined(IPTOS_DSCP_CS7)
         } else if (COMPARE(eVal, esock_atom_cs7) == 0) {
-            *val   = IPTOS_DSCP_CS7;
+            *val   = ESOCK_DSCP_CS7 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-#endif
-
-        } else if (COMPARE(eVal, esock_atom_le) == 0) {
-            *val   = ESOCK_DSCP_LE;
+        } else if (COMPARE(eVal, esock_atom_af11) == 0) {
+            *val   = ESOCK_DSCP_AF11 << ESOCK_DSCP_SHIFT;
             result = TRUE;
-
+        } else if (COMPARE(eVal, esock_atom_af12) == 0) {
+            *val   = ESOCK_DSCP_AF12 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af13) == 0) {
+            *val   = ESOCK_DSCP_AF13 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af21) == 0) {
+            *val   = ESOCK_DSCP_AF21 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af22) == 0) {
+            *val   = ESOCK_DSCP_AF22 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af23) == 0) {
+            *val   = ESOCK_DSCP_AF23 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af31) == 0) {
+            *val   = ESOCK_DSCP_AF31 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af32) == 0) {
+            *val   = ESOCK_DSCP_AF32 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af33) == 0) {
+            *val   = ESOCK_DSCP_AF33 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af41) == 0) {
+            *val   = ESOCK_DSCP_AF41 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af42) == 0) {
+            *val   = ESOCK_DSCP_AF42 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_af43) == 0) {
+            *val   = ESOCK_DSCP_AF43 << ESOCK_DSCP_SHIFT;
+            result = TRUE;
+        } else if (COMPARE(eVal, esock_atom_ef) == 0) {
+            *val   = ESOCK_DSCP_EF << ESOCK_DSCP_SHIFT;
+            result = TRUE;
         } else if (COMPARE(eVal, esock_atom_voice_admit) == 0) {
-            *val   = ESOCK_DSCP_VOICE_ADMIT;
+            *val   = ESOCK_DSCP_VOICE_ADMIT << ESOCK_DSCP_SHIFT;
             result = TRUE;
 
+            /* DSCP Pool 3 */
+        } else if (COMPARE(eVal, esock_atom_le) == 0) {
+            *val   = ESOCK_DSCP_LE << ESOCK_DSCP_SHIFT;
+            result = TRUE;
         } else if (COMPARE(eVal, esock_atom_nqb) == 0) {
-            *val   = ESOCK_DSCP_NQB;
+            *val   = ESOCK_DSCP_NQB << ESOCK_DSCP_SHIFT;
             result = TRUE;
-
         } else {
             *val   = -1;
             result = FALSE;
         }
-            
+
 #endif // ifdef ... else __WIN32__
 
         /* Is it a map (that is (new-) 'tos')? */
@@ -16759,7 +16724,7 @@ ERL_NIF_TERM encode_iptos_tos(ErlNifEnv* env, int val)
 #endif
 
     default:
-        prec = MKI(env, nativePREC);
+        prec = MKI(env, nativePREC >> ESOCK_TOS_PREC_SHIFT);
         break;
     }
 
@@ -16795,7 +16760,7 @@ ERL_NIF_TERM encode_iptos_tos(ErlNifEnv* env, int val)
 #endif
 
     default:
-        tos = MKI(env, nativeTOS);
+        tos = MKI(env, nativeTOS >> ESOCK_TOS_SHIFT);
         break;
     }
 
@@ -16819,153 +16784,64 @@ static
 ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
 {
     ERL_NIF_TERM dscp;
-    int          nativeDSCP  = IPTOS_DSCP(val);
+    int          nativeDSCP  = (val & ESOCK_DSCP_MASK) >> ESOCK_DSCP_SHIFT;
 
     /* *** IP differentiated services code points (DSCP) *** */
     switch (nativeDSCP) {
-#if defined(IPTOS_DSCP_CS0)
-    case IPTOS_DSCP_CS0:
-        dscp = esock_atom_cs0;
-        break;
-#endif
 
-#if defined(IPTOS_DSCP_CS1)
-    case IPTOS_DSCP_CS1:
-        dscp = esock_atom_cs1;
-        break;
-#endif
+        /* DSCP Pool 1 */
 
-#if defined(IPTOS_DSCP_AF11)
-    case IPTOS_DSCP_AF11:
-        dscp = esock_atom_af11;
-        break;
-#endif
+    case ESOCK_DSCP_CS0:
+        dscp = esock_atom_cs0; break;
+    case ESOCK_DSCP_CS1:
+        dscp = esock_atom_cs1; break;
+    case ESOCK_DSCP_CS2:
+        dscp = esock_atom_cs2; break;
+    case ESOCK_DSCP_CS3:
+        dscp = esock_atom_cs3; break;
+    case ESOCK_DSCP_CS4:
+        dscp = esock_atom_cs4; break;
+    case ESOCK_DSCP_CS5:
+        dscp = esock_atom_cs5; break;
+    case ESOCK_DSCP_CS6:
+        dscp = esock_atom_cs6; break;
+    case ESOCK_DSCP_CS7:
+        dscp = esock_atom_cs7; break;
+    case ESOCK_DSCP_AF11:
+        dscp = esock_atom_af11; break;
+    case ESOCK_DSCP_AF12:
+        dscp = esock_atom_af12; break;
+    case ESOCK_DSCP_AF13:
+        dscp = esock_atom_af13; break;
+    case ESOCK_DSCP_AF21:
+        dscp = esock_atom_af21; break;
+    case ESOCK_DSCP_AF22:
+        dscp = esock_atom_af22; break;
+    case ESOCK_DSCP_AF23:
+        dscp = esock_atom_af23; break;
+    case ESOCK_DSCP_AF31:
+        dscp = esock_atom_af31; break;
+    case ESOCK_DSCP_AF32:
+        dscp = esock_atom_af32; break;
+    case ESOCK_DSCP_AF33:
+        dscp = esock_atom_af33; break;
+    case ESOCK_DSCP_AF41:
+        dscp = esock_atom_af41; break;
+    case ESOCK_DSCP_AF42:
+        dscp = esock_atom_af42; break;
+    case ESOCK_DSCP_AF43:
+        dscp = esock_atom_af43; break;
+    case ESOCK_DSCP_EF:
+        dscp = esock_atom_ef; break;
+    case ESOCK_DSCP_VOICE_ADMIT:
+        dscp = esock_atom_voice_admit; break;
 
-#if defined(IPTOS_DSCP_AF12)
-    case IPTOS_DSCP_AF12:
-        dscp = esock_atom_af12;
-        break;
-#endif
+        /* DSCP Pool 3 */
 
-#if defined(IPTOS_DSCP_AF13)
-    case IPTOS_DSCP_AF13:
-        dscp = esock_atom_af13;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_CS2)
-    case IPTOS_DSCP_CS2:
-        dscp = esock_atom_cs2;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF21)
-    case IPTOS_DSCP_AF21:
-        dscp = esock_atom_af21;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF22)
-    case IPTOS_DSCP_AF22:
-        dscp = esock_atom_af22;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF23)
-    case IPTOS_DSCP_AF23:
-        dscp = esock_atom_af23;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_CS3)
-    case IPTOS_DSCP_CS3:
-        dscp = esock_atom_cs3;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF31)
-    case IPTOS_DSCP_AF31:
-        dscp = esock_atom_af31;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF32)
-    case IPTOS_DSCP_AF32:
-        dscp = esock_atom_af32;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF33)
-    case IPTOS_DSCP_AF33:
-        dscp = esock_atom_af33;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_CS4)
-    case IPTOS_DSCP_C41:
-        dscp = esock_atom_cs4;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF41)
-    case IPTOS_DSCP_AF41:
-        dscp = esock_atom_af41;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF42)
-    case IPTOS_DSCP_AF42:
-        dscp = esock_atom_af42;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_AF43)
-    case IPTOS_DSCP_AF43:
-        dscp = esock_atom_af43;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_CS5)
-    case IPTOS_DSCP_CS5:
-        dscp = esock_atom_cs5;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_EF)
-    case IPTOS_DSCP_EF:
-        dscp = esock_atom_ef;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_CS6)
-    case IPTOS_DSCP_CS6:
-        dscp = esock_atom_cs6;
-        break;
-#endif
-
-#if defined(IPTOS_DSCP_CS7)
-    case IPTOS_DSCP_CS7:
-        dscp = esock_atom_cs7;
-        break;
-#endif
-
-
-        /*
-         * And now for some values we do not (currently) have any defines for.
-         * But these are defined accordning to IANA DSCP registry.
-         * https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
-         */
-    case ESOCK_DSCP_LE: /* LE */
-        dscp = esock_atom_le;
-        break;
-
-    case ESOCK_DSCP_VOICE_ADMIT: /* VOICE-ADMIT */
-        dscp = esock_atom_voice_admit;
-        break;
-
-    case ESOCK_DSCP_NQB: /* NQB */
-        dscp = esock_atom_nqb;
-        break;
+    case ESOCK_DSCP_LE:
+        dscp = esock_atom_le; break;
+    case ESOCK_DSCP_NQB:
+        dscp = esock_atom_nqb; break;
 
     default:
         dscp = MKI(env, nativeDSCP);

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -456,6 +456,10 @@ static void (*esock_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 #define IPTOS_DSCP(x)     ((x)&IPTOS_DSCP_MASK)
 #endif
 
+#define ESOCK_DSCP_LE          0x04
+#define ESOCK_DSCP_VOICE_ADMIT 0xb0
+#define ESOCK_DSCP_NQB         0xb4
+
 
 #if defined(TCP_CA_NAME_MAX)
 #define ESOCK_OPT_TCP_CONGESTION_NAME_MAX TCP_CA_NAME_MAX
@@ -2397,6 +2401,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(key_number);                      \
     GLOBAL_ATOM_DECL(knowsepoch);		       \
     GLOBAL_ATOM_DECL(last_ack);                        \
+    GLOBAL_ATOM_DECL(le);                              \
     GLOBAL_ATOM_DECL(leave_group);                     \
     GLOBAL_ATOM_DECL(length);                          \
     GLOBAL_ATOM_DECL(level);                           \
@@ -2463,6 +2468,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(not_bound);                       \
     GLOBAL_ATOM_DECL(not_found);                       \
     GLOBAL_ATOM_DECL(not_owner);                       \
+    GLOBAL_ATOM_DECL(nqb);                             \
     GLOBAL_ATOM_DECL(num_general_errors);              \
     GLOBAL_ATOM_DECL(num_ostreams);                    \
     GLOBAL_ATOM_DECL(num_threads);                     \
@@ -2668,6 +2674,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(use_min_mtu);                     \
     GLOBAL_ATOM_DECL(use_registry);                    \
     GLOBAL_ATOM_DECL(value);                           \
+    GLOBAL_ATOM_DECL(voice_admit);                     \
     GLOBAL_ATOM_DECL(void);                            \
     GLOBAL_ATOM_DECL(v6only);                          \
     GLOBAL_ATOM_DECL(write_byte);                      \
@@ -16084,6 +16091,18 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
             result = TRUE;
 #endif
 
+#if defined(IPTOS_DSCP_CS0)
+        } else if (COMPARE(eVal, esock_atom_cs0) == 0) {
+            *val   = IPTOS_DSCP_CS0;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_CS1)
+        } else if (COMPARE(eVal, esock_atom_cs1) == 0) {
+            *val   = IPTOS_DSCP_CS1;
+            result = TRUE;
+#endif
+
 #if defined(IPTOS_DSCP_AF11)
         } else if (COMPARE(eVal, esock_atom_af11) == 0) {
             *val   = IPTOS_DSCP_AF11;
@@ -16099,6 +16118,12 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
 #if defined(IPTOS_DSCP_AF13)
         } else if (COMPARE(eVal, esock_atom_af13) == 0) {
             *val   = IPTOS_DSCP_AF13;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_CS2)
+        } else if (COMPARE(eVal, esock_atom_cs2) == 0) {
+            *val   = IPTOS_DSCP_CS2;
             result = TRUE;
 #endif
 
@@ -16120,6 +16145,12 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
             result = TRUE;
 #endif
 
+#if defined(IPTOS_DSCP_CS3)
+        } else if (COMPARE(eVal, esock_atom_cs3) == 0) {
+            *val   = IPTOS_DSCP_CS3;
+            result = TRUE;
+#endif
+
 #if defined(IPTOS_DSCP_AF31)
         } else if (COMPARE(eVal, esock_atom_af31) == 0) {
             *val   = IPTOS_DSCP_AF31;
@@ -16135,6 +16166,12 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
 #if defined(IPTOS_DSCP_AF33)
         } else if (COMPARE(eVal, esock_atom_af33) == 0) {
             *val   = IPTOS_DSCP_AF33;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_CS4)
+        } else if (COMPARE(eVal, esock_atom_cs4) == 0) {
+            *val   = IPTOS_DSCP_CS4;
             result = TRUE;
 #endif
 
@@ -16156,11 +16193,41 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
             result = TRUE;
 #endif
 
+#if defined(IPTOS_DSCP_CS5)
+        } else if (COMPARE(eVal, esock_atom_cs5) == 0) {
+            *val   = IPTOS_DSCP_CS5;
+            result = TRUE;
+#endif
+
 #if defined(IPTOS_DSCP_EF)
         } else if (COMPARE(eVal, esock_atom_ef) == 0) {
             *val   = IPTOS_DSCP_EF;
             result = TRUE;
 #endif
+
+#if defined(IPTOS_DSCP_CS6)
+        } else if (COMPARE(eVal, esock_atom_cs6) == 0) {
+            *val   = IPTOS_DSCP_CS6;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_CS7)
+        } else if (COMPARE(eVal, esock_atom_cs7) == 0) {
+            *val   = IPTOS_DSCP_CS7;
+            result = TRUE;
+#endif
+
+        } else if (COMPARE(eVal, esock_atom_le) == 0) {
+            *val   = ESOCK_DSCP_LE;
+            result = TRUE;
+
+        } else if (COMPARE(eVal, esock_atom_voice_admit) == 0) {
+            *val   = ESOCK_DSCP_VOICE_ADMIT;
+            result = TRUE;
+
+        } else if (COMPARE(eVal, esock_atom_nqb) == 0) {
+            *val   = ESOCK_DSCP_NQB;
+            result = TRUE;
 
         } else {
             *val   = -1;
@@ -16756,6 +16823,18 @@ ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
 
     /* *** IP differentiated services code points (DSCP) *** */
     switch (nativeDSCP) {
+#if defined(IPTOS_DSCP_CS0)
+    case IPTOS_DSCP_CS0:
+        dscp = esock_atom_cs0;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_CS1)
+    case IPTOS_DSCP_CS1:
+        dscp = esock_atom_cs1;
+        break;
+#endif
+
 #if defined(IPTOS_DSCP_AF11)
     case IPTOS_DSCP_AF11:
         dscp = esock_atom_af11;
@@ -16771,6 +16850,12 @@ ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
 #if defined(IPTOS_DSCP_AF13)
     case IPTOS_DSCP_AF13:
         dscp = esock_atom_af13;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_CS2)
+    case IPTOS_DSCP_CS2:
+        dscp = esock_atom_cs2;
         break;
 #endif
 
@@ -16792,6 +16877,12 @@ ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
         break;
 #endif
 
+#if defined(IPTOS_DSCP_CS3)
+    case IPTOS_DSCP_CS3:
+        dscp = esock_atom_cs3;
+        break;
+#endif
+
 #if defined(IPTOS_DSCP_AF31)
     case IPTOS_DSCP_AF31:
         dscp = esock_atom_af31;
@@ -16807,6 +16898,12 @@ ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
 #if defined(IPTOS_DSCP_AF33)
     case IPTOS_DSCP_AF33:
         dscp = esock_atom_af33;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_CS4)
+    case IPTOS_DSCP_C41:
+        dscp = esock_atom_cs4;
         break;
 #endif
 
@@ -16828,11 +16925,47 @@ ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
         break;
 #endif
 
+#if defined(IPTOS_DSCP_CS5)
+    case IPTOS_DSCP_CS5:
+        dscp = esock_atom_cs5;
+        break;
+#endif
+
 #if defined(IPTOS_DSCP_EF)
     case IPTOS_DSCP_EF:
         dscp = esock_atom_ef;
         break;
 #endif
+
+#if defined(IPTOS_DSCP_CS6)
+    case IPTOS_DSCP_CS6:
+        dscp = esock_atom_cs6;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_CS7)
+    case IPTOS_DSCP_CS7:
+        dscp = esock_atom_cs7;
+        break;
+#endif
+
+
+        /*
+         * And now for some values we do not (currently) have any defines for.
+         * But these are defined accordning to IANA DSCP registry.
+         * https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
+         */
+    case ESOCK_DSCP_LE: /* LE */
+        dscp = esock_atom_le;
+        break;
+
+    case ESOCK_DSCP_VOICE_ADMIT: /* VOICE-ADMIT */
+        dscp = esock_atom_voice_admit;
+        break;
+
+    case ESOCK_DSCP_NQB: /* NQB */
+        dscp = esock_atom_nqb;
+        break;
 
     default:
         dscp = MKI(env, nativeDSCP);

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -437,7 +437,23 @@ static void (*esock_sctp_freepaddrs)(struct sockaddr *addrs) = NULL;
 #define IPTOS_TOS_MASK     0x1E
 #endif
 #if !defined(IPTOS_TOS)
-#define IPTOS_TOS(tos)          ((tos)&IPTOS_TOS_MASK)
+#define IPTOS_TOS(tos)     ((tos)&IPTOS_TOS_MASK)
+#endif
+
+/* This macro exist on some (linux) platforms */
+#if !defined(IPTOS_PREC_MASK)
+#define IPTOS_PREC_MASK    0xe0
+#endif
+#if !defined(IPTOS_PREC)
+#define IPTOS_PREC(tos)    ((tos)&IPTOS_PREC_MASK)
+#endif
+
+/* This macro exist on some (linux) platforms */
+#if !defined(IPTOS_DSCP_MASK)
+#define IPTOS_DSCP_MASK    0xfc
+#endif
+#if !defined(IPTOS_DSCP)
+#define IPTOS_DSCP(x)     ((x)&IPTOS_DSCP_MASK)
 #endif
 
 
@@ -2051,6 +2067,9 @@ static char* extract_debug_filename(ErlNifEnv*   env,
 static BOOLEAN_T decode_ip_tos(ErlNifEnv*   env,
                                ERL_NIF_TERM eVal,
                                int*         val);
+static
+BOOLEAN_T decode_iptos_tos_value(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val);
+
 #endif
 #if defined(IP_MTU_DISCOVER)
 static BOOLEAN_T decode_ip_pmtudisc(ErlNifEnv*   env,
@@ -2074,6 +2093,8 @@ static void encode_ipv6_pmtudisc(ErlNifEnv*    env,
 #endif
 
 static ERL_NIF_TERM encode_ip_tos(ErlNifEnv* env, int val);
+static ERL_NIF_TERM encode_iptos_tos(ErlNifEnv* env, int val);
+static ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val);
 
 #if defined(IPV6_MULTICAST_HOPS) || defined(IPV6_UNICAST_HOPS)
 static
@@ -2175,6 +2196,18 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(add_membership);                  \
     GLOBAL_ATOM_DECL(add_socket);                      \
     GLOBAL_ATOM_DECL(add_source_membership);           \
+    GLOBAL_ATOM_DECL(af11);                            \
+    GLOBAL_ATOM_DECL(af12);                            \
+    GLOBAL_ATOM_DECL(af13);                            \
+    GLOBAL_ATOM_DECL(af21);                            \
+    GLOBAL_ATOM_DECL(af22);                            \
+    GLOBAL_ATOM_DECL(af23);                            \
+    GLOBAL_ATOM_DECL(af31);                            \
+    GLOBAL_ATOM_DECL(af32);                            \
+    GLOBAL_ATOM_DECL(af33);                            \
+    GLOBAL_ATOM_DECL(af41);                            \
+    GLOBAL_ATOM_DECL(af42);                            \
+    GLOBAL_ATOM_DECL(af43);                            \
     GLOBAL_ATOM_DECL(alen);                            \
     GLOBAL_ATOM_DECL(allmulti);                        \
     GLOBAL_ATOM_DECL(already);                         \
@@ -2242,6 +2275,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(cork);                            \
     GLOBAL_ATOM_DECL(counters);                        \
     GLOBAL_ATOM_DECL(credentials);                     \
+    GLOBAL_ATOM_DECL(critical_ecp);                    \
     GLOBAL_ATOM_DECL(ctrl);                            \
     GLOBAL_ATOM_DECL(ctrunc);                          \
     GLOBAL_ATOM_DECL(cum_tsn);                         \
@@ -2269,6 +2303,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(drop_source_membership);          \
     GLOBAL_ATOM_DECL(dstaddrv4);                       \
     GLOBAL_ATOM_DECL(dstaddrv6);                       \
+    GLOBAL_ATOM_DECL(dscp);                            \
     GLOBAL_ATOM_DECL(dstopts);                         \
     GLOBAL_ATOM_DECL(dup);                             \
     GLOBAL_ATOM_DECL(dup_acks_in);                     \
@@ -2276,6 +2311,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(dynamic);                         \
     GLOBAL_ATOM_DECL(echo);                            \
     GLOBAL_ATOM_DECL(eether);                          \
+    GLOBAL_ATOM_DECL(ef);                              \
     GLOBAL_ATOM_DECL(efile);                           \
     GLOBAL_ATOM_DECL(egp);                             \
     GLOBAL_ATOM_DECL(empty);                           \
@@ -2303,6 +2339,8 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(fin_wait_1);                      \
     GLOBAL_ATOM_DECL(fin_wait_2);                      \
     GLOBAL_ATOM_DECL(flags);                           \
+    GLOBAL_ATOM_DECL(flash);                           \
+    GLOBAL_ATOM_DECL(flashoverride);                   \
     GLOBAL_ATOM_DECL(flowinfo);                        \
     GLOBAL_ATOM_DECL(fragment_interleave);             \
     GLOBAL_ATOM_DECL(freebind);                        \
@@ -2325,6 +2363,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(ieee1394);                        \
     GLOBAL_ATOM_DECL(ifindex);                         \
     GLOBAL_ATOM_DECL(igmp);                            \
+    GLOBAL_ATOM_DECL(immediate);                       \
     GLOBAL_ATOM_DECL(implink);                         \
     GLOBAL_ATOM_DECL(inbound_streams);                 \
     GLOBAL_ATOM_DECL(incoming_ssn);                    \
@@ -2336,8 +2375,9 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(info);                            \
     GLOBAL_ATOM_DECL(init);                            \
     GLOBAL_ATOM_DECL(initmsg);                         \
-    GLOBAL_ATOM_DECL(invalid);                         \
     GLOBAL_ATOM_DECL(integer_range);                   \
+    GLOBAL_ATOM_DECL(internetcontrol);                 \
+    GLOBAL_ATOM_DECL(invalid);                         \
     GLOBAL_ATOM_DECL(iov);                             \
     GLOBAL_ATOM_DECL(ip);                              \
     GLOBAL_ATOM_DECL(ipcomp_level);                    \
@@ -2406,6 +2446,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(multicast_ttl);                   \
     GLOBAL_ATOM_DECL(name);                            \
     GLOBAL_ATOM_DECL(native);                          \
+    GLOBAL_ATOM_DECL(netcontrol);                      \
     GLOBAL_ATOM_DECL(netns);                           \
     GLOBAL_ATOM_DECL(netrom);                          \
     GLOBAL_ATOM_DECL(nlen);                            \
@@ -2465,6 +2506,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(ppid);			       \
     GLOBAL_ATOM_DECL(ppp);			       \
     GLOBAL_ATOM_DECL(ppromisc);			       \
+    GLOBAL_ATOM_DECL(precedence);                      \
     GLOBAL_ATOM_DECL(primary_addr);                    \
     GLOBAL_ATOM_DECL(prim_file);                       \
     GLOBAL_ATOM_DECL(prinfo);                          \
@@ -2517,6 +2559,7 @@ static const struct in6_addr in6addr_loopback =
     GLOBAL_ATOM_DECL(rights);                          \
     GLOBAL_ATOM_DECL(rm);                              \
     GLOBAL_ATOM_DECL(router_alert);                    \
+    GLOBAL_ATOM_DECL(routine);                         \
     GLOBAL_ATOM_DECL(rthdr);                           \
     GLOBAL_ATOM_DECL(rtoinfo);                         \
     GLOBAL_ATOM_DECL(rtt);                             \
@@ -8664,6 +8707,8 @@ ERL_NIF_TERM esock_setopt_multicast_if(ErlNifEnv*       env,
 
 
 /* esock_setopt_tos - Level IP TOS option
+ * The value type has "officially" the type 'iptos_value()'
+ * But for backward compat we also accept the type 'iptos_tos_value()'
  */
 
 #if defined(IP_TOS)
@@ -15989,14 +16034,9 @@ void* esock_init_cmsghdr(struct cmsghdr* cmsgP,
 
 
 /* +++ decode the ip socket option TOS +++
- * The (ip) option can be provide in two ways:
- *
- *           atom() | integer()
- *
- * When its an atom it can have the values:
- *
- *       lowdelay |  throughput | reliability | mincost
- *
+ * Officially the value type for this option is: 'iptos_value()'
+ * This means: 'iptos_native()' (an integer), 'iptos_tos()' and 'iptos_dscp()'.
+ * But for backward compat reasons we also accept 'iptos_tos_value()'
  *
  * For Windows, the Microsoft recommendation is: *Do not use*
  */
@@ -16007,7 +16047,18 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
 {
     BOOLEAN_T result = FALSE;
 
-    if (IS_ATOM(env, eVal)) {
+    /* Is it 'native'? */
+    if (IS_NUM(env, eVal)) {
+
+        if (GET_INT(env, eVal, val)) {
+            result = TRUE;
+        } else {
+            *val   = -1;
+            result = FALSE;
+        }
+
+        /* Is it an atom (that is (old-) 'tos' or 'dscp')? */
+    } else if (IS_ATOM(env, eVal)) {
 
 #ifdef __WIN32__
 
@@ -16017,6 +16068,7 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
 
 #else
 
+        /* Take the 'TOS' values first */
         if (COMPARE(eVal, esock_atom_lowdelay) == 0) {
             *val   = IPTOS_LOWDELAY;
             result = TRUE;
@@ -16032,21 +16084,95 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
             result = TRUE;
 #endif
 
+#if defined(IPTOS_DSCP_AF11)
+        } else if (COMPARE(eVal, esock_atom_af11) == 0) {
+            *val   = IPTOS_DSCP_AF11;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF12)
+        } else if (COMPARE(eVal, esock_atom_af12) == 0) {
+            *val   = IPTOS_DSCP_AF12;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF13)
+        } else if (COMPARE(eVal, esock_atom_af13) == 0) {
+            *val   = IPTOS_DSCP_AF13;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF21)
+        } else if (COMPARE(eVal, esock_atom_af21) == 0) {
+            *val   = IPTOS_DSCP_AF21;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF22)
+        } else if (COMPARE(eVal, esock_atom_af22) == 0) {
+            *val   = IPTOS_DSCP_AF22;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF23)
+        } else if (COMPARE(eVal, esock_atom_af23) == 0) {
+            *val   = IPTOS_DSCP_AF23;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF31)
+        } else if (COMPARE(eVal, esock_atom_af31) == 0) {
+            *val   = IPTOS_DSCP_AF31;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF32)
+        } else if (COMPARE(eVal, esock_atom_af32) == 0) {
+            *val   = IPTOS_DSCP_AF32;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF33)
+        } else if (COMPARE(eVal, esock_atom_af33) == 0) {
+            *val   = IPTOS_DSCP_AF33;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF41)
+        } else if (COMPARE(eVal, esock_atom_af41) == 0) {
+            *val   = IPTOS_DSCP_AF41;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF42)
+        } else if (COMPARE(eVal, esock_atom_af42) == 0) {
+            *val   = IPTOS_DSCP_AF42;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_AF43)
+        } else if (COMPARE(eVal, esock_atom_af43) == 0) {
+            *val   = IPTOS_DSCP_AF43;
+            result = TRUE;
+#endif
+
+#if defined(IPTOS_DSCP_EF)
+        } else if (COMPARE(eVal, esock_atom_ef) == 0) {
+            *val   = IPTOS_DSCP_EF;
+            result = TRUE;
+#endif
+
         } else {
             *val   = -1;
             result = FALSE;
         }
             
-#endif // ifdef __WIN32__
+#endif // ifdef ... else __WIN32__
 
-    } else if (IS_NUM(env, eVal)) {
+        /* Is it a map (that is (new-) 'tos')? */
+    } else if (IS_MAP(env, eVal)) {
 
-        if (GET_INT(env, eVal, val)) {
-            result = TRUE;
-        } else {
-            *val   = -1;
-            result = FALSE;
-        }
+        result = decode_iptos_tos_value(env, eVal, val);
 
     } else {
         *val   = -1;
@@ -16055,6 +16181,148 @@ BOOLEAN_T decode_ip_tos(ErlNifEnv* env, ERL_NIF_TERM eVal, int* val)
 
     return result;
 }
+
+static
+BOOLEAN_T decode_iptos_tos_value(ErlNifEnv* env, ERL_NIF_TERM map, int* val)
+{
+    ERL_NIF_TERM  ePREC, eTOS;
+    unsigned char prec, tos;
+    unsigned int  tmp;
+
+    if (! GET_MAP_VAL(env, map, esock_atom_precedence, &ePREC)) {
+        *val = -1;
+        return FALSE;
+    }
+
+    if (! GET_MAP_VAL(env, map, esock_atom_tos, &eTOS)) {
+        *val = -1;
+        return FALSE;
+    }
+
+
+    /*
+     * PRECEDENCE
+     *
+     * UGLY but will have to do for now...
+     */
+
+    if (IS_NUM(env, ePREC)) {
+
+        if (! GET_UINT(env, ePREC, &tmp)) {
+            *val = -1;
+            return FALSE;           
+        }
+
+        prec = (unsigned char) IPTOS_PREC(tmp);
+            
+    } else if (IS_ATOM(env, ePREC)) {
+
+#if defined(IPTOS_PREC_NETCONTROL)
+        if (IS_IDENTICAL(ePREC, esock_atom_netcontrol)) {
+            prec = IPTOS_PREC_NETCONTROL;
+        }
+#endif
+        
+#if defined(IPTOS_PREC_INTERNETCONTROL)
+        if (IS_IDENTICAL(ePREC, esock_atom_internetcontrol)) {
+            prec = IPTOS_PREC_INTERNETCONTROL;
+        }
+#endif
+        
+#if defined(IPTOS_PREC_CRITIC_ECP)
+        if (IS_IDENTICAL(ePREC, esock_atom_critical_ecp)) {
+            prec = IPTOS_PREC_CRITIC_ECP;
+        }
+#endif
+        
+#if defined(IPTOS_PREC_FLASHOVERRIDE)
+        if (IS_IDENTICAL(ePREC, esock_atom_flashoverride)) {
+            prec = IPTOS_PREC_FLASHOVERRIDE;
+        }
+#endif
+        
+#if defined(IPTOS_PREC_FLASH)
+        if (IS_IDENTICAL(ePREC, esock_atom_flash)) {
+            prec = IPTOS_PREC_FLASH;
+        }
+#endif
+
+#if defined(IPTOS_PREC_IMMEDIATE)
+        if (IS_IDENTICAL(ePREC, esock_atom_immediate)) {
+            prec = IPTOS_PREC_IMMEDIATE;
+        }
+#endif
+        
+#if defined(IPTOS_PREC_PRIORITY)
+        if (IS_IDENTICAL(ePREC, esock_atom_priority)) {
+            prec = IPTOS_PREC_PRIORITY;
+        }
+#endif
+        
+#if defined(IPTOS_PREC_ROUTINE)
+        if (IS_IDENTICAL(ePREC, esock_atom_routine)) {
+            prec = IPTOS_PREC_ROUTINE;
+        }
+#endif
+
+    } else {
+        *val = -1;
+        return FALSE;
+    }
+
+
+    /* TOS */
+
+    if (IS_NUM(env, eTOS)) {
+
+        if (! GET_UINT(env, eTOS, &tmp)) {
+            *val = -1;
+            return FALSE;           
+        }
+
+        tos = (unsigned char) IPTOS_TOS(tmp);
+            
+    } else if (IS_ATOM(env, eTOS)) {
+
+#if defined(IPTOS_LOWDELAY)
+        if (IS_IDENTICAL(eTOS, esock_atom_lowdelay)) {
+            tos = IPTOS_LOWDELAY;
+        }
+#endif
+        
+#if defined(IPTOS_THROUGHPUT)
+        if (IS_IDENTICAL(eTOS, esock_atom_throughput)) {
+            tos = IPTOS_THROUGHPUT;
+        }
+#endif
+        
+#if defined(IPTOS_RELIABILITY)
+        if (IS_IDENTICAL(eTOS, esock_atom_reliability)) {
+            tos = IPTOS_RELIABILITY;
+        }
+#endif
+        
+#if defined(IPTOS_MINCOST)
+        if (IS_IDENTICAL(eTOS, esock_atom_mincost)) {
+            tos = IPTOS_MINCOST;
+        }
+#endif
+
+        if (IS_IDENTICAL(eTOS, esock_atom_default)) {
+            tos = 0;
+        }
+
+    } else {
+        *val = -1;
+        return FALSE;
+    }
+
+    /* And put them together */
+    *val = prec | tos;
+    return TRUE;
+    
+}
+  
 #endif
 
 
@@ -16286,9 +16554,62 @@ void encode_ipv6_pmtudisc(ErlNifEnv* env, int val, ERL_NIF_TERM* eVal)
 
 
 /* +++ encode the ip socket option tos +++
- * The (ip) option can be provide as:
  *
- *       lowdelay |  throughput | reliability | mincost | integer()
+ * The TOS value have two different "definitions":
+ *
+ * * TOS field ("Classic", RFC 1349):
+ *
+ *           0,1,2      3,4,5,6    7
+ *       +------------+---------+-----+
+ *       | PRECEDENCE |   TOS   | MBZ |
+ *       +------------+---------+-----+
+ *
+ *           PRECEDENCE = Denotes importance or priority of datagram
+ *           TOS        = Type Of Service
+ *           MBZ        = Must Be Zero
+ *
+ * * Differentiated Services field (RFC 2474):
+ *
+ *
+ *           0,1,2,3,4,5       6,7
+ *       +-------------------+----+
+ *       |       DSCP        | CU |
+ *       +-------------------+----+
+ *
+ *            DSCP = Differentiated Services CodePoint
+ *            CU   = Currently Unused
+ *
+ * The (ip) option can be provided as:
+ *
+ * For decoding the value of tos can be:
+ *
+ *   iptos_value() :: iptos_tos() | iptos_dscp() | iptos_native()
+ *
+ *   iptos_tos()  :: #{precedence := iptos_tos_prec()  | non_neg_integer(),
+ *                     tos        := iptos_tos_value() | non_neg_integer()}
+ *
+ *
+ *   iptos_tos_prec()  :: netcontrol | internetcontrol | critical_ecp |
+ *                        flashoverride | flash | immediate | priority |
+ *                        routine
+ *
+ *   iptos_tos_value() :: default |
+ *                        lowdelay |  throughput | reliability | mincost
+ *
+ *   iptos_dscp() :: (cs1) af11 | af12 | af13 |
+ *                   (cs2) af21 | af22 | af23 |
+ *                   (cs3) af31 | af32 | af33 |
+ *                   (cs4) af41 | af42 | af43 |
+ *                   (cs5) ef
+ *
+ *   iptos_native() :: non_neg_integer()
+ *
+ *   ip_tos() :: #{native :: iptos_native(),
+ *                 %% According to RFC 1349
+ *                 tos    :: iptos_tos(),
+ *                 %% According to RFC 2474
+ *                 dscp   :: iptos_dscp()}
+ *
  *
  */
 
@@ -16296,47 +16617,237 @@ static
 ERL_NIF_TERM encode_ip_tos(ErlNifEnv* env, int val)
 {
     ERL_NIF_TERM result;
+    ERL_NIF_TERM native = MKI(env, val);
+    ERL_NIF_TERM tos    = encode_iptos_tos(env, val);
+    ERL_NIF_TERM dscp   = encode_iptos_dscp(env, val);
+    ERL_NIF_TERM
+        tosKeys[] = {esock_atom_native, esock_atom_tos, esock_atom_dscp},
+        tosVals[] = {native, tos, dscp};
+    unsigned int
+        numKeys = NUM(tosKeys),
+        numVals = NUM(tosVals);
 
-    switch (IPTOS_TOS(val)) {
-#if defined(IPTOS_LOWDELAY)
-    case IPTOS_LOWDELAY:
-        result = esock_atom_lowdelay;
-        break;
-#endif
-
-#if defined(IPTOS_THROUGHPUT)
-    case IPTOS_THROUGHPUT:
-        result = esock_atom_throughput;
-        break;
-#endif
-
-#if defined(IPTOS_RELIABILITY)
-    case IPTOS_RELIABILITY:
-        result = esock_atom_reliability;
-        break;
-#endif
-
-#if defined(IPTOS_MINCOST)
-    case IPTOS_MINCOST:
-        result = esock_atom_mincost;
-        break;
-#endif
-
-    default:
-        result = MKI(env, val);
-        break;
-    }
+    ESOCK_ASSERT( numKeys == numVals );
+    ESOCK_ASSERT( MKMA(env, tosKeys, tosVals, numKeys, &result) );
 
     return result;
 }
 
 
+static
+ERL_NIF_TERM encode_iptos_tos(ErlNifEnv* env, int val)
+{
+    ERL_NIF_TERM tos, prec, result;
+    int          nativeTOS  = IPTOS_TOS(val);
+    int          nativePREC = IPTOS_PREC(val);
+
+    /* *** PRECEDENCE *** */
+    switch (nativePREC) {
+#if defined(IPTOS_PREC_NETCONTROL)
+    case IPTOS_PREC_NETCONTROL:
+        prec = esock_atom_netcontrol;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_INTERNETCONTROL)
+    case IPTOS_PREC_INTERNETCONTROL:
+        prec = esock_atom_internetcontrol;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_CRITIC_ECP)
+    case IPTOS_PREC_CRITIC_ECP:
+        prec = esock_atom_critical_ecp;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_FLASHOVERRIDE)
+    case IPTOS_PREC_FLASHOVERRIDE:
+        prec = esock_atom_flashoverride;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_FLASH)
+    case IPTOS_PREC_FLASH:
+        prec = esock_atom_flash;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_IMMEDIATE)
+    case IPTOS_PREC_IMMEDIATE:
+        prec = esock_atom_immediate;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_PRIORITY)
+    case IPTOS_PREC_PRIORITY:
+        prec = esock_atom_priority;
+        break;
+#endif
+
+#if defined(IPTOS_PREC_ROUTINE)
+    case IPTOS_PREC_ROUTINE:
+        prec = esock_atom_routine;
+        break;
+#endif
+
+    default:
+        prec = MKI(env, nativePREC);
+        break;
+    }
+
+
+    /* *** TOS *** */
+    switch (nativeTOS) {
+    case 0:
+        tos = esock_atom_default;
+        break;
+
+#if defined(IPTOS_LOWDELAY)
+    case IPTOS_LOWDELAY:
+        tos = esock_atom_lowdelay;
+        break;
+#endif
+
+#if defined(IPTOS_THROUGHPUT)
+    case IPTOS_THROUGHPUT:
+        tos = esock_atom_throughput;
+        break;
+#endif
+
+#if defined(IPTOS_RELIABILITY)
+    case IPTOS_RELIABILITY:
+        tos = esock_atom_reliability;
+        break;
+#endif
+
+#if defined(IPTOS_MINCOST)
+    case IPTOS_MINCOST:
+        tos = esock_atom_mincost;
+        break;
+#endif
+
+    default:
+        tos = MKI(env, nativeTOS);
+        break;
+    }
+
+    {
+        ERL_NIF_TERM
+            tosKeys[] = {esock_atom_precedence, esock_atom_tos},
+            tosVals[] = {prec,                  tos};
+        unsigned int
+            numKeys = NUM(tosKeys),
+            numVals = NUM(tosVals);
+
+        ESOCK_ASSERT( numKeys == numVals );
+        ESOCK_ASSERT( MKMA(env, tosKeys, tosVals, numKeys, &result) );
+
+        return result;
+    }
+}
+
+
+static
+ERL_NIF_TERM encode_iptos_dscp(ErlNifEnv* env, int val)
+{
+    ERL_NIF_TERM dscp;
+    int          nativeDSCP  = IPTOS_DSCP(val);
+
+    /* *** IP differentiated services code points (DSCP) *** */
+    switch (nativeDSCP) {
+#if defined(IPTOS_DSCP_AF11)
+    case IPTOS_DSCP_AF11:
+        dscp = esock_atom_af11;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF12)
+    case IPTOS_DSCP_AF12:
+        dscp = esock_atom_af12;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF13)
+    case IPTOS_DSCP_AF13:
+        dscp = esock_atom_af13;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF21)
+    case IPTOS_DSCP_AF21:
+        dscp = esock_atom_af21;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF22)
+    case IPTOS_DSCP_AF22:
+        dscp = esock_atom_af22;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF23)
+    case IPTOS_DSCP_AF23:
+        dscp = esock_atom_af23;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF31)
+    case IPTOS_DSCP_AF31:
+        dscp = esock_atom_af31;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF32)
+    case IPTOS_DSCP_AF32:
+        dscp = esock_atom_af32;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF33)
+    case IPTOS_DSCP_AF33:
+        dscp = esock_atom_af33;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF41)
+    case IPTOS_DSCP_AF41:
+        dscp = esock_atom_af41;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF42)
+    case IPTOS_DSCP_AF42:
+        dscp = esock_atom_af42;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_AF43)
+    case IPTOS_DSCP_AF43:
+        dscp = esock_atom_af43;
+        break;
+#endif
+
+#if defined(IPTOS_DSCP_EF)
+    case IPTOS_DSCP_EF:
+        dscp = esock_atom_ef;
+        break;
+#endif
+
+    default:
+        dscp = MKI(env, nativeDSCP);
+        break;
+    }
+
+    return dscp;
+}
+
 
 #if defined(SCTP_ASSOCINFO) || defined(SCTP_RTOINOFO) || defined(SCTP_STATUS)
 
 static
-BOOLEAN_T decode_sctp_assoc_t(ErlNifEnv* env,
-                              ERL_NIF_TERM eVal,
+BOOLEAN_T decode_sctp_assoc_t(ErlNifEnv*    env,
+                              ERL_NIF_TERM  eVal,
                               sctp_assoc_t* val)
 {
     sctp_assoc_t assoc_id;

--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -490,6 +490,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(key_number);               \
     GLOBAL_ATOM_DEF(knowsepoch);	       \
     GLOBAL_ATOM_DEF(last_ack);                 \
+    GLOBAL_ATOM_DEF(le);                       \
     GLOBAL_ATOM_DEF(leave_group);              \
     GLOBAL_ATOM_DEF(length);                   \
     GLOBAL_ATOM_DEF(level);                    \
@@ -555,6 +556,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(notrailers);               \
     GLOBAL_ATOM_DEF(not_bound);                \
     GLOBAL_ATOM_DEF(not_found);                \
+    GLOBAL_ATOM_DEF(nqb);                      \
     GLOBAL_ATOM_DEF(num_general_errors);       \
     GLOBAL_ATOM_DEF(not_owner);                \
     GLOBAL_ATOM_DEF(num_ostreams);             \
@@ -759,6 +761,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(use_min_mtu);              \
     GLOBAL_ATOM_DEF(use_registry);             \
     GLOBAL_ATOM_DEF(value);                    \
+    GLOBAL_ATOM_DEF(voice_admit);              \
     GLOBAL_ATOM_DEF(void);                     \
     GLOBAL_ATOM_DEF(v6only);                   \
     GLOBAL_ATOM_DEF(write_byte);               \

--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -368,6 +368,14 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(cork);                     \
     GLOBAL_ATOM_DEF(counters);                 \
     GLOBAL_ATOM_DEF(credentials);              \
+    GLOBAL_ATOM_DEF(cs0);                      \
+    GLOBAL_ATOM_DEF(cs1);                      \
+    GLOBAL_ATOM_DEF(cs2);                      \
+    GLOBAL_ATOM_DEF(cs3);                      \
+    GLOBAL_ATOM_DEF(cs4);                      \
+    GLOBAL_ATOM_DEF(cs5);                      \
+    GLOBAL_ATOM_DEF(cs6);                      \
+    GLOBAL_ATOM_DEF(cs7);                      \
     GLOBAL_ATOM_DEF(critical_ecp);             \
     GLOBAL_ATOM_DEF(ctrl);                     \
     GLOBAL_ATOM_DEF(ctrunc);                   \

--- a/erts/emulator/nifs/common/socket_int.h
+++ b/erts/emulator/nifs/common/socket_int.h
@@ -288,6 +288,18 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(addr_unreachable);         \
     GLOBAL_ATOM_DEF(add_membership);           \
     GLOBAL_ATOM_DEF(add_source_membership);    \
+    GLOBAL_ATOM_DEF(af11);                     \
+    GLOBAL_ATOM_DEF(af12);                     \
+    GLOBAL_ATOM_DEF(af13);                     \
+    GLOBAL_ATOM_DEF(af21);                     \
+    GLOBAL_ATOM_DEF(af22);                     \
+    GLOBAL_ATOM_DEF(af23);                     \
+    GLOBAL_ATOM_DEF(af31);                     \
+    GLOBAL_ATOM_DEF(af32);                     \
+    GLOBAL_ATOM_DEF(af33);                     \
+    GLOBAL_ATOM_DEF(af41);                     \
+    GLOBAL_ATOM_DEF(af42);                     \
+    GLOBAL_ATOM_DEF(af43);                     \
     GLOBAL_ATOM_DEF(alen);                     \
     GLOBAL_ATOM_DEF(allmulti);                 \
     GLOBAL_ATOM_DEF(already);                  \
@@ -356,6 +368,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(cork);                     \
     GLOBAL_ATOM_DEF(counters);                 \
     GLOBAL_ATOM_DEF(credentials);              \
+    GLOBAL_ATOM_DEF(critical_ecp);             \
     GLOBAL_ATOM_DEF(ctrl);                     \
     GLOBAL_ATOM_DEF(ctrunc);                   \
     GLOBAL_ATOM_DEF(cum_tsn);                  \
@@ -383,6 +396,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(drop_source_membership);   \
     GLOBAL_ATOM_DEF(dstaddrv4);                \
     GLOBAL_ATOM_DEF(dstaddrv6);                \
+    GLOBAL_ATOM_DEF(dscp);                     \
     GLOBAL_ATOM_DEF(dstopts);                  \
     GLOBAL_ATOM_DEF(dup);		       \
     GLOBAL_ATOM_DEF(dup_acks_in);              \
@@ -390,6 +404,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(dynamic);                  \
     GLOBAL_ATOM_DEF(echo);                     \
     GLOBAL_ATOM_DEF(eether);                   \
+    GLOBAL_ATOM_DEF(ef);                       \
     GLOBAL_ATOM_DEF(efile);                    \
     GLOBAL_ATOM_DEF(egp);                      \
     GLOBAL_ATOM_DEF(empty);                    \
@@ -417,6 +432,8 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(fin_wait_1);               \
     GLOBAL_ATOM_DEF(fin_wait_2);               \
     GLOBAL_ATOM_DEF(flags);                    \
+    GLOBAL_ATOM_DEF(flash);                    \
+    GLOBAL_ATOM_DEF(flashoverride);            \
     GLOBAL_ATOM_DEF(flowinfo);                 \
     GLOBAL_ATOM_DEF(fragment_interleave);      \
     GLOBAL_ATOM_DEF(freebind);                 \
@@ -439,6 +456,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(ieee1394);                 \
     GLOBAL_ATOM_DEF(ifindex);                  \
     GLOBAL_ATOM_DEF(igmp);                     \
+    GLOBAL_ATOM_DEF(immediate);                \
     GLOBAL_ATOM_DEF(implink);                  \
     GLOBAL_ATOM_DEF(inbound_streams);          \
     GLOBAL_ATOM_DEF(incoming_ssn);             \
@@ -450,8 +468,9 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(info);                     \
     GLOBAL_ATOM_DEF(init);                     \
     GLOBAL_ATOM_DEF(initmsg);                  \
-    GLOBAL_ATOM_DEF(invalid);                  \
     GLOBAL_ATOM_DEF(integer_range);            \
+    GLOBAL_ATOM_DEF(internetcontrol);          \
+    GLOBAL_ATOM_DEF(invalid);                  \
     GLOBAL_ATOM_DEF(iov);                      \
     GLOBAL_ATOM_DEF(ip);                       \
     GLOBAL_ATOM_DEF(ipcomp_level);             \
@@ -520,6 +539,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(multicast_ttl);            \
     GLOBAL_ATOM_DEF(name);                     \
     GLOBAL_ATOM_DEF(native);                   \
+    GLOBAL_ATOM_DEF(netcontrol);               \
     GLOBAL_ATOM_DEF(netns);                    \
     GLOBAL_ATOM_DEF(netrom);                   \
     GLOBAL_ATOM_DEF(nlen);                     \
@@ -579,6 +599,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(ppid);                     \
     GLOBAL_ATOM_DEF(ppp);                      \
     GLOBAL_ATOM_DEF(ppromisc);		       \
+    GLOBAL_ATOM_DEF(precedence);               \
     GLOBAL_ATOM_DEF(primary_addr);             \
     GLOBAL_ATOM_DEF(prim_file);                \
     GLOBAL_ATOM_DEF(prinfo);                   \
@@ -631,6 +652,7 @@ ress-of-packed-member]
     GLOBAL_ATOM_DEF(rights);                   \
     GLOBAL_ATOM_DEF(rm);                       \
     GLOBAL_ATOM_DEF(router_alert);             \
+    GLOBAL_ATOM_DEF(routine);                  \
     GLOBAL_ATOM_DEF(rthdr);                    \
     GLOBAL_ATOM_DEF(rtoinfo);                  \
     GLOBAL_ATOM_DEF(rtt);                      \

--- a/lib/kernel/src/gen_tcp_socket.erl
+++ b/lib/kernel/src/gen_tcp_socket.erl
@@ -1235,10 +1235,18 @@ socket_getopt(Socket, DomainProps, _) when is_list(DomainProps) ->
 socket_getopt_value(
   {socket,linger}, {ok, #{onoff := OnOff, linger := Linger}}) ->
     {ok, {OnOff, Linger}};
+socket_getopt_value({ip,tos}, {ok, #{native := TOS, tos := _}}) ->
+    {ok, TOS};
 socket_getopt_value({Level,pktoptions}, {ok, PktOpts})
   when Level =:= ip,   is_list(PktOpts);
        Level =:= ipv6, is_list(PktOpts) ->
-    {ok, [{Type, Value} || #{type := Type, value := Value} <- PktOpts]};
+    {ok,
+     [case {Type, Value} of
+          {tos, #{native := TOS, tos := _}} ->
+              {Type, TOS};
+          Type_Value ->
+              Type_Value
+      end || #{type := Type, value := Value} <- PktOpts]};
 socket_getopt_value(_Tag, {ok, _Value} = Ok) -> Ok;
 socket_getopt_value(_Tag, {error, _} = Error) -> Error.
 

--- a/lib/kernel/src/gen_udp_socket.erl
+++ b/lib/kernel/src/gen_udp_socket.erl
@@ -3,7 +3,7 @@
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
-%% Copyright Ericsson AB 2021-2025. All Rights Reserved.
+%% Copyright Ericsson AB 2021-2026. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/lib/kernel/src/gen_udp_socket.erl
+++ b/lib/kernel/src/gen_udp_socket.erl
@@ -2232,24 +2232,29 @@ ctrl2ancdata([], AncData) ->
    lists:reverse(AncData);
 ctrl2ancdata([#{level := ip,
                 type  := TOS,
-                value := Value,
-                data  := _Data}| CTRL],
+		%% This is an atom: lowdelay | thoughput | reliability | mincost
+                value := _Value,
+                data  := <<DataValue:8/integer>> = _Data} = _CTRL| CTRLs],
              AncData) when (TOS =:= tos) orelse (TOS =:= recvtos) ->
-    ctrl2ancdata(CTRL, [{tos, Value}|AncData]);
+    %% 'inet' does not provide any "translation" (unlike 'socket').
+    %% Instead, it returns the data value as is.
+    %% So we have to do the same
+    %% and therefor get the value from the data field instead.
+    ctrl2ancdata(CTRLs, [{tos, DataValue}|AncData]);
 ctrl2ancdata([#{level := ip,
                 type  := TTL,
                 value := Value,
-                data  := _Data}| CTRL],
+                data  := _Data} = _CTRL| CTRLs],
              AncData) when (TTL =:= ttl) orelse (TTL =:= recvttl) ->
-    ctrl2ancdata(CTRL, [{ttl, Value}|AncData]);
+    ctrl2ancdata(CTRLs, [{ttl, Value}|AncData]);
 ctrl2ancdata([#{level := ipv6,
                 type  := tclass,
                 value := TClass,
-                data  := _Data}| CTRL],
+                data  := _Data} = _CTRL| CTRLs],
              AncData) ->
-    ctrl2ancdata(CTRL, [{tclass, TClass}|AncData]);
-ctrl2ancdata([_|CTRL], AncData) ->
-    ctrl2ancdata(CTRL, AncData).
+    ctrl2ancdata(CTRLs, [{tclass, TClass}|AncData]);
+ctrl2ancdata([_CTRL|CTRLs], AncData) ->
+    ctrl2ancdata(CTRLs, AncData).
 
 
 %% -> {ok, NewD} | {{error, Reason}, D}

--- a/lib/kernel/src/gen_udp_socket.erl
+++ b/lib/kernel/src/gen_udp_socket.erl
@@ -2232,12 +2232,12 @@ ctrl2ancdata(CTRL) ->
 
 ctrl2ancdata([], AncData) ->
     io:format("~s -> done when"
-	      "~n   AncData: ~p"
-	      "~n", [?FUNCTION_NAME, AncData]),
+              "~n   AncData: ~p"
+              "~n", [?FUNCTION_NAME, AncData]),
    lists:reverse(AncData);
 ctrl2ancdata([#{level := ip,
                 type  := TOS,
-		%% This is an atom: lowdelay | thoughput | reliability | mincost
+                %% This is an atom: lowdelay | thoughput | reliability | mincost
                 value := #{native := NativeValue} = _Value,
                 data  := <<_DataValue:8/integer>> = _Data} = _CTRL| CTRLs],
              AncData) when (TOS =:= tos) orelse (TOS =:= recvtos) ->

--- a/lib/kernel/src/gen_udp_socket.erl
+++ b/lib/kernel/src/gen_udp_socket.erl
@@ -2231,10 +2231,7 @@ ctrl2ancdata(CTRL) ->
     ctrl2ancdata(CTRL, []).
 
 ctrl2ancdata([], AncData) ->
-    io:format("~s -> done when"
-              "~n   AncData: ~p"
-              "~n", [?FUNCTION_NAME, AncData]),
-   lists:reverse(AncData);
+    lists:reverse(AncData);
 ctrl2ancdata([#{level := ip,
                 type  := TOS,
                 %% This is an atom: lowdelay | thoughput | reliability | mincost

--- a/lib/kernel/src/gen_udp_socket.erl
+++ b/lib/kernel/src/gen_udp_socket.erl
@@ -1020,6 +1020,8 @@ socket_getopt_opts(Opts, Socket, Tag) ->
 %% socket_getopt_value(pktoptions, {ok, PktOpts0}) when is_list(PktOpts0) ->
 %%     PktOpts = [{Type, Value} || #{type := Type, value := Value} <- PktOpts0],
 %%     {ok, PktOpts};
+socket_getopt_value(tos, {ok, #{native := NativeValue}}) ->
+    {ok, NativeValue};
 socket_getopt_value(_Tag, {ok, _Value} = Ok) -> Ok;
 socket_getopt_value(_Tag, {error, _} = Error) -> Error.
 
@@ -2229,18 +2231,20 @@ ctrl2ancdata(CTRL) ->
     ctrl2ancdata(CTRL, []).
 
 ctrl2ancdata([], AncData) ->
+    io:format("~s -> done when"
+	      "~n   AncData: ~p"
+	      "~n", [?FUNCTION_NAME, AncData]),
    lists:reverse(AncData);
 ctrl2ancdata([#{level := ip,
                 type  := TOS,
 		%% This is an atom: lowdelay | thoughput | reliability | mincost
-                value := _Value,
-                data  := <<DataValue:8/integer>> = _Data} = _CTRL| CTRLs],
+                value := #{native := NativeValue} = _Value,
+                data  := <<_DataValue:8/integer>> = _Data} = _CTRL| CTRLs],
              AncData) when (TOS =:= tos) orelse (TOS =:= recvtos) ->
     %% 'inet' does not provide any "translation" (unlike 'socket').
-    %% Instead, it returns the data value as is.
-    %% So we have to do the same
-    %% and therefor get the value from the data field instead.
-    ctrl2ancdata(CTRLs, [{tos, DataValue}|AncData]);
+    %% Instead, it returns the data value as is (the 'native' value).
+    %% So we have to do the same, and therefor choose the 'native' value.
+    ctrl2ancdata(CTRLs, [{tos, NativeValue}|AncData]);
 ctrl2ancdata([#{level := ip,
                 type  := TTL,
                 value := Value,

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -41,7 +41,7 @@ has been received.
 > #### Asynchronous Calls
 >
 > Some functions feature _asynchronous calls_.  This is achieved by setting
-> the `Timeout` argument to `nowait` or to a `Handle ::` `t:reference/0`.
+> the `Timeout` argument to `nowait` or to a `Handle ::`Â `t:reference/0`.
 > See the respective function's type specification.
 >
 > This module has two different implementations of asynchronous calls.
@@ -62,9 +62,9 @@ has been received.
 > - `{select, `[`SelectInfo`](`t:select_info/0`)`}`
 >
 > Where `CompletionInfo` is
-> `{completion_info, _, `[`CompletionHandle`](`t:completion_handle/0`)`}`
+> `{completion_info,Â _,Â `[`CompletionHandle`](`t:completion_handle/0`)`}`
 > and `SelectInfo` is
-> `{select_info, _, `[`SelectHandle`](`t:select_handle/0`)`}`.
+> `{select_info,Â _,Â `[`SelectHandle`](`t:select_handle/0`)`}`.
 > Both the `CompletionHandle` and the `SelectHandle`
 > are of type `t:reference/0`.
 >
@@ -83,7 +83,7 @@ has been received.
 > will probably have to be adjusted due to the already delivered data
 > in this return value.
 >
-> On `select` systems, when the `{otp, select_read}` option is `true`,
+> On `select` systems, when the `{otp,Â select_read}` option is `true`,
 > the asynchronous [`recv/3,4`](#recv-nowait),
 > [`recvfrom/3,4`](#recvfrom-nowait), and
 > [`recvmsg/3,4,5`](#recvmsg-nowait) functions may also return:
@@ -116,7 +116,7 @@ has been received.
 >
 > When a `select` message is received, it only means that the operation
 > _may now continue_, by retrying the operation (which may return
-> a new `{select, _}` value).  Some operations are retried by repeating
+> a new `{select,Â _}` value).  Some operations are retried by repeating
 > the same function call, and some have a dedicated function variant
 > to be used for the retry.  See the respective function's documentation.
 >
@@ -143,7 +143,7 @@ has been received.
 > #### Using a `Handle`
 >
 > If creating a `t:reference/0` with [`make_ref()`](`erlang:make_ref/0`)
-> and using that as the `Timeout | Handle` argument, the same `Handle`
+> and using that as the `TimeoutÂ |Â Handle` argument, the same `Handle`
 > will then be the [`SelectHandle`](`t:select_handle/0`) in the returned
 > `t:select_info/0` and the received `select` message, or be
 > the [`CompletionHandle`](`t:completion_handle/0`) in the returned
@@ -162,8 +162,8 @@ has been received.
 > message has been received it replaces the operation in progress:
 >
 > ```erlang
->     {select, {select_info, Handle}} = socket:accept(LSock, nowait),
->     {ok, Socket} = socket:accept(LSock, 1000),
+>     {select,Â {select_info,Â Handle}} = socket:accept(LSock,Â nowait),
+>     {ok,Â Socket} = socket:accept(LSock,Â 1000),
 >     :
 > ```
 > Above, `Handle` is _no longer_ valid once the second `accept/2`, call
@@ -370,6 +370,10 @@ server(Addr, Port) ->
               ip_msfilter/0,
               ip_pmtudisc/0,
               ip_tos/0,
+              iptos_value/0,
+              iptos_tos/0,
+              iptos_dscp/0,
+              iptos_native/0,
               ip_pktinfo/0,
 
               ipv6_mreq/0,
@@ -459,7 +463,7 @@ and the `t:otp_socket_option/0` with the same name.
           io_backend      := #{name := atom()},
 	  load_nif_result := undefined | ok | {error, term()}}.
 
--doc "A `t:map/0` of `Name := Counter` associations.".
+-doc "A `t:map/0` of `NameÂ :=Â Counter` associations.".
 -type socket_counters() :: #{read_byte        := non_neg_integer(),
                              read_fails       := non_neg_integer(),
                              read_pkg         := non_neg_integer(),
@@ -668,13 +672,45 @@ Lowercase `t:atom/0` values corresponding to the C library constants
 -doc """
 C: `IPTOS_*` values.
 
+Note that since there are two different representations of TOS;
+according to RFC 1349 ("classic TOS") and RFC 2474 (DSCP),
+we have three different value representations for tos: 
+Native (the raw unencoded value), (classic) tos and dscp.
+When sending or setting (the ip tos option), the user can choose
+between the three different (value) representations.
+When reading, the value is represented as a map with all three
+representations, since 'socket' does not know which one is expected.
+Its then up to the user pick the one they want.
+
 Lowercase `t:atom/0` values corresponding to the C library constants `IPTOS_*`.
 Some constant(s) may be unsupported by the platform.
 """.
--type ip_tos() :: lowdelay |
-                  throughput |
-                  reliability |
-                  mincost.
+-type ip_tos() :: #{native := iptos_native(),
+		    tos    := iptos_tos(),
+		    dscp   := iptos_dscp()}.
+
+-type iptos_value() :: iptos_tos() | iptos_dscp() | iptos_native().
+%% According to RFC 1349
+-type iptos_tos()   :: #{precedence := iptos_tos_prec()  | non_neg_integer(),
+			 tos        := iptos_tos_value() | non_neg_integer()}.
+-type iptos_tos_prec() :: netcontrol | internetcontrol | critical_ecp |
+			  flashoverride | flash | immediate | priority |
+			  routine.
+-type iptos_tos_value() :: default |
+			   lowdelay |  throughput | reliability | mincost.
+%% According to RFC 2474
+-type iptos_dscp() :: 
+	%% cs1
+	af11 | af12 | af13 |
+	%% cs2
+	af21 | af22 | af23 |
+	%% cs3
+	af31 | af32 | af33 |
+	%% cs4
+	af41 | af42 | af43 |
+	%% cs5
+	ef.
+-type iptos_native() :: non_neg_integer().
 
 -doc "C: `struct ip_pktinfo`".
 -type ip_pktinfo() ::
@@ -1065,8 +1101,8 @@ hence above all OS protocol levels.
   On `select` implementations, see [Asynchronous Calls](#asynchronous-calls),
   automatically activate select after a completed read.
 
-  Instead of `{ok, Data}` the receive operation returns
-  [`{select_read, {SelectInfo, Data}}`](`t:select_info/0`),
+  Instead of `{ok,Â Data}` the receive operation returns
+  [`{select_read,Â {SelectInfo,Â Data}}`](`t:select_info/0`),
   and the calling process can wait for a [`select` message](#async-messages)
   containing `SelectInfo` when there is data available again.
 
@@ -1316,9 +1352,10 @@ _Options for protocol level_ [_`ip`_:](`t:level/0`)
 
 - **`{ip, sendsrcaddr}`** - `Value = boolean()`
 
-- **`{ip, tos}`** - `Value =` [`ip_tos()` ](`t:ip_tos/0`)`| integer()`
+- **`{ip, tos}`** - `Value =` [`iptos_value()` ](`t:iptos_value/0`) | [`ip_tos()` ](`t:ip_tos/0`)
 
-  An `t:integer/0` value is according to the platform's header files.
+  When sending/setting the value is according to `t:iptos_value/0`.
+  When reading/getting the value is according to `t:ip_tos/0`.
 
 - **`{ip, transparent}`** - `Value = boolean()`
 
@@ -2061,9 +2098,9 @@ successfully decoded the data.
         #{level := socket,  type := rights,       data := binary()} |
         #{level := socket,  type := credentials,  data := binary()} |
         #{level := ip,      type := tos,          data := binary(),
-          value => ip_tos() | integer()}                            |
+          value => ip_tos()}                                        |
         #{level := ip,      type := recvtos,      data := binary(),
-          value := ip_tos() | integer()}                            |
+          value := ip_tos()}                                        |
         #{level := ip,      type := ttl,          data := binary(),
           value => integer()}                                       |
         #{level := ip,      type := recvttl,      data := binary(),
@@ -2102,7 +2139,7 @@ compatible what is defined in the platform's header files.
         #{level := socket,  type := rights,       data := native_value()} |
         #{level := socket,  type := credentials,  data := native_value()} |
         #{level := ip,      type := tos,          data => native_value(),
-          value => ip_tos() | integer()}                                  |
+          value => iptos_value()}                                         |
         #{level := ip,      type := ttl,          data => native_value(),
           value => integer()}                                             |
         #{level := ip,      type := hoplimit,     data => native_value(),
@@ -2259,9 +2296,9 @@ Returned by an operation that requires the caller to wait for a
 [`SelectHandle`](`t:select_handle/0`).
 
 On `select` systems, if the option
-[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
-[`{select_read, {select_info(), _}}`](`t:select_info/0`)
-is returned instead of `{ok, _}` to indicate that a new
+[`{otp,Â select_read}`](`t:otp_socket_option/0`) is set,
+[`{select_read,Â {select_info(),Â _}}`](`t:select_info/0`)
+is returned instead of `{ok,Â _}` to indicate that a new
 asynchronous receive operation has been initiated
 and the caller should wait for a
 [`select` message](#async-messages) containing the
@@ -2540,7 +2577,7 @@ option default value.
 Globally change if the socket registry is to be used or not.
 Note that its still possible to override this explicitly
 when creating an individual sockets, see [`open/2,3,4`](`open/2`)
-for more info (the [`Opts :: map/0`](`t:map/0`)).
+for more info (the [`OptsÂ ::Â map/0`](`t:map/0`)).
 """.
 -spec use_registry(D :: boolean()) -> 'ok'.
 %%
@@ -3041,15 +3078,15 @@ supports() ->
 Retrieve information about what socket features
 the module and the platform supports.
 
-If `Key1 = msg_flags` returns a list of `{Flag, boolean()}`
+If `Key1Â =Â msg_flags` returns a list of `{Flag,Â boolean()}`
 tuples for every `Flag` in `t:msg_flag/0` with the `t:boolean/0`
 indicating if the flag is supported on this platform.
 
-If `Key1 = protocols` returns a list of `{Name, boolean()}`
+If `Key1Â =Â protocols` returns a list of `{Name,Â boolean()}`
 tuples for every `Name` in`t:protocol/0` with the `t:boolean/0`
 indicating if the protocol is supported on this platform.
 
-If `Key1 = options` returns a list of `{SocketOption, boolean()}`
+If `Key1Â =Â options` returns a list of `{SocketOption,Â boolean()}`
 tuples for every `SocketOption` in `t:socket_option/0` with the `t:boolean/0`
 indicating if the socket option is supported on this platform.
 
@@ -3072,9 +3109,9 @@ supports(Key) ->
 Retrieve information about what socket features
 the module and the platform supports.
 
-If `Key1 = options`, for a `Key2` in `t:level/0` returns
-a list of `{Opt, boolean()}` tuples for all known socket options
-[`Opt` on that `Level = Key2`](`t:socket_option/0`) with the `t:boolean/0`
+If `Key1Â =Â options`, for a `Key2` in `t:level/0` returns
+a list of `{Opt,Â boolean()}` tuples for all known socket options
+[`Opt` on that `LevelÂ =Â Key2`](`t:socket_option/0`) with the `t:boolean/0`
 indicating if the socket option is supported on this platform.
 See `setopt/3` and `getopt/2`.
 
@@ -3335,16 +3372,16 @@ header files. The same goes for `Protocol` as defined in the platform's
 > #### Note {: .info }
 >
 > For some combinations of `Domain` and `Type` the platform has got
-> a default protocol that can be selected with `Protocol = default`,
+> a default protocol that can be selected with `ProtocolÂ =Â default`,
 > and the platform may allow or require selecting the default protocol,
 > or a specific protocol.
 >
 > Examples:
 >
-> - **`socket:open(inet, stream, tcp)`** - It is common that for
+> - **`socket:open(inet,Â stream,Â tcp)`** - It is common that for
 >   protocol domain and type `inet,stream` it is allowed to select
 >   the `tcp` protocol although that mostly is the default.
-> - **`socket:open(local, dgram)`** - It is common that for
+> - **`socket:open(local,Â dgram)`** - It is common that for
 >   the protocol domain `local` it is mandatory to not select a protocol,
 >   that is; to select the default protocol.
 
@@ -3551,18 +3588,18 @@ If a connection attempt is already in progress (by another process),
 
 If the time-out argument (argument 3) is `infinity` it is
 up to the OS implementation to decide when the connection
-attempt failed and then what to return; probably `{error, etimedout}`.
+attempt failed and then what to return; probably `{error,Â etimedout}`.
 The OS time-out may be very long.
 
 [](){: #connect-timeout }
 
 If the time-out argument (argument 3) is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error,Â timeout}`
 if the connection hasn't been established within `Timeout` milliseconds.
 
 > #### Note {: .info }
 >
-> Note that when this call has returned `{error, timeout}`
+> Note that when this call has returned `{error,Â timeout}`
 > the connection state of the socket is uncertain since the platform's
 > network stack may complete the connection at any time,
 > up to some platform specific time-out.
@@ -4048,7 +4085,7 @@ inherit_opts(FromSock, ToSock, [SockOpt | SockOpts], Errs) ->
 %%
 
 -doc(#{since => <<"OTP 22.0">>}).
--doc "Equivalent to [`send(Socket, Data, [], infinity)`](`send/4`).".
+-doc "Equivalent to [`send(Socket,Â Data,Â [],Â infinity)`](`send/4`).".
 -spec send(Socket, Data) -> Result when
       Socket         :: socket(),
       Data           :: iodata(),
@@ -4104,7 +4141,7 @@ The return value indicates the result from the platform's network layer:
 
 - **`ok`** - All data was accepted by the OS for delivery
 
-- **`{ok, RestData}`** - Some but not all data was accepted,
+- **`{ok,Â RestData}`** - Some but not all data was accepted,
   but no error was reported (partially successful send).  `RestData`
   is the tail of `Data` that wasn't accepted.
 
@@ -4120,16 +4157,16 @@ The return value indicates the result from the platform's network layer:
   to return this,  surely more possible for a socket of
   [type `seqpacket`](`t:type/0`).
 
-- **`{error, Reason}`** - An error has been reported and no data
-  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
+- **`{error,Â Reason}`** - An error has been reported and no data
+  was accepted for delivery.  [`ReasonÂ ::Â posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
   an argument to be invalid.
 
-- **`{error, {Reason, RestData}}`** - An error was reported but before that
+- **`{error,Â {Reason,Â RestData}}`** - An error was reported but before that
   some data was accepted for delivery. `RestData` is the tail of `Data`
-  that wasn't accepted. See `{error, Reason}` above.
+  that wasn't accepted. See `{error,Â Reason}` above.
 
   This can only happen for a socket of [type `stream`](`t:type/0`)
   when a partially successful send is retried until there is an error.
@@ -4143,9 +4180,9 @@ or return an error.
 [](){: #send-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error,Â timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestData}}` if some data was sent
+or `{error,Â {timeout,Â RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -4556,9 +4593,9 @@ or return an error.
 [](){: #sendto-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error,Â timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestData}}` if some data was sent
+or `{error,Â {timeout,Â RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -4792,9 +4829,9 @@ or return an error.
 [](){: #sendmsg-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error,Â timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestData}}` if some data was sent
+or `{error,Â {timeout,Â RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -5180,7 +5217,7 @@ The return value indicates the result from the platform's network layer:
   is the tail of `IOV` that wasn't accepted.
 
 - **`{error, Reason}`** - An error has been reported and no data
-  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
+  was accepted for delivery.  [`ReasonÂ ::Â posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
@@ -5188,7 +5225,7 @@ The return value indicates the result from the platform's network layer:
 
 - **`{error, {Reason, RestIOV}}`** -  - An error was reported but before that
   some data was accepted for delivery. `RestIOV` is the tail of `IOV`
-  that wasn't accepted. See `{error, Reason}` above.
+  that wasn't accepted. See `{error,Â Reason}` above.
 
 [](){: #sendv-infinity }
 
@@ -5199,9 +5236,9 @@ or return an error.
 [](){: #sendv-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error,Â timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestIOV}}` if some data was sent
+or `{error,Â {timeout,Â RestIOV}}` if some data was sent
 (accepted by the OS for delivery).  `RestIOV` is the tail of the data
 that hasn't been sent.
 
@@ -5452,7 +5489,7 @@ rest_iov(Written, IOV) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, infinity)`](`sendfile/5`).
+[`sendfile(Socket,Â FileHandle_or_Continuation,Â 0,Â 0,Â infinity)`](`sendfile/5`).
 """.
 -spec sendfile(Socket, FileHandle | Continuation) -> dynamic() when
       Socket       :: socket(),
@@ -5467,7 +5504,7 @@ sendfile(Socket, FileHandle_Cont) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, Timeout_or_Handle)`](`sendfile/5`).
+[`sendfile(Socket,Â FileHandle_or_Continuation,Â 0,Â 0,Â Timeout_or_Handle)`](`sendfile/5`).
 """.
 -spec sendfile(Socket,
                FileHandle | Continuation,
@@ -5485,7 +5522,7 @@ sendfile(Socket, FileHandle_Cont, Timeout_Handle) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket, FileHandle_or_Continuation, Offset, Count, infinity)`](`sendfile/5`).
+[`sendfile(Socket,Â FileHandle_or_Continuation,Â Offset,Â Count,Â infinity)`](`sendfile/5`).
 """.
 -spec sendfile(Socket,
                FileHandle | Continuation,
@@ -5513,7 +5550,7 @@ The `Offset` argument is the file offset to start reading from.
 The default offset is `0`.
 
 The `Count` argument is the number of bytes to transfer
-from `FileHandle` to `Socket`. If `Count = 0` (the default)
+from `FileHandle` to `Socket`. If `CountÂ =Â 0` (the default)
 the transfer stops at the end of file.
 
 The return value indicates the result from the platform's network layer:
@@ -5521,16 +5558,16 @@ The return value indicates the result from the platform's network layer:
 - **`{ok, BytesSent}`** - The transfer completed successfully after `BytesSent`
   bytes of data.
 
-- **`{error, Reason}`** - An error has been reported and no data
-  was transferred. [`Reason :: posix/0`](`t:posix/0`)
+- **`{error,Â Reason}`** - An error has been reported and no data
+  was transferred. [`ReasonÂ ::Â posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
   an argument to be invalid.
 
-- **`{error, {Reason, BytesSent}}`** - An error has been reported
-  but before that some data was transferred. See `{error, Reason}`
-  and `{ok, BytesSent}` above.
+- **`{error,Â {Reason,Â BytesSent}}`** - An error has been reported
+  but before that some data was transferred. See `{error,Â Reason}`
+  and `{ok,Â BytesSent}` above.
 
 [](){: #sendfile-infinity }
 
@@ -5541,9 +5578,9 @@ or return an error.
 [](){: #sendfile-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error,Â timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, BytesSent}}` if some but not all data was sent
+or `{error,Â {timeout,Â BytesSent}}` if some but not all data was sent
 (accepted by the OS for delivery).
 
 [](){: #sendfile-nowait }
@@ -5788,7 +5825,7 @@ sendfile_next(BytesSent, Offset, Count) ->
 
 -doc(#{since => <<"OTP 22.0">>}).
 -doc """
-Equivalent to [`recv(Socket, 0, [], infinity)`](`recv/4`).
+Equivalent to [`recv(Socket,Â 0,Â [],Â infinity)`](`recv/4`).
 """.
 -spec recv(Socket :: socket()) -> dynamic().
 
@@ -5800,10 +5837,10 @@ recv(Socket) ->
 Receive data on a connected socket.
 
 With argument `Length`; equivalent to
-[`recv(Socket, Length, [], infinity)`](`recv/4`).
+[`recv(Socket,Â Length,Â [],Â infinity)`](`recv/4`).
 
 With argument `Flags`; equivalent to
-[`recv(Socket, 0, Flags, infinity)`](`recv/4`) *(since OTP 24.0)*.
+[`recv(Socket,Â 0,Â Flags,Â infinity)`](`recv/4`) *(since OTP 24.0)*.
 """.
 -spec recv(Socket :: socket(), Flags :: [msg_flag() | integer()]) -> dynamic();
           (Socket :: socket(), Length :: non_neg_integer()) -> dynamic().
@@ -5821,15 +5858,15 @@ recv(Socket, Length) ->
 Receive data on a connected socket.
 
 With arguments `Length` and `Flags`; equivalent to
-[`recv(Socket, Length, Flags, infinity)`](`recv/4`).
+[`recv(Socket,Â Length,Â Flags,Â infinity)`](`recv/4`).
 
 With arguments `Length` and `TimeoutOrHandle`; equivalent to
-[`recv(Socket, Length, [], TimeoutOrHandle)`](`recv/4`).
+[`recv(Socket,Â Length,Â [],Â TimeoutOrHandle)`](`recv/4`).
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 `TimeoutOrHandle :: Handle` has been allowed *since OTP 24.0*.
 
 With arguments `Flags` and `TimeoutOrHandle`; equivalent to
-[`recv(Socket, 0, Flags, TimeoutOrHandle)`](`recv/4`)
+[`recv(Socket,Â 0,Â Flags,Â TimeoutOrHandle)`](`recv/4`)
 *(since OTP 24.0)*.
 """.
 -spec recv(Socket, Flags, TimeoutOrHandle) -> dynamic() when
@@ -5855,12 +5892,12 @@ Receive data on a connected socket.
 The argument `Length` specifies the size of the receive buffer.
 Packet oriented sockets truncate the packet if the size is too small.
 
-If `Length == 0`; a default buffer size is used, which can be set by
+If `LengthÂ ==Â 0`; a default buffer size is used, which can be set by
 [`socket:setopt(Socket, {otp,recvbuf}, BufSz)`](`setopt/3`).
 
 For a socket of [type `stream`](`t:type/0`), when a `Timeout` argument
 is used, the operation iterates until `Length` bytes has been received,
-or the operation times out.  If `Length == 0` all readily available
+or the operation times out.  If `LengthÂ ==Â 0` all readily available
 data is returned.
 
 On a `select` system, when the default receive buffer size option
@@ -5873,8 +5910,8 @@ The message `Flags` may be symbolic `t:msg_flag/0`s and/or
 `t:integer/0`s as in the platform's appropriate header files.
 The values of all symbolic flags and integers are or:ed together.
 
-When there is a socket error this function returns `{error, Reason}`,
-or if some data arrived before the error; `{error, {Reason, Data}}`
+When there is a socket error this function returns `{error,Â Reason}`,
+or if some data arrived before the error; `{error,Â {Reason,Â Data}}`
 (can only happen for a socket of [type `stream`](`t:type/0`)).
 
 [](){: #recv-infinity }
@@ -5890,14 +5927,14 @@ or if the OS reports an error for the operation.
 If the `Timeout` argument is a time-out value
 (`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has arrived after `Timeout` milliseconds,
-or `{error, {timeout, Data}}` if some but not enough data
+or `{error,Â {timeout,Â Data}}` if some but not enough data
 has been received on a socket of [type `stream`](`t:type/0`) with Length > 0.
-It *can* also return directly with `{ok, Data}` ([type `dgram`](`t:type/0`)).
+It *can* also return directly with `{ok,Â Data}` ([type `dgram`](`t:type/0`)).
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no data
-is immediately available `{error, timeout} is returned.
-`On a socket of type [`stream`](`t:type/0`), `{error, {timeout, Data}}`
+is immediately available `{error,Â timeout} is returned.
+`On a socket of type [`stream`](`t:type/0`), `{error,Â {timeout,Â Data}}`
 is returned if there is an insufficient amount of data immediately available.
 
 [](){: #recv-nowait }
@@ -5922,15 +5959,15 @@ The possible values for `CompletionStatus` in the completion message are:
 - **`{error, Reason}`** - An error occured and no data was read.
 
 On `select` systems, for a socket of type [`stream`](`t:type/0`),
-if `Length > 0` and there is some but not enough data available,
-this function will return [`{select, {SelectInfo, Data}}`](`t:select_info/0`)
+if `LengthÂ >Â 0` and there is some but not enough data available,
+this function will return [`{select,Â {SelectInfo,Â Data}}`](`t:select_info/0`)
 with partial `Data`.  A repeated call to complete the operation
 may need an updated `Length` argument.
 
 On `select` systems, if the option
-[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
-[`{select_read, {SelectInfo, Data}}`](`t:select_info/0`)
-is returned instead of `{ok, Data}` and a new asynchronous
+[`{otp,Â select_read}`](`t:otp_socket_option/0`) is set,
+[`{select_read,Â {SelectInfo,Â Data}}`](`t:select_info/0`)
+is returned instead of `{ok,Â Data}` and a new asynchronous
 receive operation has been initiated, which can be seen
 as an automatic [nowait](#recv-nowait) call whenever
 a receive operation is completed.
@@ -6302,10 +6339,10 @@ recvfrom(Socket) ->
 Receive a message on a socket.
 
 With argument `BufSz`; equivalent to
-[`recvfrom(Socket, BufSz, [], infinity)`](`recvfrom/4`).
+[`recvfrom(Socket,Â BufSz,Â [],Â infinity)`](`recvfrom/4`).
 
 With argument `Flags`; equivalent to
-[`recvfrom(Socket, 0, Flags, infinity)`](`recvfrom/4`) *(since OTP 24.0)*.
+[`recvfrom(Socket,Â 0,Â Flags,Â infinity)`](`recvfrom/4`) *(since OTP 24.0)*.
 """.
 -spec recvfrom(Socket :: socket(), Flags :: list()) -> dynamic();
               (Socket :: socket(), BufSz :: non_neg_integer()) -> dynamic().
@@ -6324,13 +6361,13 @@ recvfrom(Socket, BufSz) ->
 Receive a message on a socket.
 
 With arguments `BufSz` and `Flags`; equivalent to
-[`recvfrom(Socket, BufSz, Flags, infinity)`](`recvfrom/4`).
+[`recvfrom(Socket,Â BufSz,Â Flags,Â infinity)`](`recvfrom/4`).
 
 With arguments `BufSz` and `TimeoutOrHandle`; equivalent to
-[`recvfrom(Socket, BufSz, [], TimeoutOrHandle)`](`recvfrom/4`).
+[`recvfrom(Socket,Â BufSz,Â [],Â TimeoutOrHandle)`](`recvfrom/4`).
 
 With arguments `Flags` and `TimeoutOrHandle`; equivalent to
-[`recvfrom(Socket, 0, Flags, TimeoutOrHandle)`](`recvfrom/4`)
+[`recvfrom(Socket,Â 0,Â Flags,Â TimeoutOrHandle)`](`recvfrom/4`)
 
 `TimeoutOrHandle :: 'nowait'` has been allowed *since OTP 22.1*.
 
@@ -6388,7 +6425,7 @@ if no message has arrived after `Timeout` milliseconds.
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no message
-is immediately available `{error, timeout}` is returned.
+is immediately available `{error,Â timeout}` is returned.
 
 [](){: #recvfrom-nowait }
 
@@ -6551,10 +6588,10 @@ recvmsg(Socket) ->
 Receive a message on a socket.
 
 With argument `Flags`; equivalent to
-[`recvmsg(Socket, 0, 0, Flags, infinity)`](`recvmsg/5`).
+[`recvmsg(Socket,Â 0,Â 0,Â Flags,Â infinity)`](`recvmsg/5`).
 
 With argument `TimeoutOrHandle`; equivalent to
-[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket,Â 0,Â 0,Â [],Â TimeoutOrHandle)`](`recvmsg/5`).
 
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 
@@ -6576,10 +6613,10 @@ recvmsg(Socket, TimeoutOrHandle) ->
 Receive a message on a socket.
 
 With arguments  `Flags`; equivalent to
-[`recvmsg(Socket, 0, 0, Flags, infinity)`](`recvmsg/5`).
+[`recvmsg(Socket,Â 0,Â 0,Â Flags,Â infinity)`](`recvmsg/5`).
 
 With argument `TimeoutOrHandle`; equivalent to
-[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket,Â 0,Â 0,Â [],Â TimeoutOrHandle)`](`recvmsg/5`).
 
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 
@@ -6601,7 +6638,7 @@ recvmsg(Socket, BufSz, CtrlSz) ->
 -doc(#{since => <<"OTP 24.0">>}).
 -doc """
 Equivalent to
-[`recvmsg(Socket, BufSz, CtrlSz, [], TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket,Â BufSz,Â CtrlSz,Â [],Â TimeoutOrHandle)`](`recvmsg/5`).
 """.
 -spec recvmsg(
         Socket :: socket(), BufSz :: non_neg_integer(), CtrlSz :: non_neg_integer(),
@@ -6652,7 +6689,7 @@ if no message has arrived after `Timeout` milliseconds.
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no message
-is immediately available `{error, timeout}` is returned.
+is immediately available `{error,Â timeout}` is returned.
 
 [](){: #recvmsg-nowait }
 
@@ -7109,9 +7146,9 @@ setopt(Socket, SocketOption, Value) ->
 Set a socket option _(backwards compatibility function)_.
 
 Equivalent to [`setopt(Socket, {Level, Opt}, Value)`](`setopt/3`),
-or as a special case if `Opt = NativeOpt ::` `t:integer/0`
-and `Value =` `t:binary/0` equivalent to
-[`setopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`setopt_native/3`).
+or as a special case if `OptÂ =Â NativeOptÂ ::`Â `t:integer/0`
+and `ValueÂ =`Â `t:binary/0` equivalent to
+[`setopt_native(Socket,Â {Level,Â NativeOpt},Â ValueSpec)`](`setopt_native/3`).
 
 Use `setopt/3` or `setopt_native/3` instead to handle
 the option level and name as a single term, and to make the
@@ -7141,9 +7178,9 @@ as the option value.
 
 The socket option may be specified with an ordinary
 `t:socket_option/0` tuple, with a symbolic `Level` as
-`{`[`Level :: level/0`](`t:level/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`,
+`{`[`LevelÂ ::Â level/0`](`t:level/0`)`,Â `[`NativeOptÂ ::Â integer/0`](`t:integer/0`)`}`,
 or with integers for both `NativeLevel` and `NativeOpt` as
-`{`[`NativeLevel :: integer/0`](`t:integer/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`.
+`{`[`NativeLevelÂ ::Â integer/0`](`t:integer/0`)`,Â `[`NativeOptÂ ::Â integer/0`](`t:integer/0`)`}`.
 
 If an option is valid depends both on the platform and on
 what kind of socket it is (`t:domain/0`, `t:type/0` and `t:protocol/0`).
@@ -7238,9 +7275,9 @@ Some uses of this function is for _backwards compatibility reasons_.
 For instance, `getopt(Socket, Level, Opt)` is 
 equivalent to [`getopt(Socket, {Level, Opt})`](`getopt/2`),
 or as a special case if
-`Opt = {NativeOpt :: `[`integer/0`](`t:integer/0`)`, ValueSpec}`
+`OptÂ =Â {NativeOptÂ ::Â `[`integer/0`](`t:integer/0`)`,Â ValueSpec}`
 equivalent to
-[`getopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`getopt_native/3`).
+[`getopt_native(Socket,Â {Level,Â NativeOpt},Â ValueSpec)`](`getopt_native/3`).
 
 Use `getopt/2` or `getopt_native/3` instead to handle
 the option level and name as a single term, and to make the
@@ -7936,7 +7973,7 @@ as a completed operation; the process first in queue is notified.
 If [`SelectInfo`](`t:select_info/0`) `|`
 [`CompletionInfo`](`t:completion_info/0`) does not match
 an operation in progress for the calling process, this function returns
-`{error, {invalid, SelectInfo | CompletionInfo}}`.
+`{error,Â {invalid,Â SelectInfoÂ |Â CompletionInfo}}`.
 """.
 -spec cancel(Socket, SelectInfo | CompletionInfo)->
           'ok' | {'error', Reason} when

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -41,7 +41,7 @@ has been received.
 > #### Asynchronous Calls
 >
 > Some functions feature _asynchronous calls_.  This is achieved by setting
-> the `Timeout` argument to `nowait` or to a `Handle ::``t:reference/0`.
+> the `Timeout` argument to `nowait` or to a `Handle ::` `t:reference/0`.
 > See the respective function's type specification.
 >
 > This module has two different implementations of asynchronous calls.
@@ -62,9 +62,9 @@ has been received.
 > - `{select, `[`SelectInfo`](`t:select_info/0`)`}`
 >
 > Where `CompletionInfo` is
-> `{completion_info, _, `[`CompletionHandle`](`t:completion_handle/0`)`}`
+> `{completion_info, _, `[`CompletionHandle`](`t:completion_handle/0`)`}`
 > and `SelectInfo` is
-> `{select_info, _, `[`SelectHandle`](`t:select_handle/0`)`}`.
+> `{select_info, _, `[`SelectHandle`](`t:select_handle/0`)`}`.
 > Both the `CompletionHandle` and the `SelectHandle`
 > are of type `t:reference/0`.
 >
@@ -83,7 +83,7 @@ has been received.
 > will probably have to be adjusted due to the already delivered data
 > in this return value.
 >
-> On `select` systems, when the `{otp, select_read}` option is `true`,
+> On `select` systems, when the `{otp, select_read}` option is `true`,
 > the asynchronous [`recv/3,4`](#recv-nowait),
 > [`recvfrom/3,4`](#recvfrom-nowait), and
 > [`recvmsg/3,4,5`](#recvmsg-nowait) functions may also return:
@@ -116,7 +116,7 @@ has been received.
 >
 > When a `select` message is received, it only means that the operation
 > _may now continue_, by retrying the operation (which may return
-> a new `{select, _}` value).  Some operations are retried by repeating
+> a new `{select, _}` value).  Some operations are retried by repeating
 > the same function call, and some have a dedicated function variant
 > to be used for the retry.  See the respective function's documentation.
 >
@@ -143,7 +143,7 @@ has been received.
 > #### Using a `Handle`
 >
 > If creating a `t:reference/0` with [`make_ref()`](`erlang:make_ref/0`)
-> and using that as the `Timeout|Handle` argument, the same `Handle`
+> and using that as the `Timeout | Handle` argument, the same `Handle`
 > will then be the [`SelectHandle`](`t:select_handle/0`) in the returned
 > `t:select_info/0` and the received `select` message, or be
 > the [`CompletionHandle`](`t:completion_handle/0`) in the returned
@@ -162,8 +162,8 @@ has been received.
 > message has been received it replaces the operation in progress:
 >
 > ```erlang
->     {select, {select_info, Handle}} = socket:accept(LSock, nowait),
->     {ok, Socket} = socket:accept(LSock,1000),
+>     {select, {select_info, Handle}} = socket:accept(LSock, nowait),
+>     {ok, Socket} = socket:accept(LSock, 1000),
 >     :
 > ```
 > Above, `Handle` is _no longer_ valid once the second `accept/2`, call
@@ -463,7 +463,7 @@ and the `t:otp_socket_option/0` with the same name.
           io_backend      := #{name := atom()},
 	  load_nif_result := undefined | ok | {error, term()}}.
 
--doc "A `t:map/0` of `Name := Counter` associations.".
+-doc "A `t:map/0` of `Name := Counter` associations.".
 -type socket_counters() :: #{read_byte        := non_neg_integer(),
                              read_fails       := non_neg_integer(),
                              read_pkg         := non_neg_integer(),
@@ -1108,8 +1108,8 @@ hence above all OS protocol levels.
   On `select` implementations, see [Asynchronous Calls](#asynchronous-calls),
   automatically activate select after a completed read.
 
-  Instead of `{ok, Data}` the receive operation returns
-  [`{select_read, {SelectInfo, Data}}`](`t:select_info/0`),
+  Instead of `{ok, Data}` the receive operation returns
+  [`{select_read, {SelectInfo, Data}}`](`t:select_info/0`),
   and the calling process can wait for a [`select` message](#async-messages)
   containing `SelectInfo` when there is data available again.
 
@@ -2303,9 +2303,9 @@ Returned by an operation that requires the caller to wait for a
 [`SelectHandle`](`t:select_handle/0`).
 
 On `select` systems, if the option
-[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
-[`{select_read, {select_info(), _}}`](`t:select_info/0`)
-is returned instead of `{ok, _}` to indicate that a new
+[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
+[`{select_read, {select_info(), _}}`](`t:select_info/0`)
+is returned instead of `{ok, _}` to indicate that a new
 asynchronous receive operation has been initiated
 and the caller should wait for a
 [`select` message](#async-messages) containing the
@@ -2584,7 +2584,7 @@ option default value.
 Globally change if the socket registry is to be used or not.
 Note that its still possible to override this explicitly
 when creating an individual sockets, see [`open/2,3,4`](`open/2`)
-for more info (the [`Opts :: map/0`](`t:map/0`)).
+for more info (the [`Opts :: map/0`](`t:map/0`)).
 """.
 -spec use_registry(D :: boolean()) -> 'ok'.
 %%
@@ -3085,15 +3085,15 @@ supports() ->
 Retrieve information about what socket features
 the module and the platform supports.
 
-If `Key1 = msg_flags` returns a list of `{Flag, boolean()}`
+If `Key1 = msg_flags` returns a list of `{Flag, boolean()}`
 tuples for every `Flag` in `t:msg_flag/0` with the `t:boolean/0`
 indicating if the flag is supported on this platform.
 
-If `Key1 = protocols` returns a list of `{Name, boolean()}`
+If `Key1 = protocols` returns a list of `{Name, boolean()}`
 tuples for every `Name` in`t:protocol/0` with the `t:boolean/0`
 indicating if the protocol is supported on this platform.
 
-If `Key1 = options` returns a list of `{SocketOption, boolean()}`
+If `Key1 = options` returns a list of `{SocketOption, boolean()}`
 tuples for every `SocketOption` in `t:socket_option/0` with the `t:boolean/0`
 indicating if the socket option is supported on this platform.
 
@@ -3116,9 +3116,9 @@ supports(Key) ->
 Retrieve information about what socket features
 the module and the platform supports.
 
-If `Key1 = options`, for a `Key2` in `t:level/0` returns
-a list of `{Opt, boolean()}` tuples for all known socket options
-[`Opt` on that `Level = Key2`](`t:socket_option/0`) with the `t:boolean/0`
+If `Key1 = options`, for a `Key2` in `t:level/0` returns
+a list of `{Opt, boolean()}` tuples for all known socket options
+[`Opt` on that `Level = Key2`](`t:socket_option/0`) with the `t:boolean/0`
 indicating if the socket option is supported on this platform.
 See `setopt/3` and `getopt/2`.
 
@@ -3379,16 +3379,16 @@ header files. The same goes for `Protocol` as defined in the platform's
 > #### Note {: .info }
 >
 > For some combinations of `Domain` and `Type` the platform has got
-> a default protocol that can be selected with `Protocol = default`,
+> a default protocol that can be selected with `Protocol = default`,
 > and the platform may allow or require selecting the default protocol,
 > or a specific protocol.
 >
 > Examples:
 >
-> - **`socket:open(inet, stream, tcp)`** - It is common that for
+> - **`socket:open(inet, stream, tcp)`** - It is common that for
 >   protocol domain and type `inet,stream` it is allowed to select
 >   the `tcp` protocol although that mostly is the default.
-> - **`socket:open(local, dgram)`** - It is common that for
+> - **`socket:open(local, dgram)`** - It is common that for
 >   the protocol domain `local` it is mandatory to not select a protocol,
 >   that is; to select the default protocol.
 
@@ -3595,18 +3595,18 @@ If a connection attempt is already in progress (by another process),
 
 If the time-out argument (argument 3) is `infinity` it is
 up to the OS implementation to decide when the connection
-attempt failed and then what to return; probably `{error, etimedout}`.
+attempt failed and then what to return; probably `{error, etimedout}`.
 The OS time-out may be very long.
 
 [](){: #connect-timeout }
 
 If the time-out argument (argument 3) is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if the connection hasn't been established within `Timeout` milliseconds.
 
 > #### Note {: .info }
 >
-> Note that when this call has returned `{error, timeout}`
+> Note that when this call has returned `{error, timeout}`
 > the connection state of the socket is uncertain since the platform's
 > network stack may complete the connection at any time,
 > up to some platform specific time-out.
@@ -4092,7 +4092,7 @@ inherit_opts(FromSock, ToSock, [SockOpt | SockOpts], Errs) ->
 %%
 
 -doc(#{since => <<"OTP 22.0">>}).
--doc "Equivalent to [`send(Socket, Data, [], infinity)`](`send/4`).".
+-doc "Equivalent to [`send(Socket, Data, [], infinity)`](`send/4`).".
 -spec send(Socket, Data) -> Result when
       Socket         :: socket(),
       Data           :: iodata(),
@@ -4148,7 +4148,7 @@ The return value indicates the result from the platform's network layer:
 
 - **`ok`** - All data was accepted by the OS for delivery
 
-- **`{ok, RestData}`** - Some but not all data was accepted,
+- **`{ok, RestData}`** - Some but not all data was accepted,
   but no error was reported (partially successful send).  `RestData`
   is the tail of `Data` that wasn't accepted.
 
@@ -4164,16 +4164,16 @@ The return value indicates the result from the platform's network layer:
   to return this,  surely more possible for a socket of
   [type `seqpacket`](`t:type/0`).
 
-- **`{error, Reason}`** - An error has been reported and no data
-  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
+- **`{error, Reason}`** - An error has been reported and no data
+  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
   an argument to be invalid.
 
-- **`{error, {Reason, RestData}}`** - An error was reported but before that
+- **`{error, {Reason, RestData}}`** - An error was reported but before that
   some data was accepted for delivery. `RestData` is the tail of `Data`
-  that wasn't accepted. See `{error, Reason}` above.
+  that wasn't accepted. See `{error, Reason}` above.
 
   This can only happen for a socket of [type `stream`](`t:type/0`)
   when a partially successful send is retried until there is an error.
@@ -4187,9 +4187,9 @@ or return an error.
 [](){: #send-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestData}}` if some data was sent
+or `{error, {timeout, RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -4600,9 +4600,9 @@ or return an error.
 [](){: #sendto-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestData}}` if some data was sent
+or `{error, {timeout, RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -4836,9 +4836,9 @@ or return an error.
 [](){: #sendmsg-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestData}}` if some data was sent
+or `{error, {timeout, RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -5224,7 +5224,7 @@ The return value indicates the result from the platform's network layer:
   is the tail of `IOV` that wasn't accepted.
 
 - **`{error, Reason}`** - An error has been reported and no data
-  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
+  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
@@ -5232,7 +5232,7 @@ The return value indicates the result from the platform's network layer:
 
 - **`{error, {Reason, RestIOV}}`** -  - An error was reported but before that
   some data was accepted for delivery. `RestIOV` is the tail of `IOV`
-  that wasn't accepted. See `{error, Reason}` above.
+  that wasn't accepted. See `{error, Reason}` above.
 
 [](){: #sendv-infinity }
 
@@ -5243,9 +5243,9 @@ or return an error.
 [](){: #sendv-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, RestIOV}}` if some data was sent
+or `{error, {timeout, RestIOV}}` if some data was sent
 (accepted by the OS for delivery).  `RestIOV` is the tail of the data
 that hasn't been sent.
 
@@ -5496,7 +5496,7 @@ rest_iov(Written, IOV) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, infinity)`](`sendfile/5`).
+[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, infinity)`](`sendfile/5`).
 """.
 -spec sendfile(Socket, FileHandle | Continuation) -> dynamic() when
       Socket       :: socket(),
@@ -5511,7 +5511,7 @@ sendfile(Socket, FileHandle_Cont) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, Timeout_or_Handle)`](`sendfile/5`).
+[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, Timeout_or_Handle)`](`sendfile/5`).
 """.
 -spec sendfile(Socket,
                FileHandle | Continuation,
@@ -5529,7 +5529,7 @@ sendfile(Socket, FileHandle_Cont, Timeout_Handle) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket, FileHandle_or_Continuation, Offset, Count, infinity)`](`sendfile/5`).
+[`sendfile(Socket, FileHandle_or_Continuation, Offset, Count, infinity)`](`sendfile/5`).
 """.
 -spec sendfile(Socket,
                FileHandle | Continuation,
@@ -5557,7 +5557,7 @@ The `Offset` argument is the file offset to start reading from.
 The default offset is `0`.
 
 The `Count` argument is the number of bytes to transfer
-from `FileHandle` to `Socket`. If `Count = 0` (the default)
+from `FileHandle` to `Socket`. If `Count = 0` (the default)
 the transfer stops at the end of file.
 
 The return value indicates the result from the platform's network layer:
@@ -5565,16 +5565,16 @@ The return value indicates the result from the platform's network layer:
 - **`{ok, BytesSent}`** - The transfer completed successfully after `BytesSent`
   bytes of data.
 
-- **`{error, Reason}`** - An error has been reported and no data
-  was transferred. [`Reason :: posix/0`](`t:posix/0`)
+- **`{error, Reason}`** - An error has been reported and no data
+  was transferred. [`Reason :: posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
   an argument to be invalid.
 
-- **`{error, {Reason, BytesSent}}`** - An error has been reported
-  but before that some data was transferred. See `{error, Reason}`
-  and `{ok, BytesSent}` above.
+- **`{error, {Reason, BytesSent}}`** - An error has been reported
+  but before that some data was transferred. See `{error, Reason}`
+  and `{ok, BytesSent}` above.
 
 [](){: #sendfile-infinity }
 
@@ -5585,9 +5585,9 @@ or return an error.
 [](){: #sendfile-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error, timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error, {timeout, BytesSent}}` if some but not all data was sent
+or `{error, {timeout, BytesSent}}` if some but not all data was sent
 (accepted by the OS for delivery).
 
 [](){: #sendfile-nowait }
@@ -5832,7 +5832,7 @@ sendfile_next(BytesSent, Offset, Count) ->
 
 -doc(#{since => <<"OTP 22.0">>}).
 -doc """
-Equivalent to [`recv(Socket, 0, [], infinity)`](`recv/4`).
+Equivalent to [`recv(Socket, 0, [], infinity)`](`recv/4`).
 """.
 -spec recv(Socket :: socket()) -> dynamic().
 
@@ -5844,10 +5844,10 @@ recv(Socket) ->
 Receive data on a connected socket.
 
 With argument `Length`; equivalent to
-[`recv(Socket, Length, [], infinity)`](`recv/4`).
+[`recv(Socket, Length, [], infinity)`](`recv/4`).
 
 With argument `Flags`; equivalent to
-[`recv(Socket, 0, Flags, infinity)`](`recv/4`) *(since OTP 24.0)*.
+[`recv(Socket, 0, Flags, infinity)`](`recv/4`) *(since OTP 24.0)*.
 """.
 -spec recv(Socket :: socket(), Flags :: [msg_flag() | integer()]) -> dynamic();
           (Socket :: socket(), Length :: non_neg_integer()) -> dynamic().
@@ -5865,15 +5865,15 @@ recv(Socket, Length) ->
 Receive data on a connected socket.
 
 With arguments `Length` and `Flags`; equivalent to
-[`recv(Socket, Length, Flags, infinity)`](`recv/4`).
+[`recv(Socket, Length, Flags, infinity)`](`recv/4`).
 
 With arguments `Length` and `TimeoutOrHandle`; equivalent to
-[`recv(Socket, Length, [], TimeoutOrHandle)`](`recv/4`).
+[`recv(Socket, Length, [], TimeoutOrHandle)`](`recv/4`).
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 `TimeoutOrHandle :: Handle` has been allowed *since OTP 24.0*.
 
 With arguments `Flags` and `TimeoutOrHandle`; equivalent to
-[`recv(Socket, 0, Flags, TimeoutOrHandle)`](`recv/4`)
+[`recv(Socket, 0, Flags, TimeoutOrHandle)`](`recv/4`)
 *(since OTP 24.0)*.
 """.
 -spec recv(Socket, Flags, TimeoutOrHandle) -> dynamic() when
@@ -5899,12 +5899,12 @@ Receive data on a connected socket.
 The argument `Length` specifies the size of the receive buffer.
 Packet oriented sockets truncate the packet if the size is too small.
 
-If `Length == 0`; a default buffer size is used, which can be set by
+If `Length == 0`; a default buffer size is used, which can be set by
 [`socket:setopt(Socket, {otp,recvbuf}, BufSz)`](`setopt/3`).
 
 For a socket of [type `stream`](`t:type/0`), when a `Timeout` argument
 is used, the operation iterates until `Length` bytes has been received,
-or the operation times out.  If `Length == 0` all readily available
+or the operation times out.  If `Length == 0` all readily available
 data is returned.
 
 On a `select` system, when the default receive buffer size option
@@ -5917,8 +5917,8 @@ The message `Flags` may be symbolic `t:msg_flag/0`s and/or
 `t:integer/0`s as in the platform's appropriate header files.
 The values of all symbolic flags and integers are or:ed together.
 
-When there is a socket error this function returns `{error, Reason}`,
-or if some data arrived before the error; `{error, {Reason, Data}}`
+When there is a socket error this function returns `{error, Reason}`,
+or if some data arrived before the error; `{error, {Reason, Data}}`
 (can only happen for a socket of [type `stream`](`t:type/0`)).
 
 [](){: #recv-infinity }
@@ -5934,14 +5934,14 @@ or if the OS reports an error for the operation.
 If the `Timeout` argument is a time-out value
 (`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has arrived after `Timeout` milliseconds,
-or `{error, {timeout, Data}}` if some but not enough data
+or `{error, {timeout, Data}}` if some but not enough data
 has been received on a socket of [type `stream`](`t:type/0`) with Length > 0.
-It *can* also return directly with `{ok, Data}` ([type `dgram`](`t:type/0`)).
+It *can* also return directly with `{ok, Data}` ([type `dgram`](`t:type/0`)).
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no data
-is immediately available `{error, timeout} is returned.
-`On a socket of type [`stream`](`t:type/0`), `{error, {timeout, Data}}`
+is immediately available `{error, timeout} is returned.
+`On a socket of type [`stream`](`t:type/0`), `{error, {timeout, Data}}`
 is returned if there is an insufficient amount of data immediately available.
 
 [](){: #recv-nowait }
@@ -5966,15 +5966,15 @@ The possible values for `CompletionStatus` in the completion message are:
 - **`{error, Reason}`** - An error occured and no data was read.
 
 On `select` systems, for a socket of type [`stream`](`t:type/0`),
-if `Length > 0` and there is some but not enough data available,
-this function will return [`{select, {SelectInfo, Data}}`](`t:select_info/0`)
+if `Length > 0` and there is some but not enough data available,
+this function will return [`{select, {SelectInfo, Data}}`](`t:select_info/0`)
 with partial `Data`.  A repeated call to complete the operation
 may need an updated `Length` argument.
 
 On `select` systems, if the option
-[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
-[`{select_read, {SelectInfo, Data}}`](`t:select_info/0`)
-is returned instead of `{ok, Data}` and a new asynchronous
+[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
+[`{select_read, {SelectInfo, Data}}`](`t:select_info/0`)
+is returned instead of `{ok, Data}` and a new asynchronous
 receive operation has been initiated, which can be seen
 as an automatic [nowait](#recv-nowait) call whenever
 a receive operation is completed.
@@ -6346,10 +6346,10 @@ recvfrom(Socket) ->
 Receive a message on a socket.
 
 With argument `BufSz`; equivalent to
-[`recvfrom(Socket, BufSz, [], infinity)`](`recvfrom/4`).
+[`recvfrom(Socket, BufSz, [], infinity)`](`recvfrom/4`).
 
 With argument `Flags`; equivalent to
-[`recvfrom(Socket, 0, Flags, infinity)`](`recvfrom/4`) *(since OTP 24.0)*.
+[`recvfrom(Socket, 0, Flags, infinity)`](`recvfrom/4`) *(since OTP 24.0)*.
 """.
 -spec recvfrom(Socket :: socket(), Flags :: list()) -> dynamic();
               (Socket :: socket(), BufSz :: non_neg_integer()) -> dynamic().
@@ -6368,13 +6368,13 @@ recvfrom(Socket, BufSz) ->
 Receive a message on a socket.
 
 With arguments `BufSz` and `Flags`; equivalent to
-[`recvfrom(Socket, BufSz, Flags, infinity)`](`recvfrom/4`).
+[`recvfrom(Socket, BufSz, Flags, infinity)`](`recvfrom/4`).
 
 With arguments `BufSz` and `TimeoutOrHandle`; equivalent to
-[`recvfrom(Socket, BufSz, [], TimeoutOrHandle)`](`recvfrom/4`).
+[`recvfrom(Socket, BufSz, [], TimeoutOrHandle)`](`recvfrom/4`).
 
 With arguments `Flags` and `TimeoutOrHandle`; equivalent to
-[`recvfrom(Socket, 0, Flags, TimeoutOrHandle)`](`recvfrom/4`)
+[`recvfrom(Socket, 0, Flags, TimeoutOrHandle)`](`recvfrom/4`)
 
 `TimeoutOrHandle :: 'nowait'` has been allowed *since OTP 22.1*.
 
@@ -6432,7 +6432,7 @@ if no message has arrived after `Timeout` milliseconds.
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no message
-is immediately available `{error,Â timeout}` is returned.
+is immediately available `{error, timeout}` is returned.
 
 [](){: #recvfrom-nowait }
 
@@ -6595,10 +6595,10 @@ recvmsg(Socket) ->
 Receive a message on a socket.
 
 With argument `Flags`; equivalent to
-[`recvmsg(Socket,Â 0,Â 0,Â Flags,Â infinity)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, Flags, infinity)`](`recvmsg/5`).
 
 With argument `TimeoutOrHandle`; equivalent to
-[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
 
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 
@@ -6620,10 +6620,10 @@ recvmsg(Socket, TimeoutOrHandle) ->
 Receive a message on a socket.
 
 With arguments  `Flags`; equivalent to
-[`recvmsg(Socket, 0, 0, Flags, infinity)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, Flags, infinity)`](`recvmsg/5`).
 
 With argument `TimeoutOrHandle`; equivalent to
-[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
 
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 
@@ -6645,7 +6645,7 @@ recvmsg(Socket, BufSz, CtrlSz) ->
 -doc(#{since => <<"OTP 24.0">>}).
 -doc """
 Equivalent to
-[`recvmsg(Socket, BufSz, CtrlSz, [], TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket, BufSz, CtrlSz, [], TimeoutOrHandle)`](`recvmsg/5`).
 """.
 -spec recvmsg(
         Socket :: socket(), BufSz :: non_neg_integer(), CtrlSz :: non_neg_integer(),
@@ -6696,7 +6696,7 @@ if no message has arrived after `Timeout` milliseconds.
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no message
-is immediately available `{error, timeout}` is returned.
+is immediately available `{error, timeout}` is returned.
 
 [](){: #recvmsg-nowait }
 
@@ -7153,9 +7153,9 @@ setopt(Socket, SocketOption, Value) ->
 Set a socket option _(backwards compatibility function)_.
 
 Equivalent to [`setopt(Socket, {Level, Opt}, Value)`](`setopt/3`),
-or as a special case if `Opt = NativeOpt ::` `t:integer/0`
-and `Value =` `t:binary/0` equivalent to
-[`setopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`setopt_native/3`).
+or as a special case if `Opt = NativeOpt ::` `t:integer/0`
+and `Value =` `t:binary/0` equivalent to
+[`setopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`setopt_native/3`).
 
 Use `setopt/3` or `setopt_native/3` instead to handle
 the option level and name as a single term, and to make the
@@ -7185,9 +7185,9 @@ as the option value.
 
 The socket option may be specified with an ordinary
 `t:socket_option/0` tuple, with a symbolic `Level` as
-`{`[`Level :: level/0`](`t:level/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`,
+`{`[`Level :: level/0`](`t:level/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`,
 or with integers for both `NativeLevel` and `NativeOpt` as
-`{`[`NativeLevel :: integer/0`](`t:integer/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`.
+`{`[`NativeLevel :: integer/0`](`t:integer/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`.
 
 If an option is valid depends both on the platform and on
 what kind of socket it is (`t:domain/0`, `t:type/0` and `t:protocol/0`).
@@ -7282,9 +7282,9 @@ Some uses of this function is for _backwards compatibility reasons_.
 For instance, `getopt(Socket, Level, Opt)` is 
 equivalent to [`getopt(Socket, {Level, Opt})`](`getopt/2`),
 or as a special case if
-`Opt = {NativeOpt :: `[`integer/0`](`t:integer/0`)`, ValueSpec}`
+`Opt = {NativeOpt :: `[`integer/0`](`t:integer/0`)`, ValueSpec}`
 equivalent to
-[`getopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`getopt_native/3`).
+[`getopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`getopt_native/3`).
 
 Use `getopt/2` or `getopt_native/3` instead to handle
 the option level and name as a single term, and to make the
@@ -7980,7 +7980,7 @@ as a completed operation; the process first in queue is notified.
 If [`SelectInfo`](`t:select_info/0`) `|`
 [`CompletionInfo`](`t:completion_info/0`) does not match
 an operation in progress for the calling process, this function returns
-`{error, {invalid, SelectInfo | CompletionInfo}}`.
+`{error, {invalid, SelectInfo | CompletionInfo}}`.
 """.
 -spec cancel(Socket, SelectInfo | CompletionInfo)->
           'ok' | {'error', Reason} when

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -689,34 +689,34 @@ There are also a couple of IANA defined values (`le`, `voice_admit` and `nqb`).
 
 """.
 -type ip_tos() :: #{native := iptos_native(),
-		    tos    := iptos_tos(),
-		    dscp   := iptos_dscp()}.
+                    tos    := iptos_tos(),
+                    dscp   := iptos_dscp()}.
 
 -type iptos_value() :: iptos_tos() | iptos_dscp() | iptos_native().
 %% According to RFC 1349
 -type iptos_tos()   :: #{precedence := iptos_tos_prec()  | non_neg_integer(),
-			 tos        := iptos_tos_value() | non_neg_integer()}.
+                         tos        := iptos_tos_value() | non_neg_integer()}.
 -type iptos_tos_prec() :: netcontrol | internetcontrol | critical_ecp |
-			  flashoverride | flash | immediate | priority |
-			  routine.
+                          flashoverride | flash | immediate | priority |
+                          routine.
 -type iptos_tos_value() :: default |
-			   lowdelay |  throughput | reliability | mincost.
+                           lowdelay |  throughput | reliability | mincost.
 %% According to RFC 2474
 -type iptos_dscp() :: 
-	cs0 |
-	le |
-	cs1 |
-	af11 | af12 | af13 |
-	cs2 |
-	af21 | af22 | af23 |
-	cs3 |
-	af31 | af32 | af33 |
-	cs4 |
-	af41 | af42 | af43 |
-	cs5 |
-	voice_admit | nqb | ef |
-	cs6 |
-	cs7.
+        cs0 |
+        le |
+        cs1 |
+        af11 | af12 | af13 |
+        cs2 |
+        af21 | af22 | af23 |
+        cs3 |
+        af31 | af32 | af33 |
+        cs4 |
+        af41 | af42 | af43 |
+        cs5 |
+        voice_admit | nqb | ef |
+        cs6 |
+        cs7.
 -type iptos_native() :: non_neg_integer().
 
 -doc "C: `struct ip_pktinfo`".

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -684,6 +684,9 @@ Its then up to the user pick the one they want.
 
 Lowercase `t:atom/0` values corresponding to the C library constants `IPTOS_*`.
 Some constant(s) may be unsupported by the platform.
+
+There are also a couple of IANA defined values (`le`, `voice_admit` and `nqb`).
+
 """.
 -type ip_tos() :: #{native := iptos_native(),
 		    tos    := iptos_tos(),
@@ -700,16 +703,20 @@ Some constant(s) may be unsupported by the platform.
 			   lowdelay |  throughput | reliability | mincost.
 %% According to RFC 2474
 -type iptos_dscp() :: 
-	%% cs1
+	cs0 |
+	le |
+	cs1 |
 	af11 | af12 | af13 |
-	%% cs2
+	cs2 |
 	af21 | af22 | af23 |
-	%% cs3
+	cs3 |
 	af31 | af32 | af33 |
-	%% cs4
+	cs4 |
 	af41 | af42 | af43 |
-	%% cs5
-	ef.
+	cs5 |
+	voice_admit | nqb | ef |
+	cs6 |
+	cs7.
 -type iptos_native() :: non_neg_integer().
 
 -doc "C: `struct ip_pktinfo`".

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -41,7 +41,7 @@ has been received.
 > #### Asynchronous Calls
 >
 > Some functions feature _asynchronous calls_.  This is achieved by setting
-> the `Timeout` argument to `nowait` or to a `Handle ::`Â `t:reference/0`.
+> the `Timeout` argument to `nowait` or to a `Handle ::``t:reference/0`.
 > See the respective function's type specification.
 >
 > This module has two different implementations of asynchronous calls.
@@ -62,9 +62,9 @@ has been received.
 > - `{select, `[`SelectInfo`](`t:select_info/0`)`}`
 >
 > Where `CompletionInfo` is
-> `{completion_info,Â _,Â `[`CompletionHandle`](`t:completion_handle/0`)`}`
+> `{completion_info, _, `[`CompletionHandle`](`t:completion_handle/0`)`}`
 > and `SelectInfo` is
-> `{select_info,Â _,Â `[`SelectHandle`](`t:select_handle/0`)`}`.
+> `{select_info, _, `[`SelectHandle`](`t:select_handle/0`)`}`.
 > Both the `CompletionHandle` and the `SelectHandle`
 > are of type `t:reference/0`.
 >
@@ -83,7 +83,7 @@ has been received.
 > will probably have to be adjusted due to the already delivered data
 > in this return value.
 >
-> On `select` systems, when the `{otp,Â select_read}` option is `true`,
+> On `select` systems, when the `{otp, select_read}` option is `true`,
 > the asynchronous [`recv/3,4`](#recv-nowait),
 > [`recvfrom/3,4`](#recvfrom-nowait), and
 > [`recvmsg/3,4,5`](#recvmsg-nowait) functions may also return:
@@ -116,7 +116,7 @@ has been received.
 >
 > When a `select` message is received, it only means that the operation
 > _may now continue_, by retrying the operation (which may return
-> a new `{select,Â _}` value).  Some operations are retried by repeating
+> a new `{select, _}` value).  Some operations are retried by repeating
 > the same function call, and some have a dedicated function variant
 > to be used for the retry.  See the respective function's documentation.
 >
@@ -143,7 +143,7 @@ has been received.
 > #### Using a `Handle`
 >
 > If creating a `t:reference/0` with [`make_ref()`](`erlang:make_ref/0`)
-> and using that as the `TimeoutÂ |Â Handle` argument, the same `Handle`
+> and using that as the `Timeout|Handle` argument, the same `Handle`
 > will then be the [`SelectHandle`](`t:select_handle/0`) in the returned
 > `t:select_info/0` and the received `select` message, or be
 > the [`CompletionHandle`](`t:completion_handle/0`) in the returned
@@ -162,8 +162,8 @@ has been received.
 > message has been received it replaces the operation in progress:
 >
 > ```erlang
->     {select,Â {select_info,Â Handle}} = socket:accept(LSock,Â nowait),
->     {ok,Â Socket} = socket:accept(LSock,Â 1000),
+>     {select, {select_info, Handle}} = socket:accept(LSock, nowait),
+>     {ok, Socket} = socket:accept(LSock,1000),
 >     :
 > ```
 > Above, `Handle` is _no longer_ valid once the second `accept/2`, call
@@ -463,7 +463,7 @@ and the `t:otp_socket_option/0` with the same name.
           io_backend      := #{name := atom()},
 	  load_nif_result := undefined | ok | {error, term()}}.
 
--doc "A `t:map/0` of `NameÂ :=Â Counter` associations.".
+-doc "A `t:map/0` of `Name := Counter` associations.".
 -type socket_counters() :: #{read_byte        := non_neg_integer(),
                              read_fails       := non_neg_integer(),
                              read_pkg         := non_neg_integer(),
@@ -1101,8 +1101,8 @@ hence above all OS protocol levels.
   On `select` implementations, see [Asynchronous Calls](#asynchronous-calls),
   automatically activate select after a completed read.
 
-  Instead of `{ok,Â Data}` the receive operation returns
-  [`{select_read,Â {SelectInfo,Â Data}}`](`t:select_info/0`),
+  Instead of `{ok, Data}` the receive operation returns
+  [`{select_read, {SelectInfo, Data}}`](`t:select_info/0`),
   and the calling process can wait for a [`select` message](#async-messages)
   containing `SelectInfo` when there is data available again.
 
@@ -2296,9 +2296,9 @@ Returned by an operation that requires the caller to wait for a
 [`SelectHandle`](`t:select_handle/0`).
 
 On `select` systems, if the option
-[`{otp,Â select_read}`](`t:otp_socket_option/0`) is set,
-[`{select_read,Â {select_info(),Â _}}`](`t:select_info/0`)
-is returned instead of `{ok,Â _}` to indicate that a new
+[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
+[`{select_read, {select_info(), _}}`](`t:select_info/0`)
+is returned instead of `{ok, _}` to indicate that a new
 asynchronous receive operation has been initiated
 and the caller should wait for a
 [`select` message](#async-messages) containing the
@@ -2577,7 +2577,7 @@ option default value.
 Globally change if the socket registry is to be used or not.
 Note that its still possible to override this explicitly
 when creating an individual sockets, see [`open/2,3,4`](`open/2`)
-for more info (the [`OptsÂ ::Â map/0`](`t:map/0`)).
+for more info (the [`Opts :: map/0`](`t:map/0`)).
 """.
 -spec use_registry(D :: boolean()) -> 'ok'.
 %%
@@ -3078,15 +3078,15 @@ supports() ->
 Retrieve information about what socket features
 the module and the platform supports.
 
-If `Key1Â =Â msg_flags` returns a list of `{Flag,Â boolean()}`
+If `Key1 = msg_flags` returns a list of `{Flag, boolean()}`
 tuples for every `Flag` in `t:msg_flag/0` with the `t:boolean/0`
 indicating if the flag is supported on this platform.
 
-If `Key1Â =Â protocols` returns a list of `{Name,Â boolean()}`
+If `Key1 = protocols` returns a list of `{Name, boolean()}`
 tuples for every `Name` in`t:protocol/0` with the `t:boolean/0`
 indicating if the protocol is supported on this platform.
 
-If `Key1Â =Â options` returns a list of `{SocketOption,Â boolean()}`
+If `Key1 = options` returns a list of `{SocketOption, boolean()}`
 tuples for every `SocketOption` in `t:socket_option/0` with the `t:boolean/0`
 indicating if the socket option is supported on this platform.
 
@@ -3109,9 +3109,9 @@ supports(Key) ->
 Retrieve information about what socket features
 the module and the platform supports.
 
-If `Key1Â =Â options`, for a `Key2` in `t:level/0` returns
-a list of `{Opt,Â boolean()}` tuples for all known socket options
-[`Opt` on that `LevelÂ =Â Key2`](`t:socket_option/0`) with the `t:boolean/0`
+If `Key1 = options`, for a `Key2` in `t:level/0` returns
+a list of `{Opt, boolean()}` tuples for all known socket options
+[`Opt` on that `Level = Key2`](`t:socket_option/0`) with the `t:boolean/0`
 indicating if the socket option is supported on this platform.
 See `setopt/3` and `getopt/2`.
 
@@ -3372,16 +3372,16 @@ header files. The same goes for `Protocol` as defined in the platform's
 > #### Note {: .info }
 >
 > For some combinations of `Domain` and `Type` the platform has got
-> a default protocol that can be selected with `ProtocolÂ =Â default`,
+> a default protocol that can be selected with `Protocol = default`,
 > and the platform may allow or require selecting the default protocol,
 > or a specific protocol.
 >
 > Examples:
 >
-> - **`socket:open(inet,Â stream,Â tcp)`** - It is common that for
+> - **`socket:open(inet, stream, tcp)`** - It is common that for
 >   protocol domain and type `inet,stream` it is allowed to select
 >   the `tcp` protocol although that mostly is the default.
-> - **`socket:open(local,Â dgram)`** - It is common that for
+> - **`socket:open(local, dgram)`** - It is common that for
 >   the protocol domain `local` it is mandatory to not select a protocol,
 >   that is; to select the default protocol.
 
@@ -3588,18 +3588,18 @@ If a connection attempt is already in progress (by another process),
 
 If the time-out argument (argument 3) is `infinity` it is
 up to the OS implementation to decide when the connection
-attempt failed and then what to return; probably `{error,Â etimedout}`.
+attempt failed and then what to return; probably `{error, etimedout}`.
 The OS time-out may be very long.
 
 [](){: #connect-timeout }
 
 If the time-out argument (argument 3) is a time-out value
-(`t:non_neg_integer/0`); return `{error,Â timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if the connection hasn't been established within `Timeout` milliseconds.
 
 > #### Note {: .info }
 >
-> Note that when this call has returned `{error,Â timeout}`
+> Note that when this call has returned `{error, timeout}`
 > the connection state of the socket is uncertain since the platform's
 > network stack may complete the connection at any time,
 > up to some platform specific time-out.
@@ -4085,7 +4085,7 @@ inherit_opts(FromSock, ToSock, [SockOpt | SockOpts], Errs) ->
 %%
 
 -doc(#{since => <<"OTP 22.0">>}).
--doc "Equivalent to [`send(Socket,Â Data,Â [],Â infinity)`](`send/4`).".
+-doc "Equivalent to [`send(Socket, Data, [], infinity)`](`send/4`).".
 -spec send(Socket, Data) -> Result when
       Socket         :: socket(),
       Data           :: iodata(),
@@ -4141,7 +4141,7 @@ The return value indicates the result from the platform's network layer:
 
 - **`ok`** - All data was accepted by the OS for delivery
 
-- **`{ok,Â RestData}`** - Some but not all data was accepted,
+- **`{ok, RestData}`** - Some but not all data was accepted,
   but no error was reported (partially successful send).  `RestData`
   is the tail of `Data` that wasn't accepted.
 
@@ -4157,16 +4157,16 @@ The return value indicates the result from the platform's network layer:
   to return this,  surely more possible for a socket of
   [type `seqpacket`](`t:type/0`).
 
-- **`{error,Â Reason}`** - An error has been reported and no data
-  was accepted for delivery.  [`ReasonÂ ::Â posix/0`](`t:posix/0`)
+- **`{error, Reason}`** - An error has been reported and no data
+  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
   an argument to be invalid.
 
-- **`{error,Â {Reason,Â RestData}}`** - An error was reported but before that
+- **`{error, {Reason, RestData}}`** - An error was reported but before that
   some data was accepted for delivery. `RestData` is the tail of `Data`
-  that wasn't accepted. See `{error,Â Reason}` above.
+  that wasn't accepted. See `{error, Reason}` above.
 
   This can only happen for a socket of [type `stream`](`t:type/0`)
   when a partially successful send is retried until there is an error.
@@ -4180,9 +4180,9 @@ or return an error.
 [](){: #send-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error,Â timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error,Â {timeout,Â RestData}}` if some data was sent
+or `{error, {timeout, RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -4593,9 +4593,9 @@ or return an error.
 [](){: #sendto-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error,Â timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error,Â {timeout,Â RestData}}` if some data was sent
+or `{error, {timeout, RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -4829,9 +4829,9 @@ or return an error.
 [](){: #sendmsg-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error,Â timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error,Â {timeout,Â RestData}}` if some data was sent
+or `{error, {timeout, RestData}}` if some data was sent
 (accepted by the OS for delivery).  `RestData` is the tail of the data
 that hasn't been sent.
 
@@ -5217,7 +5217,7 @@ The return value indicates the result from the platform's network layer:
   is the tail of `IOV` that wasn't accepted.
 
 - **`{error, Reason}`** - An error has been reported and no data
-  was accepted for delivery.  [`ReasonÂ ::Â posix/0`](`t:posix/0`)
+  was accepted for delivery.  [`Reason :: posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
@@ -5225,7 +5225,7 @@ The return value indicates the result from the platform's network layer:
 
 - **`{error, {Reason, RestIOV}}`** -  - An error was reported but before that
   some data was accepted for delivery. `RestIOV` is the tail of `IOV`
-  that wasn't accepted. See `{error,Â Reason}` above.
+  that wasn't accepted. See `{error, Reason}` above.
 
 [](){: #sendv-infinity }
 
@@ -5236,9 +5236,9 @@ or return an error.
 [](){: #sendv-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error,Â timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error,Â {timeout,Â RestIOV}}` if some data was sent
+or `{error, {timeout, RestIOV}}` if some data was sent
 (accepted by the OS for delivery).  `RestIOV` is the tail of the data
 that hasn't been sent.
 
@@ -5489,7 +5489,7 @@ rest_iov(Written, IOV) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket,Â FileHandle_or_Continuation,Â 0,Â 0,Â infinity)`](`sendfile/5`).
+[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, infinity)`](`sendfile/5`).
 """.
 -spec sendfile(Socket, FileHandle | Continuation) -> dynamic() when
       Socket       :: socket(),
@@ -5504,7 +5504,7 @@ sendfile(Socket, FileHandle_Cont) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket,Â FileHandle_or_Continuation,Â 0,Â 0,Â Timeout_or_Handle)`](`sendfile/5`).
+[`sendfile(Socket, FileHandle_or_Continuation, 0, 0, Timeout_or_Handle)`](`sendfile/5`).
 """.
 -spec sendfile(Socket,
                FileHandle | Continuation,
@@ -5522,7 +5522,7 @@ sendfile(Socket, FileHandle_Cont, Timeout_Handle) ->
 Send a file on a socket.
 
 Equivalent to
-[`sendfile(Socket,Â FileHandle_or_Continuation,Â Offset,Â Count,Â infinity)`](`sendfile/5`).
+[`sendfile(Socket, FileHandle_or_Continuation, Offset, Count, infinity)`](`sendfile/5`).
 """.
 -spec sendfile(Socket,
                FileHandle | Continuation,
@@ -5550,7 +5550,7 @@ The `Offset` argument is the file offset to start reading from.
 The default offset is `0`.
 
 The `Count` argument is the number of bytes to transfer
-from `FileHandle` to `Socket`. If `CountÂ =Â 0` (the default)
+from `FileHandle` to `Socket`. If `Count = 0` (the default)
 the transfer stops at the end of file.
 
 The return value indicates the result from the platform's network layer:
@@ -5558,16 +5558,16 @@ The return value indicates the result from the platform's network layer:
 - **`{ok, BytesSent}`** - The transfer completed successfully after `BytesSent`
   bytes of data.
 
-- **`{error,Â Reason}`** - An error has been reported and no data
-  was transferred. [`ReasonÂ ::Â posix/0`](`t:posix/0`)
+- **`{error, Reason}`** - An error has been reported and no data
+  was transferred. [`Reason :: posix/0`](`t:posix/0`)
   is what the platform's network layer reported.  `closed` means
   that this socket library was informed that the socket was closed,
   and `t:invalid/0` means that this socket library found
   an argument to be invalid.
 
-- **`{error,Â {Reason,Â BytesSent}}`** - An error has been reported
-  but before that some data was transferred. See `{error,Â Reason}`
-  and `{ok,Â BytesSent}` above.
+- **`{error, {Reason, BytesSent}}`** - An error has been reported
+  but before that some data was transferred. See `{error, Reason}`
+  and `{ok, BytesSent}` above.
 
 [](){: #sendfile-infinity }
 
@@ -5578,9 +5578,9 @@ or return an error.
 [](){: #sendfile-timeout }
 
 If the `Timeout` argument is a time-out value
-(`t:non_neg_integer/0`); return `{error,Â timeout}`
+(`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has been sent within `Timeout` millisecond,
-or `{error,Â {timeout,Â BytesSent}}` if some but not all data was sent
+or `{error, {timeout, BytesSent}}` if some but not all data was sent
 (accepted by the OS for delivery).
 
 [](){: #sendfile-nowait }
@@ -5825,7 +5825,7 @@ sendfile_next(BytesSent, Offset, Count) ->
 
 -doc(#{since => <<"OTP 22.0">>}).
 -doc """
-Equivalent to [`recv(Socket,Â 0,Â [],Â infinity)`](`recv/4`).
+Equivalent to [`recv(Socket, 0, [], infinity)`](`recv/4`).
 """.
 -spec recv(Socket :: socket()) -> dynamic().
 
@@ -5837,10 +5837,10 @@ recv(Socket) ->
 Receive data on a connected socket.
 
 With argument `Length`; equivalent to
-[`recv(Socket,Â Length,Â [],Â infinity)`](`recv/4`).
+[`recv(Socket, Length, [], infinity)`](`recv/4`).
 
 With argument `Flags`; equivalent to
-[`recv(Socket,Â 0,Â Flags,Â infinity)`](`recv/4`) *(since OTP 24.0)*.
+[`recv(Socket, 0, Flags, infinity)`](`recv/4`) *(since OTP 24.0)*.
 """.
 -spec recv(Socket :: socket(), Flags :: [msg_flag() | integer()]) -> dynamic();
           (Socket :: socket(), Length :: non_neg_integer()) -> dynamic().
@@ -5858,15 +5858,15 @@ recv(Socket, Length) ->
 Receive data on a connected socket.
 
 With arguments `Length` and `Flags`; equivalent to
-[`recv(Socket,Â Length,Â Flags,Â infinity)`](`recv/4`).
+[`recv(Socket, Length, Flags, infinity)`](`recv/4`).
 
 With arguments `Length` and `TimeoutOrHandle`; equivalent to
-[`recv(Socket,Â Length,Â [],Â TimeoutOrHandle)`](`recv/4`).
+[`recv(Socket, Length, [], TimeoutOrHandle)`](`recv/4`).
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 `TimeoutOrHandle :: Handle` has been allowed *since OTP 24.0*.
 
 With arguments `Flags` and `TimeoutOrHandle`; equivalent to
-[`recv(Socket,Â 0,Â Flags,Â TimeoutOrHandle)`](`recv/4`)
+[`recv(Socket, 0, Flags, TimeoutOrHandle)`](`recv/4`)
 *(since OTP 24.0)*.
 """.
 -spec recv(Socket, Flags, TimeoutOrHandle) -> dynamic() when
@@ -5892,12 +5892,12 @@ Receive data on a connected socket.
 The argument `Length` specifies the size of the receive buffer.
 Packet oriented sockets truncate the packet if the size is too small.
 
-If `LengthÂ ==Â 0`; a default buffer size is used, which can be set by
+If `Length == 0`; a default buffer size is used, which can be set by
 [`socket:setopt(Socket, {otp,recvbuf}, BufSz)`](`setopt/3`).
 
 For a socket of [type `stream`](`t:type/0`), when a `Timeout` argument
 is used, the operation iterates until `Length` bytes has been received,
-or the operation times out.  If `LengthÂ ==Â 0` all readily available
+or the operation times out.  If `Length == 0` all readily available
 data is returned.
 
 On a `select` system, when the default receive buffer size option
@@ -5910,8 +5910,8 @@ The message `Flags` may be symbolic `t:msg_flag/0`s and/or
 `t:integer/0`s as in the platform's appropriate header files.
 The values of all symbolic flags and integers are or:ed together.
 
-When there is a socket error this function returns `{error,Â Reason}`,
-or if some data arrived before the error; `{error,Â {Reason,Â Data}}`
+When there is a socket error this function returns `{error, Reason}`,
+or if some data arrived before the error; `{error, {Reason, Data}}`
 (can only happen for a socket of [type `stream`](`t:type/0`)).
 
 [](){: #recv-infinity }
@@ -5927,14 +5927,14 @@ or if the OS reports an error for the operation.
 If the `Timeout` argument is a time-out value
 (`t:non_neg_integer/0`); return `{error, timeout}`
 if no data has arrived after `Timeout` milliseconds,
-or `{error,Â {timeout,Â Data}}` if some but not enough data
+or `{error, {timeout, Data}}` if some but not enough data
 has been received on a socket of [type `stream`](`t:type/0`) with Length > 0.
-It *can* also return directly with `{ok,Â Data}` ([type `dgram`](`t:type/0`)).
+It *can* also return directly with `{ok, Data}` ([type `dgram`](`t:type/0`)).
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no data
-is immediately available `{error,Â timeout} is returned.
-`On a socket of type [`stream`](`t:type/0`), `{error,Â {timeout,Â Data}}`
+is immediately available `{error, timeout} is returned.
+`On a socket of type [`stream`](`t:type/0`), `{error, {timeout, Data}}`
 is returned if there is an insufficient amount of data immediately available.
 
 [](){: #recv-nowait }
@@ -5959,15 +5959,15 @@ The possible values for `CompletionStatus` in the completion message are:
 - **`{error, Reason}`** - An error occured and no data was read.
 
 On `select` systems, for a socket of type [`stream`](`t:type/0`),
-if `LengthÂ >Â 0` and there is some but not enough data available,
-this function will return [`{select,Â {SelectInfo,Â Data}}`](`t:select_info/0`)
+if `Length > 0` and there is some but not enough data available,
+this function will return [`{select, {SelectInfo, Data}}`](`t:select_info/0`)
 with partial `Data`.  A repeated call to complete the operation
 may need an updated `Length` argument.
 
 On `select` systems, if the option
-[`{otp,Â select_read}`](`t:otp_socket_option/0`) is set,
-[`{select_read,Â {SelectInfo,Â Data}}`](`t:select_info/0`)
-is returned instead of `{ok,Â Data}` and a new asynchronous
+[`{otp, select_read}`](`t:otp_socket_option/0`) is set,
+[`{select_read, {SelectInfo, Data}}`](`t:select_info/0`)
+is returned instead of `{ok, Data}` and a new asynchronous
 receive operation has been initiated, which can be seen
 as an automatic [nowait](#recv-nowait) call whenever
 a receive operation is completed.
@@ -6339,10 +6339,10 @@ recvfrom(Socket) ->
 Receive a message on a socket.
 
 With argument `BufSz`; equivalent to
-[`recvfrom(Socket,Â BufSz,Â [],Â infinity)`](`recvfrom/4`).
+[`recvfrom(Socket, BufSz, [], infinity)`](`recvfrom/4`).
 
 With argument `Flags`; equivalent to
-[`recvfrom(Socket,Â 0,Â Flags,Â infinity)`](`recvfrom/4`) *(since OTP 24.0)*.
+[`recvfrom(Socket, 0, Flags, infinity)`](`recvfrom/4`) *(since OTP 24.0)*.
 """.
 -spec recvfrom(Socket :: socket(), Flags :: list()) -> dynamic();
               (Socket :: socket(), BufSz :: non_neg_integer()) -> dynamic().
@@ -6361,13 +6361,13 @@ recvfrom(Socket, BufSz) ->
 Receive a message on a socket.
 
 With arguments `BufSz` and `Flags`; equivalent to
-[`recvfrom(Socket,Â BufSz,Â Flags,Â infinity)`](`recvfrom/4`).
+[`recvfrom(Socket, BufSz, Flags, infinity)`](`recvfrom/4`).
 
 With arguments `BufSz` and `TimeoutOrHandle`; equivalent to
-[`recvfrom(Socket,Â BufSz,Â [],Â TimeoutOrHandle)`](`recvfrom/4`).
+[`recvfrom(Socket, BufSz, [], TimeoutOrHandle)`](`recvfrom/4`).
 
 With arguments `Flags` and `TimeoutOrHandle`; equivalent to
-[`recvfrom(Socket,Â 0,Â Flags,Â TimeoutOrHandle)`](`recvfrom/4`)
+[`recvfrom(Socket, 0, Flags, TimeoutOrHandle)`](`recvfrom/4`)
 
 `TimeoutOrHandle :: 'nowait'` has been allowed *since OTP 22.1*.
 
@@ -6591,7 +6591,7 @@ With argument `Flags`; equivalent to
 [`recvmsg(Socket,Â 0,Â 0,Â Flags,Â infinity)`](`recvmsg/5`).
 
 With argument `TimeoutOrHandle`; equivalent to
-[`recvmsg(Socket,Â 0,Â 0,Â [],Â TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
 
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 
@@ -6613,10 +6613,10 @@ recvmsg(Socket, TimeoutOrHandle) ->
 Receive a message on a socket.
 
 With arguments  `Flags`; equivalent to
-[`recvmsg(Socket,Â 0,Â 0,Â Flags,Â infinity)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, Flags, infinity)`](`recvmsg/5`).
 
 With argument `TimeoutOrHandle`; equivalent to
-[`recvmsg(Socket,Â 0,Â 0,Â [],Â TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket, 0, 0, [], TimeoutOrHandle)`](`recvmsg/5`).
 
 `TimeoutOrHandle :: nowait` has been allowed *since OTP 22.1*.
 
@@ -6638,7 +6638,7 @@ recvmsg(Socket, BufSz, CtrlSz) ->
 -doc(#{since => <<"OTP 24.0">>}).
 -doc """
 Equivalent to
-[`recvmsg(Socket,Â BufSz,Â CtrlSz,Â [],Â TimeoutOrHandle)`](`recvmsg/5`).
+[`recvmsg(Socket, BufSz, CtrlSz, [], TimeoutOrHandle)`](`recvmsg/5`).
 """.
 -spec recvmsg(
         Socket :: socket(), BufSz :: non_neg_integer(), CtrlSz :: non_neg_integer(),
@@ -6689,7 +6689,7 @@ if no message has arrived after `Timeout` milliseconds.
 
 `Timeout = 0` only polls the OS receive call and doesn't
 engage the Asynchronous Calls mechanisms.  If no message
-is immediately available `{error,Â timeout}` is returned.
+is immediately available `{error, timeout}` is returned.
 
 [](){: #recvmsg-nowait }
 
@@ -7146,9 +7146,9 @@ setopt(Socket, SocketOption, Value) ->
 Set a socket option _(backwards compatibility function)_.
 
 Equivalent to [`setopt(Socket, {Level, Opt}, Value)`](`setopt/3`),
-or as a special case if `OptÂ =Â NativeOptÂ ::`Â `t:integer/0`
-and `ValueÂ =`Â `t:binary/0` equivalent to
-[`setopt_native(Socket,Â {Level,Â NativeOpt},Â ValueSpec)`](`setopt_native/3`).
+or as a special case if `Opt = NativeOpt ::` `t:integer/0`
+and `Value =` `t:binary/0` equivalent to
+[`setopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`setopt_native/3`).
 
 Use `setopt/3` or `setopt_native/3` instead to handle
 the option level and name as a single term, and to make the
@@ -7178,9 +7178,9 @@ as the option value.
 
 The socket option may be specified with an ordinary
 `t:socket_option/0` tuple, with a symbolic `Level` as
-`{`[`LevelÂ ::Â level/0`](`t:level/0`)`,Â `[`NativeOptÂ ::Â integer/0`](`t:integer/0`)`}`,
+`{`[`Level :: level/0`](`t:level/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`,
 or with integers for both `NativeLevel` and `NativeOpt` as
-`{`[`NativeLevelÂ ::Â integer/0`](`t:integer/0`)`,Â `[`NativeOptÂ ::Â integer/0`](`t:integer/0`)`}`.
+`{`[`NativeLevel :: integer/0`](`t:integer/0`)`, `[`NativeOpt :: integer/0`](`t:integer/0`)`}`.
 
 If an option is valid depends both on the platform and on
 what kind of socket it is (`t:domain/0`, `t:type/0` and `t:protocol/0`).
@@ -7275,9 +7275,9 @@ Some uses of this function is for _backwards compatibility reasons_.
 For instance, `getopt(Socket, Level, Opt)` is 
 equivalent to [`getopt(Socket, {Level, Opt})`](`getopt/2`),
 or as a special case if
-`OptÂ =Â {NativeOptÂ ::Â `[`integer/0`](`t:integer/0`)`,Â ValueSpec}`
+`Opt = {NativeOpt :: `[`integer/0`](`t:integer/0`)`, ValueSpec}`
 equivalent to
-[`getopt_native(Socket,Â {Level,Â NativeOpt},Â ValueSpec)`](`getopt_native/3`).
+[`getopt_native(Socket, {Level, NativeOpt}, ValueSpec)`](`getopt_native/3`).
 
 Use `getopt/2` or `getopt_native/3` instead to handle
 the option level and name as a single term, and to make the
@@ -7973,7 +7973,7 @@ as a completed operation; the process first in queue is notified.
 If [`SelectInfo`](`t:select_info/0`) `|`
 [`CompletionInfo`](`t:completion_info/0`) does not match
 an operation in progress for the calling process, this function returns
-`{error,Â {invalid,Â SelectInfoÂ |Â CompletionInfo}}`.
+`{error, {invalid, SelectInfo | CompletionInfo}}`.
 """.
 -spec cancel(Socket, SelectInfo | CompletionInfo)->
           'ok' | {'error', Reason} when

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -685,12 +685,12 @@ Its then up to the user pick the one they want.
 Lowercase `t:atom/0` values corresponding to the C library constants `IPTOS_*`.
 Some constant(s) may be unsupported by the platform.
 
-There are also a couple of IANA defined values (`le`, `voice_admit` and `nqb`).
-
+The `t:iptos_dscp/0` values are according to IANA's
+Differentiated Services Field Codepoints registry.
 """.
 -type ip_tos() :: #{native := iptos_native(),
                     tos    := iptos_tos(),
-                    dscp   := iptos_dscp()}.
+                    dscp   := iptos_dscp() | non_neg_integer()}.
 
 -type iptos_value() :: iptos_tos() | iptos_dscp() | iptos_native().
 %% According to RFC 1349
@@ -701,7 +701,8 @@ There are also a couple of IANA defined values (`le`, `voice_admit` and `nqb`).
                           routine.
 -type iptos_tos_value() :: default |
                            lowdelay |  throughput | reliability | mincost.
-%% According to RFC 2474
+%% According to
+%% https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
 -type iptos_dscp() :: 
         cs0 |
         le |

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -674,19 +674,18 @@ C: `IPTOS_*` values.
 
 Note that since there are two different representations of TOS;
 according to RFC 1349 ("classic TOS") and RFC 2474 (DSCP),
-we have three different value representations for tos: 
-Native (the raw unencoded value), (classic) tos and dscp.
+we have three different value representations for tos:
+`native` (the raw unencoded value of the TOS octet), `tos` (classic),
+and `dscp`.
+
 When sending or setting (the ip tos option), the user can choose
 between the three different (value) representations.
 When reading, the value is represented as a map with all three
 representations, since 'socket' does not know which one is expected.
 Its then up to the user pick the one they want.
 
-Lowercase `t:atom/0` values corresponding to the C library constants `IPTOS_*`.
-Some constant(s) may be unsupported by the platform.
-
-The `t:iptos_dscp/0` values are according to IANA's
-Differentiated Services Field Codepoints registry.
+An integer `dscp` value is a DSCP field value that is not known
+from the IANA registry (see `t:iptos_dscp/0`).
 """.
 -type ip_tos() :: #{native := iptos_native(),
                     tos    := iptos_tos(),
@@ -694,6 +693,13 @@ Differentiated Services Field Codepoints registry.
 
 -type iptos_value() :: iptos_tos() | iptos_dscp() | iptos_native().
 %% According to RFC 1349
+-doc """
+Lowercase `t:atom/0` values corresponding to the C library constants `IPTOS_*`.
+The atoms are named like The C library names, but to avoid platform depencendy,
+the set of names and values follow RFC 1349, not the C library header files.
+
+An integer value is a field value that is not named in the RFC.
+""".
 -type iptos_tos()   :: #{precedence := iptos_tos_prec()  | non_neg_integer(),
                          tos        := iptos_tos_value() | non_neg_integer()}.
 -type iptos_tos_prec() :: netcontrol | internetcontrol | critical_ecp |
@@ -701,9 +707,13 @@ Differentiated Services Field Codepoints registry.
                           routine.
 -type iptos_tos_value() :: default |
                            lowdelay |  throughput | reliability | mincost.
-%% According to
-%% https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
--type iptos_dscp() :: 
+
+-doc """
+These symbolic DSCP values are according to IANA's
+[Differentiated Services Field Codepoints registry]
+(https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml).
+""".
+-type iptos_dscp() ::
         cs0 |
         le |
         cs1 |

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -3908,7 +3908,7 @@ do_otp_20102(Addr, TOSValues, InetBackend) ->
     TO   = 2000,
     Data = <<"ABC">>,
 
-    %% Any failures in the setup patr should really just result in a skip
+    %% Any failures in the setup part should really just result in a skip
     %% but for now we want everything to explode so that we do not miss stuff.
     RSock = try gen_udp:open(0, [{inet_backend, InetBackend},
 				  inet, binary, {active, false}, {ip, Addr},
@@ -3939,10 +3939,14 @@ do_otp_20102(Addr, TOSValues, InetBackend) ->
 	    end,
     
     Fun = fun(TOS) ->
+		  ?P("~s -> try set TOS: ~w", [?FUNCTION_NAME, TOS]),
 		  ok = inet:setopts(SSock, [{tos, TOS}]),
+		  ?P("~s -> try send data", [?FUNCTION_NAME]),
 		  ok = gen_udp:send(SSock, Addr, RPort, Data),
+		  ?P("~s -> try recv data with anc data (tos)",
+		     [?FUNCTION_NAME]),
 		  {ok, {_, _, Anc, _}} = gen_udp:recv(RSock, Len, TO),
-		  ?P("received Anc: ~p", [Anc]),
+		  ?P("~s -> recv Anc data: ~p", [?FUNCTION_NAME, Anc]),
 		  Anc
 	  end,
     [Fun(V) || V <- TOSValues].

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -3858,12 +3858,12 @@ otp_20102(Config) when is_list(Config) ->
                    ?P("cond check: do we support socket"),
                    case ?LIB:is_socket_supported() of
                        true ->
-			   ?P("cond check: not windows"),
-			   is_not_windows(),
+                           ?P("cond check: not windows"),
+                           is_not_windows(),
                            ?P("cond check: do we support ipv4 & recvtos & tos"),
                            has_support_ipv4(),
-			   has_support_ip_recvtos(),
-			   has_support_ip_tos();
+                           has_support_ip_recvtos(),
+                           has_support_ip_tos();
                        false ->
                            ?SKIPT("SOCKET not supported")
                    end
@@ -3889,10 +3889,10 @@ do_otp_20102(#{local_addr := Addr}) ->
 
     InetTOSValues = do_otp_20102(Addr, TOSValues, inet),
     case do_otp_20102(Addr, TOSValues, socket) of
-	InetTOSValues ->
-	    ok;
-	SocketTOSValues ->
-	    exit({unxepected, InetTOSValues, SocketTOSValues})
+        InetTOSValues ->
+            ok;
+        SocketTOSValues ->
+            exit({unxepected, InetTOSValues, SocketTOSValues})
     end,
     
     ?P("done"),
@@ -3911,47 +3911,47 @@ do_otp_20102(Addr, TOSValues, InetBackend) ->
     %% Any failures in the setup part should really just result in a skip
     %% but for now we want everything to explode so that we do not miss stuff.
     RSock = try gen_udp:open(0, [{inet_backend, InetBackend},
-				  inet, binary, {active, false}, {ip, Addr},
-				  {recvtos, true}]) of
-		{ok, RS} ->
-		    RS;
-		{error, ROReason} ->
-		    exit({failed_open, ROReason})
-	    catch
-		C1:E1:S1 ->
-		    exit({catched_open, {C1, E1, S1}})
-	    end,
+                                 inet, binary, {active, false}, {ip, Addr},
+                                 {recvtos, true}]) of
+                {ok, RS} ->
+                    RS;
+                {error, ROReason} ->
+                    exit({failed_open, ROReason})
+            catch
+                C1:E1:S1 ->
+                    exit({catched_open, {C1, E1, S1}})
+            end,
     RPort = case inet:port(RSock) of
-		{ok, RP} ->
-		    RP;
-		{error, RPReason} ->
-		    exit({failed_open, RPReason})
-	    end,
+                {ok, RP} ->
+                    RP;
+                {error, RPReason} ->
+                    exit({failed_open, RPReason})
+            end,
     SSock = try gen_udp:open(0, [{inet_backend, InetBackend},
-				  inet, binary, {active, false}, {ip, Addr}]) of
-		{ok, SS} ->
-		    SS;
-		{error, SOReason} ->
-		    exit({failed_open, SOReason})
-	    catch
-		C2:E2:S2 ->
-		    exit({catched_open, {C2, E2, S2}})
-	    end,
-    
+                                 inet, binary, {active, false}, {ip, Addr}]) of
+                {ok, SS} ->
+                    SS;
+                {error, SOReason} ->
+                    exit({failed_open, SOReason})
+            catch
+                C2:E2:S2 ->
+                    exit({catched_open, {C2, E2, S2}})
+            end,
+
     Fun = fun(TOS) ->
-		  ?P("~s -> try set TOS: ~w", [?FUNCTION_NAME, TOS]),
-		  ok = inet:setopts(SSock, [{tos, TOS}]),
-		  ?P("~s -> try send data", [?FUNCTION_NAME]),
-		  ok = gen_udp:send(SSock, Addr, RPort, Data),
-		  ?P("~s -> try recv data with anc data (tos)",
-		     [?FUNCTION_NAME]),
-		  {ok, {_, _, Anc, _}} = gen_udp:recv(RSock, Len, TO),
-		  ?P("~s -> recv Anc data: ~p", [?FUNCTION_NAME, Anc]),
-		  Anc
-	  end,
+                  ?P("~s -> try set TOS: ~w", [?FUNCTION_NAME, TOS]),
+                  ok = inet:setopts(SSock, [{tos, TOS}]),
+                  ?P("~s -> try send data", [?FUNCTION_NAME]),
+                  ok = gen_udp:send(SSock, Addr, RPort, Data),
+                  ?P("~s -> try recv data with anc data (tos)",
+                     [?FUNCTION_NAME]),
+                  {ok, {_, _, Anc, _}} = gen_udp:recv(RSock, Len, TO),
+                  ?P("~s -> recv Anc data: ~p", [?FUNCTION_NAME, Anc]),
+                  Anc
+          end,
     [Fun(V) || V <- TOSValues].
 
-			  
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 ok({ok,V}) -> V;

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -84,11 +84,16 @@
          otp_18323_opts_processing/1,
          otp_18323_open/1,
          otp_19332/1,
-         otp_19357_open_with_ipv6_option/1
+         otp_19357_open_with_ipv6_option/1,
+         otp_20102/1
 	]).
 
 -include_lib("kernel/src/inet_int.hrl").
 -include("kernel_test_lib.hrl").
+
+
+%% Used for 'has_support' functions
+-define(SLIB, socket_test_lib).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -206,7 +211,8 @@ tickets_cases() ->
     [
      {group, otp18323},
      {group, otp19332},
-     otp_19357_open_with_ipv6_option
+     otp_19357_open_with_ipv6_option,
+     otp_20102
     ].
 
 otp18323_cases() ->
@@ -3645,7 +3651,7 @@ otp_19357_open_with_ipv6_option(Config) when is_list(Config) ->
                    case ?LIB:is_socket_supported() of
                        true ->
                            ?P("cond check: do we support ipv6"),
-                           ?LIB:has_support_ipv6();
+                           has_support_ipv6();
                        false ->
                            ?SKIPT("SOCKET not supported")
                    end
@@ -3843,6 +3849,105 @@ expect(Slogan,
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+%% Tests that gen_udp using the tos socket option with inet_backend = socket
+%% is compatible with "standard" gen_udp (inet_backend = inet).
+
+otp_20102(Config) when is_list(Config) ->
+    ct:timetrap(?MINS(1)),
+    Cond = fun() ->
+                   ?P("cond check: do we support socket"),
+                   case ?LIB:is_socket_supported() of
+                       true ->
+                           ?P("cond check: do we support ipv4 & recvtos & tos"),
+                           has_support_ipv4(),
+			   has_support_ip_recvtos(),
+			   has_support_ip_tos();
+                       false ->
+                           ?SKIPT("SOCKET not supported")
+                   end
+           end,
+    Pre  = fun() ->
+                   {ok, Addr} = ?LIB:which_local_addr(inet),
+                   #{local_addr => Addr}
+           end,
+    Case = fun(State) -> do_otp_20102(State) end,
+    Post = fun(_) -> ok end,
+    ?TC_TRY(?FUNCTION_NAME, Cond, Pre, Case, Post).
+
+do_otp_20102(#{local_addr := Addr}) ->
+    ?P("~s -> entry with"
+       "~n   Addr: ~p", [?FUNCTION_NAME, Addr]),
+
+    %% First without specifying the (bind) address:
+
+    TOSValues = [8, 9, 136, 137],
+
+    %% First run this with inet_backend = inet to get the actual returned
+    %% TOS values (which we are trying to match with inet_backend = socket)
+
+    InetTOSValues = do_otp_20102(Addr, TOSValues, inet),
+    case do_otp_20102(Addr, TOSValues, socket) of
+	InetTOSValues ->
+	    ok;
+	SocketTOSValues ->
+	    exit({unxepected, InetTOSValues, SocketTOSValues})
+    end,
+    
+    ?P("done"),
+    ok.
+
+do_otp_20102(Addr, TOSValues, InetBackend) ->
+    ?P("~s -> entry with"
+       "~n   Addr:        ~p"
+       "~n   TOSValues:   ~p"
+       "~n   InetBackend: ~p", [?FUNCTION_NAME, Addr, TOSValues, InetBackend]),
+
+    Len  = 100,
+    TO   = 2000,
+    Data = <<"ABC">>,
+
+    %% Any failures in the setup patr should really just result in a skip
+    %% but for now we want everything to explode so that we do not miss stuff.
+    RSock = try gen_udp:open(0, [{inet_backend, InetBackend},
+				  inet, binary, {active, false}, {ip, Addr},
+				  {recvtos, true}]) of
+		{ok, RS} ->
+		    RS;
+		{error, ROReason} ->
+		    exit({failed_open, ROReason})
+	    catch
+		C1:E1:S1 ->
+		    exit({catched_open, {C1, E1, S1}})
+	    end,
+    RPort = case inet:port(RSock) of
+		{ok, RP} ->
+		    RP;
+		{error, RPReason} ->
+		    exit({failed_open, RPReason})
+	    end,
+    SSock = try gen_udp:open(0, [{inet_backend, InetBackend},
+				  inet, binary, {active, false}, {ip, Addr}]) of
+		{ok, SS} ->
+		    SS;
+		{error, SOReason} ->
+		    exit({failed_open, SOReason})
+	    catch
+		C2:E2:S2 ->
+		    exit({catched_open, {C2, E2, S2}})
+	    end,
+    
+    Fun = fun(TOS) ->
+		  ok = inet:setopts(SSock, [{tos, TOS}]),
+		  ok = gen_udp:send(SSock, Addr, RPort, Data),
+		  {ok, {_, _, Anc, _}} = gen_udp:recv(RSock, Len, TO),
+		  ?P("received Anc: ~p", [Anc]),
+		  Anc
+	  end,
+    [Fun(V) || V <- TOSValues].
+
+			  
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 ok({ok,V}) -> V;
 ok(NotOk) ->
     try throw(not_ok)
@@ -3906,6 +4011,27 @@ is_socket_supported() ->
             {skip, "esock not configured"}
     end.
 
+
+has_support_ipv4() ->
+    ?LIB:has_support_ipv4().
+
+has_support_ipv6() ->
+    ?LIB:has_support_ipv6().
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% These functions are used only if we already know we support 'socket'.
+
+has_support_ip_recvtos() ->
+    ?SLIB:has_support_socket_option_ip(recvtos).
+
+has_support_ip_tos() ->
+    ?SLIB:has_support_socket_option_ip(tos).
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 is_docker(Config) ->
     case which_label(Config) of

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -3858,6 +3858,8 @@ otp_20102(Config) when is_list(Config) ->
                    ?P("cond check: do we support socket"),
                    case ?LIB:is_socket_supported() of
                        true ->
+			   ?P("cond check: not windows"),
+			   is_not_windows(),
                            ?P("cond check: do we support ipv4 & recvtos & tos"),
                            has_support_ipv4(),
 			   has_support_ip_recvtos(),

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -20583,7 +20583,7 @@ api_opt_ip_recvtos_udp(InitState) ->
          #{desc => "extract the (expected) recvtos \"default\" value",
            cmd  => fun(#{sock_dst := Sock} = State) ->
                            {ok, #{tos := DefValue}} =
-			       socket:getopt(Sock, ip, tos),
+                               socket:getopt(Sock, ip, tos),
                            ?SEV_IPRINT("(expected) recvtos def value: ~w",
                                        [DefValue]),
                            {ok, State#{dst_def_value => DefValue}}
@@ -20647,9 +20647,9 @@ api_opt_ip_recvtos_udp(InitState) ->
          #{desc => "set tos = reliability on src sock",
            cmd  => fun(#{sock_src := Sock}) ->
                            ok = socket:setopt(Sock,
-					      ip, tos,
-					      #{precedence => routine,
-						tos        => throughput})
+                                              ip, tos,
+                                              #{precedence => routine,
+                                                tos        => throughput})
                    end},
 
          #{desc => "send req (to dst) (w tos = throughput)",
@@ -21247,16 +21247,16 @@ api_opt_ip_tos_udp(InitState) ->
                            end
                    end},
 
-	 %% The default value for TOS is usually 'default', but on FreeBSD...
+         %% The default value for TOS is usually 'default', but on FreeBSD...
          #{desc => "get default tos",
            cmd  => fun(#{sock := Sock, get := Get} = _State) ->
                            case Get(Sock) of
                                {ok, #{native := 0} = Value} ->
                                    ?SEV_IPRINT("expected default tos: ~p",
-					       [Value]),
+                                               [Value]),
                                    ok;
                                {ok, #{tos := #{tos := Value}}} ->
-				   %% On FreeBSD 14 & 15 default value is not 0!
+                                   %% On FreeBSD 14 & 15 default value is not 0!
                                    case os:type() of
                                        {unix, freebsd} ->
                                            case os:version() of
@@ -21286,7 +21286,7 @@ api_opt_ip_tos_udp(InitState) ->
                            end
                    end},
 
-	 %% 'mincost' does not exist on all platforms
+         %% 'mincost' does not exist on all platforms
          %% #{desc => "set tos " ++ TOS1Str,
          %%   cmd  => fun(#{sock := Sock, set := Set} = _State) ->
          %%                   socket:setopt(Sock, otp, debug, true),

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -20582,7 +20582,8 @@ api_opt_ip_recvtos_udp(InitState) ->
 
          #{desc => "extract the (expected) recvtos \"default\" value",
            cmd  => fun(#{sock_dst := Sock} = State) ->
-                           {ok, DefValue} = socket:getopt(Sock, ip, tos),
+                           {ok, #{tos := DefValue}} =
+			       socket:getopt(Sock, ip, tos),
                            ?SEV_IPRINT("(expected) recvtos def value: ~w",
                                        [DefValue]),
                            {ok, State#{dst_def_value => DefValue}}
@@ -20608,7 +20609,7 @@ api_opt_ip_recvtos_udp(InitState) ->
                            case Recv(Sock) of
                                {ok, {Src, [#{level := ip,
                                              type  := TOS,
-                                             value := DefValue}], ?BASIC_REQ}}
+                                             value := #{tos := DefValue}}], ?BASIC_REQ}}
                                  when (TOS =:= tos) orelse
                                       (TOS =:= recvtos) ->
                                    ?SEV_IPRINT("got default TOS (~w) "
@@ -20645,10 +20646,13 @@ api_opt_ip_recvtos_udp(InitState) ->
 
          #{desc => "set tos = reliability on src sock",
            cmd  => fun(#{sock_src := Sock}) ->
-                           ok = socket:setopt(Sock, ip, tos, reliability)
+                           ok = socket:setopt(Sock,
+					      ip, tos,
+					      #{precedence => routine,
+						tos        => throughput})
                    end},
 
-         #{desc => "send req (to dst) (w tos = mincost)",
+         #{desc => "send req (to dst) (w tos = throughput)",
            cmd  => fun(#{sock_src := Sock, sa_dst := Dst, send := Send}) ->
                            Send(Sock, ?BASIC_REQ, Dst, default)
                    end},
@@ -20657,7 +20661,7 @@ api_opt_ip_recvtos_udp(InitState) ->
                            case Recv(Sock) of
                                {ok, {Src, [#{level := ip,
                                              type  := TOS,
-                                             value := reliability = TOSData}],
+                                             value := #{tos := #{tos := throughput = TOSData}}}],
                                      ?BASIC_REQ}} 
                                  when ((TOS =:= tos) orelse (TOS =:= recvtos)) ->
                                    ?SEV_IPRINT("got expected TOS (~w) = ~w "
@@ -21243,14 +21247,16 @@ api_opt_ip_tos_udp(InitState) ->
                            end
                    end},
 
+	 %% The default value for TOS is usually 'default', but on FreeBSD...
          #{desc => "get default tos",
            cmd  => fun(#{sock := Sock, get := Get} = _State) ->
                            case Get(Sock) of
-                               {ok, 0 = Value} ->
-                                   ?SEV_IPRINT("expected default tos: ~p", [Value]),
+                               {ok, #{native := 0} = Value} ->
+                                   ?SEV_IPRINT("expected default tos: ~p",
+					       [Value]),
                                    ok;
-                               {ok, Value} ->
-                                   %% On FreeBSD 14 & 15 default value is not 0!
+                               {ok, #{tos := #{tos := Value}}} ->
+				   %% On FreeBSD 14 & 15 default value is not 0!
                                    case os:type() of
                                        {unix, freebsd} ->
                                            case os:version() of
@@ -21280,6 +21286,7 @@ api_opt_ip_tos_udp(InitState) ->
                            end
                    end},
 
+	 %% 'mincost' does not exist on all platforms
          %% #{desc => "set tos " ++ TOS1Str,
          %%   cmd  => fun(#{sock := Sock, set := Set} = _State) ->
          %%                   socket:setopt(Sock, otp, debug, true),
@@ -21327,7 +21334,7 @@ api_opt_ip_tos_udp(InitState) ->
          #{desc => "get tos (expect " ++ TOS2Str ++ ")",
            cmd  => fun(#{sock := Sock, get := Get} = _State) ->
                            case Get(Sock) of
-                               {ok, TOS2 = Value} ->
+                               {ok, #{tos := #{tos := TOS2 = Value}}} ->
                                    ?SEV_IPRINT("expected tos (~p)", [Value]),
                                    ok;
                                {ok, Unexpected} ->
@@ -21356,7 +21363,7 @@ api_opt_ip_tos_udp(InitState) ->
          #{desc => "get tos (expect " ++ TOS3Str ++ ")",
            cmd  => fun(#{sock := Sock, get := Get} = _State) ->
                            case Get(Sock) of
-                               {ok, TOS3 = Value} ->
+                               {ok, #{tos := #{tos := TOS3 = Value}}} ->
                                    ?SEV_IPRINT("expected tos (~p)", [Value]),
                                    ok;
                                {ok, Unexpected} ->
@@ -21385,7 +21392,7 @@ api_opt_ip_tos_udp(InitState) ->
          #{desc => "get tos (expect " ++ TOS4Str ++ ")",
            cmd  => fun(#{sock := Sock, get := Get} = _State) ->
                            case Get(Sock) of
-                               {ok, TOS4 = Value} ->
+                               {ok, #{tos := #{tos := TOS4 = Value}}} ->
                                    ?SEV_IPRINT("expected tos (~p)", [Value]),
                                    ok;
                                {ok, Unexpected} ->
@@ -21414,7 +21421,7 @@ api_opt_ip_tos_udp(InitState) ->
          #{desc => "get tos (expect " ++ TOS5Str ++ ")",
            cmd  => fun(#{sock := Sock, get := Get} = _State) ->
                            case Get(Sock) of
-                               {ok, TOS5 = Value} ->
+                               {ok, #{native := TOS5 = Value}} ->
                                    ?SEV_IPRINT("expected tos (~p)", [Value]),
                                    ok;
                                {ok, Unexpected} ->

--- a/lib/kernel/test/socket_test_lib.erl
+++ b/lib/kernel/test/socket_test_lib.erl
@@ -3,7 +3,7 @@
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
-%% Copyright Ericsson AB 2018-2025. All Rights Reserved.
+%% Copyright Ericsson AB 2018-2026. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
The implementation of the IP option TOS has been improved/fixed.
There are two differentv definitions of 'TOS':

       * RFC 1349 ("Classic" TOS)
       * RFC 2474 (DSCP)

There simple way to distinguish one from the other, so we have
implemented both.
When writing / setting, the user can choose whatever representation is "best".
When reading / getting, we use all three; native, tos and dscp all
stored in one map.