### PR TITLE
stdlib: Add check for badly formed `{Name,Arity}` attributes

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -319,6 +319,8 @@ format_error_1({invalid_unsafe,D}) ->
 format_error_1({bad_unsafe,{F,A}}) ->
     {~"unsafe function ~tw/~w undefined or not exported",
      [F,A]};
+format_error_1({invalid_fa_attribute,D}) ->
+    {~"badly formed attribute ~tw", [D]};
 format_error_1({bad_nowarn_unused_function,{F,A}}) ->
     {~"function ~tw/~w undefined", [F,A]};
 format_error_1({bad_nowarn_unused_function,{F,A},GuessFA}) ->
@@ -1898,8 +1900,7 @@ nowarn_function(Tag, Opts) ->
 func_location_warning(Type, Fs, St) ->
     foldl(fun ({F,Anno}, St0) -> add_warning(Anno, {Type,F}, St0) end, St, Fs).
 
-func_location_error(Type, [{F,Anno}|Fs], St0, FAList) ->
-    {Name, Arity} = F,
+func_location_error(Type, [{{Name, Arity}=F,Anno}|Fs], St0, FAList) ->
     PossibleAs = lists:sort([A || {FName, A} <:- FAList, FName =:= Name]),
     case PossibleAs of
         [] ->
@@ -1916,6 +1917,9 @@ func_location_error(Type, [{F,Anno}|Fs], St0, FAList) ->
             St1 = add_error(Anno, {Type,F,{Name,PossibleAs}}, St0),
             func_location_error(Type, Fs, St1, FAList)
     end;
+func_location_error(Type, [{F,Anno}|Fs], St0, FAList) ->
+    St1 = add_error(Anno, {invalid_fa_attribute,F}, St0),
+    func_location_error(Type, Fs, St1, FAList);
 func_location_error(_, [], St, _) ->
     St.
 

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -95,7 +95,8 @@
          illegal_zip_generator/1,
          record_info_0/1,
          coverage/1,
-         native_records/1]).
+         native_records/1,
+         invalid_attribute/1]).
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -137,7 +138,8 @@ all() ->
      illegal_zip_generator,
      record_info_0,
      coverage,
-     native_records].
+     native_records,
+     invalid_attribute].
 
 groups() -> 
     [{unused_vars_warn, [],
@@ -6059,6 +6061,17 @@ native_records(Conf) ->
           }
          ],
     [] = run(Conf, Ts),
+    ok.
+
+invalid_attribute(Config) ->
+    Ts = [{invalid_fa,
+           <<"-compile({nowarn_unused_function,[{a/0,b/0,0}]}).
+            ">>,
+           {[]},
+           {errors,[{{1,22},erl_lint,{invalid_fa_attribute,{{a,0},{b,0},0}}}],[]}}
+           ],
+    [] = run(Config,Ts),
+
     ok.
 
 %%%


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11397