### PR TITLE
erl_interface: Fix stack overflow in ei_s_print_term

### DIFF
--- a/lib/erl_interface/src/misc/ei_printterm.c
+++ b/lib/erl_interface/src/misc/ei_printterm.c
@@ -58,12 +58,15 @@ static void xputc(char c, FILE* fp, ei_x_buff* x)
 	ei_x_append_buf(x, &c, 1);
 }
 
-static void xputs(const char* s, FILE* fp, ei_x_buff* x)
+static int xputs(const char* s, FILE* fp, ei_x_buff* x)
 {
+    const int slen = strlen(s);
+
     if (fp != NULL)
 	fputs(s, fp);
     else
-	ei_x_append_buf(x, s, strlen(s));
+        ei_x_append_buf(x, s, slen);
+    return slen;
 }
 
 static int xprintf(FILE* fp, ei_x_buff* x, const char* fmt, ...)
@@ -74,9 +77,9 @@ static int xprintf(FILE* fp, ei_x_buff* x, const char* fmt, ...)
     if (fp != NULL) {
 	r = vfprintf(fp, fmt, ap);
     } else {
-	/* FIXME always enough in buffer??? */
+        /* We assume output is reasonable bounded */
 	char tmpbuf[2000];
-	r = vsprintf(tmpbuf, fmt, ap);
+        r = vsnprintf(tmpbuf, sizeof(tmpbuf), fmt, ap);
 	ei_x_append_buf(x, tmpbuf, strlen(tmpbuf));
     }
     va_end(ap);
@@ -353,7 +356,7 @@ static int print_term(FILE* fp, ei_x_buff* x,
                 goto err;
             }
             
-            ch_written += xprintf(fp, x, ds);
+            ch_written += xputs(ds, fp, x);
             free(ds);
             ei_free_big(b);
             

--- a/lib/erl_interface/test/ei_print_SUITE_data/ei_print_test.c
+++ b/lib/erl_interface/test/ei_print_SUITE_data/ei_print_test.c
@@ -31,11 +31,12 @@
 static void
 send_printed_buf(ei_x_buff* x)
 {
-    char* b = NULL;
     char fn[256];
     char *tmp = getenv("temp");
-    FILE* f;
-    int n, index = 0, ver;
+    FILE* f = NULL;
+    int n, n_s, index = 0, index_s, ver;
+    char* f_buf = NULL;
+    char* s_buf = NULL;
 
     if (tmp == NULL) {
         tmp = "/tmp";
@@ -44,22 +45,40 @@ send_printed_buf(ei_x_buff* x)
     strcat(fn, "/ei_print_test.txt");
     f = fopen(fn, "w+");
     ei_decode_version(x->buff, &index, &ver);
+    index_s = index;
     n = ei_print_term(f, x->buff, &index);
-    if (n < 0) {
-        fclose(f);
-        x->index = 0;
-        ei_x_format(x, "~s", "ERROR: term decoding failed");
-        send_bin_term(x);
-    } else {
+    n_s = ei_s_print_term(&s_buf, x->buff, &index_s);
+    x->index = 0;
+    if (n != n_s) {
+        ei_x_format(x, "{~s,~i,~i}",
+                    "ERROR: ei_print_term return values differ",
+                    n, n_s);
+    }
+    else if (n < 0) {
+        ei_x_format(x, "{~s,~i}", "ERROR: term decoding failed", n);
+    }
+    else {
         fseek(f, 0, SEEK_SET);
-        b = malloc(n+1);
-        fread(b, 1, n, f);
-        b[n] = '\0';
+        f_buf = malloc(n+1);
+        fread(f_buf, 1, n, f);
+        f_buf[n] = '\0';
+        if (strcmp(f_buf, s_buf) != 0) {
+            ei_x_format(x, "{~s,~s,~s}", "ERROR: ei_print_term results differ", f_buf, s_buf);
+        }
+        else {
+            ei_x_format(x, "~s", f_buf);
+        }
+    }
+    send_bin_term(x);
+
+    if (f) {
         fclose(f);
-        x->index = 0;
-        ei_x_format(x, "~s", b);
-        send_bin_term(x);
-        free(b);
+    }
+    if (f_buf) {
+        free(f_buf);
+    }
+    if (s_buf) {
+        free(s_buf);
     }
 }
 


### PR DESCRIPTION
Printing very big integer terms (> 2000 hexadecimal digits long) with `ei_s_print_term` caused stack overflow. The overflowing bytes are restricted to the ASCII values of 0-9 and A-F, which limits exploitation for code execution beyond DoS.

The friend function `ei_print_term`, which prints directly to a FILE instead of memory, does not contain this bug.