### PR TITLE
otp: create base image for new otp versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -71,15 +71,32 @@ jobs:
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
 
+  # A new OTP release that changes versions (e.g. OTP-28 -> OTP-29) relies
+  # on update-base.yml being executed before the release job. if for some
+  # reason that is not the case, the release would not be able to use the
+  # missing docker image it expects. this here simply creates the image
+  # on a release, to make sure that there are no timing dependencies.
+  build-base-docker:
+    if: github.repository == 'erlang/otp' && github.ref_type == 'tag'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/reusable-update-base.yaml
+    with:
+      branches: '["master","maint"]'
+
   setup:
     uses: ./.github/workflows/reusable-setup.yaml
 
   pack:
     name: Build Erlang/OTP (64-bit)
-    needs: setup
+    needs:
+      - build-base-docker
+      - setup
     permissions:
       contents: read
       actions: write
+    if: always()  # forces execution of 'pack' even if build-base-docker was skipped ('build-base-docker' is skipped on PRs)
     uses: ./.github/workflows/reusable-pack.yaml
     with:
       base_branch:          ${{ needs.setup.outputs.base_branch }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,6 +103,112 @@ jobs:
       full_build_and_check: ${{ needs.setup.outputs.full_build_and_check }}
       bypass_erlang_repo:   false
 
+  #
+  # BEGIN BLOCK
+  #
+  # Jobs that should always run.
+  #
+  # For details of why using !cancelled:
+  # https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
+  #
+  # If you want to run a job or step regardless of its success or failure, use
+  # the recommended alternative: if: ${{ !cancelled() }}
+  #
+  # If we change the job order and execute before `documentation` the FreeBSD job and that job is skipped:
+  # FreeBSD: SKIPPED
+  # documentation: implicit `success()` condition
+  #
+  # `success()` implies that the previous jobs were successful, but FreeBSD was skipped.
+  # this cause the `documentation ` job to be skipped.
+  #
+  documentation:
+    name: Build and Check Documentation
+    if: ${{ !cancelled() && needs.pack.result == 'success' }} # Run even if the need has failed
+    needs:
+      - setup
+      - pack
+    permissions:
+      contents: read
+      actions:  write
+    uses: ./.github/workflows/reusable-documentation.yaml
+    secrets:
+      TRIGGER_ERLANG_ORG_BUILD: ${{ secrets.TRIGGER_ERLANG_ORG_BUILD }}
+    with:
+      base_branch:              ${{ needs.setup.outputs.base_branch }}
+      base_url:                 ${{ needs.setup.outputs.docs_base_url  }}
+      trigger_erlang_org_build: ${{ github.ref_name == 'master' && github.repository == 'erlang/otp' }}
+
+  static:
+    name: Run static analysis
+    if: ${{ !cancelled() && needs.pack.result == 'success' }} # Run even if the need has failed
+    needs:
+      - setup
+      - pack
+    permissions:
+      contents: read
+      security-events: write   # needed for SARIF upload
+    uses: ./.github/workflows/reusable-static-analysis.yaml
+    with:
+      base_branch:              ${{ needs.setup.outputs.base_branch }}
+
+  test:
+    name: Test Erlang/OTP
+    needs: pack
+    if: ${{  !cancelled() && needs.pack.result == 'success' && needs.pack.outputs.changes != '[]' }}
+    permissions:
+      contents: read
+      actions:  write
+    uses: ./.github/workflows/reusable-test.yaml
+    with:
+      changes:     ${{ needs.pack.outputs.changes }}
+      base_branch: ${{ needs.pack.outputs.base_branch }}
+
+  system-test:
+    name: Test Erlang/OTP (system)
+    if: ${{ !cancelled() && needs.pack.result == 'success' }} # Run even if the need has failed
+    permissions:
+      contents: read
+      actions:  write
+    needs:
+      - pack
+      - test
+    uses: ./.github/workflows/reusable-system-test.yaml
+    with:
+      base_branch: ${{ needs.pack.outputs.base_branch }}
+
+  ## If you want to speedup this step for testing the easiest way is to create
+  ## these two commits:
+  ##
+  ##   git rm -rf lib erts system && git revert HEAD
+  ##
+  ## and then create a step that that does this:
+  ##
+  ##   - name: SBOM Sha
+  ##     run: echo "sha=$(git rev-parse HEAD~1)" >> $GITHUB_OUTPUT
+  ##
+  ## and then make sure to use that sha instead of env.OTP_SBOM_VERSION
+  sbom:
+    name: Create SBOM
+    if: ${{ !cancelled() && needs.pack.result == 'success' }} # Run even if the need has failed
+    needs:
+      - setup
+      - pack
+    uses: ./.github/workflows/reusable-sbom.yaml
+    permissions:
+      contents: write
+      actions:  write
+      packages: read
+      id-token: write
+    with:
+      base_branch:                   ${{ needs.setup.outputs.base_branch }}
+      full_build_and_check:          ${{ needs.setup.outputs.full_build_and_check }}
+      otp_sbom_version:              ${{ needs.setup.outputs.otp_sbom_version }}
+      verify_sbom:                   true
+  #
+  # END BLOCK
+  #
+
+
   build-macos:
     name: Build Erlang/OTP (macOS)
     needs: pack
@@ -210,87 +316,6 @@ jobs:
     uses: ./.github/workflows/reusable-solaris.yaml
     with:
       base_branch: ${{ needs.pack.outputs.base_branch }}
-
-  documentation:
-    name: Build and Check Documentation
-    needs:
-      - setup
-      - pack
-    permissions:
-      contents: read
-      actions:  write
-    uses: ./.github/workflows/reusable-documentation.yaml
-    secrets:
-      TRIGGER_ERLANG_ORG_BUILD: ${{ secrets.TRIGGER_ERLANG_ORG_BUILD }}
-    with:
-      base_branch:              ${{ needs.setup.outputs.base_branch }}
-      base_url:                 ${{ needs.setup.outputs.docs_base_url  }}
-      trigger_erlang_org_build: ${{ github.ref_name == 'master' && github.repository == 'erlang/otp' }}
-
-  static:
-    name: Run static analysis
-    needs:
-      - setup
-      - pack
-    permissions:
-      contents: read
-      security-events: write   # needed for SARIF upload
-    uses: ./.github/workflows/reusable-static-analysis.yaml
-    with:
-      base_branch:              ${{ needs.setup.outputs.base_branch }}
-
-  test:
-    name: Test Erlang/OTP
-    needs: pack
-    if: needs.pack.outputs.changes != '[]'
-    permissions:
-      contents: read
-      actions:  write
-    uses: ./.github/workflows/reusable-test.yaml
-    with:
-      changes:     ${{ needs.pack.outputs.changes }}
-      base_branch: ${{ needs.pack.outputs.base_branch }}
-
-  system-test:
-    name: Test Erlang/OTP (system)
-    if: ${{ !cancelled() && needs.pack.result == 'success' }} # Run even if the need has failed
-    permissions:
-      contents: read
-      actions:  write
-    needs:
-      - pack
-      - test
-    uses: ./.github/workflows/reusable-system-test.yaml
-    with:
-      base_branch: ${{ needs.pack.outputs.base_branch }}
-
-  ## If you want to speedup this step for testing the easiest way is to create
-  ## these two commits:
-  ##
-  ##   git rm -rf lib erts system && git revert HEAD
-  ##
-  ## and then create a step that that does this:
-  ##
-  ##   - name: SBOM Sha
-  ##     run: echo "sha=$(git rev-parse HEAD~1)" >> $GITHUB_OUTPUT
-  ##
-  ## and then make sure to use that sha instead of env.OTP_SBOM_VERSION
-  sbom:
-    name: Create SBOM
-    needs:
-      - setup
-      - pack
-    uses: ./.github/workflows/reusable-sbom.yaml
-    permissions:
-      contents: write
-      actions:  write
-      packages: read
-      id-token: write
-    with:
-      base_branch:                   ${{ needs.setup.outputs.base_branch }}
-      full_build_and_check:          ${{ needs.setup.outputs.full_build_and_check }}
-      otp_sbom_version:              ${{ needs.setup.outputs.otp_sbom_version }}
-      verify_sbom:                   true
 
   ## If this is an "OTP-*" tag that has been pushed we do some release work
   release:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -350,6 +350,9 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - check-files
+      - build-base-docker
+      - setup
       - pack
       - build-macos
       - build-ios

--- a/.github/workflows/reusable-update-base.yaml
+++ b/.github/workflows/reusable-update-base.yaml
@@ -1,0 +1,105 @@
+## %CopyrightBegin%
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+## Copyright Ericsson AB 2024-2025. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## %CopyrightEnd%
+
+name: Update docker base image
+run-name: "Update base Erlang/OTP build images"
+
+on:
+  workflow_call:
+    inputs:
+      branches:
+        description: 'JSON array of branches to build, e.g. ["master","maint","maint-26","maint-27"]'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+    name: Update base Erlang/OTP build images
+    if: github.repository == 'erlang/otp'
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    strategy:
+      matrix:
+        type: [debian-base, ubuntu-base, i386-debian-base]
+        branch: ${{ fromJson(inputs.branches) }}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
+        with:
+          ref: ${{ matrix.branch }}
+          persist-credentials: false
+
+      - name: Cleanup GH Runner
+        shell: bash
+        run: .github/scripts/cleanup_gh_runner.sh
+
+      - name: Docker login
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image tag exists
+        id: check
+        env:
+          BASE_TAG: ghcr.io/${{ github.repository_owner }}/otp/${{ matrix.type }}
+          BRANCH: ${{ matrix.branch }}
+        run: |
+          TAG="${BASE_TAG}:${BRANCH}"
+          if docker manifest inspect "${TAG}" > /dev/null 2>&1; then
+            echo "Tag ${TAG} already exists, skipping build."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${TAG} does not exist, proceeding with build."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build base image
+        id: base
+        if: steps.check.outputs.skip == 'false'
+        run: >-
+            BASE_TAG=ghcr.io/${{ github.repository_owner }}/otp/${{ matrix.type }}
+            BASE_USE_CACHE=false
+            .github/scripts/build-base-image.sh "${{ matrix.branch }}"
+
+      - name: Push master image
+        if: steps.check.outputs.skip == 'false' && matrix.branch == 'master'
+        env:
+          STEPS_BASE_OUTPUTS_BASE_TAG: ${{ steps.base.outputs.BASE_TAG }}
+        run: docker push ${STEPS_BASE_OUTPUTS_BASE_TAG}:latest
+
+      - name: Tag and push base image
+        if: steps.check.outputs.skip == 'false'
+        env:
+          STEPS_BASE_OUTPUTS_BASE_TAG: ${{ steps.base.outputs.BASE_TAG }}
+        run: |
+            docker tag "${STEPS_BASE_OUTPUTS_BASE_TAG}:latest" \
+              "${STEPS_BASE_OUTPUTS_BASE_TAG}:${{ matrix.branch }}"
+            docker push "${STEPS_BASE_OUTPUTS_BASE_TAG}:${{ matrix.branch }}"

--- a/.github/workflows/reusable-update-base.yaml
+++ b/.github/workflows/reusable-update-base.yaml
@@ -84,10 +84,14 @@ jobs:
       - name: Build base image
         id: base
         if: steps.check.outputs.skip == 'false'
+        env:
+          OWNER:  ${{ github.repository_owner }}
+          TYPE:   ${{ matrix.type }}
+          BRANCH: ${{ matrix.branch }}
         run: >-
-            BASE_TAG=ghcr.io/${{ github.repository_owner }}/otp/${{ matrix.type }}
+            BASE_TAG=ghcr.io/${OWNER}/otp/${TYPE}
             BASE_USE_CACHE=false
-            .github/scripts/build-base-image.sh "${{ matrix.branch }}"
+            .github/scripts/build-base-image.sh "${BRANCH}"
 
       - name: Push master image
         if: steps.check.outputs.skip == 'false' && matrix.branch == 'master'
@@ -99,7 +103,8 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         env:
           STEPS_BASE_OUTPUTS_BASE_TAG: ${{ steps.base.outputs.BASE_TAG }}
+          BRANCH: ${{ matrix.branch }}
         run: |
             docker tag "${STEPS_BASE_OUTPUTS_BASE_TAG}:latest" \
-              "${STEPS_BASE_OUTPUTS_BASE_TAG}:${{ matrix.branch }}"
-            docker push "${STEPS_BASE_OUTPUTS_BASE_TAG}:${{ matrix.branch }}"
+              "${STEPS_BASE_OUTPUTS_BASE_TAG}:${BRANCH}"
+            docker push "${STEPS_BASE_OUTPUTS_BASE_TAG}:${BRANCH}"

--- a/.github/workflows/update-base.yaml
+++ b/.github/workflows/update-base.yaml
@@ -32,51 +32,10 @@ permissions:
 
 ## Build base images to be used by other github workflows
 jobs:
-
   build:
-    name: Update base Erlang/OTP build images
-    if: github.repository == 'erlang/otp'
-    runs-on: ubuntu-latest
-
     permissions:
-      packages: write
       contents: read
-
-    strategy:
-      matrix:
-        type: [debian-base,ubuntu-base,i386-debian-base]
-        branch: [master, maint, maint-26, maint-27]
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
-        with:
-          ref: ${{ matrix.branch }}
-          persist-credentials: false
-      - name: Cleanup GH Runner
-        shell: bash
-        run: .github/scripts/cleanup_gh_runner.sh
-      - name: Docker login
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3.7.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build base image
-        id: base
-        run: >-
-            BASE_TAG=ghcr.io/${{ github.repository_owner }}/otp/${{ matrix.type }}
-            BASE_USE_CACHE=false
-            .github/scripts/build-base-image.sh "${{ matrix.branch }}"
-      - name: Push master image
-        if: matrix.branch == 'master'
-        env:
-          STEPS_BASE_OUTPUTS_BASE_TAG: ${{ steps.base.outputs.BASE_TAG }}
-        run: docker push ${STEPS_BASE_OUTPUTS_BASE_TAG}:latest
-      - name: Tag and push base image
-        env:
-          STEPS_BASE_OUTPUTS_BASE_TAG: ${{ steps.base.outputs.BASE_TAG }}
-        run: |
-            docker tag "${STEPS_BASE_OUTPUTS_BASE_TAG}:latest" \
-              "${STEPS_BASE_OUTPUTS_BASE_TAG}:${{ matrix.branch }}"
-            docker push "${STEPS_BASE_OUTPUTS_BASE_TAG}:${{ matrix.branch }}"
+      packages: write
+    uses: ./.github/workflows/reusable-update-base.yaml
+    with:
+      branches: '["master","maint","maint-26","maint-27"]'


### PR DESCRIPTION
A new OTP release that changes versions (e.g. OTP-28 -> OTP-29) relies on `update-base.yaml` being executed the night before the release job. if for some reason that is not the case or there is a failure, the release would not be able to use the (now missing) docker image it expects, and the GH release process would fail.

to avoid timing issues of releasing before a docker image is ready, we move the process of creating a suitable (ubuntu) docker image to the release step.
