### PR TITLE
erts: Fix out-of-bounds read on distributed priority send of a fragmented message

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -6187,8 +6187,10 @@ handle_altact_msg(Process *c_p, ErtsSigRecvTracing *tracing,
                 /* drop faulty encoded external message... */
                 return cnt;
             }
-            cnt += insert_prepared_prio_msg(c_p, tracing, mp, ERL_MESSAGE_TERM(mp),
-                                            token, next_nm_sig);
+            cnt += insert_prepared_prio_msg_attached(c_p, tracing, mp,
+                                                     mp->data.attached,
+                                                     ERL_MESSAGE_TERM(mp), token,
+                                                     next_nm_sig);
         }
         break;
     }

--- a/erts/emulator/test/signal_SUITE.erl
+++ b/erts/emulator/test/signal_SUITE.erl
@@ -1826,6 +1826,7 @@ priority_messages_order_test(Node) ->
     {priority_messages, true} = proc_info(Rcvr, priority_messages),
 
     {priority_alias, PrioAlias} = receive {priority_alias, _} = PA -> PA end,
+    Large = binary:copy(<<0>>, 1 bsl 20),
 
     {priority_messages, true} = proc_info(Rcvr, priority_messages),
 
@@ -1850,7 +1851,7 @@ priority_messages_order_test(Node) ->
     PrioAlias ! {msg, 6},
     erlang:send(PrioAlias, {prio_msg, 1}, [priority]),
     erlang:send(PrioAlias, {msg, 7}, []),
-    erlang:send(PrioAlias, prio_msg_2, [priority]),
+    erlang:send(PrioAlias, {prio_msg, Large}, [priority]),
     erlang:send(Rcvr, {msg, 8}, [priority]),
     wait_until(fun () -> msg_received(Rcvr, {msg, 8}) end),
     exit(LinkProc4, {link_exit, 2}),
@@ -1868,7 +1869,7 @@ priority_messages_order_test(Node) ->
               {'DOWN', Mon1, process, MonProc1, prio_down_1},
               {'EXIT', Parent, prio_func_exit_1},
               {prio_msg, 1},
-              prio_msg_2,
+              {prio_msg, Large},
               {'EXIT', LinkProc3, {prio_link_exit, 2}},
               {'DOWN', Mon3, process, MonProc3, {prio_down, 2}},
 


### PR DESCRIPTION
# Fix out-of-bounds read on distributed priority send of a fragmented message

- #11416

## What happens

A distributed `[priority]` send larger than 32 KiB to an `erlang:alias([priority])` triggers an out-of-bounds read while the receiving node saves the message: the emulator reads 8 bytes past a 40-byte allocation. It's deterministic on the first such message, on stock OTP with no third-party code. Under ASan it aborts with `heap-buffer-overflow`; on a normal build the read lands in unrelated memory and the node can crash.

## Root cause

When a distributed message arrives fragmented, `handle_altact_msg()` (`erts/emulator/beam/erl_proc_sig_queue.c`) allocates a bare message reference and attaches the fragment *separately*:

```c
mp = erts_alloc_message(0, NULL);      /* no embedded heap fragment */
...
mp->data.heap_frag = sig->hfrag.next;  /* fragment is SEPARATELY attached */
```

`erts_alloc_message(0, NULL)` returns a 40-byte `ErtsMessage` with no room for an embedded `ErlHeapFragment`.

The priority path then inserts that message through `insert_prepared_prio_msg()`, a thin wrapper that hard-codes the "combined" (embedded-fragment) case:

```c
return insert_prepared_prio_msg_attached(c_p, tracing, sig,
                                         ERTS_MSG_COMBINED_HFRAG, ...);
```

So a message whose fragment is *separately attached* gets tagged `ERTS_MSG_COMBINED_HFRAG`, which claims the fragment is *embedded* in the message allocation. `erts_save_message_in_proc()` (`erts/emulator/beam/erl_message.c:981`) trusts that tag and reads the supposedly-embedded fragment's `off_heap.first` at offset 48 of the 40-byte region — hence the 8-byte over-read.

Only sends above the 32 KiB fragmentation threshold reach this branch, which is why smaller priority messages are fine.

## The fix

`erts/emulator/beam/erl_proc_sig_queue.c` — pass the message's actual attachment through instead of reclassifying it as combined:

```c
cnt += insert_prepared_prio_msg_attached(c_p, tracing, mp,
                                         mp->data.attached,
                                         ERL_MESSAGE_TERM(mp), token,
                                         next_nm_sig);
```

`mp->data.attached` is exactly what the branch above just set, so the fragment keeps its real ownership and the save path no longer reads a fragment that was never embedded. The non-fragmented priority paths are untouched and still go through `insert_prepared_prio_msg()`.

## Regression test

`erts/emulator/test/signal_SUITE.erl` — `priority_messages_order` only ever sent small priority messages before, so it never crossed the fragmentation threshold. Its distributed priority message is now 1 MiB:

```erlang
Large = binary:copy(<<0>>, 1 bsl 20),
...
erlang:send(PrioAlias, {prio_msg, Large}, [priority]),
```

with the expected-message list updated to match. The case already runs twice — once against a local process, once against a `?CT_PEER()` node — so the 1 MiB message crosses a real distribution link, and it still asserts the *ordering* of that message against the surrounding link/monitor/exit signals. Unpatched, the case aborts; patched, it passes.

## How it was verified

Everything below ran against a Clang ASan build of this tree (`otp_release=30 erts=17.0.4 emu_type=asan`).

**A/B on the minimal reproducer.** Two builds differing in exactly one file (`erts/emulator/beam/erl_proc_sig_queue.c`), same two-node script: node `v` creates `alias([priority])`, node `u` sends 1 MiB with `[priority]`, `v` acknowledges receipt.

| | fix reverted | fix applied |
| --- | --- | --- |
| node `v` exit | **134** (SIGABRT) | **0** |
| node `u` exit | 1 (timeout, peer died) | **0** |
| 1 MiB delivered + acked | no | yes (1048576 bytes) |
| sanitizer report | yes | none |

The over-read on the unpatched build, showing the read 8 bytes past the 40-byte allocation made in `handle_altact_msg()`:

```
==427==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 8 at 0x50400069ed80 thread T6
    #0 erts_save_message_in_proc   erts/emulator/beam/erl_message.c:981:51
    #1 beam_jit_remove_message     erts/emulator/beam/jit/beam_jit_common.cpp:1170:5

0x50400069ed80 is located 8 bytes after 40-byte region [0x50400069ed50,0x50400069ed78)
allocated by thread T6 here:
    #1 erts_alloc_message          erts/emulator/beam/erl_message.h:578:22
    #2 handle_altact_msg           erts/emulator/beam/erl_proc_sig_queue.c:6163:18
    #3 erts_proc_sig_handle_incoming erts/emulator/beam/erl_proc_sig_queue.c:6874:20
```

With the fix applied the same script produces no sanitizer output and both nodes exit 0.

**OTP regression under ASan.** `signal_SUITE:priority_messages_order` via `ct:run_test/1`: `{1,0,{0,0}}` (1 ok, 0 failed, 0 skipped), no sanitizer files.

## Affected versions

Confirmed on OTP 29.0.4 (ERTS 17.0.4) and reproduced on `master` (OTP 30 dev, ERTS 17.0.4); also seen on 28.4.1. Priority messages are an OTP 28 feature, so 28.x and 29.x are affected and ≤27 is not.
