### PR TITLE
Check if port exists before calling `erts_port_dec_refc` in `enif_port_command`

### DIFF
--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -1126,7 +1126,7 @@ enif_port_command(ErlNifEnv *env, const ErlNifPort* to_port,
     else
         res = erts_port_output_async(prt, c_p->common.id, msg);
 
-    if (scheduler <= 0)
+    if (scheduler <= 0 && prt)
 	erts_port_dec_refc(prt);
 
     return res;

--- a/erts/emulator/test/dirty_nif_SUITE.erl
+++ b/erts/emulator/test/dirty_nif_SUITE.erl
@@ -1052,7 +1052,7 @@ nif_whereis(Config) when is_list(Config) ->
     ok.
 
 %% enif_port_command() from a dirty scheduler must return false, not crash,
-%% when the port is no longer alive (OTP-11221).
+%% when the port is no longer alive (GH-11221).
 dirty_port_command(Config) when is_list(Config) ->
     erl_ddll:try_load(?config(data_dir, Config), echo_drv, []),
 

--- a/erts/emulator/test/dirty_nif_SUITE.erl
+++ b/erts/emulator/test/dirty_nif_SUITE.erl
@@ -39,6 +39,7 @@
 	 dirty_process_register/1, dirty_process_trace/1,
 	 code_purge/1, literal_area/1, dirty_nif_send_traced/1,
 	 nif_whereis/1, nif_whereis_parallel/1, nif_whereis_proxy/1,
+         dirty_port_command/1,
          set_halt_options_from_nif/1,
          delay_halt/1,
          delay_halt_old_code/1,
@@ -65,6 +66,7 @@
        dirty_heap_access_nif/1,
        whereis_term/2,
        whereis_send/3,
+       dirty_port_command/2,
        dirty_terminating_literal_access/2,
        delay_halt_normal/3,
        delay_halt_io_bound/3,
@@ -94,6 +96,7 @@ all() ->
      dirty_nif_send_traced,
      nif_whereis,
      nif_whereis_parallel,
+     dirty_port_command,
      {group, halt_normal},
      {group, halt_dirty_cpu},
      {group, halt_dirty_io},
@@ -1048,6 +1051,21 @@ nif_whereis(Config) when is_list(Config) ->
     false = whereis_term(port, RegName),
     ok.
 
+%% enif_port_command() from a dirty scheduler must return false, not crash,
+%% when the port is no longer alive (OTP-11221).
+dirty_port_command(Config) when is_list(Config) ->
+    erl_ddll:try_load(?config(data_dir, Config), echo_drv, []),
+
+    Port = open_port({spawn, echo_drv}, [eof]),
+    Msg = ?MODULE_STRING " dirty port command\n",
+    ok = dirty_port_command(Port, Msg),
+    ok = receive {Port, {data, Msg}} -> ok after 1000 -> ct:fail(timeout) end,
+
+    %% Closed port: lookup returns NULL on the dirty path.
+    port_close(Port),
+    false = dirty_port_command(Port, Msg),
+    ok.
+
 nif_whereis_parallel(Config) when is_list(Config) ->
 
     %% try to be at least a little asymmetric
@@ -1179,6 +1197,7 @@ dirty_sleeper(_) -> ?nif_stub.
 dirty_heap_access_nif(_) -> ?nif_stub.
 whereis_term(_Type,_Name) -> ?nif_stub.
 whereis_send(_Type,_Name,_Msg) -> ?nif_stub.
+dirty_port_command(_Port,_Msg) -> ?nif_stub.
 dirty_terminating_literal_access(_Me, _Literal) -> ?nif_stub.
 delay_halt_normal(_Pid, _FileName, _Delay) -> ?nif_stub.
 delay_halt_io_bound(_Pid, _FileName, _Delay) -> ?nif_stub.

--- a/erts/emulator/test/dirty_nif_SUITE_data/dirty_nif_SUITE.c
+++ b/erts/emulator/test/dirty_nif_SUITE_data/dirty_nif_SUITE.c
@@ -545,6 +545,20 @@ whereis_send(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     return whereis_result_term(env, rc);
 }
 
+/* dirty_port_command(Port, Message) -> ok | false | badarg */
+static ERL_NIF_TERM
+dirty_port_command(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    ErlNifPort port;
+
+    assert(argc == 2);
+
+    if (!enif_get_local_port(env, argv[0], &port))
+        return enif_make_badarg(env);
+
+    return enif_port_command(env, &port, NULL, argv[1]) ? atom_ok : atom_false;
+}
+
 static ERL_NIF_TERM dirty_terminating_literal_access(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ErlNifPid to, self;
@@ -750,6 +764,7 @@ static ErlNifFunc nif_funcs[] =
     {"dirty_call_while_terminated_nif", 1, dirty_call_while_terminated_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"dirty_heap_access_nif", 1, dirty_heap_access_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"whereis_send", 3, whereis_send, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"dirty_port_command", 2, dirty_port_command, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"whereis_term", 2, whereis_term, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"dirty_terminating_literal_access", 2, dirty_terminating_literal_access, ERL_NIF_DIRTY_JOB_CPU_BOUND},
     {"delay_halt_normal", 3, delay_halt, 0},


### PR DESCRIPTION
Mimic check from `enif_is_port_alive`
Fixes #11221