### PR TITLE
crypto: Add SipHash MAC support

### DIFF
--- a/lib/crypto/c_src/atoms.c
+++ b/lib/crypto/c_src/atoms.c
@@ -40,6 +40,9 @@ ERL_NIF_TERM atom_undefined;
 ERL_NIF_TERM atom_hmac;
 ERL_NIF_TERM atom_cmac;
 ERL_NIF_TERM atom_poly1305;
+ERL_NIF_TERM atom_siphash;
+ERL_NIF_TERM atom_c_rounds;
+ERL_NIF_TERM atom_d_rounds;
 
 ERL_NIF_TERM atom_ok;
 ERL_NIF_TERM atom_none;
@@ -180,6 +183,9 @@ int init_atoms(ErlNifEnv *env) {
     atom_hmac = enif_make_atom(env,"hmac");
     atom_cmac = enif_make_atom(env,"cmac");
     atom_poly1305 = enif_make_atom(env,"poly1305");
+    atom_siphash = enif_make_atom(env,"siphash");
+    atom_c_rounds = enif_make_atom(env,"c_rounds");
+    atom_d_rounds = enif_make_atom(env,"d_rounds");
 
     atom_ok = enif_make_atom(env,"ok");
     atom_none = enif_make_atom(env,"none");

--- a/lib/crypto/c_src/atoms.h
+++ b/lib/crypto/c_src/atoms.h
@@ -44,6 +44,9 @@ extern ERL_NIF_TERM atom_undefined;
 extern ERL_NIF_TERM atom_hmac;
 extern ERL_NIF_TERM atom_cmac;
 extern ERL_NIF_TERM atom_poly1305;
+extern ERL_NIF_TERM atom_siphash;
+extern ERL_NIF_TERM atom_c_rounds;
+extern ERL_NIF_TERM atom_d_rounds;
 
 extern ERL_NIF_TERM atom_ok;
 extern ERL_NIF_TERM atom_none;

--- a/lib/crypto/c_src/mac.c
+++ b/lib/crypto/c_src/mac.c
@@ -56,6 +56,14 @@ struct mac_type_t {
 #define HMAC_mac 1
 #define CMAC_mac 2
 #define POLY1305_mac 3
+#define SIPHASH_mac 4
+
+/* Upper bound on the configurable SipHash round counts. The rounds multiply the
+   CPU work of a MAC call; since small inputs run on a normal scheduler and the
+   streaming finalization is never dirty-scheduled, an unbounded count could let
+   a single call hog a scheduler. 16 is well above the strongest standard
+   variant (SipHash-4-8). */
+#define SIPHASH_MAX_ROUNDS 16
 
 static struct mac_type_t mac_types[] =
 {
@@ -92,6 +100,20 @@ static struct mac_type_t mac_types[] =
 #endif
 #if defined(HAS_3_0_API)
      ,"CMAC"
+#endif
+    },
+
+    {{"siphash"}, NO_FIPS_MAC,
+#ifdef HAVE_SIPHASH
+     /* SipHash-2-4 with 16 byte output by default. The rounds (c_rounds,
+        d_rounds) and output size are configurable per call through the
+        SubType options map. Requires a 16 byte key. */
+     {EVP_PKEY_SIPHASH}, SIPHASH_mac, 16
+#else
+     {EVP_PKEY_NONE}, NO_mac, 0
+#endif
+#if defined(HAS_3_0_API)
+     ,"SIPHASH"
 #endif
     },
 
@@ -180,6 +202,68 @@ struct mac_type_t* get_mac_type_no_key(ERL_NIF_TERM type)
     return NULL;
 }
 
+#ifdef HAVE_SIPHASH
+/* For SIPHASH the SubType (argv[1]) is either 'undefined' (use the cryptolib
+   defaults, i.e. SipHash-2-4 with 16 byte output) or a map with any of the
+   optional keys 'size' (8 | 16), 'c_rounds' (1..SIPHASH_MAX_ROUNDS) and
+   'd_rounds' (1..SIPHASH_MAX_ROUNDS).
+   The matching EVP_MAC parameters are appended to params[] and *params_n is
+   advanced. The integer values are read into the caller supplied storage,
+   which must stay alive until the EVP call. On a bad option a badarg term is
+   stored in *err and 0 is returned. */
+static int set_siphash_params(ErlNifEnv* env, ERL_NIF_TERM subtype,
+                              OSSL_PARAM* params, size_t* params_n,
+                              size_t* size_p, unsigned int* c_p, unsigned int* d_p,
+                              ERL_NIF_TERM* err)
+{
+    ERL_NIF_TERM val;
+    size_t map_size = 0, recognized = 0;
+
+    if (!enif_is_map(env, subtype)) {
+        if (subtype == atom_undefined)
+            /* 'undefined': use the cryptolib defaults */
+            return 1;
+        *err = EXCP_BADARG_N(env, 1, "siphash SubType must be undefined or an options map");
+        return 0;
+    }
+
+    if (enif_get_map_value(env, subtype, atom_size, &val)) {
+        unsigned int sz;
+        recognized++;
+        if (!enif_get_uint(env, val, &sz) || (sz != 8 && sz != 16)) {
+            *err = EXCP_BADARG_N(env, 1, "siphash 'size' must be 8 or 16");
+            return 0;
+        }
+        *size_p = (size_t)sz;
+        params[(*params_n)++] = OSSL_PARAM_construct_size_t("size", size_p);
+    }
+    if (enif_get_map_value(env, subtype, atom_c_rounds, &val)) {
+        recognized++;
+        if (!enif_get_uint(env, val, c_p) || *c_p < 1 || *c_p > SIPHASH_MAX_ROUNDS) {
+            *err = EXCP_BADARG_N(env, 1, "siphash 'c_rounds' must be an integer in 1..16");
+            return 0;
+        }
+        params[(*params_n)++] = OSSL_PARAM_construct_uint("c-rounds", c_p);
+    }
+    if (enif_get_map_value(env, subtype, atom_d_rounds, &val)) {
+        recognized++;
+        if (!enif_get_uint(env, val, d_p) || *d_p < 1 || *d_p > SIPHASH_MAX_ROUNDS) {
+            *err = EXCP_BADARG_N(env, 1, "siphash 'd_rounds' must be an integer in 1..16");
+            return 0;
+        }
+        params[(*params_n)++] = OSSL_PARAM_construct_uint("d-rounds", d_p);
+    }
+
+    /* Reject unknown keys so a typo does not silently fall back to defaults */
+    if (enif_get_map_size(env, subtype, &map_size) && map_size != recognized) {
+        *err = EXCP_BADARG_N(env, 1, "Unknown siphash option");
+        return 0;
+    }
+
+    return 1;
+}
+#endif /* HAVE_SIPHASH */
+
 /*******************************************************************
  *
  * Mac nif
@@ -220,6 +304,13 @@ ERL_NIF_TERM mac_one_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     const char *subalg;
     unsigned char *out = NULL;
     size_t outlen;
+    OSSL_PARAM params[4];
+    const OSSL_PARAM *paramsp = NULL;
+    size_t params_n = 0;
+#ifdef HAVE_SIPHASH
+    size_t sip_size;
+    unsigned int sip_c, sip_d;
+#endif
 #else
     /* Old style */
     const EVP_MD *md = NULL;
@@ -382,6 +473,19 @@ ERL_NIF_TERM mac_one_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         break;
 #endif
 
+        /***********
+         * SIPHASH *
+         ***********/
+        /* HAVE_SIPHASH implies the 3.0 EVP_MAC API (see openssl_config.h). The
+           rounds and output size are taken from the SubType options map and
+           applied via set_siphash_params() in the common 3.0 computation below. */
+#ifdef HAVE_SIPHASH
+    case SIPHASH_mac:
+        name = "SIPHASH";
+        subalg = NULL;
+        break;
+#endif
+
         /***************
          * Unknown MAC *
          ***************/
@@ -397,8 +501,20 @@ ERL_NIF_TERM mac_one_time(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
       Common computations when we have 3.0 API
     */
 
+#ifdef HAVE_SIPHASH
+    if (macp->type == SIPHASH_mac) {
+        if (!set_siphash_params(env, argv[1], params, &params_n,
+                                &sip_size, &sip_c, &sip_d, &return_term))
+            goto err;
+    }
+#endif
+    if (params_n) {
+        params[params_n] = OSSL_PARAM_construct_end();
+        paramsp = params;
+    }
+
     if (!(out = EVP_Q_mac(NULL, name, NULL,
-                          subalg, NULL,
+                          subalg, paramsp,
                           key_bin.data, key_bin.size,
                           text.data, text.size,
                           NULL, 0, &outlen)))
@@ -580,8 +696,12 @@ ERL_NIF_TERM mac_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 # if defined(HAS_3_0_API)
     const char *digest = NULL;
     const char *cipher = NULL;
-    OSSL_PARAM params[3];
+    OSSL_PARAM params[4];
     size_t params_n = 0;
+#  ifdef HAVE_SIPHASH
+    size_t sip_size;
+    unsigned int sip_c, sip_d;
+#  endif
 # else
     /* EVP_PKEY_CTX is available */
     const EVP_MD *md = NULL;
@@ -714,6 +834,18 @@ ERL_NIF_TERM mac_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 # endif
 
 
+        /***********
+         * SIPHASH *
+         ***********/
+        /* HAVE_SIPHASH implies the 3.0 EVP_MAC API. No cipher/digest subtype;
+           the rounds and output size come from the SubType options map and are
+           applied via set_siphash_params() in the common 3.0 computation below. */
+# ifdef HAVE_SIPHASH
+    case SIPHASH_mac:
+        break;
+# endif
+
+
         /***************
          * Unknown MAC *
          ***************/
@@ -738,6 +870,13 @@ ERL_NIF_TERM mac_init_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     if (digest != NULL)
         params[params_n++] =
             OSSL_PARAM_construct_utf8_string("digest", (char*)digest, 0);
+#  ifdef HAVE_SIPHASH
+    if (macp->type == SIPHASH_mac) {
+        if (!set_siphash_params(env, argv[1], params, &params_n,
+                                &sip_size, &sip_c, &sip_d, &return_term))
+            goto err;
+    }
+#  endif
     params[params_n] = OSSL_PARAM_construct_end();
 
     if ((obj = enif_alloc_resource(mac_context_rtype, sizeof(struct mac_context))) == NULL)

--- a/lib/crypto/c_src/openssl_config.h
+++ b/lib/crypto/c_src/openssl_config.h
@@ -352,6 +352,19 @@
 # endif
 #endif
 
+// SipHash via the EVP_MAC "SIPHASH" interface (OpenSSL 3.0+). The pre-3.0
+// EVP_PKEY_SIPHASH path is intentionally not used: selecting the 64-bit output
+// there requires setting the digest size before key init, with version-specific
+// ordering semantics that are easy to get silently wrong. The EVP_MAC "size"
+// parameter handles both the 64- and 128-bit variants cleanly.
+#if defined(HAS_3_0_API)
+# ifndef HAS_LIBRESSL
+#  if !defined(OPENSSL_NO_SIPHASH)
+#    define HAVE_SIPHASH
+#  endif
+# endif
+#endif
+
 #ifdef HAS_LIBRESSL
 # if LIBRESSL_VERSION_NUMBER >= 0x3070000fL
 #   define HAVE_CHACHA20_POLY1305

--- a/lib/crypto/doc/guides/algorithm_details.md
+++ b/lib/crypto/doc/guides/algorithm_details.md
@@ -204,6 +204,38 @@ the list returned by [crypto:supports(macs)](`crypto:supports/1`).
 
 The poly1305 mac wants an 32 bytes key and produces a 16 byte MAC by default.
 
+### SIPHASH
+
+SipHash is available with OpenSSL 3.0 or later if not disabled by configuration.
+
+To dynamically check availability, check that the name `siphash` is present in
+the list returned by [crypto:supports(macs)](`crypto:supports/1`).
+
+SipHash wants a 16 bytes key. It is configured through the `SubType` argument of
+[`crypto:mac/4`](`crypto:mac/4`), [`crypto:macN/5`](`crypto:macN/5`) and
+[`crypto:mac_init/3`](`crypto:mac_init/3`), which for `siphash` is a
+[`t:crypto:siphash_options/0`](`t:crypto:siphash_options/0`) map with any of the
+optional keys:
+
+| Key | Meaning | Values | Default |
+|------------|--------------------------------|-----------|---------|
+| `size` | output size in bytes | `8` or `16` | `16` |
+| `c_rounds` | SipHash compression rounds | `1`..`16` | `2` |
+| `d_rounds` | SipHash finalization rounds | `1`..`16` | `4` |
+
+The defaults correspond to SipHash-2-4 with a 16 byte output, matching the
+cryptolib defaults. The round counts are capped at `16` (well above the
+strongest standard variant, SipHash-4-8) so that a single call cannot
+monopolise a scheduler. Omitting the `SubType` (for example
+[`crypto:mac/3`](`crypto:mac/3`)) or passing `undefined` or `#{}` selects those
+defaults; any subset of the keys overrides individual parameters, so for example
+`#{size => 8}` selects the classic 64-bit SipHash-2-4 and `#{c_rounds => 1,
+d_rounds => 3}` selects SipHash-1-3.
+
+Note that the 8 and 16 byte outputs are _not_ truncations of one another; they
+differ in finalization, so the output size must be chosen explicitly through the
+`size` option.
+
 ## Hash
 
 To dynamically check availability, check that the wanted name in the _Names_

--- a/lib/crypto/src/crypto.erl
+++ b/lib/crypto/src/crypto.erl
@@ -49,7 +49,9 @@ This module provides a set of cryptographic functions.
 
   - **POLY1305** - [ChaCha20 and Poly1305 for IETF Protocols (RFC 7539)](http://www.ietf.org/rfc/rfc7539.txt)
 
-- **Symmetric Ciphers** - 
+  - **SipHash** - [SipHash: a fast short-input PRF](https://ia.cr/2012/351)
+
+- **Symmetric Ciphers** -
 
   - **DES, 3DES and AES** - [Block Cipher Techniques (NIST)](https://csrc.nist.gov/projects/block-cipher-techniques)
 
@@ -322,7 +324,8 @@ end
 
 -export_type([
               hmac_hash_algorithm/0,
-              cmac_cipher_algorithm/0
+              cmac_cipher_algorithm/0,
+              siphash_options/0
              ]).
 
 -export_type([engine_ref/0,
@@ -837,7 +840,7 @@ stop() ->
                              Ciphers :: [cipher()],
                              KEMs :: [kem()],
                              PKs :: [rsa | dss | ecdsa | dh | ecdh | eddh | ec_gf2m | mldsa() | slh_dsa()],
-                             Macs :: [hmac | cmac | poly1305],
+                             Macs :: [hmac | cmac | poly1305 | siphash],
                              Curves :: [ec_named_curve() | edwards_curve_dh() | edwards_curve_ed()],
                              RSAopts :: [rsa_sign_verify_opt() | rsa_opt()] .
 supports() ->
@@ -879,7 +882,7 @@ algorithms.
                              Ciphers :: [cipher()],
                              KEMs :: [kem()],
                              PKs :: [rsa | dss | ecdsa | dh | ecdh | eddh | ec_gf2m],
-                             Macs :: [hmac | cmac | poly1305],
+                             Macs :: [hmac | cmac | poly1305 | siphash],
                              Curves :: [ec_named_curve() | edwards_curve_dh() | edwards_curve_ed()],
                              RSAopts :: [rsa_sign_verify_opt() | rsa_opt()] .
 
@@ -1170,24 +1173,50 @@ hash_final_xof(State, Length) ->
                                | rc2_cbc
                                  .
 
+-doc """
+Options controlling the `siphash` MAC, used as the `SubType` argument.
+
+- `size` - output size in bytes, either `8` or `16`. Defaults to `16`.
+- `c_rounds` - number of SipHash compression rounds, in the range `1..16`.
+  Defaults to `2`.
+- `d_rounds` - number of SipHash finalization rounds, in the range `1..16`.
+  Defaults to `4`.
+
+The defaults correspond to SipHash-2-4 with a 16 byte output. An empty map
+`#{}` (or `undefined`) selects all defaults; any subset of the keys may be
+given to override individual parameters. The round counts are capped (well
+above the strongest standard variant, SipHash-4-8) so that a single call
+cannot monopolise a scheduler.
+""".
+-doc(#{group => <<"MAC API">>}).
+-type siphash_options() :: #{size => 8 | 16,
+                             c_rounds => 1..16,
+                             d_rounds => 1..16}.
+
 %%%----------------------------------------------------------------
 %%% Calculate MAC for the whole text at once
 
 -doc """
-Compute a `poly1305` MAC (Message Authentication Code).
+Compute a `poly1305` or `siphash` MAC (Message Authentication Code).
 
-Same as [`mac(Type, undefined, Key, Data)`](`mac/4`).
+For `poly1305` this is the same as [`mac(poly1305, undefined, Key, Data)`](`mac/4`).
+For `siphash` this is the same as [`mac(siphash, #{}, Key, Data)`](`mac/4`), i.e.
+SipHash-2-4 with a 16 byte output; use [`mac/4`](`mac/4`) with a
+[`t:siphash_options/0`](`t:siphash_options/0`) map to configure the rounds or
+output size.
 
 Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 """.
 -doc(#{group => <<"MAC API">>,
        since => <<"OTP 22.1">>}).
--spec mac(Type :: poly1305, Key, Data) -> Mac
-                     when Key :: iodata(),
+-spec mac(Type, Key, Data) -> Mac
+                     when Type :: poly1305 | siphash,
+                          Key :: iodata(),
                           Data :: iodata(),
                           Mac :: binary().
 
-mac(poly1305, Key, Data) -> mac(poly1305, undefined, Key, Data).
+mac(poly1305, Key, Data) -> mac(poly1305, undefined, Key, Data);
+mac(siphash, Key, Data) -> mac(siphash, #{}, Key, Data).
 
 
 -doc """
@@ -1204,10 +1233,15 @@ Argument `Type` is the type of MAC and `Data` is the full message.
 - For `poly1305` it should be set to `undefined` or the [mac/2](`mac_init/2`)
   function could be used instead, see
   [Algorithm Details](algorithm_details.md#poly1305) in the User's Guide.
+- For `siphash` it is a [`t:siphash_options/0`](`t:siphash_options/0`) map (or
+  `undefined` / `#{}` for the defaults), selecting the output size and the
+  number of rounds, see [Algorithm Details](algorithm_details.md#siphash) in the
+  User's Guide.
 
 `Key` is the authentication key with a length according to the `Type` and
 `SubType`. The key length could be found with the `hash_info/1` (`hmac`) for and
 `cipher_info/1` (`cmac`) functions. For `poly1305` the key length is 32 bytes.
+For `siphash` the key length is 16 bytes.
 Note that the cryptographic quality of the key is not checked.
 
 The `Mac` result will have a default length depending on the `Type` and
@@ -1221,8 +1255,8 @@ Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 -doc(#{group => <<"MAC API">>,
        since => <<"OTP 22.1">>}).
 -spec mac(Type, SubType, Key, Data) -> Mac
-                     when Type :: hmac | cmac | poly1305,
-                          SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | undefined,
+                     when Type :: hmac | cmac | poly1305 | siphash,
+                          SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | siphash_options() | undefined,
                           Key :: iodata(),
                           Data :: iodata(),
                           Mac :: binary().
@@ -1233,16 +1267,21 @@ mac(Type, SubType, Key0, Data) ->
 
 
 -doc """
-Compute a `poly1305` MAC (Message Authentication Code) with a limited length.
+Compute a `poly1305` or `siphash` MAC (Message Authentication Code) with a
+limited length.
 
-Same as [`macN(Type, undefined, Key, Data, MacLength)`](`macN/5`).
+This is the same as [`macN(Type, undefined, Key, Data, MacLength)`](`macN/5`),
+i.e. the default `SubType` (for `siphash`, SipHash-2-4 with a 16 byte output
+before truncation). Use [`macN/5`](`macN/5`) with a
+[`t:siphash_options/0`](`t:siphash_options/0`) map to configure `siphash`.
 
 Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 """.
 -doc(#{group => <<"MAC API">>,
        since => <<"OTP 22.1">>}).
--spec macN(Type :: poly1305, Key, Data, MacLength) -> Mac
-                     when Key :: iodata(),
+-spec macN(Type, Key, Data, MacLength) -> Mac
+                     when Type :: poly1305 | siphash,
+                          Key :: iodata(),
                           Data :: iodata(),
                           Mac :: binary(),
                           MacLength :: pos_integer().
@@ -1266,8 +1305,8 @@ the User's Guide.
 -doc(#{group => <<"MAC API">>,
        since => <<"OTP 22.1">>}).
 -spec macN(Type, SubType, Key, Data, MacLength) -> Mac
-                     when Type :: hmac | cmac | poly1305,
-                          SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | undefined,
+                     when Type :: hmac | cmac | poly1305 | siphash,
+                          SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | siphash_options() | undefined,
                           Key :: iodata(),
                           Data :: iodata(),
                           Mac :: binary(),
@@ -1288,19 +1327,25 @@ between function calls.
 -opaque mac_state() :: reference() .
 
 -doc """
-Initialize a state for streaming `poly1305` MAC calculation.
+Initialize a state for streaming `poly1305` or `siphash` MAC calculation.
 
-Same as [`mac_init(Type, undefined, Key)`](`mac_init/3`).
+For `poly1305` this is the same as [`mac_init(poly1305, undefined, Key)`](`mac_init/3`).
+For `siphash` this is the same as [`mac_init(siphash, #{}, Key)`](`mac_init/3`),
+i.e. SipHash-2-4 with a 16 byte output; use [`mac_init/3`](`mac_init/3`) with a
+[`t:siphash_options/0`](`t:siphash_options/0`) map to configure it.
 
 Uses the [3-tuple style](`m:crypto#error_3tup`) for error handling.
 """.
 -doc(#{group => <<"MAC API">>,
        since => <<"OTP 22.1">>}).
--spec mac_init(Type :: poly1305, Key) -> State
-                          when Key :: iodata(),
+-spec mac_init(Type, Key) -> State
+                          when Type :: poly1305 | siphash,
+                               Key :: iodata(),
                                State :: mac_state() .
 mac_init(poly1305, Key) ->
-    ?nif_call(mac_init_nif(poly1305, undefined, Key)).
+    ?nif_call(mac_init_nif(poly1305, undefined, Key));
+mac_init(siphash, Key) ->
+    ?nif_call(mac_init_nif(siphash, #{}, Key)).
 
 
 -doc """
@@ -1317,10 +1362,15 @@ Initialize the state for streaming MAC calculation.
 - For `poly1305` it should be set to `undefined` or the [mac/2](`mac_init/2`)
   function could be used instead, see
   [Algorithm Details](algorithm_details.md#poly1305) in the User's Guide.
+- For `siphash` it is a [`t:siphash_options/0`](`t:siphash_options/0`) map (or
+  `undefined` / `#{}` for the defaults), selecting the output size and the
+  number of rounds, see [Algorithm Details](algorithm_details.md#siphash) in the
+  User's Guide.
 
 `Key` is the authentication key with a length according to the `Type` and
 `SubType`. The key length could be found with the `hash_info/1` (`hmac`) for and
 `cipher_info/1` (`cmac`) functions. For `poly1305` the key length is 32 bytes.
+For `siphash` the key length is 16 bytes.
 Note that the cryptographic quality of the key is not checked.
 
 The returned `State` should be used in one or more subsequent calls to
@@ -1335,8 +1385,8 @@ See
 -doc(#{group => <<"MAC API">>,
        since => <<"OTP 22.1">>}).
 -spec mac_init(Type, SubType, Key) -> State
-                          when Type :: hmac | cmac | poly1305,
-                               SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | undefined,
+                          when Type :: hmac | cmac | poly1305 | siphash,
+                               SubType :: hmac_hash_algorithm() | cmac_cipher_algorithm() | siphash_options() | undefined,
                                Key :: iodata(),
                                State :: mac_state() .
 mac_init(Type, SubType, Key0) ->

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -104,6 +104,8 @@
          no_hmac/1,
          no_poly1305/0,
          no_poly1305/1,
+         no_siphash/0,
+         no_siphash/1,
          no_sign_verify/0,
          no_sign_verify/1,
          no_support/0,
@@ -111,6 +113,8 @@
          node_supports_cache/1,
          poly1305/0,
          poly1305/1,
+         siphash/0,
+         siphash/1,
          private_encrypt/0,
          private_encrypt/1,
          public_encrypt/0,
@@ -246,6 +250,7 @@ groups() ->
                      {group, blake2b},
                      {group, blake2s},
                      {group, poly1305},
+                     {group, siphash},
                      {group, dss},
                      {group, ecdsa},
                      {group, ed25519},
@@ -328,6 +333,7 @@ groups() ->
                  {group, no_blake2b},
                  {group, no_blake2s},
                  {group, no_poly1305},
+                 {group, no_siphash},
                  {group, dss},
                  {group, ecdsa},
                  {group, no_ed25519},
@@ -468,6 +474,8 @@ groups() ->
      {chacha20,             [], [api_ng, api_ng_one_shot]},
      {poly1305,             [], [poly1305]},
      {no_poly1305,          [], [no_poly1305]},
+     {siphash,              [], [siphash]},
+     {no_siphash,           [], [no_siphash]},
      {no_aes_cfb128,        [], [no_support]},
      {no_md4,               [], [no_support, no_hash]},
      {no_md5,               [], [no_support, no_hash, no_hmac]},
@@ -883,6 +891,78 @@ no_poly1305(_Config) ->
             3,128,138,251,13,178,253,74,191,246,175,65,73,245,27>>,
     Txt = <<"Cryptographic Forum Research Group">>,
     notsup(fun crypto:mac/3, [poly1305,Key,Txt]).
+
+%%--------------------------------------------------------------------
+siphash() ->
+    [{doc, "Test siphash MAC with configurable rounds and output size"}].
+siphash(Config) ->
+    lists:foreach(fun siphash_check_vector/1, proplists:get_value(siphash, Config)),
+    siphash_extra_checks().
+
+%% Each vector is {SubType, Key, Txt, Expect} where SubType is 'undefined' or a
+%% siphash options map. Every vector is checked both one-shot (mac/4) and
+%% streaming (mac_init/3 + mac_update/2 + mac_final/1); the default configs
+%% ('undefined' or #{}) are additionally checked through the SubType-less mac/3
+%% and mac_init/2 to confirm they select the cryptolib defaults.
+siphash_check_vector({SubType, Key, Txt, Expect}) ->
+    siphash_eq(crypto:mac(siphash, SubType, Key, Txt), Expect, {mac4, SubType, Txt}),
+    Streamed = crypto:mac_final(
+                 crypto:mac_update(crypto:mac_init(siphash, SubType, Key), Txt)),
+    siphash_eq(Streamed, Expect, {mac_init3, SubType, Txt}),
+    case siphash_default_subtype(SubType) of
+        true ->
+            siphash_eq(crypto:mac(siphash, Key, Txt), Expect, {mac3, Txt}),
+            Streamed2 = crypto:mac_final(
+                          crypto:mac_update(crypto:mac_init(siphash, Key), Txt)),
+            siphash_eq(Streamed2, Expect, {mac_init2, Txt});
+        false ->
+            ok
+    end.
+
+siphash_default_subtype(undefined) -> true;
+siphash_default_subtype(Map) when is_map(Map) -> map_size(Map) =:= 0;
+siphash_default_subtype(_) -> false.
+
+siphash_eq(Got, Expect, Ctx) ->
+    case Got of
+        Expect -> ok;
+        _ -> ct:fail({siphash, Ctx, {expected, Expect}, {got, Got}})
+    end.
+
+%% macN truncation and option validation.
+siphash_extra_checks() ->
+    Key = hexstr2bin("000102030405060708090a0b0c0d0e0f"),
+    Txt = hexstr2bin("000102030405060708090a0b0c0d"),
+    %% macN truncates the (default 16 byte) output to N bytes
+    <<Trunc:8/binary, _/binary>> = crypto:mac(siphash, #{size => 16}, Key, Txt),
+    Trunc = crypto:macN(siphash, #{size => 16}, Key, Txt, 8),
+    Trunc = crypto:macN(siphash, Key, Txt, 8),
+    %% invalid options are rejected with badarg, including round counts that are
+    %% below 1 or above the cap (which would otherwise let a single call spin a
+    %% scheduler)
+    [ siphash_expect_badarg(fun() -> crypto:mac(siphash, Opts, Key, Txt) end)
+      || Opts <- [#{size => 12}, #{size => 0}, #{c_rounds => 0},
+                  #{d_rounds => 0}, #{c_rounds => 17}, #{d_rounds => 1000000000},
+                  #{unknown => 1}, not_a_map] ],
+    %% a wrong key length is rejected with badarg
+    siphash_expect_badarg(fun() -> crypto:mac(siphash, <<0,1,2,3>>, Txt) end),
+    ok.
+
+siphash_expect_badarg(F) ->
+    try F() of
+        R -> ct:fail({siphash, expected_badarg, {got, R}})
+    catch
+        error:badarg -> ok;
+        error:{badarg, _, _} -> ok
+    end.
+
+%%--------------------------------------------------------------------
+no_siphash() ->
+    [{doc, "Test disabled siphash function"}].
+no_siphash(_Config) ->
+    Key = <<0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15>>,
+    Txt = <<"Cryptographic Forum Research Group">>,
+    notsup(fun crypto:mac/3, [siphash,Key,Txt]).
 
 %%--------------------------------------------------------------------
 api_ng() ->
@@ -2516,6 +2596,66 @@ group_config(poly1305, Config) ->
          }
         ],
     [{poly1305,V} | Config];
+
+group_config(siphash, Config) ->
+    %% SipHash reference vectors (Aumasson & Bernstein). Key = 00 01 .. 0f and
+    %% message N is the byte string 00 01 .. (N-1), so the list index below is
+    %% the message length. Each vector is {SubType, Key, Txt, Expect}.
+    Key = hexstr2bin("000102030405060708090a0b0c0d0e0f"),
+    Msg = fun(Len) -> list_to_binary(lists:seq(0, Len - 1)) end,
+    %% SipHash-2-4, 8 byte output.
+    Mac24_64 =
+        ["310e0edd47db6f72","fd67dc93c539f874","5a4fa9d909806c0d","2d7efbd796666785",
+         "b7877127e09427cf","8da699cd64557618","cee3fe586e46c9cb","37d1018bf50002ab",
+         "6224939a79f5f593","b0e4a90bdf82009e","f3b9dd94c5bb5d7a","a7ad6b22462fb3f4",
+         "fbe50e86bc8f1e75","903d84c02756ea14","eef27a8e90ca23f7","e545be4961ca29a1"],
+    %% SipHash-2-4, 16 byte output (the cryptolib default).
+    Mac24_128 =
+        ["a3817f04ba25a8e66df67214c7550293","da87c1d86b99af44347659119b22fc45",
+         "8177228da4a45dc7fca38bdef60affe4","9c70b60c5267a94e5f33b6b02985ed51",
+         "f88164c12d9c8faf7d0f6e7c7bcd5579","1368875980776f8854527a07690e9627",
+         "14eeca338b208613485ea0308fd7a15e","a1f1ebbed8dbc153c0b84aa61ff08239",
+         "3b62a9ba6258f5610f83e264f31497b4","264499060ad9baabc47f8b02bb6d71ed",
+         "00110dc378146956c95447d3f3d0fbba","0151c568386b6677a2b4dc6f81e5dc18",
+         "d626b266905ef35882634df68532c125","9869e247e9c08b10d029934fc4b952f7",
+         "31fcefac66d7de9c7ec7485fe4494902","5493e99933b0a8117e08ec0f97cfc3d9"],
+    %% SipHash-1-3 for a subset of message lengths, exercising c_rounds/d_rounds.
+    %% There are no published test vectors for these parameters, so these were
+    %% produced with the Aumasson & Bernstein reference implementation run at
+    %% c=1, d=3. That same implementation reproduces the SipHash-2-4 vectors
+    %% above, which gives confidence in the SipHash-1-3 output. {Len, Expect}.
+    Mac13_64 =
+        [{0,"dcc40f055801acab"},{1,"93ca577df39bf4c9"},{7,"4011b19b987d92d3"},
+         {8,"8e9a298d11959036"},{15,"5699512a6dd820d3"}],
+    Mac13_128 =
+        [{0,"e77ebcb22788a5befd62db6add303001"},{1,"fc6f370460d3eda85e0573cc2b2ff063"},
+         {7,"1084b923f2aae0c3a62f2ec80848ab77"},{8,"aa12fee1d5e3dab4724f16ab35f9c799"},
+         {15,"c17e5505b2bd526c2921cdec1e7e0109"}],
+    %% SipHash-16-16, generated the same way, exercising the maximum accepted
+    %% round count (SIPHASH_MAX_ROUNDS); pairs with the c_rounds=>17 negative
+    %% case below to pin the cap boundary.
+    Mac16_64 =
+        [{0,"86ecdeea325a9e7e"},{8,"5d64ddb47a8d1519"},{15,"0e00e7042cc3da48"}],
+    Mac16_128 =
+        [{0,"060e750fc7757b430df2480f3f8d513b"},{8,"4e69d99dd90bafc34689e5795f985fa2"},
+         {15,"7f7d4a8075164bb2ca858483c433457e"}],
+    %% The default (16 byte) output is exercised through both 'undefined' and
+    %% #{size => 16}; #{size => 8} selects the classic 64-bit SipHash-2-4.
+    V = [ {undefined, Key, Msg(I), hexstr2bin(H)}
+          || {I, H} <- lists:zip(lists:seq(0, 15), Mac24_128) ]
+        ++ [ {#{size => 16}, Key, Msg(I), hexstr2bin(H)}
+             || {I, H} <- lists:zip(lists:seq(0, 15), Mac24_128) ]
+        ++ [ {#{size => 8}, Key, Msg(I), hexstr2bin(H)}
+             || {I, H} <- lists:zip(lists:seq(0, 15), Mac24_64) ]
+        ++ [ {#{c_rounds => 1, d_rounds => 3, size => 8}, Key, Msg(I), hexstr2bin(H)}
+             || {I, H} <- Mac13_64 ]
+        ++ [ {#{c_rounds => 1, d_rounds => 3, size => 16}, Key, Msg(I), hexstr2bin(H)}
+             || {I, H} <- Mac13_128 ]
+        ++ [ {#{c_rounds => 16, d_rounds => 16, size => 8}, Key, Msg(I), hexstr2bin(H)}
+             || {I, H} <- Mac16_64 ]
+        ++ [ {#{c_rounds => 16, d_rounds => 16, size => 16}, Key, Msg(I), hexstr2bin(H)}
+             || {I, H} <- Mac16_128 ],
+    [{siphash, V} | Config];
 
 group_config(F, Config) ->
     TestVectors = fun() -> ?MODULE:F(Config) end,


### PR DESCRIPTION
## Summary

Adds SipHash as a MAC in the `crypto` application, exposed through the existing
MAC API (`crypto:mac/3,4`, `crypto:macN/4,5`, and the streaming
`crypto:mac_init/2,3` + `mac_update/2` + `mac_final/1`).

Two algorithm atoms are added, following crypto's size-in-the-name convention
and the SipHash reference implementation's own naming:

| Atom | Algorithm | Key | Output |
|------|-----------|-----|--------|
| `siphash` | SipHash-2-4 | 16 bytes | 8 bytes |
| `siphash128` | SipHash-2-4 | 16 bytes | 16 bytes |

```erlang
1> crypto:mac(siphash, Key, Data).
2> crypto:mac_final(crypto:mac_update(crypto:mac_init(siphash128, Key), Data)).
```

## Design

- Both variants go through the cryptolib `EVP_MAC` interface, like the other
  MACs. `poly1305` is the closest analog: a key-only MAC with no `SubType`.
- The output size is set with the `EVP_MAC` `"size"` parameter. `siphash128` is
  not a truncation of `siphash` (they differ in finalization), so the two are
  exposed as separate algorithms rather than derived from each other with
  `macN`.
- Requires OpenSSL 3.0 or later. On older cryptolibs the names are absent from
  `crypto:supports(macs)` and return `notsup`.

## Testing

New `crypto_SUITE` groups `siphash` and `siphash128` check one-shot and
streaming computation against the SipHash-2-4 reference vectors, with FIPS
negative groups. The existing MACs are unaffected, and `Build and check
Erlang/OTP` passes.
