### PR TITLE
Allocate at most one empty string on binary:split/3

### DIFF
--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1843,6 +1843,7 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
     Uint extracted_offset;
     Uint extracted_size;
     Eterm extracted;
+    Eterm empty_extracted = THE_NON_VALUE;
     Uint do_trim;
     Sint i;
     Uint offset, size;
@@ -1895,12 +1896,19 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
         extracted_size = NBITS(fa->end_pos - (fad[i].pos + fad[i].len));
 
         if (!(extracted_size == 0 && do_trim)) {
-            extracted = erts_build_sub_bitstring(&fa->factory.hp,
-                                                 br_flags,
-                                                 br,
-                                                 base,
-                                                 extracted_offset,
-                                                 extracted_size);
+            if (extracted_size == 0) {
+                if (is_non_value(empty_extracted)) {
+                    empty_extracted = atom_tab(atom_val(am_Empty))->u.bin;
+                }
+                extracted = empty_extracted;
+            } else {
+                extracted = erts_build_sub_bitstring(&fa->factory.hp,
+                                                     br_flags,
+                                                     br,
+                                                     base,
+                                                     extracted_offset,
+                                                     extracted_size);
+            }
             fa->term = CONS(fa->factory.hp, extracted, fa->term);
             fa->factory.hp += 2;
 
@@ -1917,12 +1925,19 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
     extracted_size = NBITS(fad[0].pos);
 
     if (!(extracted_size == 0 && do_trim)) {
-        extracted = erts_build_sub_bitstring(&fa->factory.hp,
-                                             br_flags,
-                                             br,
-                                             base,
-                                             extracted_offset,
-                                             extracted_size);
+        if (extracted_size == 0) {
+            if (is_non_value(empty_extracted)) {
+                empty_extracted = atom_tab(atom_val(am_Empty))->u.bin;
+            }
+            extracted = empty_extracted;
+        } else {
+            extracted = erts_build_sub_bitstring(&fa->factory.hp,
+                                                 br_flags,
+                                                 br,
+                                                 base,
+                                                 extracted_offset,
+                                                 extracted_size);
+        }
         fa->term = CONS(fa->factory.hp, extracted, fa->term);
         fa->factory.hp += 2;
     }

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1843,6 +1843,7 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
     Uint extracted_offset;
     Uint extracted_size;
     Eterm extracted;
+    Eterm empty_extracted = THE_NON_VALUE;
     Uint do_trim;
     Sint i;
     Uint offset, size;
@@ -1895,12 +1896,20 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
         extracted_size = NBITS(fa->end_pos - (fad[i].pos + fad[i].len));
 
         if (!(extracted_size == 0 && do_trim)) {
-            extracted = erts_build_sub_bitstring(&fa->factory.hp,
-                                                 br_flags,
-                                                 br,
-                                                 base,
-                                                 extracted_offset,
-                                                 extracted_size);
+            if (extracted_size == 0) {
+                if (empty_extracted == THE_NON_VALUE) {
+                    empty_extracted = HEAP_BITSTRING(fa->factory.hp, base, 0, 0);
+                    fa->factory.hp += heap_bits_size(0);
+                }
+                extracted = empty_extracted;
+            } else {
+                extracted = erts_build_sub_bitstring(&fa->factory.hp,
+                                                     br_flags,
+                                                     br,
+                                                     base,
+                                                     extracted_offset,
+                                                     extracted_size);
+            }
             fa->term = CONS(fa->factory.hp, extracted, fa->term);
             fa->factory.hp += 2;
 
@@ -1917,12 +1926,20 @@ static Eterm do_split_global_result(Process *p, Eterm subject, BinaryFindContext
     extracted_size = NBITS(fad[0].pos);
 
     if (!(extracted_size == 0 && do_trim)) {
-        extracted = erts_build_sub_bitstring(&fa->factory.hp,
-                                             br_flags,
-                                             br,
-                                             base,
-                                             extracted_offset,
-                                             extracted_size);
+        if (extracted_size == 0) {
+            if (empty_extracted == THE_NON_VALUE) {
+                empty_extracted = HEAP_BITSTRING(fa->factory.hp, base, 0, 0);
+                fa->factory.hp += heap_bits_size(0);
+            }
+            extracted = empty_extracted;
+        } else {
+            extracted = erts_build_sub_bitstring(&fa->factory.hp,
+                                                 br_flags,
+                                                 br,
+                                                 base,
+                                                 extracted_offset,
+                                                 extracted_size);
+        }
         fa->term = CONS(fa->factory.hp, extracted, fa->term);
         fa->factory.hp += 2;
     }

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -521,6 +521,10 @@ do_interesting(Module) ->
     [] = binary:split(<<>>, <<",">>, [global,trim]),
     [] = binary:split(<<>>, <<",">>, [global,trim_all]),
 
+    %% Assert empty binaries are shared
+    [<<"a">>, <<>> = WS1, WS2, <<"b">>] = binary:split(<<"a,,,b">>, <<",">>, [global]),
+    true = erts_debug:same(WS1, WS2),
+
     ReplaceFn = fun(Match) -> << <<(B + 1)>> || <<B>> <= Match >> end,
     badarg = ?MASK_ERROR(
 		Module:replace(<<1,2,3,4,5,6,7,8>>,


### PR DESCRIPTION
When splitting on a binary which may allocate several empty strings,
we end-up allocating too many copies, and I thought it would be cheap
and easy to optimise for this particular case.
