### PR TITLE
Enhance optimization of `is_integer/3`

### DIFF
--- a/lib/compiler/src/beam_core_to_ssa.erl
+++ b/lib/compiler/src/beam_core_to_ssa.erl
@@ -1018,8 +1018,8 @@ build_bin_seg_integer(Bits, Val, Next) ->
                 seg=Seg,next=Next}.
 
 integer_fits_and_is_expandable(Int, Size)
-  when is_integer(Int), is_integer(Size),
-       0 < Size, Size =< ?EXPAND_MAX_SIZE_SEGMENT ->
+  when is_integer(Int),
+       is_integer(Size, 1, ?EXPAND_MAX_SIZE_SEGMENT) ->
     case <<Int:Size>> of
         <<Int:Size>> -> true;
         _ -> false
@@ -1481,8 +1481,9 @@ do_combine_lit_pat(_) ->
     throw(not_possible).
 
 combine_bin_segs(#cg_bin_seg{size=#b_literal{val=8},unit=1,type=integer,
-                             flags=[unsigned,big],seg=#b_literal{val=Int},next=Next})
-  when is_integer(Int), 0 =< Int, Int =< 255 ->
+                             flags=[unsigned,big],
+                             seg=#b_literal{val=Int},next=Next})
+  when is_integer(Int, 0, 255) ->
     <<Int,(combine_bin_segs(Next))/bits>>;
 combine_bin_segs(#cg_bin_end{}) ->
     <<>>;
@@ -2114,7 +2115,7 @@ clause_count_segments(_) -> error.
 count_segments(#cg_bin_seg{size=#b_literal{val=8},
                            unit=1,type=integer,flags=[unsigned,big],
                            seg=#b_literal{val=Int},next=Next}, Count)
-  when is_integer(Int), 0 =< Int, Int =< 255 ->
+  when is_integer(Int, 0, 255) ->
     count_segments(Next, Count + 1);
 count_segments(_, Count) when Count > 0 ->
     {literal,Count};

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -550,8 +550,7 @@ merge_tuple_update_1([], Tuple) ->
 %%%
 
 ssa_opt_split_blocks({#opt_st{ssa=Blocks0,cnt=Count0}=St, FuncDb}) ->
-    P = fun(#b_set{op={bif,is_integer},args=[_,_,_]}) -> true;
-           (#b_set{op={bif,element}}) -> true;
+    P = fun(#b_set{op={bif,element}}) -> true;
            (#b_set{op=call}) -> true;
            (#b_set{op=bs_init_writable}) -> true;
            (#b_set{op=make_fun}) -> true;
@@ -566,42 +565,46 @@ ssa_opt_split_blocks({#opt_st{ssa=Blocks0,cnt=Count0}=St, FuncDb}) ->
 %%% When the range is constant, rewrite it into 3 BIFs: is_integer/1 and two
 %%% =<'s to enable later optimization.
 %%%
-ssa_opt_is_between({#opt_st{ssa=Blocks0,cnt=Count0}=St, FuncDb}) ->
-    {Blocks1, Count1} = ssa_opt_is_between_1(Blocks0, Count0),
-    {St#opt_st{ssa=Blocks1,cnt=Count1}, FuncDb}.
+ssa_opt_is_between({#opt_st{ssa=Linear0,cnt=Count0}=St, FuncDb}) ->
+    {Linear1, Count1} = ssa_opt_is_between_1(Linear0, Count0),
+    {St#opt_st{ssa=Linear1,cnt=Count1}, FuncDb}.
 
-ssa_opt_is_between_1([{L,#b_blk{}=B}=Blk0|Ls0], Count0) ->
-    case B of
-        #b_blk{is=[#b_set{op={bif,is_integer},dst=Bool1,
-                          args=[_,#b_literal{val=Min},
-                                #b_literal{val=Max}]}],
-               last=#b_br{bool=Bool1}}=Blk when is_integer(Min),
-                                                is_integer(Max),
-                                                Min =< Max ->
-            {Blk1, Count1} = is_between_rewrite(Count0, L, Blk),
-            {Ls1, Count2} = ssa_opt_is_between_1(Ls0, Count1),
-            {Blk1++Ls1, Count2};
-        #b_blk{} ->
-            {Ls1, Count1} = ssa_opt_is_between_1(Ls0, Count0),
-            {[Blk0|Ls1], Count1}
+ssa_opt_is_between_1([{L,#b_blk{is=[_|_]=Is0,
+                                last=#b_br{bool=#b_var{},
+                                          fail=Fail}}=Blk0}=B|Bs0],
+                     Count0) when Fail =/= ?EXCEPTION_BLOCK ->
+    case {reverse(Is0),Blk0} of
+        {[#b_set{op={bif,is_integer},dst=Bool1,
+                 args=[_,_,_]}=IsInt | Prefix],
+         #b_blk{last=#b_br{bool=Bool1}}} ->
+            {Bs1, Count1} = is_between_rewrite(Count0, L, Prefix,
+                                               IsInt, Blk0),
+            {Bs2, Count2} = ssa_opt_is_between_1(Bs0, Count1),
+            {Bs1++Bs2, Count2};
+        {_, _} ->
+            {Bs1, Count1} = ssa_opt_is_between_1(Bs0, Count0),
+            {[B|Bs1], Count1}
     end;
+ssa_opt_is_between_1([B|Bs0], Count0) ->
+    {Bs1, Count1} = ssa_opt_is_between_1(Bs0, Count0),
+    {[B|Bs1], Count1};
 ssa_opt_is_between_1([], Count0) ->
     {[], Count0}.
 
-is_between_rewrite(Count0, L, Blk0) ->
+is_between_rewrite(Count0, L, Prefix, IsInt, Blk0) ->
     LowerL = Count0,
     UpperL = Count0 + 1,
     LowerBool = #b_var{name=Count0},
     UpperBool = #b_var{name=Count0 + 1},
     Count = Count0 + 2,
-    #b_blk{is=[#b_set{dst=Bool1,args=[Term,LB,UB]}|_],
-           last=#b_br{fail=Fail}=Br0} = Blk0,
-    Blk1 = Blk0#b_blk{is=[#b_set{op={bif,is_integer},dst=Bool1,
-                                 args=[Term]}],
-                      last=#b_br{bool=Bool1,succ=LowerL,fail=Fail}},
+    #b_set{args=[Term,LB,UB]} = IsInt,
+    #b_blk{last=#b_br{}=Br0} = Blk0,
+    I = IsInt#b_set{args=[Term]},
+    Is = reverse(Prefix, [I]),
+    Blk1 = Blk0#b_blk{is=Is,last=Br0#b_br{succ=LowerL}},
     BlkLower = #b_blk{is=[#b_set{op={bif,'=<'},dst=LowerBool,
                                  args=[LB,Term]}],
-                      last=#b_br{bool=LowerBool,succ=UpperL,fail=Fail}},
+                      last=Br0#b_br{bool=LowerBool,succ=UpperL}},
     BlkUpper = #b_blk{is=[#b_set{op={bif,'=<'},dst=UpperBool,
                                  args=[Term,UB]}],
                       last=Br0#b_br{bool=UpperBool}},

--- a/lib/compiler/src/beam_ssa_opt.erl
+++ b/lib/compiler/src/beam_ssa_opt.erl
@@ -3751,7 +3751,7 @@ is_bs_match_is([], _Safe) -> no.
 is_viable_match(#b_set{op=bs_match,args=Args}) ->
     case Args of
         [#b_literal{val=binary},Ctx,_,#b_literal{val=all},#b_literal{val=U}]
-          when is_integer(U), 1 =< U, U =< 256 ->
+          when is_integer(U, 1, 256) ->
             {yes,{Ctx,0,U}};
         [#b_literal{val=binary},Ctx,_,#b_literal{val=Size},#b_literal{val=U}]
           when is_integer(Size) ->

--- a/lib/compiler/src/beam_ssa_recv.erl
+++ b/lib/compiler/src/beam_ssa_recv.erl
@@ -365,7 +365,7 @@ si_remote_call_1(Dst, [Callee | Args], Lbl, Blocks) ->
                   none
           end,
     case MFA of
-        {erlang,alias,A} when is_integer(A), 0 =< A, A =< 1 ->
+        {erlang,alias,A} when is_integer(A, 0, 1) ->
             {makes_ref, Lbl, Dst};
         {erlang,demonitor,2} ->
             case Args of
@@ -380,12 +380,12 @@ si_remote_call_1(Dst, [Callee | Args], Lbl, Blocks) ->
             end;
         {erlang,make_ref,0} ->
             {makes_ref, Lbl, Dst};
-        {erlang,monitor,A} when is_integer(A), 2 =< A, A =< 3 ->
+        {erlang,monitor,A} when is_integer(A, 2, 3) ->
             {makes_ref, Lbl, Dst};
-        {erlang,spawn_monitor,A} when is_integer(A), 1 =< A, A =< 4 ->
+        {erlang,spawn_monitor,A} when is_integer(A, 1, 4) ->
             RPO = beam_ssa:rpo([Lbl], Blocks),
             si_ref_in_tuple(RPO, Blocks, Dst);
-        {erlang,spawn_request,A} when is_integer(A), 1 =< A, A =< 5 ->
+        {erlang,spawn_request,A} when is_integer(A, 1, 5) ->
             {makes_ref, Lbl, Dst};
         _ ->
             %% As an aside, spawn_opt/2-5 is trivially supported by handling it

--- a/lib/compiler/src/beam_ssa_type.erl
+++ b/lib/compiler/src/beam_ssa_type.erl
@@ -1143,9 +1143,7 @@ simplify(#b_set{op={bif,'or'},args=Args}=I, Ts, Ds) ->
     end;
 simplify(#b_set{op={bif,element},args=[#b_literal{val=Index},Tuple]}=I0, Ts, Ds) ->
     case normalized_type(Tuple, Ts) of
-        #t_tuple{size=Size} when is_integer(Index),
-                                 1 =< Index,
-                                 Index =< Size ->
+        #t_tuple{size=Size} when is_integer(Index, 1, Size) ->
             I = I0#b_set{op=get_tuple_element,
                          args=[Tuple,#b_literal{val=Index-1}]},
             simplify(I, Ts, Ds);
@@ -2460,7 +2458,7 @@ bs_size_unit([#b_literal{val=Type},#b_literal{val=[U1|_]},Value,SizeTerm|Args],
         {_,_,_} ->
             case concrete_type(SizeTerm, Ts) of
                 #t_integer{elements={Size1, Size1}}
-                  when is_integer(Size1), is_integer(U1), Size1 >= 0 ->
+                  when is_integer(Size1), Size1 >= 0, is_integer(U1) ->
                     EffectiveSize = Size1 * U1,
                     %% Adding a fixed size element
                     bs_size_unit(Args, Ts, EffectiveSize + FixedSize, Unit);
@@ -2507,9 +2505,7 @@ bs_match_type(integer, Args, Ts) ->
     case beam_types:meet(concrete_type(Size, Ts), #t_integer{}) of
         #t_integer{elements=Bounds} ->
             case beam_bounds:bounds('*', Bounds, {Unit, Unit}) of
-                {_, MaxBits} when is_integer(MaxBits),
-                                  MaxBits >= 1,
-                                  MaxBits =< 64 ->
+                {_, MaxBits} when is_integer(MaxBits, 1, 64) ->
                     case member(unsigned, Flags) of
                         true ->
                             Max = (1 bsl MaxBits) - 1,
@@ -2863,7 +2859,7 @@ infer_type({bif,is_function}, [#b_var{}=Arg], _Ts, _Ds) ->
     {[T], [T]};
 infer_type({bif,is_function}, [#b_var{}=Arg, Arity], _Ts, _Ds) ->
     case Arity of
-        #b_literal{val=V} when is_integer(V), V >= 0, V =< ?MAX_FUNC_ARGS ->
+        #b_literal{val=V} when is_integer(V, 0, ?MAX_FUNC_ARGS) ->
             T = {Arg, #t_fun{arity=V}},
             {[T], [T]};
         _ ->

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -1742,7 +1742,7 @@ verified_normal_type(#t_tuple{size=Size,elements=Es}=T) ->
     %% entire tuple to 'none'.
     _ = [verified_type(Element) ||
             Index := Element <- Es,
-            is_integer(Index), 1 =< Index, Index =< Size,
+            is_integer(Index, 1, Size),
             Index =< ?TUPLE_ELEMENT_LIMIT,
             Element =/= any, Element =/= none],
     T;
@@ -1953,7 +1953,7 @@ encode_range(Max, TypeBits, Extra) ->
     end.
 
 encode_unit(#t_bitstring{size_unit=Unit}) ->
-    true = is_integer(Unit) andalso 0 < Unit andalso Unit =< 256, %Assertion.
+    true = is_integer(Unit, 1, 256),            %Assertion.
     {?BEAM_TYPE_HAS_UNIT,<<(Unit-1):8>>};
 encode_unit(#t_union{other=Other}) ->
     encode_unit(Other);
@@ -1963,7 +1963,7 @@ encode_unit(_) ->
 %% Test whether the number is a small on a 64-bit machine.
 %% (Normally the compiler doesn't know/doesn't care whether something is
 %% bignum, but because the type representation is versioned this is safe.)
-is_small(N) when is_integer(N), -(1 bsl 59) =< N andalso N =< (1 bsl 59) - 1 ->
+is_small(N) when is_integer(N, -(1 bsl 59), (1 bsl 59) - 1) ->
     true;
 is_small(_) ->
     false.

--- a/lib/compiler/src/beam_validator.erl
+++ b/lib/compiler/src/beam_validator.erl
@@ -1581,7 +1581,7 @@ assert_bs_unit({atom,Type}, 0) ->
         utf32 -> ok;
         _ -> error({zero_unit_invalid_for_type,Type})
     end;
-assert_bs_unit({atom,_Type}, Unit) when is_integer(Unit), 0 < Unit, Unit =< 256 ->
+assert_bs_unit({atom,_Type}, Unit) when is_integer(Unit, 1, 256) ->
     ok;
 assert_bs_unit(_, Unit) ->
     error({invalid,Unit}).
@@ -1783,7 +1783,7 @@ validate_failed_bs_match([], _Ctx, Vst) ->
 
 bs_integer_type(Bounds, Unit, Flags) ->
     case beam_bounds:bounds('*', Bounds, {Unit, Unit}) of
-        {_, MaxBits} when is_integer(MaxBits), MaxBits >= 1, MaxBits =< 64 ->
+        {_, MaxBits} when is_integer(MaxBits, 1, 64) ->
             case member(signed, Flags) of
                 true ->
                     Max = (1 bsl (MaxBits - 1)) - 1,
@@ -3328,7 +3328,7 @@ verify_y_init_1(Y, Vst) ->
 
 verify_live(0, _Vst) ->
     ok;
-verify_live(Live, Vst) when is_integer(Live), 0 < Live, Live =< 1023 ->
+verify_live(Live, Vst) when is_integer(Live, 1, 1023) ->
     verify_live_1(Live - 1, Vst);
 verify_live(Live, _Vst) ->
     error({bad_number_of_live_regs,Live}).
@@ -3591,13 +3591,13 @@ check_limit({x,X}=Src) when is_integer(X) ->
     end;
 check_limit({y,Y}=Src) when is_integer(Y) ->
     if
-        0 =< Y, Y < 1024 -> ok;
+        is_integer(Y, 0, 1023) -> ok;
         1024 =< Y -> error(limit);
         Y < 0 -> error({bad_register, Src})
     end;
 check_limit({fr,Fr}=Src) when is_integer(Fr) ->
     if
-        0 =< Fr, Fr < 1023 -> ok;
+        is_integer(Fr, 0, 1022) -> ok;
         1023 =< Fr -> error(limit);
         Fr < 0 -> error({bad_register, Src})
     end.

--- a/lib/compiler/src/cerl_inline.erl
+++ b/lib/compiler/src/cerl_inline.erl
@@ -464,7 +464,7 @@ i_var_1(R, Opnd, Ctxt, Env, S) ->
 		    %% context to `copy', but not the current renaming.
 		    S3 = st__clear_inner_pending(L, S2),
 		    copy(R, Opnd, E, Ctxt, Env, S3)
-	    catch
+            catch
 		throw:X ->
  		    %% If we use destructive update for the
  		    %% `inner-pending' flag, we must make sure to clear
@@ -2344,7 +2344,7 @@ reduce_bif_call_1(erlang, element, 2, [X, Y], _Env) ->
 	    %% the elements, so lifting out a particular element is OK.
 	    T = list_to_tuple(tuple_es(Y)),
 	    N = int_val(X),
-	    if is_integer(N), N > 0, N =< tuple_size(T) ->
+            if is_integer(N, 1, tuple_size(T)) ->
 		    E = element(N, T),
 		    Es = tuple_to_list(setelement(N, T, void())),
 		    {true, make_seq(c_tuple(Es), E)};
@@ -2388,7 +2388,7 @@ reduce_bif_call_1(erlang, setelement, 3, [X, Y, Z], Env) ->
 	    %% evaluated before any part of `Y'.
 	    T = list_to_tuple(tuple_es(Y)),
 	    N = int_val(X),
-	    if is_integer(N), N > 0, N =< tuple_size(T) ->
+            if is_integer(N, 1, tuple_size(T)) ->
 		    E = element(N, T),
 		    case is_simple(Z) of
 			true ->

--- a/lib/compiler/src/core_scan.erl
+++ b/lib/compiler/src/core_scan.erl
@@ -286,9 +286,9 @@ scan1([C|Cs], Toks, Pos) when C >= $À, C =< $Þ, C /= $× ->
     scan_variable(C, Cs, Toks, Pos);
 scan1([C|Cs], Toks, Pos) when C >= $0, C =< $9 ->	%Numbers
     scan_number(C, Cs, Toks, Pos);
-scan1([$-,C|Cs], Toks, Pos) when is_integer(C), C >= $0, C =< $9 -> %Signed numbers
+scan1([$-,C|Cs], Toks, Pos) when is_integer(C, $0, $9) -> %Signed numbers
     scan_signed_number($-, C, Cs, Toks, Pos);
-scan1([$+,C|Cs], Toks, Pos) when is_integer(C), C >= $0, C =< $9 -> %Signed numbers
+scan1([$+,C|Cs], Toks, Pos) when is_integer(C, $0, $9) -> %Signed numbers
     scan_signed_number($+, C, Cs, Toks, Pos);
 scan1([$_|Cs], Toks, Pos) ->				%_ variables
     scan_variable($_, Cs, Toks, Pos);
@@ -394,18 +394,18 @@ scan_char([C|Cs], Pos) ->
     {C,Cs,Pos}.
 
 scan_escape([O1,O2,O3|Cs], Pos) when            %\<1-3> octal digits
-      is_integer(O1), O1 >= $0, O1 =< $7,
-      is_integer(O2), O2 >= $0, O2 =< $7,
-      is_integer(O3), O3 >= $0, O3 =< $7 ->
+      is_integer(O1, $0, $7),
+      is_integer(O2, $0, $7),
+      is_integer(O3, $0, $7) ->
     Val = (O1*8 + O2)*8 + O3 - 73*$0,
     {Val,Cs,Pos};
 scan_escape([O1,O2|Cs], Pos) when
-      is_integer(O1), O1 >= $0, O1 =< $7,
-      is_integer(O2), O2 >= $0, O2 =< $7 ->
+      is_integer(O1, $0, $7),
+      is_integer(O2, $0, $7) ->
     Val = (O1*8 + O2) - 9*$0,
     {Val,Cs,Pos};
 scan_escape([O1|Cs], Pos) when
-      is_integer(O1), O1 >= $0, O1 =< $7 ->
+      is_integer(O1, $0, $7) ->
     {O1 - $0,Cs,Pos};
 scan_escape([$^,C|Cs], Pos) ->			%\^X -> CTL-X
     Val = C band 31,
@@ -445,8 +445,7 @@ escape_char(C) -> C.
 %%  SPos == Start position
 %%  CPos == Current position
 
-scan_number(C, Cs0, Toks, Pos) when
-      is_integer(C), C >= $0, C =< $9 ->
+scan_number(C, Cs0, Toks, Pos) when is_integer(C, $0, $9) ->
     {Ncs,Cs,Pos1} = scan_integer(Cs0, [C], Pos),
     scan_after_int(Cs, Ncs, Toks, Pos, Pos1).
 
@@ -454,19 +453,18 @@ scan_signed_number(S, C, Cs0, Toks, Pos) ->
     {Ncs,Cs,Pos1} = scan_integer(Cs0, [C,S], Pos),
     scan_after_int(Cs, Ncs, Toks, Pos, Pos1).
 
-scan_integer([C|Cs], Stack, Pos) when
-      is_integer(C), C >= $0, C =< $9 ->
+scan_integer([C|Cs], Stack, Pos) when is_integer(C, $0, $9) ->
     scan_integer(Cs, [C|Stack], Pos);
 scan_integer(Cs, Stack, Pos) ->
     {Stack,Cs,Pos}.
 
 scan_after_int([$.,C|Cs0], Ncs0, Toks, SPos, CPos) when
-      is_integer(C), C >= $0, C =< $9 ->
+      is_integer(C, $0, $9) ->
     {Ncs,Cs,CPos1} = scan_integer(Cs0, [C,$.|Ncs0], CPos),
     scan_after_fraction(Cs, Ncs, Toks, SPos, CPos1);
 scan_after_int([$#|Cs], Ncs, Toks, SPos, CPos) ->
     case list_to_integer(reverse(Ncs)) of
-	Base when is_integer(Base), Base >= 2, Base =< 16 ->
+        Base when is_integer(Base, 2, 16) ->
 	    scan_based_int(Cs, 0, Base, Toks, SPos, CPos);
 	Base ->
 	    scan_error({base,Base}, CPos)
@@ -476,15 +474,15 @@ scan_after_int(Cs, Ncs, Toks, SPos, CPos) ->
     scan1(Cs, [{integer,SPos,N}|Toks], CPos).
 
 scan_based_int([C|Cs], SoFar, Base, Toks, SPos, CPos) when
-      is_integer(C), C >= $0, C =< $9, C < Base + $0 ->
+      is_integer(C, $0, $9), C < Base + $0 ->
     Next = SoFar * Base + (C - $0),
     scan_based_int(Cs, Next, Base, Toks, SPos, CPos);
 scan_based_int([C|Cs], SoFar, Base, Toks, SPos, CPos) when
-      is_integer(C), C >= $a, C =< $f, C < Base + $a - 10 ->
+      is_integer(C, $a, $f), C < Base + $a - 10 ->
     Next = SoFar * Base + (C - $a + 10),
     scan_based_int(Cs, Next, Base, Toks, SPos, CPos);
 scan_based_int([C|Cs], SoFar, Base, Toks, SPos, CPos) when
-      is_integer(C), C >= $A, C =< $F, C < Base + $A - 10 ->
+      is_integer(C, $A, $F), C < Base + $A - 10 ->
     Next = SoFar * Base + (C - $A + 10),
     scan_based_int(Cs, Next, Base, Toks, SPos, CPos);
 scan_based_int(Cs, SoFar, _, Toks, SPos, CPos) ->
@@ -514,7 +512,7 @@ scan_exponent(Cs, Ncs, Toks, SPos, CPos) ->
     scan_exponent1(Cs, Ncs, Toks, SPos, CPos).
 
 scan_exponent1([C|Cs0], Ncs0, Toks, SPos, CPos) when
-      is_integer(C), C >= $0, C =< $9 ->
+      is_integer(C, $0, $9) ->
     {Ncs,Cs,CPos1} = scan_integer(Cs0, [C|Ncs0], CPos),
     try list_to_float(reverse(Ncs)) of
 	N ->

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -97,7 +97,7 @@
 -endif.
 
 -define(MAX_FUNC_ARGS, 255).
--define(IS_FUNC_ARITY(A), is_integer(A) andalso 0 =< A andalso A =< ?MAX_FUNC_ARGS).
+-define(IS_FUNC_ARITY(A), is_integer(A, 0, ?MAX_FUNC_ARGS)).
 
 %% Variable value info.
 -record(sub, {v=[],                                 %Variable substitutions

--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -274,7 +274,7 @@ defined_functions(Forms) ->
 %%     ok.
 
 function({function,_,Name,Arity,Cs0}, Module, Opts)
-  when is_integer(Arity), 0 =< Arity, Arity =< 255 ->
+  when is_integer(Arity, 0, 255) ->
     #imodule{name=Mod, file=File, ws=Ws0, nifs=Nifs} = Module,
     try
         St0 = #core{vcount=0,module=Mod,function={Name,Arity},


### PR DESCRIPTION
When `is_integer/3` is used in a guard and the endpoints of the range are literal integers, the compiler attempts to replace it with an `is_integer/1` call and two range checks, because the JIT can generate very tight code for that.

Enhance the optimization so that it will always work. As implemented before this pull request, it would fail if the `ssa_opt_sink` optimization had moved additional instructions into the same block as the `is_integer/3` calls.
