### PR TITLE
runtime_tools: fix dbg:session/2 cleanup when calling process exits

### DIFF
--- a/lib/runtime_tools/src/dbg.erl
+++ b/lib/runtime_tools/src/dbg.erl
@@ -1871,18 +1871,8 @@ loop({C,T}=SurviveLinks, Table, Parent, SessionName) ->
 		  end,
 	    reply(From, {ok, Tab}),
 	    loop(SurviveLinks, Tab, Parent, SessionName);
-	{_From,stop} ->
-	    %% We want to make sure that all trace messages have been delivered
-	    %% on all nodes that might be traced. Since dbg:cn/1 does not turn off
-	    %% tracing on the node it removes from the list of active trace nodes,
-	    %% we will call trace:delivered/2 on ALL nodes that we have
-	    %% connections to.
-	    %% If it is a file trace driver, we will also flush the port.
-	    lists:foreach(fun({Node,{_Relay,Port,Session}}) ->
-				  rpc:call(Node,?MODULE,deliver_and_flush,[Session,Port])
-			  end,
-			  get()),
-	    exit(done);
+        {_From,stop} ->
+            session_cleanup(done);
 	{From, {link_to, Pid}} ->
 	    case (catch link(Pid)) of
 		{'EXIT', Reason} ->
@@ -1942,12 +1932,7 @@ loop({C,T}=SurviveLinks, Table, Parent, SessionName) ->
 	    end,
             loop(SurviveLinks, Table, Parent, SessionName);
         {'DOWN', _Ref, process, Parent, _} ->
-            case get(node()) of
-                undefined -> ok;
-                {_Relay, _Tracer, Session} ->
-                    session_destroy(Session),
-                    exit(shutdown)
-            end;
+            session_cleanup(shutdown);
 	{'EXIT', Pid, Reason} ->
 	    case lists:delete(Pid, C) of
 		C ->
@@ -1976,6 +1961,19 @@ loop({C,T}=SurviveLinks, Table, Parent, SessionName) ->
 reply(Pid, Reply) ->
     Pid ! {dbg,Reply},
     ok.
+
+session_cleanup(Reason) ->
+    %% We want to make sure that all trace messages have been delivered
+    %% on all nodes that might be traced. Since dbg:cn/1 does not turn off
+    %% tracing on the node it removes from the list of active trace nodes,
+    %% we will call trace:delivered/2 on ALL nodes that we have
+    %% connections to.
+    %% If it is a file trace driver, we will also flush the port.
+    lists:foreach(fun({Node,{_Relay,Port,Session}}) ->
+                          rpc:call(Node,?MODULE,deliver_and_flush,[Session,Port])
+                  end,
+                  get()),
+    exit(Reason).
 
 
 %%% A process-based tracer.

--- a/lib/runtime_tools/test/dbg_SUITE.erl
+++ b/lib/runtime_tools/test/dbg_SUITE.erl
@@ -501,7 +501,13 @@ port(Config) when is_list(Config) ->
         port_close(Port),
         stop(),
 
-        TraceFileDrv = list_to_atom(lists:flatten(["trace_file_drv n ",TestFile])),
+        TraceFileDrv = list_to_atom(
+                         %% priv_dir may be long on some sytems where tests are
+                         %% being run, and result in a large port command. This
+                         %% will get truncated so it doesn't exceed max atom
+                         %% size (255 chars)
+                         lists:sublist( lists:flatten(["trace_file_drv n ",TestFile]), 255)
+                        ),
         [{trace,Port,open,S,TraceFileDrv},
          {trace,Port,getting_linked,S},
          {trace,Port,closed,normal}] = flush()

--- a/lib/runtime_tools/test/dbg_SUITE.erl
+++ b/lib/runtime_tools/test/dbg_SUITE.erl
@@ -475,7 +475,7 @@ local_trace(Config) when is_list(Config) ->
         4 = ?MODULE:exported(2),
         [] = flush(),
         {ok, _} = dbg:tpl(?MODULE,not_exported,x),
-        catch ?MODULE:exported(x),
+        try ?MODULE:exported(x) catch error:badarith -> ok end,
         [{trace,S,call,{dbg_SUITE,not_exported,[x]}},
          {trace,S,exception_from,
           {dbg_SUITE,not_exported,1},

--- a/lib/runtime_tools/test/dbg_SUITE.erl
+++ b/lib/runtime_tools/test/dbg_SUITE.erl
@@ -30,7 +30,8 @@
          ip_port_busy/1, wrap_port/1, wrap_port_time/1,
          with_seq_trace/1, dead_suspend/1, local_trace/1,
          saved_patterns/1, tracer_exit_on_stop/1,
-         erl_tracer/1, distributed_erl_tracer/1]).
+         erl_tracer/1, distributed_erl_tracer/1,
+         session_parent_down/1]).
 -export([tracee1/1, tracee2/1]).
 -export([dummy/0, exported/1]).
 -export([enabled/3, trace/5, load_nif/1]).
@@ -52,7 +53,9 @@ groups() ->
                 file_port, file_port2, file_tracer, ip_port_busy,
                 wrap_port, wrap_port_time, with_seq_trace, dead_suspend,
                 local_trace, saved_patterns, tracer_exit_on_stop,
-                erl_tracer, distributed_erl_tracer]}].
+                erl_tracer, distributed_erl_tracer,
+                session_parent_down
+               ]}].
 
 init_per_suite(Config) ->
     Config.
@@ -942,6 +945,46 @@ distributed_erl_tracer(Config) ->
     [{RCall, call, RNifProxy, RCall, {?MODULE, dummy, []}, #{}}] = flush(),
 
     peer:stop(Peer),
+    ok.
+
+session_parent_down(_Config) ->
+    stop(),
+    S = self(),
+    spawn_link(
+      fun() ->
+              DbgSession = dbg:session_create(session_parent_down),
+              Pid = self(),
+              dbg:session(DbgSession,
+                          fun() ->
+                                  {ok, _} = dbg:tracer(process, {fun(Event, ok) -> S ! Event end, ok}),
+                                  {ok, Tracer} = dbg:get_tracer(),
+                                  {ok, _} = dbg:p(Pid, [call]),
+                                  {ok, _} = dbg:tp(?MODULE, dummy, []),
+                                  S ! {DbgSession, Pid, Tracer}
+                          end),
+              %% wait for monitors to be set up
+              receive go -> ok end,
+              ?MODULE:dummy()
+      end),
+
+    {DbgSession, Pid, Tracer} = receive {_, _, _} = Pids -> Pids end,
+    DbgSessionMref = erlang:monitor(process, DbgSession),
+    PidMref = erlang:monitor(process, Pid),
+    TracerMref = erlang:monitor(process, Tracer),
+    Pid ! go,
+
+    %% we don't care about order, and race conditions mean we can't rely on
+    %% order in test. We just care that all expected messages are received.
+    ExpectedMessages =
+    lists:sort(
+      [
+       {trace, Pid, call, {?MODULE, dummy, []}},
+       {'DOWN', PidMref, process, Pid, normal},
+       {'DOWN', DbgSessionMref, process, DbgSession, shutdown},
+       {'DOWN', TracerMref, process, Tracer, normal}
+      ]),
+    ExpectedMessages = lists:sort(flush()),
+
     ok.
 
 load_nif(Config) ->


### PR DESCRIPTION
If process that called `dbg:session/2` exits before `dbg:session_destroy/1` is called, an error is encountered and an error report logged, and any trace messages are lost and not delivered.

The existing logic seemed to be treating the `Session` stored in the process dictionary as a `dbg:session()` type (ie a pid), and passing it to `dbg:session_destroy/1`, however, it is actually a `trace` session, and can't be used directly as a pid in `dbg:session_destroy/1`

Instead, fix this by extracting logic from `stop` message handler clause to clean up and ensure messages are delivered in the same way.

This issue can be reproduced with the following code:

```erlang
1> spawn_link(fun() ->
     DbgSession = dbg:session_create(my_session),
     dbg:session(DbgSession, fun() ->
       dbg:tracer()
     end)
   end).
<0.102.0>
=ERROR REPORT==== 17-Jun-2026::22:04:51.331934 ===
Error in process <0.103.0> with exit value:
{badarg,[{erlang,monitor,
                 [process,{#Ref<0.3577390006.3558211590.1705>,{my_session,0}}],
                 [{error_info,#{module => erl_erts_errors}}]},
         {dbg,session_destroy,1,[{file,"dbg.erl"},{line,1741}]},
         {dbg,loop,4,[{file,"dbg.erl"},{line,1948}]}]}
```

- Added test that fails with old code, and works with fix
- Fixed compiler warnings due to deprecated `catch` usage in test module
- Fixed test failure due to long atom names being passed to `list_to_atom/1` due to long release path name on local laptop.