### PR TITLE
json: add the data mapping of Array to doc

### DIFF
--- a/lib/stdlib/src/json.erl
+++ b/lib/stdlib/src/json.erl
@@ -860,6 +860,7 @@ Supports basic data mapping:
 | Boolean  | `true \| false`        |
 | Null     | `null`                 |
 | String   | `binary()`             |
+| Array    | `list()`               |
 | Object   | `#{binary() => _}`     |
 
 ## Errors


### PR DESCRIPTION
For `encode/1`, the doc shows:

| **Erlang**             | **JSON** |
|------------------------|----------|
| `integer() \| float()` | Number   |
| `true \| false `       | Boolean  |
| `null`                 | Null     |
| `binary()`             | String   |
| `atom()`               | String   |
| `list()`               | Array    |
| `#{binary() => _}`     | Object   |
| `#{atom() => _}`       | Object   |
| `#{integer() => _}`    | Object   |

For `decode/1`, the docs shows:

| **JSON** | **Erlang**             |
|----------|------------------------|
| Number   | `integer() \| float()` |
| Boolean  | `true \| false`        |
| Null     | `null`                 |
| String   | `binary()`             |
| Object   | `#{binary() => _}`     |

It looks like the Array case was left out:
| **JSON** | **Erlang**             |
|----------|------------------------|
| Array    | `list()`               |

This PR is trying to add it.