### PR TITLE
erts: Fix possible race between ets:delete/1 and terminating fixator

### DIFF
--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -248,7 +248,7 @@ static void table_dec_refc(DbTable *tb, erts_aint_t min_val)
 static ERTS_INLINE DbTable* btid2tab(Binary* btid)
 {
     erts_atomic_t *tbref = erts_binary_to_magic_indirection(btid);
-    return (DbTable *) erts_atomic_read_nob(tbref);
+    return (DbTable *) erts_atomic_read_acqb(tbref);
 }
 
 static int
@@ -331,7 +331,7 @@ tid_clear(Process *c_p, DbTable *tb)
     DbTable *rtb;
     Binary *btid = tb->common.btid;
     erts_atomic_t *tbref = erts_binary_to_magic_indirection(btid);
-    rtb = (DbTable *) erts_atomic_xchg_nob(tbref, (erts_aint_t) NULL);
+    rtb = (DbTable *) erts_atomic_xchg_relb(tbref, (erts_aint_t) NULL);
     ASSERT(!rtb || tb == rtb);
     if (rtb) {
         table_dec_refc(tb, 1);

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -5056,6 +5056,8 @@ static void fix_table_locked(Process* p, DbTable* tb)
     DbFixation *fix;
     int use_locks = !DB_LOCK_FREE(tb);
 
+    ERTS_LC_ASSERT(DB_LOCK_FREE(tb) || erts_lc_rwmtx_is_rlocked(&tb->common.rwlock));
+
     if (use_locks)
         erts_mtx_lock(&tb->common.fixlock);
 
@@ -5100,6 +5102,8 @@ static void unfix_table_locked(Process* p,  DbTable* tb,
 {
     DbFixation* fix;
     int use_locks = !DB_LOCK_FREE(tb);
+
+    ERTS_LC_ASSERT(DB_LOCK_FREE(tb) || erts_lc_rwmtx_is_rlocked(&tb->common.rwlock));
 
     if (use_locks)
         erts_mtx_lock(&tb->common.fixlock);


### PR DESCRIPTION
1. A process terminates and calls `proc_cleanup_fixed_table()` to release its fixation of a table.
2. It calls `btid2tab()` and gets NULL, meaning the table is deleted.
3. It deallocates the `DbFixation` assuming it has been unlinked from the table.

To be sure setting the table pointer to NULL is done *after* unlinking the `DbFixation`, this PR adds memory barrier pairs in `tid_clear()` and `btid2tab()`.
