### PR TITLE
Rework decode_name to cap the decoded length according to RFC 1035

### DIFF
--- a/lib/kernel/src/inet_dns.erl
+++ b/lib/kernel/src/inet_dns.erl
@@ -173,6 +173,7 @@ decode_reply(Buffer, #dns_rec{} = Q, Mdns)
             {error, Reason}
     end.
 
+-define(MSG_HDR_SIZE, 12). % Must align with the following pattern
 do_decode(
   <<Id:16,
     QR:1,Opcode:4,AA:1,TC:1,RD:1,
@@ -785,32 +786,55 @@ decode_domain(Bin, Buffer) ->
 %% Domain name -> {RestBin,Name}
 %%
 decode_name(Bin, Buffer) ->
-    decode_name(Bin, Buffer, [], Bin, 0).
+    decode_name(Bin, Buffer, [], Bin, 0, 0).
 
-%% Tail advances with Rest until the first indirection is followed
-%% then it stays put at that Rest.
-decode_name(_, Buffer, _Labels, _Tail, Cnt) when Cnt > byte_size(Buffer) ->
-    throw(?DECODE_ERROR); %% Insanity bailout - this must be a decode loop
-decode_name(<<0,Rest/binary>>, _Buffer, Labels, Tail, Cnt) ->
-    %% Root domain, we have all labels for the domain name
-    {if Cnt =/= 0 -> Tail; true -> Rest end,
+decode_name(_Bin, _Buffer, _Labels, _Cont, NameLen, _PtrCnt)
+  when NameLen >= 255 ->
+    %% There must also be room for the root label in 255 octets
+    %%
+    %% One might also cap PtrCnt heuristicly at 20..50 but there is no
+    %% support for that in RFC 1035, although almost certainly not a problem,
+    %% and not an uncommon defensive practice.
+    %%
+    %% Now it is possible to craft a message that will have long
+    %% backwards pointer chains causing high, but not catastrophically high,
+    %% decode work.
+    throw(?DECODE_ERROR);
+decode_name(<<0,Rest/binary>>, _Buffer, Labels, Cont, _NameLen, PtrCnt) ->
+    %% Root domain; we have all labels for the domain name
+    {decode_name_rest(Rest, Cont, PtrCnt),
      decode_name_labels(Labels)};
-decode_name(<<0:2,Len:6,Label:Len/binary,Rest/binary>>,
-	     Buffer, Labels, Tail, Cnt) ->
+decode_name(
+  <<0:2,Len:6,Label:Len/binary,Rest/binary>>,
+  Buffer, Labels, Cont, NameLen, PtrCnt) ->
     %% One plain label here
-    decode_name(Rest, Buffer, [Label|Labels],
-		if Cnt =/= 0 -> Tail; true -> Rest end,
-		Cnt);
-decode_name(<<3:2,Ptr:14,Rest/binary>>, Buffer, Labels, Tail, Cnt) ->
-    %% Indirection - reposition in buffer and recurse
+    decode_name(
+      Rest, Buffer, [Label|Labels], decode_name_rest(Rest, Cont, PtrCnt),
+      NameLen + 1 + Len, PtrCnt);
+decode_name(
+  <<3:2,Ptr:14,Rest/binary>>, Buffer, Labels, Cont, NameLen, PtrCnt)
+  when
+      %% Indirection *should* point to lower offset
+      %% (stricter than RFC1035, but commonly used common sense),
+      %% and *must* not point into the header.
+      %%
+      %% This forces a pointer loop to either end when clashing
+      %% into the header, or get content and end on max NameLen.
+      Ptr < byte_size(Buffer) - (byte_size(Rest) + 2),
+      Ptr >= ?MSG_HDR_SIZE ->
+    %% Indirection - reposition in buffer
     ?MATCH_ELSE_DECODE_ERROR(
        Buffer,
        <<_:Ptr/binary,Bin/binary>>,
        decode_name(
-         Bin, Buffer, Labels,
-         if Cnt =/= 0 -> Tail; true -> Rest end,
-         Cnt+2)); % size of indirection pointer
-decode_name(_, _, _, _, _) -> throw(?DECODE_ERROR).
+         Bin, Buffer, Labels, decode_name_rest(Rest, Cont, PtrCnt),
+         NameLen, PtrCnt + 1));
+decode_name(_Bin, _Buffer, _Labels, _Cont, _NameLen, _PtrCnt) ->
+    throw(?DECODE_ERROR).
+
+decode_name_rest(Rest, _Cont, 0)        -> Rest;
+decode_name_rest(_Rest, Cont, _PtrCnt)  -> Cont.
+
 
 %% Reverse list of labels (binaries) -> domain name (string)
 decode_name_labels([]) -> ".";

--- a/lib/kernel/src/inet_dns.erl
+++ b/lib/kernel/src/inet_dns.erl
@@ -787,7 +787,11 @@ decode_characters(Data, Encoding) ->
     ?MATCH_ELSE_DECODE_ERROR(
        Data,
        <<Len,Bin:Len/binary,Rest/binary>>,
-       {Rest,unicode:characters_to_list(Bin, Encoding)}).
+       ?MATCH_ELSE_DECODE_ERROR(
+          unicode:characters_to_list(Bin, Encoding),
+          String,
+          is_list(String),
+          {Rest,String})).
 
 %% One domain name only, there must be nothing after
 %%
@@ -974,11 +978,15 @@ encode_data(Comp, Pos, ?S_NAPTR, Data) ->
     B0 = <<Order:16,Preference:16>>,
     B1 = encode_string(B0, iolist_to_binary(Flags)),
     B2 = encode_string(B1, iolist_to_binary(Services)),
-    B3 = encode_string(B2, unicode:characters_to_binary(Regexp,
-							unicode, utf8)),
-    %% Bypass name compression (RFC 2915: section 2)
-    {B,_} = encode_name(B3, gb_trees:empty(), Pos+byte_size(B3), Replacement),
-    {B,Comp};
+    case unicode:characters_to_binary(Regexp, unicode, utf8) of
+        EncRegexp when is_binary(EncRegexp) ->
+            B3 = encode_string(B2, EncRegexp),
+            %% Bypass name compression (RFC 2915: section 2)
+            {B,_} =
+                encode_name(
+                  B3, gb_trees:empty(), Pos+byte_size(B3), Replacement),
+            {B,Comp}
+    end;
 encode_data(Comp, _, ?S_TXT, Data) -> {encode_txt(Data),Comp};
 encode_data(Comp, _, ?S_SPF, Data) -> {encode_txt(Data),Comp};
 encode_data(Comp, _, ?S_URI, Data) ->

--- a/lib/kernel/src/inet_dns.erl
+++ b/lib/kernel/src/inet_dns.erl
@@ -197,14 +197,19 @@ do_decode(
            pr     = decode_boolean(PR),
            rcode  = Rcode},
     do_decode(
-      Buffer, DnsHdr, QdList, AnBuf, AnCount, NsCount, ArCount, {Opcode,Mdns}).
+      Buffer, DnsHdr, QdList, AnBuf, AnCount, NsCount, ArCount, {Opcode,Mdns});
+do_decode(<<_/binary>>, _Mdns) ->
+    throw(?DECODE_ERROR).
+
 
 do_decode_reply(
   <<Id:16, _/binary>> = Buffer,
   #dns_rec{ header = Q_H, qdlist = [Q_RR] },
   Mdns) ->
     Id =:= Q_H#dns_header.id orelse throw(badid),
-    do_decode_reply(Buffer, Q_H, Q_RR, Id, Mdns).
+    do_decode_reply(Buffer, Q_H, Q_RR, Id, Mdns);
+do_decode_reply(<<_/binary>>, _Q, _Mdns) ->
+    throw(?DECODE_ERROR).
 
 do_decode_reply(
   <<_:16,
@@ -223,27 +228,33 @@ do_decode_reply(
     %%
     QdCount == 1
         orelse throw(noquery),
-    {AnBuf, [RR], QdTC} = decode_query_section(QdBuf, QdCount, Buffer, Mdns),
-    RR#dns_query.class    =:= Q_RR#dns_query.class andalso
-        RR#dns_query.type =:= Q_RR#dns_query.type  andalso
-        inet_db:eq_domains(RR#dns_query.domain, Q_RR#dns_query.domain)
-        orelse throw(noquery),
-    H_TC = decode_boolean(TC),
-    QdTC andalso not H_TC
-        andalso throw(?DECODE_ERROR),
-    DnsHdr =
-        #dns_header{
-           id     = Id,
-           qr     = H_QR,
-           opcode = H_Opcode,
-           aa     = decode_boolean(AA),
-           tc     = H_TC,
-           rd     = H_RD,
-           ra     = decode_boolean(RA),
-           pr     = decode_boolean(PR),
-           rcode  = Rcode},
-    do_decode(
-      Buffer, DnsHdr, [RR], AnBuf, AnCount, NsCount, ArCount, {Opcode,Mdns});
+    {AnBuf, RRs, QdTC} = decode_query_section(QdBuf, QdCount, Buffer, Mdns),
+    case RRs of
+        [RR] ->
+            RR#dns_query.class    =:= Q_RR#dns_query.class andalso
+                RR#dns_query.type =:= Q_RR#dns_query.type  andalso
+                inet_db:eq_domains(RR#dns_query.domain, Q_RR#dns_query.domain)
+                orelse throw(noquery),
+            H_TC = decode_boolean(TC),
+            QdTC andalso not H_TC
+                andalso throw(?DECODE_ERROR),
+            DnsHdr =
+                #dns_header{
+                   id     = Id,
+                   qr     = H_QR,
+                   opcode = H_Opcode,
+                   aa     = decode_boolean(AA),
+                   tc     = H_TC,
+                   rd     = H_RD,
+                   ra     = decode_boolean(RA),
+                   pr     = decode_boolean(PR),
+                   rcode  = Rcode},
+            do_decode(
+              Buffer, DnsHdr, [RR], AnBuf, AnCount, NsCount, ArCount,
+              {Opcode,Mdns});
+        _ ->
+            throw(?DECODE_ERROR)
+    end;
 do_decode_reply(<<_/binary>>, _Q_H, _Q_RR, _Id, _Mdns) ->
     throw(unknown).
 

--- a/lib/kernel/src/inet_dns_tsig.erl
+++ b/lib/kernel/src/inet_dns_tsig.erl
@@ -169,7 +169,7 @@ do_verify(Pkt,
                          header = #dns_header{ qr = QR },
                          arlist = ARList },
           TS0 = #tsig_state{ id = undefined }) ->
-    QR = false, % ASSERT that the caller has not passed a response
+    QR =:= false orelse throw(formerr),
     case ARList =/= [] andalso lists:last(ARList) of
         false ->
             {error,{notauth,badsig}};
@@ -227,8 +227,10 @@ do_verify(Pkt,
           Response = #dns_rec{
                         header = #dns_header{ qr = QR },
                         arlist = ARList },
-          TS = #tsig_state{ qr = TSQR })
-  when QR =:= (TSQR > 0) -> % Query/response status the same in header and state
+          TS = #tsig_state{ qr = TSQR }) ->
+    %% Query/response status the same in header and state
+    QR =:= (TSQR > 0) orelse throw(formerr),
+    %%
     case ARList =/= [] andalso lists:last(ARList) of
         %% RFC8945, section 5.3.1: TSIG on TCP Connections
         false when TSQR == 3 -> % not 2 as we must start with a TSIG RR

--- a/lib/kernel/src/inet_dns_tsig.erl
+++ b/lib/kernel/src/inet_dns_tsig.erl
@@ -179,17 +179,19 @@ do_verify(Pkt,
            original_id = OriginalId,
            error = ?NOERROR
           } = TSigRR ->
-            {Alg,AlgSize} =
+            {Alg,AlgSize} = % AlgSize in bytes
                 case inet_dns:decode_algname(AlgName) of
-                    {A,S} when is_atom(A), is_integer(S), S > 0 ->
+                    {A,S} when is_atom(A), is_integer(S), S >= 96 ->
+                        %% {sha,96} is the smallest we know of, 96 bits
                         lists:member(A, ?ALGS_SUPPORTED)
                             orelse throw({notauth,badkey}),
-                        {A,S};
+                        {A,S bsr 3}; % Bits -> Bytes
                     A when is_atom(A) ->
                         lists:member(A, ?ALGS_SUPPORTED)
                             orelse throw({notauth,badkey}),
                         try crypto:hash_info(A) of
-                            #{ size := S } when is_integer(S), S > 0 ->
+                            #{ size := S } when is_integer(S), S >= 12 ->
+                                %% sha(96) => 12 bytes
                                 {A,S};
                             #{} ->
                                 throw({notauth,badkey})

--- a/lib/kernel/src/inet_dns_tsig.erl
+++ b/lib/kernel/src/inet_dns_tsig.erl
@@ -273,22 +273,22 @@ do_verify(Pkt, _Response, TS = #tsig_state{ alg = {_Alg,AlgSize} }, TSigRR) ->
                 andalso
                MACSize =< AlgSize,
     MACValid orelse throw(formerr),
-    PktS = iolist_to_binary([
-        <<(TS#tsig_state.id):16>>,
-        binary:part(Pkt, {2,8}),
-        begin
-            <<ARC:16>> = binary:part(Pkt, {10,2}),
-            <<(ARC - 1):16>>
+    MACCalc =
+        if
+            element(1, TS#tsig_state.mac) == ?MODULE ->
+                PktS =
+                    iolist_to_binary(
+                      [binary_part(Pkt, 0, 10),
+                       begin
+                           <<ARC:16>> = binary_part(Pkt, 10, 2),
+                           <<(ARC - 1):16>>
+                       end,
+                       binary_part(Pkt, 12, Offset-12)]),
+                mac(PktS, TS, Error, NowSigned, OtherData);
+            %% RFC8945, section 5.3.1: TSIG on TCP Connections
+            true ->
+                mac(TS, Error, NowSigned, OtherData)
         end,
-        binary:part(Pkt, {12,Offset - 12})
-    ]),
-    MACCalc = if
-        element(1, TS#tsig_state.mac) == ?MODULE ->
-            mac(PktS, TS, Error, NowSigned, OtherData);
-        %% RFC8945, section 5.3.1: TSIG on TCP Connections
-        true ->
-            mac(TS, Error, NowSigned, OtherData)
-    end,
     MACEq =
         MACSize == byte_size(MACCalc)
         andalso
@@ -333,7 +333,7 @@ macN({?MODULE,MAC}, #tsig_state{ mac = {crypto,MACState} }) ->
 macN(Pkt, TS = #tsig_state{ mac = {crypto,MACState} }) ->
     {crypto,crypto:mac_update(MACState, [
        <<(TS#tsig_state.id):16>>,
-       binary:part(Pkt, {2,byte_size(Pkt) - 2})
+       binary_part(Pkt, 2, byte_size(Pkt)-2)
     ])}.
 
 %% RFC8945, section 5.3.2: Generation of TSIG on Error Returns

--- a/lib/kernel/src/inet_dns_tsig.erl
+++ b/lib/kernel/src/inet_dns_tsig.erl
@@ -181,12 +181,24 @@ do_verify(Pkt,
           } = TSigRR ->
             {Alg,AlgSize} =
                 case inet_dns:decode_algname(AlgName) of
-                    {A,S} ->
+                    {A,S} when is_atom(A), is_integer(S), S > 0 ->
+                        lists:member(A, ?ALGS_SUPPORTED)
+                            orelse throw({notauth,badkey}),
                         {A,S};
-                    A ->
-                        {A,maps:get(size, crypto:hash_info(A))}
+                    A when is_atom(A) ->
+                        lists:member(A, ?ALGS_SUPPORTED)
+                            orelse throw({notauth,badkey}),
+                        try crypto:hash_info(A) of
+                            #{ size := S } when is_integer(S), S > 0 ->
+                                {A,S};
+                            #{} ->
+                                throw({notauth,badkey})
+                        catch error : badarg ->
+                                throw({notauth,badkey})
+                        end;
+                    _ ->
+                        throw({notauth,badkey})
                 end,
-            lists:member(Alg, ?ALGS_SUPPORTED) orelse throw({notauth,badkey}),
             Key = lists:keyfind(Name, 1, TS0#tsig_state.key),
             Key == false andalso throw({notauth,badkey}),
             TS = TS0#tsig_state{

--- a/lib/kernel/src/inet_dns_tsig.erl
+++ b/lib/kernel/src/inet_dns_tsig.erl
@@ -287,12 +287,16 @@ do_verify(Pkt, _Response, TS = #tsig_state{ alg = {_Alg,AlgSize} }, TSigRR) ->
         true ->
             mac(TS, Error, NowSigned, OtherData)
     end,
+    MACEq =
+        MACSize == byte_size(MACCalc)
+        andalso
+        crypto:hash_equals(MAC, MACCalc),
     if
         %% RFC8945, section 5.2 - MUST check time after MAC
-        MAC == MACCalc, NowSigned - Fudge < Now, NowSigned + Fudge > Now ->
+        MACEq, NowSigned - Fudge < Now, NowSigned + Fudge > Now ->
             QR = if TS#tsig_state.qr == 0 -> 1; true -> 2 end,
             {ok,TS#tsig_state{ qr = QR, mac = {?MODULE,MAC} }};
-        MAC == MACCalc ->
+        MACEq ->
             {error,{notauth,badtime}};
         true ->
             {error,{notauth,badsig}}

--- a/lib/kernel/src/inet_res.erl
+++ b/lib/kernel/src/inet_res.erl
@@ -1455,8 +1455,10 @@ query_ns(S0, {Msg, Buffer}, IP, Port, Timer, Retry, I,
                               query_tcp(
                                 TcpTimeout, Msg, Buffer, IP, Port, Verbose)};
 			{error, econnrefused} = Err ->
-                            ok = udp_close(S),
-	                    {#sock{}, Err};
+                             ok = udp_close(S),
+                             {if  S =:= undefined -> S;
+                                  true            -> #sock{}
+                              end, Err};
 			Reply -> {S, Reply}
 		     end;
 		Error ->

--- a/lib/kernel/test/inet_res_SUITE.erl
+++ b/lib/kernel/test/inet_res_SUITE.erl
@@ -39,7 +39,7 @@
          servfail_retry_timeout_default/1, servfail_retry_timeout_1000/1,
          label_compression_limit/1, update/1,
          tsig_client/1, tsig_server/1, tsig_baderror/1,
-         mdns_encode_decode/1
+         mdns_encode_decode/1, bad_decode/1
         ]).
 -export([
 	 gethostbyaddr/0, gethostbyaddr/1,
@@ -83,7 +83,7 @@ all() ->
      servfail_retry_timeout_default, servfail_retry_timeout_1000,
      label_compression_limit, update,
      tsig_client, tsig_server, tsig_baderror,
-     mdns_encode_decode,
+     mdns_encode_decode, bad_decode,
      gethostbyaddr, gethostbyaddr_v6, gethostbyname,
      gethostbyname_v6, getaddr, getaddr_v6, ipv4_to_ipv6,
      host_and_addr].
@@ -1870,6 +1870,109 @@ mdns_encode_decode(Config) when is_list(Config) ->
     %%
     %% Decoding for mDNS should set the high class field flags
     {{ok, Msg}, Msg} = {inet_dns:decode(Buffer4, true), Msg},
+    ok.
+
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Malicious packet decode
+
+bad_decode(Config) when is_list(Config) ->
+    ID=4711,
+    QR=1, OPCODE=0,
+    AA=1, TC=0, RD=0, RA=0, PR=0, RCODE=0,
+    QDCOUNT=1, ANCOUNT=1, NSCOUNT=0, ARCOUNT=1,
+    Hdr =
+        <<ID:16,
+          QR:1, OPCODE:4, AA:1, TC:1, RD:1,
+          RA:1, PR:1, 0:2, RCODE:4,
+          QDCOUNT:16, ANCOUNT:16, NSCOUNT:16, ARCOUNT:16>>,
+    EncHdr =
+        inet_dns:make_header(
+          [{id,ID},
+           {qr,true}, {opcode,'query'},
+           {aa,true}, {tc,false}, {rd,false}, {ra,false}, {pr,false},
+           {rcode,RCODE}]),
+
+    QNAME_pos = byte_size(Hdr),
+    QNAME = << 3, "com", 0 >>,  QTYPE=1, QCLASS=1,
+    Question = << QNAME/binary, QTYPE:16, QCLASS:16 >>,
+    EncQuery = inet_dns:make_dns_query([{class,in}, {type,a}, {domain,"com"}]),
+    %%
+    TTL = 1234,
+    RR1 =
+        << 3:2, QNAME_pos:14, QTYPE:16, QCLASS:16,
+           TTL:32, 4:16, 127,0,0,1 >>,
+    EncRR1 =
+        inet_dns:make_rr(
+          [{domain,"com"}, {class,in}, {type,a},
+           {ttl,TTL}, {data,{127,0,0,1}}]),
+
+    %% A 255 octets long name should be possible to decode
+    %%
+    LongNameStart = <<"abcdefghijklmnopqrstuvwxy">>, % 25 chars
+    LongLabelStart = << (byte_size(LongNameStart)), LongNameStart/binary >>,
+    LongNamePart = << "abcdefghijklmnopqrstuvwxyz01234" >>, % 31 chars
+    LongLabel = << (byte_size(LongNamePart)), LongNamePart/binary >>,
+    RR2 =
+        << LongLabelStart/binary,               % 26 octets
+           LongLabel/binary,                    % 32 octets
+           LongLabel/binary, LongLabel/binary,  % 64 octets
+           LongLabel/binary, LongLabel/binary,  % 64 octets
+           LongLabel/binary, LongLabel/binary,  % 64 octets
+           3:2, QNAME_pos:14,       % Points to:   5 octets
+           QTYPE:16, QCLASS:16,     % Sum:       255 octets
+           TTL:32, 4:16, 127,0,0,2 >>,
+    LongName =
+        binary_to_list(
+          iolist_to_binary(
+            lists:join(
+              $.,
+              [LongNameStart | lists:duplicate(7, LongNamePart)] ++ ["com"]))),
+    EncRR2 =
+        inet_dns:make_rr(
+          [{domain,LongName}, {class,in}, {type,a},
+           {ttl,TTL}, {data,{127,0,0,2}}]),
+    Msg2 =
+        << Hdr/binary, Question/binary, RR1/binary, RR2/binary >>,
+    EncMsg2 =
+        inet_dns:make_msg(
+          [{header,EncHdr},
+           {qdlist,[EncQuery]}, {anlist,[EncRR1]}, {arlist,[EncRR2]}]),
+    {{ok, EncMsg2}, _} = {inet_dns:decode(Msg2), EncMsg2},
+    RR_loop_pos = QNAME_pos + byte_size(Question) + byte_size(RR1),
+
+    %% Loop to self label, fails on name len overflow
+    RR_loop_label =
+        << 4, "test", 3:2, RR_loop_pos:14, QTYPE:16, QCLASS:16,
+           TTL:32, 4:16, 127,0,0,3 >>,
+    MsgLoop_label =
+        << Hdr/binary, Question/binary, RR1/binary, RR_loop_label/binary >>,
+    {error, formerr} = inet_dns:decode(MsgLoop_label),
+
+    %% Loop to self pointer, fails on ptr bounds check
+    RR_loop_ptr = %
+        << 3:2, RR_loop_pos:14, QTYPE:16, QCLASS:16,
+           TTL:32, 4:16, 127,0,0,3 >>,
+    MsgLoop_ptr =
+        << Hdr/binary, Question/binary, RR1/binary, RR_loop_ptr/binary >>,
+    {error, formerr} = inet_dns:decode(MsgLoop_ptr),
+
+    %% Point into header, fails on ptr bounds check
+    Hdr_tail_pos = QNAME_pos - 1,
+    RR_ptr_hdr =
+        << 7, "example", 3:2, Hdr_tail_pos:14, QTYPE:16, QCLASS:16,
+           TTL:32, 4:16, 127,0,0,4 >>,
+    MsgPtr_hdr =
+        << Hdr/binary, Question/binary, RR1/binary, RR_ptr_hdr/binary >>,
+    {error, formerr} = inet_dns:decode(MsgPtr_hdr),
+
+    %% With .info at the end, RR2's name becomes 256 bytes long
+    %% which is one to many
+    QNAME_2 = << 4, "info", 0 >>,  QTYPE=1, QCLASS=1,
+    Question_2 = << QNAME_2/binary, QTYPE:16, QCLASS:16 >>,
+    Msg2_plus =
+        << Hdr/binary, Question_2/binary, RR1/binary, RR2/binary >>,
+    {error, formerr} = inet_dns:decode(Msg2_plus),
+
     ok.
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/kernel/test/inet_res_SUITE.erl
+++ b/lib/kernel/test/inet_res_SUITE.erl
@@ -39,7 +39,7 @@
          servfail_retry_timeout_default/1, servfail_retry_timeout_1000/1,
          label_compression_limit/1, update/1,
          tsig_client/1, tsig_server/1, tsig_baderror/1,
-         mdns_encode_decode/1, bad_decode/1
+         mdns_encode_decode/1, bad_decode/1, bad_decode_2/1
         ]).
 -export([
 	 gethostbyaddr/0, gethostbyaddr/1,
@@ -83,7 +83,7 @@ all() ->
      servfail_retry_timeout_default, servfail_retry_timeout_1000,
      label_compression_limit, update,
      tsig_client, tsig_server, tsig_baderror,
-     mdns_encode_decode, bad_decode,
+     mdns_encode_decode, bad_decode, bad_decode_2,
      gethostbyaddr, gethostbyaddr_v6, gethostbyname,
      gethostbyname_v6, getaddr, getaddr_v6, ipv4_to_ipv6,
      host_and_addr].
@@ -1973,6 +1973,37 @@ bad_decode(Config) when is_list(Config) ->
         << Hdr/binary, Question_2/binary, RR1/binary, RR2/binary >>,
     {error, formerr} = inet_dns:decode(Msg2_plus),
 
+    ok.
+
+%% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Malicious packet decode
+
+bad_decode_2(Config) when is_list(Config) ->
+    %% Too short buffer
+    {error, formerr} = inet_dns:decode(<<>>),
+    {error, formerr} =
+        inet_dns:decode_reply(
+          <<>>, #dns_rec{ qdlist = [#dns_rr{}] }, true),
+
+    %% QDCOUNT says 1 but is empty
+    ID      = 4711,
+    QR      = 1,
+    OPCODE  = 0, % 'query'
+    RD      = 0, % Not set in reply
+    RCODE   = 0,
+    QDCOUNT = 1,
+    Buffer  =
+        << ID:16,
+           QR:1, OPCODE:4, 0:1, 0:1, RD:1,
+           0:1, 0:3, RCODE:4,
+           QDCOUNT:16, 0:16, 0:16, 0:16 >>,
+    Q =
+        #dns_rec{
+           header =
+               #dns_header{
+                  id = ID, qr = QR, opcode = 'query', rd = 1 },
+           qdlist = [#dns_query{ domain = "", type = 'a', class = 'in'}] },
+    {error, formerr} = inet_dns:decode_reply(Buffer, Q, false),
     ok.
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/kernel/test/inet_res_SUITE.erl
+++ b/lib/kernel/test/inet_res_SUITE.erl
@@ -2004,6 +2004,34 @@ bad_decode_2(Config) when is_list(Config) ->
                   id = ID, qr = QR, opcode = 'query', rd = 1 },
            qdlist = [#dns_query{ domain = "", type = 'a', class = 'in'}] },
     {error, formerr} = inet_dns:decode_reply(Buffer, Q, false),
+
+    %% NAPTR with broken UTF-8
+
+    %% Encode should fail
+    Replacement = "Replacement",
+    ReplBin = list_to_binary(Replacement),
+    RR1_NAPTR =
+        #dns_rr{
+           type = 'naptr',
+           data = {100,10,"Flags","Services",<<"Regex",255>>,Replacement}},
+    try inet_dns:encode(Q#dns_rec{ anlist = [RR1_NAPTR] }) of
+        Result -> error({should_not_encode, Result})
+    catch error : _ -> ok
+    end,
+
+    %% Decode should return proper error
+    RR_NAPTR =
+        #dns_rr{
+           type = 'naptr',
+           data = {100,10,"Flags","Services","Regexp",Replacement}},
+    Buffer_NAPTR = inet_dns:encode(Q#dns_rec{ anlist = [RR_NAPTR] }),
+    Tail_NAPTR = << (byte_size(ReplBin)), ReplBin/binary, 0 >>,
+    << Start_NAPTR:(byte_size(Buffer_NAPTR)-byte_size(Tail_NAPTR)-1)/binary,
+       _,
+       Tail_NAPTR/binary >> = Buffer_NAPTR,
+    {error,formerr} =
+        inet_dns:decode(<< Start_NAPTR/binary, 255, Tail_NAPTR/binary >>),
+
     ok.
 
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Also require pointers to point to lower positions in the buffer, because pointing forward is really strange and by disallowing that it becomes impossible to create pointer loops that does not add to the decoded name length.

The intent of pointers is to refer to a previously encoded name, so earlier in the buffer is reasonable, but RFC 1035 does not, however, explicitly forbid forward pointers.

By requiring only backwards pointers there is no need to cap the number of pointer hops since the message size itself becomes a limit.

It is not uncommon to cap the number of pointer hops to 15..20 or a hundred or whatever, but there is no support in RFC 1035 for that.  If forward pointers should have to be allowed, this kind of limit would be neccesary, or some other way to mitigate pointer loops...