### PR TITLE
public_key: Skip DSA tests when crypto lacks DSA support

### DIFF
--- a/lib/public_key/test/pkits_SUITE.erl
+++ b/lib/public_key/test/pkits_SUITE.erl
@@ -452,6 +452,15 @@ init_per_group(_GroupName, Config) ->
 end_per_group(_GroupName, Config) ->
     Config.
 %%--------------------------------------------------------------------
+init_per_testcase(valid_dsa_signature, Config) ->
+    case lists:member(dss, crypto:supports(public_keys)) of
+        true ->
+            Datadir = proplists:get_value(data_dir, Config),
+            put(datadir, Datadir),
+            Config;
+        false ->
+            {skip, dss_not_supported_by_crypto}
+    end;
 init_per_testcase(_Func, Config) ->
     Datadir = proplists:get_value(data_dir, Config),
     put(datadir, Datadir),

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -330,6 +330,13 @@ init_per_testcase(rsa_pss_sign_verify, Config) ->
             {skip, not_supported_by_crypto}
     end;
 
+init_per_testcase(dsa_sign_verify, Config) ->
+    case lists:member(dss, crypto:supports(public_keys)) of
+        true ->
+            Config;
+        false ->
+            {skip, dss_not_supported_by_crypto}
+    end;
 init_per_testcase(TestCase, Config) when TestCase == eddsa_sign_verify_24_compat;
                                          TestCase == pkix_crl_verify_eddsa ->
     case lists:member(eddsa, crypto:supports(public_keys)) of
@@ -1280,8 +1287,12 @@ pkix_decode_cert_empty_rdns(Config) when is_list(Config) ->
 pkix_path_validation() ->
     [{doc, "Test PKIX path validation"}].
 pkix_path_validation(Config) when is_list(Config) ->
+    KeyType = case lists:member(dss, crypto:supports(public_keys)) of
+                  true -> dsa;
+                  false -> rsa
+              end,
     CaK = {Trusted,_} =
-	erl_make_certs:make_cert([{key, dsa},
+        erl_make_certs:make_cert([{key, KeyType},
 			     {subject, [
 					{name, "Public Key"},
 					{?'id-at-name', {printableString, "public_key"}},


### PR DESCRIPTION
LibreSSL (shipped by OpenBSD) disables DSA, causing public_key_SUITE:dsa_sign_verify, public_key_SUITE:pkix_path_validation, and pkits_SUITE:valid_dsa_signature to crash with
{notsup, "Unsupported algorithm"} on OpenBSD 7.8.

Add init_per_testcase guards that check
crypto:supports(public_keys) for dss, matching the pattern already used for eddsa, mldsa, and slh_dsa tests.

For pkix_path_validation, fall back to RSA keys when DSA is unavailable since the test validates path validation logic, not the specific key algorithm.