### PR TITLE
kernel: Remove redundant check of initial code path

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -510,7 +510,7 @@ try_ebin_dirs([]) ->
 %%
 %% Add the erl_prim_loader path.
 %%
-add_loader_path(IPath0,Mode) ->
+add_loader_path(IPath,Mode) ->
     {ok,PrimP0} = erl_prim_loader:get_path(),
 
     %% All boot paths except for "." are cached by default but this can be disabled.
@@ -525,10 +525,13 @@ add_loader_path(IPath0,Mode) ->
             Pa = patch_path(Pa0),
             Pz = patch_path(Pz0),
             PrimP = patch_path(PrimP0),
-            IPath = patch_path(IPath0),
 
             Path0 = exclude_pa_pz(PrimP,Pa,Pz),
             Path1 = strip_path(Path0, Mode),
+            %% The IPath entries were already checked by make_path/2
+            %% when they were built (the trailing "." needs no check;
+            %% patch_path/1 would keep it either way), so they are not
+            %% validated again here.
             Path2 = merge_path(Path1, IPath, []),
             Path3 = cache_path(Path2),
             add_pa_pz(Path3,Pa,Pz)


### PR DESCRIPTION
## Description

When the code server starts in interactive mode, it builds the initial
code path before calling `add_loader_path/2`:

- `$ROOT/lib` entries, produced by `make_path/2`
- `ERL_LIBS` entries, also produced by `make_path/2` (filtered to `ebin`
  directories)
- a trailing `"."`

Every entry emitted by `make_path/2` has already passed an `is_dir/1`
check — either the application's `ebin` directory or an archive fallback
chosen by `try_ebin_dirs/1` — and bundles without a usable directory are
dropped. `add_loader_path/2` nevertheless ran `patch_path/1` over this
list, validating each entry a second time during startup.

That second pass cannot change the list: entries that exist are kept
as-is, and the trailing `"."` is kept in either case because
`patch_path/1` returns its input unchanged when `check_path/1` fails. In
embedded mode the initial path is empty. This change uses the initial
path as built instead of validating it again.

## Testing

- kernel `code_SUITE` passes (57/57) with the change.
- Smoke-tested that `code:get_path()` is as expected on a patched build:
  `ERL_LIBS` applications are present and `"."` remains the last entry.
- Patched builds boot correctly on macOS (Apple Silicon) and Linux
  (x86_64, Ubuntu 24.04).
