### PR TITLE
otp: adds annotations to modified vendor packages

### DIFF
--- a/.github/scripts/otp-compliance.es
+++ b/.github/scripts/otp-compliance.es
@@ -1391,9 +1391,33 @@ generate_spdx_mappings(AppSrcPath) ->
 generate_vendor_info_package(VendorSrcPath) ->
     lists:flatmap(fun decode_without_spdx_license/1, VendorSrcPath).
 
+create_annotation(Package) ->
+    Date = format_spdx_annotation_date(),
+    Ann =
+        case Package of
+            #{~"annotation" := Comment} ->
+                #{~"annotator" => ~"Person: Kiko Fernandez-Reyes (kiko@erlang.org)",
+                  ~"annotationType" => ~"REVIEW",
+                  ~"annotationDate" => iolist_to_binary(Date),
+                  ~"comment" => Comment
+                 };
+            _ ->
+                #{~"annotator" => ~"Person: Kiko Fernandez-Reyes (kiko@erlang.org)",
+                  ~"annotationType" => ~"REVIEW",
+                  ~"annotationDate" => iolist_to_binary(Date),
+                  ~"comment" => ~"Non-modified vendor package in Erlang/OTP"
+                 }
+        end,
+    #{~"annotations" => [Ann]}.
+
+format_spdx_annotation_date() ->
+    {{Y, Mo, D}, {H, Mi, S}} = calendar:universal_time(),
+    io_lib:format("~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0BZ",
+                  [Y, Mo, D, H, Mi, S]).
+
 -spec generate_spdx_vendor_packages(VendorInfoPackage :: map(), map()) -> map().
 generate_spdx_vendor_packages(VendorInfoPackages, #{~"files" := SpdxFiles}=_SPDX) ->
-    RemoveVendorInfoFields = [~"purl", ~"ID", ~"path", ~"update", ~"exclude", ~"sha"],
+    RemoveVendorInfoFields = [~"purl", ~"ID", ~"path", ~"update", ~"exclude", ~"sha", ~"annotation"],
     lists:map(fun
                   (#{~"ID" := Id, ~"path" := [_ | _]=ExplicitFiles}=Package) when is_list(ExplicitFiles) ->
                       %% Deals with the cases of creating a package out of specific files
@@ -1413,19 +1437,22 @@ generate_spdx_vendor_packages(VendorInfoPackages, #{~"files" := SpdxFiles}=_SPDX
                         lists:foldl(fun(#{~"licenseInfoInFiles" := Licenses}, Acc) ->
                                             Licenses ++ Acc
                                     end, [], Files)),
+                      AnnotationMap = create_annotation(Package),
 
                       PackageVerificationCodeValue = generate_verification_code_value(Files),
                       ExternalRefs = generate_vendor_purl(Package),
-                      Package1#{
-                                ~"SPDXID" => generate_spdxid_name(Id),
-                                ~"filesAnalyzed" => true,
-                                ~"hasFiles" => lists:map(fun (#{~"SPDXID":=Id0}) -> Id0 end, Files),
-                                ~"licenseConcluded" => ~"NOASSERTION",
-                                ~"licenseInfoFromFiles" => lists:uniq(LicenseInfoInFiles),
-                                ~"packageVerificationCode" => #{~"packageVerificationCodeValue" => PackageVerificationCodeValue},
-                                ~"comment" => ~"vendor package",
-                                ~"externalRefs" => ExternalRefs
-                       };
+                      Package2 =
+                          Package1#{
+                                    ~"SPDXID" => generate_spdxid_name(Id),
+                                    ~"filesAnalyzed" => true,
+                                    ~"hasFiles" => lists:map(fun (#{~"SPDXID":=Id0}) -> Id0 end, Files),
+                                    ~"licenseConcluded" => ~"NOASSERTION",
+                                    ~"licenseInfoFromFiles" => lists:uniq(LicenseInfoInFiles),
+                                    ~"packageVerificationCode" => #{~"packageVerificationCodeValue" => PackageVerificationCodeValue},
+                                    ~"comment" => ~"vendor package",
+                                    ~"externalRefs" => ExternalRefs
+                                   },
+                      maps:merge(Package2, AnnotationMap);
                   (#{~"ID" := Id, ~"path" := DirtyPath}=Package) when is_binary(DirtyPath) ->
                       %% Deals with the case of creating a package out of a path
                       Path = ensure_trailing_slash(cleanup_path(DirtyPath)),
@@ -1444,19 +1471,22 @@ generate_spdx_vendor_packages(VendorInfoPackages, #{~"files" := SpdxFiles}=_SPDX
                         lists:foldl(fun(#{~"licenseInfoInFiles" := Licenses}, Acc) ->
                                             Licenses ++ Acc
                                     end, [], Files)),
+                      AnnotationMap = create_annotation(Package),
 
                       PackageVerificationCodeValue = generate_verification_code_value(Files),
                       ExternalRefs = generate_vendor_purl(Package),
-                      Package1#{
-                                ~"SPDXID" => generate_spdxid_name(Id),
-                                ~"filesAnalyzed" => true,
-                                ~"hasFiles" => lists:map(fun (#{~"SPDXID":=Id0}) -> Id0 end, Files),
-                                ~"licenseConcluded" => ~"NOASSERTION",
-                                ~"licenseInfoFromFiles" => lists:uniq(LicenseInfoInFiles),
-                                ~"packageVerificationCode" => #{~"packageVerificationCodeValue" => PackageVerificationCodeValue},
-                                ~"comment" => ~"vendor package",
-                                ~"externalRefs" => ExternalRefs
-                       }
+                      Package2 =
+                          Package1#{
+                                    ~"SPDXID" => generate_spdxid_name(Id),
+                                    ~"filesAnalyzed" => true,
+                                    ~"hasFiles" => lists:map(fun (#{~"SPDXID":=Id0}) -> Id0 end, Files),
+                                    ~"licenseConcluded" => ~"NOASSERTION",
+                                    ~"licenseInfoFromFiles" => lists:uniq(LicenseInfoInFiles),
+                                    ~"packageVerificationCode" => #{~"packageVerificationCodeValue" => PackageVerificationCodeValue},
+                                    ~"comment" => ~"vendor package",
+                                    ~"externalRefs" => ExternalRefs
+                                   },
+                      maps:merge(Package2, AnnotationMap)
               end, VendorInfoPackages).
 
 get_vendor_excludes(Package) ->

--- a/erts/autoconf/vendor.info
+++ b/erts/autoconf/vendor.info
@@ -17,6 +17,7 @@
       "versionInfo": "2.72",
       "path": ["./erts/autoconf/config.guess", "./erts/autoconf/config.sub", "./erts/autoconf/install-sh"],
       "supplier": "Organization: Free Software Foundation",
-      "purl": "pkg:generic/autoconf"
+      "purl": "pkg:generic/autoconf",
+      "annotation": "Vendor package modified in Erlang/OTP"
     }
 ]

--- a/erts/emulator/asmjit/vendor.info
+++ b/erts/emulator/asmjit/vendor.info
@@ -19,6 +19,7 @@
     "exclude": ["./erts/emulator/asmjit/vendor.info"],
     "supplier": "Person: Petr Kobalicek",
     "purl": "pkg:github/asmjit/asmjit",
-    "sha": "5fe1940275d04432da841896bac0a66cc2375551"
+    "sha": "5fe1940275d04432da841896bac0a66cc2375551",
+    "annotation": "Vendor package modified in Erlang/OTP"
   }
 ]

--- a/erts/emulator/pcre/vendor.info
+++ b/erts/emulator/pcre/vendor.info
@@ -21,6 +21,7 @@
                 "./erts/emulator/pcre/pcre.mk"],
     "sha": "f454e231fe5006dd7ff8f4693fd2b8eb94333429",
     "supplier": "Person: Nicholas Wilson",
-    "purl": "pkg:github/PCRE2Project/pcre2"
+    "purl": "pkg:github/PCRE2Project/pcre2",
+    "annotation": "Vendor package modified in Erlang/OTP"
   }
 ]

--- a/erts/emulator/ryu/vendor.info
+++ b/erts/emulator/ryu/vendor.info
@@ -28,7 +28,8 @@
     "supplier": "Person: Ulf Adams",
     "purl": "pkg:github/ulfjack/ryu#ryu",
     "update": "./erts/emulator/ryu/update.sh",
-    "sha": "4c0618b0e44f7ef027ebae05d2cc7812048f7c8f"
+    "sha": "4c0618b0e44f7ef027ebae05d2cc7812048f7c8f",
+    "annotation": "Vendor package modified in Erlang/OTP"
   },
   {
     "ID": "ryu-to_chars",
@@ -45,6 +46,7 @@
     "supplier": "Organization: Microsoft Corporation",
     "purl": "pkg:github/microsoft/STL#stl/inc/xcharconv_ryu.h",
     "update": "./erts/emulator/ryu/update.sh",
-    "sha": "37d575ede5ade50ad95b857f22ed7f1be4b1f2df"
+    "sha": "37d575ede5ade50ad95b857f22ed7f1be4b1f2df",
+    "annotation": "Vendor package modified in Erlang/OTP"
   }
 ]

--- a/lib/common_test/test_server/vendor.info
+++ b/lib/common_test/test_server/vendor.info
@@ -17,6 +17,7 @@
       "versionInfo": "2.72",
       "path": ["./lib/common_test/test_server/config.guess", "./lib/common_test/test_server/config.sub", "./lib/common_test/test_server/install-sh"],
       "supplier": "Organization: Free Software Foundation",
-      "purl": "pkg:generic/autoconf"
+      "purl": "pkg:generic/autoconf",
+      "annotation": "Vendor package modified in Erlang/OTP"
     }
 ]

--- a/make/autoconf/vendor.info
+++ b/make/autoconf/vendor.info
@@ -17,6 +17,7 @@
       "versionInfo": "2.72",
       "path": ["./make/autoconf/config.guess", "./make/autoconf/config.sub", "./make/autoconf/install-sh"],
       "supplier": "Organization: Free Software Foundation",
-      "purl": "pkg:generic/autoconf"
+      "purl": "pkg:generic/autoconf",
+      "annotation": "Vendor package modified in Erlang/OTP"
     }
 ]


### PR DESCRIPTION
The vendor SPDX packages have now an annotation indicating whether these are modified vendor packages in Erlang/OTP, or whether these packages have been taken from their original repositories as is.

This is useful for identifying which vendor packages are as the original, and which ones are integrated more deeply into OTP.
