### PR TITLE
stdlib: Fix a crash caused by an invalid `import_record` attribute

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -1655,7 +1655,8 @@ build_attribute({atom,Aa,import_record}, Val) ->
     case Val of
 	[{atom,_Am,Mod},StrList] ->
 	    {attribute,Aa,import_record,{Mod,native_record_name_list(StrList)}};
-        [_,Other|_] -> error_bad_decl(Other, import_record)
+        [_,Other|_] -> error_bad_decl(Other, import_record);
+        [Other|_] -> error_bad_decl(Other, import_record)
     end;
 build_attribute({atom,Aa,record}, Val) ->
     case Val of

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -6056,6 +6056,12 @@ native_records(Conf) ->
            """,
            [{i,DataDir}, {keep_all_warnings,true}],
            {warnings, [{{1,2},erl_lint,{native_record_header,a}}]}
+          },
+          {bad_import_record,
+           <<"-import_record([rec]).">>,
+           [],
+           {errors,[{{1,36},erl_parse,"bad "++["import_record"] ++" declaration"}],
+            []}
           }
          ],
     [] = run(Conf, Ts),


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11227