### PR TITLE
ssh: harden tests against OpenSSH MaxStartups drops [troubleshooting …

### DIFF
--- a/lib/ssh/test/ssh_algorithms_SUITE.erl
+++ b/lib/ssh/test/ssh_algorithms_SUITE.erl
@@ -480,9 +480,9 @@ sshd_simple_exec(Config) ->
             {public_key,Alg} -> [{pref_public_key_algs,Alg}];
             _ -> []
         end,
-    ConnectionRef = ssh_test_lib:connect(?SSH_DEFAULT_PORT,
-                                         [proplists:get_value(pref_algs,Config)
-                                          | ClientPubKeyOpts]),
+    ConnectionRef = ssh_test_lib:connect_with_retry(?SSH_DEFAULT_PORT,
+                                                    [proplists:get_value(pref_algs,Config)
+                                                     | ClientPubKeyOpts]),
     {ok, ChannelId0} = ssh_connection:session_channel(ConnectionRef, infinity),
     success = ssh_connection:exec(ConnectionRef, ChannelId0,
 				  "echo testing", infinity),

--- a/lib/ssh/test/ssh_connection_SUITE.erl
+++ b/lib/ssh/test/ssh_connection_SUITE.erl
@@ -247,6 +247,7 @@ init_per_testcase(_TestCase, Config) ->
     Config.
 
 end_per_testcase(_TestCase, _Config) ->
+    ssh_dbg:stop(),
     ssh:stop().
 
 verify_events(_TestCase, 0) -> ok;
@@ -279,24 +280,41 @@ simple_exec_sock(_Config) ->
 
 %%--------------------------------------------------------------------
 simple_exec_two_socks(_Config) ->
+    ssh_dbg:start(fun ct:log/2),
+    ssh_dbg:on([ssh_messages, tcp]),
     Parent = self(),
-    F = fun() ->
+    F = fun(Id) ->
                 spawn_link(
                   fun() ->
+                          ?CT_LOG("~p: connecting to sshd", [Id]),
                           {ok, Sock} = ssh_test_lib:gen_tcp_connect(?SSH_DEFAULT_PORT, [{active,false}]),
-                          {ok, ConnectionRef} = ssh:connect(Sock, [{save_accepted_host, false},
-                                                                   {silently_accept_hosts, true},
-                                                                   {user_interaction, true}]),
-                          Parent ! {self(),do_simple_exec(ConnectionRef)}
+                          case ssh:connect(Sock, [{save_accepted_host, false},
+                                                  {silently_accept_hosts, true},
+                                                  {user_interaction, true}]) of
+                              {ok, ConnectionRef} ->
+                                  ?CT_LOG("~p: connected ~p", [Id, ConnectionRef]),
+                                  Res = do_simple_exec(ConnectionRef),
+                                  ?CT_LOG("~p: exec result ~p", [Id, Res]),
+                                  Parent ! {self(), Res};
+                              {error, Reason} ->
+                                  ?CT_LOG("~p: ssh:connect failed ~p", [Id, Reason]),
+                                  Parent ! {self(), {error, Reason}}
+                          end
                   end)
         end,
-    Pid1 = F(),
-    Pid2 = F(),
+    Pid1 = F(1),
+    Pid2 = F(2),
+    collect_two_socks_result(Pid1, 1),
+    collect_two_socks_result(Pid2, 2).
+
+collect_two_socks_result(Pid, Id) ->
     receive
-        {Pid1,ok} -> ok
-    end,
-    receive
-        {Pid2,ok} -> ok
+        {Pid, ok} -> ok;
+        {Pid, {error, Reason}} -> ct:fail("~p: failed ~p", [Id, Reason])
+    after 30000 ->
+            ?CT_LOG("~p (~p): timeout waiting for result, process info:~n~p",
+                    [Id, Pid, erlang:process_info(Pid)]),
+            ct:fail("~p: timeout", [Id])
     end.
 
 %%--------------------------------------------------------------------

--- a/lib/ssh/test/ssh_sftp_SUITE.erl
+++ b/lib/ssh/test/ssh_sftp_SUITE.erl
@@ -1302,19 +1302,33 @@ w2l(Config, P) ->
 verify_openssh(Config) ->
     ct:comment("Begin ~p",[grps(Config)]),
     Host = ssh_test_lib:hostname(),
+    verify_openssh_loop(Host, Config, 3, 2000).
+
+verify_openssh_loop(_Host, _Config, 0, _Delay) ->
+    ?CT_LOG("verify_openssh: all retries exhausted"),
+    {skip, "No openssh daemon (retries exhausted)"};
+verify_openssh_loop(Host, Config, Retries, Delay) ->
     case (catch ssh_sftp:start_channel(Host,
-				       [{user_interaction, false},
-					{silently_accept_hosts, true},
-                                        {save_accepted_host, false}
+                                       [{user_interaction, false},
+                                        {silently_accept_hosts, true},
+                                        {save_accepted_host, false},
+                                        {connect_timeout, 10000},
+                                        {timeout, 10000}
                                        ])) of
-	{ok, _ChannelPid, Connection} ->
-	    [{peer, {_HostName,{IPx,Portx}}}] = ssh:connection_info(Connection,[peer]),
-	    ssh:close(Connection),
-	    [{w2l, fun w2l/1},
+        {ok, _ChannelPid, Connection} ->
+            [{peer, {_HostName,{IPx,Portx}}}] =
+                ssh:connection_info(Connection,[peer]),
+            ssh:close(Connection),
+            [{w2l, fun w2l/1},
              {peer, {fmt_host(IPx),Portx}}, {group, openssh_server} | Config];
-	{error,"Key exchange failed"} ->
-	    {skip, "openssh server doesn't support the tested kex algorithm"};
-	Other ->
-            ct:log("No openssh server. Cause:~n~p~n",[Other]),
-	    {skip, "No openssh daemon (see log in testcase)"}
+        {error,"Key exchange failed"} ->
+            {skip, "openssh server doesn't support the tested kex algorithm"};
+        Other when Retries > 0 ->
+            ?CT_LOG("verify_openssh: attempt failed (~p retries left): ~p",
+                    [Retries - 1, Other]),
+            timer:sleep(Delay),
+            verify_openssh_loop(Host, Config, Retries - 1, Delay * 2);
+        Other ->
+            ?CT_LOG("No openssh server. Cause:~n~p~n",[Other]),
+            {skip, "No openssh daemon (see log in testcase)"}
     end.

--- a/lib/ssh/test/ssh_test_lib.erl
+++ b/lib/ssh/test/ssh_test_lib.erl
@@ -138,8 +138,10 @@ user_dir/1,
 get_public_key_algorithms_with_valid_host_key/1,
 get_public_key_algorithms_with_valid_host_key/2,
 remove_comment/1,
-timetrap_scale/0
+timetrap_scale/0,
+connect_with_retry/2
         ]).
+
 %% logger callbacks and related helpers
 -export([log/2,
          get_log_level/0, set_log_level/1,
@@ -195,6 +197,36 @@ do_connect(Host, Port, Options) ->
     ct:log("~p:~p ssh:connect(~p, ~p, ~p)~n -> ~p",[?MODULE,?LINE,Host, Port, Options, R]),
     {ok, ConnectionRef} = R,
     ConnectionRef.
+
+%% Connect to the system sshd with retry.
+%% Handles transient failures from OpenSSH MaxStartups drops under load.
+connect_with_retry(Port, Options) ->
+    connect_with_retry(hostname(), Port, Options).
+
+connect_with_retry(Host, Port, Options0) ->
+    Options =
+        set_opts_if_not_set([{silently_accept_hosts, true},
+                             {save_accepted_host, false},
+                             {user_interaction, false}
+                            ], Options0),
+    connect_with_retry_loop(Host, Port, Options, 3, 1000).
+
+connect_with_retry_loop(Host, Port, Options, 0, _Delay) ->
+    R = ssh:connect(Host, Port, Options),
+    ?CT_LOG("ssh:connect(~p, ~p, ...) -> ~p", [Host, Port, R]),
+    {ok, ConnectionRef} = R,
+    ConnectionRef;
+connect_with_retry_loop(Host, Port, Options, Retries, Delay) ->
+    case ssh:connect(Host, Port, Options, 10000) of
+        {ok, Ref} ->
+            ?CT_LOG("ssh:connect(~p, ~p, ...) -> {ok,~p}", [Host, Port, Ref]),
+            Ref;
+        {error, Reason} ->
+            ?CT_LOG("ssh:connect(~p, ~p, ...) failed: ~p, ~p retries left",
+                    [Host, Port, Reason, Retries - 1]),
+            timer:sleep(Delay),
+            connect_with_retry_loop(Host, Port, Options, Retries - 1, Delay * 2)
+    end.
 
 set_opts_if_not_set(OptsToSet, Options0) ->
     lists:foldl(fun({K,V}, Opts) ->


### PR DESCRIPTION
…fangorn]

ssh_algorithms_SUITE:sshd_simple_exec and
ssh_connection_SUITE:simple_exec_two_socks fail intermittently on fangorn/OffHeapMsgQ due to the local OpenSSH daemon dropping or delaying connections under load (MaxStartups 10:30:100 default).

- Add connect_with_retry/2,3 to ssh_test_lib for tests connecting to the system sshd (retries up to 3 times with backoff)
- Use connect_with_retry in sshd_simple_exec
- Add diagnostics to simple_exec_two_socks: per-connection logging, ssh_dbg tracing (ssh_messages + tcp), explicit timeout with process_info dump on failure