### PR TITLE
Sbarvick/ssh replace options race fix

### DIFF
--- a/lib/ssh/src/ssh_system_sup.erl
+++ b/lib/ssh/src/ssh_system_sup.erl
@@ -3,7 +3,7 @@
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
-%% Copyright Ericsson AB 2008-2025. All Rights Reserved.
+%% Copyright Ericsson AB 2008-2026. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@
          addresses/1,
          get_options/2,
          get_acceptor_options/1,
-         restart_acceptor/2
+         restart_acceptor/2,
+         start_restart_guard/0
         ]).
 
 %% Supervisor callback
@@ -173,20 +174,28 @@ get_acceptor_options(SysPid) ->
 restart_acceptor(SysPid, Options0) ->
     case get_daemon_listen_address(SysPid) of
         {ok,Address} ->
-            try
-                stop_listener(SysPid)
-            of
-                ok ->
-                    Options = refresh_lsocket(Options0),
-                    start_acceptor(SysPid, Address, Options)
-            catch
-                error:_Error ->
-                    Options = refresh_lsocket(Options0),
-                    start_acceptor(SysPid, Address, Options)
+            GuardId = {?MODULE, restart_acceptor, make_ref()},
+            GuardSpec =
+                #{id          => GuardId,
+                  start       => {?MODULE, start_restart_guard, []},
+                  restart     => temporary,
+                  significant => true,
+                  type        => worker},
+            case supervisor:start_child(SysPid, GuardSpec) of
+                {ok,_GuardPid} ->
+                    try restart_acceptor(SysPid, Address, Options0)
+                    after
+                        remove_restart_guard(SysPid, GuardId)
+                    end;
+                {error,Error} ->
+                    {error,Error}
             end;
         {error,Error} ->
             {error,Error}
     end.
+
+start_restart_guard() ->
+    {ok,spawn_link(fun restart_guard/0)}.
 
 %%%=========================================================================
 %%%  Supervisor callback
@@ -229,6 +238,33 @@ get_options(Sup, Address = #address{}) ->
 %%%=========================================================================
 %%%  Internal functions
 %%%=========================================================================
+
+restart_acceptor(SysPid, Address, Options0) ->
+    try
+        stop_listener(SysPid)
+    of
+        ok ->
+            Options = refresh_lsocket(Options0),
+            start_acceptor(SysPid, Address, Options)
+    catch
+        error:_Error ->
+            Options = refresh_lsocket(Options0),
+            start_acceptor(SysPid, Address, Options)
+    end.
+
+remove_restart_guard(SysPid, GuardId) ->
+    try
+        _ = supervisor:terminate_child(SysPid, GuardId),
+        _ = supervisor:delete_child(SysPid, GuardId),
+        ok
+    catch
+        exit:{noproc,_} -> ok
+    end.
+
+restart_guard() ->
+    receive
+        _ -> restart_guard()
+    end.
 
 %% A separate function because this spec is need in >1 places
 acceptor_sup_child_spec(SysSup, Address, Options) ->

--- a/lib/ssh/test/ssh_options_SUITE.erl
+++ b/lib/ssh/test/ssh_options_SUITE.erl
@@ -88,6 +88,7 @@
          raw_option/1,
          config_file/1,
          config_file_modify_algorithms_order/1,
+         daemon_replace_options_last_connection_race/1,
          daemon_replace_options_simple/1,
          daemon_replace_options_algs/1,
          daemon_replace_options_algs_connect/1,
@@ -160,6 +161,7 @@ all() ->
      raw_option,
      config_file,
      config_file_modify_algorithms_order,
+     daemon_replace_options_last_connection_race,
      daemon_replace_options_simple,
      daemon_replace_options_algs,
      daemon_replace_options_algs_connect,
@@ -1912,6 +1914,66 @@ config_file_modify_algorithms_order(Config) ->
     end.
 
     
+%%--------------------------------------------------------------------
+daemon_replace_options_last_connection_race(Config) ->
+    {DaemonRef, Host, Port} = ssh_test_lib:std_daemon(Config, []),
+    ConnectionRef = ssh_test_lib:std_connect(Config, Host, Port, []),
+    ConnectionSup = connection_sup(DaemonRef),
+    TestPid = self(),
+    PauseRef = make_ref(),
+    DebugFun =
+        fun(armed,
+            {in, {'$gen_call', _,
+                  {delete_child, {ssh_acceptor_sup, _}}}}, _) ->
+                TestPid ! {listener_stopped, PauseRef},
+                receive
+                    {continue_restart, PauseRef} -> triggered
+                end;
+           (State, _, _) ->
+                State
+        end,
+    ok = sys:install(DaemonRef, {DebugFun, armed}),
+    spawn_link(
+      fun() ->
+              Result =
+                  try ssh:daemon_replace_options(DaemonRef, []) of
+                      Reply -> Reply
+                  catch
+                      exit:Reason -> {exit, Reason}
+                  end,
+              TestPid ! {replace_result, PauseRef, Result}
+      end),
+    receive
+        {listener_stopped, PauseRef} -> ok
+    end,
+    ok = ssh:close(ConnectionRef),
+    ok = wait_for_exit_message(DaemonRef, ConnectionSup, 100),
+    DaemonRef ! {continue_restart, PauseRef},
+    receive
+        {replace_result, PauseRef, Result} ->
+            {ok, DaemonRef} = Result
+    end,
+    true = is_process_alive(DaemonRef),
+    {ok, _} = ssh:daemon_info(DaemonRef).
+
+connection_sup(DaemonRef) ->
+    [{_, ConnectionSup, supervisor, [ssh_connection_sup]}] =
+        [Child || Child = {_, _, supervisor, [ssh_connection_sup]} <-
+                      supervisor:which_children(DaemonRef)],
+    ConnectionSup.
+
+wait_for_exit_message(_, _, 0) ->
+    {error, timeout};
+wait_for_exit_message(DaemonRef, ConnectionSup, Attempts) ->
+    {messages, Messages} = process_info(DaemonRef, messages),
+    case lists:keyfind(ConnectionSup, 2, Messages) of
+        {'EXIT', ConnectionSup, _} ->
+            ok;
+        false ->
+            timer:sleep(10),
+            wait_for_exit_message(DaemonRef, ConnectionSup, Attempts - 1)
+    end.
+
 %%--------------------------------------------------------------------
 daemon_replace_options_simple(Config) ->
     SysDir = proplists:get_value(data_dir, Config),


### PR DESCRIPTION
Fixes a race in ssh:daemon_replace_options/2 where the daemon supervisor could automatically shut down if its final active connection terminated while the listener was being replaced. A temporary significant guard child now keeps the supervisor alive for the duration of the replacement. A deterministic regression test reproduces the original noproc failure and verifies the corrected behavior.

This issue was observed in older systems in which ssh:daemon_replace_options/2 was called during reconfiguration and typically included having listening ipv4 and ipv6 procs.

This fix was largely written by Codex, with much prompting and refining.