### PR TITLE
list_bif_SUITE: fix generic JIT dump helper

### DIFF
--- a/erts/emulator/beam/generators.tab
+++ b/erts/emulator/beam/generators.tab
@@ -83,6 +83,10 @@ gen.get_utf16(Fail, Ms, Flags, Dst) {
     return op;
 }
 
+is_nonempty_list_get_list/4
+is_nonempty_list_get_hd/3
+is_nonempty_list_get_tl/3
+
 // Creates an instruction that moves a literal lambda to a register.
 MakeLiteralFun(Op, Index, Arity, Dst) {
     SWord literal;

--- a/erts/emulator/beam/jit/arm/arm64_easy_wins.md
+++ b/erts/emulator/beam/jit/arm/arm64_easy_wins.md
@@ -9,3 +9,24 @@ ARM64 BEAM JIT easy wins
 Benchmark target:
 
 - A small `list_bif_SUITE` benchmark that repeatedly executes `[H|T]` style matching on a fixed list. That should exercise the fused list instructions directly and provide a realistic before/after comparison on Apple Silicon.
+
+Advanced JIT directions after audit:
+
+1. Prefer guarded shape specialization only when the compiler/loader/JIT do
+   not already carry the shape fact. For example, `is_map(M), map_get(K, M)`
+   already lets the JIT skip the duplicate `map_get/2` map test via SSA type
+   information, so an explicit ops-table fusion does not help.
+2. Reuse existing specialized instruction families before adding new ones.
+   Pattern map extraction already lowers through `get_map_elements` to
+   `i_get_map_element_hash` for literal keys, including a precomputed
+   `hashmap_make_hash(Key)`.
+3. The remaining audited `map_get/2` gap is BIF-form literal-key lookup:
+   `map_get(a, M)` and guard `map_get(a, M) =:= V` still emit
+   `bif_map_get`, while pattern `#{a := V}` emits `i_get_map_element_hash`.
+   That makes literal-key BIF lookup a narrower and better target than broad
+   `is_map` + `map_get` fusion.
+4. Cold outlined fallback is still interesting, but only with real cold block
+   placement. Without that, the hot path still needs a branch around the cold
+   code and the layout win can disappear.
+5. More macro-op fusion should start from concrete dumps that prove the loader
+   and SSA passes have not already produced an equivalent specialized opcode.

--- a/erts/emulator/beam/jit/arm/arm64_easy_wins.md
+++ b/erts/emulator/beam/jit/arm/arm64_easy_wins.md
@@ -1,0 +1,11 @@
+ARM64 BEAM JIT easy wins
+
+1. Port x86 list-fusion rules to arm for `is_nonempty_list` followed by `get_list`, `get_hd`, or `get_tl`.
+2. Audit runtime crossings to keep `emit_enter_runtime` live-register counts as small as possible on hot paths.
+3. Expand paired load/store peepholes for consecutive X/Y register traffic.
+4. Keep success paths straight-line and push slow error paths out of line.
+5. Tighten type-driven fast paths where `BeamTypeId` already proves the shape of the term.
+
+Benchmark target:
+
+- A small `list_bif_SUITE` benchmark that repeatedly executes `[H|T]` style matching on a fixed list. That should exercise the fused list instructions directly and provide a realistic before/after comparison on Apple Silicon.

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1246,6 +1246,8 @@ protected:
     void emit_i_bif(const ArgLabel &Fail,
                     const ArgWord &Bif,
                     const ArgRegister &Dst);
+    void emit_setup_guard_bif(const std::vector<ArgVal> &args,
+                              const ArgWord &Bif);
 
     void emit_error(int code);
     void emit_error(int reason, const ArgSource &Src);

--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1876,6 +1876,20 @@ protected:
         ASSERT(gp1.is_gp64() && gp2.is_gp64());
         ASSERT(gp1 != gp2);
 
+        if (mem.has_base_reg()) {
+            uint32_t base_id = mem.base_id();
+
+            if (gp1.id() == base_id) {
+                safe_ldr(gp2, mem.clone_adjusted(sizeof(Eterm)));
+                safe_ldr(gp1, mem);
+                return;
+            } else if (gp2.id() == base_id) {
+                safe_ldr(gp1, mem);
+                safe_ldr(gp2, mem.clone_adjusted(sizeof(Eterm)));
+                return;
+            }
+        }
+
         if (abs_offset <= sizeof(Eterm) * MAX_LDP_STP_DISPLACEMENT) {
             preserve_cache(
                     [&]() {

--- a/erts/emulator/beam/jit/arm/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/instr_arith.cpp
@@ -1370,6 +1370,16 @@ void BeamModuleAssembler::emit_i_bxor(const ArgLabel &Fail,
                                       const ArgSource &LHS,
                                       const ArgSource &RHS,
                                       const ArgRegister &Dst) {
+    if (arg_sources_are_same_term(LHS, RHS) &&
+        (exact_type<BeamTypeId::Integer>(LHS) ||
+         exact_type<BeamTypeId::Integer>(RHS))) {
+        auto dst = init_destination(Dst, ARG1);
+
+        mov_imm(dst.reg, make_small(0));
+        flush_var(dst);
+        return;
+    }
+
     auto [lhs, rhs] = load_sources(LHS, ARG2, RHS, ARG3);
     auto dst = init_destination(Dst, ARG1);
 

--- a/erts/emulator/beam/jit/arm/instr_arith.cpp
+++ b/erts/emulator/beam/jit/arm/instr_arith.cpp
@@ -1169,11 +1169,29 @@ void BeamGlobalAssembler::emit_i_band_body_shared() {
             &bif_mfa);
 }
 
+static bool arg_sources_are_same_term(const ArgSource &lhs,
+                                      const ArgSource &rhs) {
+    if (lhs.isXRegister() && rhs.isXRegister()) {
+        return lhs.as<ArgXRegister>().get() == rhs.as<ArgXRegister>().get();
+    } else if (lhs.isYRegister() && rhs.isYRegister()) {
+        return lhs.as<ArgYRegister>().get() == rhs.as<ArgYRegister>().get();
+    }
+
+    return lhs == rhs;
+}
+
 void BeamModuleAssembler::emit_i_band(const ArgLabel &Fail,
                                       const ArgWord &Live,
                                       const ArgSource &LHS,
                                       const ArgSource &RHS,
                                       const ArgRegister &Dst) {
+    if (arg_sources_are_same_term(LHS, RHS) &&
+        (exact_type<BeamTypeId::Integer>(LHS) ||
+         exact_type<BeamTypeId::Integer>(RHS))) {
+        mov_arg(Dst, LHS);
+        return;
+    }
+
     if (always_small(LHS) && RHS.isSmall()) {
         a64::Utils::LogicalImm ignore;
         Out<a64::Utils::LogicalImm> out(ignore);
@@ -1270,6 +1288,13 @@ void BeamModuleAssembler::emit_i_bor(const ArgLabel &Fail,
                                      const ArgSource &LHS,
                                      const ArgSource &RHS,
                                      const ArgRegister &Dst) {
+    if (arg_sources_are_same_term(LHS, RHS) &&
+        (exact_type<BeamTypeId::Integer>(LHS) ||
+         exact_type<BeamTypeId::Integer>(RHS))) {
+        mov_arg(Dst, LHS);
+        return;
+    }
+
     if (always_small(LHS) && RHS.isSmall()) {
         a64::Utils::LogicalImm ignore;
         Out<a64::Utils::LogicalImm> out(ignore);

--- a/erts/emulator/beam/jit/arm/instr_bif.cpp
+++ b/erts/emulator/beam/jit/arm/instr_bif.cpp
@@ -55,7 +55,6 @@ void BeamGlobalAssembler::emit_i_bif_guard_shared() {
     emit_enter_runtime<Update::eReductions>();
 
     a.mov(ARG1, c_p);
-    lea(ARG2, getXRef(0));
     mov_imm(ARG3, 0);
     dynamic_runtime_call<3>(ARG4); /* ARG3 is never used by guard BIFs. */
 
@@ -107,10 +106,66 @@ void BeamGlobalAssembler::emit_i_bif_body_shared() {
     }
 }
 
+void BeamModuleAssembler::emit_setup_guard_bif(const std::vector<ArgVal> &args,
+                                               const ArgWord &Bif) {
+    bool is_contiguous_mem;
+
+    ASSERT(args.size() > 0 && args.size() <= 3);
+
+    is_contiguous_mem = args[0].isRegister() && !isRegisterBacked(args[0]);
+    for (size_t i = 1; i < args.size() && is_contiguous_mem; i++) {
+        const ArgVal &prev = args[i - 1], &curr = args[i];
+
+        is_contiguous_mem =
+                curr.isRegister() && !isRegisterBacked(curr) &&
+                ArgVal::memory_relation(prev, curr) ==
+                        ArgVal::Relation::consecutive;
+    }
+
+    if (is_contiguous_mem) {
+        lea(ARG2, getArgRef(args[0]));
+    } else {
+        lea(ARG2, getXRef(0));
+
+        switch (args.size()) {
+        case 1: {
+            auto src1 = load_source(args[0]);
+            a.str(src1.reg, getXRef(0));
+            break;
+        }
+        case 2: {
+            auto [src1, src2] = load_sources(args[0], TMP1, args[1], TMP2);
+            a.stp(src1.reg, src2.reg, getXRef(0));
+            break;
+        }
+        case 3: {
+            auto [src1, src2] = load_sources(args[0], TMP1, args[1], TMP2);
+            auto src3 = load_source(args[2], TMP3);
+            a.stp(src1.reg, src2.reg, getXRef(0));
+            a.str(src3.reg, getXRef(2));
+            break;
+        }
+        default:
+            ERTS_ASSERT(!"invalid guard BIF arity");
+        }
+    }
+
+    ubif_comment(Bif);
+    mov_arg(ARG4, Bif);
+}
+
 void BeamModuleAssembler::emit_i_bif1(const ArgSource &Src1,
                                       const ArgLabel &Fail,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
+    if (Fail.get() != 0) {
+        emit_setup_guard_bif({Src1}, Bif);
+        fragment_call(ga->get_i_bif_guard_shared());
+        emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
+        mov_arg(Dst, ARG1);
+        return;
+    }
+
     auto src1 = load_source(Src1);
 
     a.str(src1.reg, getXRef(0));
@@ -124,6 +179,14 @@ void BeamModuleAssembler::emit_i_bif2(const ArgSource &Src1,
                                       const ArgLabel &Fail,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
+    if (Fail.get() != 0) {
+        emit_setup_guard_bif({Src1, Src2}, Bif);
+        fragment_call(ga->get_i_bif_guard_shared());
+        emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
+        mov_arg(Dst, ARG1);
+        return;
+    }
+
     auto [src1, src2] = load_sources(Src1, TMP1, Src2, TMP2);
 
     a.stp(src1.reg, src2.reg, getXRef(0));
@@ -138,6 +201,14 @@ void BeamModuleAssembler::emit_i_bif3(const ArgSource &Src1,
                                       const ArgLabel &Fail,
                                       const ArgWord &Bif,
                                       const ArgRegister &Dst) {
+    if (Fail.get() != 0) {
+        emit_setup_guard_bif({Src1, Src2, Src3}, Bif);
+        fragment_call(ga->get_i_bif_guard_shared());
+        emit_branch_if_not_value(ARG1, resolve_beam_label(Fail, dispUnknown));
+        mov_arg(Dst, ARG1);
+        return;
+    }
+
     auto [src1, src2] = load_sources(Src1, TMP1, Src2, TMP2);
     auto src3 = load_source(Src3, TMP3);
 
@@ -171,12 +242,7 @@ void BeamModuleAssembler::emit_i_bif(const ArgLabel &Fail,
 void BeamModuleAssembler::emit_nofail_bif1(const ArgSource &Src1,
                                            const ArgWord &Bif,
                                            const ArgRegister &Dst) {
-    auto src1 = load_source(Src1);
-
-    a.str(src1.reg, getXRef(0));
-
-    ubif_comment(Bif);
-    mov_arg(ARG4, Bif);
+    emit_setup_guard_bif({Src1}, Bif);
     fragment_call(ga->get_i_bif_guard_shared());
     mov_arg(Dst, ARG1);
 }
@@ -185,12 +251,7 @@ void BeamModuleAssembler::emit_nofail_bif2(const ArgSource &Src1,
                                            const ArgSource &Src2,
                                            const ArgWord &Bif,
                                            const ArgRegister &Dst) {
-    auto [src1, src2] = load_sources(Src1, TMP1, Src2, TMP2);
-
-    a.stp(src1.reg, src2.reg, getXRef(0));
-
-    ubif_comment(Bif);
-    mov_arg(ARG4, Bif);
+    emit_setup_guard_bif({Src1, Src2}, Bif);
     fragment_call(ga->get_i_bif_guard_shared());
     mov_arg(Dst, ARG1);
 }

--- a/erts/emulator/beam/jit/arm/instr_common.cpp
+++ b/erts/emulator/beam/jit/arm/instr_common.cpp
@@ -296,6 +296,25 @@ void BeamModuleAssembler::emit_get_list(const ArgRegister &Src,
     }
 }
 
+void BeamModuleAssembler::emit_get_list(const a64::Gp boxed_ptr,
+                                        const ArgRegister &Hd,
+                                        const ArgRegister &Tl) {
+    auto hd = init_destination(Hd, TMP2);
+    auto tl = init_destination(Tl, TMP3);
+
+    if (hd.reg == tl.reg) {
+        /* ldp with two identical registers is an illegal
+         * instruction. Produce the same result as the interpreter. */
+        a.ldr(tl.reg, a64::Mem(boxed_ptr, sizeof(Eterm)));
+        flush_var(tl);
+    } else {
+        preserve_cache([&]() {
+            a.ldp(hd.reg, tl.reg, a64::Mem(boxed_ptr));
+        });
+        flush_vars(hd, tl);
+    }
+}
+
 void BeamModuleAssembler::emit_get_hd(const ArgRegister &Src,
                                       const ArgRegister &Hd) {
     auto src = load_source(Src);
@@ -311,6 +330,44 @@ void BeamModuleAssembler::emit_get_tl(const ArgRegister &Src,
     auto src = load_source(Src);
     auto tl = init_destination(Tl, TMP2);
     a64::Gp cons_ptr = emit_ptr_val(TMP1, src.reg);
+
+    a.ldur(tl.reg, getCDRRef(cons_ptr));
+    flush_var(tl);
+}
+
+void BeamModuleAssembler::emit_is_nonempty_list_get_list(
+        const ArgLabel &Fail,
+        const ArgRegister &Src,
+        const ArgRegister &Hd,
+        const ArgRegister &Tl) {
+    auto src = load_source(Src);
+
+    emit_is_cons(resolve_beam_label(Fail, dispUnknown), src.reg);
+    untag_ptr_preserve_cache(TMP1, src.reg);
+    emit_get_list(TMP1, Hd, Tl);
+}
+
+void BeamModuleAssembler::emit_is_nonempty_list_get_hd(const ArgLabel &Fail,
+                                                       const ArgRegister &Src,
+                                                       const ArgRegister &Hd) {
+    auto src = load_source(Src);
+    emit_is_cons(resolve_beam_label(Fail, dispUnknown), src.reg);
+
+    a64::Gp cons_ptr = emit_ptr_val(TMP1, src.reg);
+    auto hd = init_destination(Hd, TMP2);
+
+    a.ldur(hd.reg, getCARRef(cons_ptr));
+    flush_var(hd);
+}
+
+void BeamModuleAssembler::emit_is_nonempty_list_get_tl(const ArgLabel &Fail,
+                                                       const ArgRegister &Src,
+                                                       const ArgRegister &Tl) {
+    auto src = load_source(Src);
+    emit_is_cons(resolve_beam_label(Fail, dispUnknown), src.reg);
+
+    a64::Gp cons_ptr = emit_ptr_val(TMP1, src.reg);
+    auto tl = init_destination(Tl, TMP2);
 
     a.ldur(tl.reg, getCDRRef(cons_ptr));
     flush_var(tl);

--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -996,10 +996,26 @@ void BeamModuleAssembler::emit_bif_map_size(const ArgLabel &Fail,
  * ================================================================
  */
 
+static bool arg_sources_are_same_term(const ArgSource &lhs,
+                                      const ArgSource &rhs) {
+    if (lhs.isXRegister() && rhs.isXRegister()) {
+        return lhs.as<ArgXRegister>().get() == rhs.as<ArgXRegister>().get();
+    } else if (lhs.isYRegister() && rhs.isYRegister()) {
+        return lhs.as<ArgYRegister>().get() == rhs.as<ArgYRegister>().get();
+    }
+
+    return lhs == rhs;
+}
+
 void BeamModuleAssembler::emit_bif_min_max(arm::CondCode cc,
                                            const ArgSource &LHS,
                                            const ArgSource &RHS,
                                            const ArgRegister &Dst) {
+    if (arg_sources_are_same_term(LHS, RHS)) {
+        mov_arg(Dst, LHS);
+        return;
+    }
+
     auto [lhs, rhs] = load_sources(LHS, ARG1, RHS, ARG2);
     auto dst = init_destination(Dst, ARG1);
     bool both_small = always_small(LHS) && always_small(RHS);

--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -856,6 +856,15 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
                                            const ArgSource &Src,
                                            const ArgRegister &Dst) {
     Label good_key = a.new_label();
+    auto get_constant_key = [&]() {
+        ASSERT(Key.isConstant());
+
+        if (Key.isImmed()) {
+            return Key.as<ArgImmed>().get();
+        } else {
+            return beamfile_get_literal(beam, Key.as<ArgLiteral>().get());
+        }
+    };
 
     mov_arg(ARG1, Src);
     mov_arg(ARG2, Key);
@@ -900,7 +909,21 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
         a.bind(good_map);
     }
 
-    if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key)) {
+    if (Fail.get() != 0 && Key.isConstant()) {
+        mov_imm(ARG3, hashmap_make_hash(get_constant_key()));
+
+        if (Key.isImmed()) {
+            fragment_call(ga->get_i_get_map_element_hash_shared());
+        } else {
+            emit_enter_runtime();
+            runtime_call<Eterm (*)(Eterm, Eterm, erts_ihash_t),
+                         get_map_element_hash>();
+            emit_leave_runtime();
+        }
+
+        emit_branch_if_not_value(ARG1,
+                                 resolve_beam_label(Fail, dispUnknown));
+    } else if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key)) {
         fragment_call(ga->get_i_get_map_element_shared());
         if (Fail.get() == 0) {
             a.b_eq(good_key);

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -182,9 +182,22 @@ is_nonempty_list Fail nqia => jump Fail
 
 is_nonempty_list f S
 
+is_nonempty_list Fail Src | get_list Src2 Hd Tl | equal(Src, Src2) =>
+    is_nonempty_list_get_list Fail Src Hd Tl
+
+is_nonempty_list Fail Src | get_hd Src2 Hd | equal(Src, Src2) =>
+    is_nonempty_list_get_hd Fail Src Hd
+
+is_nonempty_list Fail Src | get_tl Src2 Tl | equal(Src, Src2) =>
+    is_nonempty_list_get_tl Fail Src Tl
+
 get_list S d d
 get_hd S d
 get_tl S d
+
+is_nonempty_list_get_list f S d d
+is_nonempty_list_get_hd f S d
+is_nonempty_list_get_tl f S d
 
 # Old-style catch.
 catch y H

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -282,12 +282,12 @@ load_tuple_ptr s
 
 # If positions are in consecutive memory, fetch and store two words at
 # once.
-## FIXME: Fix this bug in maint, too.
 i_get_tuple_element Tuple Pos1 Dst1 |
   current_tuple Tuple2 |
   get_tuple_element Tuple3 Pos2 Dst2 |
   equal(Tuple, Tuple2) | equal(Tuple, Tuple3) |
-  consecutive_words(Pos1, Pos2) | distinct(Dst1, Dst2) =>
+  consecutive_words(Pos1, Pos2) | distinct(Dst1, Dst2) |
+  distinct(Dst1, Tuple) | distinct(Dst2, Tuple) =>
     get_two_tuple_elements Tuple Pos1 Dst1 Dst2 |
     current_tuple Tuple Dst2
 

--- a/erts/emulator/beam/jit/x86/x86_64_easy_wins.md
+++ b/erts/emulator/beam/jit/x86/x86_64_easy_wins.md
@@ -1,0 +1,8 @@
+X86-64 BEAM JIT easy wins
+
+1. Try the ARM64 guard-literal `map_get/2` prehash optimization on x86-64.
+   Audit shows x86-64 `bif_map_get` still routes literal immediate guard keys
+   through `i_get_map_element_shared`, while pattern extraction already uses
+   `i_get_map_element_hash` with a loader-computed `hashmap_make_hash(Key)`.
+   As on ARM64, scope the first attempt to `Fail != 0` guard contexts so body
+   `map_get/2` badkey/badmap exception behavior remains untouched.

--- a/erts/emulator/test/emulator_bench.spec
+++ b/erts/emulator/test/emulator_bench.spec
@@ -4,3 +4,4 @@
 {groups,"../emulator_test",hash_SUITE,[phash2_benchmark]}.
 {groups,"../emulator_test",list_bif_SUITE,[benchmarks]}.
 {groups,"../emulator_test",map_SUITE,[benchmarks]}.
+{groups,"../emulator_test",tuple_SUITE,[benchmarks]}.

--- a/erts/emulator/test/emulator_bench.spec
+++ b/erts/emulator/test/emulator_bench.spec
@@ -2,4 +2,5 @@
 {groups,"../emulator_test",binary_SUITE,[iolist_size_benchmarks]}.
 {groups,"../emulator_test",erts_debug_SUITE,[interpreter_size_bench]}.
 {groups,"../emulator_test",hash_SUITE,[phash2_benchmark]}.
+{groups,"../emulator_test",list_bif_SUITE,[benchmarks]}.
 {groups,"../emulator_test",map_SUITE,[benchmarks]}.

--- a/erts/emulator/test/list_bif_SUITE.erl
+++ b/erts/emulator/test/list_bif_SUITE.erl
@@ -21,13 +21,15 @@
 %%
 
 -module(list_bif_SUITE).
+-include_lib("common_test/include/ct_event.hrl").
 -include_lib("common_test/include/ct.hrl").
 
 -export([all/0, suite/0,
-         init_per_testcase/2, end_per_testcase/2]).
+         groups/0, init_per_testcase/2, end_per_testcase/2]).
 -export([hd_test/1,tl_test/1,t_length/1,t_list_to_pid/1,
          t_list_to_ref/1, t_list_to_ext_pidportref/1,
-         t_list_to_port/1,t_list_to_float/1,t_list_to_integer/1]).
+         t_list_to_port/1,t_list_to_float/1,t_list_to_integer/1,
+         benchmarks/1]).
 
 
 suite() ->
@@ -35,15 +37,79 @@ suite() ->
      {timetrap, {minutes, 1}}].
 
 
-all() -> 
-    [hd_test, tl_test, t_length, t_list_to_pid, t_list_to_port,
-     t_list_to_ref, t_list_to_ext_pidportref,
-     t_list_to_float, t_list_to_integer].
+all() ->
+    [{group,main}, benchmarks].
+
+groups() ->
+    [{main, [],
+      [hd_test, tl_test, t_length, t_list_to_pid, t_list_to_port,
+       t_list_to_ref, t_list_to_ext_pidportref,
+       t_list_to_float, t_list_to_integer]},
+     {benchmarks, [{repeat,10}], [benchmarks]}].
 
 init_per_testcase(_TestCase, Config) ->
     Config.
 end_per_testcase(_TestCase, Config) ->
     erts_test_utils:ept_check_leaked_nodes(Config).
+
+benchmarks(_Config) ->
+    Iterations = 5_000_000,
+
+    bench_nonempty_list_get_list(Iterations),
+    bench_nonempty_list_get_hd(Iterations),
+    bench_nonempty_list_get_tl(Iterations),
+    ok.
+
+bench_nonempty_list_get_list(Iterations) ->
+    List = [1, 2, 3, 4, 5, 6, 7, 8],
+    F = fun(N) -> nonempty_list_get_list_loop(N, List, 0) end,
+    time(bench_nonempty_list_get_list, F, Iterations).
+
+bench_nonempty_list_get_hd(Iterations) ->
+    List = [1, 2, 3, 4, 5, 6, 7, 8],
+    F = fun(N) -> nonempty_list_get_hd_loop(N, List, 0) end,
+    time(bench_nonempty_list_get_hd, F, Iterations).
+
+bench_nonempty_list_get_tl(Iterations) ->
+    List = [1, 2, 3, 4, 5, 6, 7, 8],
+    F = fun(N) -> nonempty_list_get_tl_loop(N, List, 0) end,
+    time(bench_nonempty_list_get_tl, F, Iterations).
+
+nonempty_list_get_list_loop(0, _List, Acc) ->
+    Acc;
+nonempty_list_get_list_loop(N, List, Acc) ->
+    {H, _T} = nonempty_list_get_list(List),
+    nonempty_list_get_list_loop(N - 1, List, Acc + H).
+
+nonempty_list_get_hd_loop(0, _List, Acc) ->
+    Acc;
+nonempty_list_get_hd_loop(N, List, Acc) ->
+    H = nonempty_list_get_hd(List),
+    nonempty_list_get_hd_loop(N - 1, List, Acc + H).
+
+nonempty_list_get_tl_loop(0, _List, Acc) ->
+    Acc;
+nonempty_list_get_tl_loop(N, List, Acc) ->
+    _T = nonempty_list_get_tl(List),
+    nonempty_list_get_tl_loop(N - 1, List, Acc + 1).
+
+nonempty_list_get_list([H|T]) ->
+    {H, T}.
+
+nonempty_list_get_hd([H|_]) ->
+    H.
+
+nonempty_list_get_tl([_|T]) ->
+    T.
+
+time(Name, F, Iterations) ->
+    Time = element(1, timer:tc(F, [Iterations])),
+    ct_event:notify(#event{name = benchmark_data,
+                           data = [{value, Time},
+                                   {suite, ?MODULE_STRING},
+                                   {name, atom_to_list(Name)}]}),
+    ct:pal("~s: ~p us", [atom_to_list(Name), Time]),
+    Time.
 
 %% Tests list_to_integer and string:to_integer
 t_list_to_integer(Config) when is_list(Config) ->

--- a/erts/emulator/test/list_bif_SUITE.erl
+++ b/erts/emulator/test/list_bif_SUITE.erl
@@ -163,15 +163,15 @@ dump_asm_fixture(AsmFile, DumpBase) ->
     CompilerEbin = filename:join([RootDir, "lib", "compiler", "ebin"]),
     DumpDir = filename:join(
                 filename:absname("."),
-                "list_fusion_overlap_asm_" ++
+                DumpBase ++ "_asm_" ++
                     integer_to_list(erlang:unique_integer([positive]))),
     ok = file:make_dir(DumpDir),
     try
         Eval = io_lib:format(
                  "{ok,M,Code}=compile:file(~p,[from_asm,binary,report]),"
-                 "{module,M}=code:load_binary(M,\"list_fusion_overlap\",Code),"
-                 "ok=M:M(),halt().",
-                 [AsmFile]),
+                 "{module,M}=code:load_binary(M,~p,Code),"
+                 "_=M:M(),halt().",
+                 [AsmFile, DumpBase]),
         Args = ["+JDdump", "true",
                 "-boot", Boot,
                 "-noshell",

--- a/erts/emulator/test/list_bif_SUITE.erl
+++ b/erts/emulator/test/list_bif_SUITE.erl
@@ -29,7 +29,7 @@
 -export([hd_test/1,tl_test/1,t_length/1,t_list_to_pid/1,
          t_list_to_ref/1, t_list_to_ext_pidportref/1,
          t_list_to_port/1,t_list_to_float/1,t_list_to_integer/1,
-         benchmarks/1]).
+         list_fusion_overlap/1, benchmarks/1]).
 
 
 suite() ->
@@ -44,7 +44,7 @@ groups() ->
     [{main, [],
       [hd_test, tl_test, t_length, t_list_to_pid, t_list_to_port,
        t_list_to_ref, t_list_to_ext_pidportref,
-       t_list_to_float, t_list_to_integer]},
+       t_list_to_float, t_list_to_integer, list_fusion_overlap]},
      {benchmarks, [{repeat,10}], [benchmarks]}].
 
 init_per_testcase(_TestCase, Config) ->
@@ -110,6 +110,105 @@ time(Name, F, Iterations) ->
                                    {name, atom_to_list(Name)}]}),
     ct:pal("~s: ~p us", [atom_to_list(Name), Time]),
     Time.
+
+list_fusion_overlap(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    AsmFile = filename:absname(filename:join(DataDir, "list_fusion_overlap")),
+
+    %% Verify the fixture behavior first, then verify the native code shape.
+    {ok, Mod, Code} = compile:file(AsmFile, [from_asm,binary,report]),
+    {module, Mod} = code:load_binary(Mod, "list_fusion_overlap", Code),
+    ok = Mod:Mod(),
+    true = code:delete(Mod),
+    _ = code:purge(Mod),
+
+    AsmDump = dump_list_fusion_overlap(AsmFile),
+    case overlapping_ldp_lines(AsmDump) of
+        [] ->
+            ok;
+        Lines ->
+            ct:fail("JIT emitted overlapping ldp base/destination registers:~n~ts",
+                    [join_lines(Lines)])
+    end.
+
+dump_list_fusion_overlap(AsmFile) ->
+    RootDir = required_env("ROOTDIR"),
+    BinDir = required_env("BINDIR"),
+    Erlexec = filename:join(BinDir, "erlexec"),
+    Boot = filename:join([RootDir, "bin", "start_clean"]),
+    CompilerEbin = filename:join([RootDir, "lib", "compiler", "ebin"]),
+    DumpDir = filename:join(
+                filename:absname("."),
+                "list_fusion_overlap_asm_" ++
+                    integer_to_list(erlang:unique_integer([positive]))),
+    ok = file:make_dir(DumpDir),
+    try
+        Eval = io_lib:format(
+                 "{ok,M,Code}=compile:file(~p,[from_asm,binary,report]),"
+                 "{module,M}=code:load_binary(M,\"list_fusion_overlap\",Code),"
+                 "ok=M:M(),halt().",
+                 [AsmFile]),
+        Args = ["+JDdump", "true",
+                "-boot", Boot,
+                "-noshell",
+                "-pa", CompilerEbin,
+                "-eval", lists:flatten(Eval)],
+        Env = [{"ROOTDIR", RootDir},
+               {"BINDIR", BinDir},
+               {"EMU", "beam"},
+               {"PROGNAME", "erl"}],
+        case run_erlexec(Erlexec, Args, Env, DumpDir) of
+            {0, _Output} ->
+                DumpFile = filename:join(DumpDir, "list_fusion_overlap.asm"),
+                {ok, Dump} = file:read_file(DumpFile),
+                Dump;
+            {Status, Output} ->
+                ct:fail("JIT dump failed with status ~p:~n~ts",
+                        [Status, Output])
+        end
+    after
+        _ = file:del_dir_r(DumpDir)
+    end.
+
+required_env(Name) ->
+    case os:getenv(Name) of
+        false ->
+            ct:fail("~s must be set to run the built VM", [Name]);
+        Value ->
+            Value
+    end.
+
+run_erlexec(Erlexec, Args, Env, Cwd) ->
+    Port = open_port({spawn_executable, Erlexec},
+                     [exit_status, stderr_to_stdout, binary,
+                      {args, Args}, {env, Env}, {cd, Cwd}]),
+    collect_port(Port, []).
+
+collect_port(Port, Acc) ->
+    receive
+        {Port, {data, Data}} ->
+            collect_port(Port, [Data | Acc]);
+        {Port, {exit_status, Status}} ->
+            {Status, iolist_to_binary(lists:reverse(Acc))}
+    end.
+
+overlapping_ldp_lines(AsmDump) ->
+    [Line || Line <- binary:split(AsmDump, <<"\n">>, [global]),
+             overlapping_ldp(Line)].
+
+overlapping_ldp(Line) ->
+    case re:run(Line,
+                "^\\s*ldp\\s+(x[0-9]+),\\s*(x[0-9]+),\\s*\\[(x[0-9]+)(?:[,\\]])",
+                [{capture, all_but_first, binary}]) of
+        {match, [Dst1, Dst2, Base]} ->
+            Dst1 =:= Base orelse Dst2 =:= Base;
+        nomatch ->
+            false
+    end.
+
+join_lines(Lines) ->
+    unicode:characters_to_list(
+      iolist_to_binary([[Line, $\n] || Line <- Lines])).
 
 %% Tests list_to_integer and string:to_integer
 t_list_to_integer(Config) when is_list(Config) ->

--- a/erts/emulator/test/list_bif_SUITE.erl
+++ b/erts/emulator/test/list_bif_SUITE.erl
@@ -29,7 +29,7 @@
 -export([hd_test/1,tl_test/1,t_length/1,t_list_to_pid/1,
          t_list_to_ref/1, t_list_to_ext_pidportref/1,
          t_list_to_port/1,t_list_to_float/1,t_list_to_integer/1,
-         list_fusion_overlap/1, benchmarks/1]).
+         list_fusion_overlap/1, guard_bif_arg_vector/1, benchmarks/1]).
 
 
 suite() ->
@@ -44,7 +44,8 @@ groups() ->
     [{main, [],
       [hd_test, tl_test, t_length, t_list_to_pid, t_list_to_port,
        t_list_to_ref, t_list_to_ext_pidportref,
-       t_list_to_float, t_list_to_integer, list_fusion_overlap]},
+       t_list_to_float, t_list_to_integer, list_fusion_overlap,
+       guard_bif_arg_vector]},
      {benchmarks, [{repeat,10}], [benchmarks]}].
 
 init_per_testcase(_TestCase, Config) ->
@@ -131,7 +132,30 @@ list_fusion_overlap(Config) when is_list(Config) ->
                     [join_lines(Lines)])
     end.
 
+guard_bif_arg_vector(Config) when is_list(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    AsmFile = filename:absname(filename:join(DataDir, "guard_bif_arg_vector")),
+
+    {ok, Mod, Code} = compile:file(AsmFile, [from_asm,binary,report]),
+    {module, Mod} = code:load_binary(Mod, "guard_bif_arg_vector", Code),
+    true = Mod:Mod(),
+    1000 = Mod:bench(1000, <<>>),
+    true = code:delete(Mod),
+    _ = code:purge(Mod),
+
+    AsmDump = dump_asm_fixture(AsmFile, "guard_bif_arg_vector"),
+    case redundant_guard_bif_arg_stores(AsmDump) of
+        [] ->
+            ok;
+        Lines ->
+            ct:fail("JIT copied contiguous guard BIF Y arguments into x regs:~n~ts",
+                    [join_lines(Lines)])
+    end.
+
 dump_list_fusion_overlap(AsmFile) ->
+    dump_asm_fixture(AsmFile, "list_fusion_overlap").
+
+dump_asm_fixture(AsmFile, DumpBase) ->
     RootDir = required_env("ROOTDIR"),
     BinDir = required_env("BINDIR"),
     Erlexec = filename:join(BinDir, "erlexec"),
@@ -159,7 +183,7 @@ dump_list_fusion_overlap(AsmFile) ->
                {"PROGNAME", "erl"}],
         case run_erlexec(Erlexec, Args, Env, DumpDir) of
             {0, _Output} ->
-                DumpFile = filename:join(DumpDir, "list_fusion_overlap.asm"),
+                DumpFile = filename:join(DumpDir, DumpBase ++ ".asm"),
                 {ok, Dump} = file:read_file(DumpFile),
                 Dump;
             {Status, Output} ->
@@ -205,6 +229,17 @@ overlapping_ldp(Line) ->
         nomatch ->
             false
     end.
+
+redundant_guard_bif_arg_stores(AsmDump) ->
+    [Line || Line <- binary:split(AsmDump, <<"\n">>, [global]),
+             redundant_guard_bif_arg_store(Line)].
+
+redundant_guard_bif_arg_store(Line) ->
+    %% The fixture puts binary_part/3's first two arguments in adjacent Y slots.
+    %% A redundant setup copies them into the x-register array with an STP.
+    re:run(Line,
+           "^\\s*stp\\s+x[0-9]+,\\s*x[0-9]+,\\s*\\[x19(?:,|\\])",
+           [{capture, none}]) =:= match.
 
 join_lines(Lines) ->
     unicode:characters_to_list(

--- a/erts/emulator/test/list_bif_SUITE_data/guard_bif_arg_vector.S
+++ b/erts/emulator/test/list_bif_SUITE_data/guard_bif_arg_vector.S
@@ -1,0 +1,117 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+{module, guard_bif_arg_vector}.
+
+{exports, [{guard_bif_arg_vector,0},
+           {bench,2},
+           {module_info,0},
+           {module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 17}.
+
+
+{function, guard_bif_arg_vector, 0, 2}.
+  {label,1}.
+    {func_info,{atom,guard_bif_arg_vector},{atom,guard_bif_arg_vector},0}.
+  {label,2}.
+    {move,{literal,<<>>},{x,0}}.
+    {move,{integer,0},{x,1}}.
+    {move,{integer,0},{x,2}}.
+    {call_only,3,{f,6}}.
+
+
+{function, bench, 2, 4}.
+  {label,3}.
+    {func_info,{atom,guard_bif_arg_vector},{atom,bench},2}.
+  {label,4}.
+    {move,{integer,0},{x,2}}.
+    {move,{integer,0},{x,3}}.
+    {move,{integer,0},{x,4}}.
+    {call_only,5,{f,9}}.
+
+
+{function, guard, 3, 6}.
+  {label,5}.
+    {func_info,{atom,guard_bif_arg_vector},{atom,guard},3}.
+  {label,6}.
+    {allocate,3,3}.
+    {move,{x,0},{y,0}}.
+    {move,{x,1},{y,1}}.
+    {move,{x,2},{y,2}}.
+    {gc_bif,binary_part,{f,7},3,[{y,0},{y,1},{y,2}],{x,0}}.
+    {test,is_eq_exact,{f,7},[{tr,{x,0},{t_bitstring,8,false}},{literal,<<>>}]}.
+    {move,{atom,true},{x,0}}.
+    {deallocate,3}.
+    return.
+  {label,7}.
+    {move,{atom,false},{x,0}}.
+    {deallocate,3}.
+    return.
+
+
+{function, bench_loop, 5, 9}.
+  {label,8}.
+    {func_info,{atom,guard_bif_arg_vector},{atom,bench_loop},5}.
+  {label,9}.
+    {test,is_eq_exact,{f,10},[{x,0},{integer,0}]}.
+    {move,{x,4},{x,0}}.
+    return.
+  {label,10}.
+    {allocate,5,5}.
+    {move,{x,0},{y,0}}.
+    {move,{x,1},{y,1}}.
+    {move,{x,2},{y,2}}.
+    {move,{x,3},{y,3}}.
+    {move,{x,4},{y,4}}.
+    {gc_bif,binary_part,{f,11},5,[{y,1},{y,2},{y,3}],{x,0}}.
+    {test,is_eq_exact,{f,11},[{tr,{x,0},{t_bitstring,8,false}},{literal,<<>>}]}.
+    {gc_bif,'+',{f,0},5,[{y,4},{integer,1}],{x,4}}.
+    {jump,{f,12}}.
+  {label,11}.
+    {move,{y,4},{x,4}}.
+  {label,12}.
+    {gc_bif,'-',{f,0},5,[{y,0},{integer,1}],{x,0}}.
+    {move,{y,1},{x,1}}.
+    {move,{y,2},{x,2}}.
+    {move,{y,3},{x,3}}.
+    {deallocate,5}.
+    {call_only,5,{f,9}}.
+
+
+{function, module_info, 0, 14}.
+  {label,13}.
+    {func_info,{atom,guard_bif_arg_vector},{atom,module_info},0}.
+  {label,14}.
+    {move,{atom,guard_bif_arg_vector},{x,0}}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 16}.
+  {label,15}.
+    {func_info,{atom,guard_bif_arg_vector},{atom,module_info},1}.
+  {label,16}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,guard_bif_arg_vector},{x,0}}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/erts/emulator/test/list_bif_SUITE_data/list_fusion_overlap.S
+++ b/erts/emulator/test/list_bif_SUITE_data/list_fusion_overlap.S
@@ -1,0 +1,63 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+{module, list_fusion_overlap}.
+
+{exports, [{list_fusion_overlap,0},{module_info,0},{module_info,1}]}.
+
+{attributes, []}.
+
+{labels, 8}.
+
+
+{function, list_fusion_overlap, 0, 2}.
+  {label,1}.
+    {func_info,{atom,list_fusion_overlap},{atom,list_fusion_overlap},0}.
+  {label,2}.
+    {test_heap,4,0}.
+    {put_list,{integer,2},nil,{x,2}}.
+    {put_list,{integer,1},{x,2},{x,2}}.
+    {test,is_nonempty_list,{f,3},[{x,2}]}.
+    {get_list,{x,2},{x,3},{x,2}}.
+    {test,is_eq_exact,{f,3},[{x,3},{integer,1}]}.
+    {test,is_eq_exact,{f,3},[{x,2},{literal,[2]}]}.
+    {move,{atom,ok},{x,0}}.
+    return.
+  {label,3}.
+    {badmatch,{x,2}}.
+
+
+{function, module_info, 0, 5}.
+  {label,4}.
+    {func_info,{atom,list_fusion_overlap},{atom,module_info},0}.
+  {label,5}.
+    {move,{atom,list_fusion_overlap},{x,0}}.
+    {call_ext_only,1,{extfunc,erlang,get_module_info,1}}.
+
+
+{function, module_info, 1, 7}.
+  {label,6}.
+    {func_info,{atom,list_fusion_overlap},{atom,module_info},1}.
+  {label,7}.
+    {move,{x,0},{x,1}}.
+    {move,{atom,list_fusion_overlap},{x,0}}.
+    {call_ext_only,2,{extfunc,erlang,get_module_info,2}}.

--- a/erts/emulator/test/tuple_SUITE.erl
+++ b/erts/emulator/test/tuple_SUITE.erl
@@ -30,7 +30,9 @@
          build_and_match/1, tuple_with_case/1, tuple_in_guard/1,
          get_two_tuple_elements/1,
          record_update/1,
-         bad_tuple_match/1]).
+         bad_tuple_match/1,
+         benchmarks/1]).
+-include_lib("common_test/include/ct_event.hrl").
 -include_lib("common_test/include/ct.hrl").
 
 %% Tests tuples and the BIFs:
@@ -45,20 +47,22 @@
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
-all() -> 
-    [build_and_match, t_size, t_tuple_size, t_list_to_tuple,
-     t_list_to_upper_boundry_tuple,
-     t_tuple_to_list, t_element, t_setelement,
-     t_make_tuple_2, t_make_upper_boundry_tuple_2, t_make_tuple_3,
-     t_append_element, t_append_element_upper_boundry,
-     t_insert_element, t_delete_element,
-     tuple_with_case, tuple_in_guard,
-     get_two_tuple_elements,
-     record_update,
-     bad_tuple_match].
+all() ->
+    [{group, main}, benchmarks].
 
 groups() -> 
-    [].
+    [{main, [],
+      [build_and_match, t_size, t_tuple_size, t_list_to_tuple,
+       t_list_to_upper_boundry_tuple,
+       t_tuple_to_list, t_element, t_setelement,
+       t_make_tuple_2, t_make_upper_boundry_tuple_2, t_make_tuple_3,
+       t_append_element, t_append_element_upper_boundry,
+       t_insert_element, t_delete_element,
+       tuple_with_case, tuple_in_guard,
+       get_two_tuple_elements,
+       record_update,
+       bad_tuple_match]},
+     {benchmarks, [{repeat,10}], [benchmarks]}].
 
 init_per_suite(Config) ->
     id(Config),
@@ -82,6 +86,65 @@ init_per_group(_GroupName, Config) ->
 
 end_per_group(_GroupName, Config) ->
     Config.
+
+benchmarks(_Config) ->
+    Iterations = 5_000_000,
+
+    bench_adjacent_tuple_elements(Iterations),
+    bench_nonadjacent_tuple_elements(Iterations),
+    bench_tagged_tuple_elements(Iterations),
+    ok.
+
+bench_adjacent_tuple_elements(Iterations) ->
+    Tuple = {1, 2, 3, 4, 5, 6, 7, 8},
+    F = fun(N) -> adjacent_tuple_elements_loop(N, Tuple, 0) end,
+    time(bench_adjacent_tuple_elements, F, Iterations).
+
+bench_nonadjacent_tuple_elements(Iterations) ->
+    Tuple = {1, 2, 3, 4, 5, 6, 7, 8},
+    F = fun(N) -> nonadjacent_tuple_elements_loop(N, Tuple, 0) end,
+    time(bench_nonadjacent_tuple_elements, F, Iterations).
+
+bench_tagged_tuple_elements(Iterations) ->
+    Tuple = {record, 1, 2, 3, 4, 5, 6, 7},
+    F = fun(N) -> tagged_tuple_elements_loop(N, Tuple, 0) end,
+    time(bench_tagged_tuple_elements, F, Iterations).
+
+adjacent_tuple_elements_loop(0, _Tuple, Acc) ->
+    Acc;
+adjacent_tuple_elements_loop(N, Tuple, Acc) ->
+    {A, B, C} = adjacent_tuple_elements(Tuple),
+    adjacent_tuple_elements_loop(N - 1, Tuple, Acc + A + B + C).
+
+nonadjacent_tuple_elements_loop(0, _Tuple, Acc) ->
+    Acc;
+nonadjacent_tuple_elements_loop(N, Tuple, Acc) ->
+    {A, B, C} = nonadjacent_tuple_elements(Tuple),
+    nonadjacent_tuple_elements_loop(N - 1, Tuple, Acc + A + B + C).
+
+tagged_tuple_elements_loop(0, _Tuple, Acc) ->
+    Acc;
+tagged_tuple_elements_loop(N, Tuple, Acc) ->
+    {A, B, C} = tagged_tuple_elements(Tuple),
+    tagged_tuple_elements_loop(N - 1, Tuple, Acc + A + B + C).
+
+adjacent_tuple_elements(Tuple) when tuple_size(Tuple) =:= 8 ->
+    {element(2, Tuple), element(3, Tuple), element(4, Tuple)}.
+
+nonadjacent_tuple_elements(Tuple) when tuple_size(Tuple) =:= 8 ->
+    {element(2, Tuple), element(4, Tuple), element(6, Tuple)}.
+
+tagged_tuple_elements({record, A, B, C, _D, _E, _F, _G}) ->
+    {A, B, C}.
+
+time(Name, F, Iterations) ->
+    Time = element(1, timer:tc(F, [Iterations])),
+    ct_event:notify(#event{name = benchmark_data,
+                           data = [{value, Time},
+                                   {suite, ?MODULE_STRING},
+                                   {name, atom_to_list(Name)}]}),
+    ct:pal("~s: ~p us", [atom_to_list(Name), Time]),
+    Time.
 
 
 build_and_match(Config) when is_list(Config) ->


### PR DESCRIPTION
The shared JIT dump helper in list_bif_SUITE still used the list_fusion_overlap name when creating the dump directory and loading the compiled BEAM ASM fixture.

Use the caller-provided dump base for those operations so the helper works for other fixtures, such as guard_bif_arg_vector.

ETA: this was made by mistake, the work is not complete and the title doesn't match. sorry about this.