### PR TITLE
public_key: Compile ASN.1 modules serially for reproducible output

### DIFF
--- a/lib/public_key/asn1/Makefile
+++ b/lib/public_key/asn1/Makefile
@@ -108,6 +108,12 @@ endif
 # Targets
 # ----------------------------------------------------
 
+# The RFC 5912 modules import each other cyclically. Whether a sibling
+# module's checked .asn1db exists when a module is compiled changes the
+# numbering of generated internal_object_set_argument_N names, so the
+# compilations must run in a fixed order for reproducible output.
+.NOTPARALLEL:
+
 $(TYPES): $(TARGET_FILES) $(HRL_FILES)
 
 clean:


### PR DESCRIPTION
The ASN.1 compiler names anonymous parameterized-type/object-set arguments `internal_object_set_argument_N` using a global counter. How many instantiations run while checking a module depends on whether the checked .asn1db files of its imports already exist. The RFC 5912 modules import each other cyclically and the Makefile has no inter-module dependencies, so under make -jN the .asn1db availability is a race and atoms like `getenc_internal_object_set_argument_2` vs `_1` differ between builds. Serialize this directory to get a fixed order.

Helps with issue #4417

This patch was done while working on reproducible builds for openSUSE.