### PR TITLE
stdlib: document float map key encoding in json

### DIFF
--- a/lib/stdlib/src/json.erl
+++ b/lib/stdlib/src/json.erl
@@ -115,7 +115,7 @@ Simple JSON value encodeable with `json:encode/1`.
     | list(encode_value())
     | encode_map(encode_value()).
 
--type encode_map(Value) :: #{binary() | atom() | integer() => Value}.
+-type encode_map(Value) :: #{binary() | atom() | integer() | float() => Value}.
 
 -doc """
 Generates JSON corresponding to `Term`.
@@ -133,6 +133,9 @@ Supports basic data mapping:
 | `#{binary() => _}`     | Object   |
 | `#{atom() => _}`       | Object   |
 | `#{integer() => _}`    | Object   |
+| `#{float() => _}`      | Object   |
+
+Map keys are encoded as JSON object names, which are strings.
 
 This is equivalent to `encode(Term, fun json:encode_value/2)`.
 
@@ -250,7 +253,8 @@ list_loop([Elem | Rest], Encode) -> [$,, Encode(Elem, Encode) | list_loop(Rest, 
 -doc """
 Default encoder for maps as JSON objects used by `json:encode/1`.
 
-Accepts maps with atom, binary, integer, or float keys.
+Accepts Erlang maps with atom, binary, integer, or float keys.
+The keys are encoded as JSON object names.
 """.
 -doc(#{since => <<"OTP 27.0">>}).
 -spec encode_map(encode_map(dynamic()), encoder()) -> iodata().
@@ -263,7 +267,8 @@ do_encode_map(Map, Encode) when is_function(Encode, 2) ->
 -doc """
 Encoder for maps as JSON objects.
 
-Accepts maps with atom, binary, integer, or float keys.
+Accepts Erlang maps with atom, binary, integer, or float keys.
+The keys are encoded as JSON object names.
 Verifies that no duplicate keys will be produced in the
 resulting JSON object.
 
@@ -279,7 +284,8 @@ encode_map_checked(Map, Encode) ->
 -doc """
 Encoder for lists of key-value pairs as JSON objects.
 
-Accepts lists with atom, binary, integer, or float keys.
+Accepts key-value lists with atom, binary, integer, or float keys.
+The keys are encoded as JSON object names.
 """.
 -doc(#{since => <<"OTP 27.0">>}).
 -spec encode_key_value_list([{term(), term()}], encoder()) -> iodata().
@@ -289,7 +295,8 @@ encode_key_value_list(List, Encode) when is_function(Encode, 2) ->
 -doc """
 Encoder for lists of key-value pairs as JSON objects.
 
-Accepts lists with atom, binary, integer, or float keys.
+Accepts key-value lists with atom, binary, integer, or float keys.
+The keys are encoded as JSON object names.
 Verifies that no duplicate keys will be produced in the
 resulting JSON object.
 
@@ -702,7 +709,8 @@ format_tail([], _, _, _, _) ->
 -doc """
 Format function for lists of key-value pairs as JSON objects.
 
-Accepts lists with atom, binary, integer, or float keys.
+Accepts key-value lists with atom, binary, integer, or float keys.
+The keys are encoded as JSON object names.
 """.
 -doc(#{since => <<"OTP 27.2">>}).
 
@@ -722,7 +730,8 @@ format_key_value_list(KVList, UserEnc, #{level := Level} = State) ->
 -doc """
 Format function for lists of key-value pairs as JSON objects.
 
-Accepts lists with atom, binary, integer, or float keys.
+Accepts key-value lists with atom, binary, integer, or float keys.
+The keys are encoded as JSON object names.
 Verifies that no duplicate keys will be produced in the
 resulting JSON object.
 

--- a/lib/stdlib/test/json_SUITE.erl
+++ b/lib/stdlib/test/json_SUITE.erl
@@ -258,9 +258,11 @@ test_encode_map(_Config) ->
     ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode(#{<<"foo">> => <<"bar">>})),
     ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode(#{foo => bar})),
     ?assertEqual(<<"{\"42\":\"bar\"}">>, encode(#{42 => bar})),
+    ?assertEqual(<<"{\"1.5\":\"bar\"}">>, encode(#{1.5 => bar})),
     ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode_checked(#{<<"foo">> => <<"bar">>})),
     ?assertEqual(<<"{\"foo\":\"bar\"}">>, encode_checked(#{foo => bar})),
     ?assertEqual(<<"{\"42\":\"bar\"}">>, encode_checked(#{42 => bar})),
+    ?assertEqual(<<"{\"1.5\":\"bar\"}">>, encode_checked(#{1.5 => bar})),
 
     MultiKeyMap = #{<<"foo">> => <<"foo1">>, foo => <<"foo2">>},
     ?assertError({duplicate_key, <<"foo">>}, encode_checked(MultiKeyMap)),


### PR DESCRIPTION
The `json` encoder has accepted Erlang maps with float keys since the original `json` module was added in 66a771e62a2 (`Add json module`). The runtime key dispatcher already handles floats with `key(Key, _Encode) when is_float(Key) -> [$", encode_float(Key), $"]`, which emits the key as a JSON object name.

JSON object names are strings, so this does not add non-string keys to JSON. It updates the public `encode_map/1` type and the `encode/1` data mapping table to describe the existing Erlang input behavior, and adds encode tests for both the default and checked map encoding paths.
