### PR TITLE
compiler: Fix crash when key pattern in a map comprehension is bitstring

### DIFF
--- a/lib/compiler/src/v3_core.erl
+++ b/lib/compiler/src/v3_core.erl
@@ -4819,8 +4819,10 @@ ibitstr_vars(Segs) ->
 
 ibitstr_vars(Segs, Vs) ->
     foldl(fun (#ibitstr{val=V,size=S}, Vs0) ->
-          lit_vars(V, lit_vars(S, Vs0))
-      end, Vs, Segs).
+                  lit_vars(V, lit_vars(S, Vs0));
+              (#c_bitstr{val=V,size=S}, Vs0) ->
+                  lit_vars(V, lit_vars(S, Vs0))
+          end, Vs, Segs).
 
 record_anno(L, #core{dialyzer=Dialyzer}=St) ->
     case erl_anno:record(L) andalso Dialyzer of

--- a/lib/compiler/test/compilation_SUITE.erl
+++ b/lib/compiler/test/compilation_SUITE.erl
@@ -62,7 +62,7 @@
          vsn_3/1,
          infinite_loop/0,infinite_loop/1,
          native_record/1,
-         use_nifs/1,gh_11352/1]).
+         use_nifs/1,gh_11352/1,gh_11367/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -92,7 +92,7 @@ groups() ->
        otp_7202,on_load,on_load_inline,
        string_table,otp_8949_a,split_cases,
        infinite_loop, native_record,
-       use_nifs,gh_11352]}].
+       use_nifs,gh_11352,gh_11367]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -147,6 +147,7 @@ end_per_group(_GroupName, Config) ->
 
 ?comp(use_nifs).
 ?comp(gh_11352).
+?comp(gh_11367).
 
 infinite_loop() -> [{timetrap,{minutes,1}}].
 ?comp(infinite_loop).

--- a/lib/compiler/test/compilation_SUITE_data/gh_11367.erl
+++ b/lib/compiler/test/compilation_SUITE_data/gh_11367.erl
@@ -1,0 +1,30 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(gh_11367).
+-export([?MODULE/0,f/1]).
+
+?MODULE() ->
+    ok.
+
+f(X) ->
+    #{X => X || #{<<X/binary>> := _} <- [#{<<X/binary>> => ok}]}.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11367