### PR TITLE
 asn1: Allow jer-encoding modern bitsrings even if codec config is old

### DIFF
--- a/lib/asn1/src/asn1rtt_jer.erl
+++ b/lib/asn1/src/asn1rtt_jer.erl
@@ -44,23 +44,23 @@ encode_jer(Module, Type, Val) ->
     iolist_to_binary(json:encode(Enc, EncFun)).
 
 %% {sequence,
-%%    Name::atom() % The record name used for the sequence 
+%%    Name::atom() % The record name used for the sequence
 %%    Arity::integer() % number of components
 %%    CompInfos::[CompInfo()] % list of components with name, type etc
 %%    Value::record matching name and arity
 
-encode_jer({sequence_tab,Simple,Sname,Arity,CompInfos},Value) 
+encode_jer({sequence_tab,Simple,Sname,Arity,CompInfos},Value)
   when tuple_size(Value) == Arity+1 ->
     [Sname|Clist] = tuple_to_list(Value),
     encode_jer_component_tab(CompInfos,Clist,Simple,#{});
 %% {sequence,
-%%    Name::atom() % The record name used for the sequence 
+%%    Name::atom() % The record name used for the sequence
 %%    Arity::integer() % number of components
 %%    CompInfos::[CompInfo()] % list of components with name, type etc
 %%    Value::record matching name and arity
 encode_jer({sequence_map,_Sname,_Arity,CompInfos},Value) when is_map(Value) ->
     encode_jer_component_map(CompInfos,Value,[]);
-encode_jer({sequence,Sname,Arity,CompInfos},Value) 
+encode_jer({sequence,Sname,Arity,CompInfos},Value)
   when tuple_size(Value) == Arity+1 ->
     [Sname|Clist] = tuple_to_list(Value),
     encode_jer_component(CompInfos,Clist,[]);
@@ -129,7 +129,7 @@ encode_jer({choice,Choices},{Alt,Value}) ->
         false ->
             exit({error,{asn1,{invalid_choice,Alt,Choices}}})
     end;
-    
+
 encode_jer(bit_string,Value) ->
     Str = bitstring2json(Value),
     #{value => Str, length => bit_size(Value)};
@@ -151,7 +151,7 @@ encode_jer({compact_bit_string,FixedLength}, {_,Binary}=Compact) when is_binary(
 encode_jer({compact_bit_string,FixedLength}, Compact) when is_integer(Compact) ->
     BitStr = jer_compact2bitstr(Compact),
     encode_jer({bit_string,FixedLength},BitStr);
-encode_jer({bit_string_nnl,NNL},Value) -> 
+encode_jer({bit_string_nnl,NNL},Value) ->
     Value1 = jer_bit_str2bitstr(Value,NNL),
     encode_jer(bit_string,Value1);
 encode_jer({{bit_string_nnl,NNL},FixedLength},Value) ->
@@ -241,15 +241,15 @@ decode_jer({Type = {'ENUMERATED_EXT',_EnumList},_Constr}, Val) ->
 decode_jer({typeinfo,{Module,Type}}, Val) ->
     TypeInfo = Module:typeinfo(Type),
     decode_jer(TypeInfo, Val);
-decode_jer({sequence,Sname,_Arity,CompInfos},Value) 
-  when is_map(Value) ->    
+decode_jer({sequence,Sname,_Arity,CompInfos},Value)
+  when is_map(Value) ->
     DecodedComps = decode_jer_component(CompInfos,Value,[]),
     list_to_tuple([Sname|DecodedComps]);
-decode_jer({sequence_map,_Sname,_Arity,CompInfos},Value) 
-  when is_map(Value) ->    
+decode_jer({sequence_map,_Sname,_Arity,CompInfos},Value)
+  when is_map(Value) ->
     decode_jer_component_map(CompInfos,Value,[]);
 
-%% Unfortunately we have to represent strings as lists to be compatible 
+%% Unfortunately we have to represent strings as lists to be compatible
 %% with the other backends. Should add an option to the compiler in the future
 %% which makes it possible to represent all strings as erlang binaries
 decode_jer(string,Str) when is_binary(Str) ->
@@ -304,7 +304,7 @@ decode_jer({bit_string, {_, _}},
 decode_jer({{bit_string_nnl,NNL},{_,_}},#{<<"value">> := Str, <<"length">> := Length}) ->
     BitStr = json2bitstring(binary_to_list(Str),Length),
     jer_bitstr2names(BitStr,NNL);
-decode_jer({bit_string_nnl,NNL},#{<<"value">> := Str, <<"length">> := Length}) -> 
+decode_jer({bit_string_nnl,NNL},#{<<"value">> := Str, <<"length">> := Length}) ->
     BitStr = json2bitstring(binary_to_list(Str),Length),
     jer_bitstr2names(BitStr,NNL);
 decode_jer({{bit_string_nnl,NNL},FixedLength},Str) when is_binary(Str)->
@@ -402,10 +402,10 @@ bitstring2json(BitStr) ->
     octetstring2json(binary_to_list(NewStr)).
 
 octetstring2json(List) when is_list(List) ->
-    list_to_binary([begin Num = integer_to_list(X,16), 
+    list_to_binary([begin Num = integer_to_list(X,16),
            if length(Num) == 1 -> "0"++Num;
               true -> Num
-           end 
+           end
      end|| X<-List]).
 
 oid2json(Oid) when is_tuple(Oid) ->
@@ -465,7 +465,7 @@ jer_skip_trailing_zeroes([],Acc) ->
     lists:reverse(Acc).
 
 
-    
+
 
 jer_padbitstr(BitStr,FixedLength) when bit_size(BitStr) == FixedLength ->
     BitStr;
@@ -482,7 +482,7 @@ jer_int2bitstr(0,Acc) ->
 jer_int2bitstr(Int,Acc) ->
     Bit = Int band 1,
     jer_int2bitstr(Int bsr 1,<<Acc/bitstring,Bit:1>>).
-    
+
 jer_bitstr2compact(BitStr) ->
     Size = bit_size(BitStr),
     Unused = (8 - Size rem 8) band 7,
@@ -565,9 +565,3 @@ jer_bitstr2names(<<0:1,BitStr/bitstring>>,NNL,Num,Acc) ->
     jer_bitstr2names(BitStr,NNL,Num+1,Acc);
 jer_bitstr2names(<<>>,_,_,Acc) ->
     lists:reverse(Acc).
-
-
-    
-
-    
-    

--- a/lib/asn1/src/asn1rtt_jer.erl
+++ b/lib/asn1/src/asn1rtt_jer.erl
@@ -145,10 +145,7 @@ encode_jer(compact_bit_string,Compact) ->
 encode_jer({compact_bit_string,{_,_}},Compact) ->
     BitStr = jer_compact2bitstr(Compact),
     encode_jer(bit_string,BitStr);
-encode_jer({compact_bit_string,FixedLength}, {_,Binary}=Compact) when is_binary(Binary) ->
-    BitStr = jer_compact2bitstr(Compact),
-    encode_jer({bit_string,FixedLength},BitStr);
-encode_jer({compact_bit_string,FixedLength}, Compact) when is_integer(Compact) ->
+encode_jer({compact_bit_string,FixedLength}, Compact) ->
     BitStr = jer_compact2bitstr(Compact),
     encode_jer({bit_string,FixedLength},BitStr);
 encode_jer({bit_string_nnl,NNL},Value) ->
@@ -443,7 +440,10 @@ jer_bit_str2bitstr([], _NamedBitList) ->
 jer_bit_str2bitstr(BitStr,_NamedBitList) when is_bitstring(BitStr) ->
     BitStr.
 
-jer_compact2bitstr({Unused,Binary}) ->
+jer_compact2bitstr(Bitstring) when is_bitstring(Bitstring) ->
+    Bitstring;
+jer_compact2bitstr({Unused,Binary})
+    when is_integer(Unused), is_binary(Binary) ->
     Size = bit_size(Binary) - Unused,
     <<BitStr:Size/bitstring,_/bitstring >> = Binary,
     BitStr;

--- a/lib/asn1/test/testCompactBitString.erl
+++ b/lib/asn1/test/testCompactBitString.erl
@@ -174,4 +174,12 @@ roundtrip_1(Mod, Type, In, Out) ->
     {ok,Out} = Mod:decode(Type, Encoded),
     %% Test that compact BIT STRINGs can be encoded.
     {ok,Encoded} = Mod:encode(Type, Out),
+    case Out of
+        {N,Bin} when is_binary(Bin) ->
+            %% Also test that modern bitstrings can be encoded.
+            <<Bits:(bit_size(Bin)-N)/bits,_/bits>> = Bin,
+            {ok,Encoded} = Mod:encode(Type, Bits);
+        _ ->
+            ok
+    end,
     ok.


### PR DESCRIPTION
UPER allows input of modern bitstrings even if the codec config is old+compact, match that in JER.