### PR TITLE
ssh test: Fix flaky interrupted_send race condition

### DIFF
--- a/lib/ssh/test/ssh_connection_SUITE.erl
+++ b/lib/ssh/test/ssh_connection_SUITE.erl
@@ -855,6 +855,19 @@ do_interrupted_send(Config, SendSize, EchoSize, SenderResult) ->
 			    ct:log("~p:~p ~p - That's what we expect :)",
                                    [?MODULE,?LINE, SenderResult]),
 			    ok;
+                        {SenderPid, {error, closed}} ->
+                            %% We called ssh:close(ConnectionRef) above while
+                            %% the sender was still pushing data (10 MB send,
+                            %% only 4 MB echoed). The connection teardown can
+                            %% race with the ongoing send, causing it to return
+                            %% {error, closed} instead of ok. Both outcomes are
+                            %% valid — the test's purpose is to verify the
+                            %% listener received correct echo data, not that
+                            %% the sender completes the full 10 MB transfer.
+                            ct:log("~p:~p sender got {error,closed} after "
+                                   "ssh:close - acceptable race",
+                                   [?MODULE,?LINE]),
+                            ok;
 			Msg ->
 			    ct:log("~p:~p Not expected send result: ~p",[?MODULE,?LINE,Msg]),
 			    {fail, "Not expected msg"}


### PR DESCRIPTION
The interrupted_send test calls ssh:close/1 after the listener collects its expected echo data, while the sender is still pushing the remaining 6 MB. The connection teardown can race with the ongoing send, causing {error, closed} instead of ok.

Accept both outcomes since the test's purpose is to verify the listener received correct data, not that the full send completes.