### PR TITLE
ssh: cli not handling latin1 put_char requests

### DIFF
--- a/lib/ssh/src/ssh_cli.erl
+++ b/lib/ssh/src/ssh_cli.erl
@@ -450,8 +450,13 @@ io_request(delete_after_cursor, TTY, _State) ->
     prim_tty:handle_request(TTY, delete_after_cursor);
 io_request(delete_line, TTY, _State) ->
     prim_tty:handle_request(TTY, delete_line);
+io_request({put_chars, latin1, Chars}, TTY, _State) ->
+    prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars, latin1)});
 io_request({put_chars, unicode, Chars}, TTY, _State) ->
     prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars)});
+io_request({put_chars_sync, latin1, Chars, Reply}, TTY, State) ->
+    State#state.group ! {reply, Reply, ok},
+    prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars, latin1)});
 io_request({put_chars_sync, unicode, Chars, Reply}, TTY, State) ->
     State#state.group ! {reply, Reply, ok},
     prim_tty:handle_request(TTY, {putc, unicode:characters_to_binary(Chars)});

--- a/lib/ssh/test/ssh_basic_SUITE.erl
+++ b/lib/ssh/test/ssh_basic_SUITE.erl
@@ -91,6 +91,7 @@
          shell/1,
          shell_disabled/1,
          shell_exit_status/1,
+         shell_latin1_exception/1,
          shell_no_unicode/1,
          shell_socket/1,
          shell_ssh_conn/1,
@@ -161,6 +162,7 @@ groups() ->
                              misc_ssh_options, inet_option, inet6_option,
                              shell, shell_disabled, shell_socket, shell_ssh_conn,
                              shell_no_unicode, shell_unicode_string,
+                             shell_latin1_exception,
                              close]}].
 
 %%--------------------------------------------------------------------
@@ -197,7 +199,8 @@ end_per_group(_, Config) ->
 %%--------------------------------------------------------------------
 init_per_testcase(TestCase, Config)
   when TestCase==shell_no_unicode;
-       TestCase==shell_unicode_string ->
+       TestCase==shell_unicode_string;
+       TestCase==shell_latin1_exception ->
     PrivDir = proplists:get_value(priv_dir, Config),
     UserDir = proplists:get_value(priv_dir, Config),
     SysDir =  proplists:get_value(data_dir, Config),
@@ -227,7 +230,8 @@ init_per_testcase(TestCase, Config) ->
 
 end_per_testcase(TestCase, Config)
   when TestCase==shell_no_unicode;
-       TestCase==shell_unicode_string ->
+       TestCase==shell_unicode_string;
+       TestCase==shell_latin1_exception ->
     case proplists:get_value(sftpd, Config) of
 	{Pid, _, _} ->
             try ssh:stop_daemon(Pid) catch _:_ -> ok end,
@@ -1346,6 +1350,17 @@ shell_unicode_string(Config) ->
 		  new_prompt,
 		  {type,"exit()."}
 		 ]).
+
+%%--------------------------------------------------------------------
+shell_latin1_exception(Config) ->
+    new_do_shell(proplists:get_value(io,Config),
+                 [new_prompt,
+                  {type,"1/0."},
+                  {expect,"**"},
+                  {expect,"exception error"},
+                  new_prompt,
+                  {type,"exit()."}
+                 ]).
 
 %%--------------------------------------------------------------------
 %%% Test basic connection with openssh_zlib


### PR DESCRIPTION
When starting a ssh daemon with a shell, connecting to it and pressing CTRL+C on the ssh client, a message appears on the host machine:
```
1> application:ensure_all_started(ssh).
{ok,[crypto,asn1,public_key,ssh]}
2> ssh:daemon(2222, [{shell,{shell,start,[]}}, {system_dir, "."}, {exec,erlang_eval}, {pwdfun, fun(_,_) -> true end}]).
{ok,<0.100.0>}

{unhandled_request,{put_chars_sync,latin1,<<"** ">>,undefined}}
```

This commit addresses that by properly processing latin1 encodings in `ssh_cli`, as `user_drv` already managed these cases.

I've only tested it by directly patching the module on: the two asterisks appear on the ssh client and no `unhandled_request` is shown on the host. I'm not sure how to build an automatic test case, but I could try.