### PR TITLE
erts: Fix alternate signal stack sizing on musl (AT_MINSIGSTKSZ)

### DIFF
--- a/erts/emulator/sys/unix/sys_signal_stack.c
+++ b/erts/emulator/sys/unix/sys_signal_stack.c
@@ -74,6 +74,9 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if defined(__linux__)
+#  include <sys/auxv.h>
+#endif
 
 #include "sys.h"
 #include "erl_alloc.h"
@@ -88,27 +91,23 @@
 #endif
 
 /*
- * Set alternate signal stack for the invoking thread.
+ * Set up alternate signal stack for an Erlang process scheduler thread.
  */
-static void sys_sigaltstack(void *ss_sp) {
+void sys_thread_init_signal_stack(void) {
     stack_t ss;
 
-    ss.ss_sp = ss_sp;
-    ss.ss_flags = 0;
+#if defined(__linux__) && defined(AT_MINSIGSTKSZ)
+    ss.ss_size = (size_t) getauxval(AT_MINSIGSTKSZ);
+    ss.ss_size = MAX(ss.ss_size, SIGSTKSZ);
+#else
     ss.ss_size = SIGSTKSZ;
+#endif
+    ss.ss_sp = malloc(ss.ss_size);  // Never freed
+    ss.ss_flags = 0;
 
     if (sigaltstack(&ss, NULL) < 0) {
         ERTS_INTERNAL_ERROR("Failed to set alternate signal stack");
     }
-}
-
-/*
- * Set up alternate signal stack for an Erlang process scheduler thread.
- */
-void sys_thread_init_signal_stack(void) {
-    /* This will never be freed. */
-    char *stack = malloc(SIGSTKSZ);
-    sys_sigaltstack(stack);
 }
 
 /*


### PR DESCRIPTION
## What

Size the JIT's alternate signal stack to `max(SIGSTKSZ, AT_MINSIGSTKSZ)` instead of the bare
`SIGSTKSZ`, so the emulator starts on musl/Alpine running on CPUs with large signal frames.

Fixes [#11248](https://github.com/erlang/otp/issues/11248).

## Why

On musl, `SIGSTKSZ` is a static `8192`. On CPUs whose kernel reports `AT_MINSIGSTKSZ > 8192`
(AVX-512 / AMX), `sigaltstack()` returns `ENOMEM` and the BEAM aborts at startup. glibc >= 2.34
made `SIGSTKSZ` dynamic for exactly this reason; musl did not. Affects musl JIT builds, OTP 27+.

## Reproduction (hardware-independent, any musl host)

Force sigaltstack to reject the 8192-byte request (simulating a kernel whose minimum exceeds it):

    /* shim.c — gcc -shared -fPIC shim.c -o shim.so -ldl ; LD_PRELOAD=./shim.so erl -noshell -eval 'erlang:halt().' */
    #define _GNU_SOURCE
    #include <signal.h>
    #include <errno.h>
    #include <dlfcn.h>
    static int (*real)(const stack_t*, stack_t*);
    int sigaltstack(const stack_t *ss, stack_t *old){
        if(!real) real = dlsym(RTLD_NEXT, "sigaltstack");
        if(ss && ss->ss_size <= 8192){ errno = ENOMEM; return -1; }
        return real(ss, old);
    }

Unpatched: aborts with "Failed to set alternate signal stack". Patched: boots normally.

## Notes / open questions for reviewers

- Followed the `#if defined(__linux__)` guard you suggested; happy to switch to a configure
  check for `getauxval` (`AC_CHECK_FUNCS`) instead if you'd prefer that for portability.
- This uses exactly `max(SIGSTKSZ, AT_MINSIGSTKSZ)`. If you'd like headroom above the bare
  kernel minimum (for the handler's own frames), I can add a margin — let me know the policy
  you'd want.