### PR TITLE
`gb_sets`: Add proptest for `from_ordset` with invalid input

### DIFF
--- a/lib/stdlib/test/gb_sets_property_test_SUITE.erl
+++ b/lib/stdlib/test/gb_sets_property_test_SUITE.erl
@@ -31,7 +31,7 @@ all() -> [
           balance_case,
           delete_case, delete_any_case,
           difference_case,
-          from_ordset_case,
+          from_ordset_case, from_ordset_invalid_case,
           insert_case,
           is_member_case,
           iterator_case, iterator_from_case,
@@ -67,6 +67,9 @@ difference_case(Config) ->
 
 from_ordset_case(Config) ->
     do_proptest(prop_from_ordset, Config).
+
+from_ordset_invalid_case(Config) ->
+    do_proptest(prop_from_ordset_invalid, Config).
 
 insert_case(Config) ->
     do_proptest(prop_insert, Config).

--- a/lib/stdlib/test/property_test/gb_sets_prop.erl
+++ b/lib/stdlib/test/property_test/gb_sets_prop.erl
@@ -180,6 +180,24 @@ prop_from_ordset() ->
                          gb_sets:from_ordset(ordsets:from_list(L)))
     ).
 
+prop_from_ordset_invalid() ->
+    ?FORALL(
+        L,
+        ?CT_SAFE_LIST(),
+        try
+            gb_sets:from_ordset(L)
+        of
+            _ -> is_usorted(L)
+        catch
+            error:{badarg, not_ordset} -> not is_usorted(L)
+        end
+    ).
+
+is_usorted([E1 | [E2 | _] = More]) ->
+    E1 < E2 andalso is_usorted(More);
+is_usorted([_]) -> true;
+is_usorted([]) -> true.
+
 %% --- insert/2 -------------------------------------------------------
 prop_insert() ->
     ?FORALL(


### PR DESCRIPTION
#10910 added checks for invalid input (unsorted lists and/or lists with duplicates). This PR adds a property test to the existing gb_sets property test suite for this case.