### PR TITLE
compiler: Fix crash when calling `erlang:0()` inside fun

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -2318,7 +2318,7 @@ is_simple_case_arg(_) -> false.
 %%
 
 is_bool_expr(#c_call{module=#c_literal{val=erlang},
-		     name=#c_literal{val=Name},args=Args}) ->
+		     name=#c_literal{val=Name},args=Args}) when is_atom(Name) ->
     NumArgs = length(Args),
     erl_internal:comp_op(Name, NumArgs) orelse
 	erl_internal:new_type_test(Name, NumArgs) orelse

--- a/lib/compiler/test/compilation_SUITE.erl
+++ b/lib/compiler/test/compilation_SUITE.erl
@@ -62,7 +62,8 @@
          vsn_3/1,
          infinite_loop/0,infinite_loop/1,
          native_record/1,
-         use_nifs/1,gh_11352/1,gh_11367/1]).
+         use_nifs/1,gh_11352/1,gh_11367/1,
+         gh_11414/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
@@ -92,7 +93,7 @@ groups() ->
        otp_7202,on_load,on_load_inline,
        string_table,otp_8949_a,split_cases,
        infinite_loop, native_record,
-       use_nifs,gh_11352,gh_11367]}].
+       use_nifs,gh_11352,gh_11367,gh_11414]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -148,6 +149,7 @@ end_per_group(_GroupName, Config) ->
 ?comp(use_nifs).
 ?comp(gh_11352).
 ?comp(gh_11367).
+?comp(gh_11414).
 
 infinite_loop() -> [{timetrap,{minutes,1}}].
 ?comp(infinite_loop).

--- a/lib/compiler/test/compilation_SUITE_data/gh_11414.erl
+++ b/lib/compiler/test/compilation_SUITE_data/gh_11414.erl
@@ -1,0 +1,30 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(gh_11414).
+-export([?MODULE/0]).
+
+?MODULE() ->
+    ok.
+
+run() ->
+    fun(Res) -> Res = erlang:0() end.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11414