### PR TITLE
erl_lint: add checks for wrongly encoded binary strings

### DIFF
--- a/lib/asn1/test/testInfObjExtract.erl
+++ b/lib/asn1/test/testInfObjExtract.erl
@@ -52,15 +52,15 @@ main(_Rule) ->
 roundtrip_data_object_13(SeqType) ->
     roundtrip(SeqType, {SeqType,1,true}),
     roundtrip(SeqType, {SeqType,2,<<"abc">>}),
-    roundtrip(SeqType, {SeqType,3,<<42:5>>}),
+    roundtrip(SeqType, {SeqType,3,<<10:5>>}),
     roundtrip_error(SeqType, {SeqType,4,42}).
 
 roundtrip_data_object_1(SeqType) ->
     roundtrip(SeqType, {SeqType,1,false}),
     roundtrip(SeqType, {SeqType,1,true}),
-    roundtrip_error(SeqType, {SeqType,1,42}),
+    roundtrip_error(SeqType, {SeqType,1,10}),
     roundtrip_error(SeqType, {SeqType,2,<<"abc">>}),
-    roundtrip_error(SeqType, {SeqType,3,<<42:5>>}),
+    roundtrip_error(SeqType, {SeqType,3,<<10:5>>}),
     roundtrip_error(SeqType, {SeqType,999,42}).
 
 roundtrip(T, V) ->

--- a/lib/asn1/test/testUniqueObjectSets.erl
+++ b/lib/asn1/test/testUniqueObjectSets.erl
@@ -38,7 +38,7 @@ seq_roundtrip(I, D0) ->
     end.
 
 types() ->
-    [{"CHOICE { a INTEGER, b BIT STRING }", {b,<<42:3>>}},
+    [{"CHOICE { a INTEGER, b BIT STRING }", {b,<<2:3>>}},
      {"INTEGER",42},
      {"SEQUENCE {a OCTET STRING}",{'_',<<"abc">>}},
      {"SEQUENCE {b BOOLEAN, ...}",{'_',true}},

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -726,6 +726,21 @@ value are listed.
 - **`nowarn_match_alias_pats`** - Turns off warnings for matches that
     unify constructors, such as the following: `m({a,B} = {Y,Z}) -> . . .`
 
+- **`nowarn_latin1_binary`** - Turns off warnings for binary string segments
+  with characters encoded in Latin-1 rather than UTF-8, such as writing
+  `<<"Motörhead">>` instead of `<<"Motörhead"/utf8>>` or simply `~"Motörhead"`.
+
+- **`nowarn_truncated_character`** - Turns off warnings for truncated
+  characters in binary string segments due to using the default Latin-1
+  encoding, as when writing `<<"空手🙂">>` instead of `<<"空手🙂"/utf8>>` or
+  simply `~"空手🙂"`. Note that truncation causes the resulting string to have
+  seemingly random content; in this example the first version gets encoded as
+  `<<"zKB">>`.
+
+- **`nowarn_truncated_integer`** - Turns off warnings for truncated integers in
+  binary string segments when the integer is outside the specified range of the
+  segment, for example `<<256>>`, `<<150:7>>`, or `<<-130:8/signed>>`
+
 - **`nowarn_export_var_subexpr`** - Turns off warnings for exporting
   variables out of subexpressions.
 

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -1540,14 +1540,14 @@ message_printing(Config) ->
     ] = messages(BadEncErrors),
 
     UTF8File = filename:join(DataDir, "col_utf8.erl"),
-    {ok,_,UTF8Errors} = compile:file(UTF8File, [return]),
+    {ok,_,UTF8Errors} = compile:file(UTF8File, [return,nowarn_latin1_binary]),
     [":5:23: a term is constructed, but never used\n"
      "%    5|     B = <<\"xyzåäö\">>,\t<<\"12345\">>,\n"
      "%     |                      \t^\n\n"
     ] = messages(UTF8Errors),
 
     Latin1File = filename:join(DataDir, "col_lat1.erl"),
-    {ok,_,Latin1Errors} = compile:file(Latin1File, [return]),
+    {ok,_,Latin1Errors} = compile:file(Latin1File, [return,nowarn_latin1_binary]),
     [":6:23: a term is constructed, but never used\n"
      "%    6|     B = <<\"xyzåäö\">>,\t<<\"12345\">>,\n"
      "%     |                      \t^\n\n"

--- a/lib/eunit/test/tlatin.erl
+++ b/lib/eunit/test/tlatin.erl
@@ -1,7 +1,27 @@
-% coding: latin-1
-
+%% coding: latin-1
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2015-2026. All Rights Reserved.
+%% Copyright Richard Carlsson 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
 -module(tlatin).
 
+-compile(nowarn_latin1_binary).
 -include_lib("eunit/include/eunit.hrl").
 
 'foo_ä_test_'() ->

--- a/lib/eunit/test/tutf8.erl
+++ b/lib/eunit/test/tutf8.erl
@@ -1,15 +1,35 @@
 %% coding: utf-8
-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2015-2026. All Rights Reserved.
+%% Copyright Richard Carlsson 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
 -module(tutf8).
 
+-compile(nowarn_latin1_binary).
 -include_lib("eunit/include/eunit.hrl").
 
 'foo_ö_test_'() ->
 	[
-	 {"1ö汉1", fun() -> io:format("1å汉1 ~s ~w",[<<"aö汉">>, 'Zök']), io:format([128,64,255,255]), ?assert("gö汉"=="gö汉") end}
-	 ,{<<"2ö汉2">>, fun() -> io:format("2å汉2 ~s",[<<"bö汉">>]), io:format([128,64]), ?assert("gö汉"=="gö汉") end}
+         {"1ö汉1", fun() -> io:format("1å汉1 ~s ~w",[<<"aö">>, 'Zök']), io:format([128,64,255,255]), ?assert("gö汉"=="gö汉") end}
+         ,{<<"2ö2">>, fun() -> io:format("2å汉2 ~s",[<<"bö">>]), io:format([128,64]), ?assert("gö汉"=="gö汉") end}
 	 ,{<<"3ö汉3"/utf8>>, fun() -> io:format("3å汉3 ~ts",[<<"cö汉"/utf8>>]), io:format([128,64]), ?assert("gö汉"=="gö汉") end}
-	 ,{"1ä汉1", fun() -> io:format("1ä汉1 ~s ~w",[<<"aä汉">>, 'Zbäd']), io:format([128,64,255,255]), ?assert("wå汉"=="wä汉") end}
-	 ,{<<"2ä汉2">>, fun() -> io:format("2ä汉2 ~s",[<<"bä汉">>]), io:format([128,64]), ?assert("wå汉"=="wä汉") end}
+         ,{"1ä汉1", fun() -> io:format("1ä汉1 ~s ~w",[<<"aä">>, 'Zbäd']), io:format([128,64,255,255]), ?assert("wå汉"=="wä汉") end}
+         ,{<<"2ä2">>, fun() -> io:format("2ä汉2 ~s",[<<"bä">>]), io:format([128,64]), ?assert("wå汉"=="wä汉") end}
 	 ,{<<"3ä汉"/utf8>>, fun() -> io:format("3ä汉3 ~ts",[<<"cä汉"/utf8>>]), io:format([128,64]), ?assert("wå汉"=="wä汉") end}
 	].

--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -605,6 +605,38 @@ format_error_1({bad_bitsize,Type}) ->
     {~"bad ~s bit size", [Type]};
 format_error_1(unsized_binary_in_bin_gen_pattern) ->
     ~"binary fields without size are not allowed in patterns of bit string generators";
+format_error_1(latin1_binary) ->
+    ~"""
+     binary string will be Latin-1 encoded.
+     A binary text segment with no /utf8, /utf16, or /utf32 specifier is
+     encoded using 1 byte per character (Latin-1), for historical reasons.
+     You probably only want to do this with characters in the ASCII range (0-127).
+     Characters in the range 128-255 will not be compatible with UTF-8, and codes
+     above 255 cannot be represented at all.
+     Use compile directive 'nowarn_latin1_binary' to suppress this warning
+     if Latin-1 is really what you want; otherwise specify an encoding.
+     Note that `<<"..."/utf8>>` can simply be written `~"..."` since OTP 27.
+     """;
+format_error_1(truncated_character) ->
+    ~"""
+     character code larger than 255 will be truncated.
+     A binary text segment with no /utf8, /utf16, or /utf32 specifier is
+     encoded using 1 byte per character (Latin-1), for historical reasons.
+     Characters with code points above 255 will be truncated to a single byte
+     representing a different character than the one in the source code.
+     You should either specify another encoding or change the characters that
+     are out of range, or you may suppress this warning with compile directive
+     'nowarn_truncated_character'.
+     Note that `<<"..."/utf8>>` can simply be written `~"..."` since OTP 27.
+     """;
+format_error_1({truncated_integer,Int,Bits,Sign}) ->
+    {~"""
+      integer value outside range of binary segment will be truncated.
+      The value ~w cannot be encoded as ~w bits ~tw.
+      Compile directive 'nowarn_truncated_integer' can be used to suppress this
+      warning.
+      """,
+     [Int,Bits,Sign]};
 %% --- behaviours ---
 format_error_1({conflicting_behaviours,{Name,Arity},B,FirstL,FirstB}) ->
     {~"conflicting behaviours -- callback ~tw/~w required by both '~p' and '~p' ~s",
@@ -980,6 +1012,9 @@ bool_options() ->
      {undefined_field,true},
      {unsafe_function,true},
      {possibly_unsafe_function,false},
+     {latin1_binary,true},
+     {truncated_character,true},
+     {truncated_integer,true},
      {native_record_header,true}].
 
 %% is_warn_enabled(Category, St) -> boolean().
@@ -2618,8 +2653,9 @@ bin_element({bin_element,Anno,E,Sz0,Ts}, Vt, {Esvt,St0}, Check) ->
     {Vt1,St1} = Check(E, Vt, St0),
     {Sz1,Vt2,St2} = bit_size(Sz0, Vt, St1, Check),
     {Sz2,Bt,St3} = bit_type(Anno, Sz1, Ts, St2),
-    {_Sz3,St4} = bit_size_check(Anno, Sz2, Bt, St3),
-    {vtmerge([Vt2,Vt1,Esvt]),St4}.
+    {Sz3,St4} = bit_size_check(Anno, Sz2, Bt, St3),
+    St5 = bin_element_check(erl_eval:partial_eval(E), Sz3, Bt, St4),
+    {vtmerge([Vt2,Vt1,Esvt]),St5}.
 
 bit_size(default, _Vt, St, _Check) -> {default,[],St};
 bit_size({atom,_Anno,all}, _Vt, St, _Check) -> {all,[],St};
@@ -2678,6 +2714,29 @@ elemtype_check(Anno, float, _Size, St) ->
     add_warning(Anno, {bad_bitsize,"float"}, St);
 elemtype_check(_Anno, _Type, _Size, St) ->  St.
 
+bin_element_check({string,_,_}, _Bits, #bittype{type=Type}, St0)
+ when Type =:= utf8 ; Type =:= utf16 ; Type =:= utf32 ->
+    St0;
+bin_element_check({string,Anno,List}, _Bits, #bittype{}, St0) ->
+    case lists:any(fun(Char) -> Char > 255 end, List) of
+        true -> maybe_add_warning(Anno, truncated_character, St0);
+        false ->
+            case lists:any(fun(Char) -> Char > 127 end, List) of
+                false -> St0;
+                true -> maybe_add_warning(Anno, latin1_binary, St0)
+            end
+    end;
+bin_element_check({integer,Anno,Int}, Bits, #bittype{type=integer,sign=Sign}, St0) ->
+   case Sign of
+      unsigned when Int < 0; Int >= 1 bsl Bits ->
+          maybe_add_warning(Anno, {truncated_integer,Int,Bits,Sign}, St0);
+      signed when Int >= 1 bsl (Bits-1); -Int > 1 bsl (Bits-1) ->
+          maybe_add_warning(Anno, {truncated_integer,Int,Bits,Sign}, St0);
+      _ ->
+          St0
+    end;
+bin_element_check(_, _, _, St0) ->
+    St0.
 
 %% guard([GuardTest], VarTable, State) ->
 %%      {UsedVarTable,State}

--- a/lib/stdlib/src/qlc_pt.erl
+++ b/lib/stdlib/src/qlc_pt.erl
@@ -2371,9 +2371,8 @@ qcon1(ConstOps) ->
 qcode(E, QCs, Source, Anno, State) ->
     CL = [begin
               Bin = term_to_binary(C, [compressed]),
-              {bin, Anno, [{bin_element, Anno,
-                         {string, Anno, binary_to_list(Bin)},
-                         default, default}]}
+              {bin, Anno, [{bin_element, Anno, {integer, Anno, B}, default, default}
+                           || B <- binary_to_list(Bin)]}
           end || {_,C} <- lists:keysort(1, [{qlc:template_state(),E} |
                                             qcode(QCs, Source, State)])],
     {'fun', Anno, {clauses, [{clause, Anno, [], [], [{tuple, Anno, CL}]}]}}.

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -4162,8 +4162,14 @@ bin_syntax_errors(Config) ->
               t(X) ->
                 {<<X/binary-integer>>,<<X/signed-unsigned-integer>>,
                  <<X/little-big>>,<<X/unit:4-unit:8>>};
-              t(<<_:{A,B}>>) -> ok.
-
+              t(<<_:{A,B}>>) -> ok;
+              t(_) ->
+                {<<\"\\x{aa}\">>,
+                 <<\"\\x{aaa}\">>,
+                 <<0>>,<<-1>>,
+                 <<255>>,<<256>>,
+                 <<32767:15>>,<<32768:15>>,
+                 <<-32768:16/signed>>,<<-32769:16/signed>>}.
               l() ->
                   foo.
 	    ">>,
@@ -4184,8 +4190,14 @@ bin_syntax_errors(Config) ->
 	    [{{1,27},erl_lint,non_integer_bitsize},
              {{4,21},erl_lint,non_integer_bitsize},
              {{7,12},erl_lint,{bad_bitsize,"float"}},
-             {{13,21},erl_lint,non_integer_bitsize}]}}
-	 ],
+             {{13,21},erl_lint,non_integer_bitsize},
+             {{15,20},erl_lint,latin1_binary},
+             {{16,20},erl_lint,truncated_character},
+             {{17,26},erl_lint,{truncated_integer,-1,8,unsigned}},
+             {{18,28},erl_lint,{truncated_integer,256,8,unsigned}},
+             {{19,33},erl_lint,{truncated_integer,32768,15,unsigned}},
+             {{20,41},erl_lint,{truncated_integer,-32769,16,signed}}
+            ]}}],
     [] = run(Config, Ts),
     ok.
 

--- a/lib/stdlib/test/erl_pp_SUITE.erl
+++ b/lib/stdlib/test/erl_pp_SUITE.erl
@@ -1099,13 +1099,13 @@ otp_9147(Config) when is_list(Config) ->
 %% OTP-10302. Unicode characters scanner/parser.
 otp_10302(Config) when is_list(Config) ->
     Ts = [{uni_1,
-           <<"t() -> <<(<<\"abc\\x{aaa}\">>):3/binary>>.">>}
+           <<"t() -> <<(<<\"abc\\x{aaa}\"/utf8>>):3/binary>>.">>}
           ],
     compile(Config, Ts),
     ok = pp_expr(<<"$\\x{aaa}">>),
     ok = pp_expr(<<"\"1\\x{aaa}\"">>),
     ok = pp_expr(<<"<<<<\"hej\">>/binary>>">>),
-    ok = pp_expr(<<"<< <<\"1\\x{aaa}\">>/binary>>">>),
+    ok = pp_expr(<<"<< <<\"1\\x{aaa}\"/utf8>>/binary>>">>),
 
     U = [{encoding,unicode}],
 

--- a/lib/stdlib/test/escript_SUITE_data/unicode1
+++ b/lib/stdlib/test/escript_SUITE_data/unicode1
@@ -1,6 +1,12 @@
 #!/usr/bin/env escript
 %% -*- erlang -*-
-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% %CopyrightEnd%
 -export([main/1]).
 
 main(_) ->

--- a/lib/stdlib/test/escript_SUITE_data/unicode2
+++ b/lib/stdlib/test/escript_SUITE_data/unicode2
@@ -1,7 +1,14 @@
 #!/usr/bin/env escript
 %% -*- erlang -*-
-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% %CopyrightEnd%
 -export([main/1]).
+-compile(nowarn_latin1_binary).
 
 main(_) ->
     ok = io:setopts([{encoding,latin1}]),

--- a/lib/stdlib/test/escript_SUITE_data/unicode3
+++ b/lib/stdlib/test/escript_SUITE_data/unicode3
@@ -1,6 +1,13 @@
 #!/usr/bin/env escript
 %% -*- erlang; coding: latin-1 -*-
-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% %CopyrightEnd%
+-compile(nowarn_latin1_binary).
 -export([main/1]).
 
 main(_) ->

--- a/lib/stdlib/test/escript_SUITE_data/unicode4
+++ b/lib/stdlib/test/escript_SUITE_data/unicode4
@@ -1,6 +1,13 @@
 #!/usr/bin/env escript
 %% -*- erlang; encoding:utf-8 -*-
-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% %CopyrightEnd%
+-compile(nowarn_latin1_binary).
 -export([main/1]).
 
 main(_) ->

--- a/lib/stdlib/test/escript_SUITE_data/unicode5
+++ b/lib/stdlib/test/escript_SUITE_data/unicode5
@@ -1,8 +1,14 @@
 #!/usr/bin/env escript
-%% -*- erlang -*-
+%% -*- erlang; coding: latin-1 -*-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% %CopyrightEnd%
 -export([main/1]).
-%% -*- encoding:latin-1 -*-
-
+-compile(nowarn_latin1_binary).
 main(_) ->
     ok = io:setopts([{encoding,unicode}]),
     Bin1 = <<"örn_Ѐ שלום-שלום+של 日本語">>,

--- a/lib/stdlib/test/escript_SUITE_data/unicode6
+++ b/lib/stdlib/test/escript_SUITE_data/unicode6
@@ -1,8 +1,15 @@
 #!/usr/bin/env escript
-%% -*- erlang -*-
 %%! +pc unicode
+%% -*- erlang; coding: utf-8 -*-
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2025. All Rights Reserved.
+%%
+%% %CopyrightEnd%
 -export([main/1]).
-%% -*- encoding:utf-8 -*-
+-compile(nowarn_latin1_binary).
 
 main(_) ->
     ok = io:setopts([{encoding,unicode}]),


### PR DESCRIPTION
Old code may contain binary strings on the form `<<"Åäö">>` that did not get converted to `<<"Åäö"/utf8>>` when the source file encoding was changed from Latin-1 to UTF-8. This adds a warning for such strings, which may be disabled with `nowarn_latin1_binary` in the odd case that Latin-1 encoding was actually intended.

This also adds a warning for source code literals such as `<<"Hello! 😜">>` (without utf encoding) where code points above 255 would previously get silently truncated to 1 byte per character, which is never a correct or useful result.

As requested, a warning is also provided for truncated integers as in `<<1000>>`.

Note: I chose to change the qlc transform so it no longer formats arbitrary byte sequences as Latin-1 strings, rather than keep the old format and suppress the warning.