### PR TITLE
public_key: Relax CommonName bound in relaxed decoder

### DIFF
--- a/lib/public_key/asn1/OTP-PKIX-Relaxed.asn1
+++ b/lib/public_key/asn1/OTP-PKIX-Relaxed.asn1
@@ -41,7 +41,7 @@ IMPORTS
        id-at-commonName, id-at-localityName, id-at-stateOrProvinceName, id-at-organizationName,
        id-at-organizationalUnitName, id-at-title, id-at-countryName, id-at-serialNumber,
        id-at-pseudonym, id-emailAddress,
-       ub-name, ub-common-name, ub-locality-name, ub-state-name, ub-organization-name,
+       ub-name, ub-locality-name, ub-state-name, ub-organization-name,
        ub-organizational-unit-name, ub-title, ub-serial-number, ub-pseudonym, ub-emailaddress-length
        FROM PKIX1Explicit-2009
        {iso(1) identified-organization(3) dod(6) internet(1)
@@ -133,7 +133,10 @@ OTP-X520stateOrProvinceName ::= OTPDirectoryString { ub-state-name }
 
 otp-at-x520CommonName ATTRIBUTE ::= {
     TYPE OTP-X520commonName IDENTIFIED BY id-at-commonName }
-OTP-X520commonName ::= OTPDirectoryString { ub-common-name }
+-- We accept CommonName values longer than the ub-common-name (64)
+-- SIZE constraint. Real-world certificates can use CNs exceeding
+-- 64 chars, and OTP-PKIX accepts those as well.
+OTP-X520commonName ::= OTPDirectoryString { 255 }
 
 otp-at-x520OrganizationName ATTRIBUTE ::= {
     TYPE OTP-X520organizationName IDENTIFIED BY id-at-organizationName }

--- a/lib/public_key/test/public_key_SUITE.erl
+++ b/lib/public_key/test/public_key_SUITE.erl
@@ -1225,13 +1225,12 @@ pkix_long_commonname() ->
 pkix_long_commonname(Config) when is_list(Config) ->
     Cert = long_commonname_pkix_cert(),
     OTPCert = public_key:pkix_decode_cert(Cert, otp),
-    TBSCert = OTPCert#'OTPCertificate'.tbsCertificate,
-    Issuer = TBSCert#'OTPTBSCertificate'.issuer,
-    Subj   = TBSCert#'OTPTBSCertificate'.subject,
+    RelaxedOTPCert = public_key:pkix_decode_cert(Cert, relaxed),
     ExpectedCN = "This-is-a-very-long-common-name-that-exceeds-"
                  "the-64-character-limit-for-testing.example.com",
-    check_commonname(Issuer, ExpectedCN),
-    check_commonname(Subj, ExpectedCN).
+    check_cert_commonname(OTPCert, ExpectedCN),
+    check_cert_commonname(RelaxedOTPCert, ExpectedCN),
+    true = public_key:pkix_verify(Cert, cert_public_key(OTPCert)).
 
 %%--------------------------------------------------------------------
 pkix_decode_cert() ->
@@ -2441,6 +2440,16 @@ do_check_emailaddress([_| Rest]) ->
 
 check_commonname({rdnSequence, DirName}, ExpectedCN) ->
     do_check_commonname(DirName, ExpectedCN).
+check_cert_commonname(#'OTPCertificate'{tbsCertificate = TBSCert}, ExpectedCN) ->
+    Issuer = TBSCert#'OTPTBSCertificate'.issuer,
+    Subj   = TBSCert#'OTPTBSCertificate'.subject,
+    check_commonname(Issuer, ExpectedCN),
+    check_commonname(Subj, ExpectedCN).
+
+cert_public_key(#'OTPCertificate'{tbsCertificate = TBSCert}) ->
+    PublicKeyInfo = TBSCert#'OTPTBSCertificate'.subjectPublicKeyInfo,
+    PublicKeyInfo#'OTPSubjectPublicKeyInfo'.subjectPublicKey.
+
 do_check_commonname([], _ExpectedCN) ->
     ok;
 do_check_commonname([#'AttributeTypeAndValue'{type = ?'id-at-commonName',


### PR DESCRIPTION
## Summary
- Relax `OTP-PKIX-Relaxed` CommonName decoding to 255 characters, matching `OTP-PKIX`.
- Extend the long CommonName regression to cover relaxed decoding and `public_key:pkix_verify/2`.

## Root Cause
`OTP-PKIX` accepts CommonName values longer than the X.520 64 character bound, but `OTP-PKIX-Relaxed` still used `ub-common-name`. TLS certificate verification decodes certificates through the relaxed decoder, so certificates accepted by ordinary OTP decoding could still fail validation.

Closes #11240

## Testing
- `make public_key`
- `ERL_TOP=$PWD make public_key_test`
  - `211 ok, 0 failed, 7 skipped of 218 test cases`
- `git diff --check`

`./otp_build check` was attempted. It builds and boots optimized/debug runtimes, then stops at `format-check` because local `clang-format version 22.1.8` reports formatting differences in unrelated `erts/emulator/beam/jit/*` files.