### PR TITLE
erts: Fix crash with `term_to_iovec/2` for large binary

### DIFF
--- a/erts/emulator/beam/erl_term_hashing.c
+++ b/erts/emulator/beam/erl_term_hashing.c
@@ -589,8 +589,8 @@ erts_iov_block_hash(Uint32 *hashp, Uint *sizep, ErtsIovBlockHashState *state)
     ErtsBlockHashHelperCtx *hctx = &state->hctx;
     SysIOVec *iov = state->iov;
     Uint vlen = state->vlen;
-    int vix = state->vix;
-    int ix = state->ix;
+    Uint vix = state->vix;
+    Uint ix = state->ix;
     Uint cix = 0;
     byte *final_bytes;
     Uint no_final_bytes;
@@ -600,7 +600,7 @@ erts_iov_block_hash(Uint32 *hashp, Uint *sizep, ErtsIovBlockHashState *state)
 
     do {
         Uint bsz, csz;
-        int left;
+        Uint left;
         byte *ptr;
 
         ASSERT((cix % BLOCK_HASH_BYTES_PER_ITER) == 0);

--- a/erts/emulator/beam/erl_term_hashing.h
+++ b/erts/emulator/beam/erl_term_hashing.h
@@ -59,8 +59,8 @@ typedef struct {
     SysIOVec* iov;
     Uint vlen;
     Uint tot_len;
-    int vix;
-    int ix;
+    Uint vix;
+    Uint ix;
 } ErtsIovBlockHashState;
 
 Uint32 make_hash2(Eterm);

--- a/erts/emulator/test/hash_SUITE.erl
+++ b/erts/emulator/test/hash_SUITE.erl
@@ -51,7 +51,8 @@
          test_phash2_with_small_unaligned_sub_binary/1,
          test_phash2_with_large_bin/1,
          test_phash2_with_large_unaligned_sub_binary/1,
-         test_phash2_with_super_large_unaligned_sub_binary/1]).
+         test_phash2_with_super_large_unaligned_sub_binary/1,
+         test_iovblockhash/1]).
 
 %%
 %% Define to run outside of test server
@@ -108,6 +109,7 @@ all() ->
      test_hash_zero, test_phash2_binary_aligned_and_unaligned_equal,
      test_phash2_4GB_plus_bin,
      test_phash2_10MB_plus_bin,
+     test_iovblockhash,
      {group, phash2_benchmark_tests},
      {group, phash2_benchmark}].
 
@@ -620,6 +622,22 @@ duplicate_iolist(IOList, 0) ->
 duplicate_iolist(IOList, NrOfTimes) ->
     duplicate_iolist([IOList, IOList], NrOfTimes - 1).
 
+%% This testcase needs >3 GB of free memory.
+test_iovblockhash(Config) when is_list(Config) ->
+    run_when_enough_resources(
+      fun() ->
+              {ok, Peer, N} = ?CT_PEER(),
+              erpc:call(N,
+                        fun() ->
+                                test_iovblockhash_1()
+                        end),
+              peer:stop(Peer)
+      end).
+
+test_iovblockhash_1() ->
+    BigBin = binary:copy(<<0>>, 3 bsl 30),
+    _ = term_to_iovec(BigBin, [local]),
+    ok.
 
 %% This functions is written very carefully so that the binaries
 %% created are released as quickly as possible. If they are not released


### PR DESCRIPTION
Previously, when the binary is larger than 3GiB, calling `term_to_iovec/2` with `local` could crash the emulator.