### PR TITLE
erts: Fix missing poll error

### DIFF
--- a/erts/emulator/beam/erl_driver.h
+++ b/erts/emulator/beam/erl_driver.h
@@ -174,19 +174,22 @@ typedef enum {
 /*
  * Exception code from open_port/2 will be {'EXIT',{einval,Where}}.
  */
-#define ERL_DRV_ERROR_GENERAL ((ErlDrvData) -1)
+#define ERL_DRV_ERROR_GENERAL_INT_ -1
+#define ERL_DRV_ERROR_GENERAL ((ErlDrvData) ERL_DRV_ERROR_GENERAL_INT_)
 
 /*
  * Exception code from open_port/2 will be {'EXIT',{Errno,Where}},
  * where Errno is a textual representation of the errno variable
  * (e.g. eacces if errno is EACCES).
  */
-#define ERL_DRV_ERROR_ERRNO ((ErlDrvData) -2)
+#define ERL_DRV_ERROR_ERRNO_INT_ -2
+#define ERL_DRV_ERROR_ERRNO ((ErlDrvData) ERL_DRV_ERROR_ERRNO_INT_)
 
 /*
  * Exception code from open_port/2 will be {'EXIT',{badarg,Where}}.
  */
-#define ERL_DRV_ERROR_BADARG ((ErlDrvData) -3)
+#define ERL_DRV_ERROR_BADARG_INT_ -3
+#define ERL_DRV_ERROR_BADARG ((ErlDrvData) ERL_DRV_ERROR_BADARG_INT_)
 
 typedef struct erl_io_vec {
     int vsize;			/* length of vectors */

--- a/erts/emulator/beam/erl_process.c
+++ b/erts/emulator/beam/erl_process.c
@@ -3264,7 +3264,7 @@ aux_thread(void *vix)
                     if (flgs & ERTS_SSI_FLG_SLEEPING) {
                         ASSERT(flgs & ERTS_SSI_FLG_POLL_SLEEPING);
                         ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-                        erts_check_io(ssi->psi, ERTS_POLL_INF_TIMEOUT, 0);
+                        erts_check_io(ssi->psi, ERTS_POLL_INF_TIMEOUT, false);
                     }
                 }
             }
@@ -3366,7 +3366,7 @@ poll_thread(void *vbpt)
 
     while (1) {
         erts_check_io_interrupt(psi, 0);
-        erts_check_io(psi, ERTS_POLL_INF_TIMEOUT, !0);
+        erts_check_io(psi, ERTS_POLL_INF_TIMEOUT, true);
     }
     return NULL;
 }
@@ -3561,7 +3561,7 @@ scheduler_wait(int *fcalls, ErtsSchedulerData *esdp, ErtsRunQueue *rq)
                     if (flgs & ERTS_SSI_FLG_SLEEPING) {
                         ASSERT(flgs & ERTS_SSI_FLG_POLL_SLEEPING);
                         ASSERT(flgs & ERTS_SSI_FLG_WAITING);
-                        erts_check_io(ssi->psi, timeout_time, 0);
+                        erts_check_io(ssi->psi, timeout_time, false);
                         current_time = erts_get_monotonic_time(esdp);
                     }
                 }
@@ -9960,7 +9960,7 @@ Process *erts_schedule(ErtsSchedulerData *esdp, Process *p, int calls)
 
             ERTS_MSACC_SET_STATE_CACHED_M(ERTS_MSACC_STATE_CHECK_IO);
 
-	    erts_check_io(esdp->ssi->psi, ERTS_POLL_NO_TIMEOUT, 0);
+            erts_check_io(esdp->ssi->psi, ERTS_POLL_NO_TIMEOUT, false);
 	    ERTS_MSACC_POP_STATE_M();
 
 	    current_time = erts_get_monotonic_time(esdp);

--- a/erts/emulator/beam/io.c
+++ b/erts/emulator/beam/io.c
@@ -2932,16 +2932,16 @@ erl_drv_init_ack(ErlDrvPort ix, ErlDrvData res) {
 
     if (port->async_open_port) {
         switch(err_type) {
-        case -3:
+        case ERL_DRV_ERROR_BADARG_INT_:
             resp = am_badarg;
             break;
-        case -2: {
+        case ERL_DRV_ERROR_ERRNO_INT_: {
             char *str = erl_errno_id(errno);
             resp = erts_atom_put((byte *) str, sys_strlen(str),
                                  ERTS_ATOM_ENC_LATIN1, 1);
             break;
         }
-        case -1:
+        case ERL_DRV_ERROR_GENERAL_INT_:
             resp = am_einval;
             break;
         default:
@@ -2951,7 +2951,9 @@ erl_drv_init_ack(ErlDrvPort ix, ErlDrvData res) {
 
         init_ack_send_reply(port, resp);
 
-        if (err_type == -1 || err_type == -2 || err_type == -3)
+        if (res == ERL_DRV_ERROR_BADARG ||
+            res == ERL_DRV_ERROR_ERRNO ||
+            res == ERL_DRV_ERROR_GENERAL)
             driver_failure_term(ix, am_normal, 0);
         port->drv_data = err_type;
     }

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -1930,7 +1930,7 @@ erts_create_pollset_thread(int id, ErtsThrPrgrData *tpd) {
 }
 
 void
-erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, int poll_only_thread)
+erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_thread_progress)
 {
     int pollres_len;
     int poll_ret, i;
@@ -1944,7 +1944,7 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, int poll_only
 
     pollres_len = psi->pollres_len;
 
-    if (poll_only_thread)
+    if (needs_thread_progress)
         erts_thr_progress_active(psi->tpd, 0);
 
 #if ERTS_POLL_USE_FALLBACK
@@ -1958,7 +1958,7 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, int poll_only
         poll_ret = erts_poll_wait(psi->ps, psi->pollres, &pollres_len, psi->tpd, timeout_time);
     }
 
-    if (poll_only_thread)
+    if (needs_thread_progress)
         erts_thr_progress_active(psi->tpd, 1);
 
 #ifdef ERTS_ENABLE_LOCK_CHECK

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -95,7 +95,7 @@ typedef enum {
     ERTS_EV_FLAG_IN_SCHEDULER  = ERTS_EV_FLAG_CLEAR,
     ERTS_EV_FLAG_NIF_SELECT    = ERTS_EV_FLAG_CLEAR,
 #endif
-#ifdef ERTS_POLL_USE_FALLBACK
+#ifdef ERTS_POLL_USE_FALLBACK /* This has to be an ifdef */
     ERTS_EV_FLAG_FALLBACK      = 0x10,  /* Set when kernel poll rejected fd
                                            and it was put in the nkp version */
 #else
@@ -1934,7 +1934,7 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
 {
     int pollres_len;
     int poll_ret, i;
-#ifdef ERTS_POLL_USE_SCHEDULER_POLLING
+#if ERTS_POLL_USE_SCHEDULER_POLLING
     bool is_scheduler_poll = psi->ps == get_scheduler_pollset();
 #endif
     ERTS_MSACC_PUSH_AND_SET_STATE(ERTS_MSACC_STATE_CHECK_IO);
@@ -2028,13 +2028,18 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
 
 #if ERTS_POLL_USE_SCHEDULER_POLLING
             if (state->flags & ERTS_EV_FLAG_SCHEDULER) {
-                /* In the poll thread, this fd would have been disabled due to ONESHOT,
-                   but in the scheduler pollset it needs to be disabled manually. */
-                int wake_poller = 0;
-                erts_poll_control(get_scheduler_pollset(), fd, ERTS_POLL_OP_DEL, 0, &wake_poller);
-                state->flags &= ~(ERTS_EV_FLAG_SCHEDULER|ERTS_EV_FLAG_IN_SCHEDULER);
-                state->count = 0;
-                state->last_select_pid = NIL;
+                if (is_scheduler_poll) {
+                    /* If we triggered in a scheduler pollset,
+                       then we should just remove it from the
+                       scheduler pollset. */
+                    int wake_poller = 0;
+                    erts_poll_control(psi->ps, fd, ERTS_POLL_OP_DEL, 0, &wake_poller);
+                    state->flags &= ~(ERTS_EV_FLAG_SCHEDULER|ERTS_EV_FLAG_IN_SCHEDULER);
+                    state->count = 0;
+                    state->last_select_pid = NIL;
+                } else {
+                    state->active_events = revents & ERTS_POLL_EV_IN;
+                }
             }
 #endif
         } else {

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -1934,6 +1934,9 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
 {
     int pollres_len;
     int poll_ret, i;
+#ifdef ERTS_POLL_USE_SCHEDULER_POLLING
+    bool is_scheduler_poll = psi->ps == get_scheduler_pollset();
+#endif
     ERTS_MSACC_PUSH_AND_SET_STATE(ERTS_MSACC_STATE_CHECK_IO);
 
  restart:
@@ -1982,9 +1985,6 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
 			  erl_errno_id(poll_ret), poll_ret);
 	    erts_send_error_to_logger_nogl(dsbufp);
 	}
-        // if (is_normal_sched) {
-        //     erts_fprintf(stderr, "%d: woke up\r\n", esdp->no);
-        // }
         ERTS_MSACC_POP_STATE();
 	return;
     }
@@ -2045,7 +2045,7 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
             revents &= state->active_events | ERTS_POLL_EV_NVAL;
 
 #if ERTS_POLL_USE_SCHEDULER_POLLING
-            if (psi->ps == get_scheduler_pollset()) {
+            if (is_scheduler_poll) {
                 if (!(state->events & ERTS_POLL_EV_IN) && state->flags & ERTS_EV_FLAG_SCHEDULER) {
                     /* If we triggered in a scheduler pollset and EV_IN is not set,
                        then we should just remove it from the scheduler pollset.
@@ -2176,7 +2176,7 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
 
         case ERTS_EV_TYPE_STOP_NIF: {
 #if ERTS_POLL_USE_SCHEDULER_POLLING
-            if (psi->ps == get_scheduler_pollset())
+            if (is_scheduler_poll)
                 break;
 #endif
 #if ERTS_POLL_USE_FALLBACK
@@ -2189,7 +2189,7 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
 
         case ERTS_EV_TYPE_STOP_USE: {
 #if ERTS_POLL_USE_SCHEDULER_POLLING
-            if (psi->ps == get_scheduler_pollset())
+            if (is_scheduler_poll)
                 break;
 #endif
 #if ERTS_POLL_USE_FALLBACK

--- a/erts/emulator/sys/common/erl_check_io.h
+++ b/erts/emulator/sys/common/erl_check_io.h
@@ -87,11 +87,11 @@ int erts_check_io_max_files(void);
  *
  * @param pt the poll thread structure to use.
  * @param timeout_time timeout
- * @param poll_only_thread non zero when poll is the only thing the
- *                         calling thread does
+ * @param needs_thread_progress true when the calling thread needs to have its
+ *              thread progress managed, false otherwise.
  */
 void erts_check_io(struct erts_poll_thread *pt, ErtsMonotonicTime timeout_time,
-                   int poll_only_thread);
+                   bool needs_thread_progress);
 /**
  * Initialize the check io framework. This function will parse the arguments
  * and delete any entries that it is interested in.

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -749,6 +749,12 @@ static ErlDrvSSizeT spawn_control(ErlDrvData e, unsigned int cmd, char *buf,
     if (dd->ofd)
         driver_select(dd->port_num, abs(dd->ofd->fd), ERL_DRV_WRITE | ERL_DRV_USE, 1);
 
+    /* We call ready_input directly as not all OSs trigger an input event on an
+       fd that already triggered EOF. For example ONESHOT poll on Linux and FreeBSD will not. */
+    if (dd->ifd) {
+        ready_input(e, abs(dd->ifd->fd));
+    }
+
     return 0;
 }
 
@@ -1230,9 +1236,9 @@ static int port_inp_failure(ErtsSysDriverData *dd, int res)
         if (dd->alive == 1) {
             /*
              * We have eof and want to report exit status, but the process
-             * hasn't exited yet. When it does ready_input will
-             * driver_select() this fd which will make sure that we get
-             * back here with dd->alive == -1 and dd->status set.
+             * hasn't exited yet. When it does spawn_control will call ready_input
+             * which will make sure that we get back here with dd->alive == -1 and
+             * dd->status set.
              */
             return 0;
         }

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -743,9 +743,6 @@ static ErlDrvSSizeT spawn_control(ErlDrvData e, unsigned int cmd, char *buf,
     dd->status = proto->u.sigchld.error_number;
     dd->alive = -1;
 
-    if (dd->ifd)
-        driver_select(dd->port_num, abs(dd->ifd->fd), ERL_DRV_READ | ERL_DRV_USE, 1);
-
     if (dd->ofd)
         driver_select(dd->port_num, abs(dd->ofd->fd), ERL_DRV_WRITE | ERL_DRV_USE, 1);
 

--- a/erts/emulator/sys/unix/sys_drivers.c
+++ b/erts/emulator/sys/unix/sys_drivers.c
@@ -1290,7 +1290,6 @@ static void ready_input(ErlDrvData e, ErlDrvEvent ready_fd)
                 return;
             /* hmm, child setup seems to have closed the pipe too early...
                we close the port as there is not much else we can do */
-            driver_select(port_num, ready_fd, ERL_DRV_READ, 0);
             if (res == 0)
                 errno = EPIPE;
             port_inp_failure(dd, -1);


### PR DESCRIPTION
When investigating #11278 I noticed that #11285 did not fix the issue completely on Erlang/OTP 28 and later. After a bit of digging i found that there was a race in the scheduler pollset handling when the FD returned an error.

The scenario was like this:

1. Write FD in poll-thread, used but not activated.
   Read FD in scheduler, used and activated.
2. Data arrives on read fd followed by EOF.
3. ready_input is scheduled for the data on read FD.
4. The EOF triggers the write FD to return ERROR which triggers a ready_input event and deletes the FD from the scheduler pollset and the poll-thread pollset.
5. The ready_input is ignored as there is already one in flight.
6. The running ready_input returns and does not re-arm the FD as it assumes it is already in the scheduler pollset.
7. The FD is in an EOF state, but the FD has been removed from both pollsets so no trigger ever comes which makes the port leak and never send its eof/exit_status.

This PR builds on top for #11285, but is aimed at Erlang/OTP 28 and later. It also contains some minor refactors that I found useful when debugging this.

I've not included any testcase as this is very racy and triggering it required me to run a test for a very long time.

The bug was introduced in #9275 which was part of Erlang/OTP 28.0.

