### PR TITLE
docs: Update SECURITY.md supported versions for OTP 30

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,14 +11,14 @@ please report it to erlang-security@erlang.org or https://github.com/erlang/otp/
 ## Supported Versions
 
 Erlang/OTP supports the last 3 OTP releases with security updates and patches.
-For example, if the latest release is OTP 28, we will support with maintenance and security releases:
+For example, if the latest release is OTP 30, we will support with maintenance and security releases:
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 30      | :white_check_mark: |
+| 29      | :white_check_mark: |
 | 28      | :white_check_mark: |
-| 27      | :white_check_mark: |
-| 26      | :white_check_mark: |
-| =< 25   | :x:               |
+| =< 27   | :x:               |
 
 <!--
 > %CopyrightBegin%


### PR DESCRIPTION
Add OTP 30 as a supported release and drop OTP 26, which is no longer maintained. Shift the example latest release to OTP 30 accordingly.