### PR TITLE
ssh: Fix kex_strict_violation test race on debug builds

### DIFF
--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -1394,8 +1394,14 @@ kex_strict_violation(Config) ->
            {send, ssh_msg_kexinit},
            {match, #ssh_msg_kexinit{_='_'}, receive_msg},
            {send, ssh_msg_kexdh_init_dup},
-           {match,# ssh_msg_kexdh_reply{_='_'}, receive_msg},
-           {match, disconnect(?SSH_DISCONNECT_KEY_EXCHANGE_FAILED), receive_msg}]},
+           {match, #ssh_msg_kexdh_reply{_='_'}, receive_msg},
+           %% Server processes first kexdh_init (sends newkeys), then
+           %% detects the duplicate and disconnects. Depending on timing
+           %% we may see newkeys, disconnect, or tcp_closed here.
+           %% The actual violation assertion is verified via event_logged.
+           {match, {'or', [#ssh_msg_newkeys{_='_'},
+                           {ssh_msg_disconnect, ?SSH_DISCONNECT_KEY_EXCHANGE_FAILED, '_', '_'},
+                           tcp_closed]}, receive_msg}]},
          {new_keys, "Message ssh_msg_newkeys in wrong state",
           [receive_hello,
            {send, hello},

--- a/lib/ssh/test/ssh_protocol_SUITE.erl
+++ b/lib/ssh/test/ssh_protocol_SUITE.erl
@@ -1400,7 +1400,7 @@ kex_strict_violation(Config) ->
            %% we may see newkeys, disconnect, or tcp_closed here.
            %% The actual violation assertion is verified via event_logged.
            {match, {'or', [#ssh_msg_newkeys{_='_'},
-                           {ssh_msg_disconnect, ?SSH_DISCONNECT_KEY_EXCHANGE_FAILED, '_', '_'},
+                           #ssh_msg_disconnect{code = ?SSH_DISCONNECT_KEY_EXCHANGE_FAILED},
                            tcp_closed]}, receive_msg}]},
          {new_keys, "Message ssh_msg_newkeys in wrong state",
           [receive_hello,


### PR DESCRIPTION
The "duplicated ssh_msg_kexdh_init" sub-flow expected disconnect immediately after kexdh_reply, but the server sends newkeys as part of normal first-kexdh_init processing before it detects the duplicate in {new_keys,server,init} state. On debug/lock-counting builds the timing makes newkeys (or tcp_closed) arrive before disconnect.

Accept any of newkeys, disconnect, or tcp_closed after kexdh_reply. The actual violation assertion is already verified through event_logged(server, Events, "KEX strict violation") in kex_strict_helper/3.