### PR TITLE
michal/diameter/fix-crash-in-diameter-dist-when-avp-is-short/OTP-20243

### DIFF
--- a/lib/diameter/src/base/diameter_dist.erl
+++ b/lib/diameter/src/base/diameter_dist.erl
@@ -245,7 +245,8 @@ session_id(_, 0) ->  %% give up
     false;
 
 %% Session-Id = Command Code 263, V-bit = 0.
-session_id(<<263:32, 0:1, _:7, Len:24, _/binary>> = Bin, _) ->
+%% RFC 6733 4.2 (and RFC 3588 4.2) says that minimum avp length is 8.
+session_id(<<263:32, 0:1, _:7, Len:24, _/binary>> = Bin, _) when Len >= 8 ->
     case Bin of
         <<Avp:Len/binary, _/binary>> ->
             <<_:8/binary, Sid/binary>> = Avp,

--- a/lib/diameter/test/diameter_dist_SUITE.erl
+++ b/lib/diameter/test/diameter_dist_SUITE.erl
@@ -37,7 +37,8 @@
          end_per_suite/1,
 
          %% The test cases
-         traffic/1
+         traffic/1,
+         short_length_avp_crash/1
         ]).
 
 %% diameter callbacks
@@ -114,7 +115,7 @@ suite() ->
     [{timetrap, {seconds, 90}}].
 
 all() ->
-    [traffic].
+    [traffic, short_length_avp_crash].
 
 init_per_suite(Config) ->
     ?DUTIL:init_per_suite(Config).
@@ -131,6 +132,20 @@ traffic(Config) ->
         "~n   Res: ~p", [Res]),
     Res.
 
+short_length_avp_crash(_Config) ->
+    MalformedMsg = <<1, 0, 0, 28,  %% Version=1, Length=28
+                     128, 0, 0, 1, %% Flags=Request, Command=1
+                     0, 0, 0, 0,   %% Application-Id=0
+                     0, 0, 0, 1,   %% Hop-by-Hop=1
+                     0, 0, 0, 1,   %% End-to-End=1
+                     0, 0, 1, 7,   %% AVP Code=263 (Session-Id)
+                     0,            %% Flags=0 (V-bit=0)
+                     0, 0, 4>>,    %% AVP Length=4 (minimum is 8)
+    RecvData = {recvdata, undefined, name, undefined, undefined, undefined, undefined},
+    Pkt = #diameter_packet{bin = MalformedMsg},
+    Request = {Pkt, undefined, undefined, undefined, undefined, RecvData},
+
+    discard = diameter_dist:route_session(Request, #{default => discard}).
 
 %% ===========================================================================
 


### PR DESCRIPTION
When Session-Id avp claims it's shorter than 8 bytes, we get a badmatch in diameter_dist