### PR TITLE
Fix a bug where a bool in merge was wrongly substituted

### DIFF
--- a/lib/compiler/src/beam_ssa_bool.erl
+++ b/lib/compiler/src/beam_ssa_bool.erl
@@ -130,6 +130,7 @@
              count :: beam_ssa:label(),
              dom,
              uses,
+             preds=#{} :: #{beam_ssa:label() => [beam_ssa:label()]},
              in_or=false :: boolean()}).
 
 -spec module(beam_ssa:b_module(), [compile:option()]) ->
@@ -663,7 +664,8 @@ bool_opt_rewrite(Bool, From, Br, Blocks0, St0) ->
 
     %% Optimize the digraph.
     LDefs = digraph_bool_def(G0),
-    St = St1#st{ldefs=LDefs},
+    Preds = beam_ssa:predecessors(Blocks1),
+    St = St1#st{ldefs=LDefs,preds=Preds},
     G1 = opt_digraph_top(Bool, G0, St),
     G = shortcut_branches(Root, G1, St),
 
@@ -1008,10 +1010,10 @@ ensure_single_use(Bool, G, #st{uses=U}=St) ->
             G;
         Uses ->
             Vtx = get_vertex(Bool, St),
-            ensure_single_use_1(Bool, Vtx, Uses, G)
+            ensure_single_use_1(Bool, Vtx, Uses, G, St)
     end.
 
-ensure_single_use_1(Bool, Vtx, Uses, G) ->
+ensure_single_use_1(Bool, Vtx, Uses, G, #st{preds=Preds}) ->
     Fail = case get_targets(Vtx, G) of
                {br,_,Fail0} -> Fail0;
                _ -> not_possible()
@@ -1021,13 +1023,15 @@ ensure_single_use_1(Bool, Vtx, Uses, G) ->
                    end, Uses) of
         {[_],[_]} ->
             case {graph:vertex(G, Fail),
-                  graph:in_edges(G, Fail)} of
-                {{external,Bs0}, [_]} ->
+                  graph:in_edges(G, Fail),
+                  Preds} of
+                {{external,Bs0}, [_], #{Fail := [_]}} ->
                     %% The only other use of the variable Bool
                     %% is in the failure block and it can only
-                    %% be reached through this test, so we can
-                    %% replace it with the literal `false`
-                    %% in that block.
+                    %% be reached through this test (Fail has
+                    %% a single predecessor in the digraph and
+                    %% in the function CFG), so we can replace
+                    %% it with the literal `false` in that block.
                     Bs = Bs0#{Bool => #b_literal{val=false}},
                     graph:add_vertex(G, Fail, {external,Bs});
                 _ ->

--- a/lib/compiler/test/andor_SUITE.erl
+++ b/lib/compiler/test/andor_SUITE.erl
@@ -21,10 +21,10 @@
 %%
 -module(andor_SUITE).
 
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 	 t_case/1,t_and_or/1,t_andalso/1,t_orelse/1,inside/1,overlap/1,
-	 combined/1,in_case/1,slow_compilation/1]).
+	 combined/1,in_case/1,reused_bool_in_merge/1,slow_compilation/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -37,7 +37,7 @@ all() ->
 groups() -> 
     [{p,[parallel],
       [t_case,t_and_or,t_andalso,t_orelse,inside,overlap,
-       combined,in_case,slow_compilation]}].
+       combined,in_case,reused_bool_in_merge,slow_compilation]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -495,6 +495,23 @@ in_case_1_guard(LenUp, LenDw, LenN, Rotation, Count) ->
 	false when LenUp >= 1 orelse LenDw >= 1 orelse
 	LenN =< 1 orelse Count < 4 -> not_loop;
 	false -> loop
+    end.
+
+%% GH-11088. Do not substitute a boolean with `false` if the merge block
+%% is also reached from outside the digraph through a path on which the
+%% variable holds `true`.
+reused_bool_in_merge(_Config) ->
+    #{flag := true,  rc := 0} = reused_bool_case(true,  0),
+    #{flag := false, rc := 0} = reused_bool_case(false, 0),
+    #{flag := false, rc := 3} = reused_bool_case(false, 3),
+    error_path = reused_bool_case(true, 3),
+    ok.
+
+reused_bool_case(SP, RC) ->
+    Flag = SP =:= true,
+    case {Flag, RC} of
+        {true, R} when R =/= 0 -> error_path;
+        _ -> #{flag => Flag, rc => RC}
     end.
 
 -record(state, {stack = []}).


### PR DESCRIPTION
Do not substitute a boolean with `false` if the merge block is also reached from outside the digraph through a path on which the variable holds `true`.

Fixes #11088