### PR TITLE
xmerl: Fix XPath predicate/function bugs and an is_incharset crash

### DIFF
--- a/lib/xmerl/src/xmerl_ucs.erl
+++ b/lib/xmerl/src/xmerl_ucs.erl
@@ -562,7 +562,7 @@ is_incharset(In,Charset) when is_list(In) ->
 	    {error,unsupported_charset};
 	{error,_} ->
 	    false;
-	[Int] when is_integer(Int) ->
+        L when is_list(L) ->
 	    true
     end.
 

--- a/lib/xmerl/src/xmerl_xpath_pred.erl
+++ b/lib/xmerl/src/xmerl_xpath_pred.erl
@@ -166,15 +166,15 @@ comp_expr('>', E1, E2, C) ->
 comp_expr('<', E1, E2, C) ->
     N1 = expr(E1,C),
     N2 = expr(E2,C),
-    ?boolean(compare_ineq_format(N1,N2,C) > compare_ineq_format(N2,N1,C));
+    ?boolean(compare_ineq_format(N1,N2,C) < compare_ineq_format(N2,N1,C));
 comp_expr('>=', E1, E2, C) ->
     N1 = expr(E1,C),
     N2 = expr(E2,C),
-    ?boolean(compare_ineq_format(N1,N2,C) > compare_ineq_format(N2,N1,C));
+    ?boolean(compare_ineq_format(N1,N2,C) >= compare_ineq_format(N2,N1,C));
 comp_expr('<=', E1, E2, C) ->
     N1 = expr(E1,C),
     N2 = expr(E2,C),
-    ?boolean(compare_ineq_format(N1,N2,C) > compare_ineq_format(N2,N1,C));
+    ?boolean(compare_ineq_format(N1,N2,C) =< compare_ineq_format(N2,N1,C));
 comp_expr('=', E1, E2, C) ->
     N1 = expr(E1,C),
     N2 = expr(E2,C),
@@ -508,8 +508,12 @@ contains(C, [A1, A2]) ->
 'substring-before'(C, [A1, A2]) ->
     S1 = mk_string(C, A1),
     S2 = mk_string(C, A2),
-    Pos = string:str(S1, S2),
-    ?string(string:substr(S1, 1, Pos)).
+    case string:str(S1, S2) of
+        0 ->
+            ?string([]);
+        Pos ->
+            ?string(string:substr(S1, 1, Pos - 1))
+    end.
 
 %% string: substring-after(string, string)
 'substring-after'(C, [A1, A2]) ->
@@ -536,10 +540,10 @@ substring(C, [A1, A2, A3]) ->
 
 %% number: string-length(string?)
 'string-length'(C = #xmlContext{context_node = N}, []) ->
-    length(mk_string(C, string_value(N)));
+    ?number(length(mk_string(C, string_value(N))));
 
 'string-length'(C, [A]) ->
-    length(mk_string(C, A)).
+    ?number(length(mk_string(C, A))).
 
 
 %% string: normalize-space(string?)
@@ -633,17 +637,17 @@ match_lang(_, _) ->
 
 %% number: number(object)
 number(C = #xmlContext{context_node = N}, []) ->
-    ?number(mk_number(C, string(C, N)));
+    ?number(mk_number(C, string_value(N)));
 number(C, [Arg]) ->
     ?number(mk_number(C, Arg)).
 
 
 sum(C, [Arg]) ->
     NS = mk_nodeset(C, Arg),
-    lists:foldl(
-      fun(N, Sum) ->
-	      Sum + mk_number(C, string(C, N))
-      end, 0, NS).
+    ?number(lists:foldl(
+              fun(N, Sum) ->
+                      Sum + mk_number(C, string_value(N))
+              end, 0, NS)).
 
 floor(C, [Arg]) ->
     Num = mk_number(C, Arg),
@@ -665,14 +669,14 @@ ceiling(C, [Arg]) ->
 
 
 round(C, [Arg]) ->
-    case mk_number(C, Arg) of
+    ?number(case mk_number(C, Arg) of
 	A when is_atom(A) ->
 	    A;
 	N when is_integer(N) ->
 	    N;
 	F when is_float(F) ->
 	    round(F)
-    end.
+    end).
 
 
 select_on_attribute([E = #xmlElement{attributes = Attrs}|T], K, V, Acc) ->

--- a/lib/xmerl/test/xmerl_SUITE.erl
+++ b/lib/xmerl/test/xmerl_SUITE.erl
@@ -45,7 +45,8 @@
 all() ->
     [doctests,
      {group, cpd_tests}, xpath_text1, xpath_main,
-     xpath_abbreviated_syntax, xpath_functions, xpath_namespaces,
+     xpath_abbreviated_syntax, xpath_functions, xpath_relational,
+     xpath_namespaces, ucs_is_incharset,
      {group, misc}, {group, eventp_tests},
      {group, ticket_tests}, {group, app_test},
      {group, appup_test}, {group, format_test}].
@@ -191,6 +192,10 @@ xpath_abbreviated_syntax(Config) ->
 xpath_functions(Config) ->
     file:set_cwd(filename:join(datadir(Config),xpath)),
     ok = xpath_abbrev:functions().
+
+xpath_relational(Config) ->
+    file:set_cwd(filename:join(datadir(Config),xpath)),
+    ok = xpath_abbrev:relational_operators().
 
 xpath_namespaces(Config) ->
     file:set_cwd(filename:join(datadir(Config),xpath)),
@@ -671,6 +676,16 @@ allow_entities_test(Config) ->
     %% Disallow entities
     {'EXIT',{fatal, {{error,entities_not_allowed}, _, _, _}}} =
         (catch xmerl_scan:file(File, [{allow_entities, false}])),
+    ok.
+
+%% Regression: xmerl_ucs:is_incharset/2 crashed with a case_clause on a
+%% multi-character list for charsets handled via to_unicode/2 (e.g. utf-8),
+%% because the clause only matched a single-element result.
+ucs_is_incharset(_Config) ->
+    true = xmerl_ucs:is_incharset("abc", 'utf-8'),
+    true = xmerl_ucs:is_incharset("a", 'utf-8'),
+    true = xmerl_ucs:is_incharset("abc", 'iso-8859-1'),
+    false = xmerl_ucs:is_incharset([256, 257], 'iso-8859-1'),
     ok.
 
 %%======================================================================

--- a/lib/xmerl/test/xmerl_SUITE_data/xpath/xpath_abbrev.erl
+++ b/lib/xmerl/test/xmerl_SUITE_data/xpath/xpath_abbrev.erl
@@ -1,13 +1,27 @@
-%%%-------------------------------------------------------------------
-%%% File    : xpath_abbrev.erl
-%%% Author  : Bertil Karlsson <bertil@finrod>
-%%% Description : 
-%%%
-%%% Created : 17 Jan 2006 by Bertil Karlsson <bertil@finrod>
-%%%-------------------------------------------------------------------
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+
 -module(xpath_abbrev).
 
 -export([test/0, check_node_set/2, ticket_6873/0, ticket_7496/0, functions/0]).
+-export([relational_operators/0]).
 -export([namespaces/0]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -61,7 +75,7 @@ test() ->
     Res22 = xmerl_xpath:string("blipp[@id and @test]",E),
     ok = check_node_set("blipp[@id and @test]",Res22).
 
-check_node_set("blipp",[E1,E2,E3]) -> 
+check_node_set("blipp",[E1,E2,E3]) ->
     ok = xml_element_name(E1,blipp),
     ok = xml_element_name(E2,blipp),
     ok = xml_element_name(E3,blipp),
@@ -106,7 +120,7 @@ check_node_set("/myBS_model/blipp[3]/blupp[2]",[E]) ->
     #xmlElement{name=blupp,
                 attributes=[#xmlAttribute{name=att,value="bluppc2"}]}=E,
     ok;
-check_node_set("blipp//plopp",[#xmlElement{name=plopp},#xmlElement{name=plopp}]) -> 
+check_node_set("blipp//plopp",[#xmlElement{name=plopp},#xmlElement{name=plopp}]) ->
     ok;
 check_node_set("//plopp",[E1,E2,E3]) ->
     ok = xml_element_name(E1,plopp),
@@ -218,6 +232,33 @@ ticket_7496() ->
     ok = Test(Doc3,"//*[starts-with(local-name(),'p')]",
               [parent,pet,pet]).
 
+%% Regression test for the relational operators '<', '<=' and '>='.
+%% These three clauses of xmerl_xpath_pred:comp_expr/4 each carried the
+%% body of '>' (a copy-paste error), so every one evaluated as 'a > b'.
+%% The cases below fail on the buggy code (each selects [e,f] / [] instead
+%% of the expected node sets) and pass once the operators are correct.
+relational_operators() ->
+    Test = fun(Doc, XPath, Exp) ->
+                   Result = xmerl_xpath:string(XPath, Doc),
+                   Exp = [Name || #xmlElement{name = Name} <- Result],
+                   ok
+           end,
+    {Doc,_} = xmerl_scan:string("<a><b/><c/><d/><e/><f/></a>"),
+
+    %% Relational predicates over position() (number vs number).
+    ok = Test(Doc, "/a/*[position() < 3]",  [b, c]),
+    ok = Test(Doc, "/a/*[position() <= 3]", [b, c, d]),
+    ok = Test(Doc, "/a/*[position() >= 3]", [d, e, f]),
+    ok = Test(Doc, "/a/*[position() > 3]",  [e, f]),
+
+    %% Constant relational predicates, independent of position(): each is a
+    %% boolean that is true, so it selects every child.
+    All = [b, c, d, e, f],
+    ok = Test(Doc, "/a/*[2 < 3]",  All),
+    ok = Test(Doc, "/a/*[3 <= 3]", All),
+    ok = Test(Doc, "/a/*[3 >= 3]", All),
+    ok = Test(Doc, "/a/*[3 > 2]",  All),
+    ok.
 
 functions() ->
     Test = fun(Doc, XPath, Exp) ->
@@ -234,7 +275,7 @@ functions() ->
                           end|| Obj <- Result],
                    ok
            end,
-    Foo = 
+    Foo =
     "<foo>"
     "  <bar>"
     "    <name>Xml</name>"
@@ -257,6 +298,16 @@ functions() ->
     ok = Test(Doc,"/foo/bar[starts-with(name, 'X')]",[bar,bar]),
     ok = Test(Doc,"/foo/bar[value = string(1)]/value/text()",["1"]),
 
+    %% Regression tests: substring-before used to include the separator's
+    %% first character (off-by-one); string-length and round returned bare
+    %% numbers instead of #xmlObj{type=number}; and sum and number() (no
+    %% args) called string/2 with a bare node, crashing on any non-empty
+    %% node-set.
+    ok = Test(Doc,"/foo/bar[substring-before(name, 'a') = 'Xp']",[bar]),
+    ok = Test(Doc,"/foo/bar[string-length(name) = 3]",[bar]),
+    ok = Test(Doc,"/foo/bar[round(value) = 2]",[bar]),
+    ok = Test(Doc,"/foo[sum(bar/value) = 6]",[foo]),
+    ok = Test(Doc,"/foo/bar/value[number() = 2]",[value]),
 
     {Doc2,_}= xmerl_scan:file("purchaseOrder.xml"),
     ok = Test(Doc2,"//*[starts-with(local-name(),'c')]",
@@ -265,7 +316,6 @@ functions() ->
               [city,city,comment]),
     ok = Test(Doc2,"//*[starts-with(name(),'{http://www.example.com/PO1')]",
               ['apo:purchaseOrder','apo:comment']).
-
 
 namespaces() ->
     {Doc,_} = xmerl_scan:file("purchaseOrder.xml", [{namespace_conformant, true}]),


### PR DESCRIPTION
# Summary

This fixes four correctness bugs in xmerl's XPath engine (xmerl_xpath_pred) and one crash in xmerl_ucs, each with a regression test. The bugs are independent and grouped here because they were found together while reviewing the same modules; the branch is three focused commits.

## What's fixed

### 1. XPath relational operators <, >=, <=

The four relational operators in xmerl_xpath_pred:comp_expr/4 share a comparison helper: for a OP b the code computes compare_ineq_format(A, B) OP compare_ineq_format(B, A), where compare_ineq_format/3 coerces each operand to the type XPath requires (number, or a node‑set's string value). The '>' clause was written correctly, but the '<', '>=' and '<=' clauses were copy‑pasted from it and never had their operator changed — all three used >:

```erlang
comp_expr('<', E1, E2, C) ->
    N1 = expr(E1, C), N2 = expr(E2, C),
    ?boolean(compare_ineq_format(N1, N2, C) > compare_ineq_format(N2, N1, C));
```

The result is that in any XPath predicate, a < b, a >= b and a <= b all silently evaluated a > b. //item[position() <= 3] selected the items after position 3 rather than the first three; //item[@n >= 5] behaved like > 5; and so on. Only =, != and > behaved correctly, which is why this survived — inequality predicates other than > are comparatively rare.

The fix gives each clause its correct operator (<, >=, =<), leaving the compare_ineq_format/3 machinery — and therefore the node‑set coercion semantics — untouched.

### 2. substring-before() off‑by‑one

substring-before(s1, s2) should return the part of s1 that precedes the first occurrence of s2. The implementation found the 1‑based index of the separator with string:str/2 and then took that many leading characters:

```erlang
Pos = string:str(S1, S2),
?string(string:substr(S1, 1, Pos)).
```

Because Pos is the position of the separator, substr(S1, 1, Pos) includes the separator's first character. substring-before("1999/04/01", "/") returned "1999/" instead of "1999", and substring-before("a::b", "::") returned "a:" instead of "a".

The fix rewrites the function to mirror the neighbouring substring-after/2: a case on string:str/2 that returns "" when the separator is absent (as XPath 1.0 requires) and string:substr(S1, 1, Pos - 1) otherwise. Handling the not‑found case explicitly also avoids the negative length that a naive Pos - 1 would produce when string:str/2 returns 0.

### 3. string-length(), sum(), round() and number() numeric results

Every value‑producing function in this module is expected to return an #xmlObj{} — the evaluator (eval/2) reads Obj#xmlObj.type, and the coercion helpers (mk_number/2, mk_string/2, …) only accept #xmlObj values or unevaluated expression tuples. number/2, floor/2 and ceiling/2 follow this and wrap their results in the ?number/1 macro (#xmlObj{type = number, value = V}).

string-length/2, sum/2 and round/2 did not — they returned a bare Erlang integer/float:

```erlang
'string-length'(C, [A]) ->
    length(mk_string(C, A)).            %% bare integer
```

As long as such a result is the whole predicate or feeds a comparison, it reaches eval/2 or mk_number/2, neither of which has a clause for a bare number, so evaluation crashed ({badrecord, xmlObj} from eval/2, or {unknown_expr, N} from mk_number/2 → expr/2). In practice this meant predicates like //e[string-length(@id) = 5], //total[sum(../item) > 100] or //e[round(@score) = 2] failed rather than filtering. The fix wraps each result in ?number/1.

Adding tests for sum() exposed a second, deeper bug that the return‑type crash had been masking. sum/2 (and the zero‑argument number()) computed the per‑node string value with string(C, N), but string/2 only has clauses for a list argument (string(C, []) and string(C, [Arg])) — it was being called with a bare #xmlNode. That produced a function_clause on any non‑empty node set, so sum() and number() never actually worked at all. Both now call string_value/1 directly, which is the helper that already knows how to take the string value of an individual node (element, attribute, text, …). With that and the ?number/1 wrapper, sum() and number() are functional for the first time.

### 4. xmerl_ucs:is_incharset/2 crash on multi‑character lists

is_incharset(In, Charset) reports whether In is representable in Charset. Common charsets (US‑ASCII, Latin‑1, ISO‑646) have dedicated clauses that test each character with a predicate; everything else falls through to a generic clause that attempts a conversion with to_unicode/2 and treats success as "in charset". The is_list(In) variant of that generic clause only matched a single‑element conversion result:

```erlang
is_incharset(In, Charset) when is_list(In) ->
    case to_unicode(In, Charset) of
        {error, unsupported_charset} -> {error, unsupported_charset};
        {error, _}                   -> false;
        [Int] when is_integer(Int)   -> true      %% only length‑1 results
    end.
```

to_unicode/2 returns the full list of code points, so a multi‑character input (e.g. is_incharset("abc", 'utf-8'), which routes here rather than to the Latin‑1 fast path) yields a multi‑element list that matches no branch and raises a case_clause. The function was therefore only usable for single‑character lists.

The fix replaces [Int] when is_integer(Int) with L when is_list(L): a successful to_unicode/2 conversion of any length means every character mapped, i.e. the whole input is in the charset. Error results (false / {error, unsupported_charset}) are unchanged.

## Testing

Each fix has a regression test:

- Relational operators: a new xpath_relational case (xpath_abbrev:relational_operators/0) covering <, <=, >=, > over both position() and constant operands.
- substring-before/string-length/sum/round/number(): added to the existing xpath_functions case (xpath_abbrev:functions/0).
- is_incharset/2: a new ucs_is_incharset case.

Every new test was confirmed to fail on the unfixed code (wrong‑value badmatch for the operators and substring-before; a case_clause / function_clause crash for the numeric functions and is_incharset) and to pass with the fix. The full xmerl_SUITE is green.

## Notes

All five are pure correctness fixes with no behavioural change for already‑correct inputs. No public API or record changes.