### PR TITLE
compiler: Fix internal error with `lists:keyfind/3`

### DIFF
--- a/lib/compiler/src/beam_call_types.erl
+++ b/lib/compiler/src/beam_call_types.erl
@@ -996,8 +996,10 @@ types(lists, zipwith, [Fun | [_,_]=Lists]) ->
 types(lists, keyfind, [KeyType,PosType,_]) ->
     %% Doesn't imply that the argument is a proper list; see lists:all/2
     TupleType = case meet(PosType, #t_integer{}) of
-                    #t_integer{elements={Index,Index}} when is_integer(Index),
-                                                            Index >= 1 ->
+                    #t_integer{elements={Index,Index}}
+                      when not is_integer(Index, 0, ?MAX_TUPLE_SIZE - 1) ->
+                        none;
+                    #t_integer{elements={Index,Index}} ->
                         Es = beam_types:set_tuple_element(Index, KeyType, #{}),
                         #t_tuple{size=Index,elements=Es};
                     #t_integer{} ->

--- a/lib/compiler/src/beam_types.erl
+++ b/lib/compiler/src/beam_types.erl
@@ -101,11 +101,11 @@ meet(any, T) ->
 meet(T, any) ->
     verified_type(T);
 meet(#t_union{}=A, B) ->
-    meet_unions(A, B);
+    verified_type(meet_unions(A, B));
 meet(A, #t_union{}=B) ->
-    meet_unions(B, A);
+    verified_type(meet_unions(B, A));
 meet(A, B) ->
-    glb(A, B).
+    verified_type(glb(A, B)).
 
 meet_unions(#t_union{atom=AtomA,list=ListA,number=NumberA,
                      tuple_set=TSetA,native_record_set=NSetA,

--- a/lib/compiler/test/beam_type_SUITE.erl
+++ b/lib/compiler/test/beam_type_SUITE.erl
@@ -36,7 +36,7 @@
          cover_maps_functions/1,min_max_mixed_types/1,
          not_equal/1,infer_relops/1,binary_unit/1,premature_concretization/1,
          funs/1,will_succeed/1,float_confusion/1,
-         cover_convert_ext/1, catch_setelement/1,gh_11368/1]).
+         cover_convert_ext/1, catch_setelement/1,gh_11368/1,gh_11413/1]).
 
 %% Force id/1 to return 'any'.
 -export([id/1]).
@@ -86,7 +86,8 @@ groups() ->
        float_confusion,
        cover_convert_ext,
        catch_setelement,
-       gh_11368
+       gh_11368,
+       gh_11413
       ]}].
 
 init_per_suite(Config) ->
@@ -1680,6 +1681,12 @@ prepare_request(Msg0, Seq) ->
     Flags = element(3, Msg0),
     Msg1 = setelement(3, Msg0, [request | Flags]),
     setelement(4, Msg1, Seq).
+
+gh_11413(_Config) ->
+    ?assertError(_, gh_11413_1()).
+
+gh_11413_1() ->
+    {_, _} = lists:keyfind(0, 16777216, lists:zip([], []) ).
 
 %%%
 %%% Common utilities.


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11413.
Now `list:keyfind/3` fails at runtime when trying to index above the maximum number of elements in a tuple.