### PR TITLE
ct: Include actual error reason in CTH failure test log

### DIFF
--- a/lib/common_test/src/ct_framework.erl
+++ b/lib/common_test/src/ct_framework.erl
@@ -954,7 +954,12 @@ error_notification(Mod,Func,_Args,{Error,Loc}) ->
 			 Result -> Result
 		     end;
 		 Other ->
-		     io_lib:format("~tP", [Other,5])
+                       case io_lib:printable_unicode_list(Other) of
+                           true ->
+                               Other;
+                           false ->
+                               io_lib:format("~tP", [Other, 5])
+                       end
 	     end,
     ErrorHtml =
 	"<font color=\"brown\">" ++ ct_logs:escape_chars(ErrorStr) ++ "</font>",

--- a/lib/common_test/src/ct_hooks.erl
+++ b/lib/common_test/src/ct_hooks.erl
@@ -1166,17 +1166,22 @@ catch_apply(M,F,A) ->
     catch Class:Reason:Trace ->
             ct_logs:log("Suite Hook","Call to CTH failed: ~w:~tp",
                             [Class,{Reason,Trace}]),
+            FormattedErr = format_cth_error(Class, Reason, Trace),
             throw({error_in_cth_call,
                    lists:flatten(
-                     io_lib:format("~w:~tw/~w CTH call failed: ~w:~tp~ts",
-                                   [M,F,length(A),Class,Reason,
-                                    format_cth_stackframe(Trace)]))})
+                     io_lib:format("~w:~tw/~w CTH call failed:\n~ts",
+                                   [M,F,length(A),FormattedErr]))})
     end.
 
-format_cth_stackframe([Top | _]) ->
-    io_lib:format("\n  in ~tp", [Top]);
-format_cth_stackframe([]) ->
-    "".
+format_cth_error(Class, Reason, Trace) ->
+    StackFun = fun(_, _, _) -> false end,
+    PF = fun(Term, I) ->
+                 io_lib:format("~." ++ integer_to_list(I) ++ "tp", [Term])
+         end,
+    try erl_error:format_exception(1, Class, Reason, Trace, StackFun, PF, utf8)
+    catch _:_ ->
+            io_lib:format("~w:~tp", [Class, Reason])
+    end.
 
 process_hooks_order(init, Return) when is_list(Return) ->
     maybe_save_hooks_order(Return);

--- a/lib/common_test/src/ct_hooks.erl
+++ b/lib/common_test/src/ct_hooks.erl
@@ -1163,14 +1163,20 @@ catch_apply(M,F,A, Default, Fallback) ->
 catch_apply(M,F,A) ->
     try
         erlang:apply(M,F,A)
-    catch _:Reason:Trace ->
+    catch Class:Reason:Trace ->
             ct_logs:log("Suite Hook","Call to CTH failed: ~w:~tp",
-                            [error,{Reason,Trace}]),
+                            [Class,{Reason,Trace}]),
             throw({error_in_cth_call,
                    lists:flatten(
-                     io_lib:format("~w:~tw/~w CTH call failed",
-                                   [M,F,length(A)]))})
+                     io_lib:format("~w:~tw/~w CTH call failed: ~w:~tp~ts",
+                                   [M,F,length(A),Class,Reason,
+                                    format_cth_stackframe(Trace)]))})
     end.
+
+format_cth_stackframe([Top | _]) ->
+    io_lib:format("\n  in ~tp", [Top]);
+format_cth_stackframe([]) ->
+    "".
 
 process_hooks_order(init, Return) when is_list(Return) ->
     maybe_save_hooks_order(Return);

--- a/lib/common_test/test/ct_hooks_SUITE.erl
+++ b/lib/common_test/test/ct_hooks_SUITE.erl
@@ -703,7 +703,7 @@ test_events(minimal_and_maximal_cth) ->
 test_events(faulty_cth_undef) ->
     FailReasonStr = fun(S) ->
         true = lists:prefix(
-            "undef_cth:pre_init_per_suite/3 CTH call failed: error:undef", S),
+            "undef_cth:pre_init_per_suite/3 CTH call failed:\n", S),
         match
     end,
     FailReason = {ct_cth_empty_SUITE,init_per_suite,

--- a/lib/common_test/test/ct_hooks_SUITE.erl
+++ b/lib/common_test/test/ct_hooks_SUITE.erl
@@ -701,7 +701,11 @@ test_events(minimal_and_maximal_cth) ->
     ];
 
 test_events(faulty_cth_undef) ->
-    FailReasonStr = "undef_cth:pre_init_per_suite/3 CTH call failed",
+    FailReasonStr = fun(S) ->
+        true = lists:prefix(
+            "undef_cth:pre_init_per_suite/3 CTH call failed: error:undef", S),
+        match
+    end,
     FailReason = {ct_cth_empty_SUITE,init_per_suite,
 		  {failed,FailReasonStr}},
     [
@@ -2922,7 +2926,10 @@ test_events(crash_groups) ->
      {?eh,tc_start,{ct_framework,error_in_suite}},
      {?eh,tc_done,{ct_framework,error_in_suite,
                    {failed,
-                    {error,"all_and_groups_cth:post_groups/2 CTH call failed"}}}},
+                    {error,fun(S) ->
+                        true = lists:prefix(
+                            "all_and_groups_cth:post_groups/2 CTH call failed:", S),
+                        match end}}}},
      {?eh,test_done,{'DEF','STOP_TIME'}},
      {?eh,cth,{empty_cth,terminate,[[]]}},
      {?eh,stop_logging,[]}
@@ -2942,7 +2949,10 @@ test_events(crash_all) ->
      {?eh,tc_start,{ct_framework,error_in_suite}},
      {?eh,tc_done,{ct_framework,error_in_suite,
                    {failed,
-                    {error,"all_and_groups_cth:post_all/3 CTH call failed"}}}},
+                    {error,fun(S) ->
+                        true = lists:prefix(
+                            "all_and_groups_cth:post_all/3 CTH call failed:", S),
+                        match end}}}},
      {?eh,test_done,{'DEF','STOP_TIME'}},
      {?eh,cth,{empty_cth,terminate,[[]]}},
      {?eh,stop_logging,[]}


### PR DESCRIPTION
When a CT hook callback crashes, the test case minor log only shows a generic message like "mod:fun/N CTH call failed" in the "=== Reason:" line. The actual error and stacktrace are logged earlier in the "Suite Hook" section but not propagated to the test summary.

Include the exception class, reason, and top stack frame in the thrown error string so it reaches the "=== Reason:" output that developers and automated tools use to classify failures.