### PR TITLE
compiler: Let cloned test suites run under other build systems

### DIFF
--- a/lib/compiler/test/test_lib.erl
+++ b/lib/compiler/test/test_lib.erl
@@ -135,10 +135,16 @@ get_data_dir(Config) ->
                 "_no_type_opt_SUITE",
                 "_no_ssa_opt_SUITE",
                 "_cover_SUITE"],
-    lists:foldl(fun(Suffix, Acc) ->
-                        Opts = [{return,list}],
-                        re:replace(Acc, Suffix, "_SUITE", Opts)
-                end, Data, Suffixes).
+    case filelib:is_dir(Data) of
+        true ->
+            %% Build system already provides it
+            Data;
+        false ->
+            lists:foldl(fun(Suffix, Acc) ->
+                                Opts = [{return,list}],
+                                re:replace(Acc, Suffix, "_SUITE", Opts)
+                        end, Data, Suffixes)
+    end.
 
 %% Test whether the module is cloned. We don't consider modules
 %% compiled with compatibility for an older release cloned (that


### PR DESCRIPTION
Some compiler test suites get cloned so they can be built with different compiler options. When building tests with make, they need to share the data dir, and test_lib:get_data_dir/1 does the conversion.

However, if we try to run these tests under a different build system (e.g. buck, but possibly the same would happen with rebar3) then it is more convenient to let the build system handle the aliasing of data-dir, and in that case the adapter should do nothing