### PR TITLE
erts: Add configure test for getauxval(3)

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -707,6 +707,9 @@
 /* Define to 1 if you have a good `getaddrinfo' function. */
 #undef HAVE_GETADDRINFO
 
+/* Define to 1 if you have getauxval */
+#undef HAVE_GETAUXVAL
+
 /* Define to 1 if you have the 'gethostbyname2' function. */
 #undef HAVE_GETHOSTBYNAME2
 

--- a/erts/configure
+++ b/erts/configure
@@ -18827,6 +18827,15 @@ then :
 fi
 
 
+ac_fn_check_decl "$LINENO" "getauxval" "ac_cv_have_decl_getauxval" "#include <sys/auxv.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_getauxval" = xyes
+then :
+
+printf "%s\n" "#define HAVE_GETAUXVAL 1" >>confdefs.h
+
+fi
+
        for ac_header in netpacket/packet.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "netpacket/packet.h" "ac_cv_header_netpacket_packet_h" "$ac_includes_default"

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -1920,6 +1920,13 @@ dnl Check if we have timerfds to be used for high accuracy
 dnl epoll_wait timeouts
 AC_CHECK_HEADERS([sys/timerfd.h])
 
+dnl Check if we have sys/auxv.h and getauxval
+AC_CHECK_DECL([getauxval],
+              [AC_DEFINE(HAVE_GETAUXVAL, 1,
+                         [Define to 1 if you have getauxval])],
+              [],
+              [#include <sys/auxv.h>])
+
 dnl Check if we have the header file 'netpacket/packat.h' in which
 dnl type 'struct sockaddr_ll' is defined.
 AC_CHECK_HEADERS([netpacket/packet.h],

--- a/erts/emulator/sys/unix/sys_signal_stack.c
+++ b/erts/emulator/sys/unix/sys_signal_stack.c
@@ -76,15 +76,16 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if defined(__linux__)
-#  include <sys/auxv.h>
-#endif
 
 #include "sys.h"
 #include "erl_alloc.h"
 #include "erl_vm.h"
 
 #if (defined(BEAMASM) && defined(NATIVE_ERLANG_STACK))
+
+#if defined(HAVE_GETAUXVAL)
+#  include <sys/auxv.h>
+#endif
 
 #if defined(NSIG)
 #  define HIGHEST_SIGNAL NSIG
@@ -98,7 +99,7 @@
 void sys_thread_init_signal_stack(void) {
     stack_t ss;
 
-#if defined(__linux__) && defined(AT_MINSIGSTKSZ)
+#if defined(HAVE_GETAUXVAL) && defined(AT_MINSIGSTKSZ)
     ss.ss_size = (size_t) getauxval(AT_MINSIGSTKSZ);
     ss.ss_size = MAX(ss.ss_size, SIGSTKSZ);
 #else


### PR DESCRIPTION
Adds configure test that was missing from #11249, breaking some cross-builds.