### PR TITLE
Array pruning

### DIFF
--- a/lib/stdlib/src/array.erl
+++ b/lib/stdlib/src/array.erl
@@ -329,7 +329,7 @@ new_1(_Options, _Size, _Fixed, _Default) ->
     erlang:error(badarg).
 
 new(Size, Fixed, Default) ->
-    S = find_bits(Size - 1, ?SHIFT),
+    S = find_bits(Size - 1, 0),
     C = ?NEW_CACHE(Default),
     #array{size = Size, zero = 0, fix = Fixed, cache = C, cache_index = 0,
            default = Default, elements = ?EMPTY, bits = S}.
@@ -480,6 +480,30 @@ relax(#array{size = N}=A) when is_integer(N), N >= 0 ->
 
 
 -doc """
+Changes the array size to that reported by `sparse_size/1`.
+
+If the specified array has fixed size, the resulting array also has
+fixed size.
+
+## Examples
+
+```erlang
+1> A = array:set(1, x, array:new(4, [])).
+2> array:size(A).
+4
+3> array:size(array:resize(A)).
+2
+```
+
+See also `resize/2`, `sparse_size/1`.
+""".
+-spec resize(Array :: array(Type)) -> array(Type).
+
+resize(Array) ->
+    %% eqwalizer:ignore ambiguous_union
+    resize(sparse_size(Array), Array).
+
+-doc """
 Change the array size.
 
 If `Size` is not a non-negative integer, the call fails with reason `badarg`. If
@@ -507,91 +531,117 @@ resize(Size, #array{size = N, zero = Z, cache = C, cache_index = CI, elements = 
   when is_integer(Size), Size >= 0, is_integer(N), N >= 0,
        is_integer(CI), is_integer(S) ->
     if Size > N ->
-            {E1, S1} = grow(Z + Size-1, E, S),
-	    A#array{size = Size, elements = E1, bits = S1};
-       Size < N ->
+            case Z > 0 of
+                true ->
+                    E1 = set_leaf(CI, S, E, C),
+                    %% Reset everything left of Z and maybe shrink tree
+                    {E2, Z2, S2} = shrink(Z, N, S, E1, D),
+                    {E3, S3} = grow(Z2 + Size-1, E2, S2),
+                    CI1 = 0,
+                    C1 = get_leaf(CI1, S3, E3, D),
+                    A#array{size = Size, zero = Z2, elements = E3, cache = C1, cache_index = CI1, bits = S3};
+                false ->
+                    {E1, S1} = grow(Z + Size-1, E, S),
+                    A#array{size = Size, elements = E1, bits = S1}
+            end;
+       Size < N; Z > 0 ->
             E1 = set_leaf(CI, S, E, C),
-            {E2, S1} = shrink(Z + Size-1, S, E1, D),
+            {E2, Z2, S1} = shrink(Z, Size, S, E1, D),
             CI1 = 0,
             C1 = get_leaf(CI1, S1, E2, D),
-	    A#array{size = Size, elements = E2, cache = C1, cache_index = CI1, bits = S1};
+            A#array{size = Size, zero = Z2, elements = E2, cache = C1, cache_index = CI1, bits = S1};
        true ->
-	    A
+            A
     end;
 resize(_Size, _) ->
     erlang:error(badarg).
 
 %% like grow(), but only used when explicitly resizing down
-shrink(I, _S, _E, _D) when I < 0 ->
-    S = find_bits(I, ?SHIFT),
+shrink(0, 0, _S, _E, _D) ->
+    {?EMPTY, 0, 0};
+shrink(Z, Size, S, E, D) when Z > 0 ->
+    shrink_left(Z, Size-1, S, E, D);
+shrink(0, Size, S, E, D) ->
+    shrink_right(Size-1, S, E, D, 0).
+
+shrink_left(_Z, Max, _S, ?EMPTY, _D) ->
+    S = find_bits(Max, 0),
+    {?EMPTY, 0, S};
+shrink_left(Z, Max, 0, E, D) ->
+    shrink_right(Z+Max, 0, prune_left(E, Z, D), D, Z);
+shrink_left(Z0, Max, S, E, D) when (Z0 bsr S) =:= ((Z0+Max) bsr S) ->
+    I1 = (Z0 bsr S) + 1,
+    Z = Z0 band ?MASK(S),
+    shrink_left(Z, Max, ?reduce(S), element(I1, E), D);
+shrink_left(Z0, Max, S, E, D) ->
+    {E1, S1} = shrink_left_2(Z0, S, E, D),
+    shrink_right(Z0+Max, S1, E1, D, Z0).
+
+shrink_left_2(_Z, S, ?EMPTY, _D) ->
     {?EMPTY, S};
-shrink(I, S, E, D) ->
-    shrink_1(I, S, E, D).
+shrink_left_2(Z, 0, E, D) ->
+    {prune_left(E, Z, D), 0};
+shrink_left_2(Z0, S, E, D) ->
+    IDiv = Z0 bsr S,
+    IRem = Z0 band ?MASK(S),
+    E1 = prune_left(E, IDiv, ?EMPTY),
+    I = IDiv + 1,
+    {E2, _} = shrink_left_2(IRem, ?reduce(S), element(I, E1), D),
+    {setelement(I, E1, E2), S}.
 
 %% I is the largest index, 0 or more (empty arrays handled above).
 %% This first discards any unnecessary tuples from the top
-shrink_1(I, _S, ?EMPTY, _D) ->
-    S = find_bits(I, ?SHIFT),
-    {?EMPTY, S};
-shrink_1(I, 0, E, D) ->
-    {prune(E, I, D), 0};
-shrink_1(I, S, E, D) when I < ?SIZE(S) ->
-    shrink_1(I, ?reduce(S), element(1, E), D);
-shrink_1(I, S, E, D) ->
-    shrink_2(I, S, E, D).
+shrink_right(I, _S, ?EMPTY, _D, Z) ->
+    S = find_bits(I, 0),
+    {?EMPTY, Z, S};
+shrink_right(I, 0, E, D, Z) ->
+    {prune_right(E, I, D), Z, 0};
+shrink_right(I, S, E, D, Z) when I < ?SIZE(S) ->
+    shrink_right(I, ?reduce(S), element(1, E), D, Z);
+shrink_right(I, S, E, D, Z) ->
+    shrink_right_2(I, S, E, D, Z).
 
 %% Here we have at least one top tuple that should be kept
 %% and we must not discard any intermediate levels
-shrink_2(_I, S, ?EMPTY, _D) ->
-    {?EMPTY, S};
-shrink_2(I, 0, E, D) ->
-    {prune(E, I, D), 0};
-shrink_2(I, S, E, D) ->
+shrink_right_2(_I, S, ?EMPTY, _D, Z) ->
+    {?EMPTY, Z, S};
+shrink_right_2(I, 0, E, D, Z) ->
+    {prune_right(E, I, D), Z, 0};
+shrink_right_2(I, S, E, D, Z) ->
     IDiv = I bsr S,
     IRem = I band ?MASK(S),
-    E1 = prune(E, IDiv, ?EMPTY),
+    E1 = prune_right(E, IDiv, ?EMPTY),
     I1 = IDiv + 1,
-    {E2,_} = shrink_2(IRem, ?reduce(S), element(I1, E1), D),
-    {setelement(I1, E1, E2), S}.
+    {E2, _, _} = shrink_right_2(IRem, ?reduce(S), element(I1, E1), D, Z),
+    {setelement(I1, E1, E2), Z, S}.
 
-prune(E, N, D) when is_tuple(E) ->
+prune_right(E, N, D) when is_tuple(E) ->
     if N < tuple_size(E) - 1 ->
-            list_to_tuple(prune(0, N, D, tuple_to_list(E)));
+            list_to_tuple(prune_right(0, N, D, tuple_to_list(E)));
        true ->
             E
     end.
 
-prune(I, N, D, [E|Es]) when I =< N ->
-    [E | prune(I+1, N, D, Es)];
-prune(I, N, D, [_|Es]) ->
-    [D | prune(I+1, N, D, Es)];
-prune(_I, _N, _D, []) ->
+prune_right(I, N, D, [E|Es]) when I =< N ->
+    [E | prune_right(I+1, N, D, Es)];
+prune_right(I, N, D, [_|Es]) ->
+    [D | prune_right(I+1, N, D, Es)];
+prune_right(_I, _N, _D, []) ->
     [].
 
+prune_left(E, N, D) when is_tuple(E) ->
+    if 0 < N ->
+            list_to_tuple(prune_left(0, N, D, tuple_to_list(E)));
+       true ->
+            E
+    end.
 
--doc """
-Changes the array size to that reported by `sparse_size/1`.
-
-If the specified array has fixed size, the resulting array also has
-fixed size.
-
-## Examples
-
-```erlang
-1> A = array:set(1, x, array:new(4, [])).
-2> array:size(A).
-4
-3> array:size(array:resize(A)).
-2
-```
-
-See also `resize/2`, `sparse_size/1`.
-""".
--spec resize(Array :: array(Type)) -> array(Type).
-
-resize(Array) ->
-    %% eqwalizer:ignore ambiguous_union
-    resize(sparse_size(Array), Array).
+prune_left(I, N, D, [_|Es]) when I < N ->
+    [D | prune_left(I+1, N, D, Es)];
+prune_left(I, N, D, [E|Es]) ->
+    [E | prune_left(I+1, N, D, Es)];
+prune_left(_I, _N, _D, []) ->
+    [].
 
 
 -doc """

--- a/lib/stdlib/test/array_SUITE.erl
+++ b/lib/stdlib/test/array_SUITE.erl
@@ -60,8 +60,10 @@
          doctests/1,
          %% Property tests
          prop_new/1, prop_is_array/1, prop_set_get/1, prop_size/1,
-         prop_sparse_size/1, prop_default/1, prop_fix_relax/1,
-         prop_resize/1, prop_reset/1, prop_to_list/1, prop_from_list/1,
+         prop_sparse_size/1,
+         prop_default/1, prop_fix_relax/1,
+         prop_resize/1, prop_resize_pruned/1,
+         prop_reset/1, prop_to_list/1, prop_from_list/1,
          prop_to_orddict/1, prop_from_orddict/1, prop_map/1,
          prop_foldl/1, prop_foldr/1, prop_shift/1, prop_slice/1,
          prop_append_prepend/1, prop_concat/1, prop_mapfoldl/1, prop_mapfoldr/1,
@@ -103,8 +105,10 @@ all() ->
 groups() ->
     [{property, [],
       [prop_new, prop_is_array, prop_set_get, prop_size,
-       prop_sparse_size, prop_default, prop_fix_relax,
-       prop_resize, prop_reset, prop_to_list, prop_from_list,
+       prop_sparse_size,
+       prop_default, prop_fix_relax,
+       prop_resize, prop_resize_pruned,
+       prop_reset, prop_to_list, prop_from_list,
        prop_to_orddict, prop_from_orddict, prop_map,
        prop_foldl, prop_foldr, prop_shift, prop_slice,
        prop_append_prepend, prop_concat, prop_mapfoldl, prop_mapfoldr,
@@ -1049,6 +1053,9 @@ prop_fix_relax(Config) ->
 
 prop_resize(Config) ->
     do_proptest(prop_resize, Config).
+
+prop_resize_pruned(Config) ->
+    do_proptest(prop_resize_pruned, Config).
 
 prop_reset(Config) ->
     do_proptest(prop_reset, Config).

--- a/lib/stdlib/test/property_test/array_prop.erl
+++ b/lib/stdlib/test/property_test/array_prop.erl
@@ -24,8 +24,10 @@
 -include_lib("common_test/include/ct_property_test.hrl").
 
 -export([prop_new/0, prop_is_array/0, prop_set_get/0, prop_size/0,
-         prop_sparse_size/0, prop_default/0, prop_fix_relax/0,
-         prop_resize/0, prop_reset/0, prop_to_list/0, prop_from_list/0,
+         prop_sparse_size/0,
+         prop_default/0, prop_fix_relax/0,
+         prop_resize/0, prop_resize_pruned/0,
+         prop_reset/0, prop_to_list/0, prop_from_list/0,
          prop_to_orddict/0, prop_from_orddict/0, prop_map/0,
          prop_foldl/0, prop_foldr/0, prop_shift/0, prop_slice/0,
          prop_append_prepend/0, prop_concat/0, prop_mapfoldl/0, prop_mapfoldr/0,
@@ -45,36 +47,36 @@ safe_any() ->  %% Just integers for now
 %% Generate array with list model
 
 array_with_list() ->
-    ?LET(Type, safe_any(),
-         ?LET(Def, Type,
-              ?SIZED(Size, array_with_list(Size, Type, [], array:new({default, Def}))))).
+    ?LET(TypeGen, fun() -> safe_any() end,
+         ?LET(Def, TypeGen(),
+              ?SIZED(Size, array_with_list(Size, TypeGen, [], array:new({default, Def}))))).
 
-array_with_list(Type) ->
-    ?LET(Def, Type,
-         ?SIZED(Size, array_with_list(Size, Type, [], array:new({default, Def})))).
+array_with_list(TypeGen) ->
+    ?LET(Def, TypeGen(),
+         ?SIZED(Size, array_with_list(Size, TypeGen, [], array:new({default, Def})))).
 
 array_with_list(0, _Type, List, A) ->
     {List, A};
 array_with_list(N, Type, ListAcc, ArrAcc) ->
     RC = fun({L, A}) -> array_with_list(N-1, Type, L, A) end,
     oneof([ %% Set/append/prepend many at end/beginning
-            ?LET(List, list(Type),
+            ?LET(List, list(Type()),
                  RC(array_list_append(List, ListAcc, ArrAcc))),
-            ?LET(List, list(Type),
+            ?LET(List, list(Type()),
                  RC(array_list_set(List, ListAcc, ArrAcc))),
-            ?LET(List, list(Type),
+            ?LET(List, list(Type()),
                  RC(array_list_prepend(List, ListAcc, ArrAcc))),
-            ?LET(List, list(Type),
+            ?LET(List, list(Type()),
                  RC(array_list_concat(List, ListAcc, ArrAcc))),
             %% Set and reset random position single
-            ?LET({I, V}, {small_nat(), Type},
+            ?LET({I, V}, {small_nat(), Type()},
                  RC(array_list_set(I,V,ListAcc, ArrAcc))),
             ?LET(I, small_nat(),
                  RC(array_list_reset(I, ListAcc, ArrAcc))),
             %% Resize, shift
             ?LET(I, small_nat(),
                  RC(array_list_resize(I, ListAcc, ArrAcc))),
-            ?LET(I, int(),
+            ?LET(I, Type(),
                  RC(array_list_shift(I, ListAcc, ArrAcc)))
           ]).
 
@@ -173,7 +175,7 @@ array_list_resize(NewSz0, L0, A0) ->
         L0 = array:to_list(A0), %% assert
         Size = array:size(A0),
         {L, A} =
-            if NewSz0 < Size ->
+            if NewSz0 =< Size ->
                     {L1, _L2} = lists:split(NewSz0, L0),
                     {L1, array:resize(NewSz0, A0)};
                true ->
@@ -305,6 +307,19 @@ prop_resize() ->
                              length(array:to_list(A1)) == NewSize
                      end)).
 
+prop_resize_pruned() ->
+    ?FORALL({{L0, A0}, ShiftBy0}, {array_with_list(), small_nat()},
+            begin
+                {L1, A1} = array_list_append([foo], L0, A0),
+                ShiftBy = min(ShiftBy0, array:size(A1)),
+                A2 = array:shift(ShiftBy, A1),
+                L2 = lists:sublist(L1, ShiftBy+1, length(L1)-ShiftBy),
+                {L3, A3} = array_list_resize(array:size(A2), L2, A2),
+                L4 = lists:duplicate(ShiftBy, array:default(A0)) ++ L3,
+                A4 = array:shift(-ShiftBy, A3),
+                L4 == array:to_list(A4)
+            end).
+
 prop_reset() ->
     ?FORALL({{List, A}, I},
             {array_with_list(), small_nat()},
@@ -361,7 +376,7 @@ prop_map() ->
             end).
 
 prop_foldl() ->
-    ?FORALL({{List, A}, I0, I1}, {array_with_list(int()), small_nat(), small_nat()},
+    ?FORALL({{List, A}, I0, I1}, {array_with_list(fun() -> int() end), small_nat(), small_nat()},
             case array:size(A) of
                 0 ->
                     true;
@@ -378,7 +393,7 @@ prop_foldl() ->
             end).
 
 prop_foldr() ->
-    ?FORALL({{List, A}, I0, I1}, {array_with_list(int()), small_nat(), small_nat()},
+    ?FORALL({{List, A}, I0, I1}, {array_with_list(fun() -> int() end), small_nat(), small_nat()},
             case array:size(A) of
                 0 ->
                     true;
@@ -408,7 +423,13 @@ prop_shift() ->
                                 false ->
                                     lists:duplicate(abs(Steps), array:default(A)) ++ List
                             end,
-                        A1 = array:shift(Steps, A),
+                        A1 = case Steps < 0 of
+                                 true ->
+                                     %% We need to reset it here it to prune (history) shifted values.
+                                     array:shift(Steps, array:resize(array:size(A), A));
+                                 false ->
+                                     array:shift(Steps, A)
+                             end,
                         array:is_array(A1) andalso
                             array:size(A1) =:= max(0, Size - Steps) andalso
                             array:to_list(A1) =:= Expected;
@@ -454,7 +475,7 @@ prop_concat() ->
             end).
 
 prop_mapfoldl() ->
-    ?FORALL({List, A}, array_with_list(int()),
+    ?FORALL({List, A}, array_with_list(fun() -> int() end),
             begin
                 F = fun(_I, V, Acc) -> {{mapped, V}, Acc + V} end,
                 {A1, Sum1} = array:mapfoldl(F, 0, A),
@@ -464,7 +485,7 @@ prop_mapfoldl() ->
             end).
 
 prop_mapfoldr() ->
-    ?FORALL({List, A}, array_with_list(int()),
+    ?FORALL({List, A}, array_with_list(fun() -> int() end),
             begin
                 F = fun(_I, V, Acc) -> {{mapped, V}, Acc + V} end,
                 {A1, Sum1} = array:mapfoldr(F, 0, A),
@@ -475,7 +496,7 @@ prop_mapfoldr() ->
 
 prop_sparse_mapfoldl() ->
     ?FORALL({{List, A}, I0, I1},
-            {array_with_list(int()), small_nat(), small_nat()},
+            {array_with_list(fun() -> int() end), small_nat(), small_nat()},
             case array:size(A) of
                 0 ->
                     true;
@@ -499,7 +520,7 @@ prop_sparse_mapfoldl() ->
 
 prop_sparse_mapfoldr() ->
     ?FORALL({{List, A}, I0, I1},
-            {array_with_list(int()), small_nat(), small_nat()},
+            {array_with_list(fun() -> int() end), small_nat(), small_nat()},
             case array:size(A) of
                 0 ->
                     true;


### PR DESCRIPTION
Some fixes, array start with level 0, started at level 4 for some cases.
Which caused array:prepend to extend too much, and vasting memory.

resize/1,2 should always (if possible) prune values below zero.
Added testcase and code.