### PR TITLE
beam_jit: prehash boxed literal map_get on x86-64 and arm64

### DIFF
--- a/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/arm/instr_guard_bifs.cpp
@@ -909,7 +909,15 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
         }
     } else {
         emit_enter_runtime();
-        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
+        if (!Key.isLiteral()) {
+            runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
+        } else {
+            auto literal_key =
+                    beamfile_get_literal(beam, Key.as<ArgLiteral>().get());
+            mov_imm(ARG3, hashmap_make_hash(literal_key));
+            runtime_call<Eterm (*)(Eterm, Eterm, erts_ihash_t),
+                         get_map_element_hash>();
+        }
         emit_leave_runtime();
 
         if (Fail.get() == 0) {

--- a/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
+++ b/erts/emulator/beam/jit/x86/instr_guard_bifs.cpp
@@ -664,7 +664,15 @@ void BeamModuleAssembler::emit_bif_map_get(const ArgLabel &Fail,
         }
     } else {
         emit_enter_runtime();
-        runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
+        if (!Key.isLiteral()) {
+            runtime_call<Eterm (*)(Eterm, Eterm), get_map_element>();
+        } else {
+            auto literal_key =
+                    beamfile_get_literal(beam, Key.as<ArgLiteral>().get());
+            mov_imm(ARG3, hashmap_make_hash(literal_key));
+            runtime_call<Eterm (*)(Eterm, Eterm, erts_ihash_t),
+                         get_map_element_hash>();
+        }
         emit_leave_runtime();
 
         emit_test_the_non_value(RET);

--- a/erts/emulator/test/map_SUITE.erl
+++ b/erts/emulator/test/map_SUITE.erl
@@ -780,6 +780,8 @@ t_map_get(Config) when is_list(Config) ->
 
     {'EXIT',{{badkey,{1,1}},[{erlang,map_get,_,_}|_]}} =
 	(catch map_get({1,1}, id(#{{1,1.0}=>"tuple"}))),
+    {'EXIT',{{badkey,<<"missing">>},[{erlang,map_get,_,_}|_]}} =
+        (catch map_get(<<"missing">>, M1)),
     {'EXIT',{{badkey,a},[{erlang,map_get,_,_}|_]}} = (catch map_get(a, id(#{}))),
     {'EXIT',{{badkey,a},[{erlang,map_get,_,_}|_]}} =
 	(catch map_get(a, id(#{b=>1, c=>2}))),
@@ -790,6 +792,15 @@ t_map_get(Config) when is_list(Config) ->
     false = if map_get(x, M2) =:= 1 -> true; true -> false end,
     do_badmap(fun
         (T) when map_get(x, T) =:= 1 -> ok;
+        (T) -> false = is_map(T)
+    end),
+
+    true = if map_get(<<"k2">>, M1) =:= "v3" -> true; true -> false end,
+    false = if map_get(<<"missing">>, M1) =:= "v3" -> true;
+               true -> false
+            end,
+    do_badmap(fun
+        (T) when map_get(<<"k2">>, T) =:= "v3" -> ok;
         (T) -> false = is_map(T)
     end),
 


### PR DESCRIPTION
Optimize x86-64 and ARM64 JIT code for body-context `map_get/2` when the key is a boxed literal, such as `<<"a">>`.

The previous code called `get_map_element/2`, which recomputes the key hash on every HAMT lookup. The new code passes the loader-computed hash to `get_map_element_hash/3` for boxed literal keys in body-context `map_get/2`. Immediate keys, variable keys, non-literal boxed keys, `maps:get/3` defaults, and pattern matches keep their existing paths.

Boxed literal body-context lookups now materialize the precomputed hash and call `get_map_element_hash/3` instead of `get_map_element/2`, increasing native code size at affected call sites.

OTP uses flatmaps for small maps and a HAMT, a hash array mapped trie, for larger maps. `MAP_SMALL_MAP_LIMIT` is 32 in the normal build, so the examples below use 65-entry maps to force HAMT representation.

```erlang
hamt_bin_map() ->
    maps:from_list([{<<"a">>, 1} |
                    [{integer_to_binary(I), I} || I <- lists:seq(1, 64)]]).

benefits_erlang() ->
    M = hamt_bin_map(),
    map_get(<<"a">>, M).

benefits_maps_get_2() ->
    M = hamt_bin_map(),
    maps:get(<<"a">>, M).
```

The test added in this PR compiles and loads a small module that calls `map_get(<<"a">>, M)` and `maps:get(<<"a">>, M)`, then exercises both functions against a 65-entry HAMT map. It verifies successful boxed-literal lookup and preserves the expected `badkey` and `badmap` failures for the optimized `map_get/2` path.

<details>
<summary>Control examples</summary>

```erlang
no_literal_key_erlang(K) ->
    M = hamt_bin_map(),
    map_get(K, M).

hamt_atom_map() ->
    maps:from_list([{a, 1} | [{I, I} || I <- lists:seq(1, 64)]]).

atom_key_erlang() ->
    M = hamt_atom_map(),
    map_get(a, M).

default_erlang() ->
    M = hamt_bin_map(),
    maps:get(<<"a">>, M, 0).

pattern_erlang() ->
    M = hamt_bin_map(),
    #{<<"a">> := V} = M,
    V.
```

</details>

x86-64 benchmarks compare `otp/master` at `56f1c3ec6c` against this PR at `7fc245c877`, using OTP `map_SUITE` benchmark entries with `+S 1`.

| Example | Iterations | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| `map_get(<<"a">>, M)` HAMT | 5M | 106,982.0 us / 21.4 ns/op | 73,228.0 us / 14.6 ns/op | -31.6% |
| `maps:get(<<"a">>, M)` HAMT | 5M | 109,240.0 us / 21.8 ns/op | 72,172.0 us / 14.4 ns/op | -33.9% |

The optimized cases have separated 95% confidence intervals for the mean: `map_get/2` before `[105,222.3, 108,058.1] us` vs after `[72,646.3, 73,728.7] us`; `maps:get/2` before `[107,022.7, 109,946.7] us` vs after `[70,702.2, 72,499.2] us`.

<details>
<summary>Full x86-64 benchmark statistics</summary>

| Example | Iterations | VM | n | Min us | Median us | Mean us | Stddev us | Stderr us | 95% CI mean us | Max us |
| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `map_get(<<"a">>, M)` HAMT | 5M | before | 10 | 101,818 | 106,982.0 | 106,640.2 | 2,287.7 | 723.4 | ±1,417.9 | 109,170 |
| `map_get(<<"a">>, M)` HAMT | 5M | after | 10 | 71,896 | 73,228.0 | 73,187.5 | 873.1 | 276.1 | ±541.2 | 74,520 |
| `maps:get(<<"a">>, M)` HAMT | 5M | before | 10 | 102,923 | 109,240.0 | 108,484.7 | 2,358.7 | 745.9 | ±1,462.0 | 111,194 |
| `maps:get(<<"a">>, M)` HAMT | 5M | after | 10 | 69,462 | 72,172.0 | 71,600.7 | 1,449.7 | 458.4 | ±898.5 | 73,100 |
| variable key `map_get(K, M)` HAMT | 10M | before | 20 | 206,715 | 213,425.5 | 213,554.5 | 4,413.4 | 986.9 | ±1,934.3 | 224,603 |
| variable key `map_get(K, M)` HAMT | 10M | after | 20 | 194,441 | 204,481.0 | 205,059.5 | 5,231.7 | 1,169.8 | ±2,292.9 | 212,449 |
| atom key `map_get(a, M)` HAMT | 10M | before | 20 | 37,810 | 39,342.5 | 39,438.1 | 675.8 | 151.1 | ±296.2 | 41,053 |
| atom key `map_get(a, M)` HAMT | 10M | after | 20 | 38,047 | 39,547.0 | 40,903.1 | 6,250.7 | 1,397.7 | ±2,739.5 | 67,268 |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | before | 20 | 140,557 | 148,373.0 | 148,624.6 | 8,796.5 | 1,967.0 | ±3,855.2 | 181,584 |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | after | 20 | 133,994 | 140,410.0 | 140,021.0 | 3,475.1 | 777.1 | ±1,523.0 | 149,475 |
| pattern match `#{<<"a">> := V}` HAMT | 10M | before | 20 | 134,869 | 145,028.0 | 144,666.1 | 5,623.5 | 1,257.5 | ±2,464.6 | 157,884 |
| pattern match `#{<<"a">> := V}` HAMT | 10M | after | 20 | 133,188 | 140,772.5 | 140,217.0 | 3,870.8 | 865.5 | ±1,696.5 | 146,922 |
| boxed literal key on flatmap | 10M | before | 20 | 858,958 | 910,121.0 | 918,526.2 | 40,333.5 | 9,018.9 | ±17,677.0 | 987,466 |
| boxed literal key on flatmap | 10M | after | 20 | 886,613 | 920,858.5 | 930,723.2 | 43,716.1 | 9,775.2 | ±19,159.4 | 1,033,454 |
| missing boxed literal key on HAMT | 100k | before | 20 | 44,860 | 49,261.0 | 51,577.1 | 6,489.5 | 1,451.1 | ±2,844.2 | 67,435 |
| missing boxed literal key on HAMT | 100k | after | 20 | 43,555 | 47,858.0 | 49,719.4 | 6,362.0 | 1,422.6 | ±2,788.2 | 64,484 |

</details>

ARM64/AArch64 benchmarks compare `otp/master` at `56f1c3ec6c` against this PR at `c7ac5d7fae`, with separately built `beam.jit` binaries and paired baseline/patched runs using `+S 1`.

| Example | Iterations | Before | After | Delta |
| --- | ---: | ---: | ---: | ---: |
| `map_get(<<"a">>, M)` HAMT | 30M | 931,013 us / 31.0 ns/op | 622,958 us / 20.8 ns/op | -33.1% |
| `maps:get(<<"a">>, M)` HAMT | 30M | 937,344 us / 31.2 ns/op | 631,679 us / 21.1 ns/op | -32.6% |

The optimized cases have separated 95% confidence intervals for the mean: `map_get/2` before `[924,337.2, 991,051.0] us` vs after `[623,778.5, 649,728.7] us`; `maps:get/2` before `[915,692.7, 1,055,616.3] us` vs after `[626,695.1, 693,340.7] us`.

<details>
<summary>Full ARM64/AArch64 benchmark statistics</summary>

| Example | Iterations | VM | n | Min us | Median us | Mean us | Stddev us | Stderr us | 95% CI mean us | Max us |
| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `map_get(<<"a">>, M)` HAMT | 30M | before | 15 | 906,969 | 931,013.0 | 957,694.1 | 65,913.6 | 17,018.8 | ±33,356.9 | 1,150,201 |
| `map_get(<<"a">>, M)` HAMT | 30M | after | 15 | 615,782 | 622,958.0 | 636,753.6 | 25,638.9 | 6,619.9 | ±12,975.1 | 685,384 |
| `maps:get(<<"a">>, M)` HAMT | 30M | before | 15 | 908,040 | 937,344.0 | 985,654.5 | 138,245.4 | 35,694.8 | ±69,961.8 | 1,448,813 |
| `maps:get(<<"a">>, M)` HAMT | 30M | after | 15 | 615,891 | 631,679.0 | 660,017.9 | 65,846.3 | 17,001.5 | ±33,322.8 | 859,191 |
| variable key `map_get(K, M)` HAMT | 10M | before | 15 | 313,338 | 332,475.0 | 360,084.7 | 60,976.1 | 15,743.9 | ±30,858.1 | 548,364 |
| variable key `map_get(K, M)` HAMT | 10M | after | 15 | 313,619 | 324,103.0 | 334,136.7 | 24,186.3 | 6,244.9 | ±12,239.9 | 394,921 |
| atom key `map_get(a, M)` HAMT | 10M | before | 15 | 112,944 | 116,949.0 | 124,877.1 | 19,945.4 | 5,149.9 | ±10,093.8 | 190,765 |
| atom key `map_get(a, M)` HAMT | 10M | after | 15 | 112,731 | 119,567.0 | 132,190.3 | 31,624.6 | 8,165.4 | ±16,004.3 | 209,590 |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | before | 15 | 200,442 | 206,880.0 | 222,590.8 | 33,965.0 | 8,769.7 | ±17,188.6 | 309,794 |
| default `maps:get(<<"a">>, M, 0)` HAMT | 10M | after | 15 | 200,719 | 205,646.0 | 211,604.1 | 18,138.0 | 4,683.2 | ±9,179.1 | 270,599 |
| pattern match `#{<<"a">> := V}` HAMT | 10M | before | 15 | 202,797 | 211,801.0 | 220,937.5 | 33,785.2 | 8,723.3 | ±17,097.7 | 337,126 |
| pattern match `#{<<"a">> := V}` HAMT | 10M | after | 15 | 200,869 | 208,255.0 | 255,797.2 | 167,722.5 | 43,305.8 | ±84,879.3 | 856,845 |
| boxed literal key on flatmap | 10M | before | 15 | 187,170 | 193,696.0 | 194,424.9 | 5,543.1 | 1,431.2 | ±2,805.2 | 204,700 |
| boxed literal key on flatmap | 10M | after | 15 | 186,112 | 190,618.0 | 196,225.4 | 11,553.1 | 2,983.0 | ±5,846.7 | 230,077 |
| missing boxed literal key on HAMT | 100k | before | 15 | 38,653 | 40,562.0 | 42,583.8 | 6,703.0 | 1,730.7 | ±3,392.2 | 65,917 |
| missing boxed literal key on HAMT | 100k | after | 15 | 37,560 | 38,761.0 | 46,187.9 | 11,943.4 | 3,083.8 | ±6,044.2 | 71,955 |

</details>
