### PR TITLE
Remove deprecated catch from `gen_*` behaviors

### DIFF
--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -130,8 +130,6 @@ or if bad arguments are specified.
 %%%       above monitor_return() in gen.erl!
 %%%
 
--compile(nowarn_deprecated_catch).
-
 -export([start/0, start/1, start/2,
          start_link/0, start_link/1, start_link/2,
          start_monitor/0, start_monitor/1, start_monitor/2,
@@ -1596,12 +1594,16 @@ call1(M, Handler, Query, Timeout) ->
 	    exit({Reason, {?MODULE, call, [M, Handler, Query, Timeout]}})
     end.
 
-send({global, Name}, Cmd) ->
-    catch global:send(Name, Cmd),
-    ok;
 send({via, Mod, Name}, Cmd) ->
-    catch Mod:send(Name, Cmd),
-    ok;
+    try
+        Mod:send(Name, Cmd),
+        ok
+    catch
+        _:_ ->
+            ok
+    end;
+send({global, Name}, Cmd) ->
+    send({via, global, Name}, Cmd);
 send(M, Cmd) ->
     M ! Cmd,
     ok.
@@ -1679,7 +1681,7 @@ handle_msg(Msg, Parent, ServerName, MSL, HibernateAfterTimeout, Debug) ->
 	    reply(Tag, Reply),
 	    loop(Parent, ServerName, MSL1, HibernateAfterTimeout, Debug, Hib);
 	{_From, Tag, stop} ->
-	    catch terminate_server(normal, Parent, MSL, ServerName),
+	    try terminate_server(normal, Parent, MSL, ServerName) catch _:_ -> ok end,
 	    reply(Tag, ok);
 	{_From, Tag, which_handlers} ->
 	    reply(Tag, the_handlers(MSL)),
@@ -1818,7 +1820,12 @@ server_add_handler(Mod, Args, MSL) ->
     server_add_handler(Mod, Handler, Args, MSL).
 
 server_add_handler(Mod, Handler, Args, MSL) ->
-    case catch Mod:init(Args) of
+    Res = try
+              Mod:init(Args)
+          catch
+              C:R:ST -> catch_result(C, R, ST)
+          end,
+    case Res of
         {ok, State} ->
 	    {false, ok, [Handler#handler{state = State}|MSL]};
         {ok, State, hibernate} ->
@@ -1922,7 +1929,12 @@ server_notify(_, _, [], _) ->
 server_update(Handler1, Func, Event, SName) ->
     Mod1 = Handler1#handler.module,
     State = Handler1#handler.state,
-    case catch Mod1:Func(Event, State) of
+    Res = try
+              Mod1:Func(Event, State)
+          catch
+              C:R:ST -> catch_result(C, R, ST)
+          end,
+    case Res of
 	{ok, State1} ->
 	    {ok, Handler1#handler{state = State1}};
 	{ok, State1, hibernate} ->
@@ -1955,7 +1967,12 @@ do_swap(Mod1, Handler1, Args1, State1, Handler2, Args2, SName) ->
 			  swapped, SName,
 			  {swapped, Handler2, Handler1#handler.supervised}),
     {Mod2, Handler} = new_handler(Handler2, Handler1),
-    case catch Mod2:init({Args2, State2}) of
+    Res = try
+              Mod2:init({Args2, State2})
+          catch
+              C:R:ST -> catch_result(C, R, ST)
+          end,
+    case Res of
 	{ok, State2a} ->
 	    {ok, Handler#handler{state = State2a}};
 	Other ->
@@ -2045,7 +2062,12 @@ replace(_, [], NewHa) ->
 server_call_update(Handler1, Query, SName) ->
     Mod1 = Handler1#handler.module,
     State = Handler1#handler.state,
-    case catch Mod1:handle_call(Query, State) of
+    Res = try
+              Mod1:handle_call(Query, State)
+          catch
+              C:R:ST -> catch_result(C, R, ST)
+          end,
+    case Res of
 	{ok, Reply, State1} ->
 	    {{ok, Handler1#handler{state = State1}}, Reply};
 	{ok, Reply, State1, hibernate} ->
@@ -2066,7 +2088,11 @@ server_call_update(Handler1, Query, SName) ->
 do_terminate(Mod, Handler, Args, State, LastIn, SName, Reason) ->
     case erlang:function_exported(Mod, terminate, 2) of
 	true ->
-	    Res = (catch Mod:terminate(Args, State)),
+	    Res = try
+                      Mod:terminate(Args, State)
+                  catch
+                      C:R:ST -> catch_result(C, R, ST)
+                  end,
 	    report_terminate(Handler, Reason, Args, State, LastIn, SName, Res),
 	    Res;
 	false ->
@@ -2363,3 +2389,7 @@ format_status(Opt, StatusData) ->
              {"Logged Events", Logs},
 	     {"Parent", Parent}]},
      {items, {"Installed handlers", FmtMSL}}].
+
+catch_result(throw, Throw, _StackTrace) -> Throw;
+catch_result(exit, Reason, _StackTrace) -> {'EXIT', Reason};
+catch_result(error, Reason, StackTrace) -> {'EXIT', {Reason, StackTrace}}.

--- a/lib/stdlib/src/gen_event.erl
+++ b/lib/stdlib/src/gen_event.erl
@@ -1681,7 +1681,7 @@ handle_msg(Msg, Parent, ServerName, MSL, HibernateAfterTimeout, Debug) ->
 	    reply(Tag, Reply),
 	    loop(Parent, ServerName, MSL1, HibernateAfterTimeout, Debug, Hib);
 	{_From, Tag, stop} ->
-	    try terminate_server(normal, Parent, MSL, ServerName) catch _:_ -> ok end,
+            try terminate_server(normal, Parent, MSL, ServerName) catch _:_ -> ok end,
 	    reply(Tag, ok);
 	{_From, Tag, which_handlers} ->
 	    reply(Tag, the_handlers(MSL)),
@@ -2088,7 +2088,7 @@ server_call_update(Handler1, Query, SName) ->
 do_terminate(Mod, Handler, Args, State, LastIn, SName, Reason) ->
     case erlang:function_exported(Mod, terminate, 2) of
 	true ->
-	    Res = try
+            Res = try
                       Mod:terminate(Args, State)
                   catch
                       C:R:ST -> catch_result(C, R, ST)

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -1035,9 +1035,9 @@ sync_send_event(Name, Event) ->
         gen:call(Name, '$gen_sync_event', Event)
     of
 	{ok,Res} ->
-	    Res
+            Res
     catch
-	exit:Reason ->
+        exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_event, [Name, Event]}})
     end.
 
@@ -1075,7 +1075,7 @@ sync_send_event(Name, Event, Timeout) ->
         gen:call(Name, '$gen_sync_event', Event, Timeout)
     of
 	{ok,Res} ->
-	    Res
+            Res
     catch
         exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_event, [Name, Event, Timeout]}})
@@ -1124,7 +1124,7 @@ sync_send_all_state_event(Name, Event) ->
         gen:call(Name, '$gen_sync_all_state_event', Event)
     of
 	{ok,Res} ->
-	    Res
+            Res
     catch
         exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_all_state_event, [Name, Event]}})
@@ -1154,7 +1154,7 @@ sync_send_all_state_event(Name, Event, Timeout) ->
         gen:call(Name, '$gen_sync_all_state_event', Event, Timeout)
     of
 	{ok,Res} ->
-	    Res
+            Res
     catch
         exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_all_state_event,
@@ -1667,13 +1667,13 @@ reply(Name, From, Reply, Debug, StateName) ->
 terminate(Reason, Name, From, Msg, Mod, StateName, StateData, Debug) ->
     case erlang:function_exported(Mod, terminate, 3) of
 	true ->
-	    Res = try
+            Res = try
                       Mod:terminate(Reason, StateName, StateData)
                   catch
                       C1:R1:ST1 ->
                           catch_result(C1, R1, ST1)
                   end,
-	    case Res of
+            case Res of
 		{'EXIT', R} ->
 		    FmtStateData = format_status(terminate, Mod, get(), StateData),
 		    error_info(
@@ -2035,13 +2035,13 @@ format_status(Opt, Mod, PDict, State) ->
 		end,
     case erlang:function_exported(Mod, format_status, 2) of
 	true ->
-	    Res = try
+            Res = try
                       Mod:format_status(Opt, [PDict, State])
                   catch
                       C:R:ST ->
                           catch_result(C, R, ST)
                   end,
-	    case Res of
+            case Res of
 		{'EXIT', _} -> DefStatus;
 		Else -> Else
 	    end;

--- a/lib/stdlib/src/gen_fsm.erl
+++ b/lib/stdlib/src/gen_fsm.erl
@@ -359,8 +359,6 @@ that implements the state machine.
 %%%
 %%% ---------------------------------------------------
 
--compile(nowarn_deprecated_catch).
-
 -include("logger.hrl").
 
 -export([start/3, start/4,
@@ -1013,12 +1011,16 @@ to `Module:StateName/2`.
 -spec send_event(FsmRef, Event) -> ok when
       FsmRef :: fsm_ref(),
       Event  :: term().
-send_event({global, Name}, Event) ->
-    catch global:send(Name, {'$gen_event', Event}),
-    ok;
 send_event({via, Mod, Name}, Event) ->
-    catch Mod:send(Name, {'$gen_event', Event}),
-    ok;
+    try
+        Mod:send(Name, {'$gen_event', Event}),
+        ok
+    catch
+        _:_ ->
+            ok
+    end;
+send_event({global, Name}, Event) ->
+    send_event({via, global, Name}, Event);
 send_event(Name, Event) ->
     Name ! {'$gen_event', Event},
     ok.
@@ -1029,10 +1031,13 @@ send_event(Name, Event) ->
       Event  :: term(),
       Reply  :: term().
 sync_send_event(Name, Event) ->
-    case catch gen:call(Name, '$gen_sync_event', Event) of
+    try
+        gen:call(Name, '$gen_sync_event', Event)
+    of
 	{ok,Res} ->
-	    Res;
-	{'EXIT',Reason} ->
+	    Res
+    catch
+	exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_event, [Name, Event]}})
     end.
 
@@ -1066,10 +1071,13 @@ Return value `Reply` is defined in the return value of
       Timeout :: timeout(),
       Reply   :: term().
 sync_send_event(Name, Event, Timeout) ->
-    case catch gen:call(Name, '$gen_sync_event', Event, Timeout) of
+    try
+        gen:call(Name, '$gen_sync_event', Event, Timeout)
+    of
 	{ok,Res} ->
-	    Res;
-	{'EXIT',Reason} ->
+	    Res
+    catch
+        exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_event, [Name, Event, Timeout]}})
     end.
 
@@ -1092,12 +1100,16 @@ in each state name function.
 -spec send_all_state_event(FsmRef, Event) -> ok when
       FsmRef :: fsm_ref(),
       Event :: term().
-send_all_state_event({global, Name}, Event) ->
-    catch global:send(Name, {'$gen_all_state_event', Event}),
-    ok;
 send_all_state_event({via, Mod, Name}, Event) ->
-    catch Mod:send(Name, {'$gen_all_state_event', Event}),
-    ok;
+    try
+        Mod:send(Name, {'$gen_all_state_event', Event}),
+        ok
+    catch
+        _:_ ->
+            ok
+    end;
+send_all_state_event({global, Name}, Event) ->
+    send_all_state_event({via, global, Name}, Event);
 send_all_state_event(Name, Event) ->
     Name ! {'$gen_all_state_event', Event},
     ok.
@@ -1108,10 +1120,13 @@ send_all_state_event(Name, Event) ->
       Event  :: term(),
       Reply  :: term().
 sync_send_all_state_event(Name, Event) ->
-    case catch gen:call(Name, '$gen_sync_all_state_event', Event) of
+    try
+        gen:call(Name, '$gen_sync_all_state_event', Event)
+    of
 	{ok,Res} ->
-	    Res;
-	{'EXIT',Reason} ->
+	    Res
+    catch
+        exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_all_state_event, [Name, Event]}})
     end.
 
@@ -1135,10 +1150,13 @@ and `sync_send_all_state_event`, see `send_all_state_event/2`.
       Timeout :: timeout(),
       Reply   :: term().
 sync_send_all_state_event(Name, Event, Timeout) ->
-    case catch gen:call(Name, '$gen_sync_all_state_event', Event, Timeout) of
+    try
+        gen:call(Name, '$gen_sync_all_state_event', Event, Timeout)
+    of
 	{ok,Res} ->
-	    Res;
-	{'EXIT',Reason} ->
+	    Res
+    catch
+        exit:Reason ->
 	    exit({Reason, {?MODULE, sync_send_all_state_event,
 			   [Name, Event, Timeout]}})
     end.
@@ -1340,7 +1358,13 @@ init_it(Starter, Parent, Name0, Mod, Args, Options) ->
     Name = gen:name(Name0),
     Debug = gen:debug_options(Name, Options),
     HibernateAfterTimeout = gen:hibernate_after(Options),
-    case catch Mod:init(Args) of
+    Res = try
+              Mod:init(Args)
+          catch
+              C:R:ST ->
+                  catch_result(C, R, ST)
+          end,
+    case Res of
 	{ok, StateName, StateData} ->
 	    proc_lib:init_ack(Starter, {ok, self()}),
 	    loop(Parent, Name, StateName, StateData, Mod, infinity, HibernateAfterTimeout, Debug);
@@ -1428,7 +1452,13 @@ system_terminate(Reason, _Parent, Debug,
 -doc false.
 system_code_change([Name, StateName, StateData, Mod, Time, HibernateAfterTimeout],
 		   _Module, OldVsn, Extra) ->
-    case catch Mod:code_change(OldVsn, StateName, StateData, Extra) of
+    Res = try
+              Mod:code_change(OldVsn, StateName, StateData, Extra)
+          catch
+              C:R:ST ->
+                  catch_result(C, R, ST)
+          end,
+    case Res of
 	{ok, NewStateName, NewStateData} ->
 	    {ok, [Name, NewStateName, NewStateData, Mod, Time, HibernateAfterTimeout]};
 	Else -> Else
@@ -1488,7 +1518,13 @@ print_event(Dev, {noreply, StateName}, Name) ->
 
 handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTimeout) -> %No debug here
     From = from(Msg),
-    case catch dispatch(Msg, Mod, StateName, StateData) of
+    Res = try
+              dispatch(Msg, Mod, StateName, StateData)
+          catch
+              C1:R1:ST1 ->
+                  catch_result(C1, R1, ST1)
+          end,
+    case Res of
 	{next_state, NStateName, NStateData} ->
 	    loop(Parent, Name, NStateName, NStateData, Mod, infinity, HibernateAfterTimeout, []);
 	{next_state, NStateName, NStateData, Time1} ->
@@ -1502,8 +1538,13 @@ handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTi
 	{stop, Reason, NStateData} ->
 	    terminate(Reason, Name, From, Msg, Mod, StateName, NStateData, []);
 	{stop, Reason, Reply, NStateData} when From =/= undefined ->
-	    {'EXIT', R} = (catch terminate(Reason, Name, From, Msg, Mod,
-					   StateName, NStateData, [])),
+            {'EXIT', R} = try
+                              terminate(Reason, Name, From, Msg, Mod,
+                                        StateName, NStateData, [])
+                          catch
+                              C2:R2:ST2 ->
+                                  catch_result(C2, R2, ST2)
+                          end,
 	    reply(From, Reply),
 	    exit(R);
         {'EXIT', {undef, [{Mod, handle_info, [_,_,_], _}|_]}} ->
@@ -1525,7 +1566,13 @@ handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTi
 
 handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTimeout, Debug) ->
     From = from(Msg),
-    case catch dispatch(Msg, Mod, StateName, StateData) of
+    Res = try
+              dispatch(Msg, Mod, StateName, StateData)
+          catch
+              C1:R1:ST1 ->
+                  catch_result(C1, R1, ST1)
+          end,
+    case Res of
 	{next_state, NStateName, NStateData} ->
 	    Debug1 = sys:handle_debug(Debug, fun print_event/3,
 				      Name, {noreply, NStateName}),
@@ -1544,8 +1591,13 @@ handle_msg(Msg, Parent, Name, StateName, StateData, Mod, _Time, HibernateAfterTi
 	    terminate(
               Reason, Name, From, Msg, Mod, StateName, NStateData, Debug);
 	{stop, Reason, Reply, NStateData} when From =/= undefined ->
-	    {'EXIT', R} = (catch terminate(Reason, Name, From, Msg, Mod,
-					   StateName, NStateData, Debug)),
+            {'EXIT', R} = try
+                              terminate(Reason, Name, From, Msg, Mod,
+                                        StateName, NStateData, Debug)
+                          catch
+                              C2:R2:ST2 ->
+                                  catch_result(C2, R2, ST2)
+                          end,
 	    _ = reply(Name, From, Reply, Debug, StateName),
 	    exit(R);
 	{'EXIT', What} ->
@@ -1615,7 +1667,13 @@ reply(Name, From, Reply, Debug, StateName) ->
 terminate(Reason, Name, From, Msg, Mod, StateName, StateData, Debug) ->
     case erlang:function_exported(Mod, terminate, 3) of
 	true ->
-	    case catch Mod:terminate(Reason, StateName, StateData) of
+	    Res = try
+                      Mod:terminate(Reason, StateName, StateData)
+                  catch
+                      C1:R1:ST1 ->
+                          catch_result(C1, R1, ST1)
+                  end,
+	    case Res of
 		{'EXIT', R} ->
 		    FmtStateData = format_status(terminate, Mod, get(), StateData),
 		    error_info(
@@ -1977,10 +2035,20 @@ format_status(Opt, Mod, PDict, State) ->
 		end,
     case erlang:function_exported(Mod, format_status, 2) of
 	true ->
-	    case catch Mod:format_status(Opt, [PDict, State]) of
+	    Res = try
+                      Mod:format_status(Opt, [PDict, State])
+                  catch
+                      C:R:ST ->
+                          catch_result(C, R, ST)
+                  end,
+	    case Res of
 		{'EXIT', _} -> DefStatus;
 		Else -> Else
 	    end;
 	_ ->
 	    DefStatus
     end.
+
+catch_result(throw, Throw, _StackTrace) -> Throw;
+catch_result(exit, Reason, _StackTrace) -> {'EXIT', Reason};
+catch_result(error, Reason, StackTrace) -> {'EXIT', {Reason, StackTrace}}.

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -1216,7 +1216,7 @@ call(ServerRef, Request) ->
         gen:call(ServerRef, '$gen_call', Request)
     of
 	{ok,Res} ->
-	    Res
+            Res
     catch
         exit:Reason ->
 	    exit({Reason, {?MODULE, call, [ServerRef, Request]}})
@@ -1299,7 +1299,7 @@ call(ServerRef, Request, Timeout) ->
         gen:call(ServerRef, '$gen_call', Request, Timeout)
     of
 	{ok,Res} ->
-	    Res
+            Res
     catch
         exit:Reason ->
 	    exit({Reason, {?MODULE, call, [ServerRef, Request, Timeout]}})

--- a/lib/stdlib/src/gen_server.erl
+++ b/lib/stdlib/src/gen_server.erl
@@ -184,8 +184,6 @@ using exit signals.
 %%%
 %%% ---------------------------------------------------
 
--compile(nowarn_deprecated_catch).
-
 %% API
 -export([start/3, start/4,
 	 start_link/3, start_link/4,
@@ -1214,10 +1212,13 @@ stop(ServerRef, Reason, Timeout) ->
                   Reply :: term().
 %%
 call(ServerRef, Request) ->
-    case catch gen:call(ServerRef, '$gen_call', Request) of
+    try
+        gen:call(ServerRef, '$gen_call', Request)
+    of
 	{ok,Res} ->
-	    Res;
-	{'EXIT',Reason} ->
+	    Res
+    catch
+        exit:Reason ->
 	    exit({Reason, {?MODULE, call, [ServerRef, Request]}})
     end.
 
@@ -1294,10 +1295,13 @@ and `Reason` can be (at least) one of:
                   Reply :: term().
 %%
 call(ServerRef, Request, Timeout) ->
-    case catch gen:call(ServerRef, '$gen_call', Request, Timeout) of
+    try
+        gen:call(ServerRef, '$gen_call', Request, Timeout)
+    of
 	{ok,Res} ->
-	    Res;
-	{'EXIT',Reason} ->
+	    Res
+    catch
+        exit:Reason ->
 	    exit({Reason, {?MODULE, call, [ServerRef, Request, Timeout]}})
     end.
 
@@ -1806,12 +1810,16 @@ to handle the request.
         Request   :: term()) ->
           ok.
 %%
-cast({global,Name}, Request) ->
-    catch global:send(Name, cast_msg(Request)),
-    ok;
 cast({via, Mod, Name}, Request) ->
-    catch Mod:send(Name, cast_msg(Request)),
-    ok;
+    try
+        Mod:send(Name, cast_msg(Request)),
+        ok
+    catch
+        _:_ ->
+            ok
+    end;
+cast({global, Name}, Request) ->
+    cast({via, global, Name}, Request);
 cast({Name,Node}=Dest, Request) when is_atom(Name), is_atom(Node) ->
     do_cast(Dest, Request);
 cast(Dest, Request) when is_atom(Dest) ->
@@ -2665,9 +2673,20 @@ system_terminate(Reason, _Parent, Debug, [ServerData, State, _Timer, _Hib]) ->
 
 -doc false.
 system_code_change([#server_data{module = Mod} = ServerData, State, Timer, Hib], _Module, OldVsn, Extra) ->
-    case catch Mod:code_change(OldVsn, State, Extra) of
-        {ok, NewState} -> {ok, [ServerData, NewState, Timer, Hib]};
-        Else -> Else
+    try
+        Mod:code_change(OldVsn, State, Extra)
+    of
+        {ok, NewState} ->
+            {ok, [ServerData, NewState, Timer, Hib]};
+        Else ->
+            Else
+    catch
+        throw:{ok, NewState} ->
+            {ok, [ServerData, NewState, Timer, Hib]};
+        throw:Else ->
+            Else;
+        Class:Reason:StackTrace ->
+            {'EXIT', catch_result(Class, Reason, StackTrace)}
     end.
 
 -doc false.


### PR DESCRIPTION
This PR removes all occurrences of the deprecated `catch` in the `gen_server`, `gen_event` and `gen_fsm` modules.