### PR TITLE
Make more tests runnable under other build systems

### DIFF
--- a/lib/common_test/src/ct_property_test.erl
+++ b/lib/common_test/src/ct_property_test.erl
@@ -206,13 +206,23 @@ init_tool(Config) ->
             {skip, "No property testing tool found"}
     end.
 
-init_tool_extensions(ToolModule) when ToolModule =:= eqc; ToolModule =:= proper ->
-    ExtDir = filename:join(code:lib_dir(common_test), proper_ext),
-    true = code:add_patha(ExtDir),
-    ct:log("Added ~ts to code path~n", [ExtDir]),
-    ok;
+init_tool_extensions(eqc) ->
+    ensure_tool_extensions(ct_quickcheck_ext);
+init_tool_extensions(proper) ->
+    ensure_tool_extensions(ct_proper_ext);
 init_tool_extensions(_) ->
     ok.
+
+ensure_tool_extensions(ExtModule) ->
+    case module_exists(ExtModule) of
+        true ->
+            ok;
+        false ->
+            ExtDir = filename:join(code:lib_dir(common_test), proper_ext),
+            true = code:add_patha(ExtDir),
+            ct:log("Added ~ts to code path~n", [ExtDir]),
+            ok
+    end.
 
 %%%----------------------------------------------------------------
 %%%


### PR DESCRIPTION
This is a complement to #11475. Running compiler tests under other build systems (in our case buck) exposes places where tests are currently assuming a code layout that is not always easy to reproduce. Here we fix another one:

* Under buck, the common_test application doesn't have a hidden `proper_exts` directory, so trying to add it to the code-path would fail. Instead, the proper_exts modules are exposed as explicit test dependency, and automatically available at runtime. So the fix is to first check if the desired extension is already available and do nothing in that case