### PR TITLE
michal/diameter/fix-infinite-loop-in-diameter-dist-when-avp-has-zero-length/OTP-20242

### DIFF
--- a/lib/diameter/src/base/diameter_dist.erl
+++ b/lib/diameter/src/base/diameter_dist.erl
@@ -258,8 +258,8 @@ session_id(<<263:32, 0:1, _:7, Len:24, _/binary>> = Bin, _) ->
 %% many AVPs and no Session-Id, which an attacker is prone to send.
 %% 8.8 or RFC 6733 says that Session-Id SHOULD (but not MUST) appear
 %% immediately following the Diameter Header, so there is no
-%% guarantee.
-session_id(<<_:40, Len:24, _/binary>> = Bin, N) ->
+%% guarantee. RFC 6733 4.2 (and RFC 3588 4.2) says that minimum avp length is 8.
+session_id(<<_:40, Len:24, _/binary>> = Bin, N) when Len >= 8 ->
     Pad = (4 - (Len rem 4)) rem 4,
     case Bin of
         <<_:Len/binary, _:Pad/binary, Rest/binary>> ->

--- a/lib/diameter/test/diameter_dist_SUITE.erl
+++ b/lib/diameter/test/diameter_dist_SUITE.erl
@@ -37,7 +37,8 @@
          end_per_suite/1,
 
          %% The test cases
-         traffic/1
+         traffic/1,
+         zero_length_avp_infinite_loop/1
         ]).
 
 %% diameter callbacks
@@ -114,7 +115,7 @@ suite() ->
     [{timetrap, {seconds, 90}}].
 
 all() ->
-    [traffic].
+    [traffic, zero_length_avp_infinite_loop].
 
 init_per_suite(Config) ->
     ?DUTIL:init_per_suite(Config).
@@ -131,6 +132,20 @@ traffic(Config) ->
         "~n   Res: ~p", [Res]),
     Res.
 
+zero_length_avp_infinite_loop(_Config) ->
+    MalformedMsg = <<1, 0, 0, 28,  %% Version=1, Length=28
+                     128, 0, 0, 1, %% Flags=Request, Command=1
+                     0, 0, 0, 0,   %% Application-Id=0
+                     0, 0, 0, 1,   %% Hop-by-Hop=1
+                     0, 0, 0, 1,   %% End-to-End=1
+                     0, 0, 0, 1,   %% AVP Code=1
+                     0,            %% Flags=0
+                     0, 0, 0>>,    %% AVP Length=0
+    RecvData = {recvdata, undefined, name, undefined, undefined, undefined, undefined},
+    Pkt = #diameter_packet{bin = MalformedMsg},
+    Request = {Pkt, undefined, undefined, undefined, undefined, RecvData},
+
+    discard = diameter_dist:route_session(Request, #{default => discard}).
 
 %% ===========================================================================
 


### PR DESCRIPTION
When non Session-Id avp is sent as having zero length, diameter_dist goes into infinite loop, when trying to move to process next avp (searching for Session-Id avp).