### PR TITLE
erts: Clarify ETS table sizing documentation

### DIFF
--- a/erts/doc/references/erl_cmd.md
+++ b/erts/doc/references/erl_cmd.md
@@ -595,8 +595,10 @@ behavior of earlier flags.
   keeping track of the memory consumption and the number of terms in ETS tables
   of type ordered_set with the write_concurrency option activated.
 
-- **`+e Number`{: #+e }** - Sets the maximum number of ETS tables. This limit is
-  [partially obsolete](`m:ets#max_ets_tables`).
+- **`+e Number`{: #+e }** - Sets a sizing hint for the internal index used to
+  look up named ETS tables. It does not limit the number of ETS tables. Values
+  below 8192 are treated as 8192, and the number of lookup buckets is rounded up
+  to a power of two. See [ETS table sizing](`m:ets#max_ets_tables`).
 
 - **`+ec`** - Forces option `compressed` on all ETS tables. Only intended for
   test and evaluation.

--- a/erts/doc/src/erlang_system_info.md
+++ b/erts/doc/src/erlang_system_info.md
@@ -368,9 +368,10 @@ Returns information about the current system (emulator) limits as specified by `
   
   Since: OTP 21.1
 
-- `ets_limit`{: #system_info_ets_limit } - Returns the limit for number of
-  ETS tables. This limit is [partially obsolete](`m:ets#max_ets_tables`) and
-  number of tables are only limited by available memory.
+- `ets_limit`{: #system_info_ets_limit } - Returns the effective sizing hint for
+  the internal index used to look up named ETS tables. Despite its historical
+  name, this value does not limit the number of ETS tables; they are limited only
+  by available memory. See [ETS table sizing](`m:ets#max_ets_tables`).
   
   Since: OTP R16B03
 

--- a/lib/stdlib/src/ets.erl
+++ b/lib/stdlib/src/ets.erl
@@ -58,16 +58,15 @@ are proportional to the logarithm of the number of objects in the table.
 
 > #### Note {: .info }
 >
-> The number of tables stored at one Erlang node _used_ to be limited. This is
-> no longer the case (except by memory usage). The previous default limit was
-> about 1400 tables and could be increased by setting the environment variable
-> `ERL_MAX_ETS_TABLES` or the command line option
-> [`+e`](`e:erts:erl_cmd.md#%2Be`) before starting the Erlang runtime system.
-> This hard limit has been removed, but it is currently useful to set the
-> `ERL_MAX_ETS_TABLES` anyway. It should be set to an approximate of the maximum
-> amount of tables used since an internal table for named tables is sized using
-> this value. If large amounts of named tables are used and `ERL_MAX_ETS_TABLES`
-> hasn't been increased, the performance of named table lookup will degrade.
+> The number of ETS tables at one Erlang node is limited only by available
+> memory. The environment variable `ERL_MAX_ETS_TABLES` and the command line
+> option [`+e`](`e:erts:erl_cmd.md#%2Be`) do not limit this number. They set a
+> sizing hint for an internal index used to look up named ETS tables.
+>
+> Workloads that keep a large number of named tables concurrently can set the
+> hint to approximately the expected peak number of named tables. A value that
+> is too small can increase hash collisions and degrade named table lookup
+> performance, while an unnecessarily large value increases memory usage.
 
 Notice that there is no automatic garbage collection for tables. Even if there
 are no references to a table from any process, it is not automatically destroyed


### PR DESCRIPTION
## Summary

- Clarify that `ERL_MAX_ETS_TABLES` and `+e` size the named ETS table
  lookup index instead of limiting the total number of ETS tables.
- Document the minimum sizing hint and power-of-two bucket rounding.
- Clarify the historical meaning of `erlang:system_info(ets_limit)`.

## Motivation

The existing `+e` and `ets_limit` documentation describes the value as a
table limit, while the runtime only uses it to size the internal index for
named ETS table lookups. This can lead operators to treat it as a capacity
limit and tune it based on the total table count instead of the expected peak
number of concurrently named tables.

## Validation

- `git diff --check`
- Generated the `stdlib` documentation with ExDoc 0.40.3.
- Generated the `erts` documentation with ExDoc 0.40.3.
