### PR TITLE
Reduce syscall and scheduler overhead in socket accept and close

### DIFF
--- a/erts/config.h.in
+++ b/erts/config.h.in
@@ -462,6 +462,9 @@
 /* Define to 1 if _Float16 can be converted from/to double. */
 #undef FLOAT16_IS_CONVERTIBLE
 
+/* Define to 1 if you have the 'accept4' function. */
+#undef HAVE_ACCEPT4
+
 /* Define to 1 if you have the <arpa/nameser.h> header file. */
 #undef HAVE_ARPA_NAMESER_H
 

--- a/erts/configure
+++ b/erts/configure
@@ -21341,6 +21341,14 @@ fi
      ;;
 esac
 
+ac_fn_c_check_func "$LINENO" "accept4" "ac_cv_func_accept4"
+if test "x$ac_cv_func_accept4" = xyes
+then :
+  printf "%s\n" "#define HAVE_ACCEPT4 1" >>confdefs.h
+
+fi
+
+
 
 
 saved_cppflags=$CPPFLAGS

--- a/erts/configure.ac
+++ b/erts/configure.ac
@@ -2243,6 +2243,10 @@ AS_CASE([$host_os],
                         [[#include <sys/socket.h>]])
         ])
 
+dnl Check for accept4, which accepts a socket and sets it non-blocking
+dnl and close-on-exec in one call
+AC_CHECK_FUNCS([accept4])
+
 
 dnl ----------------------------------------------------------------------
 dnl Checks for library functions.

--- a/erts/emulator/nifs/common/prim_socket_int.h
+++ b/erts/emulator/nifs/common/prim_socket_int.h
@@ -536,6 +536,11 @@ typedef struct {
     SOCKET             sock;
     SOCKET             origFD; // A 'socket' created from this FD
     BOOLEAN_T          closeOnClose; // Have we dup'ed or not
+    /* Set by nif_finalize_close() from finalize_close_may_block(): TRUE only
+     * for a lingering close, SO_LINGER {true, > 0}. The close path needs
+     * blocking mode only in that case, and switching to it costs two more
+     * system calls (SET_BLOCKING is F_GETFL + F_SETFL). */
+    BOOLEAN_T          closeMayBlock;
     BOOLEAN_T          selectRead; // Try to have read select active
     /* +++ The dbg flag for SSDBG +++ */
     BOOLEAN_T          dbg;

--- a/erts/emulator/nifs/common/prim_socket_int.h
+++ b/erts/emulator/nifs/common/prim_socket_int.h
@@ -536,10 +536,12 @@ typedef struct {
     SOCKET             sock;
     SOCKET             origFD; // A 'socket' created from this FD
     BOOLEAN_T          closeOnClose; // Have we dup'ed or not
-    /* Set by nif_finalize_close() from finalize_close_may_block(): TRUE only
-     * for a lingering close, SO_LINGER {true, > 0}. The close path needs
-     * blocking mode only in that case, and switching to it costs two more
-     * system calls (SET_BLOCKING is F_GETFL + F_SETFL). */
+    /* TRUE only for a lingering close, SO_LINGER {true, > 0}, which is the
+     * one case where close() can block and therefore needs the dirty
+     * scheduler and blocking mode (SET_BLOCKING is F_GETFL + F_SETFL, two
+     * more system calls).  Maintained where the option is set, and starts
+     * out TRUE so that a socket whose linger state was never established
+     * takes the blocking path. */
     BOOLEAN_T          closeMayBlock;
     BOOLEAN_T          selectRead; // Try to have read select active
     /* +++ The dbg flag for SSDBG +++ */
@@ -581,6 +583,8 @@ extern BOOLEAN_T esock_open_use_registry(ErlNifEnv*   env,
                                          ERL_NIF_TERM eopts,
                                          BOOLEAN_T    def);
 extern BOOLEAN_T esock_open_which_protocol(SOCKET sock, int* proto);
+
+extern BOOLEAN_T esock_close_may_block(SOCKET sock);
 
 extern BOOLEAN_T esock_getopt_int(SOCKET sock,
                                   int    level,

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -7644,34 +7644,13 @@ ERL_NIF_TERM nif_finalize_close_dirty(ErlNifEnv*         env,
 }
 
 
-/* Only a lingering close - SO_LINGER {onoff = true, linger > 0} -
- * can block in close(), so only then do we need the dirty scheduler.
- * The check reads descP->sock without the socket locks; a racing
- * close/down makes the getsockopt fail and we fall back to the dirty
- * path, where the proper state checks run under the locks as before.
+/* Only a lingering close - SO_LINGER {onoff = true, linger > 0} - can
+ * block in close(), so only then do we need the dirty scheduler.  The
+ * answer is already on the descriptor: closeMayBlock is maintained where
+ * the option is set and starts out TRUE, so a socket whose linger state
+ * was never established still takes the dirty path, where the proper
+ * state checks run under the locks as before.
  */
-static
-BOOLEAN_T finalize_close_may_block(ESockDescriptor* descP)
-{
-#if defined(SO_LINGER)
-    struct linger lval;
-    SOCKOPTLEN_T  lsz = sizeof(lval);
-
-    if (descP->sock == INVALID_SOCKET)
-        return FALSE;
-
-    if (sock_getopt(descP->sock, SOL_SOCKET, SO_LINGER,
-                    (void*) &lval, &lsz) != 0)
-        return TRUE;
-
-    return (lval.l_onoff != 0) && (lval.l_linger > 0);
-#else
-    /* Without SO_LINGER a close cannot linger, so it cannot block */
-    return FALSE;
-#endif
-}
-
-
 static
 ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
                                 int                argc,
@@ -7685,14 +7664,11 @@ ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
         return enif_make_badarg(env);
     }
 
-    if (finalize_close_may_block(descP)) {
-        descP->closeMayBlock = TRUE;
+    if (descP->closeMayBlock)
         return enif_schedule_nif(env, "nif_finalize_close",
                                  ERL_NIF_DIRTY_JOB_IO_BOUND,
                                  nif_finalize_close_dirty, argc, argv);
-    }
 
-    descP->closeMayBlock = FALSE;
     return nif_finalize_close_dirty(env, argc, argv);
 }
 
@@ -11443,8 +11419,27 @@ static ERL_NIF_TERM esock_setopt_level_opt(ErlNifEnv*       env,
 {
     if (socket_setopt(descP->sock, level, opt, optVal, optLen))
         return esock_make_error_errno(env, sock_errno());
-    else
-        return esock_atom_ok;
+
+#if defined(SO_LINGER)
+    /* Every setsockopt passes through here, so this is the one place that
+     * sees SO_LINGER whether it arrived as the 'linger' option or as a
+     * setopt_native.  Caching it keeps the close path from having to ask
+     * the kernel. */
+    if ((level == SOL_SOCKET) && (opt == SO_LINGER)) {
+        if (optLen == sizeof(struct linger)) {
+            struct linger* lp = (struct linger*) optVal;
+
+            descP->closeMayBlock =
+                ((lp->l_onoff != 0) && (lp->l_linger > 0)) ? TRUE : FALSE;
+        } else {
+            /* The kernel took a shape we do not parse; assume the close
+             * can block rather than cache a guess. */
+            descP->closeMayBlock = TRUE;
+        }
+    }
+#endif
+
+    return esock_atom_ok;
 }
 
 
@@ -13112,6 +13107,33 @@ ERL_NIF_TERM esock_getopt_uint_opt(ErlNifEnv*       env,
     return esock_make_ok2(env, MKUI(env, val));
 }
 #endif
+
+
+
+/* esock_close_may_block - can a close() on this socket block?
+ *
+ * Only a lingering close, SO_LINGER {onoff = true, linger > 0}, can.
+ * Fail-safe: an option we cannot read answers TRUE.
+ */
+extern
+BOOLEAN_T esock_close_may_block(SOCKET sock)
+{
+#if defined(SO_LINGER)
+    struct linger val;
+    SOCKOPTLEN_T  valSz = sizeof(val);
+
+#ifdef __WIN32__
+    if (sock_getopt(sock, SOL_SOCKET, SO_LINGER, (char*) &val, &valSz) != 0)
+#else
+    if (sock_getopt(sock, SOL_SOCKET, SO_LINGER, &val, &valSz) != 0)
+#endif
+        return TRUE;
+
+    return ((val.l_onoff != 0) && (val.l_linger > 0)) ? TRUE : FALSE;
+#else
+    return FALSE;
+#endif
+}
 
 
 
@@ -17063,7 +17085,7 @@ ESockDescriptor* esock_alloc_descriptor(SOCKET sock)
     esock_requestor_init(&descP->currentReader);
     descP->currentReaderP = NULL; // currentReader not used
     descP->buf.data = NULL;
-    descP->closeMayBlock = TRUE; /* until the close path decides otherwise */
+    descP->closeMayBlock = TRUE; /* narrowed once the linger state is known */
 #endif
     descP->readersQ.first = NULL;
     descP->readersQ.last  = NULL;

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -7606,9 +7606,9 @@ ERL_NIF_TERM nif_close(ErlNifEnv*         env,
  * Socket (ref) - Points to the socket descriptor.
  */
 static
-ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
-                                int                argc,
-                                const ERL_NIF_TERM argv[])
+ERL_NIF_TERM nif_finalize_close_dirty(ErlNifEnv*         env,
+                                      int                argc,
+                                      const ERL_NIF_TERM argv[])
 {
     ESockDescriptor* descP;
     ERL_NIF_TERM result;
@@ -7641,6 +7641,59 @@ ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
     MUNLOCK(descP->readMtx);
 
     return result;
+}
+
+
+/* Only a lingering close - SO_LINGER {onoff = true, linger > 0} -
+ * can block in close(), so only then do we need the dirty scheduler.
+ * The check reads descP->sock without the socket locks; a racing
+ * close/down makes the getsockopt fail and we fall back to the dirty
+ * path, where the proper state checks run under the locks as before.
+ */
+static
+BOOLEAN_T finalize_close_may_block(ESockDescriptor* descP)
+{
+#if defined(SO_LINGER)
+    struct linger lval;
+    SOCKOPTLEN_T  lsz = sizeof(lval);
+
+    if (descP->sock == INVALID_SOCKET)
+        return FALSE;
+
+    if (sock_getopt(descP->sock, SOL_SOCKET, SO_LINGER,
+                    (void*) &lval, &lsz) != 0)
+        return TRUE;
+
+    return (lval.l_onoff != 0) && (lval.l_linger > 0);
+#else
+    /* Without SO_LINGER a close cannot linger, so it cannot block */
+    return FALSE;
+#endif
+}
+
+
+static
+ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
+                                int                argc,
+                                const ERL_NIF_TERM argv[])
+{
+    ESockDescriptor* descP;
+
+    ESOCK_ASSERT( argc == 1 );
+
+    if (! ESOCK_GET_RESOURCE(env, argv[0], (void**) &descP)) {
+        return enif_make_badarg(env);
+    }
+
+    if (finalize_close_may_block(descP)) {
+        descP->closeMayBlock = TRUE;
+        return enif_schedule_nif(env, "nif_finalize_close",
+                                 ERL_NIF_DIRTY_JOB_IO_BOUND,
+                                 nif_finalize_close_dirty, argc, argv);
+    }
+
+    descP->closeMayBlock = FALSE;
+    return nif_finalize_close_dirty(env, argc, argv);
 }
 
 
@@ -17023,6 +17076,7 @@ ESockDescriptor* esock_alloc_descriptor(SOCKET sock)
     esock_requestor_init(&descP->currentReader);
     descP->currentReaderP = NULL; // currentReader not used
     descP->buf.data = NULL;
+    descP->closeMayBlock = TRUE; /* until the close path decides otherwise */
 #endif
     descP->readersQ.first = NULL;
     descP->readersQ.last  = NULL;
@@ -18744,7 +18798,7 @@ ErlNifFunc esock_funcs[] =
      * is called after the close *select* has "completed".
      */
     {"nif_cancel",              3, nif_cancel, 0},
-    {"nif_finalize_close",      1, nif_finalize_close, ERL_NIF_DIRTY_JOB_IO_BOUND}
+    {"nif_finalize_close",      1, nif_finalize_close, 0}
 };
 
 

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -7653,8 +7653,9 @@ ERL_NIF_TERM nif_finalize_close_dirty(ErlNifEnv*         env,
 static
 BOOLEAN_T finalize_close_may_block(ESockDescriptor* descP)
 {
+#if defined(SO_LINGER)
     struct linger lval;
-    SOCKLEN_T     lsz = sizeof(lval);
+    SOCKOPTLEN_T  lsz = sizeof(lval);
 
     if (descP->sock == INVALID_SOCKET)
         return FALSE;
@@ -7664,6 +7665,10 @@ BOOLEAN_T finalize_close_may_block(ESockDescriptor* descP)
         return TRUE;
 
     return (lval.l_onoff != 0) && (lval.l_linger > 0);
+#else
+    /* Without SO_LINGER a close cannot linger, so it cannot block */
+    return FALSE;
+#endif
 }
 
 

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -11479,56 +11479,43 @@ int socket_setopt(int sock, int level, int opt,
     int res;
 
 #if  defined(IP_TOS) && defined(SOL_IP) && defined(SO_PRIORITY)
-    int          tmpIValPRIO = 0;
-    int          tmpIValTOS = 0;
-    int          resPRIO;
-    int          resTOS;
-    SOCKOPTLEN_T tmpArgSzPRIO = sizeof(tmpIValPRIO);
-    SOCKOPTLEN_T tmpArgSzTOS  = sizeof(tmpIValTOS);
+    /* Setting IP_TOS makes the kernel derive a new SO_PRIORITY from it,
+     * so that one option - and only that one - has to have the priority
+     * saved and put back to keep the two looking independent to the
+     * user. Setting anything else leaves both alone, and paying a
+     * getsockopt for each of them plus a setsockopt to restore on every
+     * option set was most of the system calls a connection made.
+     */
+    if ((level == SOL_IP) && (opt == IP_TOS)) {
+        int          savedPRIO;
+        int          resPRIO;
+        SOCKOPTLEN_T savedSzPRIO = sizeof(savedPRIO);
 
-    resPRIO = sock_getopt(sock, SOL_SOCKET, SO_PRIORITY,
-                           &tmpIValPRIO, &tmpArgSzPRIO);
-    resTOS  = sock_getopt(sock, SOL_IP, IP_TOS,
-                          &tmpIValTOS, &tmpArgSzTOS);
+        resPRIO = sock_getopt(sock, SOL_SOCKET, SO_PRIORITY,
+                              &savedPRIO, &savedSzPRIO);
 
-    res = sock_setopt(sock, level, opt, optVal, optLen);
-    if (res == 0) {
+        res = sock_setopt(sock, level, opt, optVal, optLen);
 
-        /* Ok, now we *maybe* need to "maybe" restore PRIO and TOS...
-         * maybe, possibly, ...
-         */
+        if ((res == 0) && (resPRIO == 0)) {
+            resPRIO = sock_setopt(sock, SOL_SOCKET, SO_PRIORITY,
+                                  &savedPRIO, savedSzPRIO);
 
-        if (opt != SO_PRIORITY) {
-	    if ((opt != IP_TOS) && (resTOS == 0)) {
-		resTOS = sock_setopt(sock, SOL_IP, IP_TOS,
-                                     (void *) &tmpIValTOS,
-                                     tmpArgSzTOS);
-                res = resTOS;
-            }
-	    if ((res == 0) && (resPRIO == 0)) {
-		resPRIO = sock_setopt(sock, SOL_SOCKET, SO_PRIORITY,
-                                      &tmpIValPRIO,
-                                      tmpArgSzPRIO);
+            /* Some kernels set a SO_PRIORITY by default
+             * that you are not permitted to reset,
+             * silently ignore this error condition.
+             */
 
-                /* Some kernels set a SO_PRIORITY by default
-                 * that you are not permitted to reset,
-                 * silently ignore this error condition.
-                 */
+            if ((resPRIO != 0) && (sock_errno() == EPERM))
+                res = 0;
+            else
+                res = resPRIO;
+        }
 
-                if ((resPRIO != 0) && (sock_errno() == EPERM)) {
-                    res = 0;
-                } else {
-                    res = resPRIO;
-		}
-	    }
-	}
+        return res;
     }
-
-#else
+#endif
 
     res = sock_setopt(sock, level, opt, optVal, optLen);
-
-#endif
 
     return res;
 }

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -7606,9 +7606,9 @@ ERL_NIF_TERM nif_close(ErlNifEnv*         env,
  * Socket (ref) - Points to the socket descriptor.
  */
 static
-ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
-                                int                argc,
-                                const ERL_NIF_TERM argv[])
+ERL_NIF_TERM nif_finalize_close_dirty(ErlNifEnv*         env,
+                                      int                argc,
+                                      const ERL_NIF_TERM argv[])
 {
     ESockDescriptor* descP;
     ERL_NIF_TERM result;
@@ -7641,6 +7641,51 @@ ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
     MUNLOCK(descP->readMtx);
 
     return result;
+}
+
+
+/* Only a lingering close - SO_LINGER {onoff = true, linger > 0} -
+ * can block in close(), so only then do we need the dirty scheduler.
+ * The check reads descP->sock without the socket locks; a racing
+ * close/down makes the getsockopt fail and we fall back to the dirty
+ * path, where the proper state checks run under the locks as before.
+ */
+static
+BOOLEAN_T finalize_close_may_block(ESockDescriptor* descP)
+{
+    struct linger lval;
+    SOCKLEN_T     lsz = sizeof(lval);
+
+    if (descP->sock == INVALID_SOCKET)
+        return FALSE;
+
+    if (sock_getopt(descP->sock, SOL_SOCKET, SO_LINGER,
+                    (void*) &lval, &lsz) != 0)
+        return TRUE;
+
+    return (lval.l_onoff != 0) && (lval.l_linger > 0);
+}
+
+
+static
+ERL_NIF_TERM nif_finalize_close(ErlNifEnv*         env,
+                                int                argc,
+                                const ERL_NIF_TERM argv[])
+{
+    ESockDescriptor* descP;
+
+    ESOCK_ASSERT( argc == 1 );
+
+    if (! ESOCK_GET_RESOURCE(env, argv[0], (void**) &descP)) {
+        return enif_make_badarg(env);
+    }
+
+    if (finalize_close_may_block(descP))
+        return enif_schedule_nif(env, "nif_finalize_close",
+                                 ERL_NIF_DIRTY_JOB_IO_BOUND,
+                                 nif_finalize_close_dirty, argc, argv);
+
+    return nif_finalize_close_dirty(env, argc, argv);
 }
 
 
@@ -18744,7 +18789,7 @@ ErlNifFunc esock_funcs[] =
      * is called after the close *select* has "completed".
      */
     {"nif_cancel",              3, nif_cancel, 0},
-    {"nif_finalize_close",      1, nif_finalize_close, ERL_NIF_DIRTY_JOB_IO_BOUND}
+    {"nif_finalize_close",      1, nif_finalize_close, 0}
 };
 
 

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -11471,56 +11471,43 @@ int socket_setopt(int sock, int level, int opt,
     int res;
 
 #if  defined(IP_TOS) && defined(SOL_IP) && defined(SO_PRIORITY)
-    int          tmpIValPRIO = 0;
-    int          tmpIValTOS = 0;
-    int          resPRIO;
-    int          resTOS;
-    SOCKOPTLEN_T tmpArgSzPRIO = sizeof(tmpIValPRIO);
-    SOCKOPTLEN_T tmpArgSzTOS  = sizeof(tmpIValTOS);
+    /* Setting IP_TOS makes the kernel derive a new SO_PRIORITY from it,
+     * so that one option - and only that one - has to have the priority
+     * saved and put back to keep the two looking independent to the
+     * user. Setting anything else leaves both alone, and paying a
+     * getsockopt for each of them plus a setsockopt to restore on every
+     * option set was most of the system calls a connection made.
+     */
+    if ((level == SOL_IP) && (opt == IP_TOS)) {
+        int          savedPRIO;
+        int          resPRIO;
+        SOCKOPTLEN_T savedSzPRIO = sizeof(savedPRIO);
 
-    resPRIO = sock_getopt(sock, SOL_SOCKET, SO_PRIORITY,
-                           &tmpIValPRIO, &tmpArgSzPRIO);
-    resTOS  = sock_getopt(sock, SOL_IP, IP_TOS,
-                          &tmpIValTOS, &tmpArgSzTOS);
+        resPRIO = sock_getopt(sock, SOL_SOCKET, SO_PRIORITY,
+                              &savedPRIO, &savedSzPRIO);
 
-    res = sock_setopt(sock, level, opt, optVal, optLen);
-    if (res == 0) {
+        res = sock_setopt(sock, level, opt, optVal, optLen);
 
-        /* Ok, now we *maybe* need to "maybe" restore PRIO and TOS...
-         * maybe, possibly, ...
-         */
+        if ((res == 0) && (resPRIO == 0)) {
+            resPRIO = sock_setopt(sock, SOL_SOCKET, SO_PRIORITY,
+                                  &savedPRIO, savedSzPRIO);
 
-        if (opt != SO_PRIORITY) {
-	    if ((opt != IP_TOS) && (resTOS == 0)) {
-		resTOS = sock_setopt(sock, SOL_IP, IP_TOS,
-                                     (void *) &tmpIValTOS,
-                                     tmpArgSzTOS);
-                res = resTOS;
-            }
-	    if ((res == 0) && (resPRIO == 0)) {
-		resPRIO = sock_setopt(sock, SOL_SOCKET, SO_PRIORITY,
-                                      &tmpIValPRIO,
-                                      tmpArgSzPRIO);
+            /* Some kernels set a SO_PRIORITY by default
+             * that you are not permitted to reset,
+             * silently ignore this error condition.
+             */
 
-                /* Some kernels set a SO_PRIORITY by default
-                 * that you are not permitted to reset,
-                 * silently ignore this error condition.
-                 */
+            if ((resPRIO != 0) && (sock_errno() == EPERM))
+                res = 0;
+            else
+                res = resPRIO;
+        }
 
-                if ((resPRIO != 0) && (sock_errno() == EPERM)) {
-                    res = 0;
-                } else {
-                    res = resPRIO;
-		}
-	    }
-	}
+        return res;
     }
-
-#else
+#endif
 
     res = sock_setopt(sock, level, opt, optVal, optLen);
-
-#endif
 
     return res;
 }

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -4829,7 +4829,8 @@ ERL_NIF_TERM essio_fin_close(ErlNifEnv*       env,
      * for this ({true, integer() > 0}). For this to work we must
      * be blocking...
      */
-    SET_BLOCKING(descP->sock);
+    if (descP->closeMayBlock)
+        SET_BLOCKING(descP->sock);
     err = esock_close_socket(env, descP, TRUE);
 
 #ifdef HAVE_SENDFILE

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -1570,6 +1570,9 @@ ERL_NIF_TERM essio_open_with_fd(ErlNifEnv*       env,
     descP->protocol     = protocol;
     descP->closeOnClose = closeOnClose;
     descP->origFD       = fd;
+    /* An adopted fd is the one case where the linger state is not ours to
+     * know, so ask once here instead of on every close. */
+    descP->closeMayBlock = esock_close_may_block(sock);
 
     /* Check if we are already connected, if so change state */
     {
@@ -1790,6 +1793,8 @@ ERL_NIF_TERM essio_open_plain(ErlNifEnv*       env,
     descP->domain   = domain;
     descP->type     = type;
     descP->protocol = proto;
+    /* A socket we just created cannot have SO_LINGER set */
+    descP->closeMayBlock = FALSE;
 
     sockRef = enif_make_resource(env, descP);
     enif_release_resource(descP);
@@ -2852,6 +2857,10 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
 
     MLOCK(descP->writeMtx);
 
+    /* SO_LINGER is inherited by the accepted socket, and inheriting the
+     * cached value is safe even where it is not: the parent's TRUE only
+     * costs the child the blocking path it would have taken anyway. */
+    accDescP->closeMayBlock = descP->closeMayBlock;
     accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     accDescP->rNum     = descP->rNum;    // Inherit buffer uses
     accDescP->rNumCnt  = 0;
@@ -2957,6 +2966,7 @@ ERL_NIF_TERM essio_peeloff(ErlNifEnv*       env,
             "%s(%d) -> inherit various options\r\n",
             __FUNCTION__, descP->sock, sock) );
 
+    poDescP->closeMayBlock = descP->closeMayBlock;
     poDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     poDescP->rNum     = descP->rNum;    // Inherit buffer uses
     poDescP->rNumCnt  = 0;

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -195,10 +195,11 @@
  * ======================================================================== *
  */
 
-#ifdef HAS_ACCEPT4
-// We have to figure out what the flags are...
+#if defined(HAVE_ACCEPT4) && defined(SOCK_CLOEXEC) && defined(SOCK_NONBLOCK)
 #define sock_accept(s, addr, len)       \
-    accept4((s), (addr), (len), (SOCK_CLOEXEC))
+    accept4((s), (addr), (len), (SOCK_CLOEXEC | SOCK_NONBLOCK))
+/* The accepted socket is already non-blocking */
+#define ESSIO_ACCEPTED_NONBLOCK 1
 #else
 #define sock_accept(s, addr, len)       accept((s), (addr), (len))
 #endif
@@ -225,7 +226,14 @@
         return enif_raise_exception((e), MKA((e), "notsup"));
 #define sock_ntohs(x)                   ntohs((x))
 #define sock_htonl(x)                   htonl((x))
+#if defined(SOCK_NONBLOCK)
+#define sock_open(domain, type, proto)                                  \
+    socket((domain), (type) | SOCK_NONBLOCK, (proto))
+/* The opened socket is already non-blocking */
+#define ESSIO_OPENED_NONBLOCK 1
+#else
 #define sock_open(domain, type, proto)  socket((domain), (type), (proto))
+#endif
 #define sock_peeloff(s, aid)            ctrl.sctp.peeloff((s), (aid))
 #define sock_ensure_peeloff(E)                                         \
     if (ctrl.sctp.peeloff == NULL)                                      \
@@ -1769,7 +1777,11 @@ ERL_NIF_TERM essio_open_plain(ErlNifEnv*       env,
     }
 #endif
 
+#ifndef ESSIO_OPENED_NONBLOCK
+    /* sock_open() could not ask for it, so do it the long way:
+     * SET_NONBLOCKING is F_GETFL + F_SETFL, two more system calls. */
     SET_NONBLOCKING(sock);
+#endif
 
 
     /* Create and initiate the socket "descriptor" */
@@ -2863,7 +2875,9 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
                        &accDescP->ctrlPid,
                        &accDescP->ctrlMon) == 0 );
 
+#ifndef ESSIO_ACCEPTED_NONBLOCK
     SET_NONBLOCKING(accDescP->sock);
+#endif
 
     accDescP->writeState |= ESOCK_STATE_CONNECTED;
 

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -195,10 +195,11 @@
  * ======================================================================== *
  */
 
-#ifdef HAS_ACCEPT4
-// We have to figure out what the flags are...
+#if defined(HAVE_ACCEPT4) && defined(SOCK_CLOEXEC) && defined(SOCK_NONBLOCK)
 #define sock_accept(s, addr, len)       \
-    accept4((s), (addr), (len), (SOCK_CLOEXEC))
+    accept4((s), (addr), (len), (SOCK_CLOEXEC | SOCK_NONBLOCK))
+/* The accepted socket is already non-blocking */
+#define ESSIO_ACCEPTED_NONBLOCK 1
 #else
 #define sock_accept(s, addr, len)       accept((s), (addr), (len))
 #endif
@@ -2863,7 +2864,9 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
                        &accDescP->ctrlPid,
                        &accDescP->ctrlMon) == 0 );
 
+#ifndef ESSIO_ACCEPTED_NONBLOCK
     SET_NONBLOCKING(accDescP->sock);
+#endif
 
     accDescP->writeState |= ESOCK_STATE_CONNECTED;
 

--- a/erts/emulator/nifs/win32/win_socket_asyncio.c
+++ b/erts/emulator/nifs/win32/win_socket_asyncio.c
@@ -1792,6 +1792,8 @@ ERL_NIF_TERM esaio_open_plain(ErlNifEnv*       env,
     descP->domain   = domain;
     descP->type     = type;
     descP->protocol = proto;
+    /* A socket we just created cannot have SO_LINGER set */
+    descP->closeMayBlock = FALSE;
 
     SSDBG2( dbg, ("WIN-ESAIO",
                   "esaio_open_plain -> add to completion port\r\n") );
@@ -2605,6 +2607,7 @@ ERL_NIF_TERM esaio_accept_accepted(ErlNifEnv*       env,
 
     MLOCK(descP->writeMtx);
 
+    accDescP->closeMayBlock = descP->closeMayBlock;
     accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     accDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
     accDescP->wCtrlSz  = descP->wCtrlSz; // Inherit buffer size
@@ -7698,6 +7701,7 @@ void esaio_completion_accept_completed(ErlNifEnv*         env,
 
             MLOCK(descP->writeMtx);
 
+            accDescP->closeMayBlock = descP->closeMayBlock;
             accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
             accDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
             accDescP->wCtrlSz  = descP->wCtrlSz; // Inherit buffer size


### PR DESCRIPTION
Four commits reducing the per-connection cost of the socket NIF on Unix. Each
one removes work that only a subset of sockets actually needs.

### Close

`nif_finalize_close` always ran on a dirty scheduler, and `essio_fin_close`
always switched the socket to blocking mode before closing it. Both are there
for the lingering close, `SO_LINGER {true, > 0}`, where `close()` can hang while
the kernel flushes our buffers. Every other close paid two scheduler migrations
and two `fcntl` calls for a case that did not apply to it.

Whether the close can block is now recorded on the descriptor as
`closeMayBlock`, and both decisions read it: take the dirty path only when the
close can block, and let `essio_fin_close` skip the switch to blocking mode
otherwise.

The field is maintained where the option is set. Every `setsockopt` reaches the
kernel through `esock_setopt_level_opt`, so that one place sees `SO_LINGER`
whether it arrives as the `linger` option or as a `setopt_native`, and it
updates the field after the `setsockopt` succeeds. No `getsockopt` on the close
path at all.

The seeding rule is the part worth checking, because the unsafe direction is
caching FALSE for a socket that really does linger. The field starts out TRUE,
so anything whose linger state was never established keeps the old blocking
behaviour. It is narrowed to FALSE only where the socket is known to be fresh
(`essio_open_plain`, `esaio_open_plain`), inherited from the parent on accept
and on peeloff, and read from the kernel exactly once for an adopted fd, which
is the only case where the prior state is not ours to know. On a platform
without `SO_LINGER` a close can never linger, so the answer is FALSE and the
dirty scheduler is skipped, as before.

### Non-blocking creation

`socket()` and `accept()` were each followed by `SET_NONBLOCKING`, which is
`fcntl(F_GETFL)` + `fcntl(F_SETFL)`, so two system calls for every socket
created. Both calls can ask the kernel for it directly: `accept4()` and
`socket()` with `SOCK_NONBLOCK`. Note `HAS_ACCEPT4` was never defined anywhere,
so esock was using plain `accept()` before this; the configure check comes with
the change.

Only `SOCK_NONBLOCK`, not `SOCK_CLOEXEC`. Making an opened socket close-on-exec
would match the accepted socket, but it saves no system calls, and BEAM forks
port programs from `erl_child_setup`, which closes every inherited descriptor
above 3 at its own startup, so a socket opened later cannot reach a port program
anyway. Not worth a behaviour change.

### The priority/tos dance

The save and restore of `SO_PRIORITY` and `IP_TOS`, inherited from `inet_drv`'s
`setopt_prio_tos_trick`, ran around *every* `setsockopt`, costing two getsockopt
plus up to two restore setsockopt calls per option set.

Only half of it holds. Setting `IP_TOS` does make the kernel derive a new
`SO_PRIORITY`, so that one option has to put the priority back. Setting
`SO_PRIORITY` leaves the tos alone, and so does setting anything else: checked
on Linux 7.0 with `TCP_NODELAY`, `SO_RCVBUF` and `SO_LINGER`, none of which
disturbed either value. Doing it only for `IP_TOS`, and only for the priority,
takes setting an option on an accepted connection from four system calls to one.

### Measurements

Linux, aarch64, 10 cores, `socket` backend, loopback. Each figure is the median
of 7 runs, with the two builds interleaved run by run so that drift affects both
arms equally. Percentages are the median of the per-run paired deltas, and
"consistent" is the share of runs agreeing with its sign.

| | master | this PR | paired delta | consistent |
|---|---|---|---|---|
| connect/accept/setopts/close cycle | 56,819/s | **65,624/s** | **+14.7%** | 100% |
| accept 10k connections, 1 acceptor | 72,543/s | **76,421/s** | +5.9% | 71% |
| bulk recv, 4 GB *(control)* | | | +0.5% | 57%, noise |
| small-message ping-pong *(control)* | | | +1.0% | 71%, noise |

The paired delta is not the ratio of the two medians and can disagree with it in
sign when a result is noise, which is why the two control rows give the delta
only. Both controls sit inside the run-to-run spread on this box.

Both controls are long-lived connections, where these costs are paid once at
setup and once at teardown and amortise away, so flat is the expected result.

The table above was measured at `dbcb6ea1`, the third commit, so it does not
include the linger cache.

System calls per socket created, counted with `strace -c -f` over the churn
benchmark: `fcntl` goes from 2.76 to 0.02.

For the linger cache on its own, `getsockopt` over 4001 closes goes from 6002 to
2001, one fewer per close, on the lingering and the non-lingering path alike. On
connection churn that is worth about 1.6% (80% consistent, n=15), which is close
enough to this box's noise floor that the syscall count is the claim I would
stand behind rather than the throughput. Bulk and ping-pong are flat.

One benchmarking note for anyone reproducing this: accepting with *several*
acceptor processes on a single listening socket shows almost nothing here
(+1.7%), because both arms are then limited by the acceptor hand-off in
`essio_accept`, which is unrelated to this PR and is addressed separately in
#11537. Use a single acceptor, or a socket per acceptor, to see this PR's effect
on accept.

### Testing

`socket_api_SUITE` and `socket_SUITE` accept cases pass on Linux (86 ok / 64
skipped for unsupported features; the one failure,
`api_b_open_and_maybe_close_raw`, fails identically on an unpatched tree in this
container). `nif_SUITE` select cases pass. `socket_SUITE` and `socket_api_SUITE`
also pass on macOS, on both maint and master.

Lingering close was checked explicitly, since the close commits depend on
getting that predicate right: with `SO_LINGER {true, 2}` and a peer that never
reads, `close()` still takes ~2 s, while linger `{true, 0}`, no linger, and
linger set then unset all return immediately. For the cached version the path
that carries the state rather than setting it was checked too: a connection
accepted from a listening socket that has linger set still blocks in `close()`,
which is the case a wrongly cached FALSE would break silently. The remaining
seeded path, an adopted fd, reads the option from the kernel once at adopt time,
so it keeps the pre-patch answer by construction.

The CT results reported above are for `dbcb6ea1` and predate the linger cache.

