### PR TITLE
Improve default seed to spread out the entropy over all 3 words

### DIFF
--- a/lib/stdlib/src/rand.erl
+++ b/lib/stdlib/src/rand.erl
@@ -1006,9 +1006,19 @@ seed_s(Alg_or_State) ->
     end.
 
 default_seed() ->
-    {erlang:phash2([{node(),self()}]),
-     erlang:system_time(),
-     erlang:unique_integer()}.
+    %% The purpose of this seed is that it shall be different
+    %% for different calls in a cluster even if they coincide in time.
+    %% High entropy is hard to find and not a primary goal.
+    %%
+    %% Luckily self() in external term format contains the node name
+    %% so the seed will differ between nodes as well as between processes.
+    %% unique_integer makes the seed differ between calls.  system_time
+    %% gives some more entropy.  MD5 is used to spread out the entropy
+    %% over all 3 seed integers.
+    %%
+    SeedTerm = {self(), erlang:unique_integer(), erlang:system_time()},
+    <<A:43, B:43, C:42>> = erlang:md5(term_to_binary(SeedTerm)),
+    {A, B, C}.
 
 %% seed/2: seeds RNG with the algorithm and given values
 %% and returns the NEW state.


### PR DESCRIPTION
This fixes a spuriously failing test case for the `exro928ss` generator in the `rand` module, namely `rand_SUITE:seed/1`, on Windows.

The reason for these spurious failures stems from that the default seed is the 3 integers `{erlang:phash2([{node(),self()]), erlang:system_time(), erlang:unique_integer()}`.

For the `exro928ss` generator this makes the two first state words the same if the system time is the same for two calls.  The third seed word and all subsequent will differ, though.

The test case in question tests that two successive seeds does not give the same random number sequence.  But that is tested by simply checking if the first random value is the same.  And for the `exro928ss` generator it is the second state word that determines the first generated number, so the first number will be the same (but not subsequent numbers).

The test case could be refined to check more numbers, but this PR does a hopefully better fix, which is to use MD5 to spread out the entropy of the same 3 values over all seed words.  So even if it is just `erlang:unique_integer()` that differs between two seeds, about half of the bits in all seed words should differ.

This should minimize the probability to get the same value in any generator state word for any two default seeds.
