### PR TITLE
gh: Always build windows on pushes to erlang/otp

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -111,7 +111,7 @@ jobs:
   build-windows:
     name: Build Erlang/OTP (Windows)
     needs: pack
-    if: needs.pack.outputs.build-c-code == 'true'
+    if: needs.pack.outputs.build-c-code == 'true' || (github.event_name == 'push' && github.repository == 'erlang/otp')
     permissions:
       contents: read
       actions:  write


### PR DESCRIPTION
This makes it possible for users and tools to run Erlang on windows for each commit pushed to a branch, not just tagged releases or changes that touch c code.