### PR TITLE
erts: fix out-of-bounds pointer UB in `erts_qsort_insertion_sort`

### DIFF
--- a/erts/emulator/beam/utils.c
+++ b/erts/emulator/beam/utils.c
@@ -3498,8 +3498,15 @@ static void erts_qsort_insertion_sort(byte *base,
                                       size_t item_size,
                                       erts_void_ptr_cmp_t compare)
 {
-    byte *end = base + ((nr_of_items-1) * item_size);
     byte *unsorted_start = base;
+    byte *end;
+
+    if (nr_of_items < 2) {
+        return;
+    }
+
+    end = base + ((nr_of_items-1) * item_size);
+
     while (unsorted_start < end) {
         byte *smallest_so_far = unsorted_start;
         byte *curr = smallest_so_far + item_size;


### PR DESCRIPTION
In production, we’ve faced a segfault with the following backtrace:

```
Native Stack:
  #0  0x0000b164633ae91c  0x000000000026e91c  beam.smp eq
  #1  0x0000b164633b310c  0x000000000027310c  beam.smp erts_qsort_helper
  #2  0x0000b164633b310c  0x000000000027310c  beam.smp erts_qsort_helper
  #3  0x0000b164634d8ca0  0x0000000000398ca0  beam.smp erts_qsort hashmap_from_unsorted_array
  #4  0x0000b164634daf08  0x000000000039af08  beam.smp erts_hashmap_from_ks_and_vs_extra
  #5  0x0000b16463337740  0x00000000001f7740  beam.smp erts_gc_update_map_assoc
```

We identified UB [here](https://github.com/erlang/otp/blob/8aa53f37e2e08c9370df1b6ecc23f8a1f1f81851/erts/emulator/beam/utils.c#L3595-L3596); when `nr_of_items` is 0, the `end` pointer points to an element before the base pointer, which exhibits UB (C11 standard §6.5.6 paragraph 8).

I’ve put together the [following reproducers](https://gist.github.com/ollien/374bac57b1785e86c6c5305dd088baae) to trigger the segfault. To use them, you should

1. Clone `otp` and build it with `./configure` and `make` (compiler doesn’t matter, we just need to generate the headers)
2. In the same directory as the `otp` directory, copy down the files from the gist.
3. Run `./run_clang.sh` to repro. `./run_gcc.sh` is included for completeness to show the lack of crash with `gcc`. The scripts default to `clang-21` and `gcc-16` but you can adjust this as needed with the `CC` env var.

I can’t reproduce the exact native stack (it is UB after all :) ), but UBSan flags it either way, and running `via_insertion_sort.c` seems to loop the `fprintf` until it faults, which points to stack corruption. This appears to only manifest under clang with higher optimization levels; gcc is "immune" but that’s likely a coincidence.

### Before

```
$ ./run_clang.sh
Ubuntu clang version 21.1.8 (++20251221032842+2078da43e25a-1~exp1~20251221153008.77)
tree: otp   utils.c bug line: 3595

via_insertion_sort.c  (direct call, compile-time-constant empty count):
  -O0        exit 0 (no crash)
./run_clang.sh: line 44: 1792431 Segmentation fault      timeout 12 "$bin" > /dev/null 2> /tmp/run.err
  -O3        SIGSEGV
./run_clang.sh: line 44: 1792441 Segmentation fault      timeout 12 "$bin" > /dev/null 2> /tmp/run.err
  -O3 -flto  SIGSEGV
  UBSan      UBSan reported the UB
             beam/utils.c:3595:22: runtime error: addition of unsigned offset to 0x7ffdb01d98a0 overflowed to 0x7ffdb01d9888
             SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior beam/utils.c:3595:22

via_erts_qsort.c      (public erts_qsort, runtime empty count):
  -O0        exit 0 (no crash)
  -O3        exit 0 (no crash)
  -O3 -flto  exit 0 (no crash)
  UBSan      UBSan reported the UB
             beam/utils.c:3595:22: runtime error: addition of unsigned offset to 0x7fff829a2ce0 overflowed to 0x7fff829a2cc8
             SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior beam/utils.c:3595:22
```

### After

```
$ ./run_clang.sh
Ubuntu clang version 21.1.8 (++20251221032842+2078da43e25a-1~exp1~20251221153008.77)
tree: otp   utils.c bug line: 3599

via_insertion_sort.c  (direct call, compile-time-constant empty count):
  -O0        exit 0 (no crash)
  -O3        exit 0 (no crash)
  -O3 -flto  exit 0 (no crash)
  UBSan      exit 0 (no crash)

via_erts_qsort.c      (public erts_qsort, runtime empty count):
  -O0        exit 0 (no crash)
  -O3        exit 0 (no crash)
  -O3 -flto  exit 0 (no crash)
  UBSan      exit 0 (no crash)
```

**Disclaimer:** AI tooling was heavily used when investigating this issue; I have personally confirmed the issue, and had a colleague look at this as well. I stand behind the repro to the best of my ability.