### PR TITLE
loader-opt: index BEAM labels through a vector

### DIFF
--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -278,7 +278,7 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *_ga,
                                          const BeamFile *file)
         : BeamAssembler(getAtom(_mod)), BeamModuleAssemblerCommon(file, _mod),
           ga(_ga) {
-    rawLabels.reserve(num_labels + 1);
+    rawLabels.resize(num_labels + 1);
 
     if (logger.file() && beam) {
         /* Dig out all named labels from the BEAM-file and sort them on the
@@ -330,11 +330,11 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *_ga,
             /* The named_labels are sorted, so no need for a search. */
             if (e->label == i) {
                 erts_snprintf(tmp, sizeof(tmp), "%T/%d", e->function, e->arity);
-                rawLabels.emplace(i, a.new_named_label(tmp));
+                rawLabels[i] = a.new_named_label(tmp);
                 e++;
             } else {
                 std::string lblName = "label_" + std::to_string(i);
-                rawLabels.emplace(i, a.new_named_label(lblName.data()));
+                rawLabels[i] = a.new_named_label(lblName.data());
             }
         }
 
@@ -345,12 +345,12 @@ BeamModuleAssembler::BeamModuleAssembler(BeamGlobalAssembler *_ga,
          * labels. */
         for (int i = 1; i < num_labels; i++) {
             std::string lblName = "label_" + std::to_string(i);
-            rawLabels.emplace(i, a.new_named_label(lblName.data()));
+            rawLabels[i] = a.new_named_label(lblName.data());
         }
     } else {
         /* No output is requested, go with unnamed labels */
         for (int i = 1; i < num_labels; i++) {
-            rawLabels.emplace(i, a.new_label());
+            rawLabels[i] = a.new_label();
         }
     }
 

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -135,7 +135,11 @@ struct BeamModuleAssemblerCommon {
     Eterm mod;
 
     /* Map of label number to asmjit Label */
-    typedef std::unordered_map<BeamLabel, const Label> LabelMap;
+    /* BEAM labels are dense (1..num_labels), so they map to asmjit labels
+     * through a plain vector indexed by label number; slot 0 is unused.
+     * Label resolution happens for nearly every emitted instruction, which
+     * is too hot for a hash map. */
+    typedef std::vector<Label> LabelMap;
     LabelMap rawLabels;
 
     struct patch {


### PR DESCRIPTION
Replace the per-label hash map used during JIT code loading with a vector indexed by label number. The loader allocates the label table once after the label count is known, making repeated label address lookups direct indexed loads instead of hash lookups while preserving the existing label-number validation.

Benchmark: generated 100 modules with 100 exported functions each and timed 80 iterations of purging and loading all modules in order via code:load_abs/1 on aarch64-apple-darwin24.6.0. Baseline median/avg/p90: 41,211 / 41,633 / 44,106 us. Candidate median/avg/p90: 37,577 / 38,243 / 40,859 us.