### PR TITLE
Have two reproducible timestamps

### DIFF
--- a/erts/emulator/utils/make_alloc_types
+++ b/erts/emulator/utils/make_alloc_types
@@ -190,7 +190,7 @@ print DST "/*
  * -----------------------------------------------------------------------
  *
  * 
- * Copyright Ericsson AB ", (1900 + (localtime)[5]), ". All Rights Reserved.
+ * Copyright Ericsson AB ", (1900 + (localtime($ENV{SOURCE_DATE_EPOCH} || time))[5]), ". All Rights Reserved.
  * 
  * Licensed under the Apache License, Version 2.0 (the \"License\");
  * you may not use this file except in compliance with the License.

--- a/make/ex_doc.exs
+++ b/make/ex_doc.exs
@@ -177,7 +177,17 @@ extras =
 
 annotations = Access.get(local_config, :annotations_for_docs, fn _ -> [] end)
 
-current_datetime = System.os_time() |> DateTime.from_unix!(:native)
+current_datetime =
+  case System.get_env("SOURCE_DATE_EPOCH") do
+    nil ->
+      System.os_time() |> DateTime.from_unix!(:native)
+
+    epoch ->
+      case Integer.parse(epoch) do
+        {seconds, ""} -> DateTime.from_unix!(seconds)
+        _ -> System.os_time() |> DateTime.from_unix!(:native)
+      end
+  end
 
 ## Check if we should treat warnings as errors
 warnings_as_errors =


### PR DESCRIPTION
* copyright year in doc footers
* for the year in generated erl_alloc_types.h

Helps with issue #4417