### PR TITLE
beam_jit: prehash boxed literal map_get on arm64

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -856,6 +856,15 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
                                            const ArgSource &Src,
                                            const ArgRegister &Dst) {
     Label good_key = a.new_label();
+    auto get_constant_key = [&]() {
+        ASSERT(Key.isConstant());
+
+        if (Key.isImmed()) {
+            return Key.as<ArgImmed>().get();
+        } else {
+            return beamfile_get_literal(beam, Key.as<ArgLiteral>().get());
+        }
+    };
 
     mov_arg(ARG1, Src);
     mov_arg(ARG2, Key);
@@ -900,7 +909,14 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
         a.bind(good_map);
     }
 
-    if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key)) {
+    if (Fail.get() == 0 && Key.isConstant() && !Key.isImmed()) {
+        mov_imm(ARG3, hashmap_make_hash(get_constant_key()));
+        emit_enter_runtime();
+        runtime_call<Eterm (*)(Eterm, Eterm, erts_ihash_t),
+                     get_map_element_hash>();
+        emit_leave_runtime();
+        emit_branch_if_value(ARG1, good_key);
+    } else if (maybe_one_of<BeamTypeId::MaybeImmediate>(Key)) {
         fragment_call(ga->get_i_get_map_element_shared());
         if (Fail.get() == 0) {
             a.b_eq(good_key);

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -41,6 +41,7 @@
          t_map_compare/1,
          t_map_size/1,
          t_map_get/1,
+         t_map_get_source_shape/1,
          t_is_map/1,
          t_is_map_key/1,
 
@@ -148,7 +149,7 @@ groups() ->
        %% erlang
        t_erlang_hash, t_map_encode_decode,
        t_gc_rare_map_overflow,
-       t_map_size, t_map_get, t_is_map,
+       t_map_size, t_map_get, t_map_get_source_shape, t_is_map,
 
        %% non specific BIF related
        t_bif_build_and_check,
@@ -832,6 +833,20 @@ t_map_get(Config) when is_list(Config) ->
     end,
 
     ok.
+
+t_map_get_source_shape(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    SourceFile = filename:join(PrivDir, "map_get_source_shape.erl"),
+    ok = file:write_file(SourceFile, map_get_source_shape_module()),
+
+    {ok, _Mod, Asm} = compile:file(SourceFile, [to_asm,binary,report]),
+    true = contains_bif_arg(Asm, map_get, 2, {literal, <<"a">>}),
+    ok.
+
+map_get_source_shape_module() ->
+    <<"-module(map_get_source_shape).\n"
+      "-export([boxed_literal/1]).\n"
+      "boxed_literal(M) -> map_get(<<\"a\">>, M).\n">>.
 
 t_is_map_key(Config) when is_list(Config) ->
     %% small map
@@ -4056,6 +4071,17 @@ any_complex(0, _Map, Acc) ->
 any_complex(N, Map, Acc0) ->
     #{ Acc0 := Acc } = Map,
     any_complex(N - 1, Map, Acc).
+
+contains_bif_arg({bif, Name, _Fail, Args, _Dst}, Name, Arity, Arg)
+  when length(Args) =:= Arity ->
+    lists:member(Arg, Args);
+contains_bif_arg(Term, Name, Arity, Arg) when is_tuple(Term) ->
+    contains_bif_arg(tuple_to_list(Term), Name, Arity, Arg);
+contains_bif_arg([Head | Tail], Name, Arity, Arg) ->
+    contains_bif_arg(Head, Name, Arity, Arg) orelse
+        contains_bif_arg(Tail, Name, Arity, Arg);
+contains_bif_arg(_Term, _Name, _Arity, _Arg) ->
+    false.
 
 lookup_literal_multi_small(Iterations) ->
     Map0 = maps:from_keys(lists:seq(1, ?SMALL_MAP_SIZE), id([])),


### PR DESCRIPTION
Optimize ARM64 JIT code for body-context `map_get/2` when the key is a boxed literal, such as `<<"a">>`.

The previous code called `get_map_element/2`, which recomputes the key hash on every HAMT lookup. The new code passes the loader-computed hash to `get_map_element_hash/3` for boxed literal keys in body-context `map_get/2`. Immediate keys, variable keys, guard-context lookups, `maps:get/3` defaults, and pattern matches keep their existing paths.

Boxed literal body-context lookups now materialize the precomputed hash and call `get_map_element_hash/3` instead of `get_map_element/2`, increasing native code size at affected call sites.

A similar boxed-literal prehashing optimization appears available for the x86-64 JIT; I can follow up there if maintainers want the same treatment.

OTP uses flatmaps for small maps and a HAMT, a hash array mapped trie, for larger maps. `MAP_SMALL_MAP_LIMIT` is 32 in the normal build, so the examples below use 65-entry maps to force HAMT representation.

```erlang
hamt_bin_map() ->
    maps:from_list([{<<"a">>, 1} |
                    [{integer_to_binary(I), I} || I <- lists:seq(1, 64)]]).

benefits_erlang() ->
    M = hamt_bin_map(),
    map_get(<<"a">>, M).

benefits_maps_get_2() ->
    M = hamt_bin_map(),
    maps:get(<<"a">>, M).
```

The source-shape test added in this PR proves normal Erlang source reaches this BEAM instruction shape:

```erlang
{bif,map_get,{f,0},[{literal,<<"a">>},{x,0}],{x,0}}
```

Control examples:

```erlang
no_literal_key_erlang(K) ->
    M = hamt_bin_map(),
    map_get(K, M).

hamt_atom_map() ->
    maps:from_list([{a, 1} | [{I, I} || I <- lists:seq(1, 64)]]).

atom_key_erlang() ->
    M = hamt_atom_map(),
    map_get(a, M).

default_erlang() ->
    M = hamt_bin_map(),
    maps:get(<<"a">>, M, 0).

pattern_erlang() ->
    M = hamt_bin_map(),
    #{<<"a">> := V} = M,
    V.
```

Benchmarks compare `otp/master` at `56f1c3ec6c` against this PR at `c7ac5d7fae`, with separately built `beam.jit` binaries and paired baseline/patched runs using `+S 1`.

| Example | Iterations | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| `map_get(<<"a">>, M)` HAMT | 30M | 931,013 us / 31.0 ns/op | 622,958 us / 20.8 ns/op | -33.1% |
| `maps:get(<<"a">>, M)` HAMT | 30M | 937,344 us / 31.2 ns/op | 631,679 us / 21.1 ns/op | -32.6% |

The optimized cases have separated 95% confidence intervals for the mean: `map_get/2` before `[924,337.2, 991,051.0] us` vs after `[623,778.5, 649,728.7] us`; `maps:get/2` before `[915,692.7, 1,055,616.3] us` vs after `[626,695.1, 693,340.7] us`.


| Control | Iterations | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| variable key `map_get(K, M)` HAMT | 10M | 332,475 us / 33.2 ns/op | 324,103 us / 32.4 ns/op | -2.5% |
| atom key `map_get(a, M)` HAMT | 10M | 116,949 us / 11.7 ns/op | 119,567 us / 12.0 ns/op | +2.2% |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | 206,880 us / 20.7 ns/op | 205,646 us / 20.6 ns/op | -0.6% |
| pattern match `#{<<"a">> := V}` HAMT | 10M | 211,801 us / 21.2 ns/op | 208,255 us / 20.8 ns/op | -1.7% |


| Risk case | Iterations | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| boxed literal key on flatmap | 10M | 193,696 us / 19.4 ns/op | 190,618 us / 19.1 ns/op | -1.6% |
| missing boxed literal key on HAMT | 100k | 40,562 us / 405.6 ns/op | 38,761 us / 387.6 ns/op | -4.4% |

<details>
<summary>Full benchmark statistics</summary>

| Example | Iterations | VM | n | Min us | Median us | Mean us | Stddev us | Stderr us | 95% CI mean us | Max us |
| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `map_get(<<"a">>, M)` HAMT | 30M | before | 15 | 906,969 | 931,013.0 | 957,694.1 | 65,913.6 | 17,018.8 | ±33,356.9 | 1,150,201 |
| `map_get(<<"a">>, M)` HAMT | 30M | after | 15 | 615,782 | 622,958.0 | 636,753.6 | 25,638.9 | 6,619.9 | ±12,975.1 | 685,384 |
| `maps:get(<<"a">>, M)` HAMT | 30M | before | 15 | 908,040 | 937,344.0 | 985,654.5 | 138,245.4 | 35,694.8 | ±69,961.8 | 1,448,813 |
| `maps:get(<<"a">>, M)` HAMT | 30M | after | 15 | 615,891 | 631,679.0 | 660,017.9 | 65,846.3 | 17,001.5 | ±33,322.8 | 859,191 |
| variable key `map_get(K, M)` HAMT | 10M | before | 15 | 313,338 | 332,475.0 | 360,084.7 | 60,976.1 | 15,743.9 | ±30,858.1 | 548,364 |
| variable key `map_get(K, M)` HAMT | 10M | after | 15 | 313,619 | 324,103.0 | 334,136.7 | 24,186.3 | 6,244.9 | ±12,239.9 | 394,921 |
| atom key `map_get(a, M)` HAMT | 10M | before | 15 | 112,944 | 116,949.0 | 124,877.1 | 19,945.4 | 5,149.9 | ±10,093.8 | 190,765 |
| atom key `map_get(a, M)` HAMT | 10M | after | 15 | 112,731 | 119,567.0 | 132,190.3 | 31,624.6 | 8,165.4 | ±16,004.3 | 209,590 |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | before | 15 | 200,442 | 206,880.0 | 222,590.8 | 33,965.0 | 8,769.7 | ±17,188.6 | 309,794 |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | after | 15 | 200,719 | 205,646.0 | 211,604.1 | 18,138.0 | 4,683.2 | ±9,179.1 | 270,599 |
| pattern match `#{<<"a">> := V}` HAMT | 10M | before | 15 | 202,797 | 211,801.0 | 220,937.5 | 33,785.2 | 8,723.3 | ±17,097.7 | 337,126 |
| pattern match `#{<<"a">> := V}` HAMT | 10M | after | 15 | 200,869 | 208,255.0 | 255,797.2 | 167,722.5 | 43,305.8 | ±84,879.3 | 856,845 |
| boxed literal key on flatmap | 10M | before | 15 | 187,170 | 193,696.0 | 194,424.9 | 5,543.1 | 1,431.2 | ±2,805.2 | 204,700 |
| boxed literal key on flatmap | 10M | after | 15 | 186,112 | 190,618.0 | 196,225.4 | 11,553.1 | 2,983.0 | ±5,846.7 | 230,077 |
| missing boxed literal key on HAMT | 100k | before | 15 | 38,653 | 40,562.0 | 42,583.8 | 6,703.0 | 1,730.7 | ±3,392.2 | 65,917 |
| missing boxed literal key on HAMT | 100k | after | 15 | 37,560 | 38,761.0 | 46,187.9 | 11,943.4 | 3,083.8 | ±6,044.2 | 71,955 |

</details>







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized map element retrieval operations with specialized fast-path handling for scenarios involving constant keys. The implementation precomputes key hashes and leverages dedicated runtime helpers to reduce execution overhead in common map access patterns.

* **Tests**
  * Added comprehensive test coverage for map get operations with literal keys. The new test verifies correct compilation behavior and validates that map operations with boxed literal keys generate expected output during the compilation and assembly process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->