### PR TITLE
inets: httpd validate options before doing a config reload

### DIFF
--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -520,13 +520,14 @@ do_reload_config(ConfigList, Mode) ->
 	    Address = proplists:get_value(bind_address, Config, any), 
 	    Port    = proplists:get_value(port, Config, 80),
 	    Profile = proplists:get_value(profile, Config, default),
-	    case block(Address, Port, Profile, Mode) of
-		ok ->
-		    reload(Config, Address, Port, Profile),
-		    unblock(Address, Port, Profile);
-		Error ->
-		    Error
-	    end;
+            case block(Address, Port, Profile, Mode) of
+                ok ->
+                    Result = reload(Config, Address, Port, Profile),
+                    unblock(Address, Port, Profile),
+                    Result;
+                Error ->
+                    Error
+            end;
 	Error ->
 	    Error
     end.

--- a/lib/inets/src/http_server/httpd_conf.erl
+++ b/lib/inets/src/http_server/httpd_conf.erl
@@ -22,9 +22,10 @@
 
 %% Application internal API
 -export([load_mime_types/1, store/1, store/2,
-	 remove/1, remove_all/1, get_config/3, get_config/4,
-	 lookup_socket_type/1, 
-	 lookup/2, lookup/3, lookup/4, 
+         remove/1, remove_all/1, get_config/3, get_config/4,
+         validate_config/1,
+         lookup_socket_type/1,
+         lookup/2, lookup/3, lookup/4,
 	 validate_properties/1, white_space_clean/1]).
 
 -define(VMODULE,"CONF").
@@ -329,7 +330,14 @@ is_bind_address(Value, IpFamily) ->
 	_ ->
 	    false
     end.
- 
+
+validate_config(ConfigList) ->
+    try validate_config_params(ConfigList) of
+        ok -> ok
+    catch
+        throw:Error -> {error, {invalid_option, Error}}
+    end.
+
 store(ConfigList0) -> 
     try validate_config_params(ConfigList0) of
 	ok ->
@@ -462,7 +470,9 @@ remove_all(ConfigDB) ->
     remove_traverse(ConfigDB, lists:append(Modules,[?MODULE])).
 
 remove(ConfigDB) ->
-    ets:delete(ConfigDB),
+    try ets:delete(ConfigDB)
+    catch _:_ -> ok
+    end,
     ok.
 
 -spec get_config(Address, Port, Profile) -> [tuple()] when

--- a/lib/inets/src/http_server/httpd_manager.erl
+++ b/lib/inets/src/http_server/httpd_manager.erl
@@ -304,6 +304,8 @@ handle_info(Info, State) ->
     report_error(State, String),
     {noreply, State}.
 
+terminate(_, #state{config_db = undefined}) ->
+    ok;
 terminate(_, #state{config_db = Db}) -> 
     httpd_conf:remove_all(Db),
     ok.
@@ -376,18 +378,21 @@ handle_reload(Config, State) ->
 
 do_reload(Config, #state{config_db = Db} = State) ->
     case (catch check_constant_values(Db, Config)) of
-	ok ->
-	    %% If something goes wrong between the remove 
-	    %% and the store where fu-ed
-	    httpd_conf:remove_all(Db),
-	    case httpd_conf:store(Config) of
-		{ok, NewConfigDB} ->
-		    {continue, ok, State#state{config_db = NewConfigDB}};
-		Error ->
-		    {stop, Error, State}
-	    end;
-	Error ->
-	    {continue, Error, State}
+        ok ->
+            case httpd_conf:validate_config(Config) of
+                ok ->
+                    httpd_conf:remove_all(Db),
+                    case httpd_conf:store(Config) of
+                        {ok, NewConfigDB} ->
+                            {continue, ok, State#state{config_db = NewConfigDB}};
+                        Error ->
+                            {stop, Error, State#state{config_db = undefined}}
+                    end;
+                Error ->
+                    {continue, Error, State}
+            end;
+        Error ->
+            {continue, Error, State}
     end.
 
 check_constant_values(Db, Config) ->

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -123,7 +123,8 @@ groups() ->
 		   non_disturbing_1_0,
            disturbing_1_1,
            disturbing_1_0,
-		   reload_config_file
+                   reload_config_file,
+                   reload_invalid_config_survives
 		  ]},
      {post, [], [chunked_post, chunked_chunked_encoded_post, post_204]},
      {basic_auth, [], [basic_auth_1_1, basic_auth_1_0, verify_href_1_1]},
@@ -1787,6 +1788,36 @@ reload_config_file(Config) when is_list(Config) ->
     ok = file:write_file(HttpdConf, NewConfig),
     ok = httpd:reload_config(HttpdConf, non_disturbing),
     "httpd_test_new" = proplists:get_value(server_name, httpd:info(Server)).
+%%-------------------------------------------------------------------------
+%% Verify that a reload with invalid config (non-existing server_root)
+%% returns an error and leaves the server running with old config intact.
+%% Regression test for ERIERL-1314.
+reload_invalid_config_survives(Config) when is_list(Config) ->
+    ServerRoot = proplists:get_value(server_root, Config),
+    DocRoot = proplists:get_value(doc_root, Config),
+    HttpdConfig = [{port, 0},
+                   {server_name, "httpd_survive_test"},
+                   {server_root, ServerRoot},
+                   {document_root, DocRoot},
+                   {bind_address, "localhost"}],
+    {ok, Server} = inets:start(httpd, HttpdConfig),
+    Info = httpd:info(Server),
+    Port = proplists:get_value(port, Info),
+
+    %% Attempt reload with non-existing server_root and different server_name
+    BadConfig = [{port, Port},
+                 {server_name, "httpd_should_not_appear"},
+                 {server_root, "/tmp/non_existing_erierl1314"},
+                 {document_root, DocRoot},
+                 {bind_address, "localhost"}],
+    {error, {invalid_option, {non_existing, {server_root, _}}}} =
+        httpd:reload_config(BadConfig, disturbing),
+
+    %% Server must still be alive with the OLD config
+    ?assert(is_process_alive(Server)),
+    "httpd_survive_test" = proplists:get_value(server_name, httpd:info(Server)),
+
+    inets:stop(httpd, Server).
 %%-------------------------------------------------------------------------
 mime_types_format(Config) when is_list(Config) -> 
     DataDir = proplists:get_value(data_dir, Config),


### PR DESCRIPTION
This prevents reloading httpd into an unrecoverable state. The server will now validate the options before reloading, and keep running in case the options are in fact invalid. In case of a successful check, but storing a new config fails for some reason, the server will terminate. just like before.