### PR TITLE
Add non_executable option to binary_to_term/2

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -516,6 +516,7 @@ atom normal_exit
 atom nosuspend
 atom no_fail
 atom no_float
+atom non_executable
 atom no_integer
 atom no_network
 atom no_start_optimize

--- a/erts/emulator/beam/external.c
+++ b/erts/emulator/beam/external.c
@@ -1317,7 +1317,7 @@ Eterm erts_decode_ext(ErtsHeapFactory* factory, const byte **ext, Uint32 flags)
         erts_factory_undo(factory);
 	return THE_NON_VALUE;
     }
-    ASSERT(!(flags & ~ERTS_DIST_EXT_BTT_SAFE));
+    ASSERT(!(flags & ~(ERTS_DIST_EXT_BTT_SAFE|ERTS_DIST_EXT_BTT_NON_EXECUTABLE)));
     ep = dec_term(NULL, factory, ep, &obj, NULL, flags);
     if (!ep) {
 	return THE_NON_VALUE;
@@ -2153,6 +2153,9 @@ BIF_RETTYPE binary_to_term_2(BIF_ALIST_2)
         opt = CAR(list_val(opts));
         if (opt == am_safe) {
             ctx.flags |= ERTS_DIST_EXT_BTT_SAFE;
+        }
+        else if (opt == am_non_executable) {
+            ctx.flags |= ERTS_DIST_EXT_BTT_NON_EXECUTABLE;
         }
         else if (opt == am_used) {
             ctx.used_bytes = 1;
@@ -4990,6 +4993,9 @@ dec_term_atom_common:
                 Eterm temp;
                 Sint arity;
 
+                if (flags & ERTS_DIST_EXT_BTT_NON_EXECUTABLE) {
+                    goto error;
+                }
                 if ((ep = dec_atom(edep, ep, &mod, flags)) == NULL) {
                     goto error;
                 }
@@ -5090,6 +5096,10 @@ dec_term_atom_common:
 		unsigned num_free;
 		int i;
 		Eterm temp;
+
+                if (flags & ERTS_DIST_EXT_BTT_NON_EXECUTABLE) {
+                    goto error;
+                }
 
 		ep += 4;	/* Skip total size in bytes */
 		arity = *ep++;

--- a/erts/emulator/beam/external.h
+++ b/erts/emulator/beam/external.h
@@ -129,10 +129,11 @@ typedef struct {
  * They are used to indicate various bits of state necessary to decode binaries
  * in a variety of scenarios.
  */
-#define ERTS_DIST_EXT_DFLAG_HDR      ((Uint32) 0x1)
-#define ERTS_DIST_EXT_ATOM_TRANS_TAB ((Uint32) 0x2)
-#define ERTS_DIST_EXT_BTT_SAFE       ((Uint32) 0x4)
-#define ERTS_DIST_EXT_INTERNAL_NC    ((Uint32) 0x8)
+#define ERTS_DIST_EXT_DFLAG_HDR             ((Uint32) 0x1)
+#define ERTS_DIST_EXT_ATOM_TRANS_TAB        ((Uint32) 0x2)
+#define ERTS_DIST_EXT_BTT_SAFE              ((Uint32) 0x4)
+#define ERTS_DIST_EXT_INTERNAL_NC           ((Uint32) 0x8)
+#define ERTS_DIST_EXT_BTT_NON_EXECUTABLE    ((Uint32) 0x10)
 
 #define ERTS_DIST_CON_ID_MASK ((Uint32) 0x00ffffff)
 

--- a/erts/emulator/test/binary_SUITE.erl
+++ b/erts/emulator/test/binary_SUITE.erl
@@ -68,6 +68,7 @@
          unsorted_map_in_map/1,
 	 bad_term_to_binary/1,
 	 bad_binary_to_term_2/1,safe_binary_to_term2/1,
+     non_executable_binary_to_term2/1,
 	 bad_binary_to_term/1, bad_terms/1, more_bad_terms/1,
          big_binary_to_term/1,
 	 otp_5484/1,otp_5933/1,
@@ -99,6 +100,7 @@ all() ->
      b2t_used_big, t2b_deterministic,
      t2b_minor_version,
      bad_binary_to_term_2, safe_binary_to_term2,
+     non_executable_binary_to_term2,
      bad_binary_to_term, bad_terms, t_hash, bad_size,
      big_binary_to_term,
      sub_bin_copy, bad_term_to_binary, t2b_system_limit,
@@ -1208,6 +1210,30 @@ safe_binary_to_term2(Config) when is_list(Config) ->
     fullsweep_after = binary_to_term_stress(<<131,100,0,15,"fullsweep_after">>, [safe]), % should be a good atom
     BadExtFun = <<131,113,100,0,4,98,108,117,101,100,0,4,109,111,111,110,97,3>>,
     bad_bin_to_term(BadExtFun, [safe]),
+    ok.
+
+%% Test the non_executable option for binary_to_term/2
+non_executable_binary_to_term2(Config) when is_list(Config) ->
+    hello = binary_to_term_stress(term_to_binary(hello), [non_executable]),
+    {1,[2,3]} = binary_to_term_stress(term_to_binary({1,[2,3]}), [non_executable]),
+
+    %% External fun references
+    ExtFun = term_to_binary(fun erlang:length/1),
+    bad_bin_to_term(ExtFun, [non_executable]),
+
+    %% Anonymous funs
+    Fun0 = term_to_binary(fun() -> ok end),
+    bad_bin_to_term(Fun0, [non_executable]),
+    Fun1 = term_to_binary(fun(X) -> X end),
+    bad_bin_to_term(Fun1, [non_executable]),
+
+    %% A fun nested inside another term
+    Nested = term_to_binary({wrapper, [fun() -> ok end]}),
+    bad_bin_to_term(Nested, [non_executable]),
+
+    %% Composing with safe
+    bad_bin_to_term(ExtFun, [safe, non_executable]),
+    hello = binary_to_term_stress(term_to_binary(hello), [safe, non_executable]),
     ok.
 
 %% OTP-18306 Decode binary/bitstring with size >= 2Gbyte

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -1360,6 +1360,26 @@ The allowed options are:
   tjenixen
   ```
 
+- **`non_executable`** - Use this option when receiving binaries from a source
+  that should not be allowed to deliver executable terms.
+
+  When enabled, decoding fails with a `badarg` error if the binary contains
+  any function references, including anonymous funs (`fun () -> ... end`) and
+  external function references (`fun Module:Name/Arity`). This is useful when
+  the consumer never expects to receive a function from the producer and
+  wishes to defend against attacks that would otherwise smuggle a function
+  through the encoded term.
+
+  The `non_executable` option can be combined with `safe`.
+
+  ## Examples
+
+  ```erlang
+  1> Bin = term_to_binary(fun erlang:length/1).
+  2> binary_to_term(Bin, [non_executable]).
+  ** exception error: bad argument
+  ```
+
 - **`used`** - Changes the return value to `{Term, Used}` where `Used` is the
   number of bytes actually read from `Binary`.
 
@@ -1374,7 +1394,8 @@ The allowed options are:
   {<<131,119,5,104,101,108,108,111>>, <<"world">>}
   ```
 
-Failure: `badarg` if `safe` is specified and unsafe data is decoded.
+Failure: `badarg` if `safe` is specified and unsafe data is decoded, or if
+`non_executable` is specified and the binary contains a function reference.
 
 See also `term_to_binary/1`, `binary_to_term/1`, and `list_to_existing_atom/1`.
 """.
@@ -1382,7 +1403,7 @@ See also `term_to_binary/1`, `binary_to_term/1`, and `list_to_existing_atom/1`.
 -doc #{ category => terms }.
 -spec binary_to_term(Binary, Opts) -> term() | {term(), Used} when
       Binary :: ext_binary(),
-      Opt :: safe | used,
+      Opt :: safe | non_executable | used,
       Opts :: [Opt],
       Used :: pos_integer().
 binary_to_term(_Binary, _Opts) ->

--- a/system/doc/design_principles/secure_coding.md
+++ b/system/doc/design_principles/secure_coding.md
@@ -1026,6 +1026,13 @@ One issue with this being the potential for atom exhaustion, but more
 importantly you could potentially end up with a `mnesia` table containing
 harmful data ([`CWE-502`]). Other examples are `m:dets` and `m:disk_log`.
 
+The `erlang:binary_to_term/2` function can be used to deserialize data
+and must also only be used with trusted data. It is recommended to use
+both the `safe` flag, to avoid atom exhaustion ([`DSG-003`]), and
+the `non_executable` flag, to raise when deserializing external or
+anonymous functions. The latter protects untrusted data from potentially
+escalating into remote code execution.
+
 JSON is an example of a better format to use when communicating with untrusted
 entities. Erlang/OTP provides the `m:json` module for JSON encoding/decoding.
 XML is another example of a format that can be used. The [`xmerl`] application


### PR DESCRIPTION
The option rejects any function reference (anonymous or external) from being serialized. The goal is to avoid executable code from being smuggled to data structures that lazily stores computations.

For example, imagine you have a module created `lazy_lists` that accumulates operations which are executed at once. If not careful, `binary_to_term/2` could deserialize a custom lazy list which, combined with `erl_eval`, may execute any code.

Most web functionality in Elixir already does a post-pass on binary_to_term/2 to reject functions, but this allows us to do so much more efficiently.