### PR TITLE
Check arguments to time_to_seconds

### DIFF
--- a/lib/stdlib/src/calendar.erl
+++ b/lib/stdlib/src/calendar.erl
@@ -616,7 +616,7 @@ rfc3339_to_system_time_bin(
     Year = -binary_to_integer(Year0),
     Month = binary_to_integer(Month0),
     Day = binary_to_integer(Day0),
-    rfc3339_to_system_time_1(DateTimeBin, Options, Year, Month, Day, Hour, Min, Sec, binary_to_list(TimeStr));
+    rfc3339_to_system_time_1(DateTimeBin, Options, Year, Month, Day, Hour, Min, Sec, 0, binary_to_list(TimeStr));
 rfc3339_to_system_time_bin(
     <<Year0:4/binary, $-, Month0:2/binary, $-, Day0:2/binary, _T,
       Hour0:2/binary, $:, Min0:2/binary, $:, Sec0:2/binary, TimeStr/binary>> = DateTimeBin, Options) ->
@@ -626,7 +626,7 @@ rfc3339_to_system_time_bin(
     Year = binary_to_integer(Year0),
     Month = binary_to_integer(Month0),
     Day = binary_to_integer(Day0),
-    rfc3339_to_system_time_1(DateTimeBin, Options, Year, Month, Day, Hour, Min, Sec, binary_to_list(TimeStr)).
+    rfc3339_to_system_time_1(DateTimeBin, Options, Year, Month, Day, Hour, Min, Sec, 0, binary_to_list(TimeStr)).
 
 %% _T is the character separating the date and the time:
 %% Handle negative years (ISO 8601 extended format: -YYYY-MM-DD)
@@ -639,7 +639,7 @@ rfc3339_to_system_time_list(
     Year = -list_to_integer([Y1, Y2, Y3, Y4]),
     Month = list_to_integer([Mon1, Mon2]),
     Day = list_to_integer([D1, D2]),
-    rfc3339_to_system_time_1(DateTimeString, Options, Year, Month, Day, Hour, Min, Sec, TimeStr);
+    rfc3339_to_system_time_1(DateTimeString, Options, Year, Month, Day, Hour, Min, Sec, 0, TimeStr);
 rfc3339_to_system_time_list(
     [Y1, Y2, Y3, Y4, $-, Mon1, Mon2, $-, D1, D2, _T,
      H1, H2, $:, Min1, Min2, $:, S1, S2 | TimeStr] = DateTimeString, Options) ->
@@ -649,14 +649,17 @@ rfc3339_to_system_time_list(
     Year = list_to_integer([Y1, Y2, Y3, Y4]),
     Month = list_to_integer([Mon1, Mon2]),
     Day = list_to_integer([D1, D2]),
-    rfc3339_to_system_time_1(DateTimeString, Options, Year, Month, Day, Hour, Min, Sec, TimeStr).
+    rfc3339_to_system_time_1(DateTimeString, Options, Year, Month, Day, Hour, Min, Sec, 0, TimeStr).
 
-rfc3339_to_system_time_1(DateTimeIn, Options, Year, Month, Day, Hour, Min, Sec, TimeStr) ->
+rfc3339_to_system_time_1(DateTimeIn, Options, Year, Month, Day, 23, 59, 60, 0, TimeStr) ->
+    rfc3339_to_system_time_1(DateTimeIn, Options, Year, Month, Day, 23, 59, 59, 1, TimeStr);
+rfc3339_to_system_time_1(DateTimeIn, Options, Year, Month, Day, Hour, Min, Sec, LeapSec, TimeStr) ->
     Unit = proplists:get_value(unit, Options, second),
     DateTime = {{Year, Month, Day}, {Hour, Min, Sec}},
     IsFractionChar = fun(C) -> C >= $0 andalso C =< $9 orelse C =:= $. end,
     {FractionStr, UtcOffset} = lists:splitwith(IsFractionChar, TimeStr),
-    Time = datetime_to_system_time(DateTime),
+
+    Time = datetime_to_system_time(DateTime) + LeapSec,
     Secs = Time - offset_string_adjustment(Time, second, UtcOffset),
     check(DateTimeIn, Options, Secs),
     ScaledEpoch = erlang:convert_time_unit(Secs, second, Unit),
@@ -867,7 +870,7 @@ time_difference({{Y1, Mo1, D1}, {H1, Mi1, S1}},
 -doc "Returns the number of seconds since midnight up to the specified time.".
 -spec time_to_seconds(Time) -> secs_per_day() when
       Time :: time().
-time_to_seconds({H, M, S}) when is_integer(H), is_integer(M), is_integer(S) ->
+time_to_seconds({H, M, S}) when is_integer(H, 0, 23), is_integer(M, 0, 59), is_integer(S, 0, 59) ->
     H * ?SECONDS_PER_HOUR +
 	M * ?SECONDS_PER_MINUTE + S.
 

--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -2506,18 +2506,18 @@ file_header_ctime_to_datetime(FH) ->
 dos_date_time_to_datetime(DosDate, DosTime) ->
     <<Hour:5, Min:6, DoubleSec:5>> = <<DosTime:16>>,
     <<YearFrom1980:7, Month:4, Day:5>> = <<DosDate:16>>,
-
-    Datetime = {{YearFrom1980+1980, Month, Day},
-                {Hour, Min, DoubleSec * 2}},
+    Date = {YearFrom1980+1980, Month, Day},
     if DoubleSec > 29 ->
             %% If DoubleSec * 2 > 59, something is broken
             %% with this archive, but unzip wraps the value
             %% so we do the same by converting to greg seconds
             %% and then back again.
-            calendar:gregorian_seconds_to_datetime(
-              calendar:datetime_to_gregorian_seconds(Datetime));
+            Datetime0 = {Date, {Hour, Min, 0}},
+            GSec0 = calendar:datetime_to_gregorian_seconds(Datetime0),
+            GSec = GSec0 + DoubleSec * 2,
+            calendar:gregorian_seconds_to_datetime(GSec);
        true ->
-            Datetime
+            {Date, {Hour, Min, DoubleSec * 2}}
     end.
 
 dos_date_time_from_datetime({{Year, _Month, _Day}, {_Hour, _Min, _Sec}}) when Year < 1980 ->

--- a/lib/stdlib/test/calendar_SUITE.erl
+++ b/lib/stdlib/test/calendar_SUITE.erl
@@ -26,6 +26,7 @@
 
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
+         times/1,
 	 gregorian_days/1,
 	 big_gregorian_days/1,
 	 gregorian_days_edge_cases/1,
@@ -51,7 +52,7 @@
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
-    [gregorian_days, gregorian_seconds, day_of_the_week,
+    [times, gregorian_days, gregorian_seconds, day_of_the_week,
      day_of_the_week_calibrate, leap_years,
      last_day_of_the_month, local_time_to_universal_time_dst,
      iso_week_number, system_time, rfc3339, big_gregorian_days,
@@ -73,6 +74,31 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(_GroupName, Config) ->
     Config.
+
+times(Config) when is_list(Config) ->
+    ?assertError(_, calendar:time_to_seconds({1.0, 0, 0})),
+    ?assertError(_, calendar:time_to_seconds({0, 1.0, 0})),
+    ?assertError(_, calendar:time_to_seconds({0, 0, 1.0})),
+
+    0 = calendar:time_to_seconds({0, 0, 0}),
+    1 = calendar:time_to_seconds({0, 0, 1}),
+    60 = calendar:time_to_seconds({0, 1, 0}),
+    3600 = calendar:time_to_seconds({1, 0, 0}),
+    3661 = calendar:time_to_seconds({1, 1, 1}),
+    86399 = calendar:time_to_seconds({23, 59, 59}),
+
+    59 = calendar:time_to_seconds({0, 0, 59}),
+    ?assertError(_, calendar:time_to_seconds({0, 0, -1})),
+    ?assertError(_, calendar:time_to_seconds({0, 0, 60})),
+
+    3540 = calendar:time_to_seconds({0, 59, 0}),
+    ?assertError(_, calendar:time_to_seconds({0, -1, 0})),
+    ?assertError(_, calendar:time_to_seconds({0, 60, 0})),
+
+    82800 = calendar:time_to_seconds({23, 0, 0}),
+    ?assertError(_, calendar:time_to_seconds({-1, 0, 0})),
+    ?assertError(_, calendar:time_to_seconds({24, 00, 0})),
+    ok.
 
 %% Tests that date_to_gregorian_days and gregorian_days_to_date
 %% are each others inverses from ?START_YEAR-01-01 up to ?END_YEAR-01-01.
@@ -461,6 +487,12 @@ rfc3339(Config) when is_list(Config) ->
     ?assertError(_, do_parse("9999-12-31T23:59:60Z", [])),
     ?assertError(_, do_format_z(253402300799*1_000_000_000+999_999_999+1, Ns)),
     ?assertError(_, do_parse("2010-04-11T22:35:41", [])), % OTP-16514
+    ?assertError(_, do_parse("2026-04-23T-1:19:54", [])),
+    ?assertError(_, do_parse("2026-04-23T01:-9:54", [])),
+    ?assertError(_, do_parse("2026-04-23T01:09:-4", [])),
+    ?assertError(_, do_parse("2026-04-23T24:09:54", [])),
+    ?assertError(_, do_parse("2026-04-23T01:60:54", [])),
+    ?assertError(_, do_parse("2026-04-23T01:09:60", [])),
     253402300799 = do_parse("9999-12-31T23:59:59Z", []),
 
     "0000-01-01T00:00:00Z" = test_parse("0000-01-01T00:00:00.0+00:00"),


### PR DESCRIPTION
Minutes and seconds may only be within 0..59 and hours within 0..23,
but this was not checked, which made calendar:rfc3339_to_system_time/1
accept e.g. a timestamp with a negative hour as in "2026-04-23T-1:19:54Z",
or ditto for minutes or seconds (as long as the number consists of two
characters, as in "-9"). It also accepted hours larger than 23 and minutes
and seconds larger than 59. For example calendar:time_to_seconds({0,-1,5})
returned -55.