### PR TITLE
erts: Size alternate signal stack via sysconf(_SC_MINSIGSTKSZ)

### DIFF
--- a/erts/emulator/sys/unix/sys_signal_stack.c
+++ b/erts/emulator/sys/unix/sys_signal_stack.c
@@ -76,9 +76,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if defined(__linux__)
-#  include <sys/auxv.h>
-#endif
+#include <unistd.h>
 
 #include "sys.h"
 #include "erl_alloc.h"
@@ -98,9 +96,11 @@
 void sys_thread_init_signal_stack(void) {
     stack_t ss;
 
-#if defined(__linux__) && defined(AT_MINSIGSTKSZ)
-    ss.ss_size = (size_t) getauxval(AT_MINSIGSTKSZ);
-    ss.ss_size = MAX(ss.ss_size, SIGSTKSZ);
+#if defined(_SC_MINSIGSTKSZ)
+    {
+        long min = sysconf(_SC_MINSIGSTKSZ);
+        ss.ss_size = MAX((size_t) (min > 0 ? min : SIGSTKSZ), (size_t) SIGSTKSZ);
+    }
 #else
     ss.ss_size = SIGSTKSZ;
 #endif


### PR DESCRIPTION
## What

Size the scheduler thread's alternate signal stack from `sysconf(_SC_MINSIGSTKSZ)` (keeping the `SIGSTKSZ` floor) instead of `getauxval(AT_MINSIGSTKSZ)`. Fixes #11349.

## Why

#11249 sized the stack to `MAX(getauxval(AT_MINSIGSTKSZ), SIGSTKSZ)`, the bare kernel sigframe size. But musl 1.2.6's `sigaltstack()` rejects any request below `sysconf(_SC_MINSIGSTKSZ)`, which musl computes as `AT_MINSIGSTKSZ + 1024` (a 1 KiB handler margin). So on a CPU whose `AT_MINSIGSTKSZ` exceeds `SIGSTKSZ - 1024` (that is, above 7168, for example AMX hosts reporting 11952) the request is about 1 KiB short and the emulator aborts at startup with "Failed to set alternate signal stack". That is #11349, the failure that remained after #11249.

`sysconf(_SC_MINSIGSTKSZ)` is exactly the value the C library's `sigaltstack()` enforces (a strict `ss_size < min` check), so requesting at least it always passes, and it is auxv-derived and fixed at exec so there is no TOCTOU. It is also correct on glibc, where `sigaltstack()` has no userspace size check and `sysconf(_SC_MINSIGSTKSZ)` returns the kernel's enforced minimum. On musl 1.2.5 (Alpine 3.23) the expression evaluates to `MAX(auxv, SIGSTKSZ)`, the same size #11249 already requests, so nothing changes there.

## Verification

Reproduced on real hardware in public CI, on this PR's actual base: https://github.com/k-patrik/otp-sigaltstack-musl builds `erlang/otp@maint` (the bug) and this branch (the fix) from source on `alpine:3.24`, alongside an OTP-28.5.0.3 set, and runs them across GitHub's runner pool while fingerprinting each VM. On Intel Xeon Platinum 8573C runs (AMX, `AT_MINSIGSTKSZ = 11952`) `maint` aborts at startup with "Failed to set alternate signal stack" and this branch boots ([Run summary](https://github.com/k-patrik/otp-sigaltstack-musl/actions/runs/29770521620/attempts/1#summary-88453987679), [Run logs](https://github.com/k-patrik/otp-sigaltstack-musl/actions/runs/29770521620/job/88453987679#step:5:28). The 28.5.0.3 set agrees (the current and #11249 builds abort, the `sysconf` build boots), so the fix holds on both OTP 28 and 29. Draws of VMs below the threshold (AMD EPYC, Ice Lake) boot on every variant.

A minimal hardware-independent probe in that repo shows the mechanism on any musl 1.2.6 host: `sysconf(_SC_MINSIGSTKSZ) == getauxval(AT_MINSIGSTKSZ) + 1024`, and `sigaltstack()` returns `ENOMEM` one byte below `sysconf(_SC_MINSIGSTKSZ)`.
