### PR TITLE
DETS: fix fsck recovery

### DIFF
--- a/lib/stdlib/src/dets_v9.erl
+++ b/lib/stdlib/src/dets_v9.erl
@@ -1450,19 +1450,14 @@ temp_file(Head, SizeT, N) ->
     {TmpName, Fd}.
 
 %% Does not close Fd.
-fsck_input(Head, Fd, Cntrs, FileHeader) ->
-    MaxSz0 = case FileHeader#fileheader.has_md5 of
-                 true when is_list(FileHeader#fileheader.no_colls) ->
-                     ?POW(max_objsize(FileHeader#fileheader.no_colls));
+fsck_input(Head, Fd, Cntrs, _FileHeader) ->
+    %% The file is not compressed, so the bucket size
+    %% cannot exceed the filesize, for all buckets.
+    MaxSz0 = case file:position(Fd, eof) of
+                 {ok, Pos} ->
+                     Pos;
                  _ ->
-                     %% The file is not compressed, so the bucket size
-                     %% cannot exceed the filesize, for all buckets.
-                     case file:position(Fd, eof) of
-                         {ok, Pos} ->
-                             Pos;
-                         _ ->
-                             1 bsl 32
-                     end
+                     1 bsl 32
              end,
     MaxSz = erlang:max(MaxSz0, ?CHUNK_SIZE),
     State0 = fsck_read(?BASE, Fd, [], 0),


### PR DESCRIPTION
During DETS auto-repair (fsck), fsck_input/4 calculated the maximum allowed object size using the no_colls field from the file header. However, if a crash occurs, any modifications made to the table since the last proper close make the no_colls field on disk stale and therefore relying on it could lead to entries being lost.

Fix this by completely bypassing the stale no_colls check during auto-repair and always using the actual file size or the maximum size allowed.

Fixes #8513