### PR TITLE
feat: implement ets:lookup_elements/3

### DIFF
--- a/erts/emulator/beam/bif.tab
+++ b/erts/emulator/beam/bif.tab
@@ -360,6 +360,7 @@ bif ets:is_compiled_ms/1
 bif ets:lookup/2
 bif ets:lookup_element/3
 bif ets:lookup_element/4
+bif ets:lookup_elements/3
 bif ets:info/1
 bif ets:info/2
 bif ets:last/1

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -3001,6 +3001,57 @@ BIF_RETTYPE ets_lookup_element_4(BIF_ALIST_4)
 }
 
 /*
+** Get multiple elements from a term
+** get_elements_3(Tab, Key, Indexes)
+** return tuple of elements or a list of tuples of elements if bag
+*/
+BIF_RETTYPE ets_lookup_elements_3(BIF_ALIST_3)
+{
+    DbTable* tb;
+    Eterm* indexes;
+    int cret;
+    Eterm ret;
+    Eterm* tp;
+    int index_cnt;
+
+    CHECK_TABLES();
+
+    DB_BIF_GET_TABLE(tb, DB_READ, LCK_READ, BIF_ets_lookup_elements_3);
+
+    if (!is_tuple(BIF_ARG_3) || (tp = tuple_val(BIF_ARG_3),
+                                 index_cnt = arityval(tp[0]),
+                                 index_cnt < 0)) {
+        db_unlock(tb, LCK_READ);
+        BIF_ERROR(BIF_P, BADARG);
+    }
+
+    if(index_cnt==0) { return TUPLE0; }
+
+    for(int i=0; i<index_cnt; i++) {
+        if (is_not_small(tp[i+1]) || (signed_val(tp[i+1]) < 1)) {
+            db_unlock(tb, LCK_READ);
+            BIF_ERROR(BIF_P, BADARG);
+        }
+    }
+    indexes = tp+1;
+
+    cret = tb->common.meth->db_get_elements(BIF_P, tb, BIF_ARG_2,
+                                            indexes, index_cnt, &ret);
+    db_unlock(tb, LCK_READ);
+    switch (cret) {
+    case DB_ERROR_NONE:
+        BIF_RET(ret);
+    case DB_ERROR_SYSRES:
+        BIF_ERROR(BIF_P, SYSTEM_LIMIT);
+    case DB_ERROR_BADKEY:
+        BIF_P->fvalue = EXI_BAD_KEY;
+        BIF_ERROR(BIF_P, BADARG | EXF_HAS_EXT_INFO);
+    default:
+        BIF_ERROR(BIF_P, BADARG);
+    }
+}
+
+/*
  * BIF to erase a whole table and release all memory it holds
  */
 BIF_RETTYPE ets_delete_1(BIF_ALIST_1)

--- a/erts/emulator/beam/erl_db_catree.c
+++ b/erts/emulator/beam/erl_db_catree.c
@@ -125,6 +125,9 @@ static int db_member_catree(DbTable *tbl, Eterm key, Eterm *ret);
 static int db_get_element_catree(Process *p, DbTable *tbl,
                                  Eterm key,int ndex,
                                  Eterm *ret);
+static int db_get_elements_catree(Process *p, DbTable *tbl,
+                                 Eterm key, Eterm* indexes, int index_cnt,
+                                 Eterm *ret);
 static int db_erase_catree(DbTable *tbl, Eterm key, Eterm *ret);
 static int db_erase_object_catree(DbTable *tbl, Eterm object,Eterm *ret);
 static int db_slot_catree(Process *p, DbTable *tbl,
@@ -209,6 +212,7 @@ DbTableMethod db_catree =
     db_put_catree,
     db_get_catree,
     db_get_element_catree,
+    db_get_elements_catree,
     db_member_catree,
     db_erase_catree,
     db_erase_object_catree,
@@ -2045,6 +2049,19 @@ static int db_get_element_catree(Process *p, DbTable *tbl,
     int result = db_get_element_tree_common(p, &tb->common,
                                             node->u.base.root,
                                             key, ndex, ret, NULL);
+    runlock_base_node(node, tb);
+    return result;
+}
+
+static int db_get_elements_catree(Process *p, DbTable *tbl,
+                                Eterm key, Eterm* indexes, int index_cnt,
+                                Eterm *ret)
+{
+    DbTableCATree *tb = &tbl->catree;
+    DbTableCATreeNode* node = find_rlock_valid_base_node(tb, key);
+    int result = db_get_elements_tree_common(p, &tb->common,
+                                            node->u.base.root,
+                                            key, indexes, index_cnt, ret, NULL);
     runlock_base_node(node, tb);
     return result;
 }

--- a/erts/emulator/beam/erl_db_hash.c
+++ b/erts/emulator/beam/erl_db_hash.c
@@ -677,6 +677,9 @@ static int db_member_hash(DbTable *tbl, Eterm key, Eterm *ret);
 
 static int db_get_element_hash(Process *p, DbTable *tbl, 
 			       Eterm key, int pos, Eterm *ret);
+static int db_get_elements_hash(Process *p, DbTable *tbl, 
+                                Eterm key, Eterm* indexes, int index_cnt,
+                                Eterm *ret);
 
 static int db_erase_object_hash(DbTable *tbl, Eterm object,Eterm *ret);
 
@@ -857,6 +860,7 @@ DbTableMethod db_hash =
     db_put_hash,
     db_get_hash,
     db_get_element_hash,
+    db_get_elements_hash,
     db_member_hash,
     db_erase_hash,
     db_erase_object_hash,
@@ -1600,6 +1604,77 @@ static int db_get_element_hash(Process *p, DbTable *tbl,
 	    goto done;
 	}
 	b1 = b1->next;
+    }
+    retval = DB_ERROR_BADKEY;
+done:
+    RUNLOCK_HASH(lck);
+    return retval;
+}
+
+static int db_get_elements_hash(Process *p, DbTable *tbl, 
+                               Eterm key,
+                               Eterm *positions,
+                               int pos_cnt,
+                               Eterm *ret)
+{
+    DbTableHash *tb = &tbl->hash;
+    HashValue hval;
+    UWord ix;
+    HashDbTerm* b1;
+    erts_rwmtx_t* lck;
+    int retval;
+    
+    hval = MAKE_HASH(key);
+    lck = RLOCK_HASH(tb, hval);
+    ix = hash_to_ix(tb, hval);
+    b1 = BUCKET(tb, ix);
+
+
+    while(b1 != 0) {
+        if (has_live_key(tb,b1,key,hval)) {
+            for(int i=0; i<pos_cnt; i++) {
+                if (unsigned_val(positions[i]) > arityval(b1->dbterm.tpl[0])) {
+                    retval = DB_ERROR_BADITEM;
+                    goto done;
+                }
+            }
+            if (tb->common.status & (DB_BAG | DB_DUPLICATE_BAG)) {
+                HashDbTerm* b;
+                HashDbTerm* b2 = b1->next;
+                Eterm elem_list = NIL;
+
+                while(b2 != NULL && has_key(tb,b2,key,hval)) {
+                    for(int i=0; i<pos_cnt; i++) {
+                        if (unsigned_val(positions[i]) > arityval(b2->dbterm.tpl[0])
+                            && !is_pseudo_deleted(b2)) {
+                            retval = DB_ERROR_BADITEM;
+                            goto done;
+                        }
+                    }
+                    b2 = b2->next;
+                }
+                b = b1;
+                while(b != b2) {
+                    if (!is_pseudo_deleted(b)) {
+                        Eterm *hp;
+                        Eterm copy = db_copy_elements_from_ets(&tb->common, p,
+                                                               &b->dbterm, positions,
+                                                               pos_cnt, &hp, 2);
+                        elem_list = CONS(hp, copy, elem_list);
+                    }
+                    b = b->next;
+                }
+                *ret = elem_list;
+            }
+            else {
+                Eterm* hp;
+                *ret = db_copy_elements_from_ets(&tb->common, p, &b1->dbterm,
+                                                 positions, pos_cnt, &hp, 0);
+            }
+            retval = DB_ERROR_NONE;
+            goto done;
+        }
+        b1 = b1->next;
     }
     retval = DB_ERROR_BADKEY;
 done:

--- a/erts/emulator/beam/erl_db_tree.c
+++ b/erts/emulator/beam/erl_db_tree.c
@@ -427,6 +427,9 @@ static int db_member_tree(DbTable *tbl, Eterm key, Eterm *ret);
 static int db_get_element_tree(Process *p, DbTable *tbl, 
 			       Eterm key,int ndex,
 			       Eterm *ret);
+static int db_get_elements_tree(Process *p, DbTable *tbl, 
+                                Eterm key,Eterm *indexes, int index_cnt,
+                                Eterm *ret);
 static int db_erase_tree(DbTable *tbl, Eterm key, Eterm *ret);
 static int db_erase_object_tree(DbTable *tbl, Eterm object,Eterm *ret);
 static int db_slot_tree(Process *p, DbTable *tbl, 
@@ -507,6 +510,7 @@ DbTableMethod db_tree =
     db_put_tree,
     db_get_tree,
     db_get_element_tree,
+    db_get_elements_tree,
     db_member_tree,
     db_erase_tree,
     db_erase_object_tree,
@@ -1090,12 +1094,43 @@ int db_get_element_tree_common(Process *p, DbTableCommon *tb, TreeDbTerm *root, 
     return DB_ERROR_NONE;
 }
 
+int db_get_elements_tree_common(Process *p, DbTableCommon *tb, TreeDbTerm *root, Eterm key,
+                                Eterm *indexes, int index_cnt, Eterm *ret, DbTableTree *stack_container)
+{
+    /*
+     * Look the node up:
+     */
+    Eterm *hp;
+    TreeDbTerm *this;
+
+    this = find_node(tb,root,key,stack_container);
+    if (this == NULL) {
+        return DB_ERROR_BADKEY;
+    } else {
+        for(int i=0; i<index_cnt; i++){
+            if (signed_val(indexes[i]) > arityval(this->dbterm.tpl[0])) {
+                return DB_ERROR_BADPARAM;
+            }
+        }
+        *ret = db_copy_elements_from_ets(tb, p, &this->dbterm, indexes, index_cnt, &hp, 0);
+    }
+    return DB_ERROR_NONE;
+}
+
 static int db_get_element_tree(Process *p, DbTable *tbl,
 			       Eterm key, int ndex, Eterm *ret)
 {
     DbTableTree *tb = &tbl->tree;
     return db_get_element_tree_common(p, &tb->common, tb->root, key,
                                       ndex, ret, tb);
+}
+
+static int db_get_elements_tree(Process *p, DbTable *tbl,
+                                Eterm key, Eterm* indexes, int index_cnt, Eterm *ret)
+{
+    DbTableTree *tb = &tbl->tree;
+    return db_get_elements_tree_common(p, &tb->common, tb->root, key,
+                                      indexes, index_cnt, ret, tb);
 }
 
 int db_erase_tree_common(DbTable *tbl, TreeDbTerm **root, Eterm key, Eterm *ret,

--- a/erts/emulator/beam/erl_db_tree_util.h
+++ b/erts/emulator/beam/erl_db_tree_util.h
@@ -106,6 +106,9 @@ int db_get_tree_common(Process *p, DbTableCommon *tb, TreeDbTerm *root, Eterm ke
                        Eterm *ret, DbTableTree *stack_container);
 int db_get_element_tree_common(Process *p, DbTableCommon *tb, TreeDbTerm *root, Eterm key,
                                int ndex, Eterm *ret, DbTableTree *stack_container);
+int db_get_elements_tree_common(Process *p, DbTableCommon *tb, TreeDbTerm *root, Eterm key,
+                                Eterm *indexes, int index_cnt, Eterm *ret,
+                                DbTableTree *stack_container);
 int db_member_tree_common(DbTableCommon *tb, TreeDbTerm *root, Eterm key, Eterm *ret,
                           DbTableTree *stack_container);
 int db_erase_tree_common(DbTable *tbl, TreeDbTerm **root, Eterm key, Eterm *ret,

--- a/erts/emulator/beam/erl_db_util.c
+++ b/erts/emulator/beam/erl_db_util.c
@@ -3798,6 +3798,33 @@ Eterm db_copy_element_from_ets(DbTableCommon *tb, Process *p, DbTerm *obj,
     }
 }
 
+Eterm db_copy_elements_from_ets(DbTableCommon *tb,
+                                Process *p,
+                                DbTerm *obj,
+                                Eterm *positions,
+                                Uint num_positions,
+                                Eterm **hpp,
+                                Uint extra)
+{
+    Uint i;
+    Eterm *tp;
+
+    ASSERT(num_positions > 0);
+    tp = *hpp = HAlloc(p, num_positions + 1 + extra);
+    tp[0] = make_arityval(num_positions);
+    *hpp += num_positions + 1;
+    for (i = 0; i < num_positions; i++) {
+        Eterm *hp;
+        tp[i+1] = db_copy_element_from_ets(tb,
+                                           p,
+                                           obj,
+                                           unsigned_val(positions[i]),
+                                           &hp,
+                                           0);
+    }
+    return make_tuple(tp);
+}
+
 /*
  * Return the size of an element of an uncompressed ETS record.
  * Relies on each element of the ETS record being laid out contiguously,

--- a/erts/emulator/beam/erl_db_util.h
+++ b/erts/emulator/beam/erl_db_util.h
@@ -153,6 +153,12 @@ typedef struct db_table_method
 			  Eterm key, 
 			  int index, 
 			  Eterm* ret);
+    int (*db_get_elements)(Process* p, 
+                          DbTable* tb, /* [in out] */ 
+                          Eterm key,
+                          Eterm *indexes,
+                          int index_cnt, 
+                          Eterm* ret);
     int (*db_member)(DbTable* tb, /* [in out] */ 
 		     Eterm key, 
 		     Eterm* ret);
@@ -476,6 +482,9 @@ void* db_store_term_comp(DbTableCommon *tb, /*May be NULL*/
                          Uint offset,Eterm obj);
 Eterm db_copy_element_from_ets(DbTableCommon* tb, Process* p, DbTerm* obj,
 			       Uint pos, Eterm** hpp, Uint extra);
+Eterm db_copy_elements_from_ets(DbTableCommon* tb, Process* p, DbTerm* obj,
+                                Eterm* indexes, Uint index_cnt, Eterm** hpp,
+                                Uint extra);
 int db_has_map(Eterm obj);
 bool db_is_fully_bound(Eterm obj);
 int db_is_variable(Eterm obj);

--- a/lib/stdlib/src/erl_stdlib_errors.erl
+++ b/lib/stdlib/src/erl_stdlib_errors.erl
@@ -702,6 +702,25 @@ format_ets_error(lookup_element, [_,_,Pos]=Args, Cause) ->
 format_ets_error(lookup_element, [Tab, Key, Pos, _Default], Cause) ->
     % The default argument cannot cause an error.
     format_ets_error(lookup_element, [Tab, Key, Pos], Cause);
+format_ets_error(lookup_elements, [Tab,Key,[]], Cause) ->
+    %% 1 is always a valid pos - error must be in the table
+    format_ets_error(lookup_element, [Tab, Key, 1], Cause);
+format_ets_error(lookup_elements, [Tab,Key,Positions], Cause) ->
+    {InvalidPositions, ValidPositions} =
+        lists:partition(fun(Pos) ->
+                            format_non_negative_integer(Pos) =/= ""
+                        end,
+                        Positions),
+    case InvalidPositions of
+        [] ->
+            format_ets_error(lookup_element,
+                             [Tab, Key, hd(ValidPositions)],
+                             Cause);
+        [InvalidPos | _] ->
+            format_ets_error(lookup_element,
+                             [Tab, Key, InvalidPos],
+                             Cause)
+    end;
 format_ets_error(match, [_], _Cause) ->
     [bad_continuation];
 format_ets_error(match, [_,_,_]=Args, Cause) ->

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -289,7 +289,8 @@ Opaque continuation used by [`select/1,3`](`select/1`),
 -export([all/0, delete/1, delete/2, delete_all_objects/1,
          delete_object/2, first/1, first_lookup/1, give_away/3, info/1, info/2,
          insert/2, insert_new/2, is_compiled_ms/1, last/1, last_lookup/1, lookup/2,
-         lookup_element/3, lookup_element/4, match/1, match/2, match/3, match_object/1,
+         lookup_element/3, lookup_element/4, lookup_elements/3,
+         match/1, match/2, match/3, match_object/1,
          match_object/2, match_object/3, match_spec_compile/1,
          match_spec_run_r/3, member/2, new/2, next/2, next_lookup/2, prev/2, prev_lookup/2,
          rename/2, safe_fixtable/2, select/1, select/2, select/3,
@@ -964,6 +965,26 @@ none
 
 lookup_element(_, _, _, _) ->
   erlang:nif_error(undef).
+
+-doc """
+## Examples
+
+```erlang
+1> T = ets:new(t, []).
+2> ets:insert(T, {k, 10, 20, example}).
+true
+3> ets:lookup_elements(T, k, {1, 4, 2}).
+{k, example, 10}
+```
+""".
+-spec lookup_elements(Table, Key, PosSpec) -> Elem when
+      Table :: table(),
+      Key :: term(),
+      PosSpec :: tuple(),
+      Elem :: term() | [term()].
+
+lookup_elements(_, _, _) ->
+    erlang:nif_error(undef).
 
 -doc """
 Matches the objects in table `Table` against pattern `Pattern`.

--- a/lib/stdlib/test/ets_SUITE.erl
+++ b/lib/stdlib/test/ets_SUITE.erl
@@ -44,6 +44,7 @@
 	 tabfile_ext2/1, tabfile_ext3/1, tabfile_ext4/1, badfile/1]).
 -export([heavy_lookup/1, heavy_lookup_element/1, heavy_concurrent/1]).
 -export([lookup_element_mult/1, lookup_element_default/1]).
+-export([lookup_elements/1]).
 -export([foldl_ordered/1, foldr_ordered/1, foldl/1, foldr/1, fold_empty/1,
          fold_badarg/1]).
 -export([t_delete_object/1, t_init_table/1, t_whitebox/1,
@@ -205,7 +206,8 @@ all() ->
      doctests,
      error_info,
      bound_maps,
-     racy_rename
+     racy_rename,
+     lookup_elements
     ].
 
 
@@ -4445,6 +4447,21 @@ lookup_element_mult_do(Opts) ->
     ok = lem_crash_3(T),
     ets:insert(T, {0, "heap_key"}),
     ets:lookup_element(T, "heap_key", 2),
+    true = ets:delete(T),
+    verify_etsmem(EtsMem).
+
+lookup_elements(Config) when is_list(Config) ->
+    repeat_for_opts_all_table_types(fun lookup_elements_do/1).
+
+lookup_elements_do(Opts) ->
+    EtsMem = etsmem(),
+    T = ets_new(service, [{keypos, 2} | Opts]),
+    D = lists:reverse(lem_data()),
+    lists:foreach(fun(X) -> ets:insert(T, X) end, D),
+    ok = lem_crash_3(T),
+    ets:insert(T, {0, "heap_key", immed, {tup, x, y}}),
+    ?assertEqual({}, ets:lookup_elements(T, "heap_key", {})),
+    _ = ets:lookup_elements(T, "heap_key", {2,3,1,4}),
     true = ets:delete(T),
     verify_etsmem(EtsMem).
 
@@ -9591,6 +9608,13 @@ error_info(_Config) ->
 
          {lookup_element, ['$Tab', no_key, 1, default_value], [no_fail]},
          {lookup_element, [OneKeyTab, one, 4, default_value]},
+
+         {lookup_elements, ['$Tab', no_key, {0}]},
+         {lookup_elements, ['$Tab', no_key, {1}], [{error_term,badkey}]},
+         {lookup_elements, ['$Tab', no_key, {bad_pos}]},
+
+         {lookup_elements, [OneKeyTab, one, {4}]},
+         {lookup_elements, [OneKeyTab, one, {1,4}]},
 
          {match, [bad_continuation], [no_table]},
 


### PR DESCRIPTION
If `positions` is an empty tuple, an empty tuple is returned without going further into the process.

I tried to replicate existing code patterns from `lookup_element/3` for all versions of `ets` tables. `Indexes` and `Positions` are synonyms in code, but again - I tried to match existing naming per-file. 

My BEAM-memory-management skills are pretty low so please check that part twice.

Testing is a bit scarce, but `lookup_element/3` is also not tested that much directly.

I could also implement `lookup_elements/4` if needed, but just wanted this to get some review before going into that.

Ping @RobinMorisset , @ansd and @jhogberg 

Closes #10211 