### PR TITLE
michal/ssh/add-packet-alignment-validation/OTP-20137

### DIFF
--- a/lib/ssh/src/ssh_connection_handler.erl
+++ b/lib/ssh/src/ssh_connection_handler.erl
@@ -1157,6 +1157,26 @@ handle_event(info, {Proto, Sock, Info}, {hello,_}, #data{socket = Sock,
 	    {keep_state_and_data, [{next_event, internal, {info_line,Info}}]}
     end;
 
+handle_event(info, {_Proto, Sock, NewData}, StateName,
+             D0 = #data{discard_bytes_left = DiscardBytesLeft,
+                        discard_mac_already = DiscardMacAlready,
+                        discard_reason = DiscardReason}) when DiscardBytesLeft > 0 ->
+    %% Receiving data during discard proves peer is alive;
+    %% prevents keepalive timeout from interrupting camouflage
+    D1 = reset_alive(D0),
+    NewDataSize = byte_size(NewData),
+    case NewDataSize >= DiscardBytesLeft of
+        true ->
+            %% Enough bytes discarded
+            ssh_transport:finish_packet_discard(DiscardMacAlready, D1#data.ssh_params),
+            handle_packet_part_result(DiscardReason, StateName, D1);
+        false ->
+            %% We don't have enough bytes to finish packet discard,
+            %% we must get more from the socket
+            inet:setopts(Sock, [{active, once}]),
+            D = D1#data{discard_bytes_left = DiscardBytesLeft - NewDataSize},
+            {keep_state, D}
+    end;
 
 handle_event(info, {Proto, Sock, NewData}, StateName,
              D0 = #data{socket = Sock,
@@ -1164,105 +1184,16 @@ handle_event(info, {Proto, Sock, NewData}, StateName,
                         ssh_params = SshParams}) ->
     D1 = reset_alive(D0),
     try ssh_transport:handle_packet_part(
-	  D1#data.decrypted_data_buffer,
-	  <<(D1#data.encrypted_data_buffer)/binary, NewData/binary>>,
+          D1#data.decrypted_data_buffer,
+          <<(D1#data.encrypted_data_buffer)/binary, NewData/binary>>,
           D1#data.aead_data,
           D1#data.undecrypted_packet_length,
-	  D1#data.ssh_params)
+          D1#data.ssh_params)
     of
-	{packet_decrypted, DecryptedBytes, EncryptedDataRest, Ssh1} ->
-	    D2 = D1#data{ssh_params =
-                             Ssh1#ssh{recv_sequence =
-                                          ssh_transport:next_seqnum(StateName,
-                                                                    Ssh1#ssh.recv_sequence,
-                                                                    SshParams)},
-                         decrypted_data_buffer = <<>>,
-                         undecrypted_packet_length = undefined,
-                         aead_data = <<>>,
-                         encrypted_data_buffer = EncryptedDataRest},
-	    try
-		ssh_message:decode(set_kex_overload_prefix(DecryptedBytes,D2))
-	    of
-		#ssh_msg_kexinit{} = Msg ->
-		    {keep_state, D2, [{next_event, internal, prepare_next_packet},
-				     {next_event, internal, {Msg,DecryptedBytes}}
-				    ]};
-
-                #ssh_msg_global_request{}            = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_request_success{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_request_failure{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_open{}              = Msg -> {keep_state, D2,
-                                                               [{{timeout, max_initial_idle_time}, cancel} |
-                                                                ?CONNECTION_MSG(Msg)
-                                                               ]};
-                #ssh_msg_channel_open_confirmation{} = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_open_failure{}      = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_window_adjust{}     = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_data{}              = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_extended_data{}     = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_eof{}               = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_close{}             = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_request{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_failure{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-                #ssh_msg_channel_success{}           = Msg -> {keep_state, D2, ?CONNECTION_MSG(Msg)};
-
-		Msg ->
-		    {keep_state, D2, [{next_event, internal, prepare_next_packet},
-                                      {next_event, internal, Msg}
-				    ]}
-	    catch
-		Class:Reason0:Stacktrace  ->
-                    Reason = ssh_lib:trim_reason(Reason0),
-                    MsgFun =
-                        fun(debug) ->
-                                io_lib:format("Bad packet: Decrypted, but can't decode~n~p:~p~n~p",
-                                              [Class,Reason,Stacktrace],
-                                              [{chars_limit, ssh_lib:max_log_len(SshParams)}]);
-                           (_) ->
-                                io_lib:format("Bad packet: Decrypted, but can't decode ~p:~p",
-                                              [Class, Reason],
-                                              [{chars_limit, ssh_lib:max_log_len(SshParams)}])
-                        end,
-                    {Shutdown, D} =
-                        ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
-                                         ?SELECT_MSG(MsgFun),
-                                         StateName, D2),
-                    {stop, Shutdown, D}
-	    end;
-
-	{get_more, DecryptedBytes, EncryptedDataRest, AeadData, RemainingSshPacketLen, Ssh1} ->
-	    %% Here we know that there are not enough bytes in
-	    %% EncryptedDataRest to use. We must wait for more.
-	    inet:setopts(Sock, [{active, once}]),
-	    {keep_state, D1#data{encrypted_data_buffer = EncryptedDataRest,
-				 decrypted_data_buffer = DecryptedBytes,
-                                 undecrypted_packet_length = RemainingSshPacketLen,
-                                 aead_data = AeadData,
-				 ssh_params = Ssh1}};
-
-	{bad_mac, Ssh1} ->
-            {Shutdown, D} =
-                ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
-                                 "Bad packet: bad mac",
-                                 StateName, D1#data{ssh_params=Ssh1}),
-            {stop, Shutdown, D};
-
-	{error, {exceeds_max_size,PacketLen}} ->
-            {Shutdown, D} =
-                ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
-                                 io_lib:format("Bad packet: Size (~p bytes) exceeds max size",
-                                               [PacketLen]),
-                                 StateName, D1),
-            {stop, Shutdown, D};
-
-    {error, exceeds_max_decompressed_size} ->
-            {Shutdown, D} =
-                ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
-                                 "Bad packet: Size after decompression exceeds max size",
-                                 StateName, D1),
-            {stop, Shutdown, D}
+        Result ->
+            handle_packet_part_result(Result, StateName, D1)
     catch
-	Class:Reason0:Stacktrace ->
+        Class:Reason0:Stacktrace ->
             MsgFun =
                 fun(debug) ->
                         io_lib:format("Bad packet: Couldn't decrypt~n~p:~p~n~p",
@@ -1478,6 +1409,119 @@ handle_event(Type, Ev, StateName, D0) ->
         ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR, Details, StateName, D0),
     {stop, Shutdown, D}.
 
+%% Handle reason returned from handle_packet_part, or {start_packet_discard, ...}
+handle_packet_part_result({packet_decrypted, DecryptedBytes, EncryptedDataRest, Ssh},
+                          StateName,
+                          D0 = #data{ssh_params = Ssh0}) ->
+    D1 = D0#data{ssh_params =
+                     Ssh#ssh{recv_sequence =
+                                 ssh_transport:next_seqnum(StateName,
+                                                           Ssh#ssh.recv_sequence,
+                                                           Ssh0)},
+                 decrypted_data_buffer = <<>>,
+                 undecrypted_packet_length = undefined,
+                 aead_data = <<>>,
+                 encrypted_data_buffer = EncryptedDataRest},
+    try
+        ssh_message:decode(set_kex_overload_prefix(DecryptedBytes,D1))
+    of
+        #ssh_msg_kexinit{} = Msg ->
+            {keep_state, D1, [{next_event, internal, prepare_next_packet},
+                              {next_event, internal, {Msg,DecryptedBytes}}
+                             ]};
+
+        #ssh_msg_global_request{}            = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_request_success{}           = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_request_failure{}           = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_open{}              = Msg -> {keep_state, D1,
+                                                       [{{timeout, max_initial_idle_time}, cancel} |
+                                                        ?CONNECTION_MSG(Msg)
+                                                       ]};
+        #ssh_msg_channel_open_confirmation{} = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_open_failure{}      = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_window_adjust{}     = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_data{}              = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_extended_data{}     = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_eof{}               = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_close{}             = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_request{}           = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_failure{}           = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+        #ssh_msg_channel_success{}           = Msg -> {keep_state, D1, ?CONNECTION_MSG(Msg)};
+
+        Msg ->
+            {keep_state, D1, [{next_event, internal, prepare_next_packet},
+                              {next_event, internal, Msg}
+                             ]}
+    catch
+        Class:Reason0:Stacktrace  ->
+            Reason = ssh_lib:trim_reason(Reason0),
+            MsgFun =
+                fun(debug) ->
+                        io_lib:format("Bad packet: Decrypted, but can't decode~n~p:~p~n~p",
+                                      [Class,Reason,Stacktrace],
+                                      [{chars_limit, ssh_lib:max_log_len(Ssh0)}]);
+                   (_) ->
+                        io_lib:format("Bad packet: Decrypted, but can't decode ~p:~p",
+                                      [Class, Reason],
+                                      [{chars_limit, ssh_lib:max_log_len(Ssh0)}])
+                end,
+            {Shutdown, D} =
+                ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
+                                 ?SELECT_MSG(MsgFun),
+                                 StateName, D1),
+            {stop, Shutdown, D}
+    end;
+handle_packet_part_result({get_more, DecryptedBytes, EncryptedDataRest, AeadData, RemainingSshPacketLen, Ssh},
+                          _StateName, D0 = #data{socket = Sock}) ->
+    %% Here we know that there are not enough bytes in
+    %% EncryptedDataRest to use. We must wait for more.
+    inet:setopts(Sock, [{active, once}]),
+    {keep_state, D0#data{encrypted_data_buffer = EncryptedDataRest,
+                         decrypted_data_buffer = DecryptedBytes,
+                         undecrypted_packet_length = RemainingSshPacketLen,
+                         aead_data = AeadData,
+                         ssh_params = Ssh}};
+handle_packet_part_result({bad_mac, Ssh}, StateName, D0) ->
+    {Shutdown, D} =
+        ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
+                         "Bad packet: bad mac",
+                         StateName, D0#data{ssh_params=Ssh}),
+    {stop, Shutdown, D};
+handle_packet_part_result({error, {exceeds_max_size, PacketLen}}, StateName, D0) ->
+    {Shutdown, D} =
+        ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
+                         io_lib:format("Bad packet: Size (~p bytes) exceeds max size",
+                                       [PacketLen]),
+                         StateName, D0),
+    {stop, Shutdown, D};
+handle_packet_part_result({error, exceeds_max_decompressed_size}, StateName, D0) ->
+    {Shutdown, D} =
+        ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
+                         "Bad packet: Size after decompression exceeds max size",
+                         StateName, D0),
+    {stop, Shutdown, D};
+handle_packet_part_result({error, {packet_not_aligned, PacketLen, BlockSize}}, StateName, D0) ->
+    {Shutdown, D} =
+        ?send_disconnect(?SSH_DISCONNECT_PROTOCOL_ERROR,
+                         io_lib:format("Bad packet: Size (~p bytes) not aligned to block size (~p)",
+                                       [PacketLen, BlockSize]),
+                         StateName, D0),
+    {stop, Shutdown, D};
+handle_packet_part_result({start_packet_discard, DiscardBytesLeft, DiscardMacAlready, DiscardReason, Ssh},
+                          StateName, D) when DiscardBytesLeft =< 0 ->
+    %% Immediately upon start of packet discard we have enough bytes from the socket,
+    %% we can finish packet discard
+    ssh_transport:finish_packet_discard(DiscardMacAlready, Ssh),
+    handle_packet_part_result(DiscardReason, StateName, D#data{ssh_params = Ssh});
+handle_packet_part_result({start_packet_discard, DiscardBytesLeft, DiscardMacAlready, DiscardReason, Ssh},
+                          _StateName, D0 = #data{socket = Sock}) ->
+    %% We don't have enough bytes to finish packet discard, we must get more from the socket
+    inet:setopts(Sock, [{active, once}]),
+    D = D0#data{discard_bytes_left = DiscardBytesLeft,
+                discard_mac_already = DiscardMacAlready,
+                discard_reason = DiscardReason,
+                ssh_params = Ssh},
+    {keep_state, D}.
 
 %%--------------------------------------------------------------------
 -spec terminate(any(),

--- a/lib/ssh/src/ssh_fsm.hrl
+++ b/lib/ssh/src/ssh_fsm.hrl
@@ -30,38 +30,27 @@
 %% Internal process state
 %%====================================================================
 -record(data, {
-	  starter                               :: pid()
-						 | undefined,
-	  auth_user                             :: string()
-						 | undefined,
-	  connection_state                      :: #connection{}
-						 | undefined,
-	  latest_channel_id         = 0         :: non_neg_integer()
-                                                 | undefined,
-	  transport_protocol                    :: atom()
-                                                 | undefined,	% ex: tcp
-	  transport_cb                          :: atom()
-                                                 | undefined,	% ex: gen_tcp
-	  transport_close_tag                   :: atom()
-                                                 | undefined,	% ex: tcp_closed
-	  ssh_params                            :: #ssh{}
-                                                 | undefined,
-	  socket                                :: gen_tcp:socket()
-                                                 | undefined,
-	  decrypted_data_buffer     = <<>>      :: binary()
-                                                 | undefined,
-	  encrypted_data_buffer     = <<>>      :: binary()
-                                                 | undefined,
-	  aead_data                 = <<>>      :: binary()
-                                                 | undefined,
-	  undecrypted_packet_length             :: undefined | non_neg_integer(),
-	  key_exchange_init_msg                 :: #ssh_msg_kexinit{}
-						 | undefined,
-	  last_size_rekey           = 0         :: non_neg_integer(),
-	  event_queue               = []        :: list(),
-	  inet_initial_buffer_size              :: pos_integer()
-						 | undefined
-	 }).
+               starter                               :: pid() | undefined,
+               auth_user                             :: string() | undefined,
+               connection_state                      :: #connection{} | undefined,
+               latest_channel_id         = 0         :: non_neg_integer() | undefined,
+               transport_protocol                    :: atom() | undefined,  % ex: tcp
+               transport_cb                          :: atom() | undefined,  % ex: gen_tcp
+               transport_close_tag                   :: atom() | undefined,  % ex: tcp_closed
+               ssh_params                            :: #ssh{} | undefined,
+               socket                                :: gen_tcp:socket() | undefined,
+               decrypted_data_buffer     = <<>>      :: binary() | undefined,
+               encrypted_data_buffer     = <<>>      :: binary() | undefined,
+               aead_data                 = <<>>      :: binary() | undefined,
+               undecrypted_packet_length             :: undefined | non_neg_integer(),
+               key_exchange_init_msg                 :: #ssh_msg_kexinit{} | undefined,
+               last_size_rekey           = 0         :: non_neg_integer(),
+               event_queue               = []        :: list(),
+               inet_initial_buffer_size              :: pos_integer() | undefined,
+               discard_bytes_left        = 0         :: integer(),
+               discard_mac_already       = 0         :: non_neg_integer(),
+               discard_reason                        :: term()
+              }).
 
 
 %%====================================================================

--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -59,7 +59,8 @@
 	 sha/1,
          get_host_key/2,
          call_KeyCb/3,
-         public_algo/1]).
+         public_algo/1,
+         finish_packet_discard/2]).
 
 -behaviour(ssh_dbg).
 -export([ssh_dbg_trace_points/0, ssh_dbg_flags/1, ssh_dbg_on/1, ssh_dbg_off/1, ssh_dbg_format/2]).
@@ -1501,7 +1502,7 @@ pack(Data, Ssh=#ssh{}) ->
     pack(Data, Ssh, 0).
 
 %%% Note: pack/3 is only to be called from tests that wants
-%%% to deliberetly send packets with wrong PacketLength!
+%%% to deliberately send packets with wrong PacketLength!
 %%% Use pack/2 for all other purposes!
 pack(PlainText,
      #ssh{send_sequence = SeqNum,
@@ -1548,23 +1549,55 @@ pack(aead, _, PlainText, DeltaLenTst, Ssh0) ->
 
 %%%================================================================
 handle_packet_part(<<>>, Encrypted0, AEAD0, undefined, #ssh{decrypt = CryptoAlg,
-                                                            recv_mac = MacAlg} = Ssh0) ->
+                                                            recv_mac = MacAlg,
+                                                            recv_mac_size = MacSize,
+                                                            decrypt_block_size = BlockSize0} = Ssh0) ->
     %% New ssh packet
-    case get_length(pkt_type(CryptoAlg), mac_type(MacAlg), Encrypted0, Ssh0) of
-	get_more ->
-	    %% too short to get the length
-	    {get_more, <<>>, Encrypted0, AEAD0, undefined, Ssh0};
+    BlockSize = max(8, BlockSize0),
+    PktType = pkt_type(CryptoAlg),
+    MacType = mac_type(MacAlg),
+    case get_length(PktType, MacType, Encrypted0, Ssh0) of
+        get_more ->
+            %% Too short to get the length
+            {get_more, <<>>, Encrypted0, AEAD0, undefined, Ssh0};
 
-	{ok, PacketLen, _, _, _, _} when PacketLen > ?SSH_MAX_PACKET_SIZE ->
-	    %% far too long message than expected
-	    {error, {exceeds_max_size,PacketLen}};
-	
-	{ok, PacketLen, Decrypted, Encrypted1, AEAD,
-	 #ssh{recv_mac_size = MacSize} = Ssh1} ->
-	    %% enough bytes so we got the length and can calculate how many
-	    %% more bytes to expect for a full packet
-	    TotalNeeded = (4 + PacketLen + MacSize),
-	    handle_packet_part(Decrypted, Encrypted1, AEAD, TotalNeeded, Ssh1)
+        {ok, PacketLen, _, _, _, _} = Result when PacketLen > ?SSH_MAX_PACKET_SIZE ->
+            %% Far too long message
+            start_packet_discard(Result, {error, {exceeds_max_size, PacketLen}});
+
+        {ok, PacketLen, _, _, _, _} = Result when (4 + PacketLen) rem BlockSize /= 0,
+                                                  PktType /= aead,
+                                                  MacType /= enc_then_mac ->
+            %% RFC 4253 section 6, packet_length (including size of packet_length field itself)
+            %% must be divisible by max(8, decrypt_block_size)
+            start_packet_discard(Result, {error, {packet_not_aligned, PacketLen, BlockSize}});
+
+        {ok, PacketLen, _, _, _, _} when PacketLen rem BlockSize /= 0,
+                                         PktType =:= aead ->
+            %% If CryptoAlg is 'AEAD_AES_*_GCM':
+            %% RFC 5647 section 8.2 for AES-GCM packet_length is not encrypted, so it does not count
+            %% towards data that must be divisible by max(8, decrypt_block_size)
+            %% If CryptAlg is 'chacha20-poly1305@openssh.com':
+            %% draft-josefsson-ssh-chacha20-poly1305-openssh-01 section 3 packet length is encrypted
+            %% separately with key K_1 and rest of packet is encrypted with key K_2, so packet_length
+            %% does not count towards data that must be divisible by max(8, decrypt_block_size)
+            %% Packet discard is not needed for aead ciphers.
+            {error, {packet_not_aligned, PacketLen, BlockSize}};
+
+        {ok, PacketLen, _, _, _, _} when PacketLen rem BlockSize /= 0,
+                                         MacType =:= enc_then_mac ->
+            %% For enc_then_mac modes, packet_length is not encrypted, so it does not count
+            %% towards data that must be divisible by max(8, decrypt_block_size)
+            %% See section 1.5 of
+            %% https://github.com/openssh/openssh-portable/blob/8ec21f6274108e93601173ec4e6f7528b90b0003/PROTOCOL
+            %% Packet discard is not needed for enc_then_mac.
+            {error, {packet_not_aligned, PacketLen, BlockSize}};
+
+        {ok, PacketLen, Decrypted, Encrypted1, AEAD, Ssh1} ->
+            %% Enough bytes so we got the length and can calculate how many
+            %% more bytes to expect for a full packet
+            TotalNeeded = (4 + PacketLen + MacSize),
+            handle_packet_part(Decrypted, Encrypted1, AEAD, TotalNeeded, Ssh1)
     end;
 
 handle_packet_part(DecryptedPfx, EncryptedBuffer, AEAD, TotalNeeded, Ssh0) 
@@ -1599,7 +1632,11 @@ unpack(common, rfc4253, DecryptedPfx, EncryptedBuffer, _AEAD, TotalNeeded,
         true ->
             {ok, payload(PlainPkt), NextPacketBytes, Ssh1};
         false ->
-            {bad_mac, Ssh1}
+            %% See explanation in start_packet_discard/2
+            DiscardBytesLeft = ?SSH_MAX_PACKET_SIZE - byte_size(DecryptedPfx) - byte_size(EncryptedBuffer),
+            %% How many bytes were already checked against mac during processing of current packet
+            DiscardMacAlready = byte_size(PlainPkt),
+            start_packet_discard(DiscardBytesLeft, DiscardMacAlready, {bad_mac, Ssh1}, Ssh1)
     end;
 
 unpack(common, enc_then_mac, <<?UINT32(PlainLen)>>, EncryptedBuffer, _AEAD, _TotalNeeded,
@@ -1612,6 +1649,7 @@ unpack(common, enc_then_mac, <<?UINT32(PlainLen)>>, EncryptedBuffer, _AEAD, _Tot
             <<CompressedPlainText:CompressedPlainTextLen/binary, _Padding/binary>> = PlainRest,
             {ok, CompressedPlainText, NextPacketBytes, Ssh1};
         false ->
+            %% Packet discard not needed for enc_then_mac
             {bad_mac, Ssh0}
     end;
                     
@@ -1622,11 +1660,47 @@ unpack(aead, _, DecryptedPfx, EncryptedBuffer, AEAD, TotalNeeded,
     <<EncryptedSfx:MoreNeeded/binary, Mac:MacSize/binary, NextPacketBytes/binary>> = EncryptedBuffer,
     case decrypt(Ssh0, {AEAD,EncryptedSfx,Mac}) of
         {Ssh1, error} ->
+            %% Packet discard not needed for aead
             {bad_mac, Ssh1};
         {Ssh1, DecryptedSfx} ->
             DecryptedPacket = <<DecryptedPfx/binary, DecryptedSfx/binary>>,
             {ok, payload(DecryptedPacket), NextPacketBytes, Ssh1}
     end.
+
+%%%----------------------------------------------------------------
+start_packet_discard({ok, _PacketLen, Decrypted, Encrypted, _AEAD, Ssh}, DiscardReason) ->
+    %% How many bytes missing until we read ?SSH_MAX_PACKET_SIZE from the socket,
+    %% during processing of current packet
+    DiscardBytesLeft = ?SSH_MAX_PACKET_SIZE - byte_size(Decrypted) - byte_size(Encrypted),
+    start_packet_discard(DiscardBytesLeft, 0, DiscardReason, Ssh).
+
+%%%----------------------------------------------------------------
+start_packet_discard(DiscardBytesLeft, DiscardMacAlready, DiscardReason,
+                     Ssh = #ssh{decrypt = CryptoAlg,
+                                recv_mac = MacAlg}) ->
+    CipherIsCbc = cipher_is_cbc(CryptoAlg),
+    MacType = mac_type(MacAlg),
+    case CipherIsCbc =:= true andalso MacType /= enc_then_mac of
+        true ->
+            %% Not safe to return error immediately because of CVE-2008-5161
+            {start_packet_discard, DiscardBytesLeft, DiscardMacAlready, DiscardReason, Ssh};
+        false ->
+            DiscardReason
+    end.
+
+%%%----------------------------------------------------------------
+finish_packet_discard(MacAlready, #ssh{recv_mac = Algorithm,
+                                       recv_mac_size = MacSize,
+                                       recv_mac_key = Key,
+                                       recv_sequence = SeqNum}) when MacSize > 0 ->
+    Data = binary:copy(<<"a">>, ?SSH_MAX_PACKET_SIZE - MacAlready),
+    %% Compute MAC over dummy data for timing camouflage only —
+    %% no comparison needed (no wire MAC exists, result is discarded).
+    %% OpenSSH does the same: (void) mac_compute(...) in ssh_packet_stop_discard.
+    _ = mac(Algorithm, Key, SeqNum, Data),
+    ok;
+finish_packet_discard(_MacAlready, _Ssh) ->
+    ok.
 
 %%%----------------------------------------------------------------
 get_length(common, rfc4253, EncryptedBuffer, #ssh{decrypt_block_size = BlockSize} = Ssh0) ->
@@ -1758,7 +1832,8 @@ do_verify(PlainText, HashAlg, Sig, Key, _) ->
                  key_bytes,
                  iv_bytes,
                  block_bytes,
-                 pkt_type = common
+                 pkt_type = common,
+                 is_cbc = false
                 }).
 
 %%% Start of a more parameterized crypto handling.
@@ -1780,25 +1855,29 @@ cipher('3des-cbc') ->
     #cipher{impl = des_ede3_cbc,
             key_bytes = 24,
             iv_bytes = 8,
-            block_bytes = 8};
+            block_bytes = 8,
+            is_cbc = true};
     
 cipher('aes128-cbc') ->
     #cipher{impl = aes_128_cbc,
             key_bytes = 16,
             iv_bytes = 16,
-            block_bytes = 16};
+            block_bytes = 16,
+            is_cbc = true};
 
 cipher('aes192-cbc') ->
     #cipher{impl = aes_192_cbc,
             key_bytes = 24,
             iv_bytes = 16,
-            block_bytes = 16};
+            block_bytes = 16,
+            is_cbc = true};
 
 cipher('aes256-cbc') ->
     #cipher{impl = aes_256_cbc,
             key_bytes = 32,
             iv_bytes = 16,
-            block_bytes = 16};
+            block_bytes = 16,
+            is_cbc = true};
 
 cipher('aes128-ctr') ->
     #cipher{impl = aes_128_ctr,
@@ -1830,6 +1909,8 @@ cipher(_) ->
 
 
 pkt_type(SshCipher) -> (cipher(SshCipher))#cipher.pkt_type.
+
+cipher_is_cbc(SshCipher) -> (cipher(SshCipher))#cipher.is_cbc.
 
 mac_type('hmac-sha2-256-etm@openssh.com') -> enc_then_mac;
 mac_type('hmac-sha2-512-etm@openssh.com') -> enc_then_mac;

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -50,7 +50,7 @@
 
 -export([
          bad_long_service_name/1,
-         bad_packet_length/2,
+         bad_packet_length/5,
          bad_service_name/1,
          bad_service_name/2,
          bad_service_name_length/2,
@@ -105,6 +105,8 @@
          no_ext_info_s2/1,
          packet_length_too_large/1,
          packet_length_too_short/1,
+         packet_length_longer_than_max/1,
+         bad_mac/1,
          preferred_algorithms/1,
          service_name_length_too_large/1,
          service_name_length_too_short/1,
@@ -136,6 +138,27 @@
                                    [{client2server,Ciphs}, {server2client,Ciphs}]
                           end)()
         ).
+
+-define(COMMON_CIPHERS, ['aes256-ctr',
+                         'aes192-ctr',
+                         'aes128-ctr']).
+-define(COMMON_CBC_CIPHERS, ['aes256-cbc',
+                             'aes192-cbc',
+                             'aes128-cbc',
+                             '3des-cbc']).
+-define(ALL_COMMON_CIPHERS, ?COMMON_CBC_CIPHERS ++ ?COMMON_CIPHERS).
+-define(AEAD_CIPHERS, ['AEAD_AES_256_GCM',
+                       'AEAD_AES_128_GCM',
+                       'chacha20-poly1305@openssh.com']).
+-define(MACS, ['hmac-sha2-512',
+               'hmac-sha2-256',
+               'hmac-sha1',
+               'hmac-sha1-96'
+              ]).
+-define(ETM_MACS, ['hmac-sha2-512-etm@openssh.com',
+                   'hmac-sha2-256-etm@openssh.com',
+                   'hmac-sha1-etm@openssh.com']).
+
 -define(HARDCODED_KEXDH_REPLY,
         #ssh_msg_kexdh_reply{
            public_host_key = {{{'ECPoint',<<73,72,235,162,96,101,154,59,217,114,123,192,96,105,250,29,214,76,60,63,167,21,221,118,246,168,152,2,7,172,137,125>>},
@@ -180,7 +203,7 @@ all() ->
      {group,kex},
      {group,service_requests},
      {group,authentication},
-     {group,packet_size_error},
+     {group,packet_error},
      {group,field_size_error},
      {group,ext_info},
      {group,preferred_algorithms},
@@ -198,12 +221,14 @@ groups() ->
 		       lib_match,
 		       lib_no_match
 		      ]},
-     {packet_size_error, [], [packet_length_too_large,
-			      packet_length_too_short,
-			      decompression_bomb_client,
-			      decompression_bomb_client_after_auth,
-			      decompression_bomb_server,
-			      decompression_bomb_server_after_auth]},
+     {packet_error, [], [decompression_bomb_client,
+                         decompression_bomb_client_after_auth,
+                         decompression_bomb_server,
+                         decompression_bomb_server_after_auth,
+                         {group, common},
+                         {group, common_cbc},
+                         {group, enc_then_mac},
+                         {group, aead}]},
      {field_size_error, [], [service_name_length_too_large,
 			     service_name_length_too_short]},
      {kex, [], [custom_kexinit,
@@ -257,7 +282,23 @@ groups() ->
                   client_guesses_incorrectly]},
      {dh, [], [{group, guess}]},
      {ecdh, [], [{group, guess}]},
-     {hybrid, [], [{group, guess}]}
+     {hybrid, [], [{group, guess}]},
+     {common, [], [packet_length_too_short,
+                   packet_length_too_large,
+                   packet_length_longer_than_max,
+                   bad_mac]},
+     {common_cbc, [], [packet_length_too_short,
+                       packet_length_too_large,
+                       packet_length_longer_than_max,
+                       bad_mac]},
+     {enc_then_mac, [], [packet_length_too_short,
+                         packet_length_too_large,
+                         packet_length_longer_than_max,
+                         bad_mac]},
+     {aead, [], [packet_length_too_short,
+                packet_length_too_large,
+                packet_length_longer_than_max,
+                bad_mac]}
     ].
 
 
@@ -289,6 +330,18 @@ init_per_group(guess, Config) ->
         _ ->
             {skip, "Not enough public key algorithms supported"}
     end;
+init_per_group(common, Config0) ->
+    Config = [{discard, false} | Config0],
+    get_supported_alg_groups_or_skip([{cipher, ?COMMON_CIPHERS}, {mac, ?MACS}], Config);
+init_per_group(common_cbc, Config0) ->
+    Config = [{discard, true} | Config0],
+    get_supported_alg_groups_or_skip([{cipher, ?COMMON_CBC_CIPHERS}, {mac, ?MACS}], Config);
+init_per_group(enc_then_mac, Config0) ->
+    Config = [{discard, false} | Config0],
+    get_supported_alg_groups_or_skip([{cipher, ?ALL_COMMON_CIPHERS}, {mac, ?ETM_MACS}], Config);
+init_per_group(aead, Config0) ->
+    Config = [{discard, false} | Config0],
+    get_supported_alg_groups_or_skip([{cipher, ?AEAD_CIPHERS}], Config);
 init_per_group(_GroupName, Config) ->
     Config.
 
@@ -349,11 +402,28 @@ init_per_testcase(TC, Config) when TC == gex_client_init_option_groups ;
 		      | Opts]);
 init_per_testcase(decompression_bomb_client, Config) ->
     start_std_daemon(Config, [{preferred_algorithms, [{compression, ['zlib']}]}]);
+init_per_testcase(TC, Config) when TC == packet_length_too_short;
+                                   TC == packet_length_too_large;
+                                   TC == packet_length_longer_than_max;
+                                   TC == bad_mac ->
+    Algs = proplists:get_value(preferred_algorithms, Config),
+    start_std_daemon(Config, [{preferred_algorithms, [{kex, [?DEFAULT_KEX]} | Algs]}]);
 init_per_testcase(_TestCase, Config) ->
     check_std_daemon_works(Config, ?LINE).
 
-end_per_testcase(Tc, Config) when Tc == no_common_alg_server_disconnects;
-                                  Tc == custom_kexinit ->
+end_per_testcase(TC, Config) when TC == no_common_alg_server_disconnects;
+                                  TC == custom_kexinit;
+                                  TC == gex_client_init_option_groups;
+                                  TC == gex_client_init_option_groups_moduli_file;
+                                  TC == gex_client_init_option_groups_file;
+                                  TC == gex_server_gex_limit;
+                                  TC == gex_client_old_request_exact;
+                                  TC == gex_client_old_request_noexact;
+                                  TC == decompression_bomb_client;
+                                  TC == packet_length_too_short;
+                                  TC == packet_length_too_large;
+                                  TC == packet_length_longer_than_max;
+                                  TC == bad_mac ->
     stop_std_daemon(Config);
 end_per_testcase(TC, Config) when TC == kex_strict_negotiated;
                                   TC == kex_strict_violation_key_exchange;
@@ -363,15 +433,6 @@ end_per_testcase(TC, Config) when TC == kex_strict_negotiated;
                                   TC == kex_strict_msg_unknown ->
     ssh_test_lib:set_log_level(proplists:get_value(saved_log_level, Config)),
     Config;
-end_per_testcase(TC, Config) when TC == gex_client_init_option_groups ;
-				  TC == gex_client_init_option_groups_moduli_file ;
-				  TC == gex_client_init_option_groups_file ;
-				  TC == gex_server_gex_limit ;
-				  TC == gex_client_old_request_exact ;
-				  TC == gex_client_old_request_noexact ->
-    stop_std_daemon(Config);
-end_per_testcase(decompression_bomb_client, Config) ->
-    stop_std_daemon(Config);
 end_per_testcase(_TestCase, Config) ->
     check_std_daemon_works(Config, ?LINE).
 
@@ -847,34 +908,85 @@ bad_service_name(Config, Name) ->
 	  ], InitialState).
 
 %%%--------------------------------------------------------------------
-packet_length_too_large(Config) -> bad_packet_length(Config, +4).
+%%% Both packet_length_too_large and packet_length_too_short check for misaligned block size
+packet_length_too_large(Config) -> bad_packet_length(Config, 50, +4, false, 0).
 
-packet_length_too_short(Config) -> bad_packet_length(Config, -4).
-    
-bad_packet_length(Config, LengthExcess) ->
-    PacketFun = 
-	fun(Msg, Ssh) ->
-		BinMsg = ssh_message:encode(Msg),
-		ssh_transport:pack(BinMsg, Ssh, LengthExcess)
-	end,
-    {ok,InitialState} = connect_and_kex(Config),
-    {ok,_} =
-	ssh_trpt_test_lib:exec(
-	  [{set_options, [print_ops, print_seqnums, print_messages]},
-	   {send, {special,
-		   #ssh_msg_service_request{name="ssh-userauth"},
-		   PacketFun}},
-	   %% Prohibit remote decoder starvation:	   
-	   {send, #ssh_msg_service_request{name="ssh-userauth"}},
-	   {match, disconnect(), receive_msg}
-	  ], InitialState).
+packet_length_too_short(Config) -> bad_packet_length(Config, 50, -4, false, 1).
+
+%%%--------------------------------------------------------------------
+packet_length_longer_than_max(Config) -> bad_packet_length(Config, ?SSH_MAX_PACKET_SIZE, 0, true, 0).
+
+bad_packet_length(Config, DataLength, LengthExcess, ImmediateDisconnect, OvershootAmount) ->
+    Parent = self(),
+    PacketFun =
+        fun(Msg, Ssh) ->
+                BinMsg = ssh_message:encode(Msg),
+                {Packet, _} = Result = ssh_transport:pack(BinMsg, Ssh, LengthExcess),
+                Parent ! {size, byte_size(Packet)},
+                Result
+        end,
+    test_packet_discard(Config, PacketFun, DataLength, ImmediateDisconnect, OvershootAmount).
+
+%%%--------------------------------------------------------------------
+bad_mac(Config) ->
+    Parent = self(),
+    PacketFun =
+        fun(Msg, #ssh{send_mac_size = MacSize} = Ssh0) ->
+                BinMsg = ssh_message:encode(Msg),
+                %% Replace mac in packet with invalid mac
+                {Packet0, Ssh} = ssh_transport:pack(BinMsg, Ssh0),
+                PacketSize = byte_size(Packet0),
+                PacketData = binary:part(Packet0, PacketSize, -MacSize),
+                FakeMac = binary:copy(<<"a">>, MacSize),
+                Packet = <<PacketData/binary, FakeMac/binary>>,
+                Parent ! {size, PacketSize},
+                {Packet, Ssh}
+        end,
+    test_packet_discard(Config, PacketFun, 50, false, 0).
+
+%%%--------------------------------------------------------------------
+test_packet_discard(Config, PacketFun, DataLength, ImmediateDisconnect, OvershootAmount) ->
+    {ok, InitialState} = ssh_trpt_test_lib:exec(
+                           [{set_options, [print_ops, {print_messages,detail}]}]),
+    Algs = proplists:get_value(preferred_algorithms, Config, []),
+    {ok, AfterKexState} = connect_and_kex(Config, InitialState, [{kex, [?DEFAULT_KEX]} | Algs]),
+    {ok, AfterSendState0} =
+        ssh_trpt_test_lib:exec(
+          [{set_options, [print_ops, print_seqnums, print_messages]},
+           {send, {special,
+                   #ssh_msg_ignore{data = binary:copy(<<"a">>, DataLength)},
+                   PacketFun}}
+          ], AfterKexState),
+
+    Size = receive {size, S} -> S end,
+    Missing = ?SSH_MAX_PACKET_SIZE - Size,
+    case proplists:get_value(discard, Config) == false orelse ImmediateDisconnect of
+        true ->
+            %% Packet discard is not needed or we already sent as much (or more)
+            %% than ?SSH_MAX_PACKET_SIZE, we get disconnect
+            {ok, _} =
+                ssh_trpt_test_lib:exec([{match, disconnect(), receive_msg}], AfterSendState0);
+        false ->
+            %% Packet is too short to cause disconnect immediately
+            {error, {_, receive_timeout, AfterSendState1}} =
+                ssh_trpt_test_lib:exec([{match, disconnect(), receive_msg}], AfterSendState0),
+            %% We send some data but not enough to reach ?SSH_MAX_PACKET_SIZE, still no disconnect
+            {error, {_, receive_timeout, AfterSendState}} =
+                ssh_trpt_test_lib:exec([{send, binary:copy(<<"a">>, Missing - 1)},
+                                        {match, disconnect(), receive_msg}], AfterSendState1),
+            %% We send exactly (or more) the amount to reach (or go past) ?SSH_MAX_PACKET_SIZE,
+            %% we get disconnect
+            {ok, _} =
+                ssh_trpt_test_lib:exec([{send, binary:copy(<<"a">>, 1 + OvershootAmount)},
+                                        {match, disconnect(), receive_msg}], AfterSendState)
+    end.
 
 %%%--------------------------------------------------------------------
 decompression_bomb_client(Config) ->
     {ok, InitialState} = connect_and_kex(Config, ssh_trpt_test_lib:exec([]),
                                          [{kex, [?DEFAULT_KEX]},
                                           {cipher, ?DEFAULT_CIPHERS},
-                                          {compression, ['zlib']}], dh),
+                                          {compression, ['zlib']}]),
     %% ?SSH_MAX_PACKET_SIZE - 9 is enough to trigger disconnect because Payload of ssh packet becomes:
     %% 1 byte message identifier
     %% 4 bytes length of data field
@@ -893,7 +1005,7 @@ decompression_bomb_client_after_auth(Config) ->
     {ok, InitialState} = connect_and_kex(Config, ssh_trpt_test_lib:exec([]),
                                          [{kex, [?DEFAULT_KEX]},
                                           {cipher, ?DEFAULT_CIPHERS},
-                                          {compression, ['zlib@openssh.com']}], dh),
+                                          {compression, ['zlib@openssh.com']}]),
     {User, Pwd} = server_user_password(Config),
     {ok, AfterAuthState} =
         ssh_trpt_test_lib:exec(
@@ -2126,12 +2238,12 @@ chk_pref_algs(Config,
 
 filter_supported(K, Algs) -> Algs -- (Algs--supported(K)).
 
-supported(cipher) ->
+supported(Key) when Key =:= cipher; Key =:= mac; Key =:= compression ->
     proplists:get_value(
       server2client,
-      ssh_transport:supported_algorithms(cipher));
-supported(K) ->
-    ssh_transport:supported_algorithms(K).
+      ssh_transport:supported_algorithms(Key));
+supported(Key) ->
+    ssh_transport:supported_algorithms(Key).
 
 to_lists(L) -> lists:map(fun erlang:atom_to_list/1, L).
     
@@ -2226,6 +2338,9 @@ connect_and_kex(Config) ->
 
 connect_and_kex(Config, InitialState) ->
     ClientAlgs = [{kex,[?DEFAULT_KEX]}, {cipher,?DEFAULT_CIPHERS}],
+    connect_and_kex(Config, InitialState, ClientAlgs).
+
+connect_and_kex(Config, InitialState, ClientAlgs) ->
     connect_and_kex(Config, InitialState, ClientAlgs, dh).
 
 connect_and_kex(Config, InitialState, ClientAlgs, Variant) ->
@@ -2505,3 +2620,32 @@ get_specific_ops(ecdh) ->
     {ssh_msg_kex_ecdh_init_guess, ssh_msg_kex_ecdh_init, #ssh_msg_kex_ecdh_reply{_='_'}};
 get_specific_ops(hybrid) ->
     {ssh_msg_kex_hybrid_init_guess, ssh_msg_kex_hybrid_init, #ssh_msg_kex_hybrid_reply{_='_'}}.
+
+%%%----------------------------------------------------------------
+get_supported_alg_groups_or_skip(Groups, Config) ->
+    try
+        SupportedGroups =
+            lists:filtermap(fun({Key, Group}) ->
+                                    case get_supported_alg_group_or_skip(Key, Group) of
+                                        [] ->
+                                            false;
+                                        {Key, SupportedGroup} ->
+                                            {true, {Key, SupportedGroup}}
+                                    end
+                            end, Groups),
+        [{preferred_algorithms, SupportedGroups} | Config]
+    catch
+        throw : Other ->
+            Other
+    end.
+
+%%%----------------------------------------------------------------
+get_supported_alg_group_or_skip(_, []) ->
+    [];
+get_supported_alg_group_or_skip(Key, Algorithms) ->
+    case filter_supported(Key, Algorithms) of
+        [] ->
+            throw({skip, "Required algorithms not supported."});
+        Supported ->
+            {Key, Supported}
+    end.


### PR DESCRIPTION
Besides implementing packet alignment validation check from RFC 4253 6, so check: 

> Note that the length of the concatenation of 'packet_length', 'padding_length', 'payload', and 'random padding' MUST be a multiple of the cipher block size or 8, whichever is larger.

This now also implements fix for OpenSSH CVE-2008-5161, so packet discard functionality.