### PR TITLE
erts: Fix missing exit_status caused by SIGCHLD race

### DIFF
--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -747,6 +747,12 @@ static ErlDrvSSizeT spawn_control(ErlDrvData e, unsigned int cmd, char *buf,
     if (dd->ofd)
         driver_select(dd->port_num, abs(dd->ofd->fd), ERL_DRV_WRITE | ERL_DRV_USE, 1);
 
+    /* We call ready_input directly as not all OSs trigger an input event on an
+       fd that already triggered EOF. For example ONESHOT poll on Linux and FreeBSD will not. */
+    if (dd->ifd) {
+        ready_input(e, abs(dd->ifd->fd));
+    }
+
     return 0;
 }
 
@@ -1228,9 +1234,9 @@ static int port_inp_failure(ErtsSysDriverData *dd, int res)
         if (dd->alive == 1) {
             /*
              * We have eof and want to report exit status, but the process
-             * hasn't exited yet. When it does ready_input will
-             * driver_select() this fd which will make sure that we get
-             * back here with dd->alive == -1 and dd->status set.
+             * hasn't exited yet. When it does spawn_control will call ready_input
+             * which will make sure that we get back here with dd->alive == -1 and
+             * dd->status set.
              */
             return 0;
         }


### PR DESCRIPTION
Consider this scenario:

1. Read FD signals EOF
2. ready_input called and read returns 0
3. call port_inp_failure, wait for SigChld
4. spawn_control called with SigChld, triggering driver_select on read fd
5. ready_input called again and now exit_status is delivered

Not all OSs actually trigger a second poll signal when we re-select on an FD has already signaled EOF. So if that trigger never happens then step 5 is left out and no exit_status is delivered.

closes #11278