### PR TITLE
Fix `ets:member` locking

### DIFF
--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -1522,8 +1522,8 @@ static int db_member_hash(DbTable *tbl, Eterm key, Eterm *ret)
     erts_rwmtx_t* lck;
 
     hval = MAKE_HASH(key);
-    ix = hash_to_ix(tb, hval);
     lck = RLOCK_HASH(tb, hval);
+    ix = hash_to_ix(tb, hval);
     b1 = BUCKET(tb, ix);
 
     while(b1 != 0) {


### PR DESCRIPTION
`db_member_hash` (backing `ets:member` for `set`, `bag` and `duplicate_bag` tables AFAIK) did locking _after_ the call to `hash_to_ix` which does the slot calculation for a hash (where even a comment above this very `hash_to_ix` says "RLOCK_HASH or WLOCK_HASH must be done before."). This could lead to `ets:member` spuriously returning `false` for a value which is actually a member for a table that faces high insert load (or so AI says :woman_shrugging:).