### PR TITLE
kernel: Fix pg not deleting empty remote groups

### DIFF
--- a/lib/kernel/src/pg.erl
+++ b/lib/kernel/src/pg.erl
@@ -518,7 +518,12 @@ update_global_view_and_notify(Node, [{Group, Add, Remove} | Tail], Subscriptions
 update_global_view_and_notify(Node, [{Group, Add, Remove} | Tail], Subscriptions, {Scope, Monitors}) ->
     case ets:lookup(Scope, Group) of
         [{_Group, All, Local}] ->
-            ets:insert(Scope, {Group, Add ++ (All -- Remove), Local});
+            case Add ++ (All -- Remove) of
+                [] ->
+                    ets:delete(Scope, Group);
+                NewAll ->
+                    ets:insert(Scope, {Group, NewAll, Local})
+            end;
         _ ->
             ets:insert(Scope, {Group, Add, []})
     end,

--- a/lib/kernel/test/pg_SUITE.erl
+++ b/lib/kernel/test/pg_SUITE.erl
@@ -312,6 +312,11 @@ empty_group_by_remote_leave(Config) when is_list(Config) ->
     {_, _, NewRemoteMap} = maps:get(RemoteNode, element(8, sys:get_state(?FUNCTION_NAME))),
     % empty group should be deleted.
     ?assertEqual(#{}, NewRemoteMap),
+    % regression test: which_groups/1 must not keep listing a group that has
+    % zero members after the last *remote* member leaves (it only reflects
+    % the peer's cached local_data correctly; the ETS-backed global view
+    % used by which_groups/1 must also be pruned).
+    ?assertEqual([], pg:which_groups(?FUNCTION_NAME)),
 
     %% another variant of emptying a group remotely: join([Pi1, Pid2]) and leave ([Pid2, Pid1])
     RemotePid2 = spawn_sleeper_at(Node),
@@ -323,6 +328,7 @@ empty_group_by_remote_leave(Config) when is_list(Config) ->
     sync_via({?FUNCTION_NAME, Node}, ?FUNCTION_NAME),
     ?assertEqual([], pg:get_members(?FUNCTION_NAME, ?FUNCTION_NAME)),
     {_, _, NewRemoteMap} = maps:get(RemoteNode, element(8, sys:get_state(?FUNCTION_NAME))),
+    ?assertEqual([], pg:which_groups(?FUNCTION_NAME)),
     peer:stop(Peer),
     ok.
 


### PR DESCRIPTION
Fixes #11360

## What this fixes

After a node (or its last process) leaves a `pg` group, other nodes keep listing that group in `pg:which_groups/1` even though it has no members anymore. Only `pg:get_members/2` correctly reveals that the group is empty. `which_groups/1` cannot tell a phantom (empty) group apart froma real one.

This means any code that uses `pg:which_groups/1` to enumerate "currently active" groups (for example to track cluster membership via `{member, Node}` groups, as we do in our own pg-based service registry) will accumulate a permanently growing set of stale phantom entries for every node/process that has ever disconnected from a long-running cluster.

## Root cause

`update_global_view_and_notify/4` in `lib/kernel/src/pg.erl` has two clauses depending on whether an update originates locally (`Node =:= node()`) or remotely. The local-update clause already deletes the ETS row for a group once its resulting member list is empty:

```erlang
case Add ++ (All -- Remove) of
    [] -> ets:delete(Scope, Group);
    NewAll -> ets:insert(Scope, {Group, NewAll, Add ++ (Local -- Remove)})
end
```

but the remote-update clause did not have this check, and unconditionally inserted, even when empty:

```erlang
ets:insert(Scope, {Group, Add ++ (All -- Remove), Local})
```

`which_groups/1` matches every row in the ETS table regardless of member count, so once the last *remote* member of a group leaves, the row is left behind as `{Group, [], Local}` forever.

## The fix

Mirror the local-update clause's empty check in the remote-update clause, deleting the row instead of inserting an empty one.

## Test coverage

`empty_group_by_remote_leave` already exercises this exact scenario (a remote node joining and then leaving a group), but it only asserted on `get_members/2` and on the peer's internal cached `local_data`, never on `which_groups/1` — which is why this went uncaught. I added the missing `which_groups/1` assertions to that test case; they fail without the fix and pass with it.

Before the fix, on `maint` (kernel-11.0.3):

```
{expression, "pg : which_groups ( ? FUNCTION_NAME )"},
{expected, []},
{value, [empty_group_by_remote_leave]}
```

After the fix: `1 ok, 0 failed`.

I also reproduced the underlying issue on `iex` (elixir), described in the issue
