### PR TITLE
kernel: Publish code_server mode before registering

### DIFF
--- a/lib/kernel/src/code_server.erl
+++ b/lib/kernel/src/code_server.erl
@@ -89,6 +89,16 @@ get_mode() ->
 %% -----------------------------------------------------------
 
 init(Ref, Parent, [Root,Mode]) ->
+    %% The mode must be readable as soon as the name resolves:
+    %% error_handler routes lazy loads through code:ensure_loaded/1
+    %% (which reads this term via get_mode/0) once
+    %% whereis(code_server) succeeds, and processes already running
+    %% during kernel start -- notably the logger kernel process --
+    %% can hit an undefined function while init/3 is still building
+    %% the code path. Publishing the term only after register/2 left
+    %% a window where such a load raised badarg, killing logger and
+    %% the whole boot (GH-11353).
+    persistent_term:put(?MODULE, Mode),
     register(?MODULE, self()),
     process_flag(trap_exit, true),
 
@@ -120,7 +130,6 @@ init(Ref, Parent, [Root,Mode]) ->
 		   moddb = Db,
 		   namedb = create_namedb(Path, Root)},
 
-    persistent_term:put(?MODULE, Mode),
     Parent ! {Ref,{ok,self()}},
     loop(State).
 


### PR DESCRIPTION
Fixes #11353.

`error_handler` routes lazy loads through `code:ensure_loaded/1` (which reads the mode from `persistent_term` via `code_server:get_mode/0`) as soon as `whereis(code_server)` succeeds — but `code_server:init/3` registered the name first and published the term last, after the full code-path setup. A process hitting an undefined function inside that window crashes with badarg; when it's the logger kernel process handling an early-boot event, logger dies and boot halts with `Kernel pid terminated (logger)`.

The issue has a deterministic, Elixir-free reproduction (bootstrap-only boot script + unreadable cwd, flipping crash/pass 5/5 with the cwd bit alone, confirmed on OTP 28 x86_64 and OTP 27 arm64). Boot scripts that only `primLoad` the bootstrap module set — the shape `mix release` generates, so every Elixir release's `eval`/migration path — are the exposed population.

This change publishes the term before registering, so a caller reaching `ensure_loaded` in the window blocks in the gen call until `loop/1` serves it — the same semantics as a call arriving just after init completes.

Verified against the reproduction in #11353 by interposing the recompiled module into the failing boot: 5/5 boots pass with the fix where 5/5 crashed without it.