### PR TITLE
common_test: Handle {error,closed} in ct_netconfc:ssh_channel/2

### DIFF
--- a/lib/common_test/src/ct_netconfc.erl
+++ b/lib/common_test/src/ct_netconfc.erl
@@ -2588,9 +2588,9 @@ ssh_channel(#connection{reference=CM}=Connection0,
                 failure ->
                     ssh_connection:close(CM,Ch),
                     {error,{ssh,could_not_execute_netconf_subsystem}};
-                {error,timeout} ->
+                {error,Reason} ->
                     ssh_connection:close(CM,Ch),
-                    {error,{ssh,could_not_execute_netconf_subsystem,timeout}}
+                    {error,{ssh,could_not_execute_netconf_subsystem,Reason}}
             end;
         {error, Reason} ->
             {error,{ssh,could_not_open_channel,Reason}}


### PR DESCRIPTION
ssh_connection:subsystem/4 can return {error, closed} when the remote server drops the connection during subsystem negotiation. The case expression only handled {error, timeout}, causing a case_clause crash.

Replace the specific {error,timeout} pattern with a generic {error,Reason} to handle all error reasons.