### PR TITLE
public_key: Validate OCSP responder certificate validity period

### DIFF
--- a/lib/public_key/src/pubkey_cert.erl
+++ b/lib/public_key/src/pubkey_cert.erl
@@ -47,7 +47,8 @@
          match_name/3,
 	 extensions_list/1,
          cert_auth_key_id/1,
-         time_str_2_gregorian_sec/1
+         time_str_2_gregorian_sec/1,
+         parse_and_check_validity_dates/1
         ]).
 
 %% Generate test data

--- a/lib/public_key/src/pubkey_ocsp.erl
+++ b/lib/public_key/src/pubkey_ocsp.erl
@@ -218,6 +218,17 @@ is_responder_cert({byKey, Key}, #cert{otp = Cert}) ->
 
 is_authorized_responder(CombinedResponderCert = #cert{otp = ResponderCert},
                         IssuerCert, IsTrustedResponderFun) ->
+    case pubkey_cert:parse_and_check_validity_dates(ResponderCert) of
+        ok ->
+            check_responder_authorization(CombinedResponderCert,
+                                          ResponderCert, IssuerCert,
+                                          IsTrustedResponderFun);
+        _ExpiredOrError ->
+            not_authorized_responder
+    end.
+
+check_responder_authorization(CombinedResponderCert, ResponderCert,
+                              IssuerCert, IsTrustedResponderFun) ->
     Case1 =
         %% the CA who issued the certificate in question signed the
         %% response

--- a/lib/public_key/test/pubkey_ocsp_SUITE.erl
+++ b/lib/public_key/test/pubkey_ocsp_SUITE.erl
@@ -107,7 +107,8 @@
 %% Common Test interface functions -----------------------------------
 %%--------------------------------------------------------------------
 all() ->
-    [ocsp_test, designated_responder].
+    [ocsp_test, designated_responder,
+     ocsp_responder_cert_expired, ocsp_responder_cert_not_yet_valid].
 
 groups() ->
     [].
@@ -263,6 +264,44 @@ designated_responder(Config) when is_list(Config) ->
     ok.
 
 %%--------------------------------------------------------------------
+ocsp_responder_cert_expired() ->
+    [{doc, "Verify that an expired responder certificate is rejected. "
+      "RFC 5280 Section 4.1.2.5 requires validity period checking."}].
+ocsp_responder_cert_expired(Config) when is_list(Config) ->
+    {ok, OcspResponse} =
+        pubkey_ocsp:decode_response(?OCSP_RESPONSE_DER),
+    ExpiredCert = set_cert_validity(?ISSUER_CERT,
+                                    {generalTime, "20180101000000Z"},
+                                    {generalTime, "20200101000000Z"}),
+    IsTrustedFun = fun(_) -> true end,
+    {error, ocsp_responder_cert_not_found} =
+        pubkey_ocsp:verify_response(OcspResponse,
+                                    [#cert{otp = ExpiredCert}],
+                                    ?NONCE,
+                                    ?ISSUER_CERT,
+                                    IsTrustedFun),
+    ok.
+
+%%--------------------------------------------------------------------
+ocsp_responder_cert_not_yet_valid() ->
+    [{doc, "Verify that a not-yet-valid responder certificate is rejected. "
+      "RFC 5280 Section 4.1.2.5 requires validity period checking."}].
+ocsp_responder_cert_not_yet_valid(Config) when is_list(Config) ->
+    {ok, OcspResponse} =
+        pubkey_ocsp:decode_response(?OCSP_RESPONSE_DER),
+    FutureCert = set_cert_validity(?ISSUER_CERT,
+                                   {generalTime, "21000101000000Z"},
+                                   {generalTime, "21100101000000Z"}),
+    IsTrustedFun = fun(_) -> true end,
+    {error, ocsp_responder_cert_not_found} =
+        pubkey_ocsp:verify_response(OcspResponse,
+                                    [#cert{otp = FutureCert}],
+                                    ?NONCE,
+                                    ?ISSUER_CERT,
+                                    IsTrustedFun),
+    ok.
+
+%%--------------------------------------------------------------------
 %% Helpers -----------------------------------------------------------
 %%--------------------------------------------------------------------
 
@@ -357,3 +396,9 @@ build_ocsp_response(IssuerName, IssuerKey, NonceExt, SignKey) ->
                 parameters = asn1_NOVALUE},
         signature = Signature,
         certs = asn1_NOVALUE}.
+
+set_cert_validity(OtpCert, NotBefore, NotAfter) ->
+    TBS = OtpCert#'OTPCertificate'.tbsCertificate,
+    NewValidity = #'Validity'{notBefore = NotBefore, notAfter = NotAfter},
+    NewTBS = TBS#'OTPTBSCertificate'{validity = NewValidity},
+    OtpCert#'OTPCertificate'{tbsCertificate = NewTBS}.


### PR DESCRIPTION
public_key: Validate OCSP responder certificate validity period
The OCSP responder certificate's notBefore/notAfter fields were not
checked, allowing expired or not-yet-valid certificates to be accepted
as valid OCSP responders.

Add validity period verification before evaluating responder
authorization (RFC 5280 Section 4.1.2.5, RFC 6960 Section 4.2.2.2).