### PR TITLE
otp: add ruleset check in main.yaml

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -321,3 +321,50 @@ jobs:
           persist-credentials: false
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # ratchet:zizmorcore/zizmor-action@v0.5.2
+
+  # This job checks that the most important jobs are successful.
+  # the use of conditionals, e.g., `if:` at the job level makes
+  # the jobs included in the GH Settngs Ruleset to fail.
+  # Instead of removing those jobs from being tested or letting
+  # them fail, the script below marks as OK a skipped job.
+  # a failed job is a failure, and an success job is success.
+  ruleset-checker:
+    name: Ruleset Checker
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - pack
+      - build-macos
+      - build-ios
+      - build-windows
+      - build-flavors
+      - build
+      - freebsd
+      - openbsd
+      - solaris
+      - documentation
+      - static
+      - test
+      - system-test
+      - sbom
+      - zizmor
+    steps:
+      - name: Check Ruleset Results
+        shell: bash
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          failed=false
+          while IFS= read -r entry; do
+            name=$(echo "$entry"   | jq -r '.[0]')
+            result=$(echo "$entry" | jq -r '.[1]')
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "❌ Job '$name' was: $result"
+              failed=true
+            else
+              echo "✅ Job '$name' was: $result"
+            fi
+          done < <(echo "$RESULTS" | jq -c 'to_entries[] | [.key, .value.result]')
+          if [[ "$failed" == "true" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
gh rulesets allow owners of the project to set which checks (jobs) must have completed successfully before allowing merging of a pull request. however, the current ruleset contains jobs that are optionally executed, meaning that they depend on a `if:` condition.

Jobs in a ruleset are supposed to always be executed. This means that there are (at times) pull requests where one needs to skip the ruleset constraint because the job in the ruleset was simply skipped.

Example: (https://github.com/erlang/otp/pull/11044)
<img width="1906" height="1034" alt="image" src="https://github.com/user-attachments/assets/6e1187e6-97e3-4296-90b4-754ec54147b5" />

To overcome this limitation, we write in `main.yaml` a new job that considers all jobs that should be checked for success, and consider skipped jobs as successful as well. Failed or cancelled jobs will be considered a failure.

If there is any job that should pass and fails, it is easy to know which one was.