### PR TITLE
github: skip base system, only update ports in FreeBSD vm action

### DIFF
--- a/.github/workflows/reusable-freebsd.yaml
+++ b/.github/workflows/reusable-freebsd.yaml
@@ -50,9 +50,10 @@ jobs:
             copyback: false
             disable-cache: true
             prepare: |
-              pkg update
-              pkg upgrade -y
-              pkg install -y bash gmake gtar autoconf ncurses pkgconf
+              # Don't update base FreeBSD system, only required ports
+              pkg update -fr FreeBSD-ports
+              pkg upgrade -yr FreeBSD-ports
+              pkg install -yr FreeBSD-ports bash gmake gtar autoconf ncurses pkgconf
 
             run: |
                 tar -xzf ./otp_src.tar.gz


### PR DESCRIPTION
In FreeBSD 15.0, the pkg(8) tool can suppor both ports-derived packages, and also the base system (kernel + userland) packages. It is not necessary to update the base system (equivalent to base.txz and kernel.txz distribution archives), which also requires a reboot.