### PR TITLE
ei: Fix decode bignum

### DIFF
--- a/.github/dockerfiles/Dockerfile.64-bit
+++ b/.github/dockerfiles/Dockerfile.64-bit
@@ -54,7 +54,7 @@ ENV SKIPPED_OSSF_LDFLAGS="-Wl,-z,nodlopen -fPIE -fPIC -shared"
 ## Configure (if not cached), check that no application are disabled and then make
 RUN if [ ! -f Makefile ]; then \
       touch README.md && \
-      ./configure --prefix="/Erlang ∅⊤℞" --enable-pie && \
+      ./configure --prefix="/Erlang ∅⊤℞" --enable-pie --with-gmp && \
       if cat lib/*/CONF_INFO || cat lib/*/SKIP || cat lib/SKIP-APPLICATIONS; then exit 1; fi && \
       find . -type f -newer README.md | xargs tar --transform 's:^./:otp/:' -cf ../otp_cache.tar; \
     fi && \

--- a/.github/dockerfiles/Dockerfile.ubuntu-base
+++ b/.github/dockerfiles/Dockerfile.ubuntu-base
@@ -24,7 +24,7 @@
 ARG BASE=gitpod/workspace-full
 FROM $BASE
 
-ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssl-dev unixodbc-dev libsctp-dev lksctp-tools libgmp3-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev"
+ENV INSTALL_LIBS="zlib1g-dev libncurses5-dev libssl-dev unixodbc-dev libsctp-dev lksctp-tools libgmp3-dev libwxbase3.0-dev libwxgtk3.0-gtk3-dev libwxgtk-webview3.0-gtk3-dev libgmp-dev"
 
 USER root
 

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -83,6 +83,7 @@ jobs:
             -e CTRUN_TIMEOUT=90 -e SPEC_POSTFIX=gh \
             -e TEST_NEEDS_RELEASE=true -e "RELEASE_ROOT=/buildroot/otp/Erlang ∅⊤℞" \
             -e EXTRA_ARGS="-ct_hooks cth_surefire [{path,\"/buildroot/otp/$DIR/make_test_dir/${MATRIX_TYPE}_junit.xml\"}]" \
+            -e CONFIG_FLAGS="--with-gmp" \
             -v "$PWD/make_test_dir:/buildroot/otp/$DIR/make_test_dir" \
             -v "$PWD/scripts:/buildroot/otp/scripts" \
             otp "./otp_build download_gdb_tools && make emulator && make TYPE=${TYPE} && make ${APP}_test TYPE=${TYPE}"

--- a/erts/configure
+++ b/erts/configure
@@ -3794,6 +3794,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"

--- a/lib/common_test/configure
+++ b/lib/common_test/configure
@@ -1943,6 +1943,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"

--- a/lib/common_test/test_server/configure
+++ b/lib/common_test/test_server/configure
@@ -721,6 +721,7 @@ enable_debug_mode
 enable_m64_build
 enable_m32_build
 enable_largefile
+with_gmp
 enable_shlib_thread_safety
 enable_year2038
 '
@@ -1358,6 +1359,12 @@ Optional Features:
   --disable-largefile     omit support for large files
   --enable-shlib-thread-safety  enable thread safety for build shared libraries
   --disable-year2038      don't support timestamps after 2038
+
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-gmp=PATH         specify location of GNU MP include and lib
+  --with-gmp              use GNU MP (will search for it)
 
 Some influential environment variables:
   CC          C compiler command
@@ -2430,6 +2437,123 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -3864,6 +3988,201 @@ fi
 
 
 #--------------------------------------------------------------------
+# Test for gmp availability
+#--------------------------------------------------------------------
+
+ac_header= ac_cache=
+for ac_item in $ac_header_c_list
+do
+  if test $ac_cache; then
+    ac_fn_c_check_header_compile "$LINENO" $ac_header ac_cv_header_$ac_cache "$ac_includes_default"
+    if eval test \"x\$ac_cv_header_$ac_cache\" = xyes; then
+      printf "%s\n" "#define $ac_item 1" >> confdefs.h
+    fi
+    ac_header= ac_cache=
+  elif test $ac_header; then
+    ac_cache=$ac_item
+  else
+    ac_header=$ac_item
+  fi
+done
+
+
+
+
+
+
+
+
+if test $ac_cv_header_stdlib_h = yes && test $ac_cv_header_string_h = yes
+then :
+
+printf "%s\n" "#define STDC_HEADERS 1" >>confdefs.h
+
+fi
+
+
+
+# Check whether --with-gmp was given.
+if test ${with_gmp+y}
+then :
+  withval=$with_gmp;
+fi
+
+
+# We don't just want any GNU MP version, we want 4.1 or later
+# that contain the import/export functions we need.
+
+
+if test "x$with_gmp" = "xyes"
+then :
+
+    for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
+	as_ac_Header=`printf "%s\n" "ac_cv_header_$dir/include/gmp.h" | sed "$as_sed_sh"`
+ac_fn_c_check_header_compile "$LINENO" "$dir/include/gmp.h" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"
+then :
+  ac_cv_gmp=yes
+else case e in #(
+  e) ac_cv_gmp=no ;;
+esac
+fi
+
+	if test $ac_cv_gmp = yes ; then
+	    CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
+	    LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
+
+printf "%s\n" "#define HAVE_GMP_H 1" >>confdefs.h
+
+	    break
+	fi
+    done
+    if test $ac_cv_gmp = no ; then
+	as_fn_error $? "No GNU MP installation found" "$LINENO" 5
+    fi
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __gmpz_export in -lgmp" >&5
+printf %s "checking for __gmpz_export in -lgmp... " >&6; }
+if test ${ac_cv_lib_gmp___gmpz_export+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_check_lib_save_LIBS=$LIBS
+LIBS="-lgmp  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char __gmpz_export (void);
+int
+main (void)
+{
+return __gmpz_export ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_gmp___gmpz_export=yes
+else case e in #(
+  e) ac_cv_lib_gmp___gmpz_export=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gmp___gmpz_export" >&5
+printf "%s\n" "$ac_cv_lib_gmp___gmpz_export" >&6; }
+if test "x$ac_cv_lib_gmp___gmpz_export" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBGMP 1" >>confdefs.h
+
+  LIBS="-lgmp $LIBS"
+
+fi
+
+    # FIXME return ERROR if no lib
+elif test "x$with_gmp" != "xno" -a -n "$with_gmp" ;then
+    # Option given with PATH to package
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GNU MP" >&5
+printf %s "checking for GNU MP... " >&6; }
+    if test ! -d "$with_gmp" ; then
+	as_fn_error $? "Invalid path to option --with-gmp=PATH" "$LINENO" 5
+    fi
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+    CFLAGS="$CFLAGS -I$with_gmp/include -L$with_gmp/lib"
+    LIB_CFLAGS="$LIB_CFLAGS -I$with_gmp/include -L$with_gmp/lib"
+
+printf "%s\n" "#define HAVE_GMP_H 1" >>confdefs.h
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __gmpz_export in -lgmp" >&5
+printf %s "checking for __gmpz_export in -lgmp... " >&6; }
+if test ${ac_cv_lib_gmp___gmpz_export+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) ac_check_lib_save_LIBS=$LIBS
+LIBS="-lgmp  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.
+   The 'extern "C"' is for builds by C++ compilers;
+   although this is not generally supported in C code supporting it here
+   has little cost and some practical benefit (sr 110532).  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char __gmpz_export (void);
+int
+main (void)
+{
+return __gmpz_export ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_gmp___gmpz_export=yes
+else case e in #(
+  e) ac_cv_lib_gmp___gmpz_export=no ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS ;;
+esac
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gmp___gmpz_export" >&5
+printf "%s\n" "$ac_cv_lib_gmp___gmpz_export" >&6; }
+if test "x$ac_cv_lib_gmp___gmpz_export" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBGMP 1" >>confdefs.h
+
+  LIBS="-lgmp $LIBS"
+
+fi
+
+    # FIXME return ERROR if no lib
+
+fi
+
+
+#--------------------------------------------------------------------
 #	Interactive UNIX requires -linet instead of -lsocket, plus it
 #	needs net/errno.h to define the socket-related error codes.
 #--------------------------------------------------------------------
@@ -3907,35 +4226,6 @@ then :
   LIBS="$LIBS -linet"
 fi
 
-ac_header= ac_cache=
-for ac_item in $ac_header_c_list
-do
-  if test $ac_cache; then
-    ac_fn_c_check_header_compile "$LINENO" $ac_header ac_cv_header_$ac_cache "$ac_includes_default"
-    if eval test \"x\$ac_cv_header_$ac_cache\" = xyes; then
-      printf "%s\n" "#define $ac_item 1" >> confdefs.h
-    fi
-    ac_header= ac_cache=
-  elif test $ac_header; then
-    ac_cache=$ac_item
-  else
-    ac_header=$ac_item
-  fi
-done
-
-
-
-
-
-
-
-
-if test $ac_cv_header_stdlib_h = yes && test $ac_cv_header_string_h = yes
-then :
-
-printf "%s\n" "#define STDC_HEADERS 1" >>confdefs.h
-
-fi
 ac_fn_c_check_header_compile "$LINENO" "net/errno.h" "ac_cv_header_net_errno_h" "$ac_includes_default"
 if test "x$ac_cv_header_net_errno_h" = xyes
 then :
@@ -4711,6 +5001,7 @@ then :
    rm -rf conftest*
    ac_cv_prog_javac_ver_1_5=yes
 
+
 else case e in #(
   e)
    echo "configure: failed program was:" 1>&5
@@ -4718,7 +5009,8 @@ else case e in #(
    echo "configure: PATH was $PATH" 1>&5
   rm -rf conftest*
   ac_cv_prog_javac_ver_1_5=no
-  ;;
+
+   ;;
 esac
 fi
 rm -f conftest* ;;

--- a/lib/common_test/test_server/configure
+++ b/lib/common_test/test_server/configure
@@ -4037,8 +4037,18 @@ fi
 if test "x$with_gmp" = "xyes"
 then :
 
-    for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
-	as_ac_Header=`printf "%s\n" "ac_cv_header_$dir/include/gmp.h" | sed "$as_sed_sh"`
+    ac_fn_c_check_header_compile "$LINENO" "gmp.h" "ac_cv_header_gmp_h" "$ac_includes_default"
+if test "x$ac_cv_header_gmp_h" = xyes
+then :
+  ac_cv_gmp=yes
+else case e in #(
+  e) ac_cv_gmp=no ;;
+esac
+fi
+
+    if test $ac_cv_gmp = no ; then
+        for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
+            as_ac_Header=`printf "%s\n" "ac_cv_header_$dir/include/gmp.h" | sed "$as_sed_sh"`
 ac_fn_c_check_header_compile "$LINENO" "$dir/include/gmp.h" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"
 then :
@@ -4048,17 +4058,19 @@ else case e in #(
 esac
 fi
 
-	if test $ac_cv_gmp = yes ; then
-	    CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
-	    LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
+            if test $ac_cv_gmp = yes ; then
+                CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
+                LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
+                break
+            fi
+        done
+    fi
+    if test $ac_cv_gmp = no ; then
+	as_fn_error $? "No GNU MP installation found" "$LINENO" 5
+    else
 
 printf "%s\n" "#define HAVE_GMP_H 1" >>confdefs.h
 
-	    break
-	fi
-    done
-    if test $ac_cv_gmp = no ; then
-	as_fn_error $? "No GNU MP installation found" "$LINENO" 5
     fi
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __gmpz_export in -lgmp" >&5
 printf %s "checking for __gmpz_export in -lgmp... " >&6; }

--- a/lib/common_test/test_server/configure.ac
+++ b/lib/common_test/test_server/configure.ac
@@ -25,6 +25,8 @@ AC_INIT
 AC_CONFIG_SRCDIR([conf_vars.in])
 AC_PREREQ([2.72])
 
+m4_include([otp.m4])
+
 AC_CANONICAL_HOST
 
 dnl Checks for programs.
@@ -76,6 +78,12 @@ fi
 AC_SYS_YEAR2038_RECOMMENDED
 
 AC_CHECK_LIB(m, sin)
+
+#--------------------------------------------------------------------
+# Test for gmp availability
+#--------------------------------------------------------------------
+
+ERL_WITH_GMP
 
 #--------------------------------------------------------------------
 #	Interactive UNIX requires -linet instead of -lsocket, plus it

--- a/lib/common_test/test_server/ts_install.erl
+++ b/lib/common_test/test_server/ts_install.erl
@@ -133,16 +133,17 @@ unix_autoconf(XConf) ->
     MXX_Build = [[$\s | Y] || Y <- string:lexemes(ConfigFlags, " \t\n"),
 		      Y == "--enable-m64-build"
 			  orelse Y == "--enable-m32-build"
-                          orelse Y == "--disable-year2038"],
+                          orelse Y == "--disable-year2038"
+                          orelse string:prefix(Y, "--with-gmp") =/= nomatch],
     Args = Host ++ Build ++ Threads ++ Debug ++ MXX_Build,
     case filelib:is_file(Configure) of
 	true ->
-	    OSXEnv = macosx_cflags(),
+            OSXEnv = c_ld_flags(),
 	    UnQuotedEnv = assign_vars(unquote(Env++OSXEnv)),
 	    io:format("Running ~ts~nEnv: ~p~n",
 		      [lists:flatten(Configure ++ Args),UnQuotedEnv]),
 	    Port = open_port({spawn, lists:flatten(["\"",Configure,"\"",Args])},
-			     [stream, eof, {env,UnQuotedEnv}]),
+                             [stream, {env,UnQuotedEnv}, exit_status]),
 	    ts_lib:print_data(Port);
 	false ->
 	    {error, no_configure_script}
@@ -196,18 +197,18 @@ get_xcomp_flag(Flag, Tag, Flags) ->
 	HostVal -> [" --",Tag,"=",HostVal]
     end.
 
-
-macosx_cflags() ->
-    case os:type() of
-	{unix, darwin} ->
-	    %% To ensure that the drivers we build can be loaded
-	    %% by the emulator, add either -m32 or -m64 to CFLAGS.
-	    WordSize = erlang:system_info(wordsize),
-	    Mflag = "-m" ++ integer_to_list(8*WordSize),
-	    [{"CFLAGS", Mflag},{"LDFLAGS", Mflag}];
-	_ ->
-	    []
-    end.
+c_ld_flags() ->
+    MFlag = case os:type() of
+                {unix, darwin} ->
+                    %% To ensure that the drivers we build can be loaded
+                    %% by the emulator, add either -m32 or -m64 to CFLAGS.
+                    WordSize = erlang:system_info(wordsize),
+                    "-m" ++ integer_to_list(8*WordSize);
+                _ ->
+                    ""
+            end,
+    [{"CFLAGS", MFlag ++ " " ++ unquote(os:getenv("CFLAGS", ""))},
+     {"LDFLAGS", MFlag ++ " " ++ unquote(os:getenv("LDFLAGS", ""))}].
 
 parse_xcomp_file(undefined) ->
     [{cross,"no"}];

--- a/lib/common_test/test_server/ts_lib.erl
+++ b/lib/common_test/test_server/ts_lib.erl
@@ -325,6 +325,15 @@ print_data(Port) ->
 	{Port, {data, Bytes}} ->
 	    io:put_chars(Bytes),
 	    print_data(Port);
+        {Port, {exit_status, 0}} -> 
+            receive
+                {'EXIT',  Port,  _} -> 
+                    ok
+            after 1 ->				% force context switch
+                    ok
+            end;
+        {Port, {exit_status, N}} ->
+            erlang:halt(N);
 	{Port, eof} ->
 	    Port ! {self(), close}, 
 	    receive

--- a/lib/crypto/configure
+++ b/lib/crypto/configure
@@ -3066,6 +3066,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -7911,8 +7911,18 @@ fi
 if test "x$with_gmp" = "xyes"
 then :
 
-    for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
-	as_ac_Header=`printf "%s\n" "ac_cv_header_$dir/include/gmp.h" | sed "$as_sed_sh"`
+    ac_fn_c_check_header_compile "$LINENO" "gmp.h" "ac_cv_header_gmp_h" "$ac_includes_default"
+if test "x$ac_cv_header_gmp_h" = xyes
+then :
+  ac_cv_gmp=yes
+else case e in #(
+  e) ac_cv_gmp=no ;;
+esac
+fi
+
+    if test $ac_cv_gmp = no ; then
+        for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
+            as_ac_Header=`printf "%s\n" "ac_cv_header_$dir/include/gmp.h" | sed "$as_sed_sh"`
 ac_fn_c_check_header_compile "$LINENO" "$dir/include/gmp.h" "$as_ac_Header" "$ac_includes_default"
 if eval test \"x\$"$as_ac_Header"\" = x"yes"
 then :
@@ -7922,17 +7932,19 @@ else case e in #(
 esac
 fi
 
-	if test $ac_cv_gmp = yes ; then
-	    CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
-	    LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
+            if test $ac_cv_gmp = yes ; then
+                CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
+                LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
+                break
+            fi
+        done
+    fi
+    if test $ac_cv_gmp = no ; then
+	as_fn_error $? "No GNU MP installation found" "$LINENO" 5
+    else
 
 printf "%s\n" "#define HAVE_GMP_H 1" >>confdefs.h
 
-	    break
-	fi
-    done
-    if test $ac_cv_gmp = no ; then
-	as_fn_error $? "No GNU MP installation found" "$LINENO" 5
     fi
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __gmpz_export in -lgmp" >&5
 printf %s "checking for __gmpz_export in -lgmp... " >&6; }

--- a/lib/erl_interface/configure
+++ b/lib/erl_interface/configure
@@ -2928,6 +2928,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"
@@ -7892,10 +7894,7 @@ esac
 fi
 
 
-# ---------------------------------------------------------------------------
-# We don't link against libgmp except for "make check"
-# but linking will also tell us that it is >= 4.1
-# ---------------------------------------------------------------------------
+
 
 
 # Check whether --with-gmp was given.
@@ -7907,6 +7906,7 @@ fi
 
 # We don't just want any GNU MP version, we want 4.1 or later
 # that contain the import/export functions we need.
+
 
 if test "x$with_gmp" = "xyes"
 then :
@@ -7926,7 +7926,7 @@ fi
 	    CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
 	    LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
 
-printf "%s\n" "#define HAVE_GMP_H /**/" >>confdefs.h
+printf "%s\n" "#define HAVE_GMP_H 1" >>confdefs.h
 
 	    break
 	fi
@@ -7998,7 +7998,7 @@ printf "%s\n" "yes" >&6; }
     CFLAGS="$CFLAGS -I$with_gmp/include -L$with_gmp/lib"
     LIB_CFLAGS="$LIB_CFLAGS -I$with_gmp/include -L$with_gmp/lib"
 
-printf "%s\n" "#define HAVE_GMP_H /**/" >>confdefs.h
+printf "%s\n" "#define HAVE_GMP_H 1" >>confdefs.h
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for __gmpz_export in -lgmp" >&5
 printf %s "checking for __gmpz_export in -lgmp... " >&6; }
@@ -8054,6 +8054,7 @@ fi
     # FIXME return ERROR if no lib
 
 fi
+
 
 
 

--- a/lib/erl_interface/configure.ac
+++ b/lib/erl_interface/configure.ac
@@ -234,47 +234,7 @@ AC_CHECK_FUNC(clock_gettime, [],
     AC_CHECK_LIB(rt, clock_gettime)
 )
 
-# ---------------------------------------------------------------------------
-# We don't link against libgmp except for "make check"
-# but linking will also tell us that it is >= 4.1
-# ---------------------------------------------------------------------------
-
-AC_ARG_WITH(gmp,
-[  --with-gmp=PATH         specify location of GNU MP include and lib
-  --with-gmp              use GNU MP (will search for it)])
-
-# We don't just want any GNU MP version, we want 4.1 or later
-# that contain the import/export functions we need.
-
-AS_IF([test "x$with_gmp" = "xyes"],
-  [
-    for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
-	AC_CHECK_HEADER($dir/include/gmp.h, ac_cv_gmp=yes, ac_cv_gmp=no)
-	if test $ac_cv_gmp = yes ; then
-	    CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
-	    LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
-	    AC_DEFINE(HAVE_GMP_H, [], [Define if you have "gmp.h"])
-	    break
-	fi
-    done
-    if test $ac_cv_gmp = no ; then
-	AC_MSG_ERROR([No GNU MP installation found])
-    fi
-    AC_CHECK_LIB(gmp, __gmpz_export)
-    # FIXME return ERROR if no lib
-elif test "x$with_gmp" != "xno" -a -n "$with_gmp" ;then
-    # Option given with PATH to package
-    AC_MSG_CHECKING(for GNU MP)
-    if test ! -d "$with_gmp" ; then
-	AC_MSG_ERROR(Invalid path to option --with-gmp=PATH)
-    fi
-    AC_MSG_RESULT(yes)
-    CFLAGS="$CFLAGS -I$with_gmp/include -L$with_gmp/lib"
-    LIB_CFLAGS="$LIB_CFLAGS -I$with_gmp/include -L$with_gmp/lib"
-    AC_DEFINE(HAVE_GMP_H, [], [Define if you have "gmp.h"])
-    AC_CHECK_LIB(gmp, __gmpz_export)
-    # FIXME return ERROR if no lib
-  ])
+ERL_WITH_GMP
 
 LM_WINDOWS_ENVIRONMENT
 	
@@ -347,7 +307,8 @@ ERL_POP_WERROR
 # ---------------------------------------------------------------------------
 
 
-AC_CONFIG_FILES([src/$host/Makefile:src/Makefile.in
-	src/$host/eidefs.mk:src/eidefs.mk.in
-	])
+AC_CONFIG_FILES(
+    [src/$host/Makefile:src/Makefile.in
+     src/$host/eidefs.mk:src/eidefs.mk.in
+    ])
 AC_OUTPUT

--- a/lib/erl_interface/include/ei.h
+++ b/lib/erl_interface/include/ei.h
@@ -642,7 +642,7 @@ int ei_global_unregister(ei_cnode *ec, int fd, const char *name);
 /* If the user included <gmp.h> we supply some more functions */
 
 #if defined(__GNU_MP_VERSION) \
-	&& __GNU_MP_VERSION == 4 && __GNU_MP_VERSION_MINOR >= 1 
+        && ((__GNU_MP_VERSION == 4 && __GNU_MP_VERSION_MINOR >= 1) || __GNU_MP_VERSION > 4)
 
 int ei_decode_bignum(const char *buf, int *index, mpz_t obj);
 int ei_encode_bignum(char *buf, int *index, mpz_t obj);

--- a/lib/erl_interface/src/decode/decode_bignum.c
+++ b/lib/erl_interface/src/decode/decode_bignum.c
@@ -20,7 +20,7 @@
  * %CopyrightEnd%
  */
 
-#include "eidef.h"
+#include "config.h"
 
 #if defined(HAVE_GMP_H) && defined(HAVE_LIBGMP)
 

--- a/lib/erl_interface/src/encode/encode_bignum.c
+++ b/lib/erl_interface/src/encode/encode_bignum.c
@@ -20,7 +20,7 @@
  * %CopyrightEnd%
  */
 
-#include "eidef.h"
+#include "config.h"
 
 #if defined(HAVE_GMP_H) && defined(HAVE_LIBGMP)
 
@@ -53,6 +53,7 @@ int ei_encode_bignum(char *buf, int *index, mpz_t obj)
 
 	if (!buf) {
 	    int numb = 8;	/* # bits in each external format limb */
+            s += 1 + 4 + 1; /* tag, arity, sign */
 	    s += (mpz_sizeinbase(obj, 2) + numb-1) / numb;
 	} else {
 	    char *arityp;
@@ -60,10 +61,10 @@ int ei_encode_bignum(char *buf, int *index, mpz_t obj)
 	    put8(s,ERL_LARGE_BIG_EXT);
 	    arityp = s;		/* fill in later */
 	    s += 4;
-	    put8(s, mpz_sign == 1); /* save sign separately */
+            put8(s, mpz_sign == 1 ? 0 : 1); /* save sign separately */
 	    mpz_export(s, &count, -1, 1, 0, 0, obj);
 	    s += count;
-	    put32le(arityp, count);
+            put32be(arityp, count);
 	}
     }
   

--- a/lib/erl_interface/test/ei_encode_SUITE.erl
+++ b/lib/erl_interface/test/ei_encode_SUITE.erl
@@ -32,6 +32,7 @@
          test_ei_encode_ulong/1,
          test_ei_encode_longlong/1,
          test_ei_encode_ulonglong/1,
+         test_ei_encode_bignum/1,
          test_ei_encode_char/1,
          test_ei_encode_misc/1,
          test_ei_encode_fails/1,
@@ -44,6 +45,7 @@ suite() ->
 all() -> 
     [test_ei_encode_long, test_ei_encode_ulong,
      test_ei_encode_longlong, test_ei_encode_ulonglong,
+     test_ei_encode_bignum,
      test_ei_encode_char, test_ei_encode_misc,
      test_ei_encode_fails, test_ei_encode_utf8_atom,
      test_ei_encode_utf8_atom_len].
@@ -146,6 +148,30 @@ test_ei_encode_ulonglong(Config) when is_list(Config) ->
     
     runner:recv_eot(P),
     ok.
+
+%% ######################################################################## %%
+
+test_ei_encode_bignum(Config) when is_list(Config) ->
+
+    P = runner:start(Config, ?test_ei_encode_bignum),
+
+    case get_binary(P) of
+        <<"skip">> ->
+            runner:recv_eot(P),
+            {skip, "GMP 4.1 or later is required for this test"};
+        <<"run">> ->
+            BigNum = 1234567890123456789012345678901234567890,
+            NegBigNum = -1 * BigNum,
+            BigNumBytes = <<210,10,63,206,150,95,188,172,184,243,219,192,117,32,201,160,3>>,
+
+            {<<111,0,0,0,17,0,BigNumBytes/binary>>, BigNum} = get_buf_and_term(P),
+            {<<111,0,0,0,17,1,BigNumBytes/binary>>, NegBigNum} = get_buf_and_term(P),
+
+            runner:recv_eot(P),
+
+            ok
+
+    end.
 
 
 %% ######################################################################## %%

--- a/lib/erl_interface/test/ei_encode_SUITE_data/ei_encode_test.c
+++ b/lib/erl_interface/test/ei_encode_SUITE_data/ei_encode_test.c
@@ -20,6 +20,10 @@
  * %CopyrightEnd%
  */
 
+#if defined(HAVE_GMP_H) && defined(HAVE_LIBGMP)
+#include <gmp.h>
+#endif
+
 #include "ei_runner.h"
 
 /*
@@ -518,6 +522,39 @@ TESTCASE(test_ei_encode_ulonglong)
     report(1);
 }
 
+/* ******************************************************************** */
+
+TESTCASE(test_ei_encode_bignum)
+{
+    ei_init();
+
+#if defined(__GNU_MP_VERSION) \
+    && ((__GNU_MP_VERSION == 4 && __GNU_MP_VERSION_MINOR >= 1) || __GNU_MP_VERSION > 4)
+
+    send_buffer("run", 3);
+
+    {
+        mpz_t obj;
+        mpz_init(obj);
+        mpz_set_str(obj, "1234567890123456789012345678901234567890", 10);
+        EI_ENCODE_1(encode_bignum, obj);
+        mpz_clear(obj);
+    }
+
+    {
+        mpz_t obj;
+        mpz_init(obj);
+        mpz_set_str(obj, "1234567890123456789012345678901234567890", 10);
+        mpz_neg(obj, obj);
+        EI_ENCODE_1(encode_bignum, obj);
+        mpz_clear(obj);
+    }
+    
+#else
+    send_buffer("skip", 4);
+#endif /* __GNU_MP_VERSION */
+    report(1);
+}
 
 /* ******************************************************************** */
 

--- a/lib/megaco/configure
+++ b/lib/megaco/configure
@@ -2813,6 +2813,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
   # Make sure we can run config.sub.
 $SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
   as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5

--- a/lib/odbc/configure
+++ b/lib/odbc/configure
@@ -2914,6 +2914,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"

--- a/lib/snmp/configure
+++ b/lib/snmp/configure
@@ -1938,6 +1938,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"

--- a/lib/wx/configure
+++ b/lib/wx/configure
@@ -3177,6 +3177,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"

--- a/make/autoconf/otp.m4
+++ b/make/autoconf/otp.m4
@@ -3512,3 +3512,49 @@ AC_SUBST(DED_LIBS)
 AC_SUBST(DED_OSTYPE)
 
 ])
+
+AC_DEFUN([ERL_WITH_GMP],
+[
+
+AC_ARG_WITH(gmp,
+[  --with-gmp=PATH         specify location of GNU MP include and lib
+  --with-gmp              use GNU MP (will search for it)])
+
+# We don't just want any GNU MP version, we want 4.1 or later
+# that contain the import/export functions we need.
+
+
+AS_IF([test "x$with_gmp" = "xyes"],
+  [
+    AC_CHECK_HEADER(gmp.h, ac_cv_gmp=yes, ac_cv_gmp=no)
+    if test $ac_cv_gmp = no ; then
+        for dir in /usr /usr/pkg /usr/local /usr/local/gmp /usr/lib/gmp /usr/gmp; do
+            AC_CHECK_HEADER($dir/include/gmp.h, ac_cv_gmp=yes, ac_cv_gmp=no)
+            if test $ac_cv_gmp = yes ; then
+                CFLAGS="$CFLAGS -I$dir/include -L$dir/lib"
+                LIB_CFLAGS="$LIB_CFLAGS -I$dir/include -L$dir/lib"
+                break
+            fi
+        done
+    fi
+    if test $ac_cv_gmp = no ; then
+	AC_MSG_ERROR([No GNU MP installation found])
+    else
+        AC_DEFINE(HAVE_GMP_H, [1], [Define if you have "gmp.h"])
+    fi
+    AC_CHECK_LIB(gmp, __gmpz_export)
+    # FIXME return ERROR if no lib
+elif test "x$with_gmp" != "xno" -a -n "$with_gmp" ;then
+    # Option given with PATH to package
+    AC_MSG_CHECKING(for GNU MP)
+    if test ! -d "$with_gmp" ; then
+	AC_MSG_ERROR(Invalid path to option --with-gmp=PATH)
+    fi
+    AC_MSG_RESULT(yes)
+    CFLAGS="$CFLAGS -I$with_gmp/include -L$with_gmp/lib"
+    LIB_CFLAGS="$LIB_CFLAGS -I$with_gmp/include -L$with_gmp/lib"
+    AC_DEFINE(HAVE_GMP_H, [1], [Define if you have "gmp.h"])
+    AC_CHECK_LIB(gmp, __gmpz_export)
+    # FIXME return ERROR if no lib
+  ])
+])

--- a/make/configure
+++ b/make/configure
@@ -3336,6 +3336,8 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
+
 no_werror_CFLAGS=$(echo " $CFLAGS " | sed 's/ -Werror / /g')
 if test "X $CFLAGS " != "X$no_werror_CFLAGS"; then
    CFLAGS="$no_werror_CFLAGS"


### PR DESCRIPTION
This PR adds testing of decode+encode of bignums using libgmp into the GH tests. It also fixes issues found in decode_bignum, which seems to not be used at all as it is completely broken.

Another path to go is to remove the libgmp bignum support completely, which would remove the needs for testing these parts.

I had to make some changes to ts in order to get libgmp built into the testing code.