### PR TITLE
xmerl: Remove leftover debug compile flags

### DIFF
--- a/lib/xmerl/src/xmerl_ucs.erl
+++ b/lib/xmerl/src/xmerl_ucs.erl
@@ -23,10 +23,6 @@
 -module(xmerl_ucs).
 -moduledoc false.
 
--compile([verbose,report_warnings,warn_unused_vars]).
-
-
-
 %%% Conversion to/from IANA recognised character sets
 -export([to_unicode/2]).
 


### PR DESCRIPTION
These flags cause printouts when running dialyzer on this file.