### PR TITLE
tools: fixes scanning lines starting with single quote

### DIFF
--- a/lib/tools/src/tags.erl
+++ b/lib/tools/src/tags.erl
@@ -391,6 +391,7 @@ word([$' | Rest]) ->
 word(Line) ->
     unquoted(Line, []).
 
+quoted([], Acc) -> {Acc, []};
 quoted([$' | Rest], Acc) -> {[$' | Acc], Rest};
 quoted([$\\ , C | Rest], Acc) ->
     quoted(Rest, [C, $\\ | Acc]);

--- a/lib/tools/test/Makefile
+++ b/lib/tools/test/Makefile
@@ -35,6 +35,7 @@ MODULES =  \
 	xref_SUITE \
 	prof_bench_SUITE \
 	crashdump_SUITE \
+	tags_SUITE \
 	ignore_cores
 
 ERL_FILES= $(MODULES:%=%.erl)

--- a/lib/tools/test/tags_SUITE.erl
+++ b/lib/tools/test/tags_SUITE.erl
@@ -1,0 +1,67 @@
+-module(tags_SUITE).
+
+%% Test server framework exports
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+
+-export([single_file/1, multiple_files/1, bad_file/1, valid_file/1]).
+
+all() ->
+    [single_file, multiple_files, bad_file, valid_file].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+single_file(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "m1.erl"),
+    TAGS = filename:join(DataDir, "TAGS"),
+
+    ok = tags:file(File, [{outdir, DataDir}]),
+    {ok, Bin} = file:read_file(TAGS),
+
+    %% TAGS format contains function name
+    {_, _} = binary:match(Bin, ~"m1"),
+    {_, _} = binary:match(Bin, ~"f").
+
+multiple_files(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File1 = filename:join(DataDir, "m1.erl"),
+    File2 = filename:join(DataDir, "m2.erl"),
+    TAGS = filename:join(DataDir, "TAGS"),
+
+    ok = tags:files([File1, File2], [{outdir, DataDir}]),
+    {ok, Bin} = file:read_file(TAGS),
+
+    %% TAGS format contains function name
+    %% TAGS format contains function name
+    {_, _} = binary:match(Bin, ~"m1"),
+    {_, _} = binary:match(Bin, ~"f"),
+    {_, _} = binary:match(Bin, ~"m2"),
+    {_, _} = binary:match(Bin, ~"g1").
+
+bad_file(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "bad.erl"),
+    TAGS = filename:join(DataDir, "TAGS"),
+
+    ok = tags:file(File, [{outdir, DataDir}]),
+    {ok, Bin} = file:read_file(TAGS),
+
+    %% TAGS format contains function name
+    {_, _} = binary:match(Bin, ~"bad"),
+    {_, _} = binary:match(Bin, ~"foo").
+
+valid_file(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    File = filename:join(DataDir, "valid.erl"),
+    TAGS = filename:join(DataDir, "TAGS"),
+
+    ok = tags:file(File, [{outdir, DataDir}]),
+    {ok, Bin} = file:read_file(TAGS),
+
+    %% TAGS format contains function name
+    {_, _} = binary:match(Bin, ~"valid"),
+    {_, _} = binary:match(Bin, ~"bar").

--- a/lib/tools/test/tags_SUITE.erl
+++ b/lib/tools/test/tags_SUITE.erl
@@ -1,3 +1,25 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
 -module(tags_SUITE).
 
 %% Test server framework exports

--- a/lib/tools/test/tags_SUITE_data/bad.erl
+++ b/lib/tools/test/tags_SUITE_data/bad.erl
@@ -1,0 +1,10 @@
+-module(bad).
+-export([foo/0]).
+
+-doc """
+'foo is an atom
+' does work
+""".
+
+foo() ->
+    ok.

--- a/lib/tools/test/tags_SUITE_data/bad.erl
+++ b/lib/tools/test/tags_SUITE_data/bad.erl
@@ -1,3 +1,25 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
 -module(bad).
 -export([foo/0]).
 

--- a/lib/tools/test/tags_SUITE_data/m1.erl
+++ b/lib/tools/test/tags_SUITE_data/m1.erl
@@ -1,3 +1,25 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
 -module(m1).
 -export([f/0]).
 f() -> ok.

--- a/lib/tools/test/tags_SUITE_data/m1.erl
+++ b/lib/tools/test/tags_SUITE_data/m1.erl
@@ -1,0 +1,3 @@
+-module(m1).
+-export([f/0]).
+f() -> ok.

--- a/lib/tools/test/tags_SUITE_data/m2.erl
+++ b/lib/tools/test/tags_SUITE_data/m2.erl
@@ -1,0 +1,3 @@
+-module(m2).
+-export([g1/0]).
+g1() -> ok.

--- a/lib/tools/test/tags_SUITE_data/m2.erl
+++ b/lib/tools/test/tags_SUITE_data/m2.erl
@@ -1,3 +1,25 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
 -module(m2).
 -export([g1/0]).
 g1() -> ok.

--- a/lib/tools/test/tags_SUITE_data/valid.erl
+++ b/lib/tools/test/tags_SUITE_data/valid.erl
@@ -1,3 +1,25 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
 -module(valid).
 -export([bar/0]).
 -doc """

--- a/lib/tools/test/tags_SUITE_data/valid.erl
+++ b/lib/tools/test/tags_SUITE_data/valid.erl
@@ -1,0 +1,7 @@
+-module(valid).
+-export([bar/0]).
+-doc """
+This is a 'quoted
+extension' in a multiline
+""".
+bar() -> ok.


### PR DESCRIPTION
the `tags.erl` is used to generate TAGS files for Emacs. There was a
case where single quote items starting in position 0 would crash the
scanner. this use case can potentially happen in docstrings, although
not too common. This fix makes the scanner to handle such cases, instead
of crashing.
