### PR TITLE
ssh: Remove nowarn_possibly_unsafe_function compile directives

### DIFF
--- a/lib/ssh/src/ssh_connection.erl
+++ b/lib/ssh/src/ssh_connection.erl
@@ -45,8 +45,6 @@ these messages are handled by
 [handle_ssh_msg/2](`c:ssh_client_channel:handle_ssh_msg/2`).
 """.
 
--compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}}]).
-
 -include_lib("kernel/include/logger.hrl").
 
 -include("ssh.hrl").
@@ -1621,7 +1619,10 @@ pty_default_dimensions(Dimension, TermData) ->
 	N when is_integer(N), N > 0 ->
 	    {N, 0};
 	_ ->
-            PixelDim = list_to_atom("pixel_" ++ atom_to_list(Dimension)),
+            PixelDim = case Dimension of
+                           width  -> pixel_width;
+                           height -> pixel_height
+                       end,
 	    case proplists:get_value(PixelDim, TermData, 0) of
 		N when is_integer(N), N > 0 ->
 		    {0, N};

--- a/lib/ssh/src/ssh_message.erl
+++ b/lib/ssh/src/ssh_message.erl
@@ -39,6 +39,7 @@
          ssh2_pubkey_encode/1,
          ssh2_privkey_decode2/1,
          oid2ssh_curvename/1,
+         oid2ssh_curve_algo/1,
          ssh_curvename2oid/1,
          %% experimental:
          ssh2_privkey_encode/1
@@ -853,6 +854,12 @@ oid2ssh_curvename(?'id-Ed448')  -> {<<"ssh-ed448">>,   'n/a'};
 oid2ssh_curvename(?'secp256r1') -> {<<"ecdsa-sha2-nistp256">>, <<"nistp256">>};
 oid2ssh_curvename(?'secp384r1') -> {<<"ecdsa-sha2-nistp384">>, <<"nistp384">>};
 oid2ssh_curvename(?'secp521r1') -> {<<"ecdsa-sha2-nistp521">>, <<"nistp521">>}.
+
+oid2ssh_curve_algo(?'id-Ed25519') -> 'ssh-ed25519';
+oid2ssh_curve_algo(?'id-Ed448')   -> 'ssh-ed448';
+oid2ssh_curve_algo(?'secp256r1')  -> 'ecdsa-sha2-nistp256';
+oid2ssh_curve_algo(?'secp384r1')  -> 'ecdsa-sha2-nistp384';
+oid2ssh_curve_algo(?'secp521r1')  -> 'ecdsa-sha2-nistp521'.
 
 %%%================================================================
 %%%

--- a/lib/ssh/src/ssh_options.erl
+++ b/lib/ssh/src/ssh_options.erl
@@ -25,6 +25,9 @@
 -module(ssh_options).
 -moduledoc false.
 
+%% file:consult/1 can create atoms from file content. This is acceptable
+%% here because the file path comes from the daemon operator's dh_gex_groups
+%% configuration — not from wire data.
 -compile([{nowarn_possibly_unsafe_function, {file, consult, 1}}]).
 
 -include("ssh.hrl").

--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -23,11 +23,8 @@
 %%
 
 %%% Description: SSH transport protocol
-
 -module(ssh_transport).
 -moduledoc false.
-
--compile([{nowarn_possibly_unsafe_function, {erlang, binary_to_atom, 1}}]).
 
 -include_lib("public_key/include/public_key.hrl").
 -include_lib("kernel/include/inet.hrl").
@@ -2279,8 +2276,7 @@ valid_key_sha_alg(_, _, _) -> false.
 
 
 valid_key_sha_alg_ec(OID, Alg) when is_tuple(OID) ->
-    {SshCurveType, _} = ssh_message:oid2ssh_curvename(OID),
-    Alg == binary_to_atom(SshCurveType);
+    Alg == ssh_message:oid2ssh_curve_algo(OID);
 valid_key_sha_alg_ec(_, _) -> false.
 
     
@@ -2289,9 +2285,8 @@ valid_key_sha_alg_ec(_, _) -> false.
 
 public_algo(#'RSAPublicKey'{}) ->   'ssh-rsa';  % FIXME: Not right with draft-curdle-rsa-sha2
 public_algo({_, #'Dss-Parms'{}}) -> 'ssh-dss';
-public_algo({#'ECPoint'{},{namedCurve,OID}}) when is_tuple(OID) -> 
-    {SshCurveType, _} = ssh_message:oid2ssh_curvename(OID),
-    binary_to_atom(SshCurveType).
+public_algo({#'ECPoint'{},{namedCurve,OID}}) when is_tuple(OID) ->
+    ssh_message:oid2ssh_curve_algo(OID).
 
 
 sha('ssh-rsa') -> sha;


### PR DESCRIPTION
Replace binary_to_atom/1 with oid2ssh_curve_algo/1 in ssh_transport (valid_key_sha_alg_ec/2, public_algo/1). The new function in ssh_message maps elliptic curve OIDs directly to algorithm atoms, eliminating the need for binary_to_atom entirely.

Replace list_to_atom/1 with an explicit pattern match in ssh_connection (pty_default_dimensions/2). The Dimension argument is always the hardcoded atom width or height.

Add a justification comment for the kept file:consult/1 directive in ssh_options — the file path comes from the daemon operator's dh_gex_groups configuration, not from wire data.