### PR TITLE
syntax tools: Fix crash when name of a native record is macro

### DIFF
--- a/lib/syntax_tools/src/erl_syntax.erl
+++ b/lib/syntax_tools/src/erl_syntax.erl
@@ -8075,8 +8075,8 @@ subtrees(T) ->
                      [record_access_field(T)]];
 		record_expr ->
 		    Type = case type(record_expr_type(T)) of
-			       atom -> [record_expr_type(T)];
-			       list -> list_elements(record_expr_type(T))
+                               list -> list_elements(record_expr_type(T));
+                               _ -> [record_expr_type(T)]
 			   end,
 		    case record_expr_argument(T) of
 			none ->

--- a/lib/syntax_tools/test/syntax_tools_SUITE.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE.erl
@@ -42,6 +42,7 @@
          wrapped_subtrees/1,
          t_abstract_type/1,t_erl_parse_type/1,t_type/1,
          t_epp_dodger/1,t_epp_dodger_clever/1,
+         gh11155/1,
          t_comment_scan/1,t_prettypr/1,test_named_fun_bind_ann/1,
          test_maybe_expr_ann/1,test_mc_ann/1,test_zip_ann/1,
          is_literal/1]).
@@ -53,7 +54,7 @@ all() ->
      revert_preserve_pos_changes,
      wrapped_subtrees,
      t_abstract_type,t_erl_parse_type,t_type,
-     t_epp_dodger,t_epp_dodger_clever,
+     t_epp_dodger,t_epp_dodger_clever,gh11155,
      t_comment_scan,t_prettypr,test_named_fun_bind_ann,
      test_maybe_expr_ann,test_mc_ann,test_zip_ann,
      is_literal].
@@ -399,6 +400,16 @@ t_epp_dodger_clever(Config) when is_list(Config) ->
     PrivDir   = ?config(priv_dir, Config),
     Filenames = ["epp_dodger_clever.erl"],
     ok = test_epp_dodger_clever(Filenames,DataDir,PrivDir),
+    ok.
+
+%% Test that erl_syntax handles macro-named native records.
+gh11155(Config) when is_list(Config) ->
+    DataDir = ?config(data_dir, Config),
+    File = filename:join(DataDir, "macro_native_record.erl"),
+    {ok, AST} = epp_dodger:parse_file(File, [no_fail]),
+    FormList = erl_syntax:form_list(AST),
+    _ = erl_syntax_lib:fold(fun(_Node, Acc) -> Acc end, ok, FormList),
+    _ = erl_syntax_lib:map(fun(Node) -> Node end, FormList),
     ok.
 
 t_comment_scan(Config) when is_list(Config) ->

--- a/lib/syntax_tools/test/syntax_tools_SUITE_data/macro_native_record.erl
+++ b/lib/syntax_tools/test/syntax_tools_SUITE_data/macro_native_record.erl
@@ -1,0 +1,28 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+
+-module(macro_native_record).
+
+-define(state, 'macro_native_record.state').
+
+-record(?state, {a}).
+
+foo() ->
+    #?state{a = 0}.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11155.