### PR TITLE
doc: Add deprecation warning to catch Expr

### DIFF
--- a/system/doc/reference_manual/expressions.md
+++ b/system/doc/reference_manual/expressions.md
@@ -1683,6 +1683,10 @@ More examples are provided in [Programming Examples](`e:system:funs.md`).
 catch Expr
 ```
 
+> #### Warning {: .warning }
+>
+> The `catch` expression is deprecated. Use [`try`](expressions.md#try) instead.
+
 Returns the value of `Expr` unless an exception is raised during the evaluation. In
 that case, the exception is caught. The return value depends on the class of the
 exception:


### PR DESCRIPTION
`catch Expr` is deprecated but this is not clear from the reference manual, one of the first pages that should be checked out by a newcomer.