### PR TITLE
stdlib: Use SOURCE_DATE_EPOCH for in-memory zip entries

### DIFF
--- a/lib/stdlib/src/zip.erl
+++ b/lib/stdlib/src/zip.erl
@@ -2712,7 +2712,13 @@ binary_io({file_info, B}, _) ->
 	    is_binary(B) -> {regular, byte_size(B)};
 	    B =:= directory -> {directory, 0}
 	end,
-    Now = calendar:local_time(),
+    Now = case os:getenv("SOURCE_DATE_EPOCH") of
+              false ->
+                  calendar:local_time();
+              Epoch ->
+                  calendar:system_time_to_local_time(
+                    list_to_integer(Epoch), second)
+          end,
     #file_info{size = Size, type = Type,
 	       access = read_write, atime = Now,
 	       mtime = Now, ctime = Now, mode =


### PR DESCRIPTION
zip:create/2,3 stamps entries created from in-memory binaries with the current local time. This makes every archive built from binaries, in particular escripts created by escript:create/2 and Elixir's mix escript.build (e.g. the rabbitmq-server escripts), unreproducible. Honor `SOURCE_DATE_EPOCH` when set.

See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Helps with issue #4417

This patch was done while working on reproducible builds for openSUSE.