### PR TITLE
Remove testing of compatibility with OTP 26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,7 +236,6 @@ JAVADOC-GENERATED
 /lib/compiler/test/*_no_ssa_opt_SUITE.erl
 /lib/compiler/test/*_post_opt_SUITE.erl
 /lib/compiler/test/*_inline_SUITE.erl
-/lib/compiler/test/*_r26_SUITE.erl
 /lib/compiler/test/*_no_module_opt_SUITE.erl
 /lib/compiler/test/*_no_type_opt_SUITE.erl
 /lib/compiler/test/*_dialyzer_SUITE.erl

--- a/erts/emulator/beam/beam_load.c
+++ b/erts/emulator/beam/beam_load.c
@@ -202,14 +202,14 @@ erts_prepare_loading(Binary* magic, Process *c_p, Eterm group_leader,
          * highest used op code to the op code for the `swap`
          * instruction introduced in OTP 23.
          *
-         * OTP 27 artificially sets the highest op code to `make_fun3`
-         * introduced in OTP 24.
+         * Newer releases sets the highest op code like this:
          *
-         * OTP 28 artificially sets the highest op code to `bs_create_bin`
-         * introduced in OTP 25.
-         *
-         * OTP 29 artificially sets the highest op code to `update_record`
-         * introduced in OTP 26.
+         * Release  Highest op code (introduced in)
+         * -------  --------------- ---------------
+         * OTP 27   make_fun3       (OTP 24)
+         * OTP 28   bs_create_bin   (OTP 25)
+         * OTP 29   update_record   (OTP 26)
+         * OTP 30   executable_line (OTP 27)
          *
          * Old BEAM files produced by OTP R12 and earlier may be
          * incompatible with the current runtime system. We used to

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -239,9 +239,6 @@ targets: $(TARGET_FILES)
 %_no_opt_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
-%_r26_SUITE.erl: %_SUITE.erl
-	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
-
 %_stripped_types_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 

--- a/erts/emulator/test/erts_test_utils.erl
+++ b/erts/emulator/test/erts_test_utils.erl
@@ -22,7 +22,7 @@
 
 -module(erts_test_utils).
 
--compile(r26).
+-compile(r27).
 
 %%
 %% THIS MODULE IS ALSO USED BY *OTHER* APPLICATIONS TEST CODE

--- a/erts/test/upgrade_SUITE.erl
+++ b/erts/test/upgrade_SUITE.erl
@@ -20,7 +20,7 @@
 %% %CopyrightEnd%
 -module(upgrade_SUITE).
 
--compile(r26).
+-compile(r27).
 
 -compile(export_all).
 

--- a/lib/common_test/src/test_server_node.erl
+++ b/lib/common_test/src/test_server_node.erl
@@ -24,8 +24,8 @@
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}},
           {nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}},
-          {nowarn_unsafe_function, {os, cmd, 1}},
-          r26]).
+          {nowarn_unsafe_function, {os, cmd, 1}}]).
+-compile(r27).
 
 %% Test Controller interface
 -export([is_release_available/1, find_release/1]).

--- a/lib/compiler/src/beam_asm.erl
+++ b/lib/compiler/src/beam_asm.erl
@@ -94,9 +94,12 @@ module(Code0, ExtraChunks, CompileInfo, CompilerOpts) ->
     {ok,Beam}.
 
 reject_unsupported_versions(Dict) ->
-    %% Emit an instruction that was added in our lowest supported
-    %% version so that it cannot be loaded by earlier releases.
-    Instr = beam_opcodes:opcode(update_record, 5),  %OTP 26
+    %% Emit an instruction that was added in our oldest supported
+    %% release so that this module cannot be loaded by earlier
+    %% releases. (For convenience, we use the release that is the
+    %% old supported during development of the next release.)
+
+    Instr = beam_opcodes:opcode(executable_line, 2), %OTP 27
     beam_dict:opcode(Instr, Dict).
 
 on_load(Fs0, Attr0) ->

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -1781,14 +1781,11 @@ verified_normal_type(#t_record{type=Type}=T) ->
 
 -define(BEAM_TYPES_VERSION_29, ?BEAM_TYPES_VERSION).
 -define(BEAM_TYPES_VERSION_27, 3).
--define(BEAM_TYPES_VERSION_26, 2).
 
 -spec convert_ext(pos_integer(), binary()) -> binary() | 'none'.
 convert_ext(?BEAM_TYPES_VERSION_29, Types) ->
     Types;
 convert_ext(?BEAM_TYPES_VERSION_27=Version, Types) ->
-    do_convert_ext(Version, Types);
-convert_ext(?BEAM_TYPES_VERSION_26=Version, Types) ->
     do_convert_ext(Version, Types);
 convert_ext(_Version, _Types) ->
     none.
@@ -1819,17 +1816,6 @@ rearrange_fun(?BEAM_TYPES_VERSION_27) ->
     fun(Bits) ->
             %% OTP 29 added a type bit for native records.
             (Bits band 16#0fff) bor ((Bits bsl 1) band 16#e000)
-    end;
-rearrange_fun(?BEAM_TYPES_VERSION_26) ->
-    ToOtp29 = rearrange_fun(?BEAM_TYPES_VERSION_27),
-    fun(Bits0) ->
-            %% OTP 27 removed #t_bs_context{} from the type
-            %% information, which used to occupy bit 2. As these
-            %% are now considered to be a regular bitstring that
-            %% happens to be mutable, we'll combine it with the
-            %% #t_bitstring{} type bit.
-            Bits = (Bits0 band 3) bor ((Bits0 band (bnot 3)) bsr 1),
-            ToOtp29(Bits)
     end.
 
 ext_type_mapping() ->

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1173,10 +1173,13 @@ expand_opt(report, Os) ->
     [report_errors,report_warnings|Os];
 expand_opt(return, Os) ->
     [return_errors,return_warnings|Os];
-expand_opt(r26, Os) ->
-    [no_bsm_opt | expand_opt(r27, Os)];
+expand_opt(r29, Os) ->
+    %% Nothing... yet.
+    Os;
+expand_opt(r28, Os) ->
+    expand_opt(r29, Os);
 expand_opt(r27, Os) ->
-    [no_long_atoms, compressed_literals | Os];
+    [no_long_atoms, compressed_literals | expand_opt(r28, Os)];
 expand_opt(beam_debug_info, Os) ->
     [beam_debug_info, no_copt, no_bsm_opt, no_bool_opt,
      no_share_opt, no_recv_opt, no_ssa_opt, no_throw_opt | Os];
@@ -2510,6 +2513,7 @@ is_obsolete(r22) -> true;
 is_obsolete(r23) -> true;
 is_obsolete(r24) -> true;
 is_obsolete(r25) -> true;
+is_obsolete(r26) -> true;
 is_obsolete(no_badrecord) -> true;
 is_obsolete(no_bs_create_bin) -> true;
 is_obsolete(no_bs_match) -> true;

--- a/lib/compiler/test/Makefile
+++ b/lib/compiler/test/Makefile
@@ -143,12 +143,6 @@ INLINE= \
 	receive \
 	record
 
-R26= \
-	bs_construct \
-	bs_match \
-	bs_utf \
-	bs_bincomp
-
 COVER=$(NO_OPT)
 
 DIALYZER = bs_match
@@ -175,8 +169,6 @@ NO_CORE_SSA_OPT_MODULES= $(NO_OPT:%=%_no_copt_ssa_SUITE)
 NO_CORE_SSA_OPT_ERL_FILES= $(NO_CORE_SSA_OPT_MODULES:%=%.erl)
 INLINE_MODULES= $(INLINE:%=%_inline_SUITE)
 INLINE_ERL_FILES= $(INLINE_MODULES:%=%.erl)
-R26_MODULES= $(R26:%=%_r26_SUITE)
-R26_ERL_FILES= $(R26_MODULES:%=%.erl)
 NO_MOD_OPT_MODULES= $(NO_MOD_OPT:%=%_no_module_opt_SUITE)
 NO_MOD_OPT_ERL_FILES= $(NO_MOD_OPT_MODULES:%=%.erl)
 NO_SSA_OPT_MODULES= $(NO_SSA_OPT:%=%_no_ssa_opt_SUITE)
@@ -226,7 +218,7 @@ make_emakefile: $(NO_BOOL_OPT_ERL_FILES) $(NO_OPT_ERL_FILES) \
                 $(NO_CORE_OPT_ERL_FILES) $(NO_CORE_SSA_OPT_ERL_FILES) \
                 $(INLINE_ERL_FILES) $(NO_MOD_OPT_ERL_FILES) \
                 $(NO_TYPE_OPT_ERL_FILES) $(DIALYZER_ERL_FILES) \
-                $(COVER_ERL_FILES) $(R26_ERL_FILES)
+                $(COVER_ERL_FILES)
 	$(ERL_TOP)/make/make_emakefile $(ERL_COMPILE_FLAGS) -o$(EBIN) $(MODULES) \
 	  > $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +no_bool_opt $(ERL_COMPILE_FLAGS) \
@@ -243,8 +235,6 @@ make_emakefile: $(NO_BOOL_OPT_ERL_FILES) $(NO_OPT_ERL_FILES) \
 	  -o$(EBIN) $(NO_CORE_SSA_OPT_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +inline $(ERL_COMPILE_FLAGS) \
 	  -o$(EBIN) $(INLINE_MODULES) >> $(EMAKEFILE)
-	$(ERL_TOP)/make/make_emakefile +r26 $(ERL_COMPILE_FLAGS) \
-	  -o$(EBIN) $(R26_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +no_module_opt $(ERL_COMPILE_FLAGS) \
 	  -o$(EBIN) $(NO_MOD_OPT_MODULES) >> $(EMAKEFILE)
 	$(ERL_TOP)/make/make_emakefile +from_core $(ERL_COMPILE_FLAGS) \
@@ -291,9 +281,6 @@ docs:
 %_inline_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
-%_r26_SUITE.erl: %_SUITE.erl
-	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
-
 %_no_module_opt_SUITE.erl: %_SUITE.erl
 	sed -e 's;-module($(basename $<));-module($(basename $@));' $< > $@
 
@@ -322,7 +309,6 @@ release_tests_spec: make_emakefile
 		$(NO_OPT_ERL_FILES) \
 		$(POST_OPT_ERL_FILES) \
 		$(INLINE_ERL_FILES) \
-	        $(R26_ERL_FILES) \
 		$(NO_CORE_OPT_ERL_FILES) \
 		$(NO_CORE_SSA_OPT_ERL_FILES) \
 		$(NO_MOD_OPT_ERL_FILES) \

--- a/lib/compiler/test/beam_debug_info_SUITE.erl
+++ b/lib/compiler/test/beam_debug_info_SUITE.erl
@@ -1088,7 +1088,6 @@ get_unique_beam_files() ->
     F = fun IsCloned(ModString) ->
                 case ModString of
                     "_dialyzer_SUITE" -> true;
-                    "_r26_SUITE" -> true;
                     [_|T] -> IsCloned(T);
                     _ -> false
                 end

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -1650,11 +1650,7 @@ cover_convert_ext(_Config) ->
     Otp27Types = <<Otp27AllTypes:16, -1:16,0:64,0:64,1:8>>,
     _ = beam_types:decode_ext(beam_types:convert_ext(Otp27Version, Otp27Types)),
 
-    Otp26AllTypes = 2#1111_1111_1111,
-    Otp26Version = 2,
-    Otp26Types = <<Otp26AllTypes:16, -1:16,0:64,0:64,1:8>>,
-    _ = beam_types:decode_ext(beam_types:convert_ext(Otp26Version, Otp26Types)),
-
+    none = beam_types:convert_ext(2, <<>>),     %OTP 26
     none = beam_types:convert_ext(1, <<>>),     %OTP 25
     none = beam_types:convert_ext(0, <<>>),
 

--- a/lib/compiler/test/bs_bincomp_SUITE.erl
+++ b/lib/compiler/test/bs_bincomp_SUITE.erl
@@ -713,8 +713,6 @@ cs(Bin) ->
             ok;
         bs_bincomp_post_opt_SUITE ->
             ok;
-        bs_bincomp_r26_SUITE ->
-            ok;
         _ ->
             ByteSize = byte_size(Bin),
             {refc_binary,ByteSize,{binary,ByteSize},_} =

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1731,27 +1731,26 @@ bc_options(Config) ->
 
     DataDir = proplists:get_value(data_dir, Config),
 
-    L = [{181, small_float, []},
+    L = [{183, small_float, []},
 
-         {181, funs, [no_ssa_opt_record,
+         {183, funs, [no_ssa_opt_record,
                       no_ssa_opt_float,
                       no_line_info,
                       no_stack_trimming,
                       no_type_opt]},
 
-         {181, small_maps, [no_type_opt]},
+         {183, small_maps, [no_type_opt]},
 
-         {181, big, [no_ssa_opt_record,
+         {183, big, [no_ssa_opt_record,
                      no_ssa_opt_float,
                      no_line_info,
                      no_type_opt]},
 
-         {181, funs, []},
-         {181, big, []},
+         {183, funs, []},
+         {183, big, []},
 
-         {182, small, [r26]},
-         {182, small, []},
-         {182, small, [no_ssa_opt_record,
+         {183, small, []},
+         {183, small, [no_ssa_opt_record,
                        no_ssa_opt_float,
                        no_line_info,
                        no_type_opt]},

--- a/lib/compiler/test/property_test/compile_prop.erl
+++ b/lib/compiler/test/property_test/compile_prop.erl
@@ -100,7 +100,6 @@ spawn_compile(Compile, Forms, Options) ->
 compiler_variants() ->
     [
      [ssalint,clint0,clint],
-     [r26,ssalint],
      [no_type_opt,ssalint],
      [no_module_opt,ssalint],
      [no_copt,ssalint,clint0],

--- a/lib/kernel/test/global_SUITE.erl
+++ b/lib/kernel/test/global_SUITE.erl
@@ -21,7 +21,7 @@
 %%
 -module(global_SUITE).
 
--compile(r26). % many_nodes()
+-compile(r27). % many_nodes()
 
 -export([all/0, suite/0, groups/0, 
 	 init_per_suite/1, end_per_suite/1,

--- a/lib/kernel/test/kernel_SUITE.erl
+++ b/lib/kernel/test/kernel_SUITE.erl
@@ -24,7 +24,7 @@
 %%%-----------------------------------------------------------------
 -module(kernel_SUITE).
 
--compile(r26).
+-compile(r27).
 
 -include_lib("common_test/include/ct.hrl").
 

--- a/lib/observer/test/crashdump_helper.erl
+++ b/lib/observer/test/crashdump_helper.erl
@@ -22,7 +22,7 @@
 
 -module(crashdump_helper).
 
--compile(r26).
+-compile(r27).
 
 -export([n1_proc/2,remote_proc/2,
          dump_maps/0,create_maps/0,

--- a/lib/sasl/test/sasl_SUITE.erl
+++ b/lib/sasl/test/sasl_SUITE.erl
@@ -21,7 +21,7 @@
 %%
 -module(sasl_SUITE).
 
--compile(r26).
+-compile(r27).
 
 -include_lib("common_test/include/ct.hrl").
 

--- a/lib/stdlib/test/stdlib_SUITE.erl
+++ b/lib/stdlib/test/stdlib_SUITE.erl
@@ -24,7 +24,7 @@
 %%%-----------------------------------------------------------------
 -module(stdlib_SUITE).
 
--compile(r26).
+-compile(r27).
 
 -include_lib("common_test/include/ct.hrl").
 -export([all/0, suite/0, init_per_suite/1, end_per_suite/1,


### PR DESCRIPTION
The oldest release currently supported is OTP 27, so we'll no longer need to do any compatibility testing with OTP 26.