### PR TITLE
Fair code permission locks

### DIFF
--- a/erts/emulator/beam/code_ix.c
+++ b/erts/emulator/beam/code_ix.c
@@ -52,24 +52,46 @@ struct code_permission {
     erts_mtx_t lock;
 
     Process *owner;
+    void (*aux_func)(void*);
     void *aux_arg;
 
-    int seized;
-    struct code_permission_queue_item {
-        Process *p;
-        void (*aux_func)(void *);
-        void *aux_arg;
+    bool seized;
+    struct code_permission_queue_item *first;
+    struct code_permission_queue_item **tail_p;
 
-        struct code_permission_queue_item *next;
-    } *queue;
+    const erts_aint32_t xstate_handover_flg;
 
 #ifdef ERTS_ENABLE_LOCK_CHECK
     int lc_soft_check;
 #endif
 };
 
-static struct code_permission code_mod_permission;
-static struct code_permission code_stage_permission;
+struct code_permission_queue_item {
+    Process *p;
+    void (*aux_func)(void *);
+    void *aux_arg;
+
+    struct code_permission_queue_item *next;
+};
+
+static struct code_permission code_mod_permission = {
+    .xstate_handover_flg = ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM
+};
+static struct code_permission code_stage_permission = {
+    .xstate_handover_flg = ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM
+};
+
+static void code_permission_init(struct code_permission* perm,
+                                 const char* name)
+{
+    erts_mtx_init(&(perm->lock), name, NIL,
+                  (ERTS_LOCK_FLAGS_PROPERTY_STATIC |
+                   ERTS_LOCK_FLAGS_CATEGORY_GENERIC));
+    perm->seized = false;
+    perm->first = NULL;
+    perm->tail_p = &(perm->first);
+}
+
 
 #ifdef DEBUG
 static erts_tsd_key_t needs_code_barrier;
@@ -85,12 +107,8 @@ void erts_code_ix_init(void)
     erts_atomic32_init_nob(&the_active_code_index, 0);
     erts_atomic32_init_nob(&the_staging_code_index, 0);
 
-    erts_mtx_init(&code_mod_permission.lock,
-        "code_mod_permission", NIL,
-        ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
-    erts_mtx_init(&code_stage_permission.lock,
-        "code_stage_permission", NIL,
-        ERTS_LOCK_FLAGS_PROPERTY_STATIC | ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
+    code_permission_init(&code_mod_permission, "code_mod_permission");
+    code_permission_init(&code_stage_permission, "code_stage_permission");
 
 #ifdef DEBUG
     erts_tsd_key_create(&needs_code_barrier,
@@ -164,31 +182,82 @@ void erts_abort_staging_code_ix(void)
 }
 
 #if defined(DEBUG) || defined(ADDRESS_SANITIZER)
-#    define CWP_DBG_FORCE_TRAP
+/*
+ * To make sure we can handle failed attempts correctly at all call sites,
+ * always force a fail at the first attempt.
+ */
+static bool CWP_DBG_FORCE_TRAP(Process *c_p)
+{
+    if (erts_atomic32_read_nob(&c_p->xstate)
+        & (ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM |
+           ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM)) {
+        // Don't fail when we already got the permission
+        return false;
+    }
+
+    if (!(c_p->flags & F_DBG_FORCED_TRAP)) {
+        c_p->flags |= F_DBG_FORCED_TRAP;
+        return true;
+    } else {
+        // back from forced trap
+        c_p->flags &= ~F_DBG_FORCED_TRAP;
+        return false;
+    }
+}
+#else
+# define CWP_DBG_FORCE_TRAP(P) false
 #endif
 
 #ifdef ERTS_ENABLE_LOCK_CHECK
-static int has_code_permission(struct code_permission *lock);
+static int has_code_permission(struct code_permission *lock, Process *owner);
 #endif
 
-static int try_seize_code_permission(struct code_permission *perm,
-                                     Process* c_p,
-                                     void (*aux_func)(void *),
-                                     void *aux_arg)
+static bool try_seize_code_permission(struct code_permission *perm,
+                                      Process* c_p,
+                                      void (*aux_func)(void *),
+                                      void *aux_arg)
 {
-    int success;
+    bool success;
 
     ASSERT(!!c_p != !!aux_func);
-    ASSERT(!erts_thr_progress_is_blocking()); /* To avoid deadlock */
+    ASSERT(!!aux_arg == !!aux_func);
+    ERTS_LC_ASSERT(!erts_thr_progress_is_blocking()); /* To avoid deadlock */
+
+    if (c_p) {
+        if (erts_atomic32_read_nob(&c_p->xstate) & perm->xstate_handover_flg) {
+            /*
+             * This process already got the permission.
+             * Must have been given to us as waiter.
+             */
+            ASSERT(perm->seized);
+            ASSERT(perm->owner == c_p);
+            ASSERT(!perm->aux_arg && !perm->aux_func);
+            (void) erts_atomic32_read_band_nob(&c_p->xstate,
+                                               ~(perm->xstate_handover_flg));
+            return true;
+        }
+    }
+
 
     erts_mtx_lock(&perm->lock);
-    success = !perm->seized;
 
-    if (success) {
+    if (!perm->seized) {
         perm->owner = c_p;
+        perm->aux_func = aux_func;
         perm->aux_arg = aux_arg;
-        perm->seized = 1;
-    } else { /* Already locked */
+        perm->seized = true;
+        success = true;
+    }
+    else if (aux_func && aux_func == perm->aux_func
+             && aux_arg == perm->aux_arg) {
+        /*
+         * This aux job already got the permission.
+         * Must have been given to us as waiter.
+         */
+        ASSERT(!perm->owner);
+        success = true;
+    }
+    else { /* Locked by someone else */
         struct code_permission_queue_item* qitem;
 
         qitem = erts_alloc(ERTS_ALC_T_CODE_IX_LOCK_Q, sizeof(*qitem));
@@ -206,8 +275,13 @@ static int try_seize_code_permission(struct code_permission *perm,
             qitem->aux_arg = aux_arg;
         }
 
-        qitem->next = perm->queue;
-        perm->queue = qitem;
+        // Link last in wait queue
+        qitem->next = NULL;
+        ASSERT(*(perm->tail_p) == NULL);
+        *(perm->tail_p) = qitem;
+        perm->tail_p = &(qitem->next);
+
+        success = false;
     }
 
     erts_mtx_unlock(&perm->lock);
@@ -215,19 +289,55 @@ static int try_seize_code_permission(struct code_permission *perm,
     return success;
 }
 
-static void release_code_permission(struct code_permission *perm) {
-    ERTS_LC_ASSERT(has_code_permission(perm));
+static void release_code_permission(struct code_permission *perm,
+                                    Process* owner)
+{
+    ERTS_LC_ASSERT(has_code_permission(perm, owner));
 
     erts_mtx_lock(&perm->lock);
 
-    /* Unleash the entire herd */
-    while (perm->queue != NULL) {
-        struct code_permission_queue_item* qitem = perm->queue;
+    perm->seized = false;
+    perm->owner = NULL;
+    perm->aux_func = NULL;
+    perm->aux_arg = NULL;
+#ifdef ERTS_ENABLE_LOCK_CHECK
+    perm->lc_soft_check = 0;
+#endif
+
+    /* Find first eligible waiter */
+    while (perm->first != NULL && !perm->seized) {
+        struct code_permission_queue_item* qitem = perm->first;
+
+        perm->first = qitem->next;
+        if (perm->first == NULL) {
+            perm->tail_p = &(perm->first);
+        }
 
         if (qitem->p) {
             erts_proc_lock(qitem->p, ERTS_PROC_LOCK_STATUS);
 
             if (!ERTS_PROC_IS_EXITING(qitem->p)) {
+                erts_aint32_t xstate;
+
+                /*
+                 * Avoid processes doing potentially long GC.
+                 * Resume them and let them retry after GC is done.
+                 * This can only happen if someone has sent the waiting
+                 * suspended process a GC signal.
+                 */
+                xstate = erts_atomic32_read_nob(&(qitem->p->xstate));
+                while (!(xstate & ERTS_PXSFLG_GC)) {
+                    erts_aint32_t act =
+                        erts_atomic32_cmpxchg_nob(&(qitem->p->xstate),
+                                                  xstate | perm->xstate_handover_flg,
+                                                  xstate);
+                    if (act == xstate) {
+                        perm->seized = true;
+                        perm->owner = qitem->p;
+                        break;
+                    }
+                    xstate = act;
+                }
                 erts_resume(qitem->p, ERTS_PROC_LOCK_STATUS);
             }
 
@@ -236,25 +346,21 @@ static void release_code_permission(struct code_permission *perm) {
         } else { /* aux work */
             ErtsSchedulerData *esdp = erts_get_scheduler_data();
             ASSERT(esdp && esdp->type == ERTS_SCHED_NORMAL);
+            perm->seized = true;
+            perm->aux_func = qitem->aux_func;
+            perm->aux_arg = qitem->aux_arg;
             erts_schedule_misc_aux_work((int) esdp->no,
                                         qitem->aux_func,
                                         qitem->aux_arg);
         }
 
-        perm->queue = qitem->next;
         erts_free(ERTS_ALC_T_CODE_IX_LOCK_Q, qitem);
     }
 
-    perm->owner = NULL;
-    perm->aux_arg = NULL;
-    perm->seized = 0;
-#ifdef ERTS_ENABLE_LOCK_CHECK
-    perm->lc_soft_check = 0;
-#endif
     erts_mtx_unlock(&perm->lock);
 }
 
-int erts_try_seize_code_mod_permission_aux(void (*aux_func)(void *),
+bool erts_try_seize_code_mod_permission_aux(void (*aux_func)(void *),
                                            void *aux_arg)
 {
     ASSERT(aux_func != NULL);
@@ -269,71 +375,51 @@ void erts_lc_soften_code_mod_permission_check(void)
 }
 #endif
 
-int erts_try_seize_code_mod_permission(Process* c_p)
+bool erts_try_seize_code_mod_permission(Process* c_p)
 {
     ASSERT(c_p != NULL);
 
-#ifdef CWP_DBG_FORCE_TRAP
-    if (!(c_p->flags & F_DBG_FORCED_TRAP)) {
-        c_p->flags |= F_DBG_FORCED_TRAP;
-        return 0;
-    } else {
-        /* back from forced trap */
-        c_p->flags &= ~F_DBG_FORCED_TRAP;
-    }
-#endif
+    if (CWP_DBG_FORCE_TRAP(c_p))
+        return false;
 
     return try_seize_code_permission(&code_mod_permission, c_p, NULL, NULL);
 }
 
 void erts_release_code_mod_permission(void)
 {
-    release_code_permission(&code_mod_permission);
+    release_code_permission(&code_mod_permission, NULL);
 }
 
-int erts_try_seize_code_stage_permission(Process* c_p)
+bool erts_try_seize_code_stage_permission(Process* c_p)
 {
     ASSERT(c_p != NULL);
 
-#ifdef CWP_DBG_FORCE_TRAP
-    if (!(c_p->flags & F_DBG_FORCED_TRAP)) {
-        c_p->flags |= F_DBG_FORCED_TRAP;
-        return 0;
-    } else {
-        /* back from forced trap */
-        c_p->flags &= ~F_DBG_FORCED_TRAP;
-    }
-#endif
+    if (CWP_DBG_FORCE_TRAP(c_p))
+        return false;
 
     return try_seize_code_permission(&code_stage_permission, c_p, NULL, NULL);
 }
 
 void erts_release_code_stage_permission(void) {
-    release_code_permission(&code_stage_permission);
+    release_code_permission(&code_stage_permission, NULL);
 }
 
-int erts_try_seize_code_load_permission(Process* c_p) {
+bool erts_try_seize_code_load_permission(Process* c_p) {
     ASSERT(c_p != NULL);
 
-#ifdef CWP_DBG_FORCE_TRAP
-    if (!(c_p->flags & F_DBG_FORCED_TRAP)) {
-        c_p->flags |= F_DBG_FORCED_TRAP;
-        return 0;
-    } else {
-        /* back from forced trap */
-        c_p->flags &= ~F_DBG_FORCED_TRAP;
+    if (CWP_DBG_FORCE_TRAP(c_p)) {
+        return false;
     }
-#endif
 
     if (try_seize_code_permission(&code_stage_permission, c_p, NULL, NULL)) {
         if (try_seize_code_permission(&code_mod_permission, c_p, NULL, NULL)) {
-            return 1;
+            return true;
         }
 
         erts_release_code_stage_permission();
     }
 
-    return 0;
+    return false;
 }
 
 void erts_release_code_load_permission(void) {
@@ -341,10 +427,36 @@ void erts_release_code_load_permission(void) {
     erts_release_code_stage_permission();
 }
 
+void erts_reject_code_permissions(Process *p) {
+    const erts_aint32_t xstate = erts_atomic32_read_nob(&p->xstate);
+
+    ASSERT(erts_atomic32_read_acqb(&p->state)
+           & (ERTS_PSFLG_EXITING | ERTS_PSFLG_GC));
+
+    if (xstate & ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM) {
+        release_code_permission(&code_mod_permission, p);
+        erts_atomic32_read_band_nob(&p->xstate,
+                                    ~ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM);
+    }
+    if (xstate & ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM) {
+        release_code_permission(&code_stage_permission, p);
+        erts_atomic32_read_band_nob(&p->xstate,
+                                    ~ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM);
+    }
+}
+
+
 #ifdef ERTS_ENABLE_LOCK_CHECK
-static int has_code_permission(struct code_permission *perm)
+static int has_code_permission(struct code_permission *perm,
+                               Process *owner)
 {
-    const ErtsSchedulerData *esdp = erts_get_scheduler_data();
+    const ErtsSchedulerData *esdp;
+
+    if (owner) {
+        return perm->seized && perm->owner == owner;
+    }
+
+    esdp = erts_get_scheduler_data();
 
     if (esdp && esdp->type == ERTS_SCHED_NORMAL) {
         int res;
@@ -394,11 +506,11 @@ int erts_has_code_load_permission(void) {
 }
 
 int erts_has_code_stage_permission(void) {
-    return has_code_permission(&code_stage_permission);
+    return has_code_permission(&code_stage_permission, NULL);
 }
 
 int erts_has_code_mod_permission(void) {
-    return has_code_permission(&code_mod_permission);
+    return has_code_permission(&code_mod_permission, NULL);
 }
 #endif
 

--- a/erts/emulator/beam/code_ix.h
+++ b/erts/emulator/beam/code_ix.h
@@ -174,10 +174,10 @@ ErtsCodeIndex erts_staging_code_ix(void);
  * Main process lock (only) must be held.
  * System thread progress must not be blocked.
  * Caller must not already have the code modification or staging permissions.
- * Caller is suspended and *must* yield if 0 is returned. */
-int erts_try_seize_code_load_permission(struct process* c_p);
+ * Caller is suspended and *must* yield if false is returned. */
+bool erts_try_seize_code_load_permission(struct process* c_p);
 
-/** @brief Release code loading permission. Resumes any suspended waiters. */
+/** @brief Release code loading permission. Resumes first suspended waiters. */
 void erts_release_code_load_permission(void);
 
 /** @brief Try to seize exclusive code staging permission. Needed for code
@@ -188,15 +188,20 @@ void erts_release_code_load_permission(void);
  *
  * * Main process lock (only) must be held.
  * * System thread progress must not be blocked.
- * * Caller is suspended and *must* yield if 0 is returned.
  * * Caller must not already have the code modification or staging permissions.
  *   
  *   That is, it is _NOT_ possible to add code modification permission when you
  *   already have staging permission. The other way around is fine however.
+ *
+ * If true is returned, calling BIF must either release before returning or
+ * schedule aux job that will eventually release.
+ *
+ * If false is returned, caller is suspended and *must* schedule itself to
+ * UNCONDITIONALLY call this function again.
  */
-int erts_try_seize_code_stage_permission(struct process* c_p);
+bool erts_try_seize_code_stage_permission(struct process* c_p);
 
-/** @brief Release code stage permission. Resumes any suspended waiters. */
+/** @brief Release code stage permission. Resumes first suspended waiter. */
 void erts_release_code_stage_permission(void);
 
 /** @brief Try to seize exclusive code modification permission. Needed for
@@ -207,11 +212,17 @@ void erts_release_code_stage_permission(void);
  *
  * * Main process lock (only) must be held.
  * * System thread progress must not be blocked.
- * * Caller is suspended and *must* yield if 0 is returned.
  * * Caller must not already have the code modification permission, but may
  *   have staging permission.
+ *
+ * If true is returned, calling BIF must either release before returning
+ * or schedule aux job that will eventually release.
+ *
+ * If false is returned, caller is suspended and *must* schedule itself to
+ * UNCONDITIONALLY call this function again.
+ *
  */
-int erts_try_seize_code_mod_permission(struct process* c_p);
+bool erts_try_seize_code_mod_permission(struct process* c_p);
 
 /** @brief As \c erts_try_seize_code_mod_permission but for aux work.
  *
@@ -220,7 +231,7 @@ int erts_try_seize_code_mod_permission(struct process* c_p);
  * On failure return false and aux work func(arg) will be scheduled when
  * permission is released.
  */
-int erts_try_seize_code_mod_permission_aux(void (*func)(void *),
+bool erts_try_seize_code_mod_permission_aux(void (*func)(void *),
                                            void *arg);
 
 #ifdef ERTS_ENABLE_LOCK_CHECK
@@ -229,9 +240,20 @@ void erts_lc_soften_code_mod_permission_check(void);
 # define erts_lc_soften_code_mod_permission_check() ((void)0)
 #endif
 
-/** @brief Release code modification permission. Resumes any suspended
- * waiters. */
+/** @brief Release code modification permission. Resumes first suspended
+ * waiter.
+ */
 void erts_release_code_mod_permission(void);
+
+/** @brief Reject all code permissions. Resumes first suspended waiters.
+ *         Is called by exiting or garbing process that got permission(s)
+ *         but don't want it. A garbing process should be scheduled to try again
+ *         to seize permission after GC is done.
+ *
+ *  @param c_p[in]      Current process.
+ */
+void erts_reject_code_permissions(struct process* c_p);
+
 
 /* Prepare the "staging area" to be a complete copy of the active code.
  *

--- a/erts/emulator/beam/emu/bif_instrs.tab
+++ b/erts/emulator/beam/emu/bif_instrs.tab
@@ -263,6 +263,9 @@ call_light_bif(Bif, Exp) {
 
     ERTS_CHK_MBUF_SZ(c_p);
     ASSERT(!ERTS_PROC_IS_EXITING(c_p) || is_non_value(result));
+    ASSERT(!(erts_atomic32_read_nob(&c_p->xstate)
+             & (ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM |
+                ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM)));
     ERTS_VERIFY_UNUSED_TEMP_ALLOC(c_p);
     ERTS_HOLE_CHECK(c_p);
     ERTS_REQ_PROC_MAIN_LOCK(c_p);

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -4583,6 +4583,10 @@ BIF_RETTYPE erts_debug_get_internal_state_1(BIF_ALIST_1)
         else if (ERTS_IS_ATOM_STR("debugger_support", BIF_ARG_1)) {
             return erts_debugger_flags & ERTS_DEBUGGER_ENABLED ? am_true : am_false;
         }
+        else if (ERTS_IS_ATOM_STR("dirty_gc_limit", BIF_ARG_1)) {
+            ERTS_CT_ASSERT(ERTS_POTENTIALLY_LONG_GC_HSIZE < MAX_SMALL);
+            return make_small(ERTS_POTENTIALLY_LONG_GC_HSIZE);
+        }
     }
     else if (is_tuple(BIF_ARG_1)) {
 	Eterm* tp = tuple_val(BIF_ARG_1);

--- a/erts/emulator/beam/erl_bif_trace.c
+++ b/erts/emulator/beam/erl_bif_trace.c
@@ -316,28 +316,18 @@ erts_internal_trace_pattern_4(BIF_ALIST_4)
 {
     ErtsTraceSession* session;
 
-    if (!term_to_session(BIF_ARG_1, &session, false)) {
-        goto session_error;
-    }
-
     if (!erts_try_seize_code_mod_permission(BIF_P)) {
-        erts_deref_trace_session(session);
         ERTS_BIF_YIELD4(BIF_TRAP_EXPORT(BIF_erts_internal_trace_pattern_4),
                         BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3, BIF_ARG_4);
     }
 
-    /* Double check liveness with seized code mod permission */
-    if (!erts_is_trace_session_alive(session)) {
+    if (!term_to_session(BIF_ARG_1, &session, false)) {
         erts_release_code_mod_permission();
-        erts_deref_trace_session(session);
-        goto session_error;
+        BIF_P->fvalue = am_session;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
     }
 
     return trace_pattern(BIF_P, session, BIF_ARG_2, BIF_ARG_3, BIF_ARG_4);
-
-session_error:
-    BIF_P->fvalue = am_session;
-    BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
 }
 
 static Eterm
@@ -911,30 +901,21 @@ Eterm erts_internal_trace_4(BIF_ALIST_4)
     ErtsTraceSession* session;
     Eterm ret;
 
-    if (!term_to_session(BIF_ARG_1, &session, false)) {
-        goto session_error;
-    }
     if (!erts_try_seize_code_mod_permission(BIF_P)) {
-        erts_deref_trace_session(session);
         ERTS_BIF_YIELD4(BIF_TRAP_EXPORT(BIF_erts_internal_trace_4),
                         BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3, BIF_ARG_4);
     }
 
-    /* Double check liveness with seized code mod permission */
-    if (!erts_is_trace_session_alive(session)) {
+    if (!term_to_session(BIF_ARG_1, &session, false)) {
         erts_release_code_mod_permission();
-        erts_deref_trace_session(session);
-        goto session_error;
+        BIF_P->fvalue = am_session;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
     }
 
     ret = trace(BIF_P, session, BIF_ARG_2, BIF_ARG_3, BIF_ARG_4);
 
     erts_deref_trace_session(session);
     return ret;
-
-session_error:
-    BIF_P->fvalue = am_session;
-    BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
 }
 
 static
@@ -1298,19 +1279,24 @@ Eterm
 erts_internal_trace_session_destroy_1(BIF_ALIST_1)
 {
     ErtsTraceSession* session;
+
+    if (!erts_try_seize_code_mod_permission(BIF_P)) {
+        ERTS_BIF_YIELD1(BIF_TRAP_EXPORT(BIF_erts_internal_trace_session_destroy_1),
+                        BIF_P, BIF_ARG_1);
+    }
+
     if (!term_to_session(BIF_ARG_1, &session, true)) {
+        erts_release_code_mod_permission();
         BIF_P->fvalue = am_badopt;
         BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
     }
     if (!erts_is_trace_session_alive(session)) {
+        erts_release_code_mod_permission();
         erts_deref_trace_session(session);
         BIF_RET(am_false);
     }
-    if (!erts_try_seize_code_mod_permission(BIF_P)) {
-        erts_deref_trace_session(session);
-        ERTS_BIF_YIELD1(BIF_TRAP_EXPORT(BIF_erts_internal_trace_session_destroy_1),
-                        BIF_P, BIF_ARG_1);
-    }
+
+
     if (erts_atomic_cmpxchg_nob(&session->state,
                                 ERTS_TRACE_SESSION_CLEARING,
                                 ERTS_TRACE_SESSION_ALIVE)
@@ -1423,27 +1409,19 @@ Eterm erts_internal_trace_info_3(BIF_ALIST_3)
     bool to_be_continued = false;
     Eterm ret;
 
-    if (BIF_ARG_1 == am_any) {
-        /* trace:session_info */
-        session = NULL;
-    }
-    else if (!term_to_session(BIF_ARG_1, &session, true)) {
-        goto session_error;
-    }
-
     if (!erts_try_seize_code_mod_permission(BIF_P)) {
-        if (session) {
-            erts_deref_trace_session(session);
-        }
         ERTS_BIF_YIELD3(BIF_TRAP_EXPORT(BIF_erts_internal_trace_info_3),
                         BIF_P, BIF_ARG_1, BIF_ARG_2, BIF_ARG_3);
     }
 
-    /* Double check session liveness with seized code mod permission */
-    if (session && !erts_is_trace_session_alive(session)) {
+    if (BIF_ARG_1 == am_any) {
+        /* trace:session_info */
+        session = NULL;
+    }
+    else if (!term_to_session(BIF_ARG_1, &session, false)) {
         erts_release_code_mod_permission();
-        erts_deref_trace_session(session);
-        goto session_error;
+        BIF_P->fvalue = am_session;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
     }
 
     ret = trace_info(BIF_P, session, BIF_ARG_2, BIF_ARG_3, &to_be_continued);
@@ -1454,10 +1432,6 @@ Eterm erts_internal_trace_info_3(BIF_ALIST_3)
         }
     }
     return ret;
-
-session_error:
-    BIF_P->fvalue = am_session;
-    BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
 }
 
 static

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -715,6 +715,37 @@ check_for_possibly_long_gc(Process *p, Uint ygen_usage)
     }
 }
 
+static void set_proc_state_gc(Process* p, bool is_garbing)
+{
+    /*
+     * Q: Why two GC flags? One in 'state' and one in 'xstate'?
+     *
+     * A: Just code convenience. We needed a GC flag in 'xstate' to be accessed
+     *    atomically together with the HANDOVER_CODE_*_PERM flags. The old one
+     *    in 'state' could be replaced by the new one in 'xstate' but that
+     *    would require refactoring all the places where it's currently read.
+     */
+    if (is_garbing) {
+        const erts_aint32_t old_xstate =
+            erts_atomic32_read_bor_nob(&p->xstate, ERTS_PXSFLG_GC);
+        erts_atomic32_read_bor_nob(&p->state, ERTS_PSFLG_GC);
+
+        if (old_xstate & (ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM |
+                          ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM)) {
+            /*
+             * We don't want to hold code permissions during a potentially
+             * long GC. Process will retry to seize permission(s) after GC is
+             * done. This can only happen with a race between other processes
+             * giving us code permission and sending us GC signal.
+             */
+            erts_reject_code_permissions(p);
+        }
+    }
+    else {
+        erts_atomic32_read_band_nob(&p->xstate, ~ERTS_PXSFLG_GC);
+        erts_atomic32_read_band_nob(&p->state, ~ERTS_PSFLG_GC);
+    }
+}
 
 /*
  * Garbage collect a process.
@@ -768,7 +799,7 @@ garbage_collect(Process* p, ErlHeapFragment *live_hf_end,
 
     ERTS_MSACC_SET_STATE_CACHED(ERTS_MSACC_STATE_GC);
 
-    erts_atomic32_read_bor_nob(&p->state, ERTS_PSFLG_GC);
+    set_proc_state_gc(p, true);
     if (erts_system_monitor_long_gc)
 	start_time = erts_get_monotonic_time(esdp);
 
@@ -849,7 +880,7 @@ do_major_collection:
     delay_gc_after_start:
         /* erts_send_exit_signal looks for ERTS_PSFLG_GC, so
            we have to remove it after the signal is sent */
-        erts_atomic32_read_band_nob(&p->state, ~ERTS_PSFLG_GC);
+        set_proc_state_gc(p, false);
 
         /* We have to make sure that we have space for need on the heap */
         res = delay_garbage_collection(p, need, fcalls);
@@ -864,7 +895,7 @@ do_major_collection:
     ERTS_CHK_OFFHEAP(p);
     ErtsGcQuickSanityCheck(p);
 
-    erts_atomic32_read_band_nob(&p->state, ~ERTS_PSFLG_GC);
+    set_proc_state_gc(p, false);
 
     if (ERTS_IS_P_TRACED_FL(p, F_TRACE_GC)) {
         trace_gc(p, gc_trace_end_tag, reclaimed_now, THE_NON_VALUE);
@@ -1006,7 +1037,7 @@ garbage_collect_hibernate(Process* p, int check_long_gc)
         p->flags = flags;
     }
 
-    erts_atomic32_read_bor_nob(&p->state, ERTS_PSFLG_GC);
+    set_proc_state_gc(p, true);
     ErtsGcQuickSanityCheck(p);
 
     heap_size = p->heap_sz + (p->old_htop - p->old_heap) + p->mbuf_sz;
@@ -1089,7 +1120,7 @@ garbage_collect_hibernate(Process* p, int check_long_gc)
 
     ErtsGcQuickSanityCheck(p);
 
-    erts_atomic32_read_band_nob(&p->state, ~ERTS_PSFLG_GC);
+    set_proc_state_gc(p, false);
 
     return gc_cost(final_size, final_size);
 }
@@ -1182,7 +1213,7 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
     /*
      * Set GC state.
      */
-    erts_atomic32_read_bor_nob(&p->state, ERTS_PSFLG_GC);
+    set_proc_state_gc(p, true);
 
     /*
      * Just did a major collection (which has discarded the old heap),
@@ -1349,7 +1380,7 @@ erts_garbage_collect_literals(Process* p, Eterm* literals,
     /*
      * Restore status.
      */
-    erts_atomic32_read_band_nob(&p->state, ~ERTS_PSFLG_GC);
+    set_proc_state_gc(p, false);
 
     reds += (Sint64) gc_cost((p->htop - p->heap) + byte_lit_size/sizeof(Uint), 0);
 

--- a/erts/emulator/beam/erl_gc.h
+++ b/erts/emulator/beam/erl_gc.h
@@ -23,11 +23,11 @@
 #ifndef __ERL_GC_H__
 #define __ERL_GC_H__
 
+#define ERTS_POTENTIALLY_LONG_GC_HSIZE (128*1024) /* Words */
+
 #if defined(ERL_WANT_GC_INTERNALS__) || defined(ERTS_DO_INCL_GLB_INLINE_FUNC_DEF)
 
 /* GC declarations used by beam/erl_gc.c */
-
-#define ERTS_POTENTIALLY_LONG_GC_HSIZE (128*1024) /* Words */
 
 #include "erl_map.h"
 #include "erl_fun.h"

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -14212,6 +14212,11 @@ erts_do_exit_process(Process* p, Eterm reason)
 
     erts_proc_unlock(p, ERTS_PROC_LOCKS_ALL_MINOR);
 
+    if (erts_atomic32_read_nob(&p->xstate) & (ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM |
+                                              ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM)) {
+        erts_reject_code_permissions(p);
+    }
+
     if (ERTS_IS_P_TRACED_FL(p, F_TRACE_PROCS))
         trace_proc(p, ERTS_PROC_LOCK_MAIN, p, am_exit, reason);
 

--- a/erts/emulator/beam/erl_process.h
+++ b/erts/emulator/beam/erl_process.h
@@ -1404,6 +1404,15 @@ void erts_check_for_holes(Process* p);
 /* MAYBE_SELF_SIGS - We might have outstanding signals
    from ourselves to ourselves. */
 #define ERTS_PXSFLG_MAYBE_SELF_SIGS	(((erts_aint32_t) 1) << 8)
+/* HANDOVER_CODE_MOD_PERM - Waiting process was given the code mod permission
+   but has not yet seized the lock. */
+#define ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM   (((erts_aint32_t) 1) << 9)
+/* HANDOVER_CODE_STAGE_PERM - Waiting process was given the code stage permission
+   but has not yet seized the lock. */
+#define ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM (((erts_aint32_t) 1) << 10)
+/* GC - Process is garbage collecting */
+#define ERTS_PXSFLG_GC			     (((erts_aint32_t) 1) << 11)
+
 
 #define ERTS_PXSFLGS_QMASK 		ERTS_PSFLGS_QMASK
 #define ERTS_PXSFLGS_IN_CPU_PRQ_MASK_OFFSET 0

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -359,6 +359,9 @@ static Eterm debug_call_light_bif(Process *c_p,
     PROCESS_MAIN_CHK_LOCKS(c_p);
     ERTS_REQ_PROC_MAIN_LOCK(c_p);
     ERTS_ASSERT_TRACER_REFS(&c_p->common);
+    ERTS_ASSERT(!(erts_atomic32_read_nob(&c_p->xstate) &
+                  (ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM |
+                   ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM)));
 
     return result;
 }

--- a/erts/emulator/beam/jit/x86/instr_bif.cpp
+++ b/erts/emulator/beam/jit/x86/instr_bif.cpp
@@ -401,6 +401,9 @@ static Eterm debug_call_light_bif(Process *c_p,
     PROCESS_MAIN_CHK_LOCKS(c_p);
     ERTS_REQ_PROC_MAIN_LOCK(c_p);
     ERTS_ASSERT_TRACER_REFS(&c_p->common);
+    ERTS_ASSERT(!(erts_atomic32_read_nob(&c_p->xstate) &
+                  (ERTS_PXSFLG_HANDOVER_CODE_MOD_PERM |
+                   ERTS_PXSFLG_HANDOVER_CODE_STAGE_PERM)));
 
     return result;
 }

--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -146,6 +146,7 @@ MODULES= \
 	erts_test_destructor \
 	crypto_reference \
 	literal_area_collector_test \
+        erts_test_sync_tracer \
         ext_records
 
 NO_OPT= bs_bincomp \

--- a/erts/emulator/test/code_SUITE.erl
+++ b/erts/emulator/test/code_SUITE.erl
@@ -32,6 +32,8 @@
          call_purged_fun_code_altered/1,
          multi_proc_purge/1, t_check_old_code/1,
          many_purges/1,
+         code_permission/1,
+         code_permission_gc/1,
          external_fun/1,get_chunk/1,module_md5/1,
          constant_pools/1,constant_refc_binaries/1,
          fake_literals/1,
@@ -45,6 +47,8 @@
 -define(line_trace, 1).
 -include_lib("common_test/include/ct.hrl").
 
+-compile([nowarn_deprecated_catch]).
+
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
@@ -55,6 +59,8 @@ all() ->
      call_purged_fun_code_altered,
      multi_proc_purge, t_check_old_code, external_fun, get_chunk,
      module_md5, many_purges,
+     code_permission,
+     code_permission_gc,
      constant_pools, constant_refc_binaries, fake_literals,
      false_dependency,
      coverage, fun_confusion, t_copy_literals, t_copy_literals_frags,
@@ -514,6 +520,169 @@ many_purges_test(File, Code, N, I) ->
     io:format("Purge #~p. Load=~p Delete=~p Purge=~p",
               [I, T1-T0, T2-T1, T3-T2]),
     many_purges_test(File, Code, N, I+1).
+
+%% Whitebox unit test for the code_mod_permission lock
+code_permission(_Config) ->
+    Tester = self(),
+    LockerFun = fun() ->
+                        receive lock -> ok end,
+                        true = erts_debug:set_internal_state(code_mod_permission, true),
+                        Tester ! {self(), locked},
+                        receive unlock -> ok end,
+                        true = erts_debug:set_internal_state(code_mod_permission, false),
+                        Tester ! {self(), unlocked}
+                end,
+    Locker1 = spawn_link(LockerFun),
+    {Locker2, MRef2} = spawn_opt(LockerFun,[link,monitor]),
+    {Locker3, MRef3} = spawn_opt(LockerFun,[link,monitor]),
+    Locker4 = spawn_link(LockerFun),
+    Locker5 = spawn_link(LockerFun),
+
+    AllLockers = [Locker1, Locker2, Locker3, Locker4, Locker5],
+    try
+        Locker1 ! lock,
+        {Locker1, locked} = receive_any(),
+
+        Locker2 ! lock,
+        wait_suspended(Locker2),
+        %% Second suspend to prevent it from seizing the permission
+        erlang:suspend_process(Locker2),
+
+        Locker3 ! lock,
+        wait_suspended(Locker3),
+
+        Locker4 ! lock,
+        wait_suspended(Locker4),
+        %% Second suspend to prevent it from seizing the permission
+        erlang:suspend_process(Locker4),
+
+        Locker5 ! lock,
+        wait_suspended(Locker5),
+
+        %% Test killing process waiting in queue
+        unlink(Locker3),
+        exit_signal(Locker3, kill),
+        {'DOWN', MRef3, process, Locker3, killed} = receive_any(),
+
+        Locker1 ! unlock,
+        {Locker1, unlocked} = receive_any(),
+
+        %% Test killing process after lock handover but before getting scheduled
+        unlink(Locker2),
+        exit_signal(Locker2, kill),
+        receive {'DOWN', MRef2, process, Locker2, killed} -> ok end,
+
+        %% Test garbing process after lock handover but before getting scheduled
+        %% It should release its lock and try again after GC.
+        true = erlang:garbage_collect(Locker4),
+        erlang:resume_process(Locker4),
+        {Locker5, locked} = receive_any(),
+        Locker5 ! unlock,
+        {Locker5, unlocked} = receive_any(),
+
+        {Locker4, locked} = receive_any(),
+        Locker4 ! unlock,
+        {Locker4, unlocked} = receive_any(),
+        ok
+    after
+        %% Spam 'unlock' to make sure we don't leave it locked
+        %% before returning back to common_test.
+        [Locker ! unlock || Locker <- AllLockers]
+    end.
+
+wait_suspended(Pid) ->
+    wait_suspended(Pid, 10_000).
+
+wait_suspended(Pid, Timeout) when Timeout > 0 ->
+    Sleep = 10,
+    timer:sleep(Sleep),
+    case process_info(Pid, status) of
+        {status,suspended} ->
+            suspended;
+        {status,_} ->
+            wait_suspended(Pid, Timeout - Sleep)
+    end.
+
+%% Whitebox unit test for the code_mod_permission lock and GC
+code_permission_gc(Config) ->
+    erts_test_sync_tracer:init(Config),
+    Tester = self(),
+    LockerFun = fun() ->
+                         receive lock -> ok end,
+                         true = erts_debug:set_internal_state(code_mod_permission, true),
+                         Tester ! {self(), locked},
+                         receive unlock -> ok end,
+                         true = erts_debug:set_internal_state(code_mod_permission, false),
+                         Tester ! {self(), unlocked}
+                 end,
+    GC_LockerFun = fun() ->
+                           %% Grow heap to make it do dirty GC when asked to
+                           DirtyGCWords = erts_debug:get_internal_state(dirty_gc_limit),
+                           put(data, lists:seq(1,DirtyGCWords div 2)),
+                           erlang:garbage_collect(),
+
+                           Tester ! {self(), ~"heap inflated"},
+                           LockerFun()
+                   end,
+
+    Locker1 = spawn_link(LockerFun),
+    Locker2 = spawn_link(GC_LockerFun),
+    Locker3 = spawn_link(LockerFun),
+
+    %% We want to unlock the code permission while the first in wait queue
+    %% is garbing and verify that it does NOT get the permission but is instead
+    %% given to the next waiter.
+    %% To make this scenario happen we make use of a NIF tracer module
+    %% that blocks inside the GC trace point and waits for a sync
+    %% from another thread.
+    Tracer = {erts_test_sync_tracer, self()},
+    TS = trace:session_create(code_permission_gc, Tracer, []),
+    {Locker2, ~"heap inflated"} = receive_any(),
+    trace:process(TS, Locker2, true, [garbage_collection]),
+
+    AllLockers = [Locker1, Locker2, Locker3],
+    try
+        Locker1 ! lock,
+        {Locker1, locked} = receive_any(),
+
+        Locker2 ! lock,
+        wait_suspended(Locker2),
+
+        Locker3 ! lock,
+        wait_suspended(Locker3),
+
+        erts_test_sync_tracer:set_sync(false),
+        erts_test_sync_tracer:enable_trace(true),
+        async = erlang:garbage_collect(Locker2, [{async, {Locker2, ~"done garbing"}},
+                                                 {type, major}]),
+
+        ok = erts_test_sync_tracer:wait_sync(true, 10_000),
+        erts_test_sync_tracer:enable_trace(false),
+
+        %% Now release lock and verify second in queue Locker3 get it
+        %% and not the garbing Locker2
+
+        Locker1 ! unlock,
+        receive {Locker1, unlocked} -> ok end,
+        receive {Locker3, locked} -> ok end,
+
+        %% Release Locker2 from blocking in GC
+        erts_test_sync_tracer:set_sync(false),
+        {garbage_collect, {Locker2, ~"done garbing"}, true} = receive_any(),
+
+        Locker3 ! unlock,
+        receive {Locker3, unlocked} -> ok end,
+        receive {Locker2, locked} -> ok end,
+        Locker2 ! unlock,
+        {Locker2, unlocked} = receive_any(),
+
+        ok
+    after
+        %% Spam 'unlock' to make sure we don't leave it locked
+        %% before returning back to common_test.
+        [Locker ! unlock || Locker <- AllLockers],
+        trace:session_destroy(TS)
+    end.
 
 external_fun(Config) when is_list(Config) ->
     false = erlang:function_exported(another_code_test, x, 1),
@@ -1441,4 +1610,10 @@ run_sys_proc_test(Test, Config) ->
         {Res1, Res2}
     after
         TestLowOSRL = erlang:system_flag(outstanding_system_requests_limit, OSRL)
+    end.
+
+receive_any() ->
+    receive M -> M
+    after 10_000 ->
+            ct:fail({timeout, receive_any})
     end.

--- a/erts/emulator/test/code_SUITE_data/Makefile.src
+++ b/erts/emulator/test/code_SUITE_data/Makefile.src
@@ -1,0 +1,34 @@
+# %CopyrightBegin%
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright Ericsson AB 2026. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# %CopyrightEnd%
+
+include @erts_lib_make_ethread@
+include @erts_lib_make_internal@
+
+NIF_LIBS = erts_test_sync_tracer@dll@
+
+SHLIB_EXTRA_CFLAGS =  $(ETHR_DEFS) -I@erts_lib_include_internal@ -I@erts_lib_include_internal_generated@
+
+all: $(NIF_LIBS)
+
+WSL=@WSL@
+
+@SHLIB_RULES@
+
+$(NIF_LIBS): erts_test_sync_tracer.c

--- a/erts/emulator/test/code_SUITE_data/erts_test_sync_tracer.c
+++ b/erts/emulator/test/code_SUITE_data/erts_test_sync_tracer.c
@@ -1,0 +1,195 @@
+/*
+ * %CopyrightBegin%
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright Ericsson AB 2026. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * %CopyrightEnd%
+ */
+
+#include <erl_nif.h>
+#include <erl_internal_test.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+
+static ERL_NIF_TERM atom_discard;
+static ERL_NIF_TERM atom_ok;
+static ERL_NIF_TERM atom_trace;
+static ERL_NIF_TERM atom_true;
+static ERL_NIF_TERM atom_false;
+
+#define ASSERT(expr) assert(expr)
+
+static ethr_atomic_t the_trace_enabled; // ERL_NIF_TERM
+static ethr_atomic_t the_sync; // ERL_NIF_TERM
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+{
+
+    atom_discard = enif_make_atom(env, "discard");
+    atom_ok = enif_make_atom(env, "ok");
+    atom_trace = enif_make_atom(env, "trace");
+    atom_true = enif_make_atom(env, "true");
+    atom_false = enif_make_atom(env, "false");
+
+    erts_internal_test.ethr_atomic_init(&the_trace_enabled, atom_discard);
+    erts_internal_test.ethr_atomic_init(&the_sync, atom_ok);
+
+    *priv_data = NULL;
+
+    return 0;
+}
+
+static void unload(ErlNifEnv* env, void* priv_data)
+{
+
+}
+
+static int upgrade(ErlNifEnv* env, void** priv_data, void** old_priv_data,
+                   ERL_NIF_TERM load_info)
+{
+    if (*old_priv_data != NULL) {
+        return -1; /* Don't know how to do that */
+    }
+    if (*priv_data != NULL) {
+        return -1; /* Don't know how to do that */
+    }
+    if (load(env, priv_data, load_info)) {
+        return -1;
+    }
+    return 0;
+}
+
+static ERL_NIF_TERM nifs_loaded(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    return enif_make_atom(env, "true");
+}
+
+static ERL_NIF_TERM enabled(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ASSERT(argc == 3);
+
+    //enif_fprintf(stderr, "erts_test_sync_tracer.enabled(%T, %T, %T)\n",
+    //             argv[0], argv[1], argv[2]);
+
+    return (ERL_NIF_TERM) erts_internal_test.ethr_atomic_read(&the_trace_enabled);
+}
+
+static bool term_to_bool(ERL_NIF_TERM term, bool *res)
+{
+    if (term == atom_true) {
+        *res = true;
+        return true;
+    }
+    else if (term == atom_false) {
+        *res = false;
+        return true;
+    }
+    else {
+        return false;
+    }
+}
+
+static ERL_NIF_TERM enable_trace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    bool is_enabled;
+    if (!term_to_bool(argv[0], &is_enabled)) {
+        return enif_make_badarg(env);
+    }
+    erts_internal_test.ethr_atomic_set(&the_trace_enabled,
+                                       is_enabled ? atom_trace : atom_discard);
+    return atom_ok;
+}
+
+
+static void do_wait_for_sync(ERL_NIF_TERM wait_for)
+{
+    int wait_ms = 10000;
+    ERL_NIF_TERM sync;
+
+    //enif_fprintf(stderr, "Wait for the_sync=%T\n", wait_for);
+    while (wait_ms > 0) {
+        sync = erts_internal_test.ethr_atomic_read(&the_sync);
+        if (sync == wait_for) {
+            //enif_fprintf(stderr, "Got the_sync=%T\n", wait_for);
+            return;
+        }
+        erts_internal_test.erts_milli_sleep(1);
+        wait_ms--;
+        if (wait_ms % 1000 == 0) {
+            //enif_fprintf(stderr, "wait_ms = %d, the_sync=%T\n", wait_ms, sync);
+        }
+    }
+    enif_fprintf(stderr, "Gave up waiting for %T, the_sync=%T\n", wait_for, sync);
+}
+
+static ERL_NIF_TERM trace(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    const ERL_NIF_TERM tracerState = argv[1];
+    ErlNifPid to;
+
+    ASSERT(argc == 5);
+
+    //enif_fprintf(stderr, "erts_test_sync_tracer.trace(%T, %T, %T, %T, %T)\n",
+    //             argv[0], argv[1], argv[2], argv[3], argv[4]);
+
+    if (!enif_get_local_pid(env, tracerState, &to)) {
+        enif_fprintf(stderr, "erts_test_sync_tracer.trace tracerState is not a pid: %T\n",
+                     tracerState);
+        return atom_ok;
+    }
+
+    // Sending a message does not work as it will probably be enqueued
+    // and not sent until we are scheduled out.
+    //enif_send(env, &to, NULL, enif_make_tuple2(env, argv[2], argv[0]));
+
+    erts_internal_test.ethr_atomic_set(&the_sync, atom_true);
+    do_wait_for_sync(atom_false);
+
+    return atom_ok;
+}
+
+static ERL_NIF_TERM set_sync(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    if (!enif_is_atom(env, argv[0])) {
+        return enif_make_badarg(env);
+    }
+    //enif_fprintf(stderr, "Set sync to %T\n", argv[0]);
+    erts_internal_test.ethr_atomic_set(&the_sync, argv[0]);
+    return atom_ok;
+}
+
+static ERL_NIF_TERM get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ERL_NIF_TERM sync = erts_internal_test.ethr_atomic_read(&the_sync);
+    ASSERT(enif_is_atom(env, sync));
+    return sync;
+}
+
+static ErlNifFunc nif_funcs[] = {
+    {"enabled", 3, enabled},
+    {"trace", 5, trace},
+    {"nifs_loaded", 0, nifs_loaded},
+    {"set_sync", 1, set_sync},
+    {"get_sync", 0, get_sync},
+    {"enable_trace", 1, enable_trace}
+};
+
+ERL_NIF_INIT(erts_test_sync_tracer, nif_funcs, load, NULL, upgrade, unload)

--- a/erts/emulator/test/erts_test_sync_tracer.erl
+++ b/erts/emulator/test/erts_test_sync_tracer.erl
@@ -1,0 +1,82 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(erts_test_sync_tracer).
+
+%% A NIF test tracer module to sync threads
+%% at trace points (like GC).
+%% The test case must make sure to run on different threads
+%% otherwise a single thread will block in trace point
+%% waiting for itself.
+
+-export([init/1,
+         enabled/3, trace/5,
+         enable_trace/1,
+         set_sync/1, wait_sync/2]).
+-nifs([nifs_loaded/0,
+       enabled/3, trace/5,
+       enable_trace/1,
+       set_sync/1, get_sync/0]).
+
+init(Config) ->
+    case nifs_loaded() of
+        true ->
+            ok;
+        false ->
+            Data = proplists:get_value(data_dir, Config),
+            NifLib = filename:join(Data, atom_to_list(?MODULE)),
+            ok = erlang:load_nif(NifLib, []),
+            ok
+    end.
+
+nifs_loaded() ->
+    false.
+
+%% Wait for other thread to block at trace point
+wait_sync(Sync, Timeout) ->
+    case {get_sync(), Timeout} of
+        {Sync, _} ->
+            ok;
+        {Other, 0} ->
+            {timeout, Other};
+        {Other, _} ->
+            case Timeout rem 1000 of
+                0 -> erlang:display({"Waiting", Timeout,"for",Sync,"got",Other});
+                _ -> ok
+            end,
+            timer:sleep(1),
+            wait_sync(Sync, Timeout - 1)
+    end.
+
+%% Our own control NIFs
+enable_trace(_) ->
+    erlang:nif_error(~"NIF not loaded").
+set_sync(_Sync) ->
+    erlang:nif_error(~"NIF not loaded").
+get_sync() ->
+    erlang:nif_error(~"NIF not loaded").
+
+%% erl_tracer callback NIFs:
+enabled(_, _, _) ->
+    erlang:nif_error(~"NIF not loaded").
+trace(_, _, _, _, _) ->
+    erlang:nif_error(~"NIF not loaded").

--- a/erts/emulator/test/persistent_term_SUITE_data/erts_test_destructor.c
+++ b/erts/emulator/test/persistent_term_SUITE_data/erts_test_destructor.c
@@ -71,7 +71,7 @@ static void resource_dtor(ErlNifEnv* env, void* obj)
 
     if (p->msg_env) {
         enif_send(env, &p->to, p->msg_env, p->msg);
-        enif_free(p->msg_env);
+        enif_free_env(p->msg_env);
     }
 }
 


### PR DESCRIPTION
Code permission locks are used by Erlang processes to gain exclusive access while loading code, purging code or changing trace settings.

The earlier implementation of these locks used a naive but robust release-the-herd implementation. That have been seen to cause starvation problems with long latencies when massive concurrency is provoked (tprof_SUITE).

This PR implements a fair handover of code permission locks to the first waiting process only. Special care is taken if that waiting process terminates or garbage collects before the BIF is called to confirm the seizing of the lock.