### PR TITLE
ssh: Close socket in kex_strict_helper to prevent eaddrinuse

### DIFF
--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -1517,7 +1517,8 @@ kex_strict_helper(Config0, TestMessages, ExpectedReason) ->
              {user_interaction, false}
             | proplists:get_value(extra_options,Config,[])
             ]}] ++
-              TestMessages,
+              TestMessages ++
+              [close_socket],
           InitialState),
     ct:sleep(100),
     {ok, Events} = ssh_test_lib:get_log_events(Config),


### PR DESCRIPTION
The kex_strict_helper function creates a TCP connection for each test iteration but never closes the client socket. On OpenBSD, the lingering sockets in TIME_WAIT cause gen_tcp:connect to fail with eaddrinuse on subsequent iterations due to ephemeral port collision with {reuseaddr, true}.

Add close_socket to the test message sequence so the socket is released before the next iteration begins