### PR TITLE
ssh: Filter benign driver_select race in test event analysis

### DIFF
--- a/lib/ssh/test/ssh_test_lib.erl
+++ b/lib/ssh/test/ssh_test_lib.erl
@@ -1526,10 +1526,21 @@ print_interesting_events([], Cnt) ->
     {ok, Cnt};
 print_interesting_events([#{level := Level} = Event | Tail], Cnt)
   when Level /= info, Level /= notice, Level /= debug ->
-    ct:log("------------~nInteresting event found:~n~p~n==========~n", [Event]),
-    print_interesting_events(Tail, Cnt + 1);
+    case is_benign_event(Event) of
+        true ->
+            print_interesting_events(Tail, Cnt);
+        false ->
+            ct:log("------------~nInteresting event found:~n~p~n==========~n", [Event]),
+            print_interesting_events(Tail, Cnt + 1)
+    end;
 print_interesting_events([_|Tail], Cnt) ->
     print_interesting_events(Tail, Cnt).
+
+%% Known-benign event: driver_select race during fd handoff between ports
+is_benign_event(#{msg := {_Fmt, [Msg]}}) when is_list(Msg) ->
+    string:find(Msg, "ignored repeated call") =/= nomatch;
+is_benign_event(_) ->
+    false.
 
 %% logger callbacks
 log(LogEvent = #{level:=_Level,msg:=_Msg,meta:=_Meta},


### PR DESCRIPTION
The emulator logs an error-level "ignored repeated call" message when two ports call driver_select on the same fd. This occurs in tests using the {fd, Fd} option where the original gen_tcp port and SSH's internal port briefly share the fd. The message is harmless and does not indicate an SSH bug.

Filter it in print_interesting_events/2 so it doesn't cause spurious test failures on high-scheduler machines.