### PR TITLE
Optimize the `erlang:md5/1` BIF

### DIFF
--- a/erts/emulator/beam/erl_bif_chksum.c
+++ b/erts/emulator/beam/erl_bif_chksum.c
@@ -457,10 +457,15 @@ md5_1(BIF_ALIST_1)
     Eterm bin, rest;
     int res, err;
     erts_md5_state context;
+    Sint32 reds;
 
     erts_md5_init(&context);
 
-    rest = do_chksum(&md5_wrap,BIF_P,BIF_ARG_1,100,(void *) &context,&res,
+    /* Calibrate so that each reduction will do one round of MD5
+     * calculation (process 4 bytes). Round down to a multiple of 64
+     * bytes to avoid unnecessary copying to/from the state buffer. */
+    reds = (4 * ERTS_BIF_REDS_LEFT(BIF_P)) & ~0x3f;
+    rest = do_chksum(&md5_wrap,BIF_P,BIF_ARG_1,reds,(void *) &context,&res,
                      &err);
 
     if (err != 0) {
@@ -494,6 +499,7 @@ md5_2(BIF_ALIST_2)
     Eterm rest;
     Eterm bin;
     int res, err;
+    Sint32 reds;
 
     /* No need to check context, this function cannot be called with unaligned
      * or badly sized context as it's always trapped to. */
@@ -504,7 +510,8 @@ md5_2(BIF_ALIST_2)
     (void)size;
 
     sys_memcpy(&context, bytes, sizeof(erts_md5_state));
-    rest = do_chksum(&md5_wrap, BIF_P, BIF_ARG_2, 100, (void*)&context, &res,
+    reds = (4 * ERTS_BIF_REDS_LEFT(BIF_P)) & ~0x3f;
+    rest = do_chksum(&md5_wrap, BIF_P, BIF_ARG_2, reds, (void*)&context, &res,
                      &err);
 
     if (err != 0) {
@@ -549,6 +556,7 @@ md5_update_2(BIF_ALIST_2)
     Eterm bin;
     int res, err;
     Uint size;
+    Sint32 reds;
 
     bytes = erts_get_aligned_binary_bytes(BIF_ARG_1, &size, &temp_alloc);
     if (bytes == NULL || size != sizeof(erts_md5_state)) {
@@ -560,7 +568,8 @@ md5_update_2(BIF_ALIST_2)
 
     erts_free_aligned_binary_bytes(temp_alloc);
 
-    rest = do_chksum(&md5_wrap, BIF_P, BIF_ARG_2, 100, (void *)context, &res,
+    reds = (4 * ERTS_BIF_REDS_LEFT(BIF_P)) & ~0x3f;
+    rest = do_chksum(&md5_wrap, BIF_P, BIF_ARG_2, reds, (void *)context, &res,
                      &err);
 
     if (err != 0) {

--- a/erts/emulator/beam/erl_md5.c
+++ b/erts/emulator/beam/erl_md5.c
@@ -107,7 +107,7 @@ void erts_md5_update(erts_md5_state* state, const uint8_t* msg, size_t msg_len)
         }
     }
 
-    while (left > 64) {
+    while (left >= 64) {
         hash_part(part, state);
         left -= 64;
         part += 64;
@@ -115,6 +115,7 @@ void erts_md5_update(erts_md5_state* state, const uint8_t* msg, size_t msg_len)
     }
 
     if (left > 0) {
+        ASSERT(left < 64);
         sys_memcpy(state->buf, part, left);
         state->len = left;
     }
@@ -225,12 +226,7 @@ static size_t pad(const uint8_t* last_part, size_t size, uint8_t pad_buf[],
     const uint64_t tot_bit_size = tot_size * 8;
     uint8_t* pad_ptr = pad_buf;
 
-    if (filled > (64-8)) {
-        zeroes = 2*64 - 8 - filled;
-    }
-    else {
-        zeroes = 64 - 8 - filled;
-    }
+    zeroes = (64 - 8 - filled) & (64 - 1);
 
     sys_memcpy(pad_ptr, last_part, size);
     pad_ptr += size;

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -76,7 +76,8 @@ MODULES= \
 	warnings_SUITE \
 	z_SUITE \
 	zlc_SUITE \
-	test_lib
+	test_lib \
+        erl_md5
 
 NO_BOOL_OPT= \
 	guard \

--- a/lib/compiler/test/beam_bounds_SUITE.erl
+++ b/lib/compiler/test/beam_bounds_SUITE.erl
@@ -21,10 +21,12 @@
 %%
 
 -module(beam_bounds_SUITE).
+-feature(compr_assign, enable).
 -include_lib("stdlib/include/assert.hrl").
 
 -export([all/0, suite/0, groups/0, init_per_suite/1, end_per_suite/1,
          init_per_group/2, end_per_group/2,
+         init_per_testcase/2, end_per_testcase/2,
          addition_bounds/1, subtraction_bounds/1,
          multiplication_bounds/1, division_bounds/1, rem_bounds/1,
          band_bounds/1, bor_bounds/1, bxor_bounds/1,
@@ -34,12 +36,15 @@
          min_bounds/1, max_bounds/1,
          abs_bounds/1,
          infer_lt_gt_bounds/1,
-         redundant_masking/1]).
+         redundant_masking/1,
+         erl_md5/1
+        ]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [{group,p}].
+    [erl_md5,
+     {group,p}].
 
 groups() ->
     [{p,[parallel],
@@ -76,6 +81,14 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(_GroupName, Config) ->
     Config.
+
+init_per_testcase(Case, Config) when is_atom(Case), is_list(Config) ->
+    _ = rand:uniform(),                                %Seed generator
+    io:format("Seed: ~p", [rand:export_seed()]),
+    Config.
+
+end_per_testcase(Case, Config) when is_atom(Case), is_list(Config) ->
+    ok.
 
 addition_bounds(_Config) ->
     test_commutative('+', {-12,12}),
@@ -423,7 +436,84 @@ infer_lt_gt_bounds(_Config) ->
 
     ok.
 
-%%% Utilities
+
+redundant_masking(_Config) ->
+    Min = -7,
+    Max = 15,
+    Seq = lists:seq(Min, Max),
+    _ = [test_redundant_masking({A,B}, M) ||
+            A <- Seq,
+            B <- lists:nthtail(A-Min, Seq),
+            M <- Seq],
+
+    false = beam_bounds:is_masking_redundant({'-inf',10}, 16#ff),
+    false = beam_bounds:is_masking_redundant({0,'+inf'}, 16#ff),
+    ok.
+
+test_redundant_masking({A,B}=R, M) ->
+    ShouldBe = test_redundant_masking(A, B, M),
+    case beam_bounds:is_masking_redundant(R, M) of
+        ShouldBe ->
+            ok;
+        false when M band (M + 1) =/= 0 ->
+            %% M + 1 is not a power of two.
+            ok;
+        false when A =:= B ->
+            ok;
+        Unexpected ->
+            io:format("beam_bounds:is_masking_redundant(~p, ~p) "
+                      "evaluates to ~p; should be ~p\n",
+                      [R,M,Unexpected,ShouldBe]),
+            ct:fail(bad_boolean)
+    end.
+
+test_redundant_masking(A, B, M) when A =< B ->
+    A band M =:= A andalso test_redundant_masking(A + 1, B, M);
+test_redundant_masking(_, _, _) -> true.
+
+erl_md5(_Config) ->
+    281949768489412648962353822266799178366 = check_md5(~""),
+    123957004363873451094272536567338222994 = check_md5(~"hello"),
+
+    [] = [Size || Size <- lists:seq(0, 127),
+                  Bin = rand:bytes(Size),
+                  erlang:md5(Bin) =/= erl_md5:md5(Bin)],
+
+    Msg = rand:bytes(1_000_000),
+
+    F1 = fun() -> erlang:md5(Msg) end,
+    F2 = fun() -> erl_md5:md5(Msg) end,
+
+    {T1,MD5} = bench(F1),
+    {T2,MD5} = bench(F2),
+
+    Comment = io_lib:format("erl_md5 is ~p times slower than the md5/1 BIF",
+                            [round(T2 / T1 * 100) / 100]),
+    {comment, Comment}.
+
+check_md5(Bin) ->
+    MD5 = erlang:md5(Bin),
+    MD5 = erl_md5:md5(Bin),
+    <<Res:128>> = MD5,
+    Res.
+
+bench(F) ->
+    %% Return the shortest time.
+    lists:min([do_bench(F) || _ <- lists:seq(1, 100)]).
+
+do_bench(F) ->
+    G = fun() ->
+                exit(timer:tc(F))
+        end,
+    {Pid,Ref} = spawn_monitor(G),
+    receive
+        {'DOWN',Ref,process,Pid,Result} ->
+            Result
+    end.
+
+%%%
+%%% Common utilities.
+%%%
 
 infer_lt_gt(R1, R2) ->
     case beam_bounds:infer_relop_types('>', R2, R1) of
@@ -596,44 +686,6 @@ rel_op_2(Op, A, C, D, BoolResult0) when C =< D ->
     rel_op_2(Op, A, C + 1, D, BoolResult);
 rel_op_2(_Op, _, _, _, BoolResult) ->
     BoolResult.
-
-redundant_masking(_Config) ->
-    Min = -7,
-    Max = 15,
-    Seq = lists:seq(Min, Max),
-    _ = [test_redundant_masking({A,B}, M) ||
-            A <- Seq,
-            B <- lists:nthtail(A-Min, Seq),
-            M <- Seq],
-
-    false = beam_bounds:is_masking_redundant({'-inf',10}, 16#ff),
-    false = beam_bounds:is_masking_redundant({0,'+inf'}, 16#ff),
-    ok.
-
-test_redundant_masking({A,B}=R, M) ->
-    ShouldBe = test_redundant_masking(A, B, M),
-    case beam_bounds:is_masking_redundant(R, M) of
-        ShouldBe ->
-            ok;
-        false when M band (M + 1) =/= 0 ->
-            %% M + 1 is not a power of two.
-            ok;
-        false when A =:= B ->
-            ok;
-        Unexpected ->
-            io:format("beam_bounds:is_masking_redundant(~p, ~p) "
-                      "evaluates to ~p; should be ~p\n",
-                      [R,M,Unexpected,ShouldBe]),
-            ct:fail(bad_boolean)
-    end.
-
-test_redundant_masking(A, B, M) when A =< B ->
-    A band M =:= A andalso test_redundant_masking(A + 1, B, M);
-test_redundant_masking(_, _, _) -> true.
-
-%%%
-%%% Common utilities.
-%%%
 
 id(I) ->
     I.

--- a/lib/compiler/test/erl_md5.erl
+++ b/lib/compiler/test/erl_md5.erl
@@ -1,0 +1,140 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(erl_md5).
+-export([md5/1]).
+
+-define(MAX32, ((1 bsl 32)-1)).
+-define(CLAMP(X), ((X) band ?MAX32)).
+
+-define(SHIFT_1(I), element((I band 3) + 1, {7,12,17,22})).
+-define(SHIFT_2(I), element((I band 3) + 1, {5, 9,14,20})).
+-define(SHIFT_3(I), element((I band 3) + 1, {4,11,16,23})).
+-define(SHIFT_4(I), element((I band 3) + 1, {6,10,15,21})).
+
+-define(CONST_1(I), element((I - 0) + 1,
+        {16#d76aa478, 16#e8c7b756, 16#242070db, 16#c1bdceee,
+         16#f57c0faf, 16#4787c62a, 16#a8304613, 16#fd469501,
+         16#698098d8, 16#8b44f7af, 16#ffff5bb1, 16#895cd7be,
+         16#6b901122, 16#fd987193, 16#a679438e, 16#49b40821})).
+
+-define(CONST_2(I), element((I - 16) + 1,
+        {16#f61e2562, 16#c040b340, 16#265e5a51, 16#e9b6c7aa,
+         16#d62f105d, 16#02441453, 16#d8a1e681, 16#e7d3fbc8,
+         16#21e1cde6, 16#c33707d6, 16#f4d50d87, 16#455a14ed,
+         16#a9e3e905, 16#fcefa3f8, 16#676f02d9, 16#8d2a4c8a})).
+
+-define(CONST_3(I), element((I - 32) + 1,
+         {16#fffa3942, 16#8771f681, 16#6d9d6122, 16#fde5380c,
+         16#a4beea44, 16#4bdecfa9, 16#f6bb4b60, 16#bebfbc70,
+         16#289b7ec6, 16#eaa127fa, 16#d4ef3085, 16#04881d05,
+         16#d9d4d039, 16#e6db99e5, 16#1fa27cf8, 16#c4ac5665})).
+
+-define(CONST_4(I), element((I - 48) + 1,
+        {16#f4292244, 16#432aff97, 16#ab9423a7, 16#fc93a039,
+         16#655b59c3, 16#8f0ccc92, 16#ffeff47d, 16#85845dd1,
+         16#6fa87e4f, 16#fe2ce6e0, 16#a3014314, 16#4e0811a1,
+         16#f7537e82, 16#bd3af235, 16#2ad7d2bb, 16#eb86d391})).
+
+md5(Msg0) when is_binary(Msg0) ->
+    A0 = 16#67452301,
+    B0 = 16#efcdab89,
+    C0 = 16#98badcfe,
+    D0 = 16#10325476,
+
+    BitSize = bit_size(Msg0),
+    <<Main:(BitSize band -512)/bits,Rest/bits>> = Msg0,
+    Tail = pad(Rest, BitSize),
+    hash1(Main, A0, B0, C0, D0, Tail).
+
+hash1(<<_:512/bits,Rest/binary>>=Msg, A0, B0, C0, D0, Tail) ->
+    {A,B,C,D} = hash_part_1(Msg, A0, B0, C0, D0, 0),
+    hash1(Rest,
+          ?CLAMP(A0+A),
+          ?CLAMP(B0+B),
+          ?CLAMP(C0+C),
+          ?CLAMP(D0+D),
+          Tail);
+hash1(<<>>, A, B, C, D, <<>>) ->
+    <<A:32/little, B:32/little, C:32/little, D:32/little>>;
+hash1(<<>>, A, B, C, D, Tail) ->
+    hash1(Tail, A, B, C, D, <<>>).
+
+hash_part_1(<<Msg/binary>> = Msg0, A, B, C, D, I) when I < 16 ->
+    Const = ?CONST_1(I),
+    Shift = ?SHIFT_1(I),
+    G = I,
+    <<_:G/unit:32, M:32/unsigned-little, _/binary>> = Msg,
+    F0 = D bxor (B band (C bxor D)),
+    F = ?CLAMP(F0 + A + M + Const),
+    FRot = (F bsl Shift) bor (F bsr (32-Shift)),
+    BUpd = ?CLAMP(B + FRot),
+    %% A <= D,  B <= B + F_Rotated, D <= C, C <= B,
+    hash_part_1(Msg0, D, BUpd, B, C, I+1);
+hash_part_1(Msg, A, B, C, D, I) ->
+    hash_part_2(Msg, A, B, C, D, I).
+
+hash_part_2(<<Msg/binary>> = Msg0, A, B, C, D, I) when I < 32 ->
+    Const = ?CONST_2(I),
+    Shift = ?SHIFT_2(I),
+    G = (5*I + 1) rem 16,
+    <<_:G/unit:32, M:32/unsigned-little, _/binary>> = Msg,
+    F0 = C bxor (D band (B bxor C)),
+    F = ?CLAMP(F0 + A + M + Const),
+    FRot = (F bsl Shift) bor (F bsr (32-Shift)),
+    BUpd = ?CLAMP(B + FRot),
+    %% A <= D,  B <= B + F_Rotated, D <= C, C <= B,
+    hash_part_2(Msg0, D, BUpd, B, C, I+1);
+hash_part_2(Msg, A, B, C, D, I) ->
+    hash_part_3(Msg, A, B, C, D, I).
+
+hash_part_3(<<Msg/binary>> = Msg0, A, B, C, D, I) when I < 48 ->
+    Const = ?CONST_3(I),
+    Shift = ?SHIFT_3(I),
+    G = (3*I + 5) rem 16,
+    <<_:G/unit:32, M:32/unsigned-little, _/binary>> = Msg,
+    F0 = B bxor C bxor D,
+    F = ?CLAMP(F0 + A + M + Const),
+    FRot = (F bsl Shift) bor (F bsr (32-Shift)),
+    BUpd = ?CLAMP(B + FRot),
+    %% A <= D,  B <= B + F_Rotated, D <= C, C <= B,
+    hash_part_3(Msg0, D, BUpd, B, C, I+1);
+hash_part_3(Msg, A, B, C, D, I) ->
+    hash_part_4(Msg, A, B, C, D, I).
+
+hash_part_4(<<Msg/binary>> = Msg0, A, B, C, D, I) when I < 64 ->
+    Const = ?CONST_4(I),
+    Shift = ?SHIFT_4(I),
+    G = (7*I) rem 16,
+    <<_:G/unit:32, M:32/unsigned-little, _/binary>> = Msg,
+    F0 = C bxor (B bor (bnot D)),
+    F = ?CLAMP(F0 + A + M + Const),
+    FRot = (F bsl Shift) bor (F bsr (32-Shift)),
+    BUpd = ?CLAMP(B + FRot),
+    %% A <= D,  B <= B + F_Rotated, D <= C, C <= B,
+    hash_part_4(Msg0, D, BUpd, B, C, I+1);
+hash_part_4(_, A, B, C, D, _) ->
+    {A,B,C,D}.
+
+pad(Msg, Size) when is_binary(Msg) ->
+    Filled = ((Size + 1) rem 512),
+    Zeros = (512 - 64 - Filled) band (512 - 1),
+    <<Msg/bits, 1:1, 0:Zeros, Size:64/little>>.


### PR DESCRIPTION
`erlang:md5/1` & friends would yield far too often, which would unnecessarily reduce its performance.