### PR TITLE
sasl: tolerate dead processes during code_change

### DIFF
--- a/lib/sasl/src/release_handler_1.erl
+++ b/lib/sasl/src/release_handler_1.erl
@@ -509,12 +509,16 @@ resume(Pids) ->
     lists:foreach(fun(Pid) -> catch sys:resume(Pid) end, Pids).
 
 change_code(Pids, Mod, Vsn, Extra, Timeout) ->
-    Fun = fun(Pid) -> 
-		  case sys_change_code(Pid, Mod, Vsn, Extra, Timeout) of
+    Fun = fun(Pid) ->
+		  case catch sys_change_code(Pid, Mod, Vsn, Extra, Timeout) of
 		      ok ->
 			  ok;
 		      {error,Reason} ->
-			  throw({code_change_failed,Pid,Mod,Vsn,Reason})
+			  throw({code_change_failed,Pid,Mod,Vsn,Reason});
+		      _ ->
+			  % The process has terminated; a dead process
+			  % is not running old code.
+			  ok
 		  end
 	  end,
     lists:foreach(Fun, Pids).

--- a/lib/sasl/src/release_handler_1.erl
+++ b/lib/sasl/src/release_handler_1.erl
@@ -510,17 +510,17 @@ resume(Pids) ->
 
 change_code(Pids, Mod, Vsn, Extra, Timeout) ->
     Fun = fun(Pid) ->
-		  case catch sys_change_code(Pid, Mod, Vsn, Extra, Timeout) of
-		      ok ->
-			  ok;
-		      {error,Reason} ->
-			  throw({code_change_failed,Pid,Mod,Vsn,Reason});
-		      _ ->
-			  % The process has terminated; a dead process
-			  % is not running old code.
-			  ok
-		  end
-	  end,
+                  case catch sys_change_code(Pid, Mod, Vsn, Extra, Timeout) of
+                      ok ->
+                          ok;
+                      {error,Reason} ->
+                          throw({code_change_failed,Pid,Mod,Vsn,Reason});
+                      _ ->
+                          %% The process has terminated; a dead process
+                          %% is not running old code.
+                          ok
+                  end
+          end,
     lists:foreach(Fun, Pids).
 
 sys_change_code(Pid, Mod, Vsn, Extra, default) ->


### PR DESCRIPTION
If a process exits between suspend and code_change, the release install currently fails with a noproc exit. Since a dead process is not running old code, the process death is safe to ignore. This is consistent with the `sys:suspend` behaviour which also ignores dying processes. 

This patch is coming from a situation I had on a hot code deployment, where an expected sub-tree shut down caused the whole relup to fail. Sample failure:
```
release_handler:install_release(Vsn="2.9.8" Opts=[]) failed, 
Reason={'EXIT', {noproc, {sys, change_code, [<0.257241978.5>, 'my_proc', 39822361629682753496278469507860562273, []]}}}
```

Failing code_change still fail the relup, as it goes through the error tuple path.