### PR TITLE
loader-opt: keep JIT metadata line file indexes

### DIFF
--- a/erts/emulator/beam/jit/arm/beam_asm.hpp
+++ b/erts/emulator/beam/jit/arm/beam_asm.hpp
@@ -1958,6 +1958,6 @@ protected:
 void *beamasm_metadata_insert(std::string module_name,
                               ErtsCodePtr base_address,
                               size_t code_size,
-                              const std::vector<AsmRange> &ranges);
+                              const AsmMetadata &metadata);
 void beamasm_metadata_early_init();
 void beamasm_metadata_late_init();

--- a/erts/emulator/beam/jit/arm/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/arm/beam_asm_global.cpp
@@ -62,9 +62,9 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
         VirtMem::protect_jit_memory(VirtMem::ProtectJitAccess::kReadExecute);
     }
 
-    std::vector<AsmRange> ranges;
+    AsmMetadata metadata;
 
-    ranges.reserve(emitPtrs.size());
+    metadata.ranges.reserve(emitPtrs.size());
 
     for (auto val : emitPtrs) {
         ErtsCodePtr start = (ErtsCodePtr)getCode(labels[val.first]);
@@ -76,16 +76,17 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
             stop = (ErtsCodePtr)((char *)getBaseAddress() + code.code_size());
         }
 
-        ranges.push_back(AsmRange{start,
-                                  stop,
-                                  code.label_entry_of(labels[val.first]).name(),
-                                  {}});
+        metadata.ranges.push_back(
+                AsmRange{start,
+                         stop,
+                         code.label_entry_of(labels[val.first]).name(),
+                         {}});
     }
 
     (void)beamasm_metadata_insert("global",
                                   (ErtsCodePtr)getBaseAddress(),
                                   code.code_size(),
-                                  ranges);
+                                  metadata);
 
     /* `this->get_xxx` are populated last to ensure that we crash if we use
      * them instead of labels in global code. */

--- a/erts/emulator/beam/jit/beam_jit_common.cpp
+++ b/erts/emulator/beam/jit/beam_jit_common.cpp
@@ -373,10 +373,34 @@ void *BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
 
     char name_buffer[MAX_ATOM_SZ_LIMIT];
     std::string module_name = getAtom(mod);
-    std::vector<AsmRange> ranges;
+    AsmMetadata metadata;
+    std::vector<AsmRange> &ranges = metadata.ranges;
     ERTS_DECL_AM(erts_beamasm);
 
     ranges.reserve(functions.size() + 2);
+
+    if (line_table && beam) {
+        Uint32 file_count = beam->lines.name_count;
+
+        metadata.files.reserve(file_count);
+
+        for (Uint32 i = 0; i < file_count; i++) {
+            Eterm fname = line_table->fname_ptr[i];
+            Sint n;
+
+            ERTS_ASSERT(is_nil(fname) || is_list(fname));
+
+            int res = erts_unicode_list_to_buf(fname,
+                                               (byte *)name_buffer,
+                                               sizeof(name_buffer),
+                                               sizeof(name_buffer) / 4,
+                                               &n);
+
+            ERTS_ASSERT(res != -1);
+
+            metadata.files.emplace_back(name_buffer, n);
+        }
+    }
 
     ASSERT((ErtsCodePtr)getBaseAddress() == (ErtsCodePtr)header);
     ASSERT(functions.size() == header->num_functions);
@@ -429,6 +453,8 @@ void *BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
             const void **line_cursor = line_table->func_tab[i];
             const int loc_size = line_table->loc_size;
 
+            lines.reserve(line_table->func_tab[i + 1] - line_cursor);
+
             /* Register all lines belonging to this function. */
             while ((intptr_t)line_cursor[0] < (intptr_t)stop) {
                 ptrdiff_t line_index;
@@ -444,25 +470,12 @@ void *BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
                 }
 
                 if (loc != LINE_INVALID_LOCATION) {
-                    Uint32 file;
-                    Eterm fname;
-                    int res;
+                    Uint32 file = LOC_FILE(loc);
 
-                    file = LOC_FILE(loc);
-                    fname = line_table->fname_ptr[file];
-
-                    ERTS_ASSERT(is_nil(fname) || is_list(fname));
-
-                    res = erts_unicode_list_to_buf(fname,
-                                                   (byte *)name_buffer,
-                                                   sizeof(name_buffer),
-                                                   sizeof(name_buffer) / 4,
-                                                   &n);
-
-                    ERTS_ASSERT(res != -1);
+                    ERTS_ASSERT(file < metadata.files.size());
 
                     lines.push_back({.start = line_cursor[0],
-                                     .file = std::string(name_buffer, n),
+                                     .file = file,
                                      .line = LOC_LINE(loc)});
                 }
 
@@ -473,7 +486,7 @@ void *BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
         ranges.push_back({.start = start,
                           .stop = stop,
                           .name = function_name,
-                          .lines = lines});
+                          .lines = std::move(lines)});
     }
 
     /* Push info about the footer */
@@ -485,7 +498,7 @@ void *BeamModuleAssembler::register_metadata(const BeamCodeHeader *header) {
     return beamasm_metadata_insert(module_name,
                                    (ErtsCodePtr)code.base_address(),
                                    code.code_size(),
-                                   ranges);
+                                   metadata);
 #else
     return NULL;
 #endif

--- a/erts/emulator/beam/jit/beam_jit_common.hpp
+++ b/erts/emulator/beam/jit/beam_jit_common.hpp
@@ -62,11 +62,16 @@ struct AsmRange {
 
     struct LineData {
         ErtsCodePtr start;
-        const std::string file;
+        Uint32 file;
         unsigned line;
     };
 
     const std::vector<LineData> lines;
+};
+
+struct AsmMetadata {
+    std::vector<std::string> files;
+    std::vector<AsmRange> ranges;
 };
 
 /* This is a partial class for `BeamAssembler`, containing various fields and

--- a/erts/emulator/beam/jit/beam_jit_metadata.cpp
+++ b/erts/emulator/beam/jit/beam_jit_metadata.cpp
@@ -157,14 +157,17 @@ static void beamasm_init_late_gdb() {
 static void *beamasm_insert_gdb_info(std::string module_name,
                                      ErtsCodePtr base_address,
                                      size_t code_size,
-                                     const std::vector<AsmRange> &ranges) {
+                                     const AsmMetadata &metadata) {
     Sint symfile_size = sizeof(struct debug_info) + module_name.size() + 1;
+    const std::vector<AsmRange> &ranges = metadata.ranges;
 
     for (const auto &range : ranges) {
         symfile_size += sizeof(struct range_info) + range.name.size() + 1;
 
         for (const auto &line : range.lines) {
-            symfile_size += sizeof(struct line_info) + line.file.size() + 1;
+            const std::string &file = metadata.files[line.file];
+
+            symfile_size += sizeof(struct line_info) + file.size() + 1;
         }
     }
 
@@ -204,13 +207,13 @@ static void *beamasm_insert_gdb_info(std::string module_name,
         symfile += sizeof(*range_info) + range_info->name_length;
 
         for (const auto &line : range.lines) {
+            const std::string &file = metadata.files[line.file];
             auto line_info = (struct line_info *)symfile;
+
             line_info->start_offset = (char *)line.start - (char *)base_address;
             line_info->line_number = (uint32_t)line.line;
-            line_info->file_length = (uint16_t)line.file.size() + 1;
-            sys_memcpy(line_info->file,
-                       line.file.c_str(),
-                       line_info->file_length);
+            line_info->file_length = (uint16_t)file.size() + 1;
+            sys_memcpy(line_info->file, file.c_str(), line_info->file_length);
 
             symfile += sizeof(*line_info) + line_info->file_length;
         }
@@ -375,7 +378,9 @@ public:
         return true;
     }
 
-    void update(const std::vector<AsmRange> &ranges) {
+    void update(const AsmMetadata &metadata) {
+        const std::vector<AsmRange> &ranges = metadata.ranges;
+
         struct JitCodeLoadRecord {
             RecordHeader header;
             Uint32 pid;
@@ -416,8 +421,10 @@ public:
                 debug_info.nr_entry = range.lines.size() + 1;
 
                 for (const auto &line : range.lines) {
+                    const std::string &file = metadata.files[line.file];
+
                     debug_info.header.total_size += sizeof(debug_entry);
-                    debug_info.header.total_size += line.file.size() + 1;
+                    debug_info.header.total_size += file.size() + 1;
                 }
 
                 /* Add a dummy line to terminate the function. Otherwise, the
@@ -428,12 +435,14 @@ public:
                 fwrite(&debug_info, sizeof(debug_info), 1, file);
 
                 for (const auto &line : range.lines) {
+                    const std::string &line_file = metadata.files[line.file];
+
                     debug_entry.line_addr = (Uint64)line.start;
                     debug_entry.line = line.line;
                     debug_entry.column = 0;
 
                     fwrite(&debug_entry, sizeof(debug_entry), 1, file);
-                    fwrite(line.file.c_str(), line.file.size() + 1, 1, file);
+                    fwrite(line_file.c_str(), line_file.size() + 1, 1, file);
                 }
 
                 debug_entry.line_addr = (Uint64)range.stop;
@@ -497,8 +506,8 @@ public:
         return true;
     }
 
-    void update(const std::vector<AsmRange> &ranges) {
-        for (const auto &range : ranges) {
+    void update(const AsmMetadata &metadata) {
+        for (const auto &range : metadata.ranges) {
             char *start = (char *)range.start, *stop = (char *)range.stop;
             ptrdiff_t size = stop - start;
             fprintf(file, "%p %tx $%s\n", start, size, range.name.c_str());
@@ -539,16 +548,16 @@ public:
                               ERTS_LOCK_FLAGS_CATEGORY_GENERIC);
     }
 
-    void update(const std::vector<AsmRange> &ranges) {
+    void update(const AsmMetadata &metadata) {
         if (modes) {
             erts_mtx_lock(&mutex);
 #    ifdef HAVE_LINUX_PERF_DUMP_SUPPORT
             if (modes & DUMP) {
-                perf_dump.update(ranges);
+                perf_dump.update(metadata);
             }
 #    endif
             if (modes & MAP) {
-                perf_map.update(ranges);
+                perf_map.update(metadata);
             }
             erts_mtx_unlock(&mutex);
         }
@@ -577,16 +586,16 @@ void beamasm_metadata_late_init() {
 void *beamasm_metadata_insert(std::string module_name,
                               ErtsCodePtr base_address,
                               size_t code_size,
-                              const std::vector<AsmRange> &ranges) {
+                              const AsmMetadata &metadata) {
 #ifdef HAVE_LINUX_PERF_SUPPORT
-    perf.update(ranges);
+    perf.update(metadata);
 #endif
 
 #ifdef HAVE_GDB_SUPPORT
     return beamasm_insert_gdb_info(module_name,
                                    base_address,
                                    code_size,
-                                   ranges);
+                                   metadata);
 #else
     return NULL;
 #endif

--- a/erts/emulator/beam/jit/x86/beam_asm.hpp
+++ b/erts/emulator/beam/jit/x86/beam_asm.hpp
@@ -1877,6 +1877,6 @@ protected:
 void *beamasm_metadata_insert(std::string module_name,
                               ErtsCodePtr base_address,
                               size_t code_size,
-                              const std::vector<AsmRange> &ranges);
+                              const AsmMetadata &metadata);
 void beamasm_metadata_early_init();
 void beamasm_metadata_late_init();

--- a/erts/emulator/beam/jit/x86/beam_asm_global.cpp
+++ b/erts/emulator/beam/jit/x86/beam_asm_global.cpp
@@ -63,9 +63,9 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
     }
 
 #ifndef WIN32
-    std::vector<AsmRange> ranges;
+    AsmMetadata metadata;
 
-    ranges.reserve(emitPtrs.size());
+    metadata.ranges.reserve(emitPtrs.size());
 
     for (auto val : emitPtrs) {
         ErtsCodePtr start = (ErtsCodePtr)getCode(labels[val.first]);
@@ -77,7 +77,7 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
             stop = (ErtsCodePtr)((char *)getBaseAddress() + code.code_size());
         }
 
-        ranges.push_back(
+        metadata.ranges.push_back(
                 {.start = start,
                  .stop = stop,
                  .name = code.label_entry_of(labels[val.first]).name()});
@@ -86,7 +86,7 @@ BeamGlobalAssembler::BeamGlobalAssembler(JitAllocator *allocator)
     (void)beamasm_metadata_insert("global",
                                   (ErtsCodePtr)getBaseAddress(),
                                   code.code_size(),
-                                  ranges);
+                                  metadata);
 #endif
 
     /* `this->get_xxx` are populated last to ensure that we crash if we use them


### PR DESCRIPTION
JIT metadata line entries already reference source files by index in the module line table. Preserve that shape in the intermediate JIT metadata representation by storing one converted file table alongside the ranges, and have each LineData entry keep the file index.

This avoids converting and copying the same filename into every line entry while keeping the final expansion at the GDB/perf metadata writers, where those external formats require filename bytes.

Benchmark: generated 100 modules with 100 exported functions each and timed 80 iterations of purging and loading all modules in order via code:load_abs/1 on aarch64-apple-darwin24.6.0. Baseline median/avg/p90: 37,577 / 38,243 / 40,859 us. Candidate median/avg/p90: 36,122 / 36,664 / 39,144 us.