### PR TITLE
otp: fix GH CI OpenVEX generation

### DIFF
--- a/.github/scripts/create-openvex-pr.sh
+++ b/.github/scripts/create-openvex-pr.sh
@@ -20,6 +20,7 @@
 ##
 ## %CopyrightEnd%
 
+set -e   # exit immediately if any command fails
 
 REPO=$1
 BRANCH_NAME=$2
@@ -45,7 +46,6 @@ if [ "$PR_STATUS" = "CLOSED" ] || [ "$PR_STATUS" = "MERGED" ] || [ "$FOUND_PR" -
   gh pr create --repo "$REPO" -B master \
                --title "Automatic update of OpenVEX Statements for erlang/otp" \
                --body "Automatic Action. There is a vulnerability from GH Advisories without a matching OpenVEX statement"
-  exit 0
 else
   echo "❌ Pull request #$BRANCH_NAME is OPEN. Create a PR once the PR is closed or merged."
   exit 0

--- a/.github/workflows/openvex-sync.yml
+++ b/.github/workflows/openvex-sync.yml
@@ -67,6 +67,12 @@ jobs:
         run: |
           echo "${STEPS_APP_TOKEN_OUTPUTS_TOKEN}" | gh auth login --with-token
 
+      # register `gh` as git credential helper => git push in otp-compliance
+      # uses the token from `gh`. otherwise, `persist-credentials` should not be `false`.
+      # changing `persist-credentials` is not a good option
+      - name: Configure git to use gh as credential helper
+        run: gh auth setup-git
+
       - name: Get GitHub App User ID
         id: get-user-id
         env:


### PR DESCRIPTION
Fixes the automatic generation of OpenVEX statements for reported Erlang/OTP vulnerabilities.

The issue was that when we added `persist-credentials: false` as follows, the scripts that execute lost the token and could not push to the remote.

```
- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6.0.2
  with:
    ref: 'master' # '' = default branch
    persist-credentials: false
```
