### PR TITLE
compiler: Fix nomatch crash with map comprehension in `v3_core`

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -2788,6 +2788,7 @@ add_bound_vars({mc, Pairs, BoundVars}, AccPat) ->
 %% add_pre_bound_vars(Ctx, Pre) -> Ctx.
 %%  Add variables bound in pre-expressions (from filters) to mc context.
 add_pre_bound_vars({lc, E}, _Pre) -> {lc, E};
+add_pre_bound_vars({mc, Pairs, nomatch}, _Pre) -> {mc, Pairs, nomatch};
 add_pre_bound_vars({mc, Pairs, BoundVars}, Pre) ->
     NewVars = ordsets:union([pre_expr_vars(E) || E <- Pre]),
     {mc, Pairs, ordsets:union(NewVars, BoundVars)}.

--- a/lib/compiler/test/compilation_SUITE.erl
+++ b/lib/compiler/test/compilation_SUITE.erl
@@ -62,7 +62,7 @@
          vsn_3/1,
          infinite_loop/0,infinite_loop/1,
          native_record/1,
-         use_nifs/1]).
+         use_nifs/1,gh_11352/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -92,7 +92,7 @@ groups() ->
        otp_7202,on_load,on_load_inline,
        string_table,otp_8949_a,split_cases,
        infinite_loop, native_record,
-       use_nifs]}].
+       use_nifs,gh_11352]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -146,6 +146,7 @@ end_per_group(_GroupName, Config) ->
 ?comp(native_record).
 
 ?comp(use_nifs).
+?comp(gh_11352).
 
 infinite_loop() -> [{timetrap,{minutes,1}}].
 ?comp(infinite_loop).

--- a/lib/compiler/test/compilation_SUITE_data/gh_11352.erl
+++ b/lib/compiler/test/compilation_SUITE_data/gh_11352.erl
@@ -1,0 +1,36 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(gh_11352).
+-export([?MODULE/0]).
+
+?MODULE() ->
+    ok.
+
+f6() ->
+    #{
+        ok => ok
+     || <<>> = [] := _ <- ok,
+        begin
+            _ = ok
+        end
+    }.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11352.