### PR TITLE
erts: Fix bug in `is_in_range` instruction for x86 JIT

### DIFF
--- a/erts/emulator/beam/jit/x86/instr_common.cpp
+++ b/erts/emulator/beam/jit/x86/instr_common.cpp
@@ -2717,14 +2717,17 @@ void BeamModuleAssembler::emit_is_in_range(ArgLabel const &Small,
                         RET);
                     a.ja(resolve_beam_label(Small));
                 },
-                ARG1);
+                ARG1,
+                RET);
     } else {
-        preserve_cache([&]() {
-            cmp(ARG1, Min.as<ArgImmed>().get(), RET);
-            a.jl(resolve_beam_label(Small));
-            cmp(ARG1, Max.as<ArgImmed>().get(), RET);
-            a.jg(resolve_beam_label(Large));
-        });
+        preserve_cache(
+                [&]() {
+                    cmp(ARG1, Min.as<ArgImmed>().get(), RET);
+                    a.jl(resolve_beam_label(Small));
+                    cmp(ARG1, Max.as<ArgImmed>().get(), RET);
+                    a.jg(resolve_beam_label(Large));
+                },
+                RET);
     }
 
 test_done:

--- a/erts/emulator/test/op_SUITE.erl
+++ b/erts/emulator/test/op_SUITE.erl
@@ -26,7 +26,7 @@
          bsl_bsr/1,logical/1,t_not/1,relop_simple/1,relop/1,
          complex_relop/1,unsafe_fusing/1,
          range_tests/1,combined_relops/1,typed_relop/1,
-         term_equivalence/1]).
+         term_equivalence/1,is_in_range/1]).
 
 -import(lists, [foldl/3,flatmap/2]).
 
@@ -37,7 +37,8 @@ suite() ->
 all() ->
     [bsl_bsr, logical, t_not, relop_simple, relop,
      complex_relop, unsafe_fusing, range_tests,
-     combined_relops, typed_relop, term_equivalence].
+     combined_relops, typed_relop, term_equivalence,
+     is_in_range].
 
 %% Test the bsl and bsr operators.
 bsl_bsr(Config) when is_list(Config) ->
@@ -1045,6 +1046,28 @@ cmp_float(A0, B0) ->
         A < B -> -1;
         A > B -> +1;
         A =:= B -> 0
+    end.
+
+is_in_range(_Config) ->
+    10.0 = is_in_range_1(id(10)),
+    0.0 = is_in_range_1(id(0)),
+    100.0 = is_in_range_1(id(100)),
+    101 = is_in_range_2(id(100)),
+    0 = is_in_range_2(id(0)),
+    ok.
+
+is_in_range_1(X) ->
+    D = X band 16#FFFFFFFF,
+    case D > 0 andalso D < 16#80000000 of
+        true  -> D / 1;
+        false -> 0.0
+    end.
+
+is_in_range_2(X) ->
+    D = X band 16#FFFFFFFF,
+    case D > 0 andalso D < 16#80000000 of
+        true  -> D + 1;
+        false -> 0
     end.
 
 %% Converts a float to a number which, when compared with other such converted


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11419.
aarch64 is not affected.