### PR TITLE
dialyzer: fixes multiple fns declared in same line

### DIFF
--- a/lib/dialyzer/src/typer_core.erl
+++ b/lib/dialyzer/src/typer_core.erl
@@ -593,11 +593,18 @@ write_typed_file([Ch|Chs] = Chars, File, Info, LineNo, Acc, Analysis) ->
               _ ->
                 {Info, [Ch|Acc]}
             end,
-          write_typed_file(Chs, File, NewInfo, NewLineNo, NewAcc, Analysis);
+          NewFuncs = flush_line(Line, RestFuncs, Info, File, [], Analysis),
+          write_typed_file(Chs, File, NewInfo#info{functions=NewFuncs}, NewLineNo, NewAcc, Analysis);
         _ ->
           write_typed_file(Chs, File, Info, LineNo, [Ch|Acc], Analysis)
       end
   end.
+
+flush_line(Line, [{Line,F,A}|RestFuncs], Info, File, Acc, Analysis) ->
+  ok = raw_write(F, A, Info, File, Acc, Analysis),
+  flush_line(Line, RestFuncs, Info, File, Acc, Analysis);
+flush_line(_Line, Rest, _Info, _File, _Acc, _Analysis) ->
+  Rest.
 
 raw_write(F, A, Info, File, Content, #analysis{mode = Mode} = Analysis) ->
   TypeInfo = get_type_string(F, A, Info, file, Analysis),

--- a/lib/dialyzer/test/typer_SUITE.erl
+++ b/lib/dialyzer/test/typer_SUITE.erl
@@ -25,7 +25,8 @@
          smoke/1,
          smoke_incremental_plt/1,
          gh_6296_no_spec_flag_does_not_break_records/1,
-         contract_violation/1]).
+         contract_violation/1,
+         typer_multiple_fun_in_same_line/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -35,7 +36,8 @@ all() ->
     [smoke,
      smoke_incremental_plt,
      gh_6296_no_spec_flag_does_not_break_records,
-     contract_violation].
+     contract_violation,
+     typer_multiple_fun_in_same_line].
 
 smoke(Config) ->
     OutDir = proplists:get_value(priv_dir, Config),
@@ -89,6 +91,31 @@ gh_6296_no_spec_flag_does_not_break_records(Config) ->
            "^-spec record_pattern",
            "^-spec some_other_function_to_trigger_the_issue",
            "^_OK_"],
+    run(Config, Args, Src, Res),
+    ok.
+
+typer_multiple_fun_in_same_line(Config) ->
+    Code = <<"-module(typer_multiple_fun).
+              f() -> ok. g() -> ok.">>,
+    PrivDir = proplists:get_value(priv_dir, Config),
+    Src = filename:join(PrivDir, "typer_multiple_fun.erl"),
+    ok = file:write_file(Src, Code),
+    {ok, Beam} = compile(Config, Code, typer_multiple_fun, []),
+    Plt = PrivDir ++ "dialyzer_iplt",
+    _ = dialyzer:run([{analysis_type, incremental},
+                      {files, [Beam]},
+                      {apps, [stdlib, kernel, erts]},
+                      {from, byte_code},
+                      {init_plt, Plt},
+                      {output_plt, Plt}]),
+    Args = io_lib:format("--no_spec --show --plt ~ts", [Plt]),
+    Res = ["^$",
+           "^%% File:",
+           "^%% ----",
+           "^-spec f",
+           "^-spec g",
+           "^_OK_"],
+
     run(Config, Args, Src, Res),
     ok.
 


### PR DESCRIPTION
Typer crashes when multiple functions are written in the same line.
For example, the following crashes `typer`

```
-module(m).
f() -> ok. g() -> ok.
```

While this is not idiomatic code, `typer` should not crash, and should print the function specs accordingly
