### PR TITLE
Support byte ranges in binary patterns

### DIFF
--- a/erts/emulator/beam/atom.names
+++ b/erts/emulator/beam/atom.names
@@ -147,6 +147,7 @@ atom blocked_normal
 atom bm
 atom bnot
 atom bor
+atom br
 atom bxor
 atom break_ignored
 atom breakpoint

--- a/erts/emulator/beam/beam_transform_helpers.c
+++ b/erts/emulator/beam/beam_transform_helpers.c
@@ -25,7 +25,9 @@
 #endif
 
 #include "sys.h"
+#include "global.h"
 #include "beam_load.h"
+#include "erl_bif_unique.h"
 #include "erl_map.h"
 #include "beam_transform_helpers.h"
 
@@ -136,6 +138,29 @@ beam_load_sort_select_vals(BeamOpArg* base, size_t n)
 {
     qsort(base, n, 2 * sizeof(BeamOpArg),
           (int (*)(const void *, const void *)) oparg_compare);
+}
+
+int
+beam_load_compile_binary_pattern(LoaderState *stp, BeamOpArg pattern)
+{
+    Eterm heap[ERTS_MAGIC_REF_THING_SIZE + 3];
+    Binary *bin;
+    Eterm compiled, magic_ref, source, tag;
+    Eterm *hp = heap;
+    ErlOffHeap off_heap;
+
+    source = beamfile_get_literal(&stp->beam, pattern.val);
+    if (!erts_binary_compile_pattern(source, &tag, &bin)) {
+        return 0;
+    }
+
+    ERTS_INIT_OFF_HEAP(&off_heap);
+    magic_ref = erts_mk_magic_ref(&hp, &off_heap, bin);
+    compiled = TUPLE2(hp, tag, magic_ref);
+
+    stp->loaded_binary_pattern = beamfile_add_literal(&stp->beam, compiled, 0);
+    erts_cleanup_offheap(&off_heap);
+    return 1;
 }
 
 static int

--- a/erts/emulator/beam/beam_transform_helpers.h
+++ b/erts/emulator/beam/beam_transform_helpers.h
@@ -27,4 +27,5 @@ int beam_load_safe_mul(UWord a, UWord b, UWord* resp);
 int beam_load_map_key_sort(LoaderState* stp, BeamOpArg Size, BeamOpArg* Rest);
 Eterm beam_load_get_term(LoaderState* stp, BeamOpArg Key);
 void beam_load_sort_select_vals(BeamOpArg* base, size_t n);
+int beam_load_compile_binary_pattern(LoaderState *stp, BeamOpArg pattern);
 #endif

--- a/erts/emulator/beam/emu/load.h
+++ b/erts/emulator/beam/emu/load.h
@@ -147,6 +147,9 @@ struct LoaderState_ {
     /* Translates lambda indexes to their canonical literal, if any. */
     SWord *lambda_literals;
 
+    /* Dynamic literal produced by the current binary pattern transform. */
+    SWord loaded_binary_pattern;
+
     int otp_20_or_higher;
 
     Uint last_func_start;

--- a/erts/emulator/beam/emu/ops.tab
+++ b/erts/emulator/beam/emu/ops.tab
@@ -904,6 +904,23 @@ call_ext_last u==0 u$func:os:perf_counter/0 D =>
 call_ext_only u==0 u$func:os:perf_counter/0 =>
     i_perf_counter | return
 
+# Compile literal binary search patterns while loading. Invalid patterns decline
+# these transforms and retain their original runtime error behavior.
+#
+
+move Pattern=q X0=x==0 |
+  call_ext _Ar=u _Func=u$bif:binary:compile_pattern/1 |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern(X0)
+move Pattern=q X0=x==0 |
+  call_ext_last _Ar=u _Func=u$bif:binary:compile_pattern/1 D |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern_last(X0, D)
+move Pattern=q X0=x==0 |
+  call_ext_only _Ar=u _Func=u$bif:binary:compile_pattern/1 |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern_only(X0)
+
 #
 # BIFs like process_info/1,2 require up-to-date information about the current
 # emulator state, which the ordinary call_light_bif instruction doesn't save.

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -1100,18 +1100,23 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
     return -1;
 }
 
+int erts_binary_compile_pattern(Eterm argument, Eterm *tag, Binary **binp)
+{
+    return do_binary_match_compile(argument, tag, binp) == 0;
+}
+
 BIF_RETTYPE binary_compile_pattern_1(BIF_ALIST_1)
 {
     Binary *bin;
-    Eterm tag, ret;
+    Eterm magic_ref, ret, tag;
     Eterm *hp;
 
-    if (do_binary_match_compile(BIF_ARG_1,&tag,&bin)) {
-	BIF_ERROR(BIF_P,BADARG);
+    if (!erts_binary_compile_pattern(BIF_ARG_1, &tag, &bin)) {
+        BIF_ERROR(BIF_P, BADARG);
     }
-    hp = HAlloc(BIF_P, ERTS_MAGIC_REF_THING_SIZE+3);
-    ret = erts_mk_magic_ref(&hp, &MSO(BIF_P), bin);
-    ret = TUPLE2(hp, tag, ret);
+    hp = HAlloc(BIF_P, ERTS_MAGIC_REF_THING_SIZE + 3);
+    magic_ref = erts_mk_magic_ref(&hp, &MSO(BIF_P), bin);
+    ret = TUPLE2(hp, tag, magic_ref);
     BIF_RET(ret);
 }
 

--- a/erts/emulator/beam/erl_bif_binary.c
+++ b/erts/emulator/beam/erl_bif_binary.c
@@ -41,6 +41,21 @@
 #include "erl_bits.h"
 #include "erl_bif_unique.h"
 
+#if !defined(ERTS_BINARY_NO_INTRINSICS)
+#  if defined(__SSE2__) || defined(_M_X64) || \
+      (defined(_M_IX86) && defined(_M_IX86_FP) && (_M_IX86_FP >= 2))
+#    define ERTS_BINARY_X86_SSE2
+#  endif
+#  if defined(__ARM_NEON) || defined(_M_ARM64)
+#    define ERTS_BINARY_ARM_NEON
+#  endif
+#  if defined(ERTS_BINARY_X86_SSE2)
+#    include <emmintrin.h>
+#  elif defined(ERTS_BINARY_ARM_NEON)
+#    include <arm_neon.h>
+#  endif
+#endif
+
 
 /*
  * The native implementation functions for the module binary.
@@ -211,6 +226,31 @@ typedef struct _bm_data {
     Sint *badshift;
     Sint *goodshift;
 } BMData;
+
+typedef struct _byte_range {
+    byte low;
+    byte high;
+} ByteRange;
+
+typedef struct _br_data {
+    Uint singleton_count;
+    Uint range_count;
+    Uint upper_bound;
+    Uint lower_bound;
+    byte member[ALPHABET_SIZE];
+    byte data[1];
+} BRData;
+
+typedef struct _br_match_mask {
+    Uint bits;
+#if defined(ERTS_BINARY_ARM_NEON)
+    byte lanes[16];
+#endif
+} BRMatchMask;
+
+#define BR_SINGLETONS(Brd) ((Brd)->data)
+#define BR_RANGES(Brd)                                                     \
+    ((ByteRange *)&(Brd)->data[(Brd)->singleton_count])
 
 typedef struct _ac_find_all_state {
     ACNode *q;
@@ -427,6 +467,103 @@ static int cleanup_my_data_ac(Binary *bp)
 }
 static int cleanup_my_data_bm(Binary *bp)
 {
+    return 1;
+}
+static int cleanup_my_data_br(Binary *bp)
+{
+    return 1;
+}
+
+static int create_brdata(Eterm ranges, Eterm *tag, Binary **the_bin)
+{
+    byte member[ALPHABET_SIZE] = {0};
+    Uint singleton_count = 0;
+    Uint range_count = 0;
+    Uint upper_bound = ALPHABET_SIZE;
+    Uint lower_bound = ALPHABET_SIZE;
+    Uint singleton_index = 0;
+    Uint range_index = 0;
+    Uint i;
+    Eterm list = ranges;
+    Binary *mb;
+    BRData *brd;
+
+    while (is_list(list)) {
+        Eterm range = CAR(list_val(list));
+        Eterm *tuple;
+        Sint low, high;
+
+        if (is_not_tuple(range)) {
+            return 0;
+        }
+        tuple = tuple_val(range);
+        if (arityval(tuple[0]) != 2 ||
+            !term_to_Sint(tuple[1], &low) ||
+            !term_to_Sint(tuple[2], &high) ||
+            low < 0 || high > 255 || low > high) {
+            return 0;
+        }
+        sys_memset(&member[low], 1, high - low + 1);
+        list = CDR(list_val(list));
+    }
+    if (is_not_nil(list)) {
+        return 0;
+    }
+
+    for (i = 0; i < ALPHABET_SIZE; i++) {
+        if (member[i] && (i == 0 || !member[i - 1])) {
+            Uint low = i;
+
+            while (i + 1 < ALPHABET_SIZE && member[i + 1]) {
+                i++;
+            }
+            if (low == i) {
+                singleton_count++;
+            } else if (low == 0) {
+                upper_bound = i;
+            } else if (i == ALPHABET_SIZE - 1) {
+                lower_bound = low;
+            } else {
+                range_count++;
+            }
+        }
+    }
+    if (singleton_count + range_count == 0 &&
+        upper_bound == ALPHABET_SIZE && lower_bound == ALPHABET_SIZE) {
+        return 0;
+    }
+
+    mb = erts_create_magic_binary(offsetof(BRData, data) +
+                                  singleton_count +
+                                  range_count * sizeof(ByteRange),
+                                  cleanup_my_data_br);
+    brd = ERTS_MAGIC_BIN_DATA(mb);
+    brd->singleton_count = singleton_count;
+    brd->range_count = range_count;
+    brd->upper_bound = upper_bound;
+    brd->lower_bound = lower_bound;
+    sys_memcpy(brd->member, member, sizeof(member));
+    for (i = 0; i < ALPHABET_SIZE; i++) {
+        if (member[i] && (i == 0 || !member[i - 1])) {
+            Uint low = i;
+
+            while (i + 1 < ALPHABET_SIZE && member[i + 1]) {
+                i++;
+            }
+            if (low == i) {
+                BR_SINGLETONS(brd)[singleton_index++] = i;
+            } else if (low == 0 || i == ALPHABET_SIZE - 1) {
+                continue;
+            } else {
+                ByteRange *range = &BR_RANGES(brd)[range_index++];
+                range->low = low;
+                range->high = i;
+            }
+        }
+    }
+
+    *tag = am_br;
+    *the_bin = mb;
     return 1;
 }
 
@@ -993,6 +1130,306 @@ static BFReturn bm_find_all_non_overlapping(BinaryFindContext *ctx,
     return (m == 0) ? BF_NOT_FOUND : BF_OK;
 }
 
+#define BR_LOOP_FACTOR 16
+#define BR_SIMD_RANGE_LIMIT 16
+
+#if defined(ERTS_BINARY_X86_SSE2) || defined(ERTS_BINARY_ARM_NEON)
+static ERTS_FORCE_INLINE int br_simd_eligible(const BRData *brd)
+{
+    return brd->singleton_count + brd->range_count +
+               (brd->upper_bound < ALPHABET_SIZE) +
+               (brd->lower_bound < ALPHABET_SIZE) <=
+           BR_SIMD_RANGE_LIMIT;
+}
+#endif
+
+static const byte *br_find_byte_scalar(const BRData *brd,
+                                       const byte *subject,
+                                       const byte *end)
+{
+    while (subject < end) {
+        if (brd->member[*subject]) {
+            return subject;
+        }
+        subject++;
+    }
+    return NULL;
+}
+
+static const byte *br_find_byte(const BRData *brd,
+                                const byte *subject,
+                                Uint length,
+                                BRMatchMask *match_mask)
+{
+    const byte *end = subject + length;
+
+    if (match_mask != NULL) {
+        match_mask->bits = 0;
+    }
+
+#if defined(ERTS_BINARY_X86_SSE2)
+    if (br_simd_eligible(brd)) {
+        while (subject + 16 <= end) {
+            __m128i bytes = _mm_loadu_si128((const __m128i *)subject);
+            __m128i matches = _mm_setzero_si128();
+            Uint singleton_index;
+            Uint range_index;
+            Uint mask;
+
+            for (singleton_index = 0;
+                 singleton_index < brd->singleton_count;
+                 singleton_index++) {
+                __m128i singleton =
+                    _mm_set1_epi8(BR_SINGLETONS(brd)[singleton_index]);
+                matches = _mm_or_si128(matches,
+                                       _mm_cmpeq_epi8(bytes, singleton));
+            }
+            if (brd->upper_bound < ALPHABET_SIZE) {
+                __m128i high = _mm_set1_epi8(brd->upper_bound);
+                matches = _mm_or_si128(
+                    matches,
+                    _mm_cmpeq_epi8(_mm_min_epu8(bytes, high), bytes));
+            }
+            if (brd->lower_bound < ALPHABET_SIZE) {
+                __m128i low = _mm_set1_epi8(brd->lower_bound);
+                matches = _mm_or_si128(
+                    matches,
+                    _mm_cmpeq_epi8(_mm_max_epu8(bytes, low), bytes));
+            }
+            for (range_index = 0;
+                 range_index < brd->range_count;
+                 range_index++) {
+                __m128i low = _mm_set1_epi8(BR_RANGES(brd)[range_index].low);
+                __m128i high = _mm_set1_epi8(BR_RANGES(brd)[range_index].high);
+                __m128i ge = _mm_cmpeq_epi8(_mm_max_epu8(bytes, low), bytes);
+                __m128i le = _mm_cmpeq_epi8(_mm_min_epu8(bytes, high), bytes);
+                matches = _mm_or_si128(matches, _mm_and_si128(ge, le));
+            }
+            mask = (Uint)_mm_movemask_epi8(matches);
+            if (mask != 0) {
+                Uint offset = 0;
+
+                if (match_mask != NULL) {
+                    match_mask->bits = mask;
+                    return subject;
+                }
+                while ((mask & 1) == 0) {
+                    mask >>= 1;
+                    offset++;
+                }
+                return subject + offset;
+            }
+            subject += 16;
+        }
+    }
+#elif defined(ERTS_BINARY_ARM_NEON)
+    if (br_simd_eligible(brd)) {
+        while (subject + 16 <= end) {
+            uint8x16_t bytes = vld1q_u8(subject);
+            uint8x16_t matches = vdupq_n_u8(0);
+            Uint singleton_index;
+            Uint range_index;
+
+            for (singleton_index = 0;
+                 singleton_index < brd->singleton_count;
+                 singleton_index++) {
+                uint8x16_t singleton =
+                    vdupq_n_u8(BR_SINGLETONS(brd)[singleton_index]);
+                matches = vorrq_u8(matches, vceqq_u8(bytes, singleton));
+            }
+            if (brd->upper_bound < ALPHABET_SIZE) {
+                uint8x16_t high = vdupq_n_u8(brd->upper_bound);
+                matches = vorrq_u8(matches, vcleq_u8(bytes, high));
+            }
+            if (brd->lower_bound < ALPHABET_SIZE) {
+                uint8x16_t low = vdupq_n_u8(brd->lower_bound);
+                matches = vorrq_u8(matches, vcgeq_u8(bytes, low));
+            }
+            for (range_index = 0;
+                 range_index < brd->range_count;
+                 range_index++) {
+                uint8x16_t low =
+                    vdupq_n_u8(BR_RANGES(brd)[range_index].low);
+                uint8x16_t high =
+                    vdupq_n_u8(BR_RANGES(brd)[range_index].high);
+                matches = vorrq_u8(matches,
+                                   vandq_u8(vcgeq_u8(bytes, low),
+                                            vcleq_u8(bytes, high)));
+            }
+            {
+                uint64x2_t match_words = vreinterpretq_u64_u8(matches);
+
+                if (vgetq_lane_u64(match_words, 0) != 0 ||
+                    vgetq_lane_u64(match_words, 1) != 0) {
+                    if (match_mask != NULL) {
+                        vst1q_u8(match_mask->lanes, matches);
+                        match_mask->bits = 1;
+                        return subject;
+                    } else {
+                        byte lanes[16];
+                        Uint offset;
+
+                        vst1q_u8(lanes, matches);
+                        for (offset = 0; offset < 16; offset++) {
+                            if (lanes[offset]) {
+                                return subject + offset;
+                            }
+                        }
+                    }
+                }
+            }
+            subject += 16;
+        }
+    }
+#endif
+
+    return br_find_byte_scalar(brd, subject, end);
+}
+
+static void br_init_find_first_match(BinaryFindContext *ctx)
+{
+    BMFindFirstState *state = &ctx->u.ff.d.bm;
+    state->pos = ctx->hsstart;
+    state->len = ctx->hsend;
+}
+
+static BFReturn br_find_first_match(BinaryFindContext *ctx,
+                                    const byte *haystack)
+{
+    BMFindFirstState *state = &ctx->u.ff.d.bm;
+    BRData *brd = ERTS_MAGIC_BIN_DATA(ctx->pat_bin);
+    Uint i = state->pos;
+    Uint len = state->len;
+    Uint scan_length = MIN(len - i, ctx->reds);
+    const byte *found = br_find_byte(brd, haystack + i, scan_length, NULL);
+
+    if (found != NULL) {
+        ctx->reds -= found - (haystack + i) + 1;
+        ctx->u.ff.pos = found - haystack;
+        ctx->u.ff.len = 1;
+        return BF_OK;
+    }
+
+    ctx->reds -= scan_length;
+    i += scan_length;
+    if (i < len) {
+        state->pos = i;
+        return BF_RESTART;
+    }
+    return BF_NOT_FOUND;
+}
+
+static void br_init_find_all(BinaryFindContext *ctx)
+{
+    BMFindAllState *state = &ctx->u.fa.d.bm;
+    state->pos = ctx->hsstart;
+    state->len = ctx->hsend;
+    state->m = 0;
+    state->allocated = 0;
+    state->out = NULL;
+}
+
+static ERTS_FORCE_INLINE void br_add_find_all_match(Uint pos,
+                                                    Uint *match_count,
+                                                    Uint *allocated,
+                                                    FindallData **matches)
+{
+    if (*match_count >= *allocated) {
+        if (*allocated == 0) {
+            *allocated = 10;
+            *matches = erts_alloc(ERTS_ALC_T_BINARY_FIND,
+                                  sizeof(FindallData) * *allocated);
+        } else {
+            *allocated *= 2;
+            *matches = erts_realloc(ERTS_ALC_T_BINARY_FIND,
+                                    *matches,
+                                    sizeof(FindallData) * *allocated);
+        }
+    }
+    (*matches)[*match_count].pos = pos;
+    (*matches)[*match_count].len = 1;
+    (*match_count)++;
+}
+
+static BFReturn br_find_all_non_overlapping(BinaryFindContext *ctx,
+                                            const byte *haystack)
+{
+    BMFindAllState *state = &ctx->u.fa.d.bm;
+    BRData *brd = ERTS_MAGIC_BIN_DATA(ctx->pat_bin);
+    Uint i = state->pos;
+    Uint len = state->len;
+    Uint m = state->m;
+    Uint allocated = state->allocated;
+    FindallData *out = state->out;
+    Uint reds = ctx->reds;
+
+    while (i < len && reds > 0) {
+        Uint scan_length = MIN(len - i, reds);
+        BRMatchMask match_mask;
+        const byte *found = br_find_byte(brd,
+                                         haystack + i,
+                                         scan_length,
+                                         &match_mask);
+
+        if (found == NULL) {
+            i += scan_length;
+            reds -= scan_length;
+            break;
+        }
+
+        if (match_mask.bits != 0) {
+            Uint block_pos = found - haystack;
+            Uint consumed = block_pos - i + 16;
+
+#if defined(ERTS_BINARY_ARM_NEON)
+            Uint offset;
+
+            for (offset = 0; offset < 16; offset++) {
+                if (match_mask.lanes[offset]) {
+                    br_add_find_all_match(block_pos + offset,
+                                          &m,
+                                          &allocated,
+                                          &out);
+                }
+            }
+#else
+            while (match_mask.bits != 0) {
+                Uint offset = 0;
+                Uint remaining = match_mask.bits;
+
+                while ((remaining & 1) == 0) {
+                    remaining >>= 1;
+                    offset++;
+                }
+                br_add_find_all_match(block_pos + offset,
+                                      &m,
+                                      &allocated,
+                                      &out);
+                match_mask.bits &= match_mask.bits - 1;
+            }
+#endif
+            i = block_pos + 16;
+            reds -= consumed;
+        } else {
+            Uint match_pos = found - haystack;
+
+            reds -= match_pos - i + 1;
+            br_add_find_all_match(match_pos, &m, &allocated, &out);
+            i = match_pos + 1;
+        }
+    }
+
+    state->pos = i;
+    state->m = m;
+    state->allocated = allocated;
+    state->out = out;
+    ctx->reds = reds;
+    if (i < len) {
+        return BF_RESTART;
+    }
+    return m == 0 ? BF_NOT_FOUND : BF_OK;
+}
+
 /*
  * Interface functions (i.e. "bif's")
  */
@@ -1012,6 +1449,12 @@ static int do_binary_match_compile(Eterm argument, Eterm *tag, Binary **binp)
     words = 0;
 
     if (is_list(argument)) {
+        Eterm head = CAR(list_val(argument));
+
+        if (is_tuple(head)) {
+            return create_brdata(argument, tag, binp) ? 0 : -1;
+        }
+
 	t = argument;
 	while (is_list(t)) {
 	    b = CAR(list_val(t));
@@ -1157,6 +1600,18 @@ static BinaryFindSearch bf_search_bm_single = {
     NULL
 };
 
+static BinaryFindSearch bf_search_br_global = {
+    br_init_find_all,
+    br_find_all_non_overlapping,
+    bm_clean_find_all
+};
+
+static BinaryFindSearch bf_search_br_single = {
+    br_init_find_first_match,
+    br_find_first_match,
+    NULL
+};
+
 static void bf_context_init(BinaryFindContext *ctx, BinaryFindResult not_found,
 			    BinaryFindResult single, BinaryFindResult global,
 			    Binary *pat_bin)
@@ -1172,6 +1627,9 @@ static void bf_context_init(BinaryFindContext *ctx, BinaryFindResult not_found,
 	} else if (ctx->pat_type == am_ac) {
 	    ctx->search = &bf_search_ac_global;
 	    ctx->loop_factor = AC_LOOP_FACTOR;
+        } else if (ctx->pat_type == am_br) {
+            ctx->search = &bf_search_br_global;
+            ctx->loop_factor = BR_LOOP_FACTOR;
 	}
     } else {
 	ctx->found = single;
@@ -1181,6 +1639,9 @@ static void bf_context_init(BinaryFindContext *ctx, BinaryFindResult not_found,
 	} else if (ctx->pat_type == am_ac) {
 	    ctx->search = &bf_search_ac_single;
 	    ctx->loop_factor = AC_LOOP_FACTOR;
+        } else if (ctx->pat_type == am_br) {
+            ctx->search = &bf_search_br_single;
+            ctx->loop_factor = BR_LOOP_FACTOR;
 	}
     }
     ctx->trap_term = THE_NON_VALUE;
@@ -1231,7 +1692,7 @@ static void bf_context_dump(BinaryFindContext *ctx)
 	BMData *bm;
 	bm = ERTS_MAGIC_BIN_DATA(ctx->pat_bin);
 	dump_bm_data(bm);
-    } else {
+    } else if (ctx->pat_type == am_ac) {
 	ACTrie *act;
 	act = ERTS_MAGIC_BIN_DATA(ctx->pat_bin);
 	dump_ac_trie(act);
@@ -1255,7 +1716,7 @@ static BFReturn maybe_binary_match_compile(BinaryFindContext *ctx, Eterm arg, Bi
 	if (arityval(*tp) != 2 || is_not_atom(tp[1])) {
 	    return BF_BADARG;
 	}
-	if (((tp[1] != am_bm) && (tp[1] != am_ac)) ||
+        if (((tp[1] != am_bm) && (tp[1] != am_ac) && (tp[1] != am_br)) ||
 	    !is_internal_magic_ref(tp[2])) {
 	    return BF_BADARG;
 	}
@@ -1263,7 +1724,9 @@ static BFReturn maybe_binary_match_compile(BinaryFindContext *ctx, Eterm arg, Bi
 	if ((tp[1] == am_bm &&
 	     ERTS_MAGIC_BIN_DESTRUCTOR(*pat_bin) != cleanup_my_data_bm) ||
 	    (tp[1] == am_ac &&
-	     ERTS_MAGIC_BIN_DESTRUCTOR(*pat_bin) != cleanup_my_data_ac)) {
+             ERTS_MAGIC_BIN_DESTRUCTOR(*pat_bin) != cleanup_my_data_ac) ||
+            (tp[1] == am_br &&
+             ERTS_MAGIC_BIN_DESTRUCTOR(*pat_bin) != cleanup_my_data_br)) {
 	    *pat_bin = NULL;
 	    return BF_BADARG;
 	}
@@ -1475,6 +1938,8 @@ static BFReturn do_binary_find(Process *p, Eterm subject, BinaryFindContext **ct
 #ifdef HARDDEBUG
 	    if (ctx->pat_type == am_ac) {
 		erts_printf("Trap ac!\n");
+            } else if (ctx->pat_type == am_br) {
+                erts_printf("Trap br!\n");
 	    } else {
 		erts_printf("Trap bm!\n");
 	    }

--- a/erts/emulator/beam/generators.tab
+++ b/erts/emulator/beam/generators.tab
@@ -70,6 +70,47 @@ gen.get_float2(Fail, Ms, Live, Size, Unit, Flags, Dst) {
     return op;
 }
 
+LoadedBinaryPatternMove(Op, Dst) {
+    $BeamOpNameArity($Op, move, 2);
+    ($Op)->a[0].type = TAG_q;
+    ($Op)->a[0].val = S->loaded_binary_pattern;
+    ($Op)->a[1] = $Dst;
+}
+
+gen.loaded_binary_pattern(Dst) {
+    BeamOp *move;
+    $NewBeamOp(S, move);
+
+    $LoadedBinaryPatternMove(move, Dst);
+    return move;
+}
+
+gen.loaded_binary_pattern_last(Dst, Deallocate) {
+    BeamOp *move, *deallocate, *ret;
+    $NewBeamOp(S, move);
+    $NewBeamOp(S, deallocate);
+    $NewBeamOp(S, ret);
+
+    $LoadedBinaryPatternMove(move, Dst);
+    $BeamOpNameArity(deallocate, deallocate, 1);
+    deallocate->a[0] = Deallocate;
+    $BeamOpNameArity(ret, return, 0);
+    move->next = deallocate;
+    deallocate->next = ret;
+    return move;
+}
+
+gen.loaded_binary_pattern_only(Dst) {
+    BeamOp *move, *ret;
+    $NewBeamOp(S, move);
+    $NewBeamOp(S, ret);
+
+    $LoadedBinaryPatternMove(move, Dst);
+    $BeamOpNameArity(ret, return, 0);
+    move->next = ret;
+    return move;
+}
+
 gen.get_utf16(Fail, Ms, Flags, Dst) {
     BeamOp* op;
     $NewBeamOp(S, op);

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -1450,6 +1450,7 @@ Sint erts_re_set_loop_limit(Sint limit);
 /* erl_bif_binary.c */
 void erts_init_bif_binary(void);
 Sint erts_binary_set_loop_limit(Sint limit);
+int erts_binary_compile_pattern(Eterm argument, Eterm *tag, Binary **binp);
 
 /* erl_bif_persistent.c */
 Eterm erts_persistent_term_get(Eterm key);

--- a/erts/emulator/beam/jit/arm/ops.tab
+++ b/erts/emulator/beam/jit/arm/ops.tab
@@ -82,6 +82,10 @@ move S X0=x==0 | line _Loc | call_last Ar Func D =>
 move S X0=x==0 | line _Loc | call_only Ar Func =>
     move S X0 | call_only Ar Func
 
+# Move literal call arguments past line instructions so they can participate
+# in load-time call transformations.
+move S=c X0=x==0 | line Loc => line Loc | move S X0
+
 # The line number in int_func_start/5 can be NIL.
 func_line n => empty_func_line
 
@@ -394,6 +398,23 @@ move Src Dst | trim N u => move_trim Src Dst N
 move_two_trim y d y d t
 
 move_trim s d t
+
+# Compile literal binary search patterns while loading. Invalid patterns decline
+# these transforms and retain their original runtime error behavior.
+#
+
+move Pattern=q X0=x==0 |
+  call_ext _Ar=u _Func=u$bif:binary:compile_pattern/1 |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern(X0)
+move Pattern=q X0=x==0 |
+  call_ext_last _Ar=u _Func=u$bif:binary:compile_pattern/1 D |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern_last(X0, D)
+move Pattern=q X0=x==0 |
+  call_ext_only _Ar=u _Func=u$bif:binary:compile_pattern/1 |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern_only(X0)
 
 move Src Dst => i_move Src Dst
 

--- a/erts/emulator/beam/jit/load.h
+++ b/erts/emulator/beam/jit/load.h
@@ -95,6 +95,9 @@ struct LoaderState_ {
     /* Translates lambda indexes to their canonical literal, if any. */
     SWord *lambda_literals;
 
+    /* Dynamic literal produced by the current binary pattern transform. */
+    SWord loaded_binary_pattern;
+
     void *ba; /* Assembler used to create x86/AArch64 assembly */
 
     const void *executable_region; /* Native module after codegen */

--- a/erts/emulator/beam/jit/x86/ops.tab
+++ b/erts/emulator/beam/jit/x86/ops.tab
@@ -82,6 +82,10 @@ move S X0=x==0 | line _Loc | call_last Ar Func D =>
 move S X0=x==0 | line _Loc | call_only Ar Func =>
      move S X0 | call_only Ar Func
 
+# Move literal call arguments past line instructions so they can participate
+# in load-time call transformations.
+move S=c X0=x==0 | line Loc => line Loc | move S X0
+
 # The line number in int_func_start/5 can be NIL.
 func_line n => empty_func_line
 
@@ -362,6 +366,23 @@ move S1=d D1=d | move S2=d D2=d | consecutive_words(S2, D1, S1, D2) =>
     move_two_words S2 D2 S1 D1
 move S1=d D1=d | move S2=d D2=d | consecutive_words(S2, D2, S1, D1) =>
     move_two_words S2 D2 S1 D1
+
+# Compile literal binary search patterns while loading. Invalid patterns decline
+# these transforms and retain their original runtime error behavior.
+#
+
+move Pattern=q X0=x==0 |
+  call_ext _Ar=u _Func=u$bif:binary:compile_pattern/1 |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern(X0)
+move Pattern=q X0=x==0 |
+  call_ext_last _Ar=u _Func=u$bif:binary:compile_pattern/1 D |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern_last(X0, D)
+move Pattern=q X0=x==0 |
+  call_ext_only _Ar=u _Func=u$bif:binary:compile_pattern/1 |
+  load_binary_pattern(Pattern) =>
+    loaded_binary_pattern_only(X0)
 
 move Src Dst => i_move Src Dst
 

--- a/erts/emulator/beam/predicates.tab
+++ b/erts/emulator/beam/predicates.tab
@@ -199,6 +199,13 @@ pred.map_key_sort(Size, Rest) {
     return beam_load_map_key_sort(S, Size, Rest);
 }
 
+// Compile a literal binary search pattern and retain its dynamic literal index
+// for loaded_binary_pattern(). A failed compilation declines the transform so
+// that the original call retains its runtime error behavior.
+pred.load_binary_pattern(Pattern) {
+    return beam_load_compile_binary_pattern(S, Pattern);
+}
+
 // Test that two operands are distinct.
 pred.distinct(Val1, Val2) {
     if (Val1.type != Val2.type) {

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -903,6 +903,10 @@ simplify_call(Call, _, _, Args) ->
 
 valid_binary_pattern(Pattern) when is_binary(Pattern) ->
     byte_size(Pattern) > 0;
+valid_binary_pattern([{Low,High}|Ranges]) ->
+    is_integer(Low) andalso is_integer(High) andalso
+        0 =< Low andalso Low =< High andalso High =< 255 andalso
+        valid_binary_range_list(Ranges);
 valid_binary_pattern([Pattern|Patterns]) ->
     is_binary(Pattern) andalso byte_size(Pattern) > 0 andalso
         valid_binary_pattern_list(Patterns);
@@ -915,6 +919,15 @@ valid_binary_pattern_list([Pattern|Patterns]) ->
 valid_binary_pattern_list([]) ->
     true;
 valid_binary_pattern_list(_) ->
+    false.
+
+valid_binary_range_list([{Low,High}|Ranges]) ->
+    is_integer(Low) andalso is_integer(High) andalso
+        0 =< Low andalso Low =< High andalso High =< 255 andalso
+        valid_binary_range_list(Ranges);
+valid_binary_range_list([]) ->
+    true;
+valid_binary_range_list(_) ->
     false.
 
 %% rewrite_call(Call0, Mod, Func, Args, Sub) -> Call

--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -881,8 +881,41 @@ simplify_call(_Call, maps, new, []) ->
     #c_literal{val=#{}};
 simplify_call(Call, maps, size, [Map]) ->
     rewrite_call(Call, erlang, map_size, [Map]);
+%% Expose literal binary search patterns to the loader, which can replace the
+%% generated compile_pattern/1 call with a compiled-pattern literal. Leave
+%% invalid patterns alone to preserve the original exception and stacktrace.
+simplify_call(Call, binary, Name,
+              [Subject,#c_literal{val=Pattern}=PatternLiteral|Rest]=Args)
+  when Name =:= match; Name =:= matches; Name =:= split ->
+    case length(Rest) =< 1 andalso valid_binary_pattern(Pattern) of
+        true ->
+            Anno = [compiler_generated | Call#c_call.anno],
+            Compile = #c_call{anno=Anno,
+                              module=#c_literal{val=binary},
+                              name=#c_literal{val=compile_pattern},
+                              args=[PatternLiteral]},
+            Call#c_call{args=[Subject,Compile|Rest]};
+        false ->
+            Call#c_call{args=Args}
+    end;
 simplify_call(Call, _, _, Args) ->
     Call#c_call{args=Args}.
+
+valid_binary_pattern(Pattern) when is_binary(Pattern) ->
+    byte_size(Pattern) > 0;
+valid_binary_pattern([Pattern|Patterns]) ->
+    is_binary(Pattern) andalso byte_size(Pattern) > 0 andalso
+        valid_binary_pattern_list(Patterns);
+valid_binary_pattern(_) ->
+    false.
+
+valid_binary_pattern_list([Pattern|Patterns]) ->
+    is_binary(Pattern) andalso byte_size(Pattern) > 0 andalso
+        valid_binary_pattern_list(Patterns);
+valid_binary_pattern_list([]) ->
+    true;
+valid_binary_pattern_list(_) ->
+    false.
 
 %% rewrite_call(Call0, Mod, Func, Args, Sub) -> Call
 %%  Rewrites a call to the given MFA.

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -32,12 +32,13 @@
          redundant_stack_frame/1,export_from_case/1,
          empty_values/1,cover_letrec_effect/1,
          receive_effect/1,nested_lets/1,
-         map_effect/1]).
+         map_effect/1,literal_binary_patterns/1]).
 
 -export([foo/0,foo/1,foo/2,foo/3]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include_lib("syntax_tools/include/merl.hrl").
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -55,7 +56,7 @@ groups() ->
        redundant_stack_frame,export_from_case,
        empty_values,cover_letrec_effect,
        receive_effect,nested_lets,
-       map_effect]}].
+       map_effect,literal_binary_patterns]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -874,6 +875,60 @@ map_effect_1() ->
 map_effect_2(Map) ->
     Map#{key := value},
     ok.
+
+literal_binary_patterns(_Config) ->
+    Mod = literal_binary_patterns,
+    Forms = ?Q(["-module('@Mod@').",
+                "-export([match2/1, match3/1, matches2/1, matches3/1,",
+                "         split2/1, split3/1, empty/1]).",
+                "match2(Binary) -> binary:match(Binary, <<\"needle\">>).",
+                "match3(Binary) -> binary:match(Binary, <<\"needle\">>, []).",
+                "matches2(Binary) -> binary:matches(Binary, [<<\"needle\">>, <<\"thread\">>]).",
+                "matches3(Binary) -> binary:matches(Binary, [<<\"needle\">>, <<\"thread\">>], []).",
+                "split2(Binary) -> binary:split(Binary, <<\"needle\">>).",
+                "split3(Binary) -> binary:split(Binary, <<\"needle\">>, []).",
+                "empty(Binary) -> binary:match(Binary, [])."]),
+    AbstractForms = [erl_syntax:revert(Form) || Form <- Forms],
+    {ok,Mod,{Mod,_Exports,_Attrs,_Anno,Funs,_},_Warnings} =
+        compile:forms(AbstractForms, [return,to_asm]),
+
+    assert_literal_pattern_wrapped(match2, 1, match, 2, Funs),
+    assert_literal_pattern_wrapped(match3, 1, match, 3, Funs),
+    assert_literal_pattern_wrapped(matches2, 1, matches, 2, Funs),
+    assert_literal_pattern_wrapped(matches3, 1, matches, 3, Funs),
+    assert_literal_pattern_wrapped(split2, 1, split, 2, Funs),
+    assert_literal_pattern_wrapped(split3, 1, split, 3, Funs),
+
+    Empty = function_instructions(empty, 1, Funs),
+    false = has_ext_call(binary, compile_pattern, 1, Empty),
+    true = has_ext_call(binary, match, 2, Empty),
+    ok.
+
+assert_literal_pattern_wrapped(Name, Arity, BinaryFunction, BinaryArity, Funs) ->
+    Instructions = function_instructions(Name, Arity, Funs),
+    true = has_ext_call(binary, compile_pattern, 1, Instructions),
+    true = has_ext_call(binary, BinaryFunction, BinaryArity, Instructions).
+
+function_instructions(Name, Arity, Funs) ->
+    {function,Name,Arity,_Label,Instructions} = lists:keyfind(Name, 2, Funs),
+    Instructions.
+
+has_ext_call(Module, Function, Arity, Instructions) ->
+    lists:any(fun(Instruction) ->
+                      is_ext_call(Instruction, Module, Function, Arity)
+              end, Instructions).
+
+is_ext_call({call_ext,Arity,{extfunc,Module,Function,Arity}},
+            Module, Function, Arity) ->
+    true;
+is_ext_call({call_ext_last,Arity,{extfunc,Module,Function,Arity},_Deallocate},
+            Module, Function, Arity) ->
+    true;
+is_ext_call({call_ext_only,Arity,{extfunc,Module,Function,Arity}},
+            Module, Function, Arity) ->
+    true;
+is_ext_call(_Instruction, _Module, _Function, _Arity) ->
+    false.
 
 %%% Common utility functions.
 

--- a/lib/compiler/test/core_fold_SUITE.erl
+++ b/lib/compiler/test/core_fold_SUITE.erl
@@ -880,14 +880,16 @@ literal_binary_patterns(_Config) ->
     Mod = literal_binary_patterns,
     Forms = ?Q(["-module('@Mod@').",
                 "-export([match2/1, match3/1, matches2/1, matches3/1,",
-                "         split2/1, split3/1, empty/1]).",
+                "         split2/1, split3/1, ranges/1, empty/1, bad_range/1]).",
                 "match2(Binary) -> binary:match(Binary, <<\"needle\">>).",
                 "match3(Binary) -> binary:match(Binary, <<\"needle\">>, []).",
                 "matches2(Binary) -> binary:matches(Binary, [<<\"needle\">>, <<\"thread\">>]).",
                 "matches3(Binary) -> binary:matches(Binary, [<<\"needle\">>, <<\"thread\">>], []).",
                 "split2(Binary) -> binary:split(Binary, <<\"needle\">>).",
                 "split3(Binary) -> binary:split(Binary, <<\"needle\">>, []).",
-                "empty(Binary) -> binary:match(Binary, [])."]),
+                "ranges(Binary) -> binary:match(Binary, [{0, 31}, {127, 255}]).",
+                "empty(Binary) -> binary:match(Binary, []).",
+                "bad_range(Binary) -> binary:match(Binary, [{2, 1}])."]),
     AbstractForms = [erl_syntax:revert(Form) || Form <- Forms],
     {ok,Mod,{Mod,_Exports,_Attrs,_Anno,Funs,_},_Warnings} =
         compile:forms(AbstractForms, [return,to_asm]),
@@ -898,10 +900,14 @@ literal_binary_patterns(_Config) ->
     assert_literal_pattern_wrapped(matches3, 1, matches, 3, Funs),
     assert_literal_pattern_wrapped(split2, 1, split, 2, Funs),
     assert_literal_pattern_wrapped(split3, 1, split, 3, Funs),
+    assert_literal_pattern_wrapped(ranges, 1, match, 2, Funs),
 
     Empty = function_instructions(empty, 1, Funs),
     false = has_ext_call(binary, compile_pattern, 1, Empty),
     true = has_ext_call(binary, match, 2, Empty),
+    BadRange = function_instructions(bad_range, 1, Funs),
+    false = has_ext_call(binary, compile_pattern, 1, BadRange),
+    true = has_ext_call(binary, match, 2, BadRange),
     ok.
 
 assert_literal_pattern_wrapped(Name, Arity, BinaryFunction, BinaryArity, Funs) ->

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -214,6 +214,11 @@ a pattern is not significant.
 The list of binaries used for search alternatives must be flat, proper, and
 non-empty.
 
+When a valid `Pattern` is a literal in compiled code, the pattern can be
+compiled while its module is loaded. This applies both to calls to
+`compile_pattern/1` and to literal patterns passed directly to `match`,
+`matches`, or `split`, avoiding repeated compilation at runtime.
+
 If `Pattern` is not a binary or a flat proper non-empty list of binaries with
 length greater than 0, a `badarg` exception is raised.
 

--- a/lib/stdlib/src/binary.erl
+++ b/lib/stdlib/src/binary.erl
@@ -68,6 +68,9 @@ useful for referencing the last `N` bytes of a binary as
 -type part() :: {Start :: non_neg_integer(), Length :: integer()}.
 -export_type([part/0]).
 
+-type byte_range() :: {Low :: byte(), High :: byte()}.
+-export_type([byte_range/0]).
+
 %%% BIFs.
 
 -export([at/2, bin_to_list/1, bin_to_list/2, bin_to_list/3,
@@ -214,13 +217,19 @@ a pattern is not significant.
 The list of binaries used for search alternatives must be flat, proper, and
 non-empty.
 
+A non-empty list of `{Low, High}` tuples matches any byte in the inclusive
+range `Low..High`. Ranges are alternatives and can overlap; for example,
+`[{0, 31}, {127, 255}]` matches any non-printable ASCII byte. A tuple such as
+`{32, 32}` matches one byte value.
+
 When a valid `Pattern` is a literal in compiled code, the pattern can be
 compiled while its module is loaded. This applies both to calls to
 `compile_pattern/1` and to literal patterns passed directly to `match`,
 `matches`, or `split`, avoiding repeated compilation at runtime.
 
-If `Pattern` is not a binary or a flat proper non-empty list of binaries with
-length greater than 0, a `badarg` exception is raised.
+If `Pattern` is not a binary, a flat proper non-empty list of binaries with
+length greater than 0, or a proper non-empty list of valid byte ranges, a
+`badarg` exception is raised.
 
 ## Examples
 
@@ -232,7 +241,7 @@ length greater than 0, a `badarg` exception is raised.
 """.
 -doc(#{since => <<"OTP R14B">>}).
 -spec compile_pattern(Pattern) -> cp() when
-      Pattern :: PatternBinary | [PatternBinary,...],
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...],
       PatternBinary :: nonempty_binary().
 
 compile_pattern(_) ->
@@ -482,7 +491,7 @@ longest_common_suffix(_) ->
 -doc(#{since => <<"OTP R14B">>}).
 -spec match(Subject, Pattern) -> Found | nomatch when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Found :: part().
 
@@ -529,7 +538,7 @@ position, the longest is returned.
 -doc(#{since => <<"OTP R14B">>}).
 -spec match(Subject, Pattern, Options) -> Found | nomatch when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Found :: part(),
       Options :: [Option],
@@ -542,7 +551,7 @@ match(_, _, _) ->
 -doc(#{since => <<"OTP R14B">>}).
 -spec matches(Subject, Pattern) -> Found when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Found :: [part()].
 
@@ -588,7 +597,7 @@ size of `Subject`, `Start + Length` < 0 or `Start + Length` is > size of
 -doc(#{since => <<"OTP R14B">>}).
 -spec matches(Subject, Pattern, Options) -> Found when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Found :: [part()],
       Options :: [Option],
@@ -709,7 +718,7 @@ referenced_byte_size(_) ->
 -doc(#{since => <<"OTP R14B">>}).
 -spec split(Subject, Pattern) -> Parts when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Parts :: [binary()].
 
@@ -773,7 +782,7 @@ For a description of `Pattern`, see `compile_pattern/1`.
 -doc(#{since => <<"OTP R14B">>}).
 -spec split(Subject, Pattern, Options) -> Parts when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Options :: [Option],
       Option :: {scope, part()} | trim | global | trim_all,
@@ -792,7 +801,7 @@ split(_, _, _) ->
 -doc(#{since => <<"OTP R14B">>}).
 -spec replace(Subject, Pattern, Replacement) -> Result when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Replacement :: binary() | fun((binary()) -> binary()),
       Result :: binary().
@@ -856,7 +865,7 @@ For a description of `Pattern`, see `compile_pattern/1`.
 -doc(#{since => <<"OTP R14B">>}).
 -spec replace(Subject, Pattern, Replacement, Options) -> Result when
       Subject :: binary(),
-      Pattern :: PatternBinary | [PatternBinary,...] | cp(),
+      Pattern :: PatternBinary | [PatternBinary,...] | [byte_range(),...] | cp(),
       PatternBinary :: nonempty_binary(),
       Replacement :: binary() | fun((binary()) -> binary()),
       Options :: [Option],

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -22,7 +22,7 @@
 -module(binary_module_SUITE).
 
 -export([all/0, suite/0,
-	 interesting/1,scope_return/1,random_ref_comp/1,random_ref_sr_comp/1,
+	 interesting/1,literal_patterns/1,scope_return/1,random_ref_comp/1,random_ref_sr_comp/1,
 	 random_ref_fla_comp/1,parts/1, bin_to_list/1, list_to_bin/1,
 	 copy/1, referenced/1,guard/1,encode_decode/1,badargs/1,longest_common_trap/1,
          check_no_invalid_read_bug/1,error_info/1, hex_encoding/1, join/1, doctests/1]).
@@ -36,7 +36,7 @@ suite() ->
      {timetrap,{minutes,10}}].
 
 all() ->
-    [scope_return,interesting, random_ref_fla_comp, random_ref_sr_comp,
+    [scope_return,interesting, literal_patterns, random_ref_fla_comp, random_ref_sr_comp,
      random_ref_comp, parts, bin_to_list, list_to_bin, copy,
      referenced, guard, encode_decode, badargs,
      longest_common_trap, check_no_invalid_read_bug,
@@ -382,6 +382,23 @@ scope_loop(Bin,N,M) ->
 interesting(Config) when is_list(Config) ->
     X = do_interesting(binary),
     X = do_interesting(binref).
+
+literal_patterns(Config) when is_list(Config) ->
+    %% A successful load-time compilation replaces the call with one module
+    %% literal, so repeated calls return the exact same magic reference.
+    BM = literal_compiled_bm_pattern(),
+    BM = literal_compiled_bm_pattern(),
+    {bm, _} = BM,
+    AC = literal_compiled_ac_pattern(),
+    AC = literal_compiled_ac_pattern(),
+    {ac, _} = AC,
+    ok.
+
+literal_compiled_bm_pattern() ->
+    binary:compile_pattern(<<"needle">>).
+
+literal_compiled_ac_pattern() ->
+    binary:compile_pattern([<<"needle">>, <<"thread">>]).
 
 do_interesting(Module) ->
     {0,4} = Module:match(<<"123456">>,

--- a/lib/stdlib/test/binary_module_SUITE.erl
+++ b/lib/stdlib/test/binary_module_SUITE.erl
@@ -22,7 +22,7 @@
 -module(binary_module_SUITE).
 
 -export([all/0, suite/0,
-	 interesting/1,literal_patterns/1,scope_return/1,random_ref_comp/1,random_ref_sr_comp/1,
+         interesting/1,literal_patterns/1,byte_ranges/1,scope_return/1,random_ref_comp/1,random_ref_sr_comp/1,
 	 random_ref_fla_comp/1,parts/1, bin_to_list/1, list_to_bin/1,
 	 copy/1, referenced/1,guard/1,encode_decode/1,badargs/1,longest_common_trap/1,
          check_no_invalid_read_bug/1,error_info/1, hex_encoding/1, join/1, doctests/1]).
@@ -36,7 +36,7 @@ suite() ->
      {timetrap,{minutes,10}}].
 
 all() ->
-    [scope_return,interesting, literal_patterns, random_ref_fla_comp, random_ref_sr_comp,
+    [scope_return,interesting, literal_patterns, byte_ranges, random_ref_fla_comp, random_ref_sr_comp,
      random_ref_comp, parts, bin_to_list, list_to_bin, copy,
      referenced, guard, encode_decode, badargs,
      longest_common_trap, check_no_invalid_read_bug,
@@ -51,6 +51,12 @@ badargs(Config) when is_list(Config) ->
     badarg = ?MASK_ERROR(binary:compile_pattern([<<1,2,3>>|<<1,2>>])),
     badarg = ?MASK_ERROR(binary:compile_pattern(<<1,2,3:3>>)),
     badarg = ?MASK_ERROR(binary:compile_pattern(<<>>)),
+    badarg = ?MASK_ERROR(binary:compile_pattern([{2,1}])),
+    badarg = ?MASK_ERROR(binary:compile_pattern([{-1,1}])),
+    badarg = ?MASK_ERROR(binary:compile_pattern([{0,256}])),
+    badarg = ?MASK_ERROR(binary:compile_pattern([{0,1.0}])),
+    badarg = ?MASK_ERROR(binary:compile_pattern([{0,1}|bad_tail])),
+    badarg = ?MASK_ERROR(binary:compile_pattern([{0,1},<<"mixed">>])),
     badarg = ?MASK_ERROR(binary:match(<<1,2,3:3>>,<<1>>)),
     badarg = ?MASK_ERROR(binary:matches(<<1,2,3:3>>,<<1>>)),
     badarg = ?MASK_ERROR(binary:match(<<1,2,3>>,<<1>>,
@@ -399,6 +405,50 @@ literal_compiled_bm_pattern() ->
 
 literal_compiled_ac_pattern() ->
     binary:compile_pattern([<<"needle">>, <<"thread">>]).
+
+byte_ranges(Config) when is_list(Config) ->
+    Pattern = [{0, 31}, {$", $"}, {$\\, $\\}, {127, 255}],
+    {br, _} = Compiled = binary:compile_pattern(Pattern),
+
+    {1, 1} = binary:match(<<$a, 0, $b>>, Pattern),
+    {1, 1} = binary:match(<<$a, $", $b>>, Compiled),
+    [{1, 1}, {3, 1}] = binary:matches(<<$a, 0, $b, 255>>, Compiled),
+    [<<"a">>, <<"b">>, <<>>] = binary:split(<<$a, 0, $b, 255>>, Compiled,
+                                                  [global]),
+    <<"a_b_">> = binary:replace(<<$a, 0, $b, 255>>, Compiled, <<"_">>,
+                                    [global]),
+    nomatch = binary:match(<<0, $a>>, Pattern, [{scope, {1, 1}}]),
+
+    %% Overlapping and adjacent ranges are normalized into the same byte set.
+    {0, 1} = binary:match(<<15>>, [{10, 12}, {12, 14}, {15, 15}]),
+    {0, 1} = binary:match(<<42>>, [{0, 255}]),
+    {1, 1} = binary:match(<<32, 31>>, [{0, 31}]),
+    {1, 1} = binary:match(<<127, 128>>, [{128, 255}]),
+
+    %% Exercise SIMD block boundaries and the scalar tail on aligned and
+    %% unaligned subjects.
+    _ = [begin
+             Prefix = binary:copy(<<$a>>, Offset),
+             Subject = <<Prefix/binary, $">>,
+             {Offset, 1} = binary:match(Subject, Pattern),
+             {Offset, 1} = binary:match(make_unaligned(Subject), Pattern)
+         end || Offset <- lists:seq(0, 31)],
+
+    %% Exercise the SIMD range loop with 3 and 9 normalized ranges, and the
+    %% table-driven fallback with 17 normalized ranges.
+    _ = [begin
+             Ranges = [{Byte, Byte} || Byte <- lists:seq(0, 2 * (Count - 1), 2)],
+             Last = 2 * (Count - 1),
+             {1, 1} = binary:match(<<1, Last>>, Ranges)
+         end || Count <- [3, 9, 17]],
+
+    %% Exercise converting every lane in consecutive SIMD masks into match
+    %% positions, including an unaligned subject and the scalar tail.
+    Dense = list_to_binary(lists:seq(0, 32)),
+    DenseMatches = [{Position, 1} || Position <- lists:seq(0, 32)],
+    DenseMatches = binary:matches(Dense, [{0, 255}]),
+    DenseMatches = binary:matches(make_unaligned(Dense), [{0, 255}]),
+    ok.
 
 do_interesting(Module) ->
     {0,4} = Module:match(<<"123456">>,

--- a/lib/stdlib/test/stdlib_bench_SUITE.erl
+++ b/lib/stdlib/test/stdlib_bench_SUITE.erl
@@ -25,6 +25,7 @@
 -compile([export_all, nowarn_export_all]).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("common_test/include/ct_event.hrl").
+-include("../src/swar_ascii.hrl").
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 suite() -> [{ct_hooks,[{ts_install_cth,[{nodenames,2}]}]}].
@@ -46,7 +47,16 @@ groups() ->
       [match_single_pattern_no_match,
        matches_single_pattern_no_match,
        matches_single_pattern_eventual_match,
-       matches_single_pattern_frequent_match]},
+       matches_single_pattern_frequent_match,
+       byte_ranges_ascii_valid, byte_ranges_ascii_invalid_first,
+       byte_ranges_ascii_invalid_last,
+       byte_ranges_ascii_swar_valid, byte_ranges_ascii_swar_invalid_first,
+       byte_ranges_ascii_swar_invalid_last,
+       byte_ranges_ascii_unicode_valid,
+       byte_ranges_ascii_unicode_invalid_first,
+       byte_ranges_ascii_unicode_invalid_last,
+       byte_ranges_ascii_guard_valid, byte_ranges_ascii_guard_invalid_first,
+       byte_ranges_ascii_guard_invalid_last]},
      {base64,[{repeat,5}],
       [decode_binary, decode_binary_to_string,
        decode_list, decode_list_to_string,
@@ -183,6 +193,76 @@ matches_single_pattern_frequent_match(_Config) ->
     Binary = binary:copy(<<"abc\n">>, 1000000),
     comment(test(100, binary, matches, [Binary, <<"abc">>])).
 
+byte_ranges_ascii_valid(_Config) ->
+    byte_ranges_ascii_benchmark(valid, br).
+
+byte_ranges_ascii_invalid_first(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_first, br).
+
+byte_ranges_ascii_invalid_last(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_last, br).
+
+byte_ranges_ascii_swar_valid(_Config) ->
+    byte_ranges_ascii_benchmark(valid, swar).
+
+byte_ranges_ascii_swar_invalid_first(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_first, swar).
+
+byte_ranges_ascii_swar_invalid_last(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_last, swar).
+
+byte_ranges_ascii_unicode_valid(_Config) ->
+    byte_ranges_ascii_benchmark(valid, unicode).
+
+byte_ranges_ascii_unicode_invalid_first(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_first, unicode).
+
+byte_ranges_ascii_unicode_invalid_last(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_last, unicode).
+
+byte_ranges_ascii_guard_valid(_Config) ->
+    byte_ranges_ascii_benchmark(valid, guard).
+
+byte_ranges_ascii_guard_invalid_first(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_first, guard).
+
+byte_ranges_ascii_guard_invalid_last(_Config) ->
+    byte_ranges_ascii_benchmark(invalid_last, guard).
+
+byte_ranges_ascii_benchmark(Scenario, Implementation) ->
+    Valid = binary:copy(<<"Az09-._~">>, 128),
+    Binary = case Scenario of
+                 valid -> Valid;
+                 invalid_first -> <<255, Valid/binary>>;
+                 invalid_last -> <<Valid/binary, 255>>
+             end,
+    Pattern = binary:compile_pattern([{128, 255}]),
+    Fun = case Implementation of
+              br -> fun() -> binary:match(Binary, Pattern) =:= nomatch end;
+              swar -> fun() -> all_ascii_swar(Binary) end;
+              unicode -> fun() -> unicode:bin_is_7bit(Binary) end;
+              guard -> fun() -> all_ascii_guard(Binary) end
+          end,
+    Suite = lists:concat(["stdlib_binary_ascii_", Implementation, "_", Scenario]),
+    comment(test_fun(100000, Suite, Fun)).
+
+all_ascii_swar(<<W:56, Rest/binary>>)
+  when W band ?SWAR_MASK80 =:= 0 ->
+    all_ascii_swar(Rest);
+all_ascii_swar(<<Byte, Rest/binary>>) when Byte < 128 ->
+    all_ascii_swar(Rest);
+all_ascii_swar(<<_, _/binary>>) ->
+    false;
+all_ascii_swar(<<>>) ->
+    true.
+
+all_ascii_guard(<<Byte, Rest/binary>>) when Byte < 128 ->
+    all_ascii_guard(Rest);
+all_ascii_guard(<<_, _/binary>>) ->
+    false;
+all_ascii_guard(<<>>) ->
+    true.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 decode_binary(_Config) ->
@@ -243,6 +323,19 @@ test(Iter, Mod, Fun, Args) ->
     F = fun() -> loop(Iter, Mod, Fun, Args) end,
     {Time, ok} = timer:tc(fun() -> lspawn(F) end),
     report_mfa(Iter, Time, Mod).
+
+test_fun(Iter, Suite, Fun) ->
+    F = fun() -> loop_fun(Iter, Fun) end,
+    {Time, ok} = timer:tc(fun() -> lspawn(F) end),
+    Tps = round((Iter*1000000)/Time),
+    ct_event:notify(#event{name = benchmark_data,
+                           data = [{suite, Suite}, {value, Tps}]}),
+    Tps.
+
+loop_fun(0, _Fun) -> garbage_collect(), ok;
+loop_fun(N, Fun) ->
+    _ = Fun(),
+    loop_fun(N - 1, Fun).
 
 loop(0, _M, _F, _A) -> garbage_collect(), ok;
 loop(N, M, F, A) ->


### PR DESCRIPTION
Allow non-empty lists of inclusive byte-range tuples
in binary:compile_pattern/1 and the binary match, matches,
split, and replace operations. Those ranges are compiled
into a new pattern which uses SIMD for up to 16 normalized
entries.

ASCII validation throughput on arm64 macOS (million calls/s):

                       SIMD   Unicode   SWAR   Guard
    Valid ASCII       14.40      2.74   2.74    0.41
    Invalid last      13.78      3.00   2.74    0.41
    Invalid first     42.30    148.81  91.83  104.38

SIMD is the one added by this pull request, Unicode is
`unicode:bin_is_7bit/1`. Guard is the equivalent guard
implementation and a SWAR optimized guard. The native
unicode:bin_is_7bit/1 can be removed in a future commit.

As shown in the benchmarks above, the new byte ranges are
clear winners for validating data, as most times you are
expecting to fully traverse binaries without matches.
For parsing, byte ranges can be faster than guards, but may
be beaten by SWAR on certain payloads.

## Implementation notes

The first commit is actually #11468. Without that commit,
the SWAR usage in json is much faster than this implementation
due to the cost of compiling the pattern. With that commit,
they are in the same order of magnitude, and one edges the
other depending on how frequent the matches are (with SIMD
being up to 3x faster when there are no matches). This pull
request will be rebased if and when that one is merged.

Also note this functionality could be added by adding new
functions, such as find_byte and find_bytes, but I thought
adding new compile patterns is the best approach as we can
reuse all infrastructure for match/matches/replace/split.