### PR TITLE
compiler: Suppress incorrect `useless_building` warning

### DIFF
--- a/lib/compiler/src/sys_core_fold.erl
+++ b/lib/compiler/src/sys_core_fold.erl
@@ -2901,7 +2901,7 @@ void() -> #c_literal{val=ok}.
 descend(_Core, #sub{top=false}=Sub) ->
     Sub;
 descend(Core, #sub{top=true}=Sub) ->
-    case should_suppress_warning(Core) of
+    case is_compiler_generated(Core) of
         true ->
             %% In a list comprehension being ignored such as:
             %%

--- a/lib/compiler/test/warnings_SUITE.erl
+++ b/lib/compiler/test/warnings_SUITE.erl
@@ -47,7 +47,7 @@
 	 underscore/1,no_warnings/1,
 	 bit_syntax/1,inlining/1,tuple_calls/1,
          recv_opt_info/1,opportunistic_warnings/1,
-         eep49/1,inline_list_funcs/1]).
+         eep49/1,inline_list_funcs/1,gh_11472/1]).
 
 init_per_testcase(_Case, Config) ->
     Config.
@@ -71,7 +71,7 @@ groups() ->
        redundant_boolean_clauses,
        underscore,no_warnings,bit_syntax,inlining,
        tuple_calls,recv_opt_info,opportunistic_warnings,
-       eep49,inline_list_funcs]}].
+       eep49,inline_list_funcs,gh_11472]}].
 
 init_per_suite(Config) ->
     test_lib:recompile(?MODULE),
@@ -1360,6 +1360,25 @@ inline_list_funcs(Config) ->
            []}
          ],
     run(Config, Ts),
+
+    ok.
+
+gh_11472(Config) ->
+    Ts = [{nowarn,
+           <<"-export([f/1]).
+              f(Acc) ->
+                X = 0,
+                {Y} =
+                    begin
+                    _Fresh1 = {[X | Acc]},
+                    _Fresh1
+                    end,
+                Y.
+            ">>,
+           [],
+           []}
+           ],
+    [] = run(Config,Ts),
 
     ok.
 


### PR DESCRIPTION
Fix https://github.com/erlang/otp/issues/11472