### PR TITLE
erts: Report the effective atom_limit

### DIFF
--- a/erts/emulator/beam/index.c
+++ b/erts/emulator/beam/index.c
@@ -60,11 +60,15 @@ IndexTable*
 erts_index_init(ErtsAlcType_t type, IndexTable* t, char* name,
 		int size, int limit, HashFunctions fun)
 {
-    Uint base_size = (((Uint)limit+INDEX_PAGE_SIZE-1)/INDEX_PAGE_SIZE)*sizeof(IndexSlot*);
+    /* Round up to a whole number of pages; the table only enforces its limit at
+     * a page boundary, so this is the effective limit reported to the user. */
+    Uint pages = ((Uint)limit+INDEX_PAGE_SIZE-1)/INDEX_PAGE_SIZE;
+    Uint effective_limit = pages*INDEX_PAGE_SIZE;
+    Uint base_size = pages*sizeof(IndexSlot*);
     hash_init(type, &t->htable, name, 3*size/4, fun);
 
     t->size = 0;
-    t->limit = limit;
+    t->limit = effective_limit <= INT_MAX ? (int)effective_limit : limit;
     t->entries = 0;
     t->type = type;
     t->seg_table = (IndexSlot***) erts_alloc(type, base_size);

--- a/erts/emulator/test/system_info_SUITE.erl
+++ b/erts/emulator/test/system_info_SUITE.erl
@@ -537,11 +537,13 @@ get_ets_limit(EtsMax) ->
     Res.
 
 
-%% Verify system_info(atom_limit) reflects max atoms settings
-%% (using " +t").
+%% Verify system_info(atom_limit) reflects max atoms settings (using " +t"),
+%% reported as the effective limit (the requested size rounded up to a whole
+%% number of index-table pages of 1024 entries).
 atom_limit(Config0) when is_list(Config0) ->
     {ok, Peer, Node} = ?CT_PEER(["+t", "2186042"]),
-    2186042 = rpc:call(Node, erlang, system_info, [atom_limit]),
+    %% 2186042 rounded up to a multiple of 1024 = 2135 * 1024.
+    2186240 = rpc:call(Node, erlang, system_info, [atom_limit]),
     peer:stop(Peer).
 
 %% Verify that system_info(atom_count) works.


### PR DESCRIPTION
erts_index_init() grows its table one INDEX_PAGE_SIZE page at a time and only checks the limit when allocating a new page, so the effective limit is the requested value rounded up to a whole number of pages. Store that rounded value in t->limit so that erlang:system_info(atom_limit) reports the limit actually enforced, like process_limit and port_limit do, rather than echoing back the raw +t value.