### PR TITLE
httpd: accept OPTIONS http method

### DIFF
--- a/lib/inets/doc/notes.md
+++ b/lib/inets/doc/notes.md
@@ -21,10 +21,6 @@ limitations under the License.
 -->
 # Inets Release Notes
 
-## Unreleased
-
-- \[httpd] - Method "OPTIONS" now allowed.
-
 ## Inets 9.7.1
 
 ### Fixed Bugs and Malfunctions

--- a/lib/inets/doc/notes.md
+++ b/lib/inets/doc/notes.md
@@ -21,6 +21,10 @@ limitations under the License.
 -->
 # Inets Release Notes
 
+## Unreleased
+
+- \[httpd] - Method "OPTIONS" now allowed.
+
 ## Inets 9.7.1
 
 ### Fixed Bugs and Malfunctions

--- a/lib/inets/src/http_server/httpd_example.erl
+++ b/lib/inets/src/http_server/httpd_example.erl
@@ -28,6 +28,7 @@
          get_reply_headers/3,
          put/3,
          patch/3,
+         options/3,
          post/3, 
          yahoo/3, 
          test1/3, 
@@ -116,6 +117,15 @@ do_patch(Env,{Input,_Body}) ->
     default(Env,Input);
 do_patch(Env,Input) ->
     default(Env,Input).
+
+%% ------------------------------------------------------
+options(SessionID, Env, Input) ->
+    mod_esi:deliver(SessionID, do_options(Env, Input)).
+
+do_options(Env, {Input, _Body}) ->
+    default(Env, Input);
+do_options(Env, Input) ->
+    default(Env, Input).
 
 %% ------------------------------------------------------
 get_bin(SessionID, Env, Input) ->

--- a/lib/inets/src/http_server/httpd_request.erl
+++ b/lib/inets/src/http_server/httpd_request.erl
@@ -87,8 +87,8 @@ body_data(Headers, Body) when is_binary(Body)->
 %%-------------------------------------------------------------------------
 %% validate(Method, Uri, Version) -> ok | {error, {bad_request, Reason} |
 %%			     {error, {not_supported, {Method, Uri, Version}}
-%%      Method = "HEAD" | "GET" | "POST" | "PATCH" | "TRACE" | "PUT"
-%%               | "DELETE"
+%%      Method = "HEAD" | "GET" | "POST" | "PATCH" | "OPTIONS" | "TRACE"
+%%               | "PUT" | "DELETE"
 %%      Uri = uri()
 %%      Version = "HTTP/N.M"      
 %% Description: Checks that HTTP-request-line is valid.
@@ -104,6 +104,8 @@ validate("DELETE", Uri, "HTTP/1." ++ _N) ->
 validate("POST", Uri, "HTTP/1." ++ _N) ->
     validate_uri(Uri);
 validate("PATCH", Uri, "HTTP/1." ++ _N) ->
+    validate_uri(Uri);
+validate("OPTIONS", Uri, "HTTP/1." ++ _N) ->
     validate_uri(Uri);
 validate("TRACE", Uri, "HTTP/1." ++ N) when hd(N) >= $1 ->
     validate_uri(Uri);

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -336,7 +336,8 @@ alias_match_str(Alias, erl_script_alias) ->
 %%------------------------ Erl mechanism --------------------------------
 
 erl(#mod{method = Method} = ModData, ESIBody, Modules) 
-  when (Method =:= "GET") orelse (Method =:= "HEAD") orelse (Method =:= "DELETE") ->
+  when (Method =:= "GET") orelse (Method =:= "HEAD") orelse
+       (Method =:= "DELETE") orelse (Method =:= "OPTIONS") ->
     case httpd_util:split(ESIBody,":|%3A|/",2) of
 	{ok, [ModuleName, FuncAndInput]} ->
 	    case httpd_util:split(FuncAndInput,"[\?/]",2) of

--- a/lib/inets/src/http_server/mod_esi.erl
+++ b/lib/inets/src/http_server/mod_esi.erl
@@ -69,7 +69,7 @@ ignore.
 
 - **`{server_port, integer()}`** - Servers port number.
 
-- **`{request_method, "GET" | "PUT" | "DELETE" | "POST" | "PATCH"}`** - HTTP
+- **`{request_method, "HEAD" | "GET" | "PUT" | "DELETE" | "POST" | "PATCH" | "OPTIONS"}`** - HTTP
 request method.
 
 - **`{remote_adress, inet:ip_address()}`** - The clients ip address.

--- a/lib/inets/test/http_format_SUITE.erl
+++ b/lib/inets/test/http_format_SUITE.erl
@@ -455,48 +455,80 @@ validate_request_line() ->
      " and protocol version."}].
 validate_request_line(Config) when is_list(Config) ->
 
-    %% HTTP/0.9 not supported
-    {error, {bad_version, "HTTP/0.9"}} = 
-	httpd_request:validate("GET", "http://www.erlang/org", "HTTP/0.9"),
-    {error, {bad_version, "HTTP/0.9"}} =
-	httpd_request:validate("HEAD", "http://www.erlang/org", "HTTP/0.9"),
-    {error, {bad_version, "HTTP/0.9"}} =
-	httpd_request:validate("TRACE", "http://www.erlang/org", "HTTP/0.9"),
-    {error, {bad_version, "HTTP/0.9"}} =
-	httpd_request:validate("POST", "http://www.erlang/org", "HTTP/0.9"),
+    Uri = "http://www.erlang/org",
 
-    %% HTTP/1.* 
-    {ok, "http://www.erlang/org"} = httpd_request:validate("HEAD", "http://www.erlang/org", 
-			       "HTTP/1.1"),
-    {ok, "http://www.erlang/org"} = httpd_request:validate("GET", "http://www.erlang/org", 
-			       "HTTP/1.1"),  
-    {ok, "http://www.erlang/org"} = httpd_request:validate("POST","http://www.erlang/org", 
-			       "HTTP/1.1"),
-    {ok, "http://www.erlang/org"} = httpd_request:validate("TRACE","http://www.erlang/org",
-                                                           "HTTP/1.1"),
-    {error, {not_supported, 
-	     {"FOOBAR", "http://www.erlang/org", "HTTP/1.1"}}} =
-	httpd_request:validate("FOOBAR", "http://www.erlang/org", 
-			       "HTTP/1.1"),
+    %% HTTP/0.9 not supported for any method
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("GET", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("HEAD", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("POST", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("PUT", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("DELETE", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("PATCH", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("OPTIONS", Uri, "HTTP/0.9"),
+    {error, {bad_version, "HTTP/0.9"}} =
+        httpd_request:validate("TRACE", Uri, "HTTP/0.9"),
+
+    %% All standard methods accepted on HTTP/1.1
+    {ok, Uri} = httpd_request:validate("HEAD", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("GET", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("POST", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("PUT", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("DELETE", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("PATCH", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("OPTIONS", Uri, "HTTP/1.1"),
+    {ok, Uri} = httpd_request:validate("TRACE", Uri, "HTTP/1.1"),
+
+    %% All standard methods (except TRACE) accepted on HTTP/1.0
+    {ok, Uri} = httpd_request:validate("HEAD", Uri, "HTTP/1.0"),
+    {ok, Uri} = httpd_request:validate("GET", Uri, "HTTP/1.0"),
+    {ok, Uri} = httpd_request:validate("POST", Uri, "HTTP/1.0"),
+    {ok, Uri} = httpd_request:validate("PUT", Uri, "HTTP/1.0"),
+    {ok, Uri} = httpd_request:validate("DELETE", Uri, "HTTP/1.0"),
+    {ok, Uri} = httpd_request:validate("PATCH", Uri, "HTTP/1.0"),
+    {ok, Uri} = httpd_request:validate("OPTIONS", Uri, "HTTP/1.0"),
+    %% TRACE requires HTTP/1.1+
+    {error, {not_supported, {"TRACE", Uri, "HTTP/1.0"}}} =
+        httpd_request:validate("TRACE", Uri, "HTTP/1.0"),
+
+    %% OPTIONS with asterisk-form URI (RFC 9110 Section 7.1)
+    {ok, "*"} = httpd_request:validate("OPTIONS", "*", "HTTP/1.1"),
+
+    %% Unknown method rejected
+    {error, {not_supported,
+             {"FOOBAR", Uri, "HTTP/1.1"}}} =
+        httpd_request:validate("FOOBAR", Uri, "HTTP/1.1"),
+
     %%% Will work after normalization
-    Uri = "http://127.0.0.1:8888/../../../../../etc/passwd",
-    {ok, "http://127.0.0.1:8888/etc/passwd"} = httpd_request:validate("GET", Uri, "HTTP/1.1"),
+    TraversalUri = "http://127.0.0.1:8888/../../../../../etc/passwd",
+    {ok, "http://127.0.0.1:8888/etc/passwd"} =
+        httpd_request:validate("GET", TraversalUri, "HTTP/1.1"),
 
-    Uri2 = 
-	"http://127.0.0.1:8888/././././././../../../../../etc/passwd",
-    {ok, "http://127.0.0.1:8888/etc/passwd"} = httpd_request:validate("GET", Uri2, "HTTP/1.1"),
+    TraversalUri2 =
+        "http://127.0.0.1:8888/././././././../../../../../etc/passwd",
+    {ok, "http://127.0.0.1:8888/etc/passwd"} =
+        httpd_request:validate("GET", TraversalUri2, "HTTP/1.1"),
 
-    HexUri = "http://127.0.0.1:8888/%2e%2e/%2e%2e/%2e%2e/" 
-	"home/foobar/test.html",
-    {ok, "http://127.0.0.1:8888/home/foobar/test.html"}  = httpd_request:validate("GET", HexUri, "HTTP/1.1"),
+    HexUri = "http://127.0.0.1:8888/%2e%2e/%2e%2e/%2e%2e/"
+        "home/foobar/test.html",
+    {ok, "http://127.0.0.1:8888/home/foobar/test.html"} =
+        httpd_request:validate("GET", HexUri, "HTTP/1.1"),
 
-    NewUri = 
-	"http://127.0.0.1:8888/foobar/../../../home/foobar/test.html",
-    {ok,"http://127.0.0.1:8888/home/foobar/test.html"} = httpd_request:validate("GET", NewUri, "HTTP/1.1"),
-    
-    Uri1 = 
-	"http://127.0.0.1:8888/../home/foobar/test.html",
-    {ok,"http://127.0.0.1:8888/home/foobar/test.html"}  = httpd_request:validate("GET", Uri1, "HTTP/1.1").
+    NewUri =
+        "http://127.0.0.1:8888/foobar/../../../home/foobar/test.html",
+    {ok, "http://127.0.0.1:8888/home/foobar/test.html"} =
+        httpd_request:validate("GET", NewUri, "HTTP/1.1"),
+
+    Uri1 =
+        "http://127.0.0.1:8888/../home/foobar/test.html",
+    {ok, "http://127.0.0.1:8888/home/foobar/test.html"} =
+        httpd_request:validate("GET", Uri1, "HTTP/1.1").
 
 %%-------------------------------------------------------------------------
 check_content_length_encoding() ->

--- a/lib/inets/test/httpd_SUITE.erl
+++ b/lib/inets/test/httpd_SUITE.erl
@@ -142,8 +142,8 @@ groups() ->
                      cgi_bin_env] ++ load()},
      {http_1_1_parallel, [parallel],
       [host, chunked, expect, cgi, cgi_chunked_encoding_test,
-       trace, range, if_modified_since, mod_esi_chunk_timeout,
-       esi_put, esi_patch, esi_post, esi_headers]
+       trace, options, range, if_modified_since, mod_esi_chunk_timeout,
+       esi_put, esi_patch, esi_post, esi_options, esi_headers]
       ++ http_head() ++ http_get()},
      {http_1_0, [], [cgi_bin_env, {group, http_1_0_parallel} | load()]},
      {http_1_0_parallel, [parallel], [host, cgi, trace] ++ http_head() ++ http_get()},
@@ -1004,6 +1004,15 @@ esi_patch(Config) when is_list(Config) ->
 		     Config, [{statuscode, 200}]).
 
 %%-------------------------------------------------------------------------
+esi_options() ->
+    [{doc, "Test mod_esi OPTIONS"}].
+
+esi_options(Config) when is_list(Config) ->
+    ok = http_status("OPTIONS /cgi-bin/erl/httpd_example/options ",
+                     Config, [{statuscode, 200}]),
+    ok = http_status("OPTIONS * ", Config, [{statuscode, 501}]).
+
+%%-------------------------------------------------------------------------
 esi_post() ->
     [{doc, "Test mod_esi POST"}].
 
@@ -1406,6 +1415,15 @@ trace(Config) when is_list(Config) ->
     Cb = proplists:get_value(version_cb, Config),
     Cb:trace(proplists:get_value(type, Config), proplists:get_value(port, Config), 
 	     proplists:get_value(host, Config), proplists:get_value(node, Config)).
+%%-------------------------------------------------------------------------
+options() ->
+    [{doc, "Test OPTIONS method - accepted by httpd but no built-in handler"}].
+
+options(Config) when is_list(Config) ->
+    %% OPTIONS to a path - passes validation, no module handles it -> 501
+    ok = http_status("OPTIONS / ", Config, [{statuscode, 501}]),
+    %% OPTIONS * (asterisk-form, RFC 9110 Section 7.1) -> 501
+    ok = http_status("OPTIONS * ", Config, [{statuscode, 501}]).
 %%-------------------------------------------------------------------------
 light() ->
     [{doc, "Test light load"}].


### PR DESCRIPTION
Hello!

Closes: https://github.com/erlang/otp/issues/11119

Thanks to Torbjörn Törnkvist (https://github.com/etnt) for the original investigation and patch.

I had a look for somewhere to write a test for this, but I was unable to locate any existing tests for the other methods, so I was not sure what test code I ought to write for this addition.

I also noticed that erts `packet_parser.c` does not know of all the HTTP methods. Should that be corrected also?

edit: Oops, I intended to target maint with this PR, but selected master by mistake. Can you correct that, or should I remake the PR?