### PR TITLE
Narrow definition of the code:debug_call() type

### DIFF
--- a/lib/kernel/src/code.erl
+++ b/lib/kernel/src/code.erl
@@ -437,7 +437,7 @@ common reasons.
 -nominal debug_value() :: {debug_name(), debug_source()}.
 -nominal debug_atom_or_var() :: atom() | debug_var().
 -nominal debug_call() :: MFA :: {debug_atom_or_var(), debug_atom_or_var(), arity()}
-                       | FA :: {debug_atom_or_var(), arity()}
+                       | FA :: {atom(), arity()}
                        | debug_var().
 -nominal debug_info() :: [{debug_line(), #{frame_size => debug_frame(),
                                            vars => [debug_value()],


### PR DESCRIPTION
When a debugger uses `code:get_debug_info()` it gets back, for each line, what function-calls occur, as a list of `debug_call()`. These can be remote (MFA triple), local (FA tuple), or just a program variable for the case `F(...)`.

For MFA triples, both `M` and `F` can be an atom (when statically known) or a program variable.

With the current definition, for FA tuples, `F` is also designed as "either an atom or a program variable", but this is too wide, as `F` can only be an `atom` in this case; the dynamic case is already covered by the plain variable.

So we restrict the local FA case to be just a tuple `{atom(), arity()}`.