### PR TITLE
ssh: remove OpenSSH 7.2 SHA-1 signature workaround

### DIFF
--- a/lib/ssh/src/ssh_transport.erl
+++ b/lib/ssh/src/ssh_transport.erl
@@ -1586,14 +1586,6 @@ do_verify(PlainText, HashAlg, Sig, {#'ECPoint'{},_} = Key, _) when HashAlg =/= u
         _ ->
             false
     end;
-
-do_verify(PlainText, HashAlg, Sig, #'RSAPublicKey'{}=Key, #ssh{role = server,
-                                                               c_version = "SSH-2.0-OpenSSH_7."++_})
-  when HashAlg == sha256; HashAlg == sha512 ->
-    %% Public key signing bug in OpenSSH >= 7.2
-    public_key:verify(PlainText, HashAlg, Sig, Key)
-        orelse public_key:verify(PlainText, sha, Sig, Key);
-
 do_verify(PlainText, HashAlg, Sig, Key, _) ->
     public_key:verify(PlainText, HashAlg, Sig, Key).
 


### PR DESCRIPTION
  Remove the do_verify/5 clause that accepted SHA-1 signatures from
  clients identifying as OpenSSH 7.x when rsa-sha2-* was negotiated.

  The workaround (OTP-14827 / ERL-531, OTP 20, Dec 2017) addressed a
  distro-specific issue where portable OpenSSH builds linked against
  certain OpenSSL versions signed with SHA-1 despite negotiating SHA-2.
  The same OpenSSH version worked correctly on OpenBSD (LibreSSL).

  Removing because:
  - The client banner is unauthenticated — any peer can spoof it to
    trigger SHA-1 acceptance, weakening server-side verification.
  - The underlying distro/build issue has not existed for years.
  - No version string can correctly identify affected builds.
  - No other SSH implementation carries peer-version workarounds.