### PR TITLE
Allow preprocessor in example modules

### DIFF
--- a/lib/common_test/src/common_test.app.src
+++ b/lib/common_test/src/common_test.app.src
@@ -82,7 +82,7 @@
   {applications, [kernel,stdlib]},
   {env, []},
   {runtime_dependencies,
-   ["compiler-10.0",
+   ["compiler-@OTP-20337@",
     "crypto-4.5",
     "debugger-4.1",
     "erts-7.0",

--- a/lib/common_test/src/ct_doctest.erl
+++ b/lib/common_test/src/ct_doctest.erl
@@ -278,13 +278,14 @@ if it were in a file. For example:
 -module(my_module).
 -export([foo/0]).
 foo() ->
-    ok.
+    {?MODULE, ?FUNCTION_NAME, ?LINE}.
 ```
 
 The module is then available for use in following prompts. For example:
 
 ```
 1> my_module:foo().
+{my_module, foo, 4}
 ```
 
 ### Edge cases
@@ -752,52 +753,23 @@ run_test(Code, InitialBindings, Options) ->
                                             end
                                     end, InitialBindings, Tests),
                     [ok];
-                {match, [_Line_Number, _Prefix = <<"-module(">>, _Code]} ->
-                    [compile_string(Code)];
+                {match, [_Line_Number, _Prefix = <<"-module(">>, ModContent]} ->
+                    [ModName | _] = binary:split(ModContent, [<<")">>]),
+                    [compile_string(Code, ModName)];
                 _ ->
                     []
             end
     end.
 
-compile_string(Code) ->
-
-    Toks =
-        case erl_scan:string(unicode:characters_to_list(Code),
-                             0,
-                             [text]) of
-            {ok, T, _} ->
-                T;
-            {error, {Line,Mod,Reason}, _} ->
-                Message = io_lib:format("unknown:~p: ~ts",[Line, Mod:format_error(Reason)]),
-                throw({error,#{ message => Message, context => Code}})
-        end,
-
-    Forms = parse_tokens(Code, Toks),
-
-    {attribute,_,module,ModuleName} = lists:keyfind(module, 3, Forms),
-
-    case compile:forms(Forms, [binary, return_errors, {source, atom_to_list(ModuleName) ++ ".erl"}]) of
+compile_string(Code, ModName) ->
+    FileName = unicode:characters_to_list(ModName) ++ ".erl",
+    case compile:string(Code, [binary, return_errors, {source, FileName}]) of
         {ok, Module, Binary} ->
-            {module, Module} = code:load_binary(Module, "nofile", Binary),
+            {module, Module} = code:load_binary(Module, FileName, Binary),
             ok;
         {error, Errors, Warnings} ->
             Messages = [begin [{_, M}] = sys_messages:format_messages(File, "", Msgs, []), M end || {File, Msgs} <- Errors ++ Warnings],
             throw({error,#{ message => Messages, context => Code}})
-    end.
-
-parse_tokens(_Code, []) -> [];
-parse_tokens(Code, Toks) ->
-    case lists:splitwith(fun(T) ->
-            element(1, T) =/= dot
-        end, Toks) of
-        {Ts, [{dot, _} = Dot | Rest]} ->
-            case erl_parse:parse_form(Ts ++ [Dot]) of
-                {ok, Forms} ->
-                    [Forms | parse_tokens(Code, Rest)];
-                {error, {Line, Mod, Reason}} ->
-                    Message = io_lib:format("unknown:~p: ~ts",[Line, Mod:format_error(Reason)]),
-                    throw({error,#{ message => Message, context => Code}})
-            end
     end.
 
 check_prompt_numbers(Tests) ->

--- a/lib/common_test/src/ct_doctest.erl
+++ b/lib/common_test/src/ct_doctest.erl
@@ -349,7 +349,8 @@ Options for doctest execution.
                     {missing_tests, [{atom(), arity()}]} |
                     {skip_tests, [moduledoc |
                                   {function | type | callback, atom(), arity()}]} |
-                    {verbose, boolean()}].
+                    {verbose, boolean()} |
+                    {compile_options, [compile:option()]}].
 
 -record(options,
         { parser = fun parse_markdown_builtin/1 :: fun((unicode:unicode_binary()) -> term()),
@@ -357,7 +358,8 @@ Options for doctest execution.
           missing_tests = false :: [{atom(), arity()}] | false,
           skip_tests = [] :: [moduledoc |
                               {function | type | callback, atom(), arity()}],
-          verbose = false :: boolean() }).
+          verbose = false :: boolean(),
+          compile_options = [] :: [compile:option()] }).
 
 -doc #{equiv => module(Module, [])}.
 -spec module(module()) ->
@@ -639,6 +641,8 @@ options(OptionsList) ->
                             Acc#options{ skip_tests = proplists:get_value(skip_tests, OptionsList) };
                         (verbose, Acc) ->
                             Acc#options{ verbose = proplists:get_value(verbose, OptionsList) };
+                        (compile_options, Acc) ->
+                            Acc#options{ compile_options = proplists:get_value(compile_options, OptionsList) };
                         (_Key, Acc) ->
                             Acc
                 end, #options{}, proplists:get_keys(OptionsList)).
@@ -755,15 +759,15 @@ run_test(Code, InitialBindings, Options) ->
                     [ok];
                 {match, [_Line_Number, _Prefix = <<"-module(">>, ModContent]} ->
                     [ModName | _] = binary:split(ModContent, [<<")">>]),
-                    [compile_string(Code, ModName)];
+                    [compile_string(Code, ModName, Options#options.compile_options)];
                 _ ->
                     []
             end
     end.
 
-compile_string(Code, ModName) ->
+compile_string(Code, ModName, CompileOptions) ->
     FileName = unicode:characters_to_list(ModName) ++ ".erl",
-    case compile:string(Code, [binary, return_errors, {source, FileName}]) of
+    case compile:string(Code, [binary, return_errors, {source, FileName} | CompileOptions]) of
         {ok, Module, Binary} ->
             {module, Module} = code:load_binary(Module, FileName, Binary),
             ok;

--- a/lib/common_test/test/ct_doctest_SUITE.erl
+++ b/lib/common_test/test/ct_doctest_SUITE.erl
@@ -28,7 +28,7 @@
 -export([api_branches/1, module_result_modes/1,
          docs_filtering_and_error_formatting/1, parser_prompt_parsing/1,
          runtime_failure_matching/1, parse_rewrite_helpers/1, file_support/1,
-         external_parser/1, module/1,
+         external_parser/1, module/1, module_preprocessor/1,
          type_and_callback_docs/1, verbose_option/1,
          skipped_blocks_option/1, missing_tests_option/1,
          skip_tests_option/1,
@@ -47,6 +47,7 @@ all() ->
      file_support,
      external_parser,
      module,
+     module_preprocessor,
      type_and_callback_docs,
      verbose_option,
      skipped_blocks_option,
@@ -141,11 +142,16 @@ file_support(Config) ->
 
 module(_Config) ->
 
-    ExpectedSubstrings = ["unknown:2: unterminated atom starting with 'ok.\\n'",
-                          "unknown:2: syntax error before: ok",
-                          "test.erl:2: function f/0 undefined"],
+    ExpectedSubstrings = ["test.erl:3:11: unterminated atom starting with 'ok.",
+                          "test.erl:3:7: syntax error before: ok",
+                          "test.erl:3:2: function f/0 undefined"],
 
     expect_error_count(ct_doctest_module_mod, [], 3, ExpectedSubstrings).
+
+module_preprocessor(_Config) ->
+    %% Test that module code blocks support preprocessor features:
+    %% ?MODULE macro, -define macros, and -record definitions.
+    ok = ct_doctest:module(ct_doctest_module_preproc_mod).
 
 external_parser(Config) ->
     DataDir = ?config(data_dir, Config),

--- a/lib/common_test/test/ct_doctest_SUITE_data/ct_doctest_module_preproc_mod.erl
+++ b/lib/common_test/test/ct_doctest_SUITE_data/ct_doctest_module_preproc_mod.erl
@@ -1,0 +1,87 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+-module(ct_doctest_module_preproc_mod).
+-moduledoc """
+Test that module code blocks in doctests support preprocessor features
+like macros and records via epp.
+""".
+
+-export([uses_module_macro/0, uses_define/0, uses_record/0]).
+
+-doc """
+Module code block using ?MODULE macro:
+
+```erlang
+-module(macro_mod).
+-export([name/0]).
+name() -> ?MODULE.
+```
+
+```erlang
+1> macro_mod:name().
+macro_mod
+```
+""".
+uses_module_macro() ->
+    ok.
+
+-doc """
+Module code block using -define macro:
+
+```erlang
+-module(define_mod).
+-export([value/0]).
+-define(VALUE, 42).
+value() -> ?VALUE.
+```
+
+```erlang
+1> define_mod:value().
+42
+```
+""".
+uses_define() ->
+    ok.
+
+-doc """
+Module code block using -record:
+
+```erlang
+-module(record_mod).
+-export([new/2, name/1, age/1]).
+-record(person, {name, age}).
+new(Name, Age) -> #person{name = Name, age = Age}.
+name(#person{name = N}) -> N.
+age(#person{age = A}) -> A.
+```
+
+```erlang
+1> P = record_mod:new(alice, 30).
+2> record_mod:name(P).
+alice
+3> record_mod:age(P).
+30
+```
+""".
+uses_record() ->
+    ok.

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -208,6 +208,7 @@ source code.
 %% High-level interface.
 -export([file/1,file/2,noenv_file/2,format_error/1]).
 -export([forms/1,forms/2,noenv_forms/2]).
+-export([string/1,string/2,noenv_string/2]).
 -export([output_generated/1,noenv_output_generated/1]).
 -export([options/0]).
 -export([env_compiler_options/0]).
@@ -1047,6 +1048,54 @@ noenv_forms(Forms, Opts) when is_list(Opts) ->
 noenv_forms(Forms, Opt) when is_atom(Opt) ->
     noenv_forms(Forms, [Opt|?DEFAULT_OPTIONS]).
 
+-doc #{ equiv => string(String, []) }.
+-doc #{ since => <<"OTP @OTP-20337@">> }.
+-spec string(String :: unicode:chardata()) -> CompRet :: comp_ret().
+
+string(String) -> string(String, ?DEFAULT_OPTIONS).
+
+-doc """
+Compiles an Erlang source code string.
+
+Analogous to [`file/1`](`file/1`), but takes a `t:unicode:chardata/0` containing
+Erlang source code as first argument. The source code is run through the
+Erlang preprocessor (`epp`) just as when compiling a file, so directives
+such as `-include`, `-define`, and `-ifdef` are supported.
+
+Option `binary` is implicit, that is, no object code file is produced.
+
+The `source` option can be used to set the source file name that will
+appear in error messages and the `module_info/1` function. If not given,
+it defaults to the module name with a `.erl` extension.
+
+The `{include_path_open, Fun}` option can be used to provide a custom function
+for opening include files (see `epp:open/1`), allowing compilation
+entirely in memory without touching the file system.
+
+```erlang
+1> compile:string("-module(foo). -export([bar/0]). bar() -> ok.").
+{ok,foo,<<...>>}
+```
+""".
+-doc #{ since => <<"OTP @OTP-20337@">> }.
+-spec string(String :: unicode:chardata(), Options :: [option()] | option()) ->
+          CompRet :: comp_ret().
+
+string(String, Opts) when is_list(Opts) ->
+    do_compile({string,String}, [binary|Opts++env_default_opts()]);
+string(String, Opt) when is_atom(Opt) ->
+    string(String, [Opt|?DEFAULT_OPTIONS]).
+
+-doc #{ equiv => noenv_string(String, []) }.
+-doc #{ since => <<"OTP @OTP-20337@">> }.
+-spec noenv_string(String :: unicode:chardata(), Options :: [option()] | option()) ->
+          comp_ret().
+
+noenv_string(String, Opts) when is_list(Opts) ->
+    do_compile({string,String}, [binary|Opts]);
+noenv_string(String, Opt) when is_atom(Opt) ->
+    noenv_string(String, [Opt|?DEFAULT_OPTIONS]).
+
 -doc """
 Works like `output_generated/1`, except that the environment variable
 `ERL_COMPILER_OPTIONS` is not consulted.
@@ -1301,6 +1350,14 @@ internal({forms,Forms}, Opts0) ->
                        strip_columns(Forms)
                end,
     internal_comp(Ps, NewForms, Source, "", Compile);
+internal({string,String}, Opts0) ->
+    Bin = unicode:characters_to_binary(String),
+    {ok, Fd} = file:open(Bin, [ram, read, binary, cooked]),
+    try
+        do_parse_string(Fd, Opts0)
+    after
+        file:close(Fd)
+    end;
 internal({file,File}, Opts) ->
     {Ext,Ps} = passes(file, Opts),
     Compile = build_compile(Opts),
@@ -2003,6 +2060,71 @@ parse_module(_Code, St) ->
 	{error,_}=Ret ->
 	    Ret
     end.
+
+do_parse_string(Fd, Opts0) ->
+    StartLocation = case with_columns(Opts0) of
+                        true ->
+                            {1,1};
+                        false ->
+                            1
+                    end,
+    case erl_features:init_parse_state(Opts0, fun erl_scan:f_reserved_word/1) of
+        {ok, {Features, ResWordFun}} ->
+            PathOpenOpt = case proplists:get_value(include_path_open, Opts0) of
+                              undefined -> [];
+                              PathOpenFun -> [{include_path_open, PathOpenFun}]
+                          end,
+            Name = proplists:get_value(source, Opts0, "string"),
+            EppOpts = [{fd, Fd},
+                       {name, Name},
+                       {includes, ["." | inc_paths(Opts0)]},
+                       {macros, pre_defs(Opts0)},
+                       {default_encoding, utf8},
+                       {location, StartLocation},
+                       {reserved_word_fun, ResWordFun},
+                       {features, Features},
+                       extra |
+                       PathOpenOpt ++
+                       case member(check_ssa, Opts0) of
+                           true ->
+                               [{compiler_internal, [ssa_checks]}];
+                           false ->
+                               []
+                       end],
+            {ok, Epp, Extra0} = epp:open(EppOpts),
+            try
+                Forms0 = epp:parse_file(Epp),
+                Epp ! {get_features, self()},
+                UsedFtrs = receive {features, X} -> X end,
+                Extra = [{features, UsedFtrs} | Extra0],
+                Encoding = proplists:get_value(encoding, Extra),
+                {_, Ps} = passes(forms, Opts0),
+                Source = proplists:get_value(source, Opts0, source_from_forms(Forms0)),
+                Opts1 = proplists:delete(source, Opts0),
+                Compile0 = build_compile(Opts1),
+                St0 = metadata_add_features(UsedFtrs, Compile0),
+                Opts2 = [{features, UsedFtrs} | St0#compile.options],
+                St1 = St0#compile{encoding=Encoding, options=Opts2},
+                Forms = case with_columns(Opts2 ++ compile_options(Forms0)) of
+                            true ->
+                                Forms0;
+                            false ->
+                                strip_columns(Forms0)
+                        end,
+                internal_comp(Ps, Forms, Source, "", St1)
+            after
+                epp:close(Epp)
+            end;
+        {error, {Mod, Reason}} ->
+            Source = proplists:get_value(source, Opts0, "string"),
+            Es = [{Source, [{none, Mod, Reason}]}],
+            {error, {errors, Es, []}}
+    end.
+
+source_from_forms([{attribute,_,module,Mod}|_]) ->
+    atom_to_list(Mod) ++ ".erl";
+source_from_forms([_|T]) -> source_from_forms(T);
+source_from_forms([]) -> "string".
 
 deterministic_filename(#compile{ifile=File,options=Opts}) ->
     SourceName0 = proplists:get_value(source, Opts, File),

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -980,15 +980,12 @@ file(File, Opts) when is_list(Opts) ->
 file(File, Opt) ->
     file(File, [Opt|?DEFAULT_OPTIONS]).
 
--doc """
-Is the same as
-[`forms(Forms, [verbose,report_errors,report_warnings])`](`forms/2`).
-""".
+-doc #{ equiv => forms(Forms, ?DEFAULT_OPTIONS) }.
 -spec forms(forms()) -> CompRet :: comp_ret().
 
 forms(Forms) -> forms(Forms, ?DEFAULT_OPTIONS).
 
--doc """
+-doc """"
 Analogous to [`file/1`](`file/1`), but takes a list of forms (in either Erlang
 abstract or Core Erlang format representation) as first argument.
 
@@ -996,7 +993,63 @@ Option `binary` is implicit, that is, no object code file is
 produced. For options that normally produce a listing file, such as
 'E', the internal format for that compiler pass (an Erlang term,
 usually not a binary) is returned instead of a binary.
-""".
+
+## Examples
+
+Parsing using `m:erl_scan` and `m:erl_parse`:
+
+```erlang
+1> Program = """
+ -module(test).
+ -export([foo/0]).
+ foo() -> bar.
+
+ """.
+2> ParseForms =
+    fun 
+        Parse("", Loc) ->
+            [];
+        Parse(String, Loc) ->
+            case erl_scan:tokens("", String, Loc) of
+                {done, {ok, Tokens, NewLoc}, Cont} ->
+                    {ok, Form} = erl_parse:parse_form(Tokens),
+                    [Form | Parse(Cont, NewLoc)]
+            end
+    end.
+3> Forms = ParseForms(Program, {1,1}).
+[{attribute,{1,2},module,test},
+ {attribute,{2,2},export,[{foo,0}]},
+ {function,{3,1},
+           foo,0,
+           [{clause,{3,1},[],[],[{atom,{3,10},bar}]}]}]
+4> compile:forms(Forms).
+{ok,test,
+    <<70,79,82,49,0,0,1,196,66,69,65,77,65,116,85,56,0,0,0,
+      52,255,255,255,250,64,116,...>>}
+```
+
+Parsing using `epp`:
+
+```erlang
+1> Program = ~"""
+ -module(test).
+ -export([foo/0]).
+ foo() -> bar.
+
+ """.
+2> {ok, IoServer} = file:open(Program, [read, binary, ram, cooked]).
+3> {ok, Forms} = epp:parse_file("test.erl", [{fd, IoServer}]).
+{ok,[{attribute,1,file,{"test.erl",1}},
+     {attribute,1,module,test},
+     {attribute,2,export,[{foo,0}]},
+     {function,3,foo,0,[{clause,3,[],[],[{atom,3,bar}]}]},
+     {eof,4}]}
+4> compile:forms(Forms).
+{ok,test,
+    <<70,79,82,49,0,0,1,196,66,69,65,77,65,116,85,56,0,0,0,
+      52,255,255,255,250,64,116,...>>}
+```
+"""".
 -spec forms(Forms :: forms(), Options :: [option()] | option()) -> CompRet :: comp_ret().
 
 forms(Forms, Opts) when is_list(Opts) ->
@@ -1051,7 +1104,6 @@ noenv_forms(Forms, Opt) when is_atom(Opt) ->
 -doc #{ equiv => string(String, []) }.
 -doc #{ since => <<"OTP @OTP-20337@">> }.
 -spec string(String :: unicode:chardata()) -> CompRet :: comp_ret().
-
 string(String) -> string(String, ?DEFAULT_OPTIONS).
 
 -doc """
@@ -1062,25 +1114,29 @@ Erlang source code as first argument. The source code is run through the
 Erlang preprocessor (`epp`) just as when compiling a file, so directives
 such as `-include`, `-define`, and `-ifdef` are supported.
 
-Option `binary` is implicit, that is, no object code file is produced.
-
-The `source` option can be used to set the source file name that will
-appear in error messages and the `module_info/1` function. If not given,
-it defaults to the module name with a `.erl` extension.
+Option `binary` is implicit, that is, no object code file is
+produced. For options that normally produce a listing file, such as
+'E', the internal format for that compiler pass (an Erlang term,
+usually not a binary) is returned instead of a binary.
 
 The `{include_path_open, Fun}` option can be used to provide a custom function
 for opening include files (see `epp:open/1`), allowing compilation
 entirely in memory without touching the file system.
 
+## Examples
+
 ```erlang
-1> compile:string("-module(foo). -export([bar/0]). bar() -> ok.").
+1> {ok, foo, Bin} = compile:string("-module(foo). -export([bar/0]). bar() -> ok.").
 {ok,foo,<<...>>}
+2> code:load_binary(foo, "foo.erl", Bin).
+{module, foo}
+3> foo:bar().
+ok
 ```
 """.
 -doc #{ since => <<"OTP @OTP-20337@">> }.
 -spec string(String :: unicode:chardata(), Options :: [option()] | option()) ->
           CompRet :: comp_ret().
-
 string(String, Opts) when is_list(Opts) ->
     do_compile({string,String}, [binary|Opts++env_default_opts()]);
 string(String, Opt) when is_atom(Opt) ->

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -1049,6 +1049,7 @@ noenv_forms(Forms, Opt) when is_atom(Opt) ->
     noenv_forms(Forms, [Opt|?DEFAULT_OPTIONS]).
 
 -doc #{ equiv => string(String, []) }.
+-doc #{ since => <<"OTP @OTP-1234567@">> }.
 -spec string(String :: unicode:chardata()) -> CompRet :: comp_ret().
 
 string(String) -> string(String, ?DEFAULT_OPTIONS).
@@ -1076,6 +1077,7 @@ entirely in memory without touching the file system.
 {ok,foo,<<...>>}
 ```
 """.
+-doc #{ since => <<"OTP @OTP-1234567@">> }.
 -spec string(String :: unicode:chardata(), Options :: [option()] | option()) ->
           CompRet :: comp_ret().
 
@@ -1085,6 +1087,7 @@ string(String, Opt) when is_atom(Opt) ->
     string(String, [Opt|?DEFAULT_OPTIONS]).
 
 -doc #{ equiv => noenv_string(String, []) }.
+-doc #{ since => <<"OTP @OTP-1234567@">> }.
 -spec noenv_string(String :: unicode:chardata(), Options :: [option()] | option()) ->
           comp_ret().
 

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -208,6 +208,7 @@ source code.
 %% High-level interface.
 -export([file/1,file/2,noenv_file/2,format_error/1]).
 -export([forms/1,forms/2,noenv_forms/2]).
+-export([string/1,string/2,noenv_string/2]).
 -export([output_generated/1,noenv_output_generated/1]).
 -export([options/0]).
 -export([env_compiler_options/0]).
@@ -1047,6 +1048,51 @@ noenv_forms(Forms, Opts) when is_list(Opts) ->
 noenv_forms(Forms, Opt) when is_atom(Opt) ->
     noenv_forms(Forms, [Opt|?DEFAULT_OPTIONS]).
 
+-doc #{ equiv => string(String, []) }.
+-spec string(String :: unicode:chardata()) -> CompRet :: comp_ret().
+
+string(String) -> string(String, ?DEFAULT_OPTIONS).
+
+-doc """
+Compiles an Erlang source code string.
+
+Analogous to [`file/1`](`file/1`), but takes a `t:unicode:chardata/0` containing
+Erlang source code as first argument. The source code is run through the
+Erlang preprocessor (`epp`) just as when compiling a file, so directives
+such as `-include`, `-define`, and `-ifdef` are supported.
+
+Option `binary` is implicit, that is, no object code file is produced.
+
+The `source` option can be used to set the source file name that will
+appear in error messages and the `module_info/1` function. If not given,
+it defaults to the module name with a `.erl` extension.
+
+The `{include_path_open, Fun}` option can be used to provide a custom function
+for opening include files (see `epp:open/1`), allowing compilation
+entirely in memory without touching the file system.
+
+```erlang
+1> compile:string("-module(foo). -export([bar/0]). bar() -> ok.").
+{ok,foo,<<...>>}
+```
+""".
+-spec string(String :: unicode:chardata(), Options :: [option()] | option()) ->
+          CompRet :: comp_ret().
+
+string(String, Opts) when is_list(Opts) ->
+    do_compile({string,String}, [binary|Opts++env_default_opts()]);
+string(String, Opt) when is_atom(Opt) ->
+    string(String, [Opt|?DEFAULT_OPTIONS]).
+
+-doc #{ equiv => noenv_string(String, []) }.
+-spec noenv_string(String :: unicode:chardata(), Options :: [option()] | option()) ->
+          comp_ret().
+
+noenv_string(String, Opts) when is_list(Opts) ->
+    do_compile({string,String}, [binary|Opts]);
+noenv_string(String, Opt) when is_atom(Opt) ->
+    noenv_string(String, [Opt|?DEFAULT_OPTIONS]).
+
 -doc """
 Works like `output_generated/1`, except that the environment variable
 `ERL_COMPILER_OPTIONS` is not consulted.
@@ -1301,6 +1347,14 @@ internal({forms,Forms}, Opts0) ->
                        strip_columns(Forms)
                end,
     internal_comp(Ps, NewForms, Source, "", Compile);
+internal({string,String}, Opts0) ->
+    Bin = unicode:characters_to_binary(String),
+    {ok, Fd} = file:open(Bin, [ram, read, binary, cooked]),
+    try
+        do_parse_string(Fd, Opts0)
+    after
+        file:close(Fd)
+    end;
 internal({file,File}, Opts) ->
     {Ext,Ps} = passes(file, Opts),
     Compile = build_compile(Opts),
@@ -2003,6 +2057,71 @@ parse_module(_Code, St) ->
 	{error,_}=Ret ->
 	    Ret
     end.
+
+do_parse_string(Fd, Opts0) ->
+    StartLocation = case with_columns(Opts0) of
+                        true ->
+                            {1,1};
+                        false ->
+                            1
+                    end,
+    case erl_features:init_parse_state(Opts0, fun erl_scan:f_reserved_word/1) of
+        {ok, {Features, ResWordFun}} ->
+            PathOpenOpt = case proplists:get_value(include_path_open, Opts0) of
+                              undefined -> [];
+                              PathOpenFun -> [{include_path_open, PathOpenFun}]
+                          end,
+            Name = proplists:get_value(source, Opts0, "string"),
+            EppOpts = [{fd, Fd},
+                       {name, Name},
+                       {includes, ["." | inc_paths(Opts0)]},
+                       {macros, pre_defs(Opts0)},
+                       {default_encoding, utf8},
+                       {location, StartLocation},
+                       {reserved_word_fun, ResWordFun},
+                       {features, Features},
+                       extra |
+                       PathOpenOpt ++
+                       case member(check_ssa, Opts0) of
+                           true ->
+                               [{compiler_internal, [ssa_checks]}];
+                           false ->
+                               []
+                       end],
+            {ok, Epp, Extra0} = epp:open(EppOpts),
+            try
+                Forms0 = epp:parse_file(Epp),
+                Epp ! {get_features, self()},
+                UsedFtrs = receive {features, X} -> X end,
+                Extra = [{features, UsedFtrs} | Extra0],
+                Encoding = proplists:get_value(encoding, Extra),
+                {_, Ps} = passes(forms, Opts0),
+                Source = proplists:get_value(source, Opts0, source_from_forms(Forms0)),
+                Opts1 = proplists:delete(source, Opts0),
+                Compile0 = build_compile(Opts1),
+                St0 = metadata_add_features(UsedFtrs, Compile0),
+                Opts2 = [{features, UsedFtrs} | St0#compile.options],
+                St1 = St0#compile{encoding=Encoding, options=Opts2},
+                Forms = case with_columns(Opts2 ++ compile_options(Forms0)) of
+                            true ->
+                                Forms0;
+                            false ->
+                                strip_columns(Forms0)
+                        end,
+                internal_comp(Ps, Forms, Source, "", St1)
+            after
+                epp:close(Epp)
+            end;
+        {error, {Mod, Reason}} ->
+            Source = proplists:get_value(source, Opts0, "string"),
+            Es = [{Source, [{none, Mod, Reason}]}],
+            {error, {errors, Es, []}}
+    end.
+
+source_from_forms([{attribute,_,module,Mod}|_]) ->
+    atom_to_list(Mod) ++ ".erl";
+source_from_forms([_|T]) -> source_from_forms(T);
+source_from_forms([]) -> "string".
 
 deterministic_filename(#compile{ifile=File,options=Opts}) ->
     SourceName0 = proplists:get_value(source, Opts, File),

--- a/lib/compiler/src/compile.erl
+++ b/lib/compiler/src/compile.erl
@@ -980,15 +980,12 @@ file(File, Opts) when is_list(Opts) ->
 file(File, Opt) ->
     file(File, [Opt|?DEFAULT_OPTIONS]).
 
--doc """
-Is the same as
-[`forms(Forms, [verbose,report_errors,report_warnings])`](`forms/2`).
-""".
+-doc #{ equiv => forms(Forms, ?DEFAULT_OPTIONS) }.
 -spec forms(forms()) -> CompRet :: comp_ret().
 
 forms(Forms) -> forms(Forms, ?DEFAULT_OPTIONS).
 
--doc """
+-doc """"
 Analogous to [`file/1`](`file/1`), but takes a list of forms (in either Erlang
 abstract or Core Erlang format representation) as first argument.
 
@@ -996,7 +993,63 @@ Option `binary` is implicit, that is, no object code file is
 produced. For options that normally produce a listing file, such as
 'E', the internal format for that compiler pass (an Erlang term,
 usually not a binary) is returned instead of a binary.
-""".
+
+## Examples
+
+Parsing using `m:erl_scan` and `m:erl_parse`:
+
+```erlang
+1> Program = """
+ -module(test).
+ -export([foo/0]).
+ foo() -> bar.
+
+ """.
+2> ParseForms =
+    fun 
+        Parse("", Loc) ->
+            [];
+        Parse(String, Loc) ->
+            case erl_scan:tokens("", String, Loc) of
+                {done, {ok, Tokens, NewLoc}, Cont} ->
+                    {ok, Form} = erl_parse:parse_form(Tokens),
+                    [Form | Parse(Cont, NewLoc)]
+            end
+    end.
+3> Forms = ParseForms(Program, {1,1}).
+[{attribute,{1,2},module,test},
+ {attribute,{2,2},export,[{foo,0}]},
+ {function,{3,1},
+           foo,0,
+           [{clause,{3,1},[],[],[{atom,{3,10},bar}]}]}]
+4> compile:forms(Forms).
+{ok,test,
+    <<70,79,82,49,0,0,1,196,66,69,65,77,65,116,85,56,0,0,0,
+      52,255,255,255,250,64,116,...>>}
+```
+
+Parsing using `epp`:
+
+```erlang
+1> Program = ~"""
+ -module(test).
+ -export([foo/0]).
+ foo() -> bar.
+
+ """.
+2> {ok, IoServer} = file:open(Program, [read, binary, ram, cooked]).
+3> {ok, Forms} = epp:parse_file("test.erl", [{fd, IoServer}]).
+{ok,[{attribute,1,file,{"test.erl",1}},
+     {attribute,1,module,test},
+     {attribute,2,export,[{foo,0}]},
+     {function,3,foo,0,[{clause,3,[],[],[{atom,3,bar}]}]},
+     {eof,4}]}
+4> compile:forms(Forms).
+{ok,test,
+    <<70,79,82,49,0,0,1,196,66,69,65,77,65,116,85,56,0,0,0,
+      52,255,255,255,250,64,116,...>>}
+```
+"""".
 -spec forms(Forms :: forms(), Options :: [option()] | option()) -> CompRet :: comp_ret().
 
 forms(Forms, Opts) when is_list(Opts) ->
@@ -1051,7 +1104,6 @@ noenv_forms(Forms, Opt) when is_atom(Opt) ->
 -doc #{ equiv => string(String, []) }.
 -doc #{ since => <<"OTP @OTP-1234567@">> }.
 -spec string(String :: unicode:chardata()) -> CompRet :: comp_ret().
-
 string(String) -> string(String, ?DEFAULT_OPTIONS).
 
 -doc """
@@ -1062,25 +1114,29 @@ Erlang source code as first argument. The source code is run through the
 Erlang preprocessor (`epp`) just as when compiling a file, so directives
 such as `-include`, `-define`, and `-ifdef` are supported.
 
-Option `binary` is implicit, that is, no object code file is produced.
-
-The `source` option can be used to set the source file name that will
-appear in error messages and the `module_info/1` function. If not given,
-it defaults to the module name with a `.erl` extension.
+Option `binary` is implicit, that is, no object code file is
+produced. For options that normally produce a listing file, such as
+'E', the internal format for that compiler pass (an Erlang term,
+usually not a binary) is returned instead of a binary.
 
 The `{include_path_open, Fun}` option can be used to provide a custom function
 for opening include files (see `epp:open/1`), allowing compilation
 entirely in memory without touching the file system.
 
+## Examples
+
 ```erlang
-1> compile:string("-module(foo). -export([bar/0]). bar() -> ok.").
+1> {ok, foo, Bin} = compile:string("-module(foo). -export([bar/0]). bar() -> ok.").
 {ok,foo,<<...>>}
+2> code:load_binary(foo, "foo.erl", Bin).
+{module, foo}
+3> foo:bar().
+ok
 ```
 """.
 -doc #{ since => <<"OTP @OTP-1234567@">> }.
 -spec string(String :: unicode:chardata(), Options :: [option()] | option()) ->
           CompRet :: comp_ret().
-
 string(String, Opts) when is_list(Opts) ->
     do_compile({string,String}, [binary|Opts++env_default_opts()]);
 string(String, Opt) when is_atom(Opt) ->

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -45,7 +45,7 @@
          compile_attribute/1, message_printing/1, other_options/1,
          transforms/1, erl_compile_api/1, types_pp/1, bs_init_writable/1,
          annotations_pp/1, option_order/1,
-         sys_coverage/1
+         sys_coverage/1, doctests/1
 	]).
 
 -import_record(v3_core, [c_case, c_clause, c_fun, c_literal,
@@ -72,7 +72,7 @@ all() ->
      deterministic_docs,
      compile_attribute, message_printing, other_options, transforms,
      erl_compile_api, types_pp, bs_init_writable, annotations_pp,
-     option_order, sys_coverage].
+     option_order, sys_coverage, doctests].
 
 groups() -> 
     [].
@@ -2553,6 +2553,17 @@ sys_coverage_2(DataDir) ->
     true = lists:keymember(executable_line, 1, Is),
 
     ok.
+
+doctests(_Config) ->
+    PathOpen = fun(Path, Filename, Modes) ->
+                       case file:path_open(Path, Filename, Modes) of
+                           {error, enoent} ->
+                               {ok, FD} = file:open(~"", [ram, cooked | Modes]),
+                               {ok, FD, filename:basename(Filename)};
+                           Else -> Else
+                       end
+               end,
+    ct_doctest:module(compile, [], [{compile_options, [{include_path_open, PathOpen}]}]).
 
 %%%
 %%% Utilities.

--- a/lib/compiler/test/compile_SUITE.erl
+++ b/lib/compiler/test/compile_SUITE.erl
@@ -27,11 +27,11 @@
 -include_lib("stdlib/include/erl_compile.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
--export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1, 
+-export([all/0, suite/0,groups/0,init_per_suite/1, end_per_suite/1,
 	 init_per_group/2,end_per_group/2,
 	 app_test/1,appup_test/1,bigE_roundtrip/1,
 	 debug_info/4, custom_debug_info/1, custom_compile_info/1,
-	 file_1/1, forms_2/1, module_mismatch/1, outdir/1,
+         file_1/1, forms_2/1, string_1/1, module_mismatch/1, outdir/1,
 	 binary/1, makedep/1, cond_and_ifdef/1, listings/1, listings_big/1,
 	 other_output/1, encrypted_abstr/1,
 	 strict_record/1, utf8_atoms/1, utf8_functions/1, extra_chunks/1,
@@ -60,7 +60,7 @@ suite() -> [{ct_hooks,[ts_install_cth]}].
 
 all() -> 
     [app_test, appup_test, bigE_roundtrip, file_1,
-     forms_2, module_mismatch, outdir,
+     forms_2, string_1, module_mismatch, outdir,
      binary, makedep, cond_and_ifdef, listings, listings_big,
      other_output, encrypted_abstr, tuple_calls,
      strict_record, utf8_atoms, utf8_functions, extra_chunks,
@@ -324,6 +324,169 @@ forms_compile_and_load(Code, Opts) ->
     _ = Mod:module_info(),
     true = code:delete(simple),
     false = code:purge(simple),
+    ok.
+
+string_1(_Config) ->
+    %% Basic compilation from string.
+    {ok,foo,BinFoo} = compile:string("-module(foo). -export([bar/0]). bar() -> hello."),
+    {module,foo} = code:load_binary(foo, "foo.erl", BinFoo),
+    hello = foo:bar(),
+    true = code:delete(foo),
+    false = code:purge(foo),
+
+    %% Binary input.
+    {ok,binmod,BinMod} = compile:string(<<"-module(binmod). -export([g/0]). g() -> ok.">>),
+    {module,binmod} = code:load_binary(binmod, "binmod.erl", BinMod),
+    ok = binmod:g(),
+    true = code:delete(binmod),
+    false = code:purge(binmod),
+
+    %% Preprocessor: macros with -define.
+    {ok,macmod,BinMac} = compile:string(
+        "-module(macmod). -export([f/0]).\n"
+        "-define(X, 42).\n"
+        "f() -> ?X.\n"),
+    {module,macmod} = code:load_binary(macmod, "macmod.erl", BinMac),
+    42 = macmod:f(),
+    true = code:delete(macmod),
+    false = code:purge(macmod),
+
+    %% Preprocessor: records.
+    {ok,recmod,BinRec} = compile:string(
+        "-module(recmod). -export([new/0]).\n"
+        "-record(point, {x = 0, y = 0}).\n"
+        "new() -> #point{x = 1, y = 2}.\n"),
+    {module,recmod} = code:load_binary(recmod, "recmod.erl", BinRec),
+    {point,1,2} = recmod:new(),
+    true = code:delete(recmod),
+    false = code:purge(recmod),
+
+    %% Preprocessor: -ifdef/-endif.
+    {ok,ifmod,BinIf} = compile:string(
+        "-module(ifmod). -export([f/0]).\n"
+        "-ifdef(NOTDEFINED).\n"
+        "f() -> wrong.\n"
+        "-else.\n"
+        "f() -> right.\n"
+        "-endif.\n"),
+    {module,ifmod} = code:load_binary(ifmod, "ifmod.erl", BinIf),
+    right = ifmod:f(),
+    true = code:delete(ifmod),
+    false = code:purge(ifmod),
+
+    %% Preprocessor: predefined macros via options.
+    {ok,defmod,BinDef} = compile:string(
+        "-module(defmod). -export([f/0]).\n"
+        "f() -> ?MY_VALUE.\n",
+        [{d,'MY_VALUE',99}]),
+    {module,defmod} = code:load_binary(defmod, "defmod.erl", BinDef),
+    99 = defmod:f(),
+    true = code:delete(defmod),
+    false = code:purge(defmod),
+
+    %% Preprocessor: ?MODULE.
+    {ok,modmac,BinModMac} = compile:string(
+        "-module(modmac). -export([name/0]).\n"
+        "name() -> ?MODULE.\n"),
+    {module,modmac} = code:load_binary(modmac, "modmac.erl", BinModMac),
+    modmac = modmac:name(),
+    true = code:delete(modmac),
+    false = code:purge(modmac),
+
+    %% Source option.
+    {ok,srcmod,BinSrc} = compile:string(
+        "-module(srcmod). -export([f/0]). f() -> ok.",
+        [{source,"my_source.erl"}]),
+    {module,srcmod} = code:load_binary(srcmod, "srcmod.erl", BinSrc),
+    Info = srcmod:module_info(compile),
+    SrcInfo = proplists:get_value(source, Info),
+    true = lists:suffix("my_source.erl", SrcInfo),
+    true = code:delete(srcmod),
+    false = code:purge(srcmod),
+
+    %% Syntax error returns error.
+    error = compile:string("-module(bad). f( ->"),
+
+    %% Syntax error with return_errors option.
+    {error,[{"string",[{_,_,_}|_]}],_} =
+        compile:string("-module(bad). f( ->", [return_errors]),
+
+    %% Source option affects error filenames.
+    {error,[{"bad.erl",[{_,_,_}|_]}],_} =
+        compile:string("-module(bad). f( ->",
+                       [return_errors, {source, "bad.erl"}]),
+
+    %% Cover: option not in a list (undocumented feature).
+    {ok,smod,_} = compile:string("-module(smod). -export([f/0]). f() -> ok.", binary),
+
+    %% noenv_string/2.
+    {ok,nmod,_} = compile:noenv_string(
+        "-module(nmod). -export([f/0]). f() -> ok.", []),
+
+    %% include_path_open: include from in-memory files.
+    Headers = #{
+        "my_header.hrl" =>
+            <<"-record(point, {x, y}).\n"
+              "-define(ORIGIN, #point{x=0, y=0}).\n">>
+    },
+    PathOpen = fun(_Path, Name, _Modes) ->
+        case maps:find(Name, Headers) of
+            {ok, Content} ->
+                {ok, Fd} = file:open(Content, [ram, read, binary, cooked]),
+                {ok, Fd, Name};
+            error ->
+                {error, enoent}
+        end
+    end,
+    {ok,incmod,BinInc} = compile:string(
+        "-module(incmod).\n"
+        "-include(\"my_header.hrl\").\n"
+        "-export([f/0]).\n"
+        "f() -> ?ORIGIN.\n",
+        [{include_path_open, PathOpen}]),
+    {module,incmod} = code:load_binary(incmod, "incmod.erl", BinInc),
+    {point,0,0} = incmod:f(),
+    true = code:delete(incmod),
+    false = code:purge(incmod),
+
+    %% include_path_open: nested includes from in-memory files.
+    Headers2 = #{
+        "types.hrl" =>
+            <<"-type my_int() :: integer().\n">>,
+        "all.hrl" =>
+            <<"-include(\"types.hrl\").\n"
+              "-define(DEFAULT, 0).\n">>
+    },
+    PathOpen2 = fun(_Path, Name, _Modes) ->
+        case maps:find(Name, Headers2) of
+            {ok, Content} ->
+                {ok, Fd} = file:open(Content, [ram, read, binary, cooked]),
+                {ok, Fd, Name};
+            error ->
+                {error, enoent}
+        end
+    end,
+    {ok,nestmod,BinNest} = compile:string(
+        "-module(nestmod).\n"
+        "-include(\"all.hrl\").\n"
+        "-export([f/0]).\n"
+        "-spec f() -> my_int().\n"
+        "f() -> ?DEFAULT.\n",
+        [{include_path_open, PathOpen2}]),
+    {module,nestmod} = code:load_binary(nestmod, "nestmod.erl", BinNest),
+    0 = nestmod:f(),
+    true = code:delete(nestmod),
+    false = code:purge(nestmod),
+
+    %% include_path_open: missing include returns error.
+    PathOpenNone = fun(_Path, _Name, _Modes) -> {error, enoent} end,
+    {error, _, _} = compile:string(
+        "-module(missinc).\n"
+        "-include(\"nonexistent.hrl\").\n"
+        "-export([f/0]).\n"
+        "f() -> ok.\n",
+        [{include_path_open, PathOpenNone}, return_errors]),
+
     ok.
 
 module_mismatch(Config) when is_list(Config) ->

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -1418,6 +1418,7 @@ more of the following options:
   ram file is wrapped in a pid-based I/O server, making it compatible with the
   `m:io` module (for example, `io:get_line/2`, `io:scan_erl_form/3`).
 
+  Since OTP @OTP-123456789@
 
 - **`sync`** - On platforms supporting it, enables the POSIX `O_SYNC`
   synchronous I/O flag or its platform-dependent equivalent (for example,

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -1410,8 +1410,14 @@ more of the following options:
 
   This option is not allowed on `raw` files.
 
-- **`ram`** - `File` must be `t:iodata/0`. Returns an `t:fd/0`, which lets
-  module `file` operate on the data in-memory as if it is a file.
+- **`ram`**{: #ram } - `File` must be `t:iodata/0`. Returns an `t:fd/0` (or a `t:io_server/0`
+  if combined with `cooked`), which lets the modules `m:file` and `m:io`
+  operate on the data in-memory as if it is a file.
+
+- **`cooked`** - Only meaningful together with `ram`. When specified, the
+  ram file is wrapped in a pid-based I/O server, making it compatible with the
+  `m:io` module (for example, `io:get_line/2`, `io:scan_erl_form/3`).
+
 
 - **`sync`** - On platforms supporting it, enables the POSIX `O_SYNC`
   synchronous I/O flag or its platform-dependent equivalent (for example,
@@ -1492,7 +1498,15 @@ open(Item, ModeList) when is_list(ModeList) ->
         {true, false} ->
             raw_file_io:open(file_name(Item), ModeList);
         {false, true} ->
-            ram_file:open(Item, ModeList);
+            case lists:member(cooked, ModeList) of
+                true ->
+                    file_io_server:start_handle(
+                      self(),
+                      fun(_, _) -> ram_file:open(Item, [binary | ModeList -- [cooked]]) end,
+                      ModeList -- [ram, cooked]);
+                false ->
+                    ram_file:open(Item, ModeList)
+            end;
         {true, true} ->
             erlang:error(badarg, [Item, ModeList])
     end;

--- a/lib/kernel/src/file.erl
+++ b/lib/kernel/src/file.erl
@@ -1410,8 +1410,15 @@ more of the following options:
 
   This option is not allowed on `raw` files.
 
-- **`ram`** - `File` must be `t:iodata/0`. Returns an `t:fd/0`, which lets
-  module `file` operate on the data in-memory as if it is a file.
+- **`ram`**{: #ram } - `File` must be `t:iodata/0`. Returns an `t:fd/0` (or a `t:io_server/0`
+  if combined with `cooked`), which lets the modules `m:file` and `m:io`
+  operate on the data in-memory as if it is a file.
+
+- **`cooked`** - Only meaningful together with `ram`. When specified, the
+  ram file is wrapped in a pid-based I/O server, making it compatible with the
+  `m:io` module (for example, `io:get_line/2`, `io:scan_erl_form/3`).
+
+  Since OTP @OTP-20340@
 
 - **`sync`** - On platforms supporting it, enables the POSIX `O_SYNC`
   synchronous I/O flag or its platform-dependent equivalent (for example,
@@ -1492,7 +1499,15 @@ open(Item, ModeList) when is_list(ModeList) ->
         {true, false} ->
             raw_file_io:open(file_name(Item), ModeList);
         {false, true} ->
-            ram_file:open(Item, ModeList);
+            case lists:member(cooked, ModeList) of
+                true ->
+                    file_io_server:start_handle(
+                      self(),
+                      fun(_, _) -> ram_file:open(Item, [binary | ModeList -- [cooked]]) end,
+                      ModeList -- [ram, cooked]);
+                false ->
+                    ram_file:open(Item, ModeList)
+            end;
         {true, true} ->
             erlang:error(badarg, [Item, ModeList])
     end;

--- a/lib/kernel/src/file_io_server.erl
+++ b/lib/kernel/src/file_io_server.erl
@@ -28,6 +28,7 @@
 
 -export([format_error/1]).
 -export([start/3, start_link/3]).
+-export([start_handle/3, start_link_handle/3]).
 
 -export([count_and_find/3]).
 
@@ -60,27 +61,36 @@ start_link(Owner, FileName, ModeList)
   when is_pid(Owner), (is_list(FileName) orelse is_binary(FileName)), is_list(ModeList) ->
     do_start(spawn_link, Owner, FileName, ModeList).
 
+start_handle(Owner, OpenFun, ModeList)
+  when is_pid(Owner), is_function(OpenFun, 2), is_list(ModeList) ->
+    do_start_handle(spawn, Owner, OpenFun, ModeList).
+
+start_link_handle(Owner, OpenFun, ModeList)
+  when is_pid(Owner), is_function(OpenFun, 2), is_list(ModeList) ->
+    do_start_handle(spawn_link, Owner, OpenFun, ModeList).
+
 %%%-----------------------------------------------------------------
 %%% Server starter, dispatcher and helpers
 
 do_start(Spawn, Owner, FileName, ModeList) ->
+    OpenFun = fun(ReadMode, Opts0) ->
+                      Opts = maybe_add_read_ahead(ReadMode, Opts0),
+                      raw_file_io:open(FileName, [raw | Opts])
+              end,
+    do_start_handle(Spawn, Owner, OpenFun, ModeList).
+
+do_start_handle(Spawn, Owner, OpenFun, ModeList) ->
     Self = self(),
     Ref = make_ref(),
     Utag = erlang:dt_spread_tag(true),
-    Pid = 
+    Pid =
 	erlang:Spawn(
 	  fun() ->
 		  erlang:dt_restore_tag(Utag),
-		  %% process_flag(trap_exit, true),
 		  case parse_options(ModeList) of
-                      {ReadMode, UnicodeMode, Opts0} ->
-                          Opts = maybe_add_read_ahead(ReadMode, Opts0),
-			  case raw_file_io:open(FileName, [raw | Opts]) of
-			      {error, Reason} = Error ->
-				  Self ! {Ref, Error},
-				  exit(Reason);
+                      {ReadMode, UnicodeMode, Opts} ->
+                          case OpenFun(ReadMode, Opts) of
 			      {ok, Handle} ->
-				  %% XXX must I handle R6 nodes here?
 				  M = erlang:monitor(process, Owner),
 				  Self ! {Ref, ok},
 				  server_loop(
@@ -89,7 +99,10 @@ do_start(Spawn, Owner, FileName, ModeList) ->
 					   mref      = M,
 					   buf       = <<>>,
 					   read_mode = ReadMode,
-					   unic = UnicodeMode})
+                                           unic = UnicodeMode});
+                              {error, Reason} = Error ->
+                                  Self ! {Ref, Error},
+                                  exit(Reason)
 			  end;
 		      {error,Reason1} = Error1 ->
 			  Self ! {Ref, Error1},

--- a/lib/kernel/src/ram_file.erl
+++ b/lib/kernel/src/ram_file.erl
@@ -28,8 +28,8 @@
 
 %% Generic file contents operations
 -export([open/2, close/1]).
--export([write/2, read/2, copy/3,
-	 pread/2, pread/3, pwrite/2, pwrite/3, 
+-export([write/2, read/2, read_line/1, copy/3,
+         pread/2, pread/3, pwrite/2, pwrite/3,
 	 position/2, truncate/1, datasync/1, sync/1]).
 
 %% Specialized file operations
@@ -145,7 +145,42 @@ read(#file_descriptor{module = ?MODULE, data = Port}, Sz)
 	    {error, einval}
     end.
 
-write(#file_descriptor{module = ?MODULE, data = Port}, Bytes) -> 
+read_line(#file_descriptor{module = ?MODULE} = Fd) ->
+    read_line(Fd, []).
+
+read_line(Fd, Acc) ->
+    case read(Fd, 256) of
+        {ok, Data} ->
+            case binary:match(Data, <<"\n">>) of
+                {Pos, 1} ->
+                    %% Check for \r\n: replace with just \n.
+                    Before =
+                        case binary:part(Data, 0, Pos + 1) of
+                            <<CRNLData:(Pos - 1)/binary, "\r\n">> ->
+                                <<CRNLData:(Pos - 1)/binary, "\n">>;
+                            NLData ->
+                                NLData
+                        end,
+                    %% Seek back the unread portion after the \n.
+                    AfterSize = byte_size(Data) - Pos - 1,
+                    {ok, _} = position(Fd, {cur, -AfterSize}),
+
+                    if
+                       Acc =:= [] ->
+                            {ok, Before};
+                       Acc =/= [] ->
+                            {ok, iolist_to_binary(lists:reverse(Acc, [Before]))}
+                    end;
+                nomatch ->
+                    read_line(Fd, [Data | Acc])
+            end;
+        eof when Acc =:= [] ->
+            eof;
+        eof ->
+            {ok, iolist_to_binary(lists:reverse(Acc))}
+    end.
+
+write(#file_descriptor{module = ?MODULE, data = Port}, Bytes) ->
     case call_port(Port, [?RAM_FILE_WRITE | Bytes]) of
 	{ok, _Sz} ->
 	    ok;

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -91,7 +91,8 @@
 
 -export([large_file/0, large_file/1, large_write/0, large_write/1]).
 
--export([read_line_1/1, read_line_2/1, read_line_3/1,read_line_4/1]).
+-export([read_line_1/1,read_line_2/1,read_line_3/1,read_line_4/1,read_line_5/1,
+         read_line_6/1]).
 
 -export([advise/1]).
 
@@ -139,7 +140,7 @@ all() ->
      delayed_write, read_ahead, segment_read, segment_write,
      ipread, interleaved_read_write, otp_5814, otp_10852,
      large_file, large_write, read_line_1, read_line_2, read_line_3,
-     read_line_4, standard_io, old_io_protocol,
+     read_line_4, read_line_5, read_line_6, standard_io, old_io_protocol,
      unicode_mode, {group, bench}
     ].
 
@@ -4602,6 +4603,50 @@ read_line_4(Config) when is_list(Config) ->
       end || {_,File,_,Y} <- All , Y =:= fail],
     read_line_remove_files(All),
     ok.
+%% read_line with ram file.
+read_line_5(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    All = read_line_testdata(PrivDir),
+    read_line_create_files(All),
+    [ begin
+          io:format("read_line_all: ~s~n",[File]),
+          {X,_} = read_line_all5(File),
+          true
+      end || {_,File,X,_} <- All ],
+    [ begin
+          io:format("read_line_all_alternating: ~s~n",[File]),
+          {Y,_} = read_line_all_alternating5(File),
+          true
+      end || {_,File,_,Y} <- All , Y =/= fail],
+    [ begin
+          io:format("read_line_all_alternating (failing as should): ~s~n",[File]),
+          {'EXIT',_} = (catch read_line_all_alternating5(File)),
+          true
+      end || {_,File,_,Y} <- All , Y =:= fail],
+    read_line_remove_files(All),
+    ok.
+%% read_line with cooked ram file.
+read_line_6(Config) when is_list(Config) ->
+    PrivDir = proplists:get_value(priv_dir, Config),
+    All = read_line_testdata(PrivDir),
+    read_line_create_files(All),
+    [ begin
+          io:format("read_line_all: ~s~n",[File]),
+          {X,_} = read_line_all6(File),
+          true
+      end || {_,File,X,_} <- All ],
+    [ begin
+          io:format("read_line_all_alternating: ~s~n",[File]),
+          {Y,_} = read_line_all_alternating6(File),
+          true
+      end || {_,File,_,Y} <- All , Y =/= fail],
+    [ begin
+          io:format("read_line_all_alternating (failing as should): ~s~n",[File]),
+          {'EXIT',_} = (catch read_line_all_alternating6(File)),
+          true
+      end || {_,File,_,Y} <- All , Y =:= fail],
+    read_line_remove_files(All),
+    ok.
 
 rl_lines() ->
     [ <<"hej">>,<<"hopp">>,<<"i">>,<<"lingon\rskogen">>].
@@ -4716,6 +4761,24 @@ read_line_all4(Filename) ->
     Bin = re:replace(list_to_binary([element(2,file:read_file(Filename))]),
 		     "\r\n","\n",[global,{return,binary}]),
     {length(X),Bin}.
+read_line_all5(Filename) ->
+    {ok, Content} = file:read_file(Filename),
+    {ok,F} = file:open(Content,[read,binary,ram]),
+    X=read_rl_lines2(F),
+    file:close(F),
+    Bin = list_to_binary([B || {ok,B} <- X]),
+    Bin = re:replace(list_to_binary([element(2,file:read_file(Filename))]),
+                     "\r\n","\n",[global,{return,binary}]),
+    {length(X),Bin}.
+read_line_all6(Filename) ->
+    {ok, Content} = file:read_file(Filename),
+    {ok,F} = file:open(Content,[read,binary,ram,cooked]),
+    X=read_rl_lines2(F),
+    file:close(F),
+    Bin = list_to_binary([B || {ok,B} <- X]),
+    Bin = re:replace(list_to_binary([element(2,file:read_file(Filename))]),
+                     "\r\n","\n",[global,{return,binary}]),
+    {length(X),Bin}.
 
 read_rl_lines(F) ->
     case ?PRIM_FILE:read_line(F) of
@@ -4769,6 +4832,24 @@ read_line_all_alternating4(Filename) ->
     Bin = list_to_binary([B || {ok,B} <- X]),
     Bin = re:replace(list_to_binary([element(2,file:read_file(Filename))]),
 		     "\r\n","\n",[global,{return,binary}]),
+    {length(X),Bin}.
+read_line_all_alternating5(Filename) ->
+    {ok, Content} = file:read_file(Filename),
+    {ok,F} = file:open(Content,[read,binary,ram]),
+    X=read_rl_lines2(F,true),
+    file:close(F),
+    Bin = list_to_binary([B || {ok,B} <- X]),
+    Bin = re:replace(list_to_binary([element(2,file:read_file(Filename))]),
+                     "\r\n","\n",[global,{return,binary}]),
+    {length(X),Bin}.
+read_line_all_alternating6(Filename) ->
+    {ok, Content} = file:read_file(Filename),
+    {ok,F} = file:open(Content,[read,binary,ram,cooked]),
+    X=read_rl_lines2(F,true),
+    file:close(F),
+    Bin = list_to_binary([B || {ok,B} <- X]),
+    Bin = re:replace(list_to_binary([element(2,file:read_file(Filename))]),
+                     "\r\n","\n",[global,{return,binary}]),
     {length(X),Bin}.
 
 read_rl_lines(F,Alternate) ->

--- a/lib/kernel/test/ram_file_SUITE.erl
+++ b/lib/kernel/test/ram_file_SUITE.erl
@@ -29,7 +29,8 @@
 -export([open_modes/1, pread_pwrite/1, position/1,
 	 truncate/1, sync/1, get_file_and_size/1,
 	 large_file_errors/1, large_file_light/1,
-	 large_file_heavy/0, large_file_heavy/1]).
+         large_file_heavy/0, large_file_heavy/1,
+         cooked_ram/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("kernel/include/file.hrl").
@@ -46,7 +47,8 @@ suite() ->
 all() -> 
     [open_modes, pread_pwrite, position,
      truncate, sync, get_file_and_size,
-     large_file_errors, large_file_light, large_file_heavy].
+     large_file_errors, large_file_light, large_file_heavy,
+     cooked_ram].
 
 groups() -> 
     [].
@@ -445,6 +447,46 @@ do_large_file_heavy(_Config) ->
     {ok, 0}         = ?FILE_MODULE:position(Fd, cur),
     ok              = ?FILE_MODULE:close(Fd),
     ok.
+
+%% Test cooked option for ram files.
+%% The cooked option wraps a ram file in a pid-based I/O server,
+%% making it usable with the io module (unlike a plain ram file
+%% which returns a raw file descriptor).
+cooked_ram(_Config) ->
+    Data = <<"hello, world\nline two\n">>,
+
+    %% Basic read via io module.
+    {ok, Fd1} = ?FILE_MODULE:open(Data, [ram, read, binary, cooked]),
+    
+    <<"hello, world\n">> = io:get_line(Fd1, ''),
+    <<"line two\n">> = io:get_line(Fd1, ''),
+    eof = io:get_line(Fd1, ''),
+    ok = ?FILE_MODULE:close(Fd1),
+
+    %% Write and read back.
+    {ok, Fd2} = ?FILE_MODULE:open(<<>>, [ram, write, read, binary, cooked]),
+    
+    ok = io:put_chars(Fd2, "test data"),
+    {ok, 0} = ?FILE_MODULE:position(Fd2, bof),
+    {ok, <<"test data">>} = ?FILE_MODULE:read(Fd2, 100),
+    ok = ?FILE_MODULE:close(Fd2),
+
+    %% io:scan_erl_form works (needed for epp).
+    ErlData = <<"-module(test).\n">>,
+    {ok, Fd3} = ?FILE_MODULE:open(ErlData, [ram, read, binary, cooked]),
+    {ok, Tokens, _} = io:scan_erl_form(Fd3, '', 1),
+    true = is_list(Tokens),
+    ok = ?FILE_MODULE:close(Fd3),
+
+    %% io:setopts and io:getopts work on cooked ram files.
+    {ok, Fd4} = ?FILE_MODULE:open(Data, [ram, read, binary, cooked]),
+    io:setopts(Fd4, [{binary, false}]),
+    {ok, "hello, world\nline two\n"} = ?FILE_MODULE:read(Fd4, 100),
+    false = proplists:get_value(binary, io:getopts(Fd4)),
+    ok = ?FILE_MODULE:close(Fd4),
+
+    ok.
+
 
 %%--------------------------------------------------------------------------
 %% Utility functions

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -20,11 +20,31 @@
 %% %CopyrightEnd%
 
 -module(epp).
--moduledoc """
+-moduledoc """"
 An Erlang code preprocessor.
 
 The Erlang code preprocessor includes functions that are used by the `m:compile`
 module to preprocess macros and include files before the parsing takes place.
+For example:
+
+```erlang
+1> file:read_file("example.erl").
+{ok, ~"""
+      -module(example).
+
+      -export([foo/0]).
+
+      foo() -> ?MODULE.
+      """}
+2> epp:parse_file("example.erl", []).
+{ok,[{attribute,1,file,{"example.erl",1}},
+     {attribute,1,module,example},
+     {attribute,3,export,[{foo,0}]},
+     {function,5,foo,0,[{clause,5,[],[],[{atom,5,example}]}]},
+     {eof,5}]}
+```
+
+## Encoding
 
 The Erlang source file _encoding_{: #encoding } is selected by a comment in one
 of the first two lines of the source file. The first string matching the regular
@@ -32,7 +52,7 @@ expression `coding\s*[:=]\s*([-a-zA-Z0-9])+` selects the encoding. If the
 matching string is not a valid encoding, it is ignored. The valid encodings are
 `Latin-1` and `UTF-8`, where the case of the characters can be chosen freely.
 
-_Examples:_
+### Examples
 
 ```erlang
 %% coding: utf-8
@@ -64,7 +84,7 @@ Module:format_error(ErrorDescriptor)
 ### See Also
 
 `m:erl_parse`
-""".
+"""".
 
 -compile([{nowarn_possibly_unsafe_function, {erlang, list_to_atom, 1}}]).
 
@@ -90,6 +110,72 @@ Module:format_error(ErrorDescriptor)
 -doc "Handle to the `epp` server.".
 -type epp_handle() :: pid().
 -type source_encoding() :: latin1 | utf8.
+
+-doc """"
+The `t:option/0` are the options that can be used to customize the preprocessing.
+
+* **`{default_encoding, DefEncoding}`** - sets the default encoding of the file. The default encoding is
+  used if no valid encoding is found in the file. The valid encodings are `latin1` and `utf8`,
+  where the case of the characters can be chosen freely. If unset, it defaults to `utf8`.
+
+* **`{includes, IncludePath}`** - sets the include path for the file. The include path is used to resolve
+  `-include`, `-include_lib` directives.
+
+* **`{source_name, SourceName}`** - sets the file name of the implicit -file() attributes inserted
+  during preprocessing. If unset it will default to the name of the opened file.
+
+* **`{macros, PredefMacros}`** - sets the predefined `t:macros/0` for the file. `PredefMacros` is a list of
+  macros that are defined before preprocessing starts.
+
+* **`{deterministic, Enabled}`** - if set to `true`, will reduce the file name of the
+  implicit -file() attributes inserted during preprocessing to only the basename of the path. 
+
+* **`{extra, Enabled}`** - if set to `true`, the return value is `{ok, Epp, Extra}` instead of `{ok, Epp}`,
+  where `Extra` contains which encoding was detected from the file.
+
+* **`{location, StartLocation}`** - sets the initial location of the file. The option `location` is forwarded
+  to the Erlang token scanner, see [`erl_scan:tokens/3,4`](`erl_scan:tokens/3`). For example:
+
+  ```erlang
+  1> file:read_file("example.erl").
+  {ok, ~"""
+        -module(example).
+
+        -export([foo/0]).
+
+        foo() -> ?MODULE.
+        """}
+  2> epp:parse_file("example.erl", [{location, {1, 1}}]).
+  {ok,[{attribute,{1,1},file,{"example.erl",1}},
+       {attribute,{1,2},module,example},
+       {attribute,{3,2},export,[{foo,0}]},
+       {function,{5,1},
+                 foo,0,
+                 [{clause,{5,1},[],[],[{atom,{5,11},example}]}]},
+       {eof,{5,18}}]}
+  ```
+
+* **`{fd, FileDescriptor}`** - use an already opened file descriptor to read from instead of a file name.
+  The file descriptor is expected to be an `t:file:io_server/0`. This enables in-memory preprocessing
+  using [ram files](`m:file#ram`), where the main source file can be served from memory without touching disk.
+
+  See `parse_file/2` for an example of how to use this option.
+
+* **`{compiler_internal,term()}`** - forwarded to the Erlang token
+  scanner, see [`{compiler_internal,term()}`](`m:erl_scan#compiler_interal`) in `erl_scan:string/3`.
+"""".
+-type option() ::
+        {default_encoding, DefEncoding :: source_encoding()} |
+        {includes, IncludePath :: [ DirectoryName :: file:name()]} |
+        {macros, PredefMacros :: macros()} |
+        {source_name, SourceName :: file:name()} |
+        {deterministic, boolean()} |
+        {location, StartLocation :: erl_anno:location()} |
+        {reserved_word_fun, Fun :: fun((atom()) -> boolean())} |
+        {features, [Feature :: atom()]} |
+        {fd, OpenedFile :: file:io_server()} |
+        'extra' |
+        {'compiler_internal', [term()]}.
 
 -type ifdef() :: 'ifdef' | 'ifndef' | 'if' | 'else'.
 
@@ -147,7 +233,7 @@ Module:format_error(ErrorDescriptor)
 %% parse_file(FileName, IncludePath, PreDefMacros)
 %% macro_defs(Epp)
 
--doc "Equivalent to `epp:open([{name, FileName}, {includes, IncludePath}])`.".
+-doc #{ equiv => open([{name, FileName}, {includes, IncludePath}]) }.
 -spec open(FileName, IncludePath) ->
 	{'ok', Epp} | {'error', ErrorDescriptor} when
       FileName :: file:name(),
@@ -158,10 +244,7 @@ Module:format_error(ErrorDescriptor)
 open(Name, Path) ->
     open(Name, Path, []).
 
--doc """
-Equivalent to
-`epp:open([{name, FileName}, {includes, IncludePath}, {macros, PredefMacros}])`.
-""".
+-doc #{ equiv => open([{name, FileName}, {includes, IncludePath}, {macros, PredefMacros}]) }.
 -spec open(FileName, IncludePath, PredefMacros) ->
 	{'ok', Epp} | {'error', ErrorDescriptor} when
       FileName :: file:name(),
@@ -173,39 +256,46 @@ Equivalent to
 open(Name, Path, Pdm) ->
     open([{name, Name}, {includes, Path}, {macros, Pdm}]).
 
--doc """
+-doc """"
 Opens a file for preprocessing.
 
-If you want to change the file name of the implicit -file() attributes inserted
-during preprocessing, you can do with `{source_name, SourceName}`. If unset it
-will default to the name of the opened file.
+The function is used to start parsing of an Erlang source file. To get the forms from the file
+use `scan_erl_form/1` or `parse_erl_form/1`. When finished, the `m:epp` server should be closed with
+`close/1`. Use this function if you want to scan or parse a file incrementally. To scan or parse
+a whole file at once, use `scan_file/2` and `parse_file/3` respectively.
 
-Setting `{deterministic, Enabled}` will additionally reduce the file name of the
-implicit -file() attributes inserted during preprocessing to only the basename
-of the path.
+When using `open/1` the option `name` must always be specified and is the name of the file to
+preprocess. This name is used in error messages and in the implicit `-file()` attributes
+generated during preprocessing.
 
-If `extra` is specified in `Options`, the return value is `{ok, Epp, Extra}`
-instead of `{ok, Epp}`.
+See `t:option/0` for the other available options and what they do.
 
-The option `location` is forwarded to the Erlang token scanner, see
-[`erl_scan:tokens/3,4`](`erl_scan:tokens/3`).
+## Examples
 
-The `{compiler_internal,term()}` option is forwarded to the Erlang token
-scanner, see [`{compiler_internal,term()}`](`m:erl_scan#compiler_interal`).
-""".
+```erlang
+1> file:read_file("example.erl").
+{ok, ~"""
+      -module(example).
+
+      -export([foo/0]).
+
+      foo() -> ?MODULE.
+      """}
+2> {ok, EPP} = epp:open("example.erl", []).
+3> epp:scan_erl_form(EPP).
+{ok,[{'-',1},{atom,1,file},{'(',1},{string,1,"example.erl"},
+     {',',1},{integer,1,1},{')',1},{dot,1}]}
+4> epp:parse_erl_form(EPP).
+{ok,{attribute,1,module,example}}
+5> epp:close(EPP).
+ok
+```
+
+"""".
 -doc(#{since => <<"OTP 17.0">>}).
 -spec open(Options) ->
 		  {'ok', Epp} | {'ok', Epp, Extra} | {'error', ErrorDescriptor} when
-      Options :: [{'default_encoding', DefEncoding :: source_encoding()} |
-		  {'includes', IncludePath :: [DirectoryName :: file:name()]} |
-		  {'source_name', SourceName :: file:name()} |
-		  {'deterministic', Enabled :: boolean()} |
-		  {'macros', PredefMacros :: macros()} |
-		  {'name',FileName :: file:name()} |
-		  {'location',StartLocation :: erl_anno:location()} |
-		  {'fd',FileDescriptor :: file:io_device()} |
-		  'extra' |
-                  {'compiler_internal', [term()]}],
+      Options :: [option() | {'name',FileName :: file:name()}],
       Epp :: epp_handle(),
       Extra :: [{'encoding', source_encoding() | 'none'}],
       ErrorDescriptor :: term().
@@ -231,8 +321,7 @@ open(Options) ->
     end.
 
 -doc "Closes the preprocessing of a file.".
--spec close(Epp) -> 'ok' when
-      Epp :: epp_handle().
+-spec close(Epp :: epp_handle()) -> 'ok'.
 
 close(Epp) ->
     %% Make sure that close is synchronous as a courtesy to test
@@ -244,7 +333,9 @@ close(Epp) ->
 
 -doc """
 Returns the raw tokens of the next Erlang form from the opened Erlang source
-file. A tuple `{eof, Line}` is returned at the end of the file. The first form
+file.
+
+A tuple `{eof, Line}` is returned at the end of the file. The first form
 corresponds to an implicit attribute `-file(File,1).`, where `File` is the file
 name.
 """.
@@ -262,8 +353,9 @@ scan_erl_form(Epp) ->
     epp_request(Epp, scan_erl_form).
 
 -doc """
-Returns the next Erlang form from the opened Erlang source file. Tuple
-`{eof, Location}` is returned at the end of the file. The first form corresponds
+Returns the next Erlang form from the opened Erlang source file.
+
+Tuple `{eof, Location}` is returned at the end of the file. The first form corresponds
 to an implicit attribute `-file(File,1).`, where `File` is the file name.
 """.
 -spec parse_erl_form(Epp) ->
@@ -367,18 +459,30 @@ format_error_1(E) -> file:format_error(E).
 
 -doc """
 Preprocesses an Erlang source file returning a list of the lists of raw tokens
-of each form. Notice that the tuple `{eof, Line}` returned at the end of the
-file is included as a "form", and any failures to scan a form are included in
-the list as tuples `{error, ErrorInfo}`.
+of each form.
+
+Notice that the tuple `{eof, Line}` returned at the end of the file is included
+as a "form", and any failures to scan a form are included in the list as tuples
+`{error, ErrorInfo}`.
+
+For details on what each `Option` does, see `t:option/0`.
+
+## Examples
+
+```
+1> file:read_file("example.erl").
+{ok, <<"-module(example).\n\n-export([foo/0]).\n\nfoo() -> ?MODULE.", ...>>}
+2> epp:scan_file("example.erl", []).
+{ok,[[{'-',1},{atom,1,file},{'(',1},{string,1,"example.erl"},
+      {',',1},{integer,1,1},{')',1},{dot,1}], ...],
+    [{encoding,none}]}
+```
 """.
 -doc(#{since => <<"OTP 24.0">>}).
 -spec scan_file(FileName, Options) ->
         {'ok', [Form], Extra} | {error, OpenError} when
       FileName :: file:name(),
-      Options :: [{'includes', IncludePath :: [DirectoryName :: file:name()]} |
-		  {'source_name', SourceName :: file:name()} |
-		  {'macros', PredefMacros :: macros()} |
-		  {'default_encoding', DefEncoding :: source_encoding()}],
+      Options :: [option()],
       Form :: erl_scan:tokens() | {'error', ErrorInfo} | {'eof', Loc},
       Loc :: erl_anno:location(),
       ErrorInfo :: erl_scan:error_info(),
@@ -406,10 +510,7 @@ scan_file(Epp) ->
 	    [{eof,Location}]
     end.
 
--doc """
-Equivalent to
-`epp:parse_file(FileName, [{includes, IncludePath}, {macros, PredefMacros}])`.
-""".
+-doc #{ equiv => parse_file(Filename, [{includes, IncludePath}, {macros, PredefMacros}]) }.
 -spec parse_file(FileName, IncludePath, PredefMacros) ->
                 {'ok', [Form]} | {error, OpenError} when
       FileName :: file:name(),
@@ -426,36 +527,46 @@ parse_file(Ifile, Path, Predefs) ->
     parse_file(Ifile, [{includes, Path}, {macros, Predefs}]).
 
 -doc """
-Preprocesses and parses an Erlang source file. Notice that tuple
-`{eof, Location}` returned at the end of the file is included as a "form".
+Preprocesses and parses an Erlang source file.
 
-If you want to change the file name of the implicit -file() attributes inserted
-during preprocessing, you can do with `{source_name, SourceName}`. If unset it
-will default to the name of the opened file.
+Notice that tuple `{eof, Location}` returned at the end of the file is included as
+a "form".
 
-If `extra` is specified in `Options`, the return value is `{ok, [Form], Extra}`
-instead of `{ok, [Form]}`.
+See `t:option/0` for the available options and what they do.
 
-The option `location` is forwarded to the Erlang token scanner, see
-[`erl_scan:tokens/3,4`](`erl_scan:tokens/3`).
+## Examples
 
-The `{compiler_internal,term()}` option is forwarded to the Erlang token
-scanner, see [`{compiler_internal,term()}`](`m:erl_scan#compiler_interal`).
+Parse a file:
+
+```erlang
+1> file:read_file("example.erl").
+{ok, <<"-module(example).\n\n-export([foo/0]).\n\nfoo() -> ?MODULE.", ...>>}
+2> epp:parse_file("example.erl", []).
+{ok,[{attribute,1,file,{"example.erl",1}},
+     {attribute,1,module,example},
+     {attribute,3,export,[{foo,0}]},
+     {function,5,foo,0,[{clause,5,[],[],[{atom,5,example}]}]},
+     {eof,5}]}
+```
+
+Parse a ram file:
+
+```erlang
+1> {ok, IoDevice} = file:open(<<"-module(foo).\n-export([bar/0]).\nbar() ->\n?MODULE.">>,
+       [read, binary, ram, cooked]).
+2> epp:parse_file("foo.erl", [{fd, IoDevice}]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {attribute,1,module,foo},
+     {attribute,2,export,[{bar,0}]},
+     {function,3,bar,0,[{clause,3,[],[],[{atom,4,foo}]}]},
+     {eof,4}]}
+```
 """.
 -doc(#{since => <<"OTP 17.0">>}).
 -spec parse_file(FileName, Options) ->
         {'ok', [Form]} | {'ok', [Form], Extra} | {error, OpenError} when
       FileName :: file:name(),
-      Options :: [{'includes', IncludePath :: [DirectoryName :: file:name()]} |
-		  {'source_name', SourceName :: file:name()} |
-		  {'macros', PredefMacros :: macros()} |
-		  {'default_encoding', DefEncoding :: source_encoding()} |
-		  {'location',StartLocation :: erl_anno:location()} |
-                  {'reserved_word_fun', Fun :: fun((atom()) -> boolean())} |
-                  {'features', [Feature :: atom()]} |
-                  {'deterministic', boolean()} |
-		  'extra' |
-                  {'compiler_internal', [term()]}],
+      Options :: [option()],
       Form :: erl_parse:abstract_form()
             | {'error', ErrorInfo}
             | {'eof',Location},

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -230,6 +230,7 @@ The `t:option/0` are the options that can be used to customize the preprocessing
        {eof,2}]}
   ```
 
+  Since OTP @OTP-12345678@
 * **`{compiler_internal,term()}`** - forwarded to the Erlang token
   scanner, see [`{compiler_internal,term()}`](`m:erl_scan#compiler_interal`) in `erl_scan:string/3`.
 """".

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -66,6 +66,26 @@ matching string is not a valid encoding, it is ignored. The valid encodings are
 %% -*- coding: latin-1 -*-
 ```
 
+Scan a ram file using the encoding specified in the file:
+
+```erlang
+1> {ok, IoDevice} = file:open(
+       ~"""
+        %% coding: utf-8
+        -module(foo).
+        -export([bar/0]).
+        bar() ->
+            ?MODULE.
+        """, [read, binary, ram, cooked]).
+2> epp:parse_file("foo.erl", [{fd, IoDevice}, extra]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {attribute,2,module,foo},
+     {attribute,3,export,[{bar,0}]},
+     {function,4,bar,0,[{clause,4,[],[],[{atom,5,foo}]}]},
+     {eof,5}],
+    [{features,[]},{encoding,utf8}]}
+```
+
 ## Error Information
 
 `ErrorInfo` is the standard `ErrorInfo` structure that is returned from all I/O
@@ -79,6 +99,28 @@ A string describing the error is obtained with the following call:
 
 ```erlang
 Module:format_error(ErrorDescriptor)
+```
+
+### Examples
+
+```erlang
+1> {ok, IoDevice} = file:open(
+       ~"""
+        -module("foo").
+        -export([bar/0]).
+        bar() ->
+            ?MODULE.
+        """, [read, binary, ram, cooked]).
+2> {ok, Forms} = epp:parse_file("foo.erl", [{fd, IoDevice}]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {error,{1,erl_parse,[98,97,100,32,"module",32,100,101,99,108,97,114,97,116,105,111,110]}},
+     {attribute,2,export,[{bar,0}]},
+     {error,{4,epp,{undefined,'MODULE',none}}},
+     {eof,4}]}
+3> [io:format("%% ~ts~n", [M:format_error(E)]) || {error,{Loc,M,E}} <- Forms].
+%% bad module declaration
+%% undefined macro 'MODULE'
+[ok,ok]
 ```
 
 ### See Also
@@ -161,6 +203,34 @@ The `t:option/0` are the options that can be used to customize the preprocessing
 
   See `parse_file/2` for an example of how to use this option.
 
+* **`{include_path_open, Fun}`** - provide a custom function for opening include files. The function has the
+  same signature as `file:path_open/3` and is used when resolving `-include`, `-include_lib`, and
+  `-doc {file, ...}` directives. This enables fully in-memory preprocessing using [ram files](`m:file#ram`).
+  For example:
+
+  ```erlang
+  1> {ok, IoDevice} = file:open(<<"-module(foo).\n-include(\"bar.hrl\").">>,
+         [read, binary, ram, cooked]).
+  2> IncludeFileFun = fun
+         (_Path, "bar.hrl", Modes) ->
+             {ok, RamFD} = file:open(<<"-export([bar/0]).\nbar() ->\n?MODULE.">>,
+                  [ram, cooked | Modes]),
+             {ok, RamFD, "bar.hrl"};
+         (Path, Name, Modes) ->
+             file:path_open(Path, Name, Modes)
+     end.
+  3> {ok, EPP} = epp:parse_file("example.erl",
+         [{fd, IoDevice}, {include_path_open, IncludeFileFun}]).
+  {ok,[{attribute,1,file,{"example.erl",1}},
+       {attribute,1,module,foo},
+       {attribute,1,file,{"bar.hrl",1}},
+       {attribute,1,export,[{bar,0}]},
+       {function,2,bar,0,[{clause,2,[],[],[{atom,3,foo}]}]},
+       {attribute,2,file,{"example.erl",2}},
+       {eof,2}]}
+  ```
+
+  Since OTP @OTP-20341@
 * **`{compiler_internal,term()}`** - forwarded to the Erlang token
   scanner, see [`{compiler_internal,term()}`](`m:erl_scan#compiler_interal`) in `erl_scan:string/3`.
 """".
@@ -174,6 +244,12 @@ The `t:option/0` are the options that can be used to customize the preprocessing
         {reserved_word_fun, Fun :: fun((atom()) -> boolean())} |
         {features, [Feature :: atom()]} |
         {fd, OpenedFile :: file:io_server()} |
+        {include_path_open, fun((Path :: [file:name_all()],
+                                 FileName :: file:name_all(),
+                                 Modes :: [file:mode()]) ->
+                                       {ok, IoDevice :: file:io_device(),
+                                        FullName :: file:filename_all()} |
+                                       {error, term()})} |
         'extra' |
         {'compiler_internal', [term()]}.
 
@@ -217,7 +293,8 @@ The `t:option/0` are the options that can be used to customize the preprocessing
               features = [] :: [atom()],
               else_reserved = false :: boolean(),
               fname = [] :: function_name_type(),
-              deterministic = false :: boolean()
+              deterministic = false :: boolean(),
+              include_path_open = fun file:path_open/3 :: fun()
 	     }).
 
 %% open(Options)
@@ -549,7 +626,7 @@ Parse a file:
      {eof,5}]}
 ```
 
-Parse a ram file:
+Parse a module from a ram file:
 
 ```erlang
 1> {ok, IoDevice} = file:open(<<"-module(foo).\n-export([bar/0]).\nbar() ->\n?MODULE.">>,
@@ -561,6 +638,26 @@ Parse a ram file:
      {function,3,bar,0,[{clause,3,[],[],[{atom,4,foo}]}]},
      {eof,4}]}
 ```
+
+Parse a broken ram file:
+
+```erlang
+1> {ok, IoDevice} = file:open(<<"-module(Foo).\n-export([bar/0]).\nbar() ->\n?MODULE.">>,
+       [read, binary, ram, cooked]).
+2> {ok, Forms} = epp:parse_file("foo.erl", [{fd, IoDevice}]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {error,{1,erl_parse,
+             [98,97,100,32,"module",32,100,101,99,108,97,114,97,116,105,
+              111,110]}},
+     {attribute,2,export,[{bar,0}]},
+     {error,{4,epp,{undefined,'MODULE',none}}},
+     {eof,4}]}
+3> [io:format("%% ~ts~n", [M:format_error(E)]) || {error,{Loc,M,E}} <- Forms].
+%% bad module declaration
+%% undefined macro 'MODULE'
+[ok,ok]
+```
+
 """.
 -doc(#{since => <<"OTP 17.0">>}).
 -spec parse_file(FileName, Options) ->
@@ -940,6 +1037,8 @@ init_server(Pid, FileName, Options, St0) ->
             AtLocation = proplists:get_value(location, Options, 1),
 
             Deterministic = proplists:get_value(deterministic, Options, false),
+            PathOpen = proplists:get_value(include_path_open, Options,
+                                           fun file:path_open/3),
             St = St0#epp{delta=0, name=SourceName, name2=SourceName,
 			 path=Path, location=AtLocation, macs=Ms1,
 			 default_encoding=DefEncoding,
@@ -952,7 +1051,8 @@ init_server(Pid, FileName, Options, St0) ->
                             end,
                          features = Features,
                          else_reserved = ResWordFun('else'),
-                         deterministic = Deterministic},
+                         deterministic = Deterministic,
+                         include_path_open = PathOpen},
             From = wait_request(St),
             Anno = erl_anno:new(AtLocation),
             enter_file_reply(From, file_name(SourceName), Anno,
@@ -1106,7 +1206,7 @@ enter_file(_NewName, Inc, From, St)
     epp_reply(From, {error,{loc(Inc),epp,{depth,"include"}}}),
     wait_req_scan(St);
 enter_file(NewName, Inc, From, St) ->
-    case file:path_open(St#epp.path, NewName, [read]) of
+    case (St#epp.include_path_open)(St#epp.path, NewName, [read]) of
 	{ok,NewF,Pname} ->
             Loc = start_loc(St#epp.location),
 	    wait_req_scan(enter_file2(NewF, Pname, From, St, Loc));
@@ -1127,7 +1227,8 @@ enter_file2(NewF, Pname, From, St0, AtLocation) ->
          erl_scan_opts = ScanOpts,
          else_reserved = ElseReserved,
          features = Ftrs,
-         deterministic = Deterministic} = St0,
+         deterministic = Deterministic,
+         include_path_open = PathOpen} = St0,
     Ms = Ms0#{'FILE':={none,[{string,Anno,source_name(St0,Pname)}]}},
     %% update the head of the include path to be the directory of the new
     %% source file, so that an included file can always include other files
@@ -1144,7 +1245,8 @@ enter_file2(NewF, Pname, From, St0, AtLocation) ->
          erl_scan_opts = ScanOpts,
          else_reserved = ElseReserved,
          default_encoding=DefEncoding,
-         deterministic=Deterministic}.
+         deterministic=Deterministic,
+         include_path_open=PathOpen}.
 
 enter_file_reply(From, Name, LocationAnno, AtLocation, Where, Deterministic) ->
     Anno0 = erl_anno:new(AtLocation),
@@ -1327,7 +1429,7 @@ scan_filedoc_content({string, _A, DocFilename}, Dot,
                      {atom,DocLoc,Doc}, From, #epp{name = CurrentFilename} = St) ->
     %% The head of the path is the dir where the current file is
     Cwd = hd(St#epp.path),
-    case file:path_open([Cwd], DocFilename, [read, binary]) of
+    case (St#epp.include_path_open)([Cwd], DocFilename, [read, binary]) of
         {ok, NewF, Pname} ->
             case file:read_file_info(NewF) of
                 {ok, #file_info{ size = Sz }} ->
@@ -1619,14 +1721,15 @@ scan_include_lib1([{'(',_Alp},{string,_Af,NewName0}=N,{')',_Arp},{dot,_Ad}],
                   _Inc, From, St) ->
     NewName = expand_var(NewName0),
     Loc = start_loc(St#epp.location),
-    case file:path_open(St#epp.path, NewName, [read]) of
+    case (St#epp.include_path_open)(St#epp.path, NewName, [read]) of
 	{ok,NewF,Pname} ->
 	    wait_req_scan(enter_file2(NewF, Pname, From, St, Loc));
 	{error,_E1} ->
 	    case expand_lib_dir(NewName) of
 		{ok,Header} ->
-		    case file:open(Header, [read]) of
-			{ok,NewF} ->
+                    {ok, Cwd} = file:get_cwd(),
+                    case (St#epp.include_path_open)([Cwd], Header, [read]) of
+                        {ok,NewF,_} ->
 			    wait_req_scan(enter_file2(NewF, Header, From,
                                                       St, Loc));
 			{error,_E2} ->

--- a/lib/stdlib/src/epp.erl
+++ b/lib/stdlib/src/epp.erl
@@ -66,6 +66,26 @@ matching string is not a valid encoding, it is ignored. The valid encodings are
 %% -*- coding: latin-1 -*-
 ```
 
+Scan a ram file using the encoding specified in the file:
+
+```erlang
+1> {ok, IoDevice} = file:open(
+       ~"""
+        %% coding: utf-8
+        -module(foo).
+        -export([bar/0]).
+        bar() ->
+            ?MODULE.
+        """, [read, binary, ram, cooked]).
+2> epp:parse_file("foo.erl", [{fd, IoDevice}, extra]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {attribute,2,module,foo},
+     {attribute,3,export,[{bar,0}]},
+     {function,4,bar,0,[{clause,4,[],[],[{atom,5,foo}]}]},
+     {eof,5}],
+    [{features,[]},{encoding,utf8}]}
+```
+
 ## Error Information
 
 `ErrorInfo` is the standard `ErrorInfo` structure that is returned from all I/O
@@ -79,6 +99,28 @@ A string describing the error is obtained with the following call:
 
 ```erlang
 Module:format_error(ErrorDescriptor)
+```
+
+### Examples
+
+```erlang
+1> {ok, IoDevice} = file:open(
+       ~"""
+        -module("foo").
+        -export([bar/0]).
+        bar() ->
+            ?MODULE.
+        """, [read, binary, ram, cooked]).
+2> {ok, Forms} = epp:parse_file("foo.erl", [{fd, IoDevice}]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {error,{1,erl_parse,[98,97,100,32,"module",32,100,101,99,108,97,114,97,116,105,111,110]}},
+     {attribute,2,export,[{bar,0}]},
+     {error,{4,epp,{undefined,'MODULE',none}}},
+     {eof,4}]}
+3> [io:format("%% ~ts~n", [M:format_error(E)]) || {error,{Loc,M,E}} <- Forms].
+%% bad module declaration
+%% undefined macro 'MODULE'
+[ok,ok]
 ```
 
 ### See Also
@@ -161,6 +203,33 @@ The `t:option/0` are the options that can be used to customize the preprocessing
 
   See `parse_file/2` for an example of how to use this option.
 
+* **`{include_path_open, Fun}`** - provide a custom function for opening include files. The function has the
+  same signature as `file:path_open/3` and is used when resolving `-include`, `-include_lib`, and
+  `-doc {file, ...}` directives. This enables fully in-memory preprocessing using [ram files](`m:file#ram`).
+  For example:
+
+  ```erlang
+  1> {ok, IoDevice} = file:open(<<"-module(foo).\n-include(\"bar.hrl\").">>,
+         [read, binary, ram, cooked]).
+  2> IncludeFileFun = fun
+         (_Path, "bar.hrl", Modes) ->
+             {ok, RamFD} = file:open(<<"-export([bar/0]).\nbar() ->\n?MODULE.">>,
+                  [ram, cooked | Modes]),
+             {ok, RamFD, "bar.hrl"};
+         (Path, Name, Modes) ->
+             file:path_open(Path, Name, Modes)
+     end.
+  3> {ok, EPP} = epp:parse_file("example.erl",
+         [{fd, IoDevice}, {include_path_open, IncludeFileFun}]).
+  {ok,[{attribute,1,file,{"example.erl",1}},
+       {attribute,1,module,foo},
+       {attribute,1,file,{"bar.hrl",1}},
+       {attribute,1,export,[{bar,0}]},
+       {function,2,bar,0,[{clause,2,[],[],[{atom,3,foo}]}]},
+       {attribute,2,file,{"example.erl",2}},
+       {eof,2}]}
+  ```
+
 * **`{compiler_internal,term()}`** - forwarded to the Erlang token
   scanner, see [`{compiler_internal,term()}`](`m:erl_scan#compiler_interal`) in `erl_scan:string/3`.
 """".
@@ -174,6 +243,12 @@ The `t:option/0` are the options that can be used to customize the preprocessing
         {reserved_word_fun, Fun :: fun((atom()) -> boolean())} |
         {features, [Feature :: atom()]} |
         {fd, OpenedFile :: file:io_server()} |
+        {include_path_open, fun((Path :: [file:name_all()],
+                                 FileName :: file:name_all(),
+                                 Modes :: [file:mode()]) ->
+                                       {ok, IoDevice :: file:io_device(),
+                                        FullName :: file:filename_all()} |
+                                       {error, term()})} |
         'extra' |
         {'compiler_internal', [term()]}.
 
@@ -217,7 +292,8 @@ The `t:option/0` are the options that can be used to customize the preprocessing
               features = [] :: [atom()],
               else_reserved = false :: boolean(),
               fname = [] :: function_name_type(),
-              deterministic = false :: boolean()
+              deterministic = false :: boolean(),
+              include_path_open = fun file:path_open/3 :: fun()
 	     }).
 
 %% open(Options)
@@ -549,7 +625,7 @@ Parse a file:
      {eof,5}]}
 ```
 
-Parse a ram file:
+Parse a module from a ram file:
 
 ```erlang
 1> {ok, IoDevice} = file:open(<<"-module(foo).\n-export([bar/0]).\nbar() ->\n?MODULE.">>,
@@ -561,6 +637,26 @@ Parse a ram file:
      {function,3,bar,0,[{clause,3,[],[],[{atom,4,foo}]}]},
      {eof,4}]}
 ```
+
+Parse a broken ram file:
+
+```erlang
+1> {ok, IoDevice} = file:open(<<"-module(Foo).\n-export([bar/0]).\nbar() ->\n?MODULE.">>,
+       [read, binary, ram, cooked]).
+2> {ok, Forms} = epp:parse_file("foo.erl", [{fd, IoDevice}]).
+{ok,[{attribute,1,file,{"foo.erl",1}},
+     {error,{1,erl_parse,
+             [98,97,100,32,"module",32,100,101,99,108,97,114,97,116,105,
+              111,110]}},
+     {attribute,2,export,[{bar,0}]},
+     {error,{4,epp,{undefined,'MODULE',none}}},
+     {eof,4}]}
+3> [io:format("%% ~ts~n", [M:format_error(E)]) || {error,{Loc,M,E}} <- Forms].
+%% bad module declaration
+%% undefined macro 'MODULE'
+[ok,ok]
+```
+
 """.
 -doc(#{since => <<"OTP 17.0">>}).
 -spec parse_file(FileName, Options) ->
@@ -940,6 +1036,8 @@ init_server(Pid, FileName, Options, St0) ->
             AtLocation = proplists:get_value(location, Options, 1),
 
             Deterministic = proplists:get_value(deterministic, Options, false),
+            PathOpen = proplists:get_value(include_path_open, Options,
+                                           fun file:path_open/3),
             St = St0#epp{delta=0, name=SourceName, name2=SourceName,
 			 path=Path, location=AtLocation, macs=Ms1,
 			 default_encoding=DefEncoding,
@@ -952,7 +1050,8 @@ init_server(Pid, FileName, Options, St0) ->
                             end,
                          features = Features,
                          else_reserved = ResWordFun('else'),
-                         deterministic = Deterministic},
+                         deterministic = Deterministic,
+                         include_path_open = PathOpen},
             From = wait_request(St),
             Anno = erl_anno:new(AtLocation),
             enter_file_reply(From, file_name(SourceName), Anno,
@@ -1106,7 +1205,7 @@ enter_file(_NewName, Inc, From, St)
     epp_reply(From, {error,{loc(Inc),epp,{depth,"include"}}}),
     wait_req_scan(St);
 enter_file(NewName, Inc, From, St) ->
-    case file:path_open(St#epp.path, NewName, [read]) of
+    case (St#epp.include_path_open)(St#epp.path, NewName, [read]) of
 	{ok,NewF,Pname} ->
             Loc = start_loc(St#epp.location),
 	    wait_req_scan(enter_file2(NewF, Pname, From, St, Loc));
@@ -1127,7 +1226,8 @@ enter_file2(NewF, Pname, From, St0, AtLocation) ->
          erl_scan_opts = ScanOpts,
          else_reserved = ElseReserved,
          features = Ftrs,
-         deterministic = Deterministic} = St0,
+         deterministic = Deterministic,
+         include_path_open = PathOpen} = St0,
     Ms = Ms0#{'FILE':={none,[{string,Anno,source_name(St0,Pname)}]}},
     %% update the head of the include path to be the directory of the new
     %% source file, so that an included file can always include other files
@@ -1144,7 +1244,8 @@ enter_file2(NewF, Pname, From, St0, AtLocation) ->
          erl_scan_opts = ScanOpts,
          else_reserved = ElseReserved,
          default_encoding=DefEncoding,
-         deterministic=Deterministic}.
+         deterministic=Deterministic,
+         include_path_open=PathOpen}.
 
 enter_file_reply(From, Name, LocationAnno, AtLocation, Where, Deterministic) ->
     Anno0 = erl_anno:new(AtLocation),
@@ -1327,7 +1428,7 @@ scan_filedoc_content({string, _A, DocFilename}, Dot,
                      {atom,DocLoc,Doc}, From, #epp{name = CurrentFilename} = St) ->
     %% The head of the path is the dir where the current file is
     Cwd = hd(St#epp.path),
-    case file:path_open([Cwd], DocFilename, [read, binary]) of
+    case (St#epp.include_path_open)([Cwd], DocFilename, [read, binary]) of
         {ok, NewF, Pname} ->
             case file:read_file_info(NewF) of
                 {ok, #file_info{ size = Sz }} ->
@@ -1619,14 +1720,15 @@ scan_include_lib1([{'(',_Alp},{string,_Af,NewName0}=N,{')',_Arp},{dot,_Ad}],
                   _Inc, From, St) ->
     NewName = expand_var(NewName0),
     Loc = start_loc(St#epp.location),
-    case file:path_open(St#epp.path, NewName, [read]) of
+    case (St#epp.include_path_open)(St#epp.path, NewName, [read]) of
 	{ok,NewF,Pname} ->
 	    wait_req_scan(enter_file2(NewF, Pname, From, St, Loc));
 	{error,_E1} ->
 	    case expand_lib_dir(NewName) of
 		{ok,Header} ->
-		    case file:open(Header, [read]) of
-			{ok,NewF} ->
+                    {ok, Cwd} = file:get_cwd(),
+                    case (St#epp.include_path_open)([Cwd], Header, [read]) of
+                        {ok,NewF,_} ->
 			    wait_req_scan(enter_file2(NewF, Header, From,
                                                       St, Loc));
 			{error,_E2} ->

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -36,7 +36,8 @@
          gh_8268/1,
          moduledoc_include/1,
          stringify/1,
-         fun_type_arg/1
+         fun_type_arg/1,
+         doctests/1
         ]).
 
 -export([epp_parse_erl_form/2]).
@@ -84,7 +85,8 @@ all() ->
      gh_8268,
      moduledoc_include,
      stringify,
-     fun_type_arg].
+     fun_type_arg,
+     doctests].
 
 groups() ->
     [{upcase_mac, [], [upcase_mac_1, upcase_mac_2]},
@@ -2333,6 +2335,17 @@ run_test(Config, Test0, Opts0) ->
             peer:stop(Peer),
             Reply
     end.
+
+doctests(_Config) ->
+    file:write_file("example.erl",
+        ~"""
+         -module(example).
+
+         -export([foo/0]).
+
+         foo() -> ?MODULE.
+         """),
+    ct_doctest:module(epp, [{skipped_blocks, 5}]).
 
 fail() ->
     ct:fail(failed).

--- a/lib/stdlib/test/epp_SUITE.erl
+++ b/lib/stdlib/test/epp_SUITE.erl
@@ -37,6 +37,7 @@
          moduledoc_include/1,
          stringify/1,
          fun_type_arg/1,
+         include_path_open/1,
          doctests/1
         ]).
 
@@ -86,6 +87,7 @@ all() ->
      moduledoc_include,
      stringify,
      fun_type_arg,
+     include_path_open,
      doctests].
 
 groups() ->
@@ -2334,6 +2336,117 @@ run_test(Config, Test0, Opts0) ->
             Reply = rpc:call(Node, epp_test, t, []),
             peer:stop(Peer),
             Reply
+    end.
+
+%% Test the include_path_open option for epp using ram files.
+include_path_open(_Config) ->
+    %% Test 1: Basic ram file preprocessing with macros
+    Code1 = <<"-module(ram_test).\n"
+              "-export([f/0]).\n"
+              "-define(HELLO, hello).\n"
+              "f() -> {?MODULE, ?HELLO}.\n">>,
+    Forms1 = epp_open_ram(Code1, []),
+    {attribute,_,module,ram_test} = lists:keyfind(module, 3, Forms1),
+    {ok, ram_test, Bin1} = compile:forms(Forms1),
+    {module, ram_test} = code:load_binary(ram_test, "ram_test.erl", Bin1),
+    {ram_test, hello} = ram_test:f(),
+    true = code:delete(ram_test),
+    code:purge(ram_test),
+
+    %% Test 2: Ram file with -include resolved via include_path_open
+    HrlContent = <<"-record(point, {x, y}).\n"
+                   "-define(ORIGIN, #point{x=0, y=0}).\n">>,
+    Code2 = <<"-module(ram_inc).\n"
+              "-include(\"my_header.hrl\").\n"
+              "-export([origin/0]).\n"
+              "origin() -> ?ORIGIN.\n">>,
+    Files2 = #{"my_header.hrl" => HrlContent},
+    PathOpen2 = ram_include_path_open(Files2),
+    Forms2 = epp_open_ram(Code2, [{include_path_open, PathOpen2}]),
+    {attribute,_,module,ram_inc} = lists:keyfind(module, 3, Forms2),
+    {ok, ram_inc, Bin2} = compile:forms(Forms2),
+    {module, ram_inc} = code:load_binary(ram_inc, "ram_inc.erl", Bin2),
+    {point, 0, 0} = ram_inc:origin(),
+    true = code:delete(ram_inc),
+    code:purge(ram_inc),
+
+    %% Test 3: Nested includes via ram files
+    Hrl3a = <<"-define(A, a_value).\n">>,
+    Hrl3b = <<"-include(\"a.hrl\").\n"
+              "-define(B, {?A, b_value}).\n">>,
+    Code3 = <<"-module(ram_nested).\n"
+              "-include(\"b.hrl\").\n"
+              "-export([t/0]).\n"
+              "t() -> ?B.\n">>,
+    Files3 = #{"a.hrl" => Hrl3a, "b.hrl" => Hrl3b},
+    PathOpen3 = ram_include_path_open(Files3),
+    Forms3 = epp_open_ram(Code3, [{include_path_open, PathOpen3}]),
+    {ok, ram_nested, Bin3} = compile:forms(Forms3),
+    {module, ram_nested} = code:load_binary(ram_nested, "ram_nested.erl", Bin3),
+    {a_value, b_value} = ram_nested:t(),
+    true = code:delete(ram_nested),
+    code:purge(ram_nested),
+
+    %% Test 4: include_lib resolved via include_path_open
+    HrlLib = <<"-define(LIB_VAL, from_lib).\n">>,
+    Code4 = <<"-module(ram_lib).\n"
+              "-include_lib(\"myapp/include/lib.hrl\").\n"
+              "-export([t/0]).\n"
+              "t() -> ?LIB_VAL.\n">>,
+    Files4 = #{"myapp/include/lib.hrl" => HrlLib},
+    PathOpen4 = ram_include_path_open(Files4),
+    Forms4 = epp_open_ram(Code4, [{include_path_open, PathOpen4}]),
+    {ok, ram_lib, Bin4} = compile:forms(Forms4),
+    {module, ram_lib} = code:load_binary(ram_lib, "ram_lib.erl", Bin4),
+    from_lib = ram_lib:t(),
+    true = code:delete(ram_lib),
+    code:purge(ram_lib),
+
+    %% Test 5: Missing include via include_path_open gives proper error
+    Code5 = <<"-module(ram_missing).\n"
+              "-include(\"missing.hrl\").\n"
+              "-export([t/0]).\n"
+              "t() -> ok.\n">>,
+    PathOpen5 = ram_include_path_open(#{}),
+    Forms5 = epp_open_ram(Code5, [{include_path_open, PathOpen5}]),
+    {error, {2, epp, {include, file, "missing.hrl"}}} =
+        lists:keyfind(error, 1, Forms5),
+
+    ok.
+
+%% open a binary as a cooked ram file and preprocess with epp.
+epp_open_ram(Bin, ExtraOpts) ->
+    {ok, Fd} = file:open(Bin, [ram, read, binary, cooked]),
+    try
+        {ok, Epp} = epp:open([{fd, Fd}, {name, "ram_file.erl"},
+                               {location, 1} | ExtraOpts]),
+        try
+            collect_epp_forms(Epp)
+        after
+            epp:close(Epp)
+        end
+    after
+        file:close(Fd)
+    end.
+
+%% create a include_path_open function backed by in-memory files.
+ram_include_path_open(Files) ->
+    fun(Path, Name, Modes) ->
+        %% Try Name directly (for absolute paths and include_lib),
+        %% then try each path prefix.
+        Candidates = [Name | [filename:join(Dir, Name) || Dir <- Path]],
+        ram_include_path_open_try(Candidates, Files, Modes)
+    end.
+
+ram_include_path_open_try([], _Files, _Modes) ->
+    {error, enoent};
+ram_include_path_open_try([Candidate | Rest], Files, Modes) ->
+    case maps:find(Candidate, Files) of
+        {ok, Content} ->
+            {ok, Fd} = file:open(Content, [ram, read, binary, cooked]),
+            {ok, Fd, Candidate};
+        error ->
+            ram_include_path_open_try(Rest, Files, Modes)
     end.
 
 doctests(_Config) ->


### PR DESCRIPTION
This PR adds support for the preprocessor when parsing example module code using ct_doctest. It does this by adding some other new features:

1. Allows ram files to be `cooked`, that is they return a `pid()` instead of a raw handle. This makes it possible to use functions in the `io` module that epp needs.
2. Add an option to pass an open file to `epp:parse_file` so that we can pass the cooked ram file.
3. Add an option to pass a callback fun for reading includes so that include files can be provided without touching disk.
4. Add `compile:string/1,2` that instructs the compiler to compile an Erlang module from the provided string.

Then I've put all this together so that ct_doctest uses `compile:string()` to compile module examples so that tuple records, macros and other epp features work.

I think the `compiler:string/1,2` function could be useful for a variety of things as it makes it much easier to turn generated code strings into runnable code.

While doing this I also added doctests for `epp` and `compile`.

I've added special "since" commits that should be updated with the correct ticket number if/when we merge this.