### PR TITLE
Optimise allocation patterns for recvmmsg

### DIFF
--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -4297,16 +4297,14 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
             if (msgLen > bufSz)
                 msgLen = bufSz;
 
-            ESOCK_ASSERT( ALLOC_BIN(bufSz, &bufs[i]) );
+            ESOCK_ASSERT( ALLOC_BIN(msgLen, &bufs[i]) );
             sys_memcpy(bufs[i].data, recvBufs + (i * bufSz), msgLen);
-            bufs[i].size = bufSz;
 
-            ESOCK_ASSERT( ALLOC_BIN(ctrlSz, &ctrls[i]) );
             ctrlLen = (recvMmsghdrs[i].msg_hdr.msg_controllen < ctrlSz)
                 ? recvMmsghdrs[i].msg_hdr.msg_controllen
                 : ctrlSz;
+            ESOCK_ASSERT( ALLOC_BIN(ctrlLen, &ctrls[i]) );
             sys_memcpy(ctrls[i].data, recvCtrl + (i * ctrlSz), ctrlLen);
-            ctrls[i].size = ctrlSz;
 
             recvMmsghdrs[i].msg_hdr.msg_control = ctrls[i].data;
 

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -335,6 +335,37 @@ typedef struct {
 } ESSIOControl;
 
 
+#ifdef HAVE_RECVMMSG
+/* Grow-to-fit scratch block for essio_recvmmsg, kept per scheduler thread. */
+typedef struct {
+    char*  base;
+    size_t capacity;
+} ESSIOMMsgPool;
+
+static ErlNifTSDKey esock_mmsg_pool_key;
+
+/* Return this thread's scratch block, grown (grow-only) to hold 'need' bytes. */
+static ESSIOMMsgPool* essio_recvmmsg_pool(const size_t need)
+{
+    ESSIOMMsgPool* pool = enif_tsd_get(esock_mmsg_pool_key);
+    if (pool == NULL) {
+        ESOCK_ASSERT( (pool = MALLOC(sizeof(ESSIOMMsgPool))) != NULL );
+        pool->base     = NULL;
+        pool->capacity = 0;
+        enif_tsd_set(esock_mmsg_pool_key, pool);
+    }
+    if (pool->capacity < need) {
+        char* nbase = (pool->base == NULL) ?
+            (char*) MALLOC(need) : (char*) REALLOC(pool->base, need);
+        ESOCK_ASSERT( nbase != NULL );
+        pool->base     = nbase;
+        pool->capacity = need;
+    }
+    return pool;
+}
+#endif /* HAVE_RECVMMSG */
+
+
 /* ======================================================================== *
  *                          Function Forwards                               *
  * ======================================================================== *
@@ -1111,6 +1142,11 @@ int essio_init(unsigned int     numThreads,
     ctrl.sockDbg    = dataP->sockDbg;
 
     essio_sctp_init();
+
+#ifdef HAVE_RECVMMSG
+    ESOCK_ASSERT( enif_tsd_key_create("esock_mmsg_pool",
+                                      &esock_mmsg_pool_key) == 0 );
+#endif
 
     return ESOCK_IO_OK;
 }
@@ -4125,7 +4161,8 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
     struct iovec*   recvIovecs = NULL;
     ErlNifBinary*   bufs = NULL;
     ErlNifBinary*   ctrls = NULL;
-    char*           heapPool = NULL;
+    ERL_NIF_TERM*   elems = NULL;
+    ESSIOMMsgPool*  pool;
     SOCKLEN_T       addrLen = sizeof(ESockAddress);
     size_t          bufSz  = (bufLen  != 0 ? bufLen  : descP->rBufSz);
     size_t          ctrlSz = (ctrlLen != 0 ? ctrlLen : descP->rCtrlSz);
@@ -4158,21 +4195,29 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
         size_t addrs_sz    = vlen * sizeof(ESockAddress);
         size_t mmsghdrs_sz = vlen * sizeof(struct mmsghdr);
         size_t iovecs_sz   = vlen * sizeof(struct iovec);
+        size_t elems_sz    = vlen * sizeof(ERL_NIF_TERM);
+        size_t meta_sz     = bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz + iovecs_sz + elems_sz;
         size_t bufdata_sz  = vlen * bufSz;
         size_t ctrldata_sz = vlen * ctrlSz;
-        size_t total_sz = bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz + iovecs_sz + bufdata_sz + ctrldata_sz;
-        ESOCK_ASSERT((heapPool = (char*) MALLOC(total_sz)) != NULL );
-        sys_memzero(heapPool, bufs_sz + ctrls_sz + addrs_sz);
-        bufs         = (ErlNifBinary*)   (heapPool);
-        ctrls        = (ErlNifBinary*)   (heapPool + bufs_sz);
-        addrs        = (ESockAddress*)   (heapPool + bufs_sz + ctrls_sz);
-        recvMmsghdrs = (struct mmsghdr*) (heapPool + bufs_sz + ctrls_sz + addrs_sz);
-        recvIovecs   = (struct iovec*)   (heapPool + bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz);
-        recvBufs     = (unsigned char*)  (heapPool + bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz + iovecs_sz);
-        recvCtrl     = (unsigned char*)  (heapPool + bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz + iovecs_sz + bufdata_sz);
+        size_t total_sz    = meta_sz + bufdata_sz + ctrldata_sz;
+        char*  p;
+
+        pool = essio_recvmmsg_pool(total_sz);
+        p = pool->base;
+
+        /* bufs/ctrls/addrs must start zeroed for the cleanup path. */
+        sys_memzero(p, bufs_sz + ctrls_sz + addrs_sz);
+        bufs         = (ErlNifBinary*)   (p);
+        ctrls        = (ErlNifBinary*)   (p + bufs_sz);
+        addrs        = (ESockAddress*)   (p + bufs_sz + ctrls_sz);
+        recvMmsghdrs = (struct mmsghdr*) (p + bufs_sz + ctrls_sz + addrs_sz);
+        recvIovecs   = (struct iovec*)   (p + bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz);
+        elems        = (ERL_NIF_TERM*)   (p + bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz + iovecs_sz);
+        recvBufs     = (unsigned char*)  (p + meta_sz);
+        recvCtrl     = (unsigned char*)  (p + meta_sz + bufdata_sz);
     }
 
-    /* Set up mmsghdr structures to point into raw memory blocks */
+    /* Set up mmsghdr/iovec slots to point into the block. */
     for (i = 0; i < vlen; i++) {
         recvIovecs[i].iov_base = recvBufs + (i * bufSz);
         recvIovecs[i].iov_len  = bufSz;
@@ -4208,8 +4253,6 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
      */
     {
         size_t totalBytes = 0;
-        ERL_NIF_TERM* elems;
-        ESOCK_ASSERT( (elems = MALLOC(readResult * sizeof(ERL_NIF_TERM))) != NULL );
 
         for (i = 0; i < (unsigned int) readResult; i++) {
             ErlNifBinary bin;
@@ -4248,7 +4291,6 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
         }
 
         resultList = enif_make_list_from_array(env, elems, readResult);
-        enif_free(elems);
 
         /* Update packet and byte counters */
         ESOCK_CNT_INC(env, descP, sockRef, esock_atom_read_pkg, &descP->readPkgCnt, readResult);
@@ -4268,13 +4310,9 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
     }
 
 cleanup:
-    /* Free ErlNifBinary structures only for received messages.
-     * Note: recv_create_bin may have transferred ownership (set data = NULL),
-     * in which case FREE_BIN is a no-op. We only free binaries we still own.
-     * When exiting early from the allocation loop, i is at the index where
-     * allocation failed, so we free indices 0 to i-1. On successful completion,
-     * i equals readResult, so we free indices 0 to readResult-1.
-     */
+    /* Free the binaries we still own; recv_create_bin may have handed some off
+     * (data == NULL -> FREE_BIN is a no-op). The bufs/ctrls arrays were zeroed
+     * above so slots the allocation loop never reached are skipped. */
     {
         unsigned int countToFree = (i < (unsigned int) readResult) ? i : (unsigned int) readResult;
         if (countToFree > 0) {
@@ -4288,8 +4326,6 @@ cleanup:
             }
         }
     }
-
-    if (heapPool) enif_free(heapPool);
 
     return ret;
 }

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -338,8 +338,12 @@ typedef struct {
 #ifdef HAVE_RECVMMSG
 /* Grow-to-fit scratch block for essio_recvmmsg, kept per scheduler thread. */
 typedef struct {
-    char*  base;
-    size_t capacity;
+    char*        base;
+    size_t       capacity;
+    unsigned int laid_vlen;    /* dimensions the block is currently set up for */
+    size_t       laid_bufSz;
+    size_t       laid_ctrlSz;
+    unsigned int used;         /* leading slots the previous call mutated */
 } ESSIOMMsgPool;
 
 static ErlNifTSDKey esock_mmsg_pool_key;
@@ -350,8 +354,12 @@ static ESSIOMMsgPool* essio_recvmmsg_pool(const size_t need)
     ESSIOMMsgPool* pool = enif_tsd_get(esock_mmsg_pool_key);
     if (pool == NULL) {
         ESOCK_ASSERT( (pool = MALLOC(sizeof(ESSIOMMsgPool))) != NULL );
-        pool->base     = NULL;
-        pool->capacity = 0;
+        pool->base       = NULL;
+        pool->capacity   = 0;
+        pool->laid_vlen  = 0;
+        pool->laid_bufSz = 0;
+        pool->laid_ctrlSz = 0;
+        pool->used       = 0;
         enif_tsd_set(esock_mmsg_pool_key, pool);
     }
     if (pool->capacity < need) {
@@ -4205,8 +4213,6 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
         pool = essio_recvmmsg_pool(total_sz);
         p = pool->base;
 
-        /* bufs/ctrls/addrs must start zeroed for the cleanup path. */
-        sys_memzero(p, bufs_sz + ctrls_sz + addrs_sz);
         bufs         = (ErlNifBinary*)   (p);
         ctrls        = (ErlNifBinary*)   (p + bufs_sz);
         addrs        = (ESockAddress*)   (p + bufs_sz + ctrls_sz);
@@ -4215,20 +4221,43 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
         elems        = (ERL_NIF_TERM*)   (p + bufs_sz + ctrls_sz + addrs_sz + mmsghdrs_sz + iovecs_sz);
         recvBufs     = (unsigned char*)  (p + meta_sz);
         recvCtrl     = (unsigned char*)  (p + meta_sz + bufdata_sz);
-    }
 
-    /* Set up mmsghdr/iovec slots to point into the block. */
-    for (i = 0; i < vlen; i++) {
-        recvIovecs[i].iov_base = recvBufs + (i * bufSz);
-        recvIovecs[i].iov_len  = bufSz;
-        recvMmsghdrs[i].msg_hdr.msg_name       = &addrs[i];
-        recvMmsghdrs[i].msg_hdr.msg_namelen    = addrLen;
-        recvMmsghdrs[i].msg_hdr.msg_iov        = &recvIovecs[i];
-        recvMmsghdrs[i].msg_hdr.msg_iovlen     = 1;
-        recvMmsghdrs[i].msg_hdr.msg_control    = recvCtrl + (i * ctrlSz);
-        recvMmsghdrs[i].msg_hdr.msg_controllen = ctrlSz;
-        recvMmsghdrs[i].msg_hdr.msg_flags      = 0;
-        recvMmsghdrs[i].msg_len                = 0;
+        /* Full setup on (re)layout; otherwise only restore the fields the
+         * kernel and post-processing mutate, for the previously-used slots.
+         * A grow only happens when total_sz (hence the dimensions) changed,
+         * so the layout check below already covers it. 's' keeps 'i' at 0
+         * until the allocation loop below. */
+        if (vlen   != pool->laid_vlen  ||
+            bufSz  != pool->laid_bufSz ||
+            ctrlSz != pool->laid_ctrlSz) {
+            unsigned int s;
+            for (s = 0; s < vlen; s++) {
+                recvIovecs[s].iov_base = recvBufs + (s * bufSz);
+                recvIovecs[s].iov_len  = bufSz;
+                recvMmsghdrs[s].msg_hdr.msg_name       = &addrs[s];
+                recvMmsghdrs[s].msg_hdr.msg_namelen    = addrLen;
+                recvMmsghdrs[s].msg_hdr.msg_iov        = &recvIovecs[s];
+                recvMmsghdrs[s].msg_hdr.msg_iovlen     = 1;
+                recvMmsghdrs[s].msg_hdr.msg_control    = recvCtrl + (s * ctrlSz);
+                recvMmsghdrs[s].msg_hdr.msg_controllen = ctrlSz;
+                recvMmsghdrs[s].msg_hdr.msg_flags      = 0;
+                recvMmsghdrs[s].msg_len                = 0;
+            }
+            pool->laid_vlen   = vlen;
+            pool->laid_bufSz  = bufSz;
+            pool->laid_ctrlSz = ctrlSz;
+            pool->used        = 0;
+        } else {
+            unsigned int s;
+            const unsigned int used = pool->used;
+            for (s = 0; s < used; s++) {
+                recvMmsghdrs[s].msg_hdr.msg_namelen    = addrLen;
+                recvMmsghdrs[s].msg_hdr.msg_control    = recvCtrl + (s * ctrlSz);
+                recvMmsghdrs[s].msg_hdr.msg_controllen = ctrlSz;
+                recvMmsghdrs[s].msg_hdr.msg_flags      = 0;
+                recvMmsghdrs[s].msg_len                = 0;
+            }
+        }
     }
 
     ESOCK_CNT_INC(env, descP, sockRef, esock_atom_read_tries, &descP->readTries, 1);
@@ -4238,6 +4267,8 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
      */
     readResult = sock_recvmmsg(descP->sock, recvMmsghdrs, vlen, flags, NULL);
     saveErrno = ESOCK_IS_ERROR(readResult) ? sock_errno() : 0;
+
+    pool->used = (readResult > 0) ? (unsigned int) readResult : 0;
 
     if (readResult == 0) {
         ret = esock_make_ok2(env, MKEL(env));
@@ -4311,8 +4342,8 @@ ERL_NIF_TERM essio_recvmmsg(ErlNifEnv*       env,
 
 cleanup:
     /* Free the binaries we still own; recv_create_bin may have handed some off
-     * (data == NULL -> FREE_BIN is a no-op). The bufs/ctrls arrays were zeroed
-     * above so slots the allocation loop never reached are skipped. */
+     * (data == NULL -> FREE_BIN is a no-op). 'i' bounds countToFree to slots
+     * the allocation loop populated (0 on the empty/error paths). */
     {
         unsigned int countToFree = (i < (unsigned int) readResult) ? i : (unsigned int) readResult;
         if (countToFree > 0) {

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -15814,8 +15814,8 @@ sendmmsg_dirty_scheduler_udp4(_Config) when is_list(_Config) ->
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Many recvmmsg calls on one socket, varying VLen/BufSz, to exercise the
-%% recvmmsg scratch-pool reuse and grow paths.
+%% Many recvmmsg calls on one socket, varying VLen/BufSz and received
+%% count, to exercise the recvmmsg scratch-pool reuse/grow/reset paths.
 %%
 recvmmsg_pool_reuse_udp4(_Config) when is_list(_Config) ->
     ?TT(?SECS(60)),
@@ -15842,6 +15842,13 @@ recvmmsg_pool_reuse_udp4(_Config) when is_list(_Config) ->
                     recvmmsg_pool_reuse_round(S1, S2, VLen, BufSz)
                 end,
                 Rounds ++ Rounds),
+            %% Fixed layout, varying received count -> incremental reset,
+            %% incl. large-VLen/few-received.
+            lists:foreach(
+                fun(Count) ->
+                    recvmmsg_pool_reuse_count(S1, S2, 64, 512, Count)
+                end,
+                [64, 1, 30, 64, 5, 1, 40, 64]),
             ok = socket:close(S1),
             ok = socket:close(S2),
             ok
@@ -15849,11 +15856,15 @@ recvmmsg_pool_reuse_udp4(_Config) when is_list(_Config) ->
     ).
 
 recvmmsg_pool_reuse_round(S1, S2, VLen, BufSz) ->
-    Expected = [list_to_binary(io_lib:format("r~p_m~p", [VLen, N]))
-                || N <- lists:seq(1, VLen)],
+    recvmmsg_pool_reuse_count(S1, S2, VLen, BufSz, VLen).
+
+%% Send Count datagrams, receive with a recvmmsg of capacity VLen (Count =< VLen).
+recvmmsg_pool_reuse_count(S1, S2, VLen, BufSz, Count) ->
+    Expected = [list_to_binary(io_lib:format("r~p_~p_m~p", [VLen, Count, N]))
+                || N <- lists:seq(1, Count)],
     lists:foreach(fun(D) -> ok = socket:send(S2, D) end, Expected),
     {ok, Received} = socket:recvmmsg(S1, VLen, BufSz, 0, [], infinity),
-    VLen = length(Received),
+    Count = length(Received),
     ReceivedData = [Data || Msg <- Received, [Data] <- [maps:get(iov, Msg)]],
     true = lists:sort(ReceivedData) =:= lists:sort(Expected),
     ok.

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -159,6 +159,7 @@
          recvmmsg_dirty_scheduler_udp4/1,
          sendmmsg_dirty_scheduler_udp4/1,
          recvmmsg_pool_reuse_udp4/1,
+         recvmmsg_ctrl_udp4/1,
 
          %% Socket IOCTL simple
          ioctl_simple1/1,
@@ -395,7 +396,8 @@ batch_cases() ->
      sendmmsg_invalid_msg_format,
      recvmmsg_dirty_scheduler_udp4,
      sendmmsg_dirty_scheduler_udp4,
-     recvmmsg_pool_reuse_udp4
+     recvmmsg_pool_reuse_udp4,
+     recvmmsg_ctrl_udp4
     ].
 
 ioctl_cases() ->
@@ -15868,6 +15870,56 @@ recvmmsg_pool_reuse_count(S1, S2, VLen, BufSz, Count) ->
     ReceivedData = [Data || Msg <- Received, [Data] <- [maps:get(iov, Msg)]],
     true = lists:sort(ReceivedData) =:= lists:sort(Expected),
     ok.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% recvmmsg with ancillary data: enable ip pktinfo on the receiver so each
+%% datagram carries a control message, and verify recvmmsg decodes a
+%% non-empty ctrl per message (exercises the ctrl output path with actual
+%% cmsg bytes, not just the data-only empty-ctrl case).
+%%
+recvmmsg_ctrl_udp4(_Config) when is_list(_Config) ->
+    ?TT(?SECS(10)),
+    tc_try(
+        recvmmsg_ctrl_udp4,
+        fun() ->
+            has_support_ipv4(),
+            has_recvmmsg_support()
+        end,
+        fun() ->
+            {ok, S1} = socket:open(inet, dgram, udp),
+            {ok, S2} = socket:open(inet, dgram, udp),
+            {ok, Addr} = inet:getaddr("localhost", inet),
+            ok = socket:bind(S1, #{family => inet, addr => Addr, port => 0}),
+            {ok, #{port := LocalPort}} = socket:sockname(S1),
+            ok = socket:connect(S2,
+                                #{family => inet, addr => Addr,
+                                  port => LocalPort}),
+            case socket:setopt(S1, ip, pktinfo, true) of
+                {error, _} ->
+                    _ = socket:close(S1),
+                    _ = socket:close(S2),
+                    skip("ip pktinfo not supported");
+                ok ->
+                    N = 5,
+                    lists:foreach(
+                        fun(I) -> ok = socket:send(S2, integer_to_binary(I)) end,
+                        lists:seq(1, N)),
+                    {ok, Received} = socket:recvmmsg(S1, 10, 0, 0, [], infinity),
+                    N = length(Received),
+                    lists:foreach(
+                        fun(#{ctrl := Ctrl}) ->
+                            true = lists:any(
+                                     fun(#{level := ip, type := pktinfo}) -> true;
+                                        (_) -> false
+                                     end, Ctrl)
+                        end, Received),
+                    ok = socket:close(S1),
+                    ok = socket:close(S2),
+                    ok
+            end
+        end
+    ).
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -158,6 +158,7 @@
          sendmmsg_invalid_msg_format/1,
          recvmmsg_dirty_scheduler_udp4/1,
          sendmmsg_dirty_scheduler_udp4/1,
+         recvmmsg_pool_reuse_udp4/1,
 
          %% Socket IOCTL simple
          ioctl_simple1/1,
@@ -393,7 +394,8 @@ batch_cases() ->
      sendmmsg_with_addresses_udp4,
      sendmmsg_invalid_msg_format,
      recvmmsg_dirty_scheduler_udp4,
-     sendmmsg_dirty_scheduler_udp4
+     sendmmsg_dirty_scheduler_udp4,
+     recvmmsg_pool_reuse_udp4
     ].
 
 ioctl_cases() ->
@@ -15809,6 +15811,52 @@ sendmmsg_dirty_scheduler_udp4(_Config) when is_list(_Config) ->
             ok
         end
     ).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Many recvmmsg calls on one socket, varying VLen/BufSz, to exercise the
+%% recvmmsg scratch-pool reuse and grow paths.
+%%
+recvmmsg_pool_reuse_udp4(_Config) when is_list(_Config) ->
+    ?TT(?SECS(60)),
+    tc_try(
+        recvmmsg_pool_reuse_udp4,
+        fun() ->
+            has_support_ipv4(),
+            has_recvmmsg_support()
+        end,
+        fun() ->
+            {ok, S1} = socket:open(inet, dgram, udp),
+            {ok, S2} = socket:open(inet, dgram, udp),
+            {ok, Addr} = inet:getaddr("localhost", inet),
+            ok = socket:bind(S1, #{family => inet, addr => Addr, port => 0}),
+            {ok, #{port := LocalPort}} = socket:sockname(S1),
+            ok = socket:connect(S2,
+                                #{family => inet, addr => Addr,
+                                  port => LocalPort}),
+            %% Varying VLen/BufSz (repeated) -> grow and pure-reuse paths.
+            Rounds = [{5, 64}, {50, 2048}, {3, 512}, {120, 256},
+                      {10, 4096}, {1, 8}, {80, 1024}],
+            lists:foreach(
+                fun({VLen, BufSz}) ->
+                    recvmmsg_pool_reuse_round(S1, S2, VLen, BufSz)
+                end,
+                Rounds ++ Rounds),
+            ok = socket:close(S1),
+            ok = socket:close(S2),
+            ok
+        end
+    ).
+
+recvmmsg_pool_reuse_round(S1, S2, VLen, BufSz) ->
+    Expected = [list_to_binary(io_lib:format("r~p_m~p", [VLen, N]))
+                || N <- lists:seq(1, VLen)],
+    lists:foreach(fun(D) -> ok = socket:send(S2, D) end, Expected),
+    {ok, Received} = socket:recvmmsg(S1, VLen, BufSz, 0, [], infinity),
+    VLen = length(Received),
+    ReceivedData = [Data || Msg <- Received, [Data] <- [maps:get(iov, Msg)]],
+    true = lists:sort(ReceivedData) =:= lists:sort(Expected),
+    ok.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Reduces per-call allocation on the socket recvmmsg path. These optimise the case when batches aren't saturated, that is, when we request 64 datagrams but actually receive 3 or 4, we skip preparing the work for the requested 64 datagrams as it is currently done and prepare only for the 3-4 received. In my load-tests saturated batches are so much faster than `inet` but when barely loaded, `socket` falls long behind.

Three commits:

1. Per-thread scratch pool — instead of malloc/memzero/free-ing the vlen*(bufSz+ctrlSz)+metadata block every call (~197KB at vlen=64/2K/1K, even for one datagram), keep one grow-to-fit block per scheduler thread via TSD. No locking and memory bounded by scheduler-thread count, not socket count.
2. `O(messages)` per-call setup — the stable mmsghdr/iovec fields are set once per layout; a matching reuse only restores the kernel/post-processing-mutated fields for the slots the previous call used. Drops the per-call memzero too. Setup cost is now `O(messages received)`, not `O(vlen)`.
3. Right-size output binaries — allocate the data binary at msgLen (no realloc-down) and the control binary at the actual received length (no ~1 KB control alloc for data-only datagrams).

Testing: socket_SUITE recvmmsg cases pass, plus new recvmmsg_pool_reuse_udp4 (reuse/grow/varying-count) and recvmmsg_ctrl_udp4 (ip pktinfo control path — first non-data-only coverage). Each commit compiles standalone.

A benchmark on Linux 6.18, AMD Ryzen 9 9950X3D:
```
base : stock OTP-29.0.3 release  |  8.72s cpu, 143 MB rss
ours : OTP-30/erts-17.0.3        |  9.15s cpu, 172 MB rss

v1_small         v=1    buf=2048   ctrl=0    k=1    | ns/dg    790.0 ->    630.0  (1.25x)  | ns/call     790.0 ->     630.0
v64_1dg          v=64   buf=2048   ctrl=0    k=1    | ns/dg   1000.0 ->    740.0  (1.35x)  | ns/call    1000.0 ->     740.0
v256_1dg         v=256  buf=2048   ctrl=0    k=1    | ns/dg   2000.0 ->   1340.0  (1.49x)  | ns/call    2000.0 ->    1340.0
v1024_1dg        v=1024 buf=2048   ctrl=0    k=1    | ns/dg   3260.0 ->   1320.0  (2.47x)  | ns/call    3260.0 ->    1320.0
v64_64k_1dg      v=64   buf=65536  ctrl=0    k=1    | ns/dg    910.0 ->    690.0  (1.32x)  | ns/call     910.0 ->     690.0
v1024_64k_1dg    v=1024 buf=65536  ctrl=0    k=1    | ns/dg   3290.0 ->   1430.0  (2.30x)  | ns/call    3290.0 ->    1430.0
v64_full         v=64   buf=2048   ctrl=0    k=64   | ns/dg    377.3 ->    291.6  (1.29x)  | ns/call   24150.0 ->   18660.0
v256_full        v=256  buf=2048   ctrl=0    k=200  | ns/dg    503.2 ->    354.0  (1.42x)  | ns/call  100641.0 ->   70800.0
v8_ctrl          v=8    buf=2048   ctrl=512  k=1    | ns/dg    860.0 ->    660.0  (1.30x)  | ns/call     860.0 ->     660.0
```

where `v` is the requested `vLen` and `k` the actual number of datagrams.