### PR TITLE
common_test: Document fail return from init callbacks

### DIFF
--- a/lib/common_test/doc/guides/example_chapter.md
+++ b/lib/common_test/doc/guides/example_chapter.md
@@ -199,12 +199,13 @@ suite() ->
 
 %%--------------------------------------------------------------------
 %% Function: init_per_suite(Config0) ->
-%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%               Config1 | {skip,Reason} | {fail,Reason} |
+%%               {skip_and_save,Reason,Config1}
 %%
 %% Config0 = Config1 = [tuple()]
 %%   A list of key/value pairs, holding the test case configuration.
 %% Reason = term()
-%%   The reason for skipping the suite.
+%%   The reason for skipping or failing the suite.
 %%
 %% Description: Initialization before the suite.
 %%
@@ -227,14 +228,16 @@ end_per_suite(_Config) ->
 
 %%--------------------------------------------------------------------
 %% Function: init_per_group(GroupName, Config0) ->
-%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%               Config1 | {skip,Reason} | {fail,Reason} |
+%%               {skip_and_save,Reason,Config1}
 %%
 %% GroupName = atom()
 %%   Name of the test case group that is about to run.
 %% Config0 = Config1 = [tuple()]
 %%   A list of key/value pairs, holding configuration data for the group.
 %% Reason = term()
-%%   The reason for skipping all test cases and subgroups in the group.
+%%   The reason for skipping or failing all test cases and subgroups
+%%   in the group.
 %%
 %% Description: Initialization before each test case group.
 %%--------------------------------------------------------------------
@@ -396,7 +399,8 @@ suite() ->
 
 %%--------------------------------------------------------------------
 %% Function: init_per_suite(Config0) ->
-%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%               Config1 | {skip,Reason} | {fail,Reason} |
+%%               {skip_and_save,Reason,Config1}
 %% Config0 = Config1 = [tuple()]
 %% Reason = term()
 %%--------------------------------------------------------------------
@@ -412,7 +416,8 @@ end_per_suite(_Config) ->
 
 %%--------------------------------------------------------------------
 %% Function: init_per_group(GroupName, Config0) ->
-%%               Config1 | {skip,Reason} | {skip_and_save,Reason,Config1}
+%%               Config1 | {skip,Reason} | {fail,Reason} |
+%%               {skip_and_save,Reason,Config1}
 %% GroupName = atom()
 %% Config0 = Config1 = [tuple()]
 %% Reason = term()

--- a/lib/common_test/src/ct_suite.erl
+++ b/lib/common_test/src/ct_suite.erl
@@ -192,6 +192,9 @@ as `Config` to all configuration functions and test cases in the suite.
 If `{skip, Reason}` is returned, all test cases in the suite are skipped and
 `Reason` is printed in the overview log for the suite.
 
+If `{fail, Reason}` is returned, suite initialization is marked as failed and
+all test cases in the suite are skipped.
+
 For information on `save_config` and `skip_and_save`, see section
 [Saving Configuration Data](dependencies_chapter.md#save_config) in the User's
 Guide.
@@ -201,6 +204,7 @@ If this function is defined, then
 """.
 -callback init_per_suite(Config :: ct_config()) ->
     NewConfig :: ct_config() |
+    {fail, Reason :: term()} |
     {skip, Reason :: term()} |
     {skip_and_save, Reason :: term(), SaveConfig :: ct_config()}.
 
@@ -270,6 +274,9 @@ all test cases and subgroups in the group.
 If `{skip, Reason}` is returned, all test cases in the group are skipped and
 `Reason` is printed in the overview log for the group.
 
+If `{fail, Reason}` is returned, group initialization is marked as failed and
+all test cases and subgroups in the group are skipped.
+
 For information about test case groups, see section
 [Test Case Groups](write_test_chapter.md#test_case_groups) in the User's Guide.
 
@@ -278,6 +285,7 @@ If this function is defined, then
 """.
 -callback init_per_group(GroupName :: ct_groupname(), Config :: ct_config()) ->
     NewConfig :: ct_config() |
+    {fail, Reason :: term()} |
     {skip, Reason :: term()}.
 
 -doc """


### PR DESCRIPTION
## Summary

- Document that `init_per_suite/1` and `init_per_group/2` may return `{fail, Reason}`.
- Add `{fail, Reason}` to the `ct_suite` callback specs.
- Update the Common Test example suite templates to include the fail return.

## Why

Common Test already handles `{fail, Reason}` from these init callbacks, but the public callback docs and examples only mentioned skip returns. This aligns the documentation with the existing behavior.

Closes #8952.

## Testing

- `./otp_build configure`
- `make common_test` using OTP 29 in `PATH`
- `git diff --check`
