### PR TITLE
ssh: Fix flaky tests on weak machines

### DIFF
--- a/lib/ssh/test/ssh_sftp_SUITE.erl
+++ b/lib/ssh/test/ssh_sftp_SUITE.erl
@@ -285,7 +285,8 @@ init_per_testcase(read_6GB, Config) ->
             case {os:type(), erlang:system_info(system_architecture)} of
                 {{win32, _}, _} ->
                     {skip, "/dev/zero not available on Windows"};
-                {_, "aarch64"} ->
+                %% Raspberry Pi (frodo) — too slow for 6GB SFTP read
+                {_, "aarch64-unknown-linux-gnu"} ->
                     {skip, "machine too slow for test"};
                 _ ->
                     init_per_testcase(read_6GB_prepare_openssh_server, Config)

--- a/lib/ssh/test/ssh_to_openssh_SUITE.erl
+++ b/lib/ssh/test/ssh_to_openssh_SUITE.erl
@@ -524,7 +524,7 @@ tunnel_in_erlclient_erlserver_denied(Config) ->
 
 %%--------------------------------------------------------------------
 tunnel_in_erlclient_openssh_server(_Config) ->
-    C = ssh_test_lib:connect(?SSH_DEFAULT_PORT, [?ALIVE]),
+    C = ssh_test_lib:connect_with_retry(?SSH_DEFAULT_PORT, [?ALIVE]),
     {ToSock, ToHost, ToPort} = tunneling_listner(),
     
     ListenHost = {127,0,0,1},
@@ -556,7 +556,7 @@ tunnel_out_erlclient_erlserver(Config) ->
 
 %%--------------------------------------------------------------------
 tunnel_out_erlclient_openssh_server(_Config) ->
-    C = ssh_test_lib:connect(?SSH_DEFAULT_PORT, [?ALIVE]),
+    C = ssh_test_lib:connect_with_retry(?SSH_DEFAULT_PORT, [?ALIVE]),
     {ToSock, ToHost, ToPort} = tunneling_listner(),
     
     ListenHost = {127,0,0,1},


### PR DESCRIPTION
Fix read_6GB skip: use exact match for "aarch64-unknown-linux-gnu" instead of the non-matching "aarch64". The system_architecture returns the full GNU triplet, so the skip never triggered.

Fix tunnel tests: use connect_with_retry for the initial SSH connection to localhost OpenSSH, handling transient econnrefused under load on slow machines.