### PR TITLE
edoc: fix uris for link references to otp on-line documentation

### DIFF
--- a/lib/edoc/src/edoc.hrl
+++ b/lib/edoc/src/edoc.hrl
@@ -44,7 +44,7 @@
 -define(DEFAULT_FILE_SUFFIX, ".html").
 -define(DEFAULT_DOCLET, edoc_doclet).
 -define(DEFAULT_LAYOUT, edoc_layout).
--define(APP_DEFAULT, "http://www.erlang.org/edoc/doc").
+-define(APP_DEFAULT, "http://www.erlang.org/doc/apps").
 -define(CURRENT_DIR, ".").
 -define(SOURCE_DIR, "src").
 -define(EBIN_DIR, "ebin").

--- a/lib/edoc/src/edoc_refs.erl
+++ b/lib/edoc/src/edoc_refs.erl
@@ -187,8 +187,8 @@ module_absref(M, Env) ->
 
 app_ref(A, Env) ->
     case (Env#env.apps)(A) of
-	"" when Env#env.app_default == ?APP_DEFAULT ->
-	    join_uri(Env#env.app_default, escape_uri(atom_to_list(A)));
+        "" when Env#env.app_default == ?APP_DEFAULT ->
+            join_uri(Env#env.app_default, escape_uri(atom_to_list(A)));
 	"" ->
 	    join_uri(Env#env.app_default,
 		     join_uri(escape_uri(atom_to_list(A)), ?EDOC_DIR));

--- a/lib/edoc/src/edoc_refs.erl
+++ b/lib/edoc/src/edoc_refs.erl
@@ -187,6 +187,8 @@ module_absref(M, Env) ->
 
 app_ref(A, Env) ->
     case (Env#env.apps)(A) of
+	"" when Env#env.app_default == ?APP_DEFAULT ->
+	    join_uri(Env#env.app_default, escape_uri(atom_to_list(A)));
 	"" ->
 	    join_uri(Env#env.app_default,
 		     join_uri(escape_uri(atom_to_list(A)), ?EDOC_DIR));

--- a/lib/edoc/test/edoc_SUITE.erl
+++ b/lib/edoc/test/edoc_SUITE.erl
@@ -31,6 +31,7 @@
 -module(edoc_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("xmerl/include/xmerl.hrl").
 
 %% Test server specific exports
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
@@ -39,13 +40,15 @@
 %% Test cases
 -export([app/1,appup/1,build_std/1,build_map_module/1,otp_12008/1,
          build_app/1, otp_14285/1, infer_module_app_test/1,
-         module_with_feature/1, module_with_maybe/1, module_with_nominal/1]).
+         module_with_feature/1, module_with_maybe/1, module_with_nominal/1,
+         otp_reference/1]).
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() ->
     [app,appup,build_std,build_map_module,otp_12008, build_app, otp_14285,
-     infer_module_app_test, module_with_feature, module_with_nominal].
+     infer_module_app_test, module_with_feature, module_with_nominal,
+     otp_reference].
 
 groups() -> 
     [].
@@ -196,3 +199,32 @@ module_with_nominal(Config) ->
     PreprocessOpts = [{preprocess, true}, {dir, PrivDir}],
     ok = edoc:files([Source], PreprocessOpts),
     ok.
+
+otp_reference(Config) ->
+    DataDir = ?config(data_dir, Config),
+    Source = filename:join(DataDir, "module_with_links.erl"),
+    {module_with_links, Module} = edoc:get_doc(Source),
+    Functions = lists:keyfind(functions,
+	    #xmlElement.name, Module#xmlElement.content),
+    [Start] = Functions#xmlElement.content,
+    Description = lists:keyfind(description,
+	    #xmlElement.name, Start#xmlElement.content),
+    FullDescription = lists:keyfind(fullDescription,
+	    #xmlElement.name, Description#xmlElement.content),
+    A = lists:keyfind(a,
+	    #xmlElement.name, FullDescription#xmlElement.content),
+    Href1 = lists:keyfind(href,
+	    #xmlAttribute.name, A#xmlElement.attributes),
+    URI1 = uri_string:parse(Href1#xmlAttribute.value),
+    "www.erlang.org" = maps:get(host, URI1),
+    "/doc/apps/kernel/application.html" = maps:get(path, URI1),
+    % "start/1" = maps:get(fragment, URI1),
+    See = lists:keyfind(see,
+	    #xmlElement.name, Start#xmlElement.content),
+    Href2 = lists:keyfind(href,
+	    #xmlAttribute.name, See#xmlElement.attributes),
+    URI2 = uri_string:parse(Href2#xmlAttribute.value),
+    "www.erlang.org" = maps:get(host, URI2),
+    "/doc/apps/kernel/application.html" = maps:get(path, URI2).
+    % "start/1" = maps:get(fragment, URI2).
+

--- a/lib/edoc/test/edoc_SUITE.erl
+++ b/lib/edoc/test/edoc_SUITE.erl
@@ -35,7 +35,7 @@
 
 %% Test server specific exports
 -export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
-	 init_per_group/2,end_per_group/2]).
+        init_per_group/2,end_per_group/2]).
 
 %% Test cases
 -export([app/1,appup/1,build_std/1,build_map_module/1,otp_12008/1,
@@ -205,24 +205,24 @@ otp_reference(Config) ->
     Source = filename:join(DataDir, "module_with_links.erl"),
     {module_with_links, Module} = edoc:get_doc(Source),
     Functions = lists:keyfind(functions,
-	    #xmlElement.name, Module#xmlElement.content),
+        #xmlElement.name, Module#xmlElement.content),
     [Start] = Functions#xmlElement.content,
     Description = lists:keyfind(description,
-	    #xmlElement.name, Start#xmlElement.content),
+        #xmlElement.name, Start#xmlElement.content),
     FullDescription = lists:keyfind(fullDescription,
-	    #xmlElement.name, Description#xmlElement.content),
+        #xmlElement.name, Description#xmlElement.content),
     A = lists:keyfind(a,
-	    #xmlElement.name, FullDescription#xmlElement.content),
+        #xmlElement.name, FullDescription#xmlElement.content),
     Href1 = lists:keyfind(href,
-	    #xmlAttribute.name, A#xmlElement.attributes),
+        #xmlAttribute.name, A#xmlElement.attributes),
     URI1 = uri_string:parse(Href1#xmlAttribute.value),
     "www.erlang.org" = maps:get(host, URI1),
     "/doc/apps/kernel/application.html" = maps:get(path, URI1),
     % "start/1" = maps:get(fragment, URI1),
     See = lists:keyfind(see,
-	    #xmlElement.name, Start#xmlElement.content),
+        #xmlElement.name, Start#xmlElement.content),
     Href2 = lists:keyfind(href,
-	    #xmlAttribute.name, See#xmlElement.attributes),
+        #xmlAttribute.name, See#xmlElement.attributes),
     URI2 = uri_string:parse(Href2#xmlAttribute.value),
     "www.erlang.org" = maps:get(host, URI2),
     "/doc/apps/kernel/application.html" = maps:get(path, URI2).

--- a/lib/edoc/test/edoc_SUITE_data/module_with_links.erl
+++ b/lib/edoc/test/edoc_SUITE_data/module_with_links.erl
@@ -1,21 +1,21 @@
 %% %CopyrightBegin%
-%% 
+%%
 %% SPDX-License-Identifier: Apache-2.0
-%% 
+%%
 %% Copyright Ericsson AB 2026. All Rights Reserved.
-%% 
+%%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
-%% 
+%%
 %%     http://www.apache.org/licenses/LICENSE-2.0
-%% 
+%%
 %% Unless required by applicable law or agreed to in writing, software
 %% distributed under the License is distributed on an "AS IS" BASIS,
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%% 
+%%
 %% %CopyrightEnd%
 %%
 -module(module_with_links).
@@ -24,10 +24,10 @@
 -spec start() -> ok.
 %% @doc Start application.
 %%
-%% 	Start application with {@link //kernel/application:start/1. application:start/1}.
+%% Start application with {@link //kernel/application:start/1. application:start/1}.
 %%
 %% @see //kernel/application:start/1
 %%
 start() ->
-	application:start(my_app).
+        application:start(my_app).
 

--- a/lib/edoc/test/edoc_SUITE_data/module_with_links.erl
+++ b/lib/edoc/test/edoc_SUITE_data/module_with_links.erl
@@ -1,0 +1,33 @@
+%% %CopyrightBegin%
+%% 
+%% SPDX-License-Identifier: Apache-2.0
+%% 
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% 
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% 
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%% 
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%% 
+%% %CopyrightEnd%
+%%
+-module(module_with_links).
+-export([start/0]).
+
+-spec start() -> ok.
+%% @doc Start application.
+%%
+%% 	Start application with {@link //kernel/application:start/1. application:start/1}.
+%%
+%% @see //kernel/application:start/1
+%%
+start() ->
+	application:start(my_app).
+

--- a/lib/edoc/test/edoc_SUITE_data/module_with_links.erl
+++ b/lib/edoc/test/edoc_SUITE_data/module_with_links.erl
@@ -2,7 +2,7 @@
 %%
 %% SPDX-License-Identifier: Apache-2.0
 %%
-%% Copyright Ericsson AB 2026. All Rights Reserved.
+%% Copyright Vance Shipley 2026. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix #11405

Changes `?APP_DEFAULT` to match base URI for OTP on-line documentation.
Special cases application path construction when base is `?APP_DEFAULT`.

Does **NOT** yet address difference in fragment part of URIs (i.e. `#start/1` not `#start-1`).