### PR TITLE
inets: Tighten the defaults for httpd and remove nolimit

### DIFF
--- a/lib/inets/doc/guides/hardening.md
+++ b/lib/inets/doc/guides/hardening.md
@@ -229,22 +229,22 @@ or
 
 ### Request Size Limits
 
-Several size limits default to `nolimit`, which allows arbitrarily large
+Before OTP 30 several size limits default to `nolimit`, which allows arbitrarily large
 requests that can exhaust memory. Set explicit limits:
 
 ```erlang
-[{max_uri_size, 8192},              %% 8 KB URI limit
+[{max_uri_size, 8192},              %% 8 KB URI limit (default since OTP 30)
  {max_header_size, 10240},          %% 10 KB (already the default)
  {max_body_size, 10_485_760},       %% 10 MB body limit
  {max_content_length, 10_485_760}]  %% 10 MB Content-Length check
 ```
 
-- **[`max_uri_size`](`m:httpd#prop_max_uri`)** - Maximum URI length in bytes. Default: `nolimit`.
+- **[`max_uri_size`](`m:httpd#prop_max_uri`)** - Maximum URI length in bytes. Default: `8192` (8 KB).
 
 - **[`max_header_size`](`m:httpd#prop_max_header_size`)** - Maximum total header size. Default: `10240` (10 KB).
 
 - **[`max_body_size`](`m:httpd#prop_max_body_size`)** - Maximum received body size during parsing. Default:
-  `nolimit`.
+  `100_000_000` (100 MB).
 
 - **[`max_content_length`](`m:httpd#prop_max_content_length`)** - Rejects requests whose `Content-Length` header
   exceeds this value with a 413 response, before reading the body. Default:
@@ -253,7 +253,7 @@ requests that can exhaust memory. Set explicit limits:
 - **[`max_client_body_chunk`](`m:httpd#max_client_body_chunk`)** - When handling large PUT or POST bodies via
   `mod_esi`, setting this option enforces chunked delivery to the ESI
   callback. This prevents the server from buffering the entire request body
-  in memory, which could be exploited to cause memory exhaustion.
+  in memory, which could be exploited to cause memory exhaustion. Default: `nolimit`.
 
 > #### Note {: .info }
 >

--- a/lib/inets/doc/guides/hardening.md
+++ b/lib/inets/doc/guides/hardening.md
@@ -229,22 +229,23 @@ or
 
 ### Request Size Limits
 
-Several size limits default to `nolimit`, which allows arbitrarily large
-requests that can exhaust memory. Set explicit limits:
+Before Erlang/OTP 30 several size limits default to `nolimit`, which allows arbitrarily large
+requests that can exhaust memory. After and including Erlang/OTP 30 all limits have an upper bound.
+So if you are using an older version make sure to set explicit limits:
 
 ```erlang
-[{max_uri_size, 8192},              %% 8 KB URI limit
+[{max_uri_size, 8192},              %% 8 KB URI limit (default since OTP 30)
  {max_header_size, 10240},          %% 10 KB (already the default)
  {max_body_size, 10_485_760},       %% 10 MB body limit
  {max_content_length, 10_485_760}]  %% 10 MB Content-Length check
 ```
 
-- **[`max_uri_size`](`m:httpd#prop_max_uri`)** - Maximum URI length in bytes. Default: `nolimit`.
+- **[`max_uri_size`](`m:httpd#prop_max_uri`)** - Maximum URI length in bytes. Default: `8192` (8 KB).
 
 - **[`max_header_size`](`m:httpd#prop_max_header_size`)** - Maximum total header size. Default: `10240` (10 KB).
 
 - **[`max_body_size`](`m:httpd#prop_max_body_size`)** - Maximum received body size during parsing. Default:
-  `nolimit`.
+  `100_000_000` (100 MB).
 
 - **[`max_content_length`](`m:httpd#prop_max_content_length`)** - Rejects requests whose `Content-Length` header
   exceeds this value with a 413 response, before reading the body. Default:
@@ -253,7 +254,7 @@ requests that can exhaust memory. Set explicit limits:
 - **[`max_client_body_chunk`](`m:httpd#max_client_body_chunk`)** - When handling large PUT or POST bodies via
   `mod_esi`, setting this option enforces chunked delivery to the ESI
   callback. This prevents the server from buffering the entire request body
-  in memory, which could be exploited to cause memory exhaustion.
+  in memory, which could be exploited to cause memory exhaustion. Default: `nolimit`.
 
 > #### Note {: .info }
 >

--- a/lib/inets/src/http_lib/http_internal.hrl
+++ b/lib/inets/src/http_lib/http_internal.hrl
@@ -26,12 +26,12 @@
 
 -include_lib("inets/src/inets_app/inets_internal.hrl").
 
--define(HTTP_MAX_BODY_SIZE,   nolimit).
+-define(HTTP_MAX_BODY_SIZE,   ?HTTP_MAX_CONTENT_LENGTH). %% 100 MB, same as max-content length
 -define(HTTP_MAX_HEADER_SIZE, 10240).
--define(HTTP_MAX_URI_SIZE,    nolimit).
+-define(HTTP_MAX_URI_SIZE,    8192).
 -define(HTTP_MAX_VERSION_STRING, 8).
 -define(HTTP_MAX_METHOD_STRING, 20).
--define(HTTP_MAX_CONTENT_LENGTH, 100000000).
+-define(HTTP_MAX_CONTENT_LENGTH, 100000000). %% 100 MB
 
 -define(DATA_20MB, <<0:16#A000000>>).
 

--- a/lib/inets/src/http_lib/http_internal.hrl
+++ b/lib/inets/src/http_lib/http_internal.hrl
@@ -26,14 +26,15 @@
 
 -include_lib("inets/src/inets_app/inets_internal.hrl").
 
--define(HTTP_MAX_BODY_SIZE,   nolimit).
+-define(HTTP_MAX_BODY_SIZE,   ?HTTP_MAX_CONTENT_LENGTH). %% 100 MB, same as max-content length
 -define(HTTP_MAX_HEADER_SIZE, 10240).
--define(HTTP_MAX_URI_SIZE,    nolimit).
+-define(HTTP_MAX_URI_SIZE,    8192).
 -define(HTTP_MAX_VERSION_STRING, 8).
 -define(HTTP_MAX_METHOD_STRING, 20).
 -define(HTTP_MAX_CLIENTS, 150).
--define(DATA_20MB, <<0:16#A000000>>).
 -define(HTTP_MAX_CONTENT_LENGTH, 100000000). %% 100 MB
+
+-define(DATA_20MB, <<0:16#A000000>>).
 -define(HTTP_REQUEST_READ_TIMEOUT, 60). %% seconds
 
 %%% Response headers

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -172,7 +172,8 @@ property list.
   client before closing the connection. Default is `150`.
 
 - [](){: #prop_max_body_size } **`{max_body_size, integer()}`**  
-  Limits the size of the message body of an HTTP request. Default is no limit.
+  Limits the size of the message body of an HTTP request. Default is `100000000` (100
+  MB).
 
 - [](){: #prop_max_clients } **`{max_clients, integer()}`**  
   Limits the number of simultaneous requests that can be supported. Default is
@@ -187,7 +188,7 @@ property list.
   MB).
 
 - [](){: #prop_max_uri } **`{max_uri_size, integer()}`**  
-  Limits the size of the HTTP request URI. Default is no limit.
+  Limits the size of the HTTP request URI. Default is `8192` (8 KB).
 
 - [](){: #prop_max_keep_alive_req } **`{max_keep_alive_request, integer()}`**  
   The number of requests that a client can do on one connection. When the server

--- a/lib/inets/src/http_server/httpd.erl
+++ b/lib/inets/src/http_server/httpd.erl
@@ -167,17 +167,18 @@ property list.
   Instructs the server whether to use persistent connections when the client
   claims to be HTTP/1.1 compliant. Default is `true`.
 
-- [](){: #prop_keep_alive_timeout } **`{keep_alive_timeout, integer() | infinity}`**
+- [](){: #prop_keep_alive_timeout } **`{keep_alive_timeout, integer()}`**
   The number of seconds the server waits for a subsequent request from the
   client before closing the connection. This timer covers the waiting time
   for the request to arrive, starting from the connection opening or the
   moment the server sent a response to a previous request.
   Default is `150` seconds.
 
-- [](){: #prop_max_body_size } **`{max_body_size, integer() | nolimit}`**
-  Limits the size of the message body of an HTTP request. Default is no limit.
+- [](){: #prop_max_body_size } **`{max_body_size, integer()}`**  
+  Limits the size of the message body of an HTTP request.
+  Default is `100000000` (100 MB).
 
-- [](){: #prop_request_timeout } **`{request_timeout, pos_integer() | infinity}`**
+- [](){: #prop_request_timeout } **`{request_timeout, pos_integer()}`**
   Limits the time the server is allowed to be idle waiting for the next chunk
   of an HTTP request. Refreshes on every incoming chunk within the same request.
   Default is `60` seconds.
@@ -194,8 +195,8 @@ property list.
   larger than this are answered with status 413. Default is `100000000` (100
   MB).
 
-- [](){: #prop_max_uri } **`{max_uri_size, integer() | nolimit}`**
-  Limits the size of the HTTP request URI. Default is no limit.
+- [](){: #prop_max_uri } **`{max_uri_size, integer()}`**  
+  Limits the size of the HTTP request URI. Default is `8192` (8 KB).
 
 - [](){: #prop_max_keep_alive_req } **`{max_keep_alive_request, integer()}`**  
   The number of requests that a client can do on one connection. When the server
@@ -725,7 +726,7 @@ The properties for the security directories are as follows:
   relative to the `server_root`. This file is used to store persistent data for
   module `mod_security`.
 
-- [](){: #prop_max_retries } **`{max_retries, integer()}`**  
+- [](){: #prop_max_retries } **`{max_retries, integer() | infinity}`**  
   Specifies the maximum number of attempts to authenticate a user before the
   user is blocked out. If a user successfully authenticates while blocked, the
   user receives a 403 (Forbidden) response from the server. If the user makes a

--- a/lib/inets/src/http_server/httpd_conf.erl
+++ b/lib/inets/src/http_server/httpd_conf.erl
@@ -197,6 +197,12 @@ validate_config_params([{max_content_length, Value} | Rest])
 validate_config_params([{max_content_length, Value} | _]) -> 
     throw({max_content_length, Value});
 
+validate_config_params([{max_uri_size, Value} | Rest]) 
+  when is_integer(Value) andalso (Value > 0) ->
+    validate_config_params(Rest);
+validate_config_params([{max_uri_size, Value} | _]) -> 
+    throw({max_uri_size, Value});
+
 validate_config_params([{server_name, Value} | Rest])  
   when is_list(Value) ->
     validate_config_params(Rest);

--- a/lib/inets/src/http_server/httpd_conf.erl
+++ b/lib/inets/src/http_server/httpd_conf.erl
@@ -113,7 +113,6 @@ validate_properties2(Properties0) ->
         false ->
             KeepaliveTimeout = proplists:get_value(keep_alive_timeout, Properties0),
             case KeepaliveTimeout of
-                infinity -> ok; %%% timeout disabled
                 undefined -> ok;
                 _ ->
                     throw({error, invalid_keep_alive_timeout})
@@ -205,8 +204,7 @@ validate_config_params([{max_body_size, Value} | _]) ->
     throw({max_body_size, Value});
 
 validate_config_params([{request_timeout, Value} | Rest])
-  when (is_integer(Value) andalso (Value > 0));
-       Value =:= infinity ->
+  when (is_integer(Value) andalso (Value > 0)) ->
     validate_config_params(Rest);
 validate_config_params([{request_timeout, Value} | _]) ->
     throw({request_timeout, Value});
@@ -216,6 +214,12 @@ validate_config_params([{max_content_length, Value} | Rest])
     validate_config_params(Rest);
 validate_config_params([{max_content_length, Value} | _]) -> 
     throw({max_content_length, Value});
+
+validate_config_params([{max_uri_size, Value} | Rest]) 
+  when is_integer(Value) andalso (Value > 0) ->
+    validate_config_params(Rest);
+validate_config_params([{max_uri_size, Value} | _]) -> 
+    throw({max_uri_size, Value});
 
 validate_config_params([{server_name, Value} | Rest])  
   when is_list(Value) ->
@@ -284,8 +288,7 @@ validate_config_params([{max_keep_alive_request, Value} | _]) ->
     throw({max_keep_alive_request, Value});
 
 validate_config_params([{keep_alive_timeout, Value} | Rest]) 
-  when (is_integer(Value) andalso (Value >= 0));
-       Value =:= infinity ->
+  when (is_integer(Value) andalso (Value >= 0)) ->
     validate_config_params(Rest);
 validate_config_params([{keep_alive_timeout, Value} | _]) ->
     throw({keep_alive_timeout, Value});

--- a/lib/inets/src/http_server/httpd_request.erl
+++ b/lib/inets/src/http_server/httpd_request.erl
@@ -148,8 +148,7 @@ parse_method(_, _, _, Max, _, _) ->
     %% will be able to handle it.
     {error, {size_error, Max, 413, "Method unreasonably long"}, default_version()}.
 
-parse_uri(_, _, Current, MaxURI, _, _)
-  when (Current > MaxURI) andalso (MaxURI =/= nolimit) -> 
+parse_uri(_, _, Current, MaxURI, _, _) when Current > MaxURI -> 
     %% We do not know the version of the client as it comes after the
     %% uri send the lowest version in the response so that the client
     %% will be able to handle it.
@@ -180,8 +179,7 @@ parse_version(<<Octet, Rest/binary>>, Version, Current, Max, Options, Result)  w
 parse_version(_, _, _, Max,_,_) ->
     {error, {size_error, Max, 413, "Version string unreasonably long"}, default_version()}.
 
-parse_headers(_, _, _, Current, Max, _, Result) 
-  when Max =/= nolimit andalso Current > Max -> 
+parse_headers(_, _, _, Current, Max, _, Result) when Current > Max -> 
     HttpVersion = lists:nth(3, lists:reverse(Result)),
     {error, {size_error, Max, 413, "Headers unreasonably long"}, HttpVersion};
 

--- a/lib/inets/src/http_server/httpd_request.erl
+++ b/lib/inets/src/http_server/httpd_request.erl
@@ -150,8 +150,7 @@ parse_method(_, _, _, Max, _, _) ->
     %% will be able to handle it.
     {error, {size_error, Max, 413, "Method unreasonably long"}, default_version()}.
 
-parse_uri(_, _, Current, MaxURI, _, _)
-  when (Current > MaxURI) andalso (MaxURI =/= nolimit) -> 
+parse_uri(_, _, Current, MaxURI, _, _) when Current > MaxURI -> 
     %% We do not know the version of the client as it comes after the
     %% uri send the lowest version in the response so that the client
     %% will be able to handle it.
@@ -182,8 +181,7 @@ parse_version(<<Octet, Rest/binary>>, Version, Current, Max, Options, Result)  w
 parse_version(_, _, _, Max,_,_) ->
     {error, {size_error, Max, 413, "Version string unreasonably long"}, default_version()}.
 
-parse_headers(_, _, _, Current, Max, _, Result) 
-  when Max =/= nolimit andalso Current > Max -> 
+parse_headers(_, _, _, Current, Max, _, Result) when Current > Max -> 
     HttpVersion = lists:nth(3, lists:reverse(Result)),
     {error, {size_error, Max, 413, "Headers unreasonably long"}, HttpVersion};
 

--- a/lib/inets/src/http_server/httpd_request_handler.erl
+++ b/lib/inets/src/http_server/httpd_request_handler.erl
@@ -536,7 +536,7 @@ handle_body(#state{headers = Headers, body = Body,
 	_ -> 
 	    Length = list_to_integer(Headers#http_request_h.'content-length'),
 	    MaxChunk = max_client_body_chunk(ConfigDB),
-	    case Length =< MaxBodySize orelse MaxBodySize == nolimit of
+            case Length =< MaxBodySize of
 		true ->
 		    case httpd_request:body_chunk_first(Body, Length, MaxChunk) of 
                         %% This is the case that the we need more data to complete
@@ -572,7 +572,7 @@ handle_expect(#state{headers = Headers, mod =
 	      MaxBodySize) ->
     Length = list_to_integer(Headers#http_request_h.'content-length'),
     case expect(Headers, ModData#mod.http_version, ConfigDB) of
-	continue when (MaxBodySize > Length) orelse (MaxBodySize =:= nolimit) ->
+        continue when MaxBodySize > Length ->
 	    httpd_response:send_status(ModData, 100, ""),
 	    ok;
 	continue when MaxBodySize < Length ->
@@ -762,7 +762,7 @@ max_uri_size(ConfigDB) ->
     httpd_util:lookup(ConfigDB, max_uri_size, ?HTTP_MAX_URI_SIZE).
 
 max_body_size(ConfigDB) ->
-    httpd_util:lookup(ConfigDB, max_body_size, nolimit).
+    httpd_util:lookup(ConfigDB, max_body_size, ?HTTP_MAX_BODY_SIZE).
 
 max_keep_alive_request(ConfigDB) ->
     httpd_util:lookup(ConfigDB, max_keep_alive_request, infinity).

--- a/lib/inets/src/http_server/httpd_request_handler.erl
+++ b/lib/inets/src/http_server/httpd_request_handler.erl
@@ -539,7 +539,7 @@ handle_body(#state{headers = Headers, body = Body,
 	_ -> 
 	    Length = list_to_integer(Headers#http_request_h.'content-length'),
 	    MaxChunk = max_client_body_chunk(ConfigDB),
-	    case Length =< MaxBodySize orelse MaxBodySize == nolimit of
+            case Length =< MaxBodySize of
 		true ->
 		    case httpd_request:body_chunk_first(Body, Length, MaxChunk) of 
                         %% This is the case that the we need more data to complete
@@ -587,7 +587,7 @@ handle_expect(#state{headers = Headers, mod =
 	      MaxBodySize) ->
     Length = list_to_integer(Headers#http_request_h.'content-length'),
     case expect(Headers, ModData#mod.http_version, ConfigDB) of
-	continue when (MaxBodySize > Length) orelse (MaxBodySize =:= nolimit) ->
+        continue when MaxBodySize > Length ->
 	    httpd_response:send_status(ModData, 100, ""),
 	    ok;
 	continue when MaxBodySize < Length ->
@@ -791,7 +791,7 @@ max_uri_size(ConfigDB) ->
     httpd_util:lookup(ConfigDB, max_uri_size, ?HTTP_MAX_URI_SIZE).
 
 max_body_size(ConfigDB) ->
-    httpd_util:lookup(ConfigDB, max_body_size, nolimit).
+    httpd_util:lookup(ConfigDB, max_body_size, ?HTTP_MAX_BODY_SIZE).
 
 max_keep_alive_request(ConfigDB) ->
     httpd_util:lookup(ConfigDB, max_keep_alive_request, infinity).


### PR DESCRIPTION
This prevents certain types of DOS attacks. You cannot configure nolimit anymore, instead if you need that you should configure a very high value.