### PR TITLE
ssh: fix mlkem768x25519 hybrid shared secret encoding

### DIFF
--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -67,7 +67,7 @@
 -define(MIN_DH_KEY_SIZE, 400).
 
 %%% For test suites
--export([pack/3, adjust_algs_for_peer_version/2]).
+-export([pack/3, adjust_algs_for_peer_version/2, hybrid_common/4]).
 
 %%%----------------------------------------------------------------------------
 %%%
@@ -2395,10 +2395,8 @@ compute_key(Algorithm, PeerPublic, MyPrivate, Args) ->
 
 hybrid_common(K_pq_secret, Curve, PeerPublic, MyPrivate) ->
     K_cl_secret = compute_key(ecdh, PeerPublic, MyPrivate, Curve),
-    K_cl_secret_mpint = <<?Empint(K_cl_secret)>>,
-    K_cl_secret_mpint_trim =
-        binary:part(K_cl_secret_mpint, byte_size(K_cl_secret_mpint), -?X25519_PUBLICKEY_SIZE),
-    crypto:hash(sha(Curve), <<K_pq_secret/binary, K_cl_secret_mpint_trim/binary>>).
+    K_cl_secret_fixed = <<K_cl_secret:(?X25519_PUBLICKEY_SIZE*8)/big-unsigned-integer>>,
+    crypto:hash(sha(Curve), <<K_pq_secret/binary, K_cl_secret_fixed/binary>>).
 
 dh_bits(#alg{encrypt = Encrypt,
              send_mac = SendMac}) ->

--- a/lib/ssh/test/ssh_algorithms_SUITE.erl
+++ b/lib/ssh/test/ssh_algorithms_SUITE.erl
@@ -291,6 +291,14 @@ init_per_testcase(sshc_simple_exec_os_cmd, _, Config) ->
      start_pubkey_daemon([proplists:get_value(pref_algs,Config)],
                          [{extra_daemon,true}|Config]);
 
+init_per_testcase(mlkem768x25519_hybrid_secret_encoding, _, Config) ->
+    case lists:member(x25519, crypto:supports(curves))
+        andalso lists:member(mlkem768, crypto:supports(kems))
+    of
+        false -> {skip, "X25519 or ML-KEM768 not supported"};
+        true -> Config
+    end;
+
 init_per_testcase(_, _, Config) ->
     Config.
 

--- a/lib/ssh/test/ssh_algorithms_SUITE.erl
+++ b/lib/ssh/test/ssh_algorithms_SUITE.erl
@@ -42,6 +42,7 @@
 
 -export([
          interpolate/1,
+         mlkem768x25519_hybrid_secret_encoding/1,
          simple_connect/1,
          simple_exec/1,
          simple_exec_groups/0,
@@ -61,9 +62,9 @@ suite() ->
     [{ct_hooks,[ts_install_cth]},
      {timetrap,{seconds,120}}].
 
-all() -> 
+all() ->
     %% [{group,kex},{group,cipher}... etc
-    [{group,C} || C <- tags()].
+    [mlkem768x25519_hybrid_secret_encoding | [{group,C} || C <- tags()]].
 
 
 groups() ->
@@ -311,6 +312,47 @@ end_per_testcase(_TC, Config) ->
 
 %%--------------------------------------------------------------------
 %% Test Cases --------------------------------------------------------
+%%--------------------------------------------------------------------
+%% Regression test for the mlkem768x25519-sha256 hybrid key exchange: the
+%% classical (X25519) shared secret must be hashed as a fixed-width 32-byte
+%% octet string. Encoding it as a trimmed mpint dropped a genuine leading 0x00
+%% byte ~1/512 of the time (when the secret's most significant byte is 0x00 and
+%% the next byte is < 0x80), so the two peers derived different exchange hashes
+%% and the handshake failed with "incorrect signature".
+mlkem768x25519_hybrid_secret_encoding(_Config) ->
+    %% Find an X25519 key pair whose ECDH shared secret triggers the bug.
+    {PeerPublic, MyPrivate, Raw} = find_case_c_x25519(1000000),
+    32 = byte_size(Raw),
+    K_pq = crypto:strong_rand_bytes(32),
+    %% A spec-conformant peer (e.g. OpenSSH) hashes K_pq concatenated with the
+    %% X25519 secret as a fixed-width 32-byte string, preserving the leading 0x00.
+    Expected = crypto:hash(sha256, <<K_pq/binary, Raw/binary>>),
+    Got = ssh_transport:hybrid_common(K_pq, x25519, PeerPublic, MyPrivate),
+    case Got of
+        Expected ->
+            ok;
+        _ ->
+            ct:fail({hybrid_secret_encoding_mismatch,
+                     {x25519_secret, Raw},
+                     {expected, Expected},
+                     {got, Got}})
+    end.
+
+%% Search for an X25519 key pair whose ECDH shared secret has most significant
+%% byte 0x00 and next byte < 0x80 -- the value whose minimal mpint encoding is
+%% only 31 bytes, which the old code mis-trimmed. Expected after ~512 tries.
+find_case_c_x25519(0) ->
+    ct:fail("no case-C X25519 shared secret found");
+find_case_c_x25519(N) ->
+    {_MyPublic, MyPrivate} = crypto:generate_key(ecdh, x25519),
+    {PeerPublic, _PeerPrivate} = crypto:generate_key(ecdh, x25519),
+    case crypto:compute_key(ecdh, PeerPublic, MyPrivate, x25519) of
+        <<0, B1, _/binary>> = Raw when B1 < 16#80 ->
+            {PeerPublic, MyPrivate, Raw};
+        _ ->
+            find_case_c_x25519(N - 1)
+    end.
+
 %%--------------------------------------------------------------------
 %% A simple sftp transfer
 simple_sftp(Config) ->

--- a/lib/ssh/test/ssh_algorithms_SUITE.erl
+++ b/lib/ssh/test/ssh_algorithms_SUITE.erl
@@ -327,39 +327,27 @@ end_per_testcase(_TC, Config) ->
 %% byte ~1/512 of the time (when the secret's most significant byte is 0x00 and
 %% the next byte is < 0x80), so the two peers derived different exchange hashes
 %% and the handshake failed with "incorrect signature".
+%%
+%% The keys below produce a shared secret starting with <<0x00, 0x42, ...>>
+%% which triggers the edge case (0x42 < 0x80).
 mlkem768x25519_hybrid_secret_encoding(_Config) ->
-    %% Find an X25519 key pair whose ECDH shared secret triggers the bug.
-    {PeerPublic, MyPrivate, Raw} = find_case_c_x25519(1000000),
-    32 = byte_size(Raw),
-    K_pq = crypto:strong_rand_bytes(32),
+    PeerPublic = <<16#94,16#5E,16#6F,16#5A,16#CA,16#B1,16#AD,16#A6,
+                   16#31,16#CF,16#12,16#F5,16#47,16#A4,16#25,16#6B,
+                   16#6A,16#E5,16#3A,16#A2,16#48,16#6A,16#0D,16#08,
+                   16#C6,16#D6,16#73,16#2C,16#B3,16#E2,16#0E,16#5B>>,
+    MyPrivate  = <<16#58,16#EF,16#AB,16#DA,16#4C,16#C5,16#6B,16#8E,
+                   16#B2,16#43,16#8A,16#86,16#92,16#2C,16#5D,16#73,
+                   16#83,16#98,16#B4,16#38,16#0E,16#A3,16#91,16#37,
+                   16#F9,16#38,16#5B,16#E5,16#BA,16#B5,16#94,16#6D>>,
+    %% Verify the shared secret triggers the edge case
+    <<0, B1, _/binary>> = crypto:compute_key(ecdh, PeerPublic, MyPrivate, x25519),
+    true = B1 < 16#80,
     %% A spec-conformant peer (e.g. OpenSSH) hashes K_pq concatenated with the
     %% X25519 secret as a fixed-width 32-byte string, preserving the leading 0x00.
+    K_pq = crypto:strong_rand_bytes(32),
+    Raw = crypto:compute_key(ecdh, PeerPublic, MyPrivate, x25519),
     Expected = crypto:hash(sha256, <<K_pq/binary, Raw/binary>>),
-    Got = ssh_transport:hybrid_common(K_pq, x25519, PeerPublic, MyPrivate),
-    case Got of
-        Expected ->
-            ok;
-        _ ->
-            ct:fail({hybrid_secret_encoding_mismatch,
-                     {x25519_secret, Raw},
-                     {expected, Expected},
-                     {got, Got}})
-    end.
-
-%% Search for an X25519 key pair whose ECDH shared secret has most significant
-%% byte 0x00 and next byte < 0x80 -- the value whose minimal mpint encoding is
-%% only 31 bytes, which the old code mis-trimmed. Expected after ~512 tries.
-find_case_c_x25519(0) ->
-    ct:fail("no case-C X25519 shared secret found");
-find_case_c_x25519(N) ->
-    {_MyPublic, MyPrivate} = crypto:generate_key(ecdh, x25519),
-    {PeerPublic, _PeerPrivate} = crypto:generate_key(ecdh, x25519),
-    case crypto:compute_key(ecdh, PeerPublic, MyPrivate, x25519) of
-        <<0, B1, _/binary>> = Raw when B1 < 16#80 ->
-            {PeerPublic, MyPrivate, Raw};
-        _ ->
-            find_case_c_x25519(N - 1)
-    end.
+    Expected = ssh_transport:hybrid_common(K_pq, x25519, PeerPublic, MyPrivate).
 
 %%--------------------------------------------------------------------
 %% A simple sftp transfer


### PR DESCRIPTION
Closes #11208

## Summary

`mlkem768x25519-sha256` key exchange intermittently fails (~1 in 512 handshakes)
with `incorrect signature` on the peer. `hybrid_common/4` reconstructed the
classical X25519 shared secret by taking the last `?X25519_PUBLICKEY_SIZE` bytes
of its **mpint** encoding. Because mpint is minimal-length, a shared secret whose
most significant byte is `0x00` and whose next byte is `< 0x80` encodes to a
31-byte payload, and "the last 32 bytes" then includes a byte of the 4-byte
length prefix (`0x1f`) in place of the genuine leading `0x00`. The two peers hash
different octet strings, derive a different exchange hash `H`, and the signature
check fails.

This encodes the ECDH shared secret as a fixed-width big-endian octet string,
preserving leading zero bytes.
[draft-ietf-sshm-mlkem-hybrid-kex](https://datatracker.ietf.org/doc/html/draft-ietf-sshm-mlkem-hybrid-kex)
§2.4 specifies this encoding — the component secrets are hashed as fixed-length
big-endian byte arrays — and OpenSSH's `kexmlkem768x25519.c` matches it.

```diff
 hybrid_common(K_pq_secret, Curve, PeerPublic, MyPrivate) ->
     K_cl_secret = compute_key(ecdh, PeerPublic, MyPrivate, Curve),
-    K_cl_secret_mpint = <<?Empint(K_cl_secret)>>,
-    K_cl_secret_mpint_trim =
-        binary:part(K_cl_secret_mpint, byte_size(K_cl_secret_mpint), -?X25519_PUBLICKEY_SIZE),
-    crypto:hash(sha(Curve), <<K_pq_secret/binary, K_cl_secret_mpint_trim/binary>>).
+    K_cl_secret_fixed = <<K_cl_secret:(?X25519_PUBLICKEY_SIZE*8)/big-unsigned-integer>>,
+    crypto:hash(sha(Curve), <<K_pq_secret/binary, K_cl_secret_fixed/binary>>).
```

The new encoding is byte-for-byte identical to the old one in every case except
the previously-broken one, so it only changes behaviour where the handshake was
already failing.

## Probability / impact

P(trigger) = P(`secret[0]==0x00`) × P(`secret[1] < 0x80`) = 1/256 × 1/2 =
**1/512 ≈ 0.195%** per `mlkem768x25519-sha256` handshake. At any non-trivial
connection volume this is a frequent, hard-to-diagnose interop failure against
OpenSSH (which is correct).

Introduced in `95d0848c60` ("ssh: MLKEM kex ssh"), released in OTP-28.4.

## Verification

- **Deterministic unit check** (`<<0,1,0:240>>` → old code yields `1F01…`, fixed
  yields `0001…`). See linked issue.
- **Monte-Carlo**: 300k random secrets, old-vs-fixed mismatch rate 0.194%, every
  mismatch satisfies `secret[0]==0x00 ∧ secret[1] < 0x80`.
- **End-to-end against OpenSSH 10.3p1, BOTH roles**, with the hybrid code
  instrumented to count how many handshakes actually hit the trigger ("case C")
  so success is not luck-of-the-draw:

  | Role | Mode | Trigger handshakes | Failures |
  |------|------|--------------------|----------|
  | OTP daemon ← OpenSSH client | stock | 20 | **20** (1:1) |
  | OTP daemon ← OpenSSH client | fixed | 45 | **0** |
  | OTP client → OpenSSH sshd   | stock | 21 | **21** (1:1) |
  | OTP client → OpenSSH sshd   | fixed | 31 | **0** |

- **Regression test in the suite** (`ssh_algorithms_SUITE:mlkem768x25519_hybrid_secret_encoding`):
  passes with the fix, fails against the stock encoding. Run via the supported
  framework: `ts:run(ssh, ssh_algorithms_SUITE, mlkem768x25519_hybrid_secret_encoding, [batch])`
  → `TEST COMPLETE, 1 ok, 0 failed`.

- **Full `ssh_algorithms_SUITE`: `TEST COMPLETE, 930 ok, 0 failed` of 930**
