### PR TITLE
SNMP: Add user error callback to SNMP manager

### DIFF
--- a/lib/snmp/doc/snmp_app.md
+++ b/lib/snmp/doc/snmp_app.md
@@ -84,17 +84,18 @@ some of the types are common to both components.
                        {target_cache,     target_cache()}     |
                        {config,           agent_config()}
       manager_options() = [manager_option()]
-      manager_option() = {restart_type,             restart_type()}    |
-                         {net_if,                   manager_net_if()}  |
-                         {server,                   server()}          |
-                         {note_store,               note_store()}      |
-                         {config,                   manager_config()}  |
-                         {inform_request_behaviour, manager_irb()}     |
-                         {mibs,                     manager_mibs()}    |
-                         {priority,                 priority()}        |
-                         {audit_trail_log,          audit_trail_log()} |
-                         {versions,                 versions()}        |
-                         {def_user_mod,             def_user_module()  |
+      manager_option() = {restart_type,             restart_type()}     |
+                         {net_if,                   manager_net_if()}   |
+                         {server,                   server()}           |
+                         {note_store,               note_store()}       |
+                         {config,                   manager_config()}   |
+                         {inform_request_behaviour, manager_irb()}      |
+                         {mibs,                     manager_mibs()}     |
+                         {priority,                 priority()}         |
+                         {audit_trail_log,          audit_trail_log()}  |
+                         {versions,                 versions()}         |
+                         {error_report_mod,         error_report_mod()} |
+                         {def_user_mod,             def_user_module()   |
                          {def_user_data,            def_user_data()}
 ```
 
@@ -594,6 +595,13 @@ Manager specific config options and types:
   `m:snmpm_network_interface_filter` behaviour.
 
   Default is `snmpm_net_if_filter`.
+
+- **`error_report_mod() = atom() <optional>`{: #agent_error_report_mod }** -
+  Defines an error report module, implementing the `m:snmpm_error_report`
+  behaviour. Two modules are provided with the toolkit: `snmpm_error_logger` and
+  `snmpm_error_io`.
+
+  Default is `snmpm_error_logger`.
 
 - **`def_user_module() = atom() <optional>`{: #manager_def_user_module }** - The
   module implementing the default user. See the `m:snmpm_user` behaviour.

--- a/lib/snmp/src/manager/modules.mk
+++ b/lib/snmp/src/manager/modules.mk
@@ -23,6 +23,7 @@
 BEHAVIOUR_MODULES = \
 	snmpm_user \
 	snmpm_user_old \
+	snmpm_error_report \
 	snmpm_network_interface \
 	snmpm_network_interface_filter
 
@@ -30,6 +31,9 @@ MODULES = \
 	snmpm \
 	snmpm_conf \
 	snmpm_config \
+	snmpm_error \
+	snmpm_error_io \
+	snmpm_error_logger \
 	snmpm_mpd \
 	snmpm_misc_sup \
 	snmpm_net_if \

--- a/lib/snmp/src/manager/snmpm_config.erl
+++ b/lib/snmp/src/manager/snmpm_config.erl
@@ -1046,13 +1046,13 @@ init([Opts]) ->
 	ok ->
 	    {ok, #state{}};
 	{error, Reason} ->
-	    error_msg("init error: ~p", [Reason]),
+            config_err("init error: ~p", [Reason]),
 	    {stop, Reason};
 	{'EXIT', Reason} ->
-	    error_msg("init exit: ~p", [Reason]),
+            config_err("init exit: ~p", [Reason]),
 	    {stop, Reason};
 	Error ->
-	    error_msg("init failed: ~p", [Error]),
+            config_err("init failed: ~p", [Error]),
 	    {stop, Error}
     end.
 
@@ -1166,6 +1166,12 @@ do_init(Opts) ->
 	    ets:insert(snmpm_config_table, {audit_trail_log_repair, LogRep}),
 	    ets:insert(snmpm_config_table, {audit_trail_log_seqno,  LogSeqNo})
     end,
+
+    %% -- Error report module callback (optional) --
+    ?vdebug("error report mod", []),
+    ErrorReportMod = get_error_report_mod(Opts),
+    ?vtrace("using ~p as error_report_mod", [ErrorReportMod]),
+    ets:insert(snmpm_config_table, {error_report_mod, ErrorReportMod}),
 
     %% -- System default agent config --
     ?vdebug("system default agent config", []),
@@ -2007,11 +2013,11 @@ init_user_config(User) ->
 		ok ->
 		    ok;
 		{error, Reason} ->
-		    error_msg("failed register user: "
+                    config_err("failed register user: "
 			      "~n~w~n~w", [User, Reason])
 	    end;
 	{error, Reason} ->
-	    error_msg("user config check failed: "
+            config_err("user config check failed: "
 		      "~n~w~n~w", [User, Reason])
     end.
 
@@ -2458,7 +2464,7 @@ read_file(Dir, FileName, Order, Check) ->
     catch
 	throw:{error, Reason} = E:S
 	  when element(1, Reason) =:= failed_open ->
-	    error_msg("failed reading config from ~s: "
+            config_err("failed reading config from ~s: "
                       "~n   ~p", [FileName, Reason]),
 	    erlang:raise(throw, E, S)
     end.
@@ -2940,7 +2946,7 @@ do_handle_register_agent(TargetName, [{Item, Val}|Rest]) ->
 	    {error, Reason}
     end;
 do_handle_register_agent(TargetName, BadConfig) ->
-    error_msg("error during agent registration - bad config: ~n~p", 
+    config_err("error during agent registration - bad config: ~n~p",
 	      [BadConfig]),
     ets:match_delete(snmpm_agent_table, {TargetName, '_'}),
     {error, {bad_agent_config, TargetName, BadConfig}}.
@@ -3518,6 +3524,9 @@ get_atl_repair(Opts) ->
 get_atl_seqno(Opts) ->
     get_opt(seqno, Opts, false).
 
+get_error_report_mod(Opts) ->
+    get_opt(error_report_mod, Opts, snmpm_error_logger).
+
 
 %%----------------------------------------------------------------------
 
@@ -3583,8 +3592,10 @@ info_msg(F, A) ->
 warning_msg(F, A) ->
     ?snmpm_warning("Config server: " ++ F, A).
 
-error_msg(F, A) ->
-    ?snmpm_error("Config server: " ++ F, A).
+user_err(F, A) ->
+    snmpm_error:user_err("Config server: " ++ F, A).
+config_err(F, A) ->
+    snmpm_error:config_err("Config server: " ++ F, A).
 
 %% p(F) ->
 %%     p(F, []).

--- a/lib/snmp/src/manager/snmpm_error.erl
+++ b/lib/snmp/src/manager/snmpm_error.erl
@@ -1,0 +1,79 @@
+-module(snmpm_error).
+-moduledoc """
+Functions for Reporting SNMP Errors
+
+[](){: #desc }
+
+The module `snmpm_error` contains two callback functions which are called if an
+error occurs at different times during manager operation. These functions in turn
+calls the corresponding function in the configured error report module, which
+implements the actual report functionality.
+
+Two simple implementation(s) is provided with the toolkit; the modules
+`m:snmpm_error_logger` which is the default and `m:snmpm_error_io`.
+
+The error report module is configured using the directive `error_report_mod`,
+see [configuration parameters](snmp_config.md#configuration_params).
+""".
+
+-behavior(snmpm_error_report).
+
+-export([user_err/2, config_err/2]).
+
+
+%%-----------------------------------------------------------------
+%% This function is called when there is an error in a user
+%% supplied item, e.g. instrumentation function.
+%%-----------------------------------------------------------------
+
+-doc """
+The function is called if a user related error occurs at run-time, for example
+if a user defined instrumentation function returns erroneous.
+
+`Format` and `Args` are as in `io:format(Format, Args)`.
+
+""".
+
+-spec user_err(Format, Args) -> snmp:void() when
+      Format :: string(),
+      Args   :: list().
+
+user_err(Format, Args) ->
+    report_err(user_err, Format, Args).
+
+%%-----------------------------------------------------------------
+%% This function is called when there is a configuration error,
+%% either at startup (in a conf-file) or at run-time (e.g. when
+%% information in the configuration tables are inconsistent.)
+%%-----------------------------------------------------------------
+
+-doc """
+The function is called if an error occurs during the configuration phase, for
+example if a syntax error is found in a configuration file.
+
+`Format` and `Args` are as in `io:format(Format, Args)`.
+
+""".
+
+-spec config_err(Format, Args) -> snmp:void() when
+      Format :: string(),
+      Args   :: list().
+
+config_err(Format, Args) ->
+    report_err(config_err, Format, Args).
+
+report_err(Func, Format, Args) ->
+    case report_module() of
+        {ok, Mod} ->
+            try Mod:Func(Format, Args)
+            catch _:_ -> ok
+            end;
+        _ -> ok
+    end.
+
+report_module() ->
+    try ets:lookup(snmpm_config_table, error_report_mod) of
+        [{error_report_mod, Mod}] -> {ok, Mod}
+    catch
+        _:_:_ -> error
+    end.

--- a/lib/snmp/src/manager/snmpm_error_io.erl
+++ b/lib/snmp/src/manager/snmpm_error_io.erl
@@ -1,0 +1,59 @@
+-module(snmpm_error_io).
+-moduledoc """
+Functions for Reporting SNMP Errors on stdio
+
+The module `snmpm_error_io` implements the `snmpm_error_report` behaviour (see
+`m:snmpm_error_report`) containing two callback functions which are called in
+order to report SNMP errors.
+
+This module provides a simple mechanism for reporting SNMP errors. Errors are
+written to stdout using the `io` module. It is provided as an simple example.
+
+This module needs to be explicitly configured, see
+[snmpm_error](`m:snmpm_error#desc`) and
+[configuration parameters](snmp_config.md#configuration_params).
+""".
+
+-behavior(snmpm_error_report).
+
+-export([user_err/2, config_err/2]).
+
+%%-----------------------------------------------------------------
+%% This function is called when there is an error in a user
+%% supplied item, e.g. instrumentation function.
+%%-----------------------------------------------------------------
+
+-doc """
+The function is called if a user related error occurs at run-time, for example
+if a user defined instrumentation function returns erroneous.
+
+`Format` and `Args` are as in `io:format(Format, Args)`.
+""".
+-spec user_err(Format, Args) -> snmp:void() when
+      Format :: string(),
+      Args   :: list().
+
+user_err(Format, Args) ->
+    error_msg("User error", Format, Args).
+
+%%-----------------------------------------------------------------
+%% This function is called when there is a configuration error,
+%% either at startup (in a conf-file) or at run-time (e.g. when
+%% information in the configuration tables are inconsistent.)
+%%-----------------------------------------------------------------
+
+-doc """
+The function is called if an error occurs during the configuration phase, for
+example if a syntax error is found in a configuration file.
+
+`Format` and `Args` are as in `io:format(Format, Args)`.
+""".
+-spec config_err(Format, Args) -> snmp:void() when
+      Format :: string(),
+      Args   :: list().
+
+config_err(Format, Args) ->
+    error_msg("Configuration error", Format, Args).
+
+error_msg(P, F, A) ->
+    io:format("*** SNMP ~s *** ~n" ++ F ++ "~n", [P|A]).

--- a/lib/snmp/src/manager/snmpm_error_logger.erl
+++ b/lib/snmp/src/manager/snmpm_error_logger.erl
@@ -1,0 +1,93 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 1996-2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(snmpm_error_logger).
+-moduledoc """
+Functions for Reporting SNMP Errors through the error_logger
+
+The module `snmpm_error_logger` implements the `snmpm_error_report` behaviour
+(see `m:snmpm_error_report`) containing two callback functions which are called
+in order to report SNMP errors.
+
+This module provides a simple mechanism for reporting SNMP errors. Errors are
+sent to the `error_logger` after a size check. Messages are truncated after 1024
+chars. It is provided as an example.
+
+This module is the default error report module, but can be explicitly
+configured, see [snmpm_error](`m:snmpm_error#desc`) and
+[configuration parameters](snmp_config.md#configuration_params).
+
+## See Also
+
+`m:logger#desc`
+""".
+
+-behaviour(snmpm_error_report).
+
+
+%%%-----------------------------------------------------------------
+%%% Implements different error mechanisms.
+%%%-----------------------------------------------------------------
+-export([user_err/2, config_err/2]).
+
+
+%%-----------------------------------------------------------------
+%% This function is called when there is an error in a user
+%% supplied item, e.g. instrumentation function.
+%%-----------------------------------------------------------------
+
+-doc """
+The function is called if a user related error occurs at run-time, for example
+if a user defined instrumentation function returns erroneous.
+
+`Format` and `Args` are as in `io:format(Format, Args)`.
+""".
+-spec user_err(Format, Args) -> snmp:void() when
+      Format :: string(),
+      Args   :: list().
+
+user_err(F, A) ->
+    error_msg("** User error: ", F, A).
+
+
+%%-----------------------------------------------------------------
+%% This function is called when there is a configuration error,
+%% either at startup (in a conf-file) or at run-time (e.g. when
+%% information in the configuration tables are inconsistent.)
+%%-----------------------------------------------------------------
+
+-doc """
+The function is called if an error occurs during the configuration phase, for
+example if a syntax error is found in a configuration file.
+
+`Format` and `Args` are as in `io:format(Format, Args)`.
+""".
+-spec config_err(Format, Args) -> snmp:void() when
+      Format :: string(),
+      Args   :: list().
+
+config_err(F, A) ->
+    error_msg("** Configuration error: ", F, A).
+
+
+error_msg(P, F, A) ->
+    S = snmp_misc:format(1024, lists:concat([P, F, "\n"]), A),
+    logger:error("~s", [S]).

--- a/lib/snmp/src/manager/snmpm_error_report.erl
+++ b/lib/snmp/src/manager/snmpm_error_report.erl
@@ -1,0 +1,7 @@
+-module(snmpm_error_report).
+
+-callback config_err(Format, Args) -> snmp:void()
+    when Format :: string(), Args :: [term()].
+
+-callback user_err(Format, Args) -> snmp:void()
+    when Format :: string(), Args :: [term()].

--- a/lib/snmp/src/manager/snmpm_mpd.erl
+++ b/lib/snmp/src/manager/snmpm_mpd.erl
@@ -1241,10 +1241,7 @@ discard(Reason, Report) ->
     throw({discarded, Reason, Report}).
 
 user_err(F, A) ->
-    error_msg("USER ERROR: " ++ F ++ "~n", A).
+    snmpm_error:user_err("USER ERROR: " ++ F ++ "~n", A).
 
 config_err(F, A) ->
-    error_msg("CONFIG ERROR: " ++ F ++ "~n", A).
-
-error_msg(F, A) ->
-    ?snmpm_error("MPD: " ++ F, A).
+    snmpm_error:config_err("CONFIG ERROR: " ++ F ++ "~n", A).

--- a/lib/snmp/src/manager/snmpm_net_if.erl
+++ b/lib/snmp/src/manager/snmpm_net_if.erl
@@ -432,8 +432,8 @@ common_socket_opts(Opts) ->
              ESO when is_list(ESO) ->
                  ESO;
              BadESO ->
-                 error_msg("Invalid 'extra socket options' (=> ignored):"
-                           "~n   ~p", [BadESO]),
+                 config_err("Invalid 'extra socket options' (=> ignored):"
+                            "~n   ~p", [BadESO]),
                  []
          end].
 
@@ -701,16 +701,16 @@ handle_info(Info, State) ->
 handle_udp_error(#transport{socket = Socket}, Error) ->
     try inet:sockname(Socket) of
         {ok, {IP, Port}} ->
-            error_msg("UDP Error for transport: "
+            user_err("UDP Error for transport: "
                       "~n      Socket: ~p (~p, ~p)"
                       "~n      Error:  ~p", [Socket, IP, Port, Error]);
         {error, _} ->
-            error_msg("UDP Error for transport: "
+            user_err("UDP Error for transport: "
                       "~n      Socket: ~p"
                       "~n      Error:  ~p", [Socket, Error])
     catch
         _:_:_ ->
-            error_msg("UDP Error for transport: "
+            user_err("UDP Error for transport: "
                       "~n      Socket: ~p"
                       "~n      Error:  ~p", [Socket, Error])
     end.
@@ -861,7 +861,7 @@ handle_recv_msg(
 	    Pid ! {snmp_error, ErrorInfo, Domain, Addr};
 
 	Error ->
-	    error_msg("processing of received message failed: "
+            user_err("processing of received message failed: "
 		      "~n   ~p", [Error])
     end.
 
@@ -1104,11 +1104,10 @@ maybe_udp_send(
 	_ ->
 	    case select_transport_from_domain(Domain, Transports) of
 		false ->
-		    error_msg(
-		      "Can not find transport~n"
-			"   size:   ~p~n"
-		      "   to:     ~s",
-		      [sz(Msg), format_address(To)]);
+                    user_err("Can not find transport~n"
+                             "   size:   ~p~n"
+                             "   to:     ~s",
+                             [sz(Msg), format_address(To)]);
 		#transport{socket = Socket} ->
 		    udp_send(Socket, Addr, Msg)
 	    end
@@ -1128,13 +1127,13 @@ udp_send(Sock, To, Msg) ->
 		    [sz(Msg), IpAddr, IpPort, Sock]),
 	    ok;
 	{error, Reason} ->
-	    error_msg("failed sending message to ~p:~p:~n"
-		      "   ~p",[IpAddr, IpPort, Reason])
+            user_err("failed sending message to ~p:~p:~n"
+                     "   ~p",[IpAddr, IpPort, Reason])
     catch
 	error:E:S ->
-	    error_msg("failed sending message to ~p:~p:"
-		      "~n   ~p"
-		      "~n   ~p", [IpAddr, IpPort, E, S])
+            user_err("failed sending message to ~p:~p:"
+                     "~n   ~p"
+                     "~n   ~p", [IpAddr, IpPort, E, S])
     end.
 
 sz(B) when is_binary(B) ->
@@ -1154,13 +1153,13 @@ handle_disk_log(_Log, {truncated, NoLostItems}, State) ->
 	  [NoLostItems]),
     State;
 handle_disk_log(_Log, full, State) ->
-    error_msg("Failed to write to Audit Trail Log (full)", []),
+    user_err("Failed to write to Audit Trail Log (full)", []),
     State;
 handle_disk_log(_Log, {error_status, ok}, State) ->
     State;
 handle_disk_log(_Log, {error_status, {error, Reason}}, State) ->
-    error_msg("Error status received from Audit Trail Log: "
-	      "~n~p", [Reason]),
+    user_err("Error status received from Audit Trail Log: "
+             "~n~p", [Reason]),
     State;
 handle_disk_log(_Log, _Info, State) ->
     State.
@@ -1302,9 +1301,10 @@ maybe_process_extra_info(_ExtraInfo) ->
 warning_msg(F, A) ->
     ?snmpm_warning("NET-IF server: " ++ F, A).
 
-error_msg(F, A) ->
-    ?snmpm_error("NET-IF server: " ++ F, A).
-
+user_err(F, A) ->
+    snmpm_error:user_err("NET-IF server: " ++ F, A).
+config_err(F, A) ->
+    snmpm_error:config_err("NET-IF server: " ++ F, A).
 
 
 %%%-------------------------------------------------------------------

--- a/lib/snmp/src/manager/snmpm_server.erl
+++ b/lib/snmp/src/manager/snmpm_server.erl
@@ -1347,9 +1347,9 @@ handle_snmp_error(#pdu{request_id = ReqId} = Pdu, Reason, State) ->
 					 DefData, State),
 			    maybe_delete(Disco, ReqId);
 			_ ->
-			    error_msg("failed retrieving the default user "
-				      "info handling error [~w]: "
-				      "~n~w", [ReqId, Reason])
+                            user_err("failed retrieving the default user "
+                                                 "info handling error [~w]: "
+                                                 "~n~w", [ReqId, Reason])
 		    end
 	    end;
 
@@ -1395,16 +1395,16 @@ handle_snmp_error(#pdu{request_id = ReqId} = Pdu, Reason, State) ->
 		    handle_error(DefUserId, DefMod, Reason, 
 				 ReqId, DefData, State);
 		_ ->
-		    error_msg("failed retrieving the default "
-			      "user info handling error [~w]: "
-			      "~n~w",[ReqId, Reason])
+                    user_err("failed retrieving the default "
+                                         "user info handling error [~w]: "
+                                         "~n~w",[ReqId, Reason])
 	    end
     end;
 
 handle_snmp_error(CrapError, Reason, _State) ->
-    error_msg("received crap (snmp) error =>"
-	      "~n   ~p"
-              "~n   ~p", [CrapError, Reason]),
+    user_err("received crap (snmp) error =>"
+                         "~n   ~p"
+                         "~n   ~p", [CrapError, Reason]),
     ok.
 
 handle_snmp_error(Domain, Addr, ReqId, Reason, State) ->
@@ -1427,10 +1427,10 @@ handle_snmp_error(Domain, Addr, ReqId, Reason, State) ->
 			    handle_error(DefUserId, DefMod, Reason, 
 					 ReqId, DefData, State);
 			_Error2 ->
-			    error_msg("failed retrieving the default user "
-				      "info handling snmp error "
-				      "<~p,~p>: ~n~w~n~w",
-				      [Domain, Addr, ReqId, Reason])
+                            user_err("failed retrieving the default user "
+                                                 "info handling snmp error "
+                                                 "<~p,~p>: ~n~w~n~w",
+                                                 [Domain, Addr, ReqId, Reason])
 		    end
 	    end;
 	_Error3 ->
@@ -1439,10 +1439,10 @@ handle_snmp_error(Domain, Addr, ReqId, Reason, State) ->
 		    handle_error(DefUserId, DefMod, Reason, 
 				 ReqId, DefData, State);
 		_Error4 ->
-		    error_msg("failed retrieving the default user "
-			      "info handling snmp error "
-			      "<~p,~p>: ~n~w~n~w",
-			      [Domain, Addr, ReqId, Reason])
+                    user_err("failed retrieving the default user "
+                                         "info handling snmp error "
+                                         "<~p,~p>: ~n~w~n~w",
+                                         [Domain, Addr, ReqId, Reason])
 	    end
     end.
 
@@ -1521,10 +1521,10 @@ handle_snmp_pdu(#pdu{type = 'get-response', request_id = ReqId} = Pdu,
 			      ReqId, SnmpResponse, DefData, State),
 			    maybe_delete(Disco, ReqId);
 			Error ->
-			    error_msg("failed retrieving the default user "
-				      "info handling pdu from "
-				      "~p <~p,~p>: ~n~w~n~w",
-				      [Target, Domain, Addr, Error, Pdu])
+                            user_err("failed retrieving the default user "
+                                                 "info handling pdu from "
+                                                 "~p <~p,~p>: ~n~w~n~w",
+                                                 [Target, Domain, Addr, Error, Pdu])
 		    end
 	    end;
 
@@ -1599,11 +1599,11 @@ handle_snmp_pdu(#pdu{type = 'get-response', request_id = ReqId} = Pdu,
 				    handle_error(DefUserId, DefMod, Reason, 
 						 ReqId, DefData, State);
 				Error ->
-				    error_msg("failed retrieving the default "
-					      "user info handling (old) "
-					      "pdu from "
-					      "<~p,~p>: ~n~w~n~w",
-					      [Domain, Addr, Error, Pdu])
+                                    user_err("failed retrieving the default "
+                                                         "user info handling (old) "
+                                                         "pdu from "
+                                                         "<~p,~p>: ~n~w~n~w",
+                                                         [Domain, Addr, Error, Pdu])
 			    end
 		    end;
 
@@ -1626,19 +1626,19 @@ handle_snmp_pdu(#pdu{type = 'get-response', request_id = ReqId} = Pdu,
 			      pdu, ignore,
 			      SnmpInfo, DefData, State);
 			Error ->
-			    error_msg("failed retrieving the default user "
-				      "info handling (old) pdu when no user "
-				      "found from "
-				      "<~p,~p>: ~n~w~n~w",
-				      [Domain, Addr, Error, Pdu])
+                            user_err("failed retrieving the default user "
+                                                 "info handling (old) pdu when no user "
+                                                 "found from "
+                                                 "<~p,~p>: ~n~w~n~w",
+                                                 [Domain, Addr, Error, Pdu])
 		    end
 	    end
     end;
 
 
 handle_snmp_pdu(CrapPdu, Domain, Addr, _State) ->
-    error_msg("received crap (snmp) Pdu from ~w:~w =>"
-	      "~p", [Domain, Addr, CrapPdu]),
+    user_err("received crap (snmp) Pdu from ~w:~w =>"
+                         "~p", [Domain, Addr, CrapPdu]),
     ok.
 
 
@@ -1720,10 +1720,10 @@ do_handle_agent(DefUserId, DefMod,
 		ok ->
 		    ok;
 		{error, Reason} ->
-		    error_msg("failed registering agent - "
-			      "handling agent "
-			      "~p <~p,~p>: ~n~w", 
-			      [TargetName, Domain, Addr, Reason]),
+                    user_err("failed registering agent - "
+                                         "handling agent "
+                                         "~p <~p,~p>: ~n~w",
+                                         [TargetName, Domain, Addr, Reason]),
 		    ok
 	    end;
 	
@@ -1756,10 +1756,10 @@ do_handle_agent(DefUserId, DefMod,
 			ok ->
 			    ok;
 			{error, Reason} ->
-			    error_msg("failed registering agent - "
-				      "handling agent "
-				      "~p <~p,~p>: ~n~w", 
-				      [TargetName, Domain, Addr, Reason]),
+                            user_err("failed registering agent - "
+                                                 "handling agent "
+                                                 "~p <~p,~p>: ~n~w",
+                                                 [TargetName, Domain, Addr, Reason]),
 			    ok
 		    end;
 		{register, UserId2, TargetName, Config} ->  
@@ -1777,10 +1777,10 @@ do_handle_agent(DefUserId, DefMod,
 			ok ->
 			    ok;
 			{error, Reason} ->
-			    error_msg("failed registering agent - "
-				      "handling agent "
-				      "~p <~p,~p>: ~n~w", 
-				      [TargetName, Domain, Addr, Reason]),
+                            user_err("failed registering agent - "
+                                                 "handling agent "
+                                                 "~p <~p,~p>: ~n~w",
+                                                 [TargetName, Domain, Addr, Reason]),
 			    ok
 		    end;
 		_Ignore ->
@@ -1822,10 +1822,10 @@ do_handle_agent(DefUserId, DefMod,
 		      SnmpTrapInfo, DefData, State);
 
 		_ ->
-		    error_msg(
-		      "failed delivering ~w info to default user - "
-		      "regarding agent "
-		      "<~p,~p>: ~n~w", [Type, Domain, Addr, SnmpInfo])
+                    user_err(
+                      "failed delivering ~w info to default user - "
+                      "regarding agent "
+                      "<~p,~p>: ~n~w", [Type, Domain, Addr, SnmpInfo])
 	    end;
 	
 	C:E:S ->
@@ -1879,8 +1879,8 @@ handle_snmp_trap(#pdu{error_status = EStatus,
     do_handle_snmp_trap(SnmpTrapInfo, Domain, Addr, State);
 
 handle_snmp_trap(CrapTrap, Domain, Addr, _State) ->
-    error_msg("received crap (snmp) trap from ~w:~w =>"
-	      "~p", [Domain, Addr, CrapTrap]),
+    user_err("received crap (snmp) trap from ~w:~w =>"
+                         "~p", [Domain, Addr, CrapTrap]),
     ok.
 
 do_handle_snmp_trap(SnmpTrapInfo, Domain, Addr, State) ->
@@ -1910,12 +1910,12 @@ do_handle_snmp_trap(SnmpTrapInfo, Domain, Addr, State) ->
 				      trap, ignore, 
 				      SnmpTrapInfo, DefData, State);
 				Error2 ->
-				    error_msg(
-				      "failed retrieving the default "
-				      "user info handling report from "
-				      "~p <~p,~p>: ~n~w~n~w",
-				      [Target, Domain, Addr,
-				       Error2, SnmpTrapInfo])
+                                    user_err(
+                                      "failed retrieving the default "
+                                      "user info handling report from "
+                                      "~p <~p,~p>: ~n~w~n~w",
+                                      [Target, Domain, Addr,
+                                       Error2, SnmpTrapInfo])
 			    end;
 			Error3 ->
 			    %% Failed unregister agent, 
@@ -1949,12 +1949,12 @@ do_handle_snmp_trap(SnmpTrapInfo, Domain, Addr, State) ->
 		      trap, ignore, 
 		      SnmpTrapInfo, DefData, State);
 		Error5 ->
-		    error_msg(
-		      "failed retrieving "
-		      "the default user info, handling trap from <~p,~p>:"
+                    user_err(
+                      "failed retrieving "
+                      "the default user info, handling trap from <~p,~p>:"
                       "~n      Error:     ~p"
                       "~n      Trap Info: ~p",
-		      [Domain, Addr, Error5, SnmpTrapInfo])
+                      [Domain, Addr, Error5, SnmpTrapInfo])
 	    end
     end,
     ok.
@@ -2002,10 +2002,10 @@ do_handle_trap(
 		ok ->
 		    ok;
 		{error, Reason} ->
-		    error_msg("failed registering agent "
-			      "handling trap "
-			      "<~p,~p>: ~n~w", 
-			      [Domain, Addr, Reason]),
+                    user_err("failed registering agent "
+                                         "handling trap "
+                                         "<~p,~p>: ~n~w",
+                                         [Domain, Addr, Reason]),
 		    ok
 	    end;
 	{register, UserId2, Target2, Config} -> 
@@ -2020,10 +2020,10 @@ do_handle_trap(
 		ok ->
 		    reply;
 		{error, Reason} ->
-		    error_msg("failed registering agent "
-			      "handling trap "
-			      "~p <~p,~p>: ~n~w", 
-			      [Target2, Domain, Addr, Reason]),
+                    user_err("failed registering agent "
+                                         "handling trap "
+                                         "~p <~p,~p>: ~n~w",
+                                         [Target2, Domain, Addr, Reason]),
 		    reply
 	    end;
 	unregister ->
@@ -2032,10 +2032,10 @@ do_handle_trap(
 		ok ->
 		    ok;
 		{error, Reason} ->
-		    error_msg("failed unregistering agent "
-			      "handling trap "
-			      "<~p,~p>: ~n~w", 
-			      [Domain, Addr, Reason]),
+                    user_err("failed unregistering agent "
+                                         "handling trap "
+                                         "<~p,~p>: ~n~w",
+                                         [Domain, Addr, Reason]),
 		    ok
 	    end;	    
 	ignore ->
@@ -2092,11 +2092,11 @@ handle_snmp_inform(
 				      inform, Ref, 
 				      SnmpInform, DefData, State);
 				Error2 ->
-				    error_msg("failed retrieving the default "
-					      "user info handling inform from "
-					      "~p <~p,~p>: ~n~w~n~w",
-					      [Target, Domain, Addr,
-					       Error2, Pdu])
+                                    user_err("failed retrieving the default "
+                                                         "user info handling inform from "
+                                                         "~p <~p,~p>: ~n~w~n~w",
+                                                         [Target, Domain, Addr,
+                                                          Error2, Pdu])
 			    end;
 			Error3 ->
 			    %% Failed unregister agent, 
@@ -2123,17 +2123,17 @@ handle_snmp_inform(
 		      inform, Ref, 
 		      SnmpInform, DefData, State);
 		Error5 ->
-		    error_msg("failed retrieving "
-			      "the default user info handling inform from "
-			      "<~p,~p>: ~n~w~n~w",
-			      [Domain, Addr, Error5, Pdu])
+                    user_err("failed retrieving "
+                                         "the default user info handling inform from "
+                                         "<~p,~p>: ~n~w~n~w",
+                                         [Domain, Addr, Error5, Pdu])
 	    end
     end,
     ok;
 
 handle_snmp_inform(_Ref, CrapInform, Domain, Addr, _State) ->
-    error_msg("received crap (snmp) inform from ~w:~w =>"
-	      "~p", [Domain, Addr, CrapInform]),
+    user_err("received crap (snmp) inform from ~w:~w =>"
+                         "~p", [Domain, Addr, CrapInform]),
     ok.
 
 handle_inform(
@@ -2183,10 +2183,10 @@ do_handle_inform(
 		    ok ->
 			reply;
 		    {error, Reason} ->
-			error_msg("failed registering agent "
-				  "handling inform "
-				  "~p <~p,~p>: ~n~w", 
-				  [Target2, Domain, Addr, Reason]),
+                        user_err("failed registering agent "
+                                             "handling inform "
+                                             "~p <~p,~p>: ~n~w",
+                                             [Target2, Domain, Addr, Reason]),
 			reply
 		end;
 
@@ -2202,10 +2202,10 @@ do_handle_inform(
 		    ok ->
 			reply;
 		    {error, Reason} ->
-			error_msg("failed registering agent "
-				  "handling inform "
-				  "~p <~p,~p>: ~n~w", 
-				  [Target2, Domain, Addr, Reason]),
+                        user_err("failed registering agent "
+                                             "handling inform "
+                                             "~p <~p,~p>: ~n~w",
+                                             [Target2, Domain, Addr, Reason]),
 			reply
 		end;
 
@@ -2216,10 +2216,10 @@ do_handle_inform(
 		    ok ->
 			reply;
 		    {error, Reason} ->
-			error_msg("failed unregistering agent "
-				  "handling inform "
-				  "<~p,~p>: ~n~w", 
-				  [Domain, Addr, Reason]),
+                        user_err("failed unregistering agent "
+                                             "handling inform "
+                                             "<~p,~p>: ~n~w",
+                                             [Domain, Addr, Reason]),
 			reply
 		end;	    
 
@@ -2297,11 +2297,11 @@ handle_snmp_report(
 						 SnmpReport, DefData, State);
 				
 				Error2 ->
-				    error_msg("failed retrieving the default "
-					      "user info handling report from "
-					      "~p <~p,~p>: ~n~w~n~w",
-					      [Target, Domain, Addr,
-					       Error2, Pdu])
+                                    user_err("failed retrieving the default "
+                                                         "user info handling report from "
+                                                         "~p <~p,~p>: ~n~w~n~w",
+                                                         [Target, Domain, Addr,
+                                                          Error2, Pdu])
 			    end;
 			Error3 ->
 			    %% Failed unregister agent, 
@@ -2327,17 +2327,17 @@ handle_snmp_report(
 				 report, ignore, 
 				 SnmpReport, DefData, State);
 		Error5 ->
-		    error_msg("failed retrieving "
-			      "the default user info handling report from "
-			      "<~p,~p>: ~n~w~n~w",
-			      [Domain, Addr, Error5, Pdu])
+                    user_err("failed retrieving "
+                                         "the default user info handling report from "
+                                         "<~p,~p>: ~n~w~n~w",
+                                         [Domain, Addr, Error5, Pdu])
 	    end
     end,
     ok;
 
 handle_snmp_report(CrapReport, Domain, Addr, _State) ->
-    error_msg("received crap (snmp) report from ~w:~w =>"
-	      "~p", [Domain, Addr, CrapReport]),
+    user_err("received crap (snmp) report from ~w:~w =>"
+                         "~p", [Domain, Addr, CrapReport]),
     ok.
 
 %% This could be from a failed get-request, so we might have a user
@@ -2423,12 +2423,12 @@ handle_snmp_report(
 				    handle_error(DefUserId, DefMod, Reason, 
 						 ReqId, DefData, State);
 				Error ->
-				    error_msg("failed retrieving the "
-					      "default user "
-					      "info handling report from "
-					      "<~p,~p>: ~n~w~n~w~n~w",
-					      [Domain, Addr, Error,
-					       ReqId, Reason])
+                                    user_err("failed retrieving the "
+                                                         "default user "
+                                                         "info handling report from "
+                                                         "<~p,~p>: ~n~w~n~w~n~w",
+                                                         [Domain, Addr, Error,
+                                                          ReqId, Reason])
 			    end
 		    end;
 		Error ->
@@ -2441,18 +2441,18 @@ handle_snmp_report(
 			    handle_error(DefUserId, DefMod, Reason, ReqId, 
 					 DefData, State);
 			Error ->
-			    error_msg("failed retrieving "
-				      "the default user info handling "
-				      "report from "
-				      "<~p,~p>: ~n~w~n~w~n~w",
-				      [Domain, Addr, Error, ReqId, Reason])
+                            user_err("failed retrieving "
+                                                 "the default user info handling "
+                                                 "report from "
+                                                 "<~p,~p>: ~n~w~n~w~n~w",
+                                                 [Domain, Addr, Error, ReqId, Reason])
 		    end
 	    end
     end,
     ok;
 
 handle_snmp_report(CrapReqId, CrapReport, CrapInfo, Domain, Addr, _State) ->
-    error_msg(
+    user_err(
       "received crap (snmp) report from ~w:~w =>"
       "~n~p~n~p~n~p",
       [Domain, Addr, CrapReqId, CrapReport, CrapInfo]),
@@ -2502,10 +2502,10 @@ do_handle_report(
 		ok ->
 		    ok;
 		{error, Reason} ->
-		    error_msg("failed registering agent "
-			      "handling report "
-			      "<~p,~p>: ~n~w",
-			      [Domain, Addr, Reason]),
+                    user_err("failed registering agent "
+                                         "handling report "
+                                         "<~p,~p>: ~n~w",
+                                         [Domain, Addr, Reason]),
 		    ok
 	    end;
 
@@ -2521,10 +2521,10 @@ do_handle_report(
 		ok ->
 		    reply;
 		{error, Reason} ->
-		    error_msg("failed registering agent "
-			      "handling report "
-			      "~p <~p,~p>: ~n~w", 
-			      [Target2, Domain, Addr, Reason]),
+                    user_err("failed registering agent "
+                                         "handling report "
+                                         "~p <~p,~p>: ~n~w",
+                                         [Target2, Domain, Addr, Reason]),
 		    reply
 	    end;
 
@@ -2534,10 +2534,10 @@ do_handle_report(
 		ok ->
 		    ok;
 		{error, Reason} ->
-		    error_msg("failed unregistering agent "
-			      "handling report "
-			      "<~p,~p>: ~n~w", 
-			      [Domain, Addr, Reason]),
+                    user_err("failed unregistering agent "
+                                         "handling report "
+                                         "<~p,~p>: ~n~w",
+                                         [Domain, Addr, Reason]),
 		    ok
 	    end;	    
 
@@ -2769,20 +2769,20 @@ cbp_f(F, A) ->
 %%----------------------------------------------------------------------
 
 handle_invalid_result(Func, Args, C, E, S) ->
-    error_msg("Callback function failed: "
-	      "~n   Function:    ~p"
-	      "~n   Args:        ~p"
-	      "~n   Error Class: ~p"
-	      "~n   Error:       ~p"
-	      "~n   Stacktrace:  ~p", 
-	      [Func, Args, C, E, S]). 
+    user_err("Callback function failed: "
+                         "~n   Function:    ~p"
+                         "~n   Args:        ~p"
+                         "~n   Error Class: ~p"
+                         "~n   Error:       ~p"
+                         "~n   Stacktrace:  ~p",
+                         [Func, Args, C, E, S]).
 
 handle_invalid_result(Func, Args, InvalidResult) ->
-    error_msg("Callback function returned invalid result: "
-	      "~n   Function:       ~p"
-	      "~n   Args:           ~p"
-	      "~n   Invalid result: ~p", 
-	      [Func, Args, InvalidResult]).
+    user_err("Callback function returned invalid result: "
+                         "~n   Function:       ~p"
+                         "~n   Args:           ~p"
+                         "~n   Invalid result: ~p",
+                         [Func, Args, InvalidResult]).
 
 
 handle_netif_down(#state{note_store = NoteStore, 
@@ -3593,9 +3593,6 @@ warning_msg(F) ->
 warning_msg(F, A) ->
     ?snmpm_warning("Server: " ++ F, A).
 
-error_msg(F, A) ->
-    ?snmpm_error("Server: " ++ F, A).
- 
 
 %%----------------------------------------------------------------------
 
@@ -3690,3 +3687,8 @@ note_store_info(Pid) ->
 
 us() ->
     erlang:monotonic_time(micro_seconds).
+
+user_err(F, S) ->
+    snmpm_error:user_err(F, S).
+config_err(F, S) ->
+    snmpm_error:config_err(F, S).


### PR DESCRIPTION
Introduce a configurable error reporting mechanism for the SNMP manager, mirroring the pattern used in the SNMP agent.

Add the snmpm_error_report behaviour defining user_err/2 and config_err/2 callbacks, along with a dispatcher module (snmpm_error) and two implementations: snmpm_error_logger (default) and snmpm_error_io.

Add the 'error_report_mod' manager configuration option to select the error report module at startup.

Refactor snmpm_config, snmpm_net_if, snmpm_mpd, and snmpm_server to route error reports through the new callback system instead of calling the ?snmpm_error macro directly.