### PR TITLE
compiler: Fix an internal consistency check failure with `setelement`

### DIFF
--- a/lib/compiler/src/beam_ssa_pre_codegen.erl
+++ b/lib/compiler/src/beam_ssa_pre_codegen.erl
@@ -1186,7 +1186,9 @@ expand_update_tuple_is([#b_set{op=update_tuple, args=[Src | Args]}=I0 | Is],
     {SetElement, Sets, Count} = expand_update_tuple_list(Args, I0, Src, Count0),
     case {Sets, Is} of
         {[_ | _], [#b_set{op=succeeded}=I]} ->
-            {reverse(Acc, [SetElement, I]), reverse(Sets), Count};
+            #b_set{dst=Dst} = SetElement,
+            SuccI = I#b_set{args=[Dst]},
+            {reverse(Acc, [SetElement, SuccI]), reverse(Sets), Count};
         {_, _} ->
             expand_update_tuple_is(Is, Count, Sets ++ [SetElement | Acc])
     end;

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -36,7 +36,7 @@
          cover_maps_functions/1,min_max_mixed_types/1,
          not_equal/1,infer_relops/1,binary_unit/1,premature_concretization/1,
          funs/1,will_succeed/1,float_confusion/1,
-         cover_convert_ext/1, catch_setelement/1]).
+         cover_convert_ext/1, catch_setelement/1,gh_11368/1]).
 
 %% Force id/1 to return 'any'.
 -export([id/1]).
@@ -85,7 +85,8 @@ groups() ->
        will_succeed,
        float_confusion,
        cover_convert_ext,
-       catch_setelement
+       catch_setelement,
+       gh_11368
       ]}].
 
 init_per_suite(Config) ->
@@ -1670,6 +1671,15 @@ catch_setelement(_Config) ->
 catch_setelement_2(B, V) ->
     T = if B -> {1}; true -> {1,2} end,
     catch setelement(2, T, V).
+
+gh_11368(_Config) ->
+    prepare_request(id({0,0,0,0}), id({1,1,1,1})),
+    ok.
+
+prepare_request(Msg0, Seq) ->
+    Flags = element(3, Msg0),
+    Msg1 = setelement(3, Msg0, [request | Flags]),
+    setelement(4, Msg1, Seq).
 
 %%%
 %%% Common utilities.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11368.
280c0f87072d9e7c9a07e20d32dc04590fd5394e reveals this bug.