### PR TITLE
stdlib: Fix update of anon records with a tuple record

### DIFF
--- a/lib/stdlib/src/erl_expand_records.erl
+++ b/lib/stdlib/src/erl_expand_records.erl
@@ -457,8 +457,8 @@ expr({record,_A,Arg0,{_,_}=Id,Updates}, St0) ->
 expr({record,_A,Arg0,[]=Id,Updates}, St0) ->
     Anno = erl_parse:first_anno(Arg0),
     {Arg1,St1} = expr(Arg0, St0),
-    {Es1, St1} = expr_list(Updates, St0),
-    {{record,Anno,Arg1,Id,Es1},St1};
+    {Es1, St2} = expr_list(Updates, St1),
+    {{record,Anno,Arg1,Id,Es1},St2};
 expr({record,Anno0,Arg0,Name,Updates}, St0) when is_atom(Name) ->
     case St0#exprec.rec_mod of
         #{Name := {local, _}} ->

--- a/lib/stdlib/test/erl_expand_records_SUITE.erl
+++ b/lib/stdlib/test/erl_expand_records_SUITE.erl
@@ -42,7 +42,8 @@
          init/1, pattern/1, strict/1, update/1,
 	 otp_5915/1, otp_7931/1, otp_5990/1,
 	 otp_7078/1, maps/1, zlc/1,
-         side_effects/1]).
+         side_effects/1,
+         update_anon_native_record/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -57,7 +58,8 @@ suite() ->
 all() -> 
     [attributes, expr, guard, init,
      pattern, strict, update, maps,
-     side_effects, zlc, {group, tickets}].
+     side_effects, zlc, {group, tickets},
+     update_anon_native_record].
 
 groups() -> 
     [{tickets, [],
@@ -768,6 +770,23 @@ otp_7078(Config) when is_list(Config) ->
       ],
     run(Config, Ts, [strict_record_tests]),
     ok.
+
+update_anon_native_record(Config) when is_list(Config) ->
+
+    Ts = [
+          ~"""
+           -record #nr{x = 0, y = 0}.
+           -record(tup, {a,b}).
+
+           t() ->
+             R0 = #nr{},
+             T0 = #tup{},
+             R0#_{x = (T0#tup.a)},
+             ok.
+           """],
+    run(Config, Ts),
+    ok.
+
 
 id(I) -> I.
 


### PR DESCRIPTION
Before this fix if you had a tuple record operation within a native record anonymous update the compiler would crash.