### PR TITLE
github: fixes github permission token

### DIFF
--- a/.github/workflows/openvex-sync.yml
+++ b/.github/workflows/openvex-sync.yml
@@ -60,6 +60,11 @@ jobs:
           # required
           app-id: ${{ vars.ERLANG_BOT_APP_ID }}
           private-key: ${{ secrets.ERLANG_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-security-events: read
+          permission-actions: write
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Authenticate gh
         env:

--- a/.github/workflows/reusable-vendor-vulnerability-scanner.yml
+++ b/.github/workflows/reusable-vendor-vulnerability-scanner.yml
@@ -154,6 +154,10 @@ jobs:
         with:
           app-id: ${{ secrets.ERLANG_VENDOR_SCANNER_APP_ID }}
           private-key: ${{ secrets.ERLANG_VENDOR_SCANNER_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-issues: write
+          permission-content: read
+          permission-actions: write
 
       # PRs comming from a fork can use their own GH_TOKEN instead.
       # this is for security reasons that forked PRs cannot work with Github App tokens

--- a/.github/workflows/sigstore-updater.yml
+++ b/.github/workflows/sigstore-updater.yml
@@ -146,6 +146,10 @@ jobs:
         with:
           app-id: ${{ vars.ERLANG_BOT_APP_ID }}
           private-key: ${{ secrets.ERLANG_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-issues: write
+          permission-content: read
+          permission-actions: write
       - name: Authenticate gh
         if: steps.changed.outputs.found == 'true'
         env:


### PR DESCRIPTION
The GitHub App tokens inherits blanket installation permissions. This was detected by Zizmor, and this commit fixes the owner, and permissions granted to the token.
