### PR TITLE
renovate: Fix config syntax error

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -62,7 +62,7 @@
                 "actions/upload-artifact",
                 "actions/download-artifact"
             ]
-         }
+         },
         // This is used to match out the current version from vendor.info
         {
             "matchFileNames": ["**/vendor.info"],


### PR DESCRIPTION
This was introduced in #10690