### PR TITLE
michal/crypto/throw-notsup-for-eddh-and-eddsa/OTP-20215

### DIFF
--- a/lib/crypto/c_src/evp.c
+++ b/lib/crypto/c_src/evp.c
@@ -105,7 +105,7 @@ ERL_NIF_TERM evp_compute_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
     return ret;
 
 #else
-    return atom_notsup;
+    return EXCP_NOTSUP(env, "EDDH not supported");
 #endif
 }
 
@@ -178,7 +178,7 @@ ERL_NIF_TERM evp_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM a
     return ret;
 
 #else
-    return atom_notsup;
+    return EXCP_NOTSUP(env, "EDDH not supported");
 #endif
 }
 


### PR DESCRIPTION
All other `crypto:generate_key` and `crypto:compute_key` throw not supported exception when underlying algorithm is not supported, except for this one.