### PR TITLE
tools: fixes tprof not stopping tracing

### DIFF
--- a/lib/tools/src/tprof.erl
+++ b/lib/tools/src/tprof.erl
@@ -748,8 +748,8 @@ disable_trace(Server, Spec, Options) ->
 disable_session_trace(Session, Procs) ->
     disable_session_trace(Session, Procs, default_trace_options()).
 disable_session_trace(Session, Procs, Options) when Procs =:= all;
-                                                    Procs =:= new_processes;
-                                                    Procs =:= existing_processes ->
+                                                    Procs =:= new;
+                                                    Procs =:= existing ->
     trace:process(Session,  Procs, false, trace_options(Options));
 disable_session_trace(Session, {Children, PidOrName}, Options) when Children =:= children;
                                                                     Children =:= all_children ->

--- a/lib/tools/test/tprof_SUITE.erl
+++ b/lib/tools/test/tprof_SUITE.erl
@@ -40,7 +40,8 @@
     server_all/0, server_all/1,
     hierarchy/0, hierarchy/1,
     code_reload/0, code_reload/1,
-    code_load/0, code_load/1
+    code_load/0, code_load/1,
+    disable_trace/0, disable_trace/1
 ]).
 
 -include_lib("stdlib/include/assert.hrl").
@@ -53,6 +54,7 @@ suite() ->
 
 all() ->
     [call_count_ad_hoc, %% Cannot be run in parallel
+     disable_trace,     %% Cannot be run in parallel
      {group, all}].
 
 groups() ->
@@ -208,6 +210,48 @@ lists_seq_loop(N) ->
 int_to_bin_twice(M) ->
     B = integer_to_binary(M),
     <<B/binary, B/binary>>.
+
+disable_trace() ->
+    [{doc, "Test `disable_trace` does not continue tracing"}].
+
+disable_trace(_Config) when is_list(_Config) ->
+    ok = disable_trace(new),
+    ok = disable_trace(existing),
+    true;
+disable_trace(new=Trace) ->
+    {ok, TracePid} = tprof:start(#{type => call_memory, session => Trace}),
+    tprof:set_pattern(TracePid, lists, '_', '_'),
+    tprof:enable_trace(TracePid, Trace, #{set_on_spawn => true}),
+
+    Pid = spawn(fun () -> lists:sum(lists:seq(1, 5000)) end),
+    timer:sleep(100),
+
+    tprof:disable_trace(TracePid, Trace, #{set_on_spawn => true}),
+    _ = spawn(fun () -> lists:sum(lists:seq(1, 5000)) end),
+    timer:sleep(100),
+
+    Result = tprof:collect(TracePid),
+    tprof:stop(TracePid),
+
+    Expected = tprof:inspect(Result, process, percent),
+    ?assertMatch([Pid], maps:keys(Expected));
+disable_trace(existing=Trace) ->
+    {ok, TracePid} = tprof:start(#{type => call_memory, session => Trace}),
+    tprof:set_pattern(TracePid, lists, '_', '_'),
+    tprof:enable_trace(TracePid, Trace, #{set_on_spawn => false}),
+
+    Pid = spawn(fun () -> lists:sum(lists:seq(1, 5000)) end),
+    timer:sleep(100),
+
+    tprof:disable_trace(TracePid, Trace, #{set_on_spawn => false}),
+
+    {call_memory, Result} = tprof:collect(TracePid),
+    tprof:stop(TracePid),
+
+    MatchingPids = lists:flatmap(fun ({_, _, _, L}) -> [P || {P, _, _} <- L, P == Pid] end, Result),
+    ?assertMatch(0, length(Result)),
+    ?assertMatch([], MatchingPids).
+
 
 %% Ensure total is not truncated,
 %% as per https://github.com/erlang/otp/issues/8139


### PR DESCRIPTION
A call to `tprof:enable_trace(new|existing)` starts tracing processes.
To stop it, one calls `tprof:disable_trace(new|existing)`. However, the guard to stop tracing was matching on `new_processes | existing_processes`. 
The return happens to say `0` processes are traced now, but the tracing did not stop.
