### PR TITLE
Cuddle epmd tests

### DIFF
--- a/erts/epmd/test/epmd_SUITE.erl
+++ b/erts/epmd/test/epmd_SUITE.erl
@@ -398,7 +398,13 @@ get_port_nr(Config) when is_list(Config) ->
 
 %% Register with slow write and ask about port nr
 slow_get_port_nr(Config) when is_list(Config) ->
-    port_request([?EPMD_PORT2_REQ,d,$f,d,$o,d,$o]).
+    %% Pause for 200ms. The packet timeout is 1 second as per ?EPMDARGS defined
+    %% above.
+    Pause = {pause, 200},
+    port_request([?EPMD_PORT2_REQ,
+                  Pause,$f,
+                  Pause,$o,
+                  Pause,$o]).
 
 
 % Internal function used above
@@ -1024,9 +1030,8 @@ recv(Sock, Len, Timeout) ->
             exit(1)
     end.
 
-%% Send data to socket. The list can be non flat and contain
-%% the atom 'd' or tuple {d,Seconds} where this is delay
-%% put in between the sent characters.
+%% Send data to socket. The list can be nested and contain {pause,Milliseconds}
+%% to pause that many milliseconds before sending the next character.
 
 send(Sock, SendSpec) ->
     case send(SendSpec, [], Sock) of
@@ -1055,12 +1060,10 @@ send([List | Spec], RevBytes, Sock) when is_list(List) ->
         Other ->
             Other
     end;
-send([d | Spec], RevBytes, Sock) ->
-    send([{d,1000} | Spec], RevBytes, Sock);
-send([{d,S} | Spec], RevBytes, Sock) ->
+send([{pause, Ms} | Spec], RevBytes, Sock) ->
     case send_direct(Sock, lists:reverse(RevBytes)) of
         ok ->
-            timer:sleep(S),
+            timer:sleep(Ms),
             send(Spec, [], Sock);
         Any ->
             Any

--- a/erts/epmd/test/epmd_SUITE.erl
+++ b/erts/epmd/test/epmd_SUITE.erl
@@ -374,9 +374,11 @@ parse_line([$n,$a,$m,$e,$ | Buf0]) ->
         {Name, Buf1}  ->
             case Buf1 of
                 [$a,$t,$ ,$p,$o,$r,$t,$ | Buf2] ->
-                    case catch list_to_integer(Buf2) of
-                        {'EXIT', _} -> error;
+                    try list_to_integer(Buf2) of
                         Port -> {ok, {Name, Port}}
+                    catch
+                        _:_ ->
+                            error
                     end;
                 _ -> error
             end;


### PR DESCRIPTION
Our tests run epmd with a `packet_timeout` of 1 second, which causes our tests to fail more often now that the `packet_timeout` is a _packet timeout_ instead of an _activity timeout_. This commit shortens the artificial delay accordingly.