### PR TITLE
dialyzer: fix unmatched return warning tag

### DIFF
--- a/lib/dialyzer/src/dialyzer.hrl
+++ b/lib/dialyzer/src/dialyzer.hrl
@@ -67,7 +67,7 @@
 -define(WARN_RETURN_ONLY_EXIT, warn_return_only_exit).
 -define(WARN_UNDEFINED_CALLBACK, warn_undefined_callbacks).
 -define(WARN_UNKNOWN, warn_unknown).
--define(WARN_UNMATCHED_RETURN, warn_umatched_return).
+-define(WARN_UNMATCHED_RETURN, warn_unmatched_return).
 
 %%
 %% The following type has double role:

--- a/lib/dialyzer/test/abstract_SUITE.erl
+++ b/lib/dialyzer/test/abstract_SUITE.erl
@@ -8,12 +8,12 @@
 -include("dialyzer_test_constants.hrl").
 
 -export([suite/0, all/0, init_per_suite/0, init_per_suite/1, end_per_suite/1]).
--export([generated_case/1]).
+-export([generated_case/1, unmatched_return_tag/1]).
 
 suite() ->
     [{timetrap, {minutes, 1}}].
 all() ->
-    [generated_case].
+    [generated_case, unmatched_return_tag].
 
 init_per_suite() ->
   [{timetrap, ?plt_timeout}].
@@ -85,6 +85,19 @@ generated_case(Config) when is_list(Config) ->
     %% Location is a line (no column):
     "fileName.erl:3: Function bar/0 has no local return\n" =
         dialyzer:format_warning(W),
+    ok.
+
+unmatched_return_tag(Config) when is_list(Config) ->
+    [{warn_unmatched_return, _Loc, {unmatched_return, [_]}}] =
+        test([{attribute, 1, module, foo},
+              {attribute, 2, export, [{bar, 0}]},
+              {function, 3, bar, 0,
+               [{clause, 3, [], [],
+                 [{call, 4,
+                   {remote, 4, {atom, 4, erlang}, {atom, 4, process_info}},
+                   [{call, 4, {atom, 4, self}, []}, {atom, 4, links}]},
+                  {atom, 5, ok}]}]}],
+             Config, [], []),
     ok.
 
 test(Prog0, Config, COpts, DOpts) ->

--- a/lib/dialyzer/test/abstract_SUITE.erl
+++ b/lib/dialyzer/test/abstract_SUITE.erl
@@ -1,3 +1,25 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2016-2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
 %% This suite contains cases that cannot be written
 %% in Erlang itself and must be done via the abstract
 %% format.
@@ -90,13 +112,15 @@ generated_case(Config) when is_list(Config) ->
 unmatched_return_tag(Config) when is_list(Config) ->
     [{warn_unmatched_return, _Loc, {unmatched_return, [_]}}] =
         test([{attribute, 1, module, foo},
-              {attribute, 2, export, [{bar, 0}]},
-              {function, 3, bar, 0,
-               [{clause, 3, [], [],
-                 [{call, 4,
-                   {remote, 4, {atom, 4, erlang}, {atom, 4, process_info}},
-                   [{call, 4, {atom, 4, self}, []}, {atom, 4, links}]},
-                  {atom, 5, ok}]}]}],
+              {attribute, 2, export, [{a, 0}]},
+              {attribute, 3, dialyzer, [unmatched_returns]},
+              {function, 4, a, 0,
+               [{clause, 4, [], [],
+                 [{call, 5, {atom, 5, b}, []},
+                  {integer, 6, 1}]}]},
+              {function, 8, b, 0,
+               [{clause, 8, [], [],
+                 [{tuple, 9, [{atom, 9, a}, {atom, 9, b}]}]}]}],
              Config, [], []),
     ok.
 

--- a/lib/dialyzer/test/opaque_SUITE_data/src/recrec/dialyzer.hrl
+++ b/lib/dialyzer/test/opaque_SUITE_data/src/recrec/dialyzer.hrl
@@ -48,7 +48,7 @@
 -define(WARN_CONTRACT_SUPERTYPE, warn_contract_supertype).
 -define(WARN_CONTRACT_RANGE, warn_contract_range).
 -define(WARN_CALLGRAPH, warn_callgraph).
--define(WARN_UNMATCHED_RETURN, warn_umatched_return).
+-define(WARN_UNMATCHED_RETURN, warn_unmatched_return).
 -define(WARN_RACE_CONDITION, warn_race_condition).
 -define(WARN_BEHAVIOUR, warn_behaviour).
 -define(WARN_UNDEFINED_CALLBACK, warn_undefined_callbacks).


### PR DESCRIPTION
Fixes https://github.com/erlang/otp/issues/11320

Dialyzer currently returns the misspelled warning tag
`warn_umatched_return` for unmatched-return warnings from
`dialyzer:run/1`.

This changes the tag to `warn_unmatched_return`.

The warning option (`unmatched_returns`) and the warning payload
(`unmatched_return`) are already spelled correctly, so this only
affects the warning tag returned in the raw warning tuple.

This also adds a test that checks the raw warning tuple returned by
`dialyzer:run/1`, since the existing unmatched-return coverage mainly
checks formatted warning text.