### PR TITLE
Adapt the socket receive buffer size to traffic

### DIFF
--- a/erts/emulator/nifs/common/prim_socket_int.h
+++ b/erts/emulator/nifs/common/prim_socket_int.h
@@ -522,7 +522,7 @@ typedef struct {
      * the size, since it bounds the chunks such a recv may return.
      */
     size_t             rBufSzAdapt; // Current adaptive read buffer size
-    unsigned int       rBufShrinkCnt;
+    size_t             rBufSzAvg;   // EWMA of the read sizes
     BOOLEAN_T          rBufAdapt;
 #endif
     size_t             rCtrlSz; // Read control buffer size

--- a/erts/emulator/nifs/common/prim_socket_int.h
+++ b/erts/emulator/nifs/common/prim_socket_int.h
@@ -504,11 +504,11 @@ typedef struct {
     ESockCounter       accFails;
     /* +++ Config stuff +++ */
     size_t             rBufSz;  // Read buffer size (when data length = 0)
-    /* rNum and rNumCnt are used (together with rBufSz) when calling the recv 
+    /* rNum and rNumCnt are used (together with rBufSz) when calling the recv
      * function with the Length argument set to 0 (zero).
      * If rNum is 0 (zero), then rNumCnt is not used and only *one* read will
-     * be done. Also, when get'ing the value of the option (rcvbuf) with 
-     * getopt, the value will be reported as an integer. If the rNum has a 
+     * be done. Also, when get'ing the value of the option (rcvbuf) with
+     * getopt, the value will be reported as an integer. If the rNum has a
      * value greater then 0 (zero), then it will instead be reported as
      * {N, BufSz}.
      * On Windows, rNum and rNumCnt is *not* used!
@@ -516,6 +516,14 @@ typedef struct {
 #ifndef __WIN32__
     unsigned int       rNum;    // recv: Number of reads using rBufSz
     unsigned int       rNumCnt; // recv: Current number of reads (so far)
+    /* While rcvbuf is 'auto' (the initial state), a length 0 recv on a
+     * stream socket reads into a buffer that adapts to the traffic
+     * (rBufSzAdapt, only used by essio_recv). Any other rcvbuf pins
+     * the size, since it bounds the chunks such a recv may return.
+     */
+    size_t             rBufSzAdapt; // Current adaptive read buffer size
+    size_t             rBufSzAvg;   // EWMA of the read sizes
+    BOOLEAN_T          rBufAdapt;
 #endif
     size_t             rCtrlSz; // Read control buffer size
 

--- a/erts/emulator/nifs/common/prim_socket_int.h
+++ b/erts/emulator/nifs/common/prim_socket_int.h
@@ -504,6 +504,14 @@ typedef struct {
     ESockCounter       accFails;
     /* +++ Config stuff +++ */
     size_t             rBufSz;  // Read buffer size (when data length = 0)
+    /* While rcvbuf has not been set explicitly, rBufSz adapts to the
+     * traffic (grows when reads fill the buffer, shrinks back towards
+     * the default when they stop). An explicit rcvbuf pins the size,
+     * since it bounds the chunks a length 0 recv may return.
+     */
+    BOOLEAN_T          rBufAdapt;
+    size_t             rBufSzCfg;
+    unsigned int       rBufShrinkCnt;
     /* rNum and rNumCnt are used (together with rBufSz) when calling the recv 
      * function with the Length argument set to 0 (zero).
      * If rNum is 0 (zero), then rNumCnt is not used and only *one* read will

--- a/erts/emulator/nifs/common/prim_socket_int.h
+++ b/erts/emulator/nifs/common/prim_socket_int.h
@@ -504,19 +504,11 @@ typedef struct {
     ESockCounter       accFails;
     /* +++ Config stuff +++ */
     size_t             rBufSz;  // Read buffer size (when data length = 0)
-    /* While rcvbuf has not been set explicitly, rBufSz adapts to the
-     * traffic (grows when reads fill the buffer, shrinks back towards
-     * the default when they stop). An explicit rcvbuf pins the size,
-     * since it bounds the chunks a length 0 recv may return.
-     */
-    BOOLEAN_T          rBufAdapt;
-    size_t             rBufSzCfg;
-    unsigned int       rBufShrinkCnt;
-    /* rNum and rNumCnt are used (together with rBufSz) when calling the recv 
+    /* rNum and rNumCnt are used (together with rBufSz) when calling the recv
      * function with the Length argument set to 0 (zero).
      * If rNum is 0 (zero), then rNumCnt is not used and only *one* read will
-     * be done. Also, when get'ing the value of the option (rcvbuf) with 
-     * getopt, the value will be reported as an integer. If the rNum has a 
+     * be done. Also, when get'ing the value of the option (rcvbuf) with
+     * getopt, the value will be reported as an integer. If the rNum has a
      * value greater then 0 (zero), then it will instead be reported as
      * {N, BufSz}.
      * On Windows, rNum and rNumCnt is *not* used!
@@ -524,6 +516,14 @@ typedef struct {
 #ifndef __WIN32__
     unsigned int       rNum;    // recv: Number of reads using rBufSz
     unsigned int       rNumCnt; // recv: Current number of reads (so far)
+    /* While rcvbuf has not been set explicitly, a length 0 recv on a
+     * stream socket reads into a buffer that adapts to the traffic
+     * (rBufSzAdapt, only used by essio_recv). An explicit rcvbuf pins
+     * the size, since it bounds the chunks such a recv may return.
+     */
+    size_t             rBufSzAdapt; // Current adaptive read buffer size
+    unsigned int       rBufShrinkCnt;
+    BOOLEAN_T          rBufAdapt;
 #endif
     size_t             rCtrlSz; // Read control buffer size
 

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -8224,9 +8224,11 @@ ERL_NIF_TERM esock_setopt_otp_rcvbuf(ErlNifEnv*       env,
         descP->rBufSz = ESOCK_RECV_BUFFER_SIZE_MIN;
     else
         descP->rBufSz = bufSz;
+#ifndef __WIN32__
     descP->rBufAdapt     = FALSE;
-    descP->rBufSzCfg     = descP->rBufSz;
+    descP->rBufSzAdapt   = descP->rBufSz;
     descP->rBufShrinkCnt = 0;
+#endif
 
     SSDBG( descP,
            ("SOCKET", "esock_setopt_otp_rcvbuf {%d} -> ok"
@@ -11836,15 +11838,14 @@ ERL_NIF_TERM esock_getopt_otp_rcvbuf(ErlNifEnv*       env,
     }
 
 #ifdef __WIN32__
-    eVal = MKUL(env, (unsigned long) descP->rBufSzCfg);
+    eVal = MKUL(env, (unsigned long) descP->rBufSz);
 #else
-    /* The current (adapted) size is internal; report the configured one */
     if (descP->rNum == 0) {
-        eVal = MKUL(env, (unsigned long) descP->rBufSzCfg);
+        eVal = MKUL(env, (unsigned long) descP->rBufSz);
     } else {
         eVal = MKT2(env,
                     MKI(env, descP->rNum),
-                    MKUL(env, (unsigned long) descP->rBufSzCfg));
+                    MKUL(env, (unsigned long) descP->rBufSz));
     }
 #endif
 
@@ -17063,12 +17064,12 @@ ESockDescriptor* esock_alloc_descriptor(SOCKET sock)
     /* *** Config section *** */
     // sprintf(buf, "esock.cfg[" SOCKET_FORMAT_STR "]", sock);
     descP->rBufSz           = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
-    descP->rBufAdapt        = TRUE;
-    descP->rBufSzCfg        = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
-    descP->rBufShrinkCnt    = 0;
 #ifndef __WIN32__
     descP->rNum             = ESOCK_RECV_BUFFER_COUNT_DEFAULT;
     descP->rNumCnt          = 0;
+    descP->rBufAdapt        = TRUE;
+    descP->rBufSzAdapt      = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
+    descP->rBufShrinkCnt    = 0;
 #endif
     descP->rCtrlSz          = ESOCK_RECV_CTRL_BUFFER_SIZE_DEFAULT;
     descP->wCtrlSz          = ESOCK_SEND_CTRL_BUFFER_SIZE_DEFAULT;

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -2752,6 +2752,7 @@ ERL_NIF_TERM esock_atom_esock_name; // This has a "special" name ('$esock_name')
     LOCAL_ATOM_DECL(assoc_id);         \
     LOCAL_ATOM_DECL(atmark);           \
     LOCAL_ATOM_DECL(authentication);   \
+    LOCAL_ATOM_DECL(auto);             \
     LOCAL_ATOM_DECL(boolean);          \
     LOCAL_ATOM_DECL(bound);	       \
     LOCAL_ATOM_DECL(bufsz);            \
@@ -8142,10 +8143,13 @@ ERL_NIF_TERM esock_setopt_otp_ctrl_proc(ErlNifEnv*       env,
 /* esock_setopt_otp_rcvbuf - Handle the OTP (level) rcvbuf option
  * The (otp) rcvbuf option is provided as:
  *
- *       BufSz :: default | pos_integer() |
+ *       BufSz :: auto | default | pos_integer() |
  *           {N :: pos_integer(), Sz :: default | pos_integer()}
  *
  * Where N is the max number of reads.
+ * 'auto' is the initial state: the default size, adapted to the traffic
+ * by recv (on stream sockets, not on Windows). Any other value pins the
+ * size and turns adaptation off.
  * Note that on Windows the tuple variant is not allowed!
  */
 
@@ -8158,6 +8162,7 @@ ERL_NIF_TERM esock_setopt_otp_rcvbuf(ErlNifEnv*       env,
     int                 tsz; // The size of the tuple - should be 2
 #ifndef __WIN32__    
     unsigned int        n;
+    BOOLEAN_T           adapt = FALSE;
 #endif
     size_t              bufSz;
     ssize_t             z;
@@ -8174,6 +8179,12 @@ ERL_NIF_TERM esock_setopt_otp_rcvbuf(ErlNifEnv*       env,
         return esock_make_error_closed(env);
     }
 
+    if (COMPARE(eVal, atom_auto) == 0) {
+#ifndef __WIN32__
+        adapt = TRUE;
+#endif
+        eVal  = esock_atom_default;
+    }
 
 #ifdef __WIN32__
 
@@ -8224,6 +8235,11 @@ ERL_NIF_TERM esock_setopt_otp_rcvbuf(ErlNifEnv*       env,
         descP->rBufSz = ESOCK_RECV_BUFFER_SIZE_MIN;
     else
         descP->rBufSz = bufSz;
+#ifndef __WIN32__
+    descP->rBufAdapt   = adapt;
+    descP->rBufSzAdapt = descP->rBufSz;
+    descP->rBufSzAvg   = descP->rBufSz;
+#endif
 
     SSDBG( descP,
            ("SOCKET", "esock_setopt_otp_rcvbuf {%d} -> ok"
@@ -17062,6 +17078,9 @@ ESockDescriptor* esock_alloc_descriptor(SOCKET sock)
 #ifndef __WIN32__
     descP->rNum             = ESOCK_RECV_BUFFER_COUNT_DEFAULT;
     descP->rNumCnt          = 0;
+    descP->rBufAdapt        = TRUE;
+    descP->rBufSzAdapt      = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
+    descP->rBufSzAvg        = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
 #endif
     descP->rCtrlSz          = ESOCK_RECV_CTRL_BUFFER_SIZE_DEFAULT;
     descP->wCtrlSz          = ESOCK_SEND_CTRL_BUFFER_SIZE_DEFAULT;

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -8225,9 +8225,9 @@ ERL_NIF_TERM esock_setopt_otp_rcvbuf(ErlNifEnv*       env,
     else
         descP->rBufSz = bufSz;
 #ifndef __WIN32__
-    descP->rBufAdapt     = FALSE;
-    descP->rBufSzAdapt   = descP->rBufSz;
-    descP->rBufShrinkCnt = 0;
+    descP->rBufAdapt   = FALSE;
+    descP->rBufSzAdapt = descP->rBufSz;
+    descP->rBufSzAvg   = descP->rBufSz;
 #endif
 
     SSDBG( descP,
@@ -17069,7 +17069,7 @@ ESockDescriptor* esock_alloc_descriptor(SOCKET sock)
     descP->rNumCnt          = 0;
     descP->rBufAdapt        = TRUE;
     descP->rBufSzAdapt      = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
-    descP->rBufShrinkCnt    = 0;
+    descP->rBufSzAvg        = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
 #endif
     descP->rCtrlSz          = ESOCK_RECV_CTRL_BUFFER_SIZE_DEFAULT;
     descP->wCtrlSz          = ESOCK_SEND_CTRL_BUFFER_SIZE_DEFAULT;

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -2046,6 +2046,8 @@ static ERL_NIF_TERM esock_socket_info_state(ErlNifEnv*   env,
 					    unsigned int state);
 static ERL_NIF_TERM esock_socket_info_counters(ErlNifEnv*       env,
                                                ESockDescriptor* descP);
+static ERL_NIF_TERM esock_socket_info_rbuf(ErlNifEnv*       env,
+                                           ESockDescriptor* descP);
 
 static ERL_NIF_TERM mk_close_msg(ErlNifEnv*   env,
                                  ERL_NIF_TERM sockRef,
@@ -2743,6 +2745,7 @@ ERL_NIF_TERM esock_atom_esock_name; // This has a "special" name ('$esock_name')
     LOCAL_ATOM_DECL(accepting);	       \
     LOCAL_ATOM_DECL(active);	       \
     LOCAL_ATOM_DECL(adaptation_layer); \
+    LOCAL_ATOM_DECL(adapted);          \
     LOCAL_ATOM_DECL(add);              \
     LOCAL_ATOM_DECL(address);          \
     LOCAL_ATOM_DECL(addr_over);        \
@@ -2759,6 +2762,7 @@ ERL_NIF_TERM esock_atom_esock_name; // This has a "special" name ('$esock_name')
     LOCAL_ATOM_DECL(close);            \
     LOCAL_ATOM_DECL(closing);          \
     LOCAL_ATOM_DECL(code);             \
+    LOCAL_ATOM_DECL(configured);       \
     LOCAL_ATOM_DECL(cookie_life);      \
     LOCAL_ATOM_DECL(counter_wrap);     \
     LOCAL_ATOM_DECL(ctype);            \
@@ -2798,6 +2802,7 @@ ERL_NIF_TERM esock_atom_esock_name; // This has a "special" name ('$esock_name')
     LOCAL_ATOM_DECL(gifnetmask);       \
     LOCAL_ATOM_DECL(giftxqlen);        \
     LOCAL_ATOM_DECL(heartbeat_interval);  \
+    LOCAL_ATOM_DECL(held);             \
     LOCAL_ATOM_DECL(host_unknown);     \
     LOCAL_ATOM_DECL(host_unreach);     \
     LOCAL_ATOM_DECL(how);              \
@@ -2896,6 +2901,7 @@ ERL_NIF_TERM esock_atom_esock_name; // This has a "special" name ('$esock_name')
     LOCAL_ATOM_DECL(primary);          \
     LOCAL_ATOM_DECL(probe);            \
     LOCAL_ATOM_DECL(protocols);        \
+    LOCAL_ATOM_DECL(rbuf);             \
     LOCAL_ATOM_DECL(rcvall);           \
     LOCAL_ATOM_DECL(rcvall_igmpmcast); \
     LOCAL_ATOM_DECL(rcvall_mcast);     \
@@ -4698,6 +4704,7 @@ ERL_NIF_TERM esock_socket_info(ErlNifEnv*       env,
     ERL_NIF_TERM wstates   = esock_socket_info_state(env, descP->writeState);
     ERL_NIF_TERM ctype     = esock_socket_info_ctype(env, descP);
     ERL_NIF_TERM counters  = esock_socket_info_counters(env, descP);
+    ERL_NIF_TERM rbuf      = esock_socket_info_rbuf(env, descP);
     ERL_NIF_TERM readers   = esock_socket_info_readers(env, descP);
     ERL_NIF_TERM writers   = esock_socket_info_writers(env, descP);
     ERL_NIF_TERM acceptors = esock_socket_info_acceptors(env, descP);
@@ -4712,6 +4719,7 @@ ERL_NIF_TERM esock_socket_info(ErlNifEnv*       env,
                atom_wstates,
                atom_ctype,
                esock_atom_counters,
+               atom_rbuf,
                atom_num_readers,
                atom_num_writers,
                atom_num_acceptors};
@@ -4724,6 +4732,7 @@ ERL_NIF_TERM esock_socket_info(ErlNifEnv*       env,
                wstates,
                ctype,
                counters,
+               rbuf,
                readers,
                writers,
                acceptors};
@@ -4995,6 +5004,48 @@ ERL_NIF_TERM esock_socket_info_counters(ErlNifEnv*       env,
                    "\r\n", cnts) );
 
     return cnts;
+}
+
+
+/*
+ * Encode the read buffer info:
+ *
+ *     #{configured := non_neg_integer(),
+ *       adapted    := non_neg_integer(),
+ *       held       := non_neg_integer()}
+ *
+ * 'configured' is the rcvbuf size set with setopt(otp, rcvbuf) (or the
+ * default), which is what getopt(otp, rcvbuf) reports.  'adapted' is the
+ * size a length 0 recv on a stream socket currently asks for; it grows
+ * with the traffic and falls back towards 'configured', and equals
+ * 'configured' when adaptation has been turned off by an explicit
+ * rcvbuf.  'held' is how much buffer the socket is holding right now,
+ * which for a socket that is waiting for data is never more than
+ * 'configured'.
+ */
+static
+ERL_NIF_TERM esock_socket_info_rbuf(ErlNifEnv*       env,
+                                    ESockDescriptor* descP)
+{
+    ERL_NIF_TERM info;
+    ERL_NIF_TERM keys[] = {atom_configured, atom_adapted, atom_held};
+#ifdef __WIN32__
+    ERL_NIF_TERM vals[] = {MKUL(env, (unsigned long) descP->rBufSz),
+                           MKUL(env, (unsigned long) descP->rBufSz),
+                           MKUL(env, 0UL)};
+#else
+    ERL_NIF_TERM vals[] =
+        {MKUL(env, (unsigned long) descP->rBufSz),
+         MKUL(env, (unsigned long) descP->rBufSzAdapt),
+         MKUL(env, (unsigned long)
+              ((descP->buf.data == NULL) ? 0 : descP->buf.size))};
+#endif
+    unsigned int numKeys = NUM(keys);
+
+    ESOCK_ASSERT( numKeys == NUM(vals) );
+    ESOCK_ASSERT( MKMA(env, keys, vals, numKeys, &info) );
+
+    return info;
 }
 
 

--- a/erts/emulator/nifs/common/prim_socket_nif.c
+++ b/erts/emulator/nifs/common/prim_socket_nif.c
@@ -8224,6 +8224,9 @@ ERL_NIF_TERM esock_setopt_otp_rcvbuf(ErlNifEnv*       env,
         descP->rBufSz = ESOCK_RECV_BUFFER_SIZE_MIN;
     else
         descP->rBufSz = bufSz;
+    descP->rBufAdapt     = FALSE;
+    descP->rBufSzCfg     = descP->rBufSz;
+    descP->rBufShrinkCnt = 0;
 
     SSDBG( descP,
            ("SOCKET", "esock_setopt_otp_rcvbuf {%d} -> ok"
@@ -11833,14 +11836,15 @@ ERL_NIF_TERM esock_getopt_otp_rcvbuf(ErlNifEnv*       env,
     }
 
 #ifdef __WIN32__
-    eVal = MKUL(env, (unsigned long) descP->rBufSz);
+    eVal = MKUL(env, (unsigned long) descP->rBufSzCfg);
 #else
+    /* The current (adapted) size is internal; report the configured one */
     if (descP->rNum == 0) {
-        eVal = MKUL(env, (unsigned long) descP->rBufSz);
+        eVal = MKUL(env, (unsigned long) descP->rBufSzCfg);
     } else {
         eVal = MKT2(env,
                     MKI(env, descP->rNum),
-                    MKUL(env, (unsigned long) descP->rBufSz));
+                    MKUL(env, (unsigned long) descP->rBufSzCfg));
     }
 #endif
 
@@ -17059,6 +17063,9 @@ ESockDescriptor* esock_alloc_descriptor(SOCKET sock)
     /* *** Config section *** */
     // sprintf(buf, "esock.cfg[" SOCKET_FORMAT_STR "]", sock);
     descP->rBufSz           = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
+    descP->rBufAdapt        = TRUE;
+    descP->rBufSzCfg        = ESOCK_RECV_BUFFER_SIZE_DEFAULT;
+    descP->rBufShrinkCnt    = 0;
 #ifndef __WIN32__
     descP->rNum             = ESOCK_RECV_BUFFER_COUNT_DEFAULT;
     descP->rNumCnt          = 0;

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -2849,7 +2849,7 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
 
     accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     accDescP->rBufAdapt = descP->rBufAdapt;
-    accDescP->rBufSzCfg = descP->rBufSzCfg;
+    accDescP->rBufSzAdapt = descP->rBufSz;
     accDescP->rBufShrinkCnt = 0;
     accDescP->rNum     = descP->rNum;    // Inherit buffer uses
     accDescP->rNumCnt  = 0;
@@ -2955,7 +2955,7 @@ ERL_NIF_TERM essio_peeloff(ErlNifEnv*       env,
 
     poDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     poDescP->rBufAdapt = descP->rBufAdapt;
-    poDescP->rBufSzCfg = descP->rBufSzCfg;
+    poDescP->rBufSzAdapt = descP->rBufSz;
     poDescP->rBufShrinkCnt = 0;
     poDescP->rNum     = descP->rNum;    // Inherit buffer uses
     poDescP->rNumCnt  = 0;
@@ -3816,7 +3816,9 @@ ERL_NIF_TERM essio_recv(ErlNifEnv*       env,
     int          saveErrno;
     ErlNifBinary bin, *bufP;
     ssize_t      readResult;
-    size_t       bufSz = (len != 0 ? len : descP->rBufSz); // 0 means default
+    size_t       bufSz = (len != 0 ? (size_t) len : // 0 means default
+                          (descP->type == SOCK_STREAM ?
+                           descP->rBufSzAdapt : descP->rBufSz));
     ERL_NIF_TERM ret;
 
     SSDBG( descP, ("UNIX-ESSIO", "essio_recv {%d} -> entry with"
@@ -3860,17 +3862,17 @@ ERL_NIF_TERM essio_recv(ErlNifEnv*       env,
     }
     /* readResult >= 0 */
 
-    if ((len == 0) && descP->rBufAdapt) {
+    if ((len == 0) && descP->rBufAdapt && (descP->type == SOCK_STREAM)) {
         if ((size_t) readResult == bufP->size) {
-            if (descP->rBufSz < ESSIO_RECV_ADAPT_BUFFER_MAX)
-                descP->rBufSz <<= 1;
+            if (descP->rBufSzAdapt < ESSIO_RECV_ADAPT_BUFFER_MAX)
+                descP->rBufSzAdapt <<= 1;
             descP->rBufShrinkCnt = 0;
-        } else if ((descP->rBufSz > descP->rBufSzCfg) &&
-                   ((size_t) readResult < (descP->rBufSz >> 2))) {
+        } else if ((descP->rBufSzAdapt > descP->rBufSz) &&
+                   ((size_t) readResult < (descP->rBufSzAdapt >> 2))) {
             if (++descP->rBufShrinkCnt >= ESSIO_RECV_ADAPT_SHRINK_COUNT) {
-                descP->rBufSz >>= 1;
-                if (descP->rBufSz < descP->rBufSzCfg)
-                    descP->rBufSz = descP->rBufSzCfg;
+                descP->rBufSzAdapt >>= 1;
+                if (descP->rBufSzAdapt < descP->rBufSz)
+                    descP->rBufSzAdapt = descP->rBufSz;
                 descP->rBufShrinkCnt = 0;
             }
         } else {

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -214,7 +214,7 @@
  * the configured size once an EWMA of the read sizes falls below a
  * quarter of it.
  */
-#define ESSIO_RECV_ADAPT_BUFFER_MAX     (1 << 20)
+#define ESSIO_RECV_ADAPT_BUFFER_MAX     (1 << 18)
 #define ESSIO_RECV_ADAPT_EWMA_SHIFT     3
 // #define sock_close_event(e)             /* do nothing */
 #define sock_connect(s, addr, len)      connect((s), (addr), (len))

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -209,6 +209,13 @@
     if (ctrl.sctp.bindx == NULL)                             \
         return enif_raise_exception((e), MKA((e), "notsup"));
 #define sock_close(s)                   close((s))
+
+/* Adaptive read buffer: double on a filled buffer, halve back towards
+ * the configured size after this many consecutive reads that used
+ * less than a quarter of it.
+ */
+#define ESSIO_RECV_ADAPT_BUFFER_MAX     (1 << 20)
+#define ESSIO_RECV_ADAPT_SHRINK_COUNT   32
 // #define sock_close_event(e)             /* do nothing */
 #define sock_connect(s, addr, len)      connect((s), (addr), (len))
 #define sock_connectx(s, addrs, acnt, aidp) \
@@ -2841,6 +2848,9 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
     MLOCK(descP->writeMtx);
 
     accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
+    accDescP->rBufAdapt = descP->rBufAdapt;
+    accDescP->rBufSzCfg = descP->rBufSzCfg;
+    accDescP->rBufShrinkCnt = 0;
     accDescP->rNum     = descP->rNum;    // Inherit buffer uses
     accDescP->rNumCnt  = 0;
     accDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
@@ -2944,6 +2954,9 @@ ERL_NIF_TERM essio_peeloff(ErlNifEnv*       env,
             __FUNCTION__, descP->sock, sock) );
 
     poDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
+    poDescP->rBufAdapt = descP->rBufAdapt;
+    poDescP->rBufSzCfg = descP->rBufSzCfg;
+    poDescP->rBufShrinkCnt = 0;
     poDescP->rNum     = descP->rNum;    // Inherit buffer uses
     poDescP->rNumCnt  = 0;
     poDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
@@ -3846,6 +3859,24 @@ ERL_NIF_TERM essio_recv(ErlNifEnv*       env,
         return ret;
     }
     /* readResult >= 0 */
+
+    if ((len == 0) && descP->rBufAdapt) {
+        if ((size_t) readResult == bufP->size) {
+            if (descP->rBufSz < ESSIO_RECV_ADAPT_BUFFER_MAX)
+                descP->rBufSz <<= 1;
+            descP->rBufShrinkCnt = 0;
+        } else if ((descP->rBufSz > descP->rBufSzCfg) &&
+                   ((size_t) readResult < (descP->rBufSz >> 2))) {
+            if (++descP->rBufShrinkCnt >= ESSIO_RECV_ADAPT_SHRINK_COUNT) {
+                descP->rBufSz >>= 1;
+                if (descP->rBufSz < descP->rBufSzCfg)
+                    descP->rBufSz = descP->rBufSzCfg;
+                descP->rBufShrinkCnt = 0;
+            }
+        } else {
+            descP->rBufShrinkCnt = 0;
+        }
+    }
 
     ESOCK_ASSERT( recv_create_bin(bufP, readResult, &bin) );
 

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -211,11 +211,11 @@
 #define sock_close(s)                   close((s))
 
 /* Adaptive read buffer: double on a filled buffer, halve back towards
- * the configured size after this many consecutive reads that used
- * less than a quarter of it.
+ * the configured size once an EWMA of the read sizes falls below a
+ * quarter of it.
  */
 #define ESSIO_RECV_ADAPT_BUFFER_MAX     (1 << 20)
-#define ESSIO_RECV_ADAPT_SHRINK_COUNT   32
+#define ESSIO_RECV_ADAPT_EWMA_SHIFT     3
 // #define sock_close_event(e)             /* do nothing */
 #define sock_connect(s, addr, len)      connect((s), (addr), (len))
 #define sock_connectx(s, addrs, acnt, aidp) \
@@ -2850,7 +2850,7 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
     accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     accDescP->rBufAdapt = descP->rBufAdapt;
     accDescP->rBufSzAdapt = descP->rBufSz;
-    accDescP->rBufShrinkCnt = 0;
+    accDescP->rBufSzAvg = descP->rBufSz;
     accDescP->rNum     = descP->rNum;    // Inherit buffer uses
     accDescP->rNumCnt  = 0;
     accDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
@@ -2956,7 +2956,7 @@ ERL_NIF_TERM essio_peeloff(ErlNifEnv*       env,
     poDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
     poDescP->rBufAdapt = descP->rBufAdapt;
     poDescP->rBufSzAdapt = descP->rBufSz;
-    poDescP->rBufShrinkCnt = 0;
+    poDescP->rBufSzAvg = descP->rBufSz;
     poDescP->rNum     = descP->rNum;    // Inherit buffer uses
     poDescP->rNumCnt  = 0;
     poDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
@@ -3863,20 +3863,16 @@ ERL_NIF_TERM essio_recv(ErlNifEnv*       env,
     /* readResult >= 0 */
 
     if ((len == 0) && descP->rBufAdapt && (descP->type == SOCK_STREAM)) {
+        descP->rBufSzAvg -= descP->rBufSzAvg >> ESSIO_RECV_ADAPT_EWMA_SHIFT;
+        descP->rBufSzAvg += ((size_t) readResult) >> ESSIO_RECV_ADAPT_EWMA_SHIFT;
         if ((size_t) readResult == bufP->size) {
             if (descP->rBufSzAdapt < ESSIO_RECV_ADAPT_BUFFER_MAX)
                 descP->rBufSzAdapt <<= 1;
-            descP->rBufShrinkCnt = 0;
         } else if ((descP->rBufSzAdapt > descP->rBufSz) &&
-                   ((size_t) readResult < (descP->rBufSzAdapt >> 2))) {
-            if (++descP->rBufShrinkCnt >= ESSIO_RECV_ADAPT_SHRINK_COUNT) {
-                descP->rBufSzAdapt >>= 1;
-                if (descP->rBufSzAdapt < descP->rBufSz)
-                    descP->rBufSzAdapt = descP->rBufSz;
-                descP->rBufShrinkCnt = 0;
-            }
-        } else {
-            descP->rBufShrinkCnt = 0;
+                   (descP->rBufSzAvg < (descP->rBufSzAdapt >> 2))) {
+            descP->rBufSzAdapt >>= 1;
+            if (descP->rBufSzAdapt < descP->rBufSz)
+                descP->rBufSzAdapt = descP->rBufSz;
         }
     }
 

--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -209,6 +209,13 @@
     if (ctrl.sctp.bindx == NULL)                             \
         return enif_raise_exception((e), MKA((e), "notsup"));
 #define sock_close(s)                   close((s))
+
+/* Adaptive read buffer: double on a filled buffer, halve back towards
+ * the configured size once an EWMA of the read sizes falls below a
+ * quarter of it.
+ */
+#define ESSIO_RECV_ADAPT_BUFFER_MAX     (1 << 18)
+#define ESSIO_RECV_ADAPT_EWMA_SHIFT     3
 // #define sock_close_event(e)             /* do nothing */
 #define sock_connect(s, addr, len)      connect((s), (addr), (len))
 #define sock_connectx(s, addrs, acnt, aidp) \
@@ -535,6 +542,8 @@ static ERL_NIF_TERM essio_sendfile_ok(ErlNifEnv*       env,
 
 static BOOLEAN_T recv_alloc_buf(size_t          size,
                                 ErlNifBinary   *bufP);
+static void recv_release_buf(size_t          size,
+                             ErlNifBinary   *bufP);
 static BOOLEAN_T recv_create_bin(ErlNifBinary *bufP,
                                  size_t        size,
                                  ErlNifBinary *binP);
@@ -2841,6 +2850,9 @@ BOOLEAN_T essio_accept_accepted(ErlNifEnv*       env,
     MLOCK(descP->writeMtx);
 
     accDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
+    accDescP->rBufAdapt = descP->rBufAdapt;
+    accDescP->rBufSzAdapt = descP->rBufSz;
+    accDescP->rBufSzAvg = descP->rBufSz;
     accDescP->rNum     = descP->rNum;    // Inherit buffer uses
     accDescP->rNumCnt  = 0;
     accDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
@@ -2944,6 +2956,9 @@ ERL_NIF_TERM essio_peeloff(ErlNifEnv*       env,
             __FUNCTION__, descP->sock, sock) );
 
     poDescP->rBufSz   = descP->rBufSz;  // Inherit buffer size
+    poDescP->rBufAdapt = descP->rBufAdapt;
+    poDescP->rBufSzAdapt = descP->rBufSz;
+    poDescP->rBufSzAvg = descP->rBufSz;
     poDescP->rNum     = descP->rNum;    // Inherit buffer uses
     poDescP->rNumCnt  = 0;
     poDescP->rCtrlSz  = descP->rCtrlSz; // Inherit buffer size
@@ -3803,7 +3818,9 @@ ERL_NIF_TERM essio_recv(ErlNifEnv*       env,
     int          saveErrno;
     ErlNifBinary bin, *bufP;
     ssize_t      readResult;
-    size_t       bufSz = (len != 0 ? len : descP->rBufSz); // 0 means default
+    size_t       bufSz = (len != 0 ? (size_t) len : // 0 means default
+                          (descP->type == SOCK_STREAM ?
+                           descP->rBufSzAdapt : descP->rBufSz));
     ERL_NIF_TERM ret;
 
     SSDBG( descP, ("UNIX-ESSIO", "essio_recv {%d} -> entry with"
@@ -3842,10 +3859,26 @@ ERL_NIF_TERM essio_recv(ErlNifEnv*       env,
     /* Check for errors and end of stream */
     if (! recv_check_result(env, descP, sockRef, recvRef,
                             readResult, saveErrno, &ret) ) {
-        /* Keep the buffer */
+        /* Keep the buffer, but not an oversized one: we are about to
+         * report an error or wait for more data. */
+        recv_release_buf(descP->rBufSz, bufP);
         return ret;
     }
     /* readResult >= 0 */
+
+    if ((len == 0) && descP->rBufAdapt && (descP->type == SOCK_STREAM)) {
+        descP->rBufSzAvg -= descP->rBufSzAvg >> ESSIO_RECV_ADAPT_EWMA_SHIFT;
+        descP->rBufSzAvg += ((size_t) readResult) >> ESSIO_RECV_ADAPT_EWMA_SHIFT;
+        if ((size_t) readResult == bufP->size) {
+            if (descP->rBufSzAdapt < ESSIO_RECV_ADAPT_BUFFER_MAX)
+                descP->rBufSzAdapt <<= 1;
+        } else if ((descP->rBufSzAdapt > descP->rBufSz) &&
+                   (descP->rBufSzAvg < (descP->rBufSzAdapt >> 2))) {
+            descP->rBufSzAdapt >>= 1;
+            if (descP->rBufSzAdapt < descP->rBufSz)
+                descP->rBufSzAdapt = descP->rBufSz;
+        }
+    }
 
     ESOCK_ASSERT( recv_create_bin(bufP, readResult, &bin) );
 
@@ -3930,7 +3963,8 @@ ERL_NIF_TERM essio_recvfrom(ErlNifEnv*       env,
     /* Check for errors and end of stream */
     if (! recv_check_result(env, descP, sockRef, recvRef,
                             readResult, saveErrno, &ret) ) {
-        /* Keep the buffer */
+        /* Keep the buffer, but not an oversized one */
+        recv_release_buf(descP->rBufSz, bufP);
         return ret;
     }
     /* readResult >= 0 */
@@ -4051,7 +4085,8 @@ ERL_NIF_TERM essio_recvmsg(ErlNifEnv*       env,
     /* Check for errors and end of stream */
     if (! recv_check_result(env, descP, sockRef, recvRef,
                             readResult, saveErrno, &ret) ) {
-        /* Keep the data buffer */
+        /* Keep the data buffer, but not an oversized one */
+        recv_release_buf(descP->rBufSz, bufP);
         FREE_BIN(&ctrl);
         return ret;
     }
@@ -9574,6 +9609,13 @@ extern
 void essio_stop(ErlNifEnv*       env,
                 ESockDescriptor* descP)
 {
+    /* No more reads will be done, so drop the read buffer now instead of
+     * leaving it to essio_dtor().  Both socket locks are held here. */
+    if (descP->buf.data != NULL) {
+        FREE_BIN(&descP->buf);
+        descP->buf.data = NULL;
+    }
+
 #ifdef HAVE_SENDFILE
     if (descP->sendfileCountersP != NULL) {
         ESockSendfileCounters* cntP = descP->sendfileCountersP;
@@ -9828,6 +9870,23 @@ BOOLEAN_T recv_alloc_buf(size_t           size,
             return REALLOC_BIN(bufP, size);
         else
             return TRUE;
+    }
+}
+
+/* Drop a read buffer larger than 'size' (the configured rBufSz) instead of
+ * keeping it while waiting for data; an idle connection would otherwise pin
+ * an adapted buffer until essio_dtor() runs.  The buffer is scratch here,
+ * already handed over or copied out, and a recv that needs one this large
+ * allocates a fresh one anyway.  A buffer at or below 'size' is kept, which
+ * is the small message case.
+ */
+static
+void recv_release_buf(size_t           size,
+                      ErlNifBinary    *bufP)
+{
+    if ((bufP->data != NULL) && (bufP->size > size)) {
+        FREE_BIN(bufP);
+        bufP->data = NULL;
     }
 }
 

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -1080,10 +1080,10 @@ hence above all OS protocol levels.
   controlling process can set this option.
 
 - **`rcvbuf`** -
-  `BufSize :: (default | integer()>0) | {N :: integer()>0, BufSize :: (default | integer()>0)} `\-
+  `BufSize :: (auto | default | integer()>0) | {N :: integer()>0, BufSize :: (default | integer()>0)} `\-
   Receive buffer size.
 
-  The value `default` is only valid to _set_.
+  The values `auto` and `default` are only valid to _set_.
 
   `N` specifies the number of read attempts to do in a tight loop before
   assuming no more data is pending.
@@ -1093,6 +1093,15 @@ hence above all OS protocol levels.
   When the receive function returns the receive buffer is reallocated to the
   actually received size. If the data is copied or shrunk in place is up to
   the allocator, and can to some extent be configured in the Erlang VM.
+
+  The initial value is `auto`: the default size, which on a
+  [`stream`](`t:type/0`) socket is then adapted to the traffic. The buffer
+  grows when it is filled and shrinks back towards the default size when the
+  received amounts fall, so the sizes of the returned chunks vary. Setting a
+  size, or `default`, pins the buffer at that size and turns the adaptation
+  off, and `auto` turns it on again. `getopt` reports the configured size;
+  the adapted size is reported by `info/1` as the `rbuf` value.
+  Adaptation is not done on Windows.
 
   The similar socket option; `{socket,rcvbuf}` is a related option for the OS'
   protocol stack that on Unix corresponds to `SOL_SOCKET,SO_RCVBUF`.

--- a/lib/kernel/src/socket.erl
+++ b/lib/kernel/src/socket.erl
@@ -336,6 +336,7 @@ server(Addr, Port) ->
               eei/0,
 
               socket_counters/0,
+              socket_rbuf/0,
               socket_info/0,
 
               domain/0,
@@ -489,12 +490,25 @@ and the `t:otp_socket_option/0` with the same name.
                              acc_tries        := non_neg_integer(),
                              acc_waits        := non_neg_integer()}.
 
+-doc """
+Receive buffer sizes for a socket, in bytes.
+
+`configured` is the `rcvbuf` value of the `t:otp_socket_option/0`,
+`adapted` is the size the socket currently reads with, which for a
+stream socket follows the traffic up to an internal limit, and `held`
+is the size of the buffer the socket keeps allocated between reads.
+""".
+-type socket_rbuf() :: #{configured := non_neg_integer(),
+                         adapted    := non_neg_integer(),
+                         held       := non_neg_integer()}.
+
 -type socket_info() :: #{domain        := domain() | integer(),
                          type          := type() | integer(),
                          protocol      := protocol() | integer(),
                          owner         := pid(),
                          ctype         := normal | fromfd | {fromfd, integer()},
                          counters      := socket_counters(),
+                         rbuf          := socket_rbuf(),
                          num_readers   := non_neg_integer(),
                          num_writers   := non_neg_integer(),
                          num_acceptors := non_neg_integer(),

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -200,6 +200,10 @@
          api_opt_simple_otp_options/1,
          api_opt_simple_otp_meta_option/1,
          api_opt_simple_otp_rcvbuf_option/1,
+         api_opt_adaptive_otp_rcvbuf_option/1,
+         api_opt_adaptive_otp_rcvbuf_shrink/1,
+         api_opt_adaptive_otp_rcvbuf_idle/1,
+         api_opt_adaptive_otp_rcvbuf_idle_mem/1,
          api_opt_simple_otp_controlling_process/1,
          api_opt_sock_acceptconn_udp/1,
          api_opt_sock_acceptconn_tcp/1,
@@ -510,6 +514,10 @@ api_options_otp_cases() ->
      api_opt_simple_otp_options,
      api_opt_simple_otp_meta_option,
      api_opt_simple_otp_rcvbuf_option,
+     api_opt_adaptive_otp_rcvbuf_option,
+     api_opt_adaptive_otp_rcvbuf_shrink,
+     api_opt_adaptive_otp_rcvbuf_idle,
+     api_opt_adaptive_otp_rcvbuf_idle_mem,
      api_opt_simple_otp_controlling_process
     ].
 
@@ -12021,6 +12029,531 @@ api_opt_simple_otp_rcvbuf_option() ->
 
     i("await evaluator(s)"),
     ok = ?SEV_AWAIT_FINISH([Server, Client, Tester]).
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% The buffer used by a recv with Length = 0 on a stream socket adapts
+%% to the traffic while the (otp) rcvbuf option is 'auto', which is the
+%% initial value. Setting a size, or 'default', pins the buffer at that
+%% size (which bounds the returned chunks) as before, and 'auto' turns
+%% the adaptation back on. Dgram sockets read into the configured size
+%% as before. Adaptation is not implemented on Windows.
+api_opt_adaptive_otp_rcvbuf_option(_Config) when is_list(_Config) ->
+    ?TT(?SECS(30)),
+    tc_try(?FUNCTION_NAME,
+           fun() ->
+                   has_support_ipv4(),
+                   is_not_windows()
+           end,
+           fun() ->
+                   api_opt_adaptive_otp_rcvbuf_option()
+           end).
+
+api_opt_adaptive_otp_rcvbuf_option() ->
+    LSA = which_local_socket_addr(inet),
+
+    {ok, L} = socket:open(inet, stream, tcp),
+    ok = socket:bind(L, LSA#{port => 0}),
+    ok = socket:listen(L),
+    {ok, SSA}     = socket:sockname(L),
+    {ok, Default} = socket:getopt(L, otp, rcvbuf),
+
+    i("verify the buffer adapts to bulk traffic (default rcvbuf ~w)",
+      [Default]),
+    Bulk    = 64 * 1024 * 1024,
+    Client1 = aor_stream_client(SSA, Bulk),
+    {ok, S1} = socket:accept(L),
+    MaxChunk1 = aor_drain(S1, Bulk, 0),
+    i("max chunk: ~w", [MaxChunk1]),
+    if
+        MaxChunk1 > Default ->
+            ok;
+        true ->
+            exit({no_adaptation, MaxChunk1, Default})
+    end,
+    %% The adapted size is internal; getopt reports the configured size
+    {ok, Default} = socket:getopt(S1, otp, rcvbuf),
+    aor_stop_client(Client1),
+    _ = socket:close(S1),
+
+    i("verify an explicitly set rcvbuf bounds the chunks"),
+    Pinned  = 2048,
+    Bulk2   = 8 * 1024 * 1024,
+    Client2 = aori_client(SSA),
+    {ok, S2} = socket:accept(L),
+    ok = socket:setopt(S2, otp, rcvbuf, Pinned),
+    {ok, Pinned} = socket:getopt(S2, otp, rcvbuf),
+    aori_ask(Client2, {send, Bulk2}),
+    {Off1, MaxChunk2} = aori_drain(S2, Bulk2, 0, 0),
+    i("max chunk: ~w", [MaxChunk2]),
+    if
+        MaxChunk2 =< Pinned ->
+            ok;
+        true ->
+            exit({not_pinned, MaxChunk2, Pinned})
+    end,
+
+    i("verify 'default' pins the default size"),
+    ok = socket:setopt(S2, otp, rcvbuf, default),
+    {ok, Default} = socket:getopt(S2, otp, rcvbuf),
+    aori_ask(Client2, {send, Bulk2}),
+    {Off2, MaxChunk3} = aori_drain(S2, Bulk2, Off1, 0),
+    i("max chunk: ~w", [MaxChunk3]),
+    if
+        MaxChunk3 =< Default ->
+            ok;
+        true ->
+            exit({not_pinned, MaxChunk3, Default})
+    end,
+
+    i("verify 'auto' turns the adaptation back on"),
+    ok = socket:setopt(S2, otp, rcvbuf, auto),
+    {ok, Default} = socket:getopt(S2, otp, rcvbuf),
+    #{configured := Default, adapted := Default} = aori_rbuf(S2),
+    aori_ask(Client2, {send, Bulk2}),
+    {_Off3, MaxChunk4} = aori_drain(S2, Bulk2, Off2, 0),
+    i("max chunk: ~w", [MaxChunk4]),
+    if
+        MaxChunk4 > Default ->
+            ok;
+        true ->
+            exit({no_readaptation, MaxChunk4, Default})
+    end,
+    %% 'auto' only stands on its own
+    {error, _} = socket:setopt(S2, otp, rcvbuf, {2, auto}),
+    aor_stop_client(Client2),
+    _ = socket:close(S2),
+    _ = socket:close(L),
+
+    i("verify a dgram socket does not adapt"),
+    {ok, U} = socket:open(inet, dgram, udp),
+    ok = socket:bind(U, LSA#{port => 0}),
+    {ok, USA} = socket:sockname(U),
+    {ok, C}   = socket:open(inet, dgram, udp),
+    ok = socket:setopt(C, socket, sndbuf, 64 * 1024),
+    %% Datagrams that exactly fill the buffer would grow it if
+    %% adaptation was (wrongly) applied to dgram sockets
+    Fill = binary:copy(<<$x>>, Default),
+    Send = fun(Data) ->
+                   case socket:sendto(C, Data, USA) of
+                       ok                -> ok;
+                       {error, emsgsize} -> skip("dgram size not supported")
+                   end
+           end,
+    [begin
+         ok = Send(Fill),
+         {ok, D} = socket:recv(U, 0, ?SECS(5)),
+         Default = byte_size(D)
+     end || _ <- lists:seq(1, 8)],
+    %% An oversized datagram is still truncated at the configured size
+    ok = Send(binary:copy(<<$y>>, Default + 4096)),
+    {ok, T} = socket:recv(U, 0, ?SECS(5)),
+    i("oversized dgram read back as ~w bytes", [byte_size(T)]),
+    Default = byte_size(T),
+    _ = socket:close(C),
+    _ = socket:close(U),
+    ok.
+
+aor_stream_client(SSA, Bytes) ->
+    Self = self(),
+    spawn_monitor(
+      fun() ->
+              {ok, S} = socket:open(inet, stream, tcp),
+              ok = socket:connect(S, SSA),
+              Chunk = binary:copy(<<$x>>, 1024 * 1024),
+              aor_send(S, Chunk, Bytes),
+              receive
+                  {Self, stop} ->
+                      _ = socket:close(S),
+                      exit(normal)
+              end
+      end).
+
+aor_send(_S, _Chunk, Bytes) when Bytes =< 0 ->
+    ok;
+aor_send(S, Chunk, Bytes) ->
+    ok = socket:send(S, Chunk),
+    aor_send(S, Chunk, Bytes - byte_size(Chunk)).
+
+aor_drain(_S, Bytes, MaxChunk) when Bytes =< 0 ->
+    MaxChunk;
+aor_drain(S, Bytes, MaxChunk) ->
+    {ok, Data} = socket:recv(S, 0, ?SECS(10)),
+    Sz = byte_size(Data),
+    aor_drain(S, Bytes - Sz, max(Sz, MaxChunk)).
+
+aor_stop_client({Pid, MRef}) ->
+    Pid ! {self(), stop},
+    receive
+        {'DOWN', MRef, process, Pid, normal} ->
+            ok;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            exit({client, Reason})
+    end.
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% A stream socket that has been driven up to the adaptation ceiling
+%% and then only sees small messages shrinks its buffer back to the
+%% configured size, so a burst does not leave the socket reading into
+%% a large buffer for the rest of its life. The shrink follows an
+%% average of the read sizes, so it takes a run of small reads rather
+%% than one, and it must not get in the way of growing again.
+%% Adaptation is not implemented on Windows.
+api_opt_adaptive_otp_rcvbuf_shrink(_Config) when is_list(_Config) ->
+    ?TT(?SECS(60)),
+    tc_try(?FUNCTION_NAME,
+           fun() ->
+                   has_support_ipv4(),
+                   is_not_windows()
+           end,
+           fun() ->
+                   api_opt_adaptive_otp_rcvbuf_shrink()
+           end).
+
+api_opt_adaptive_otp_rcvbuf_shrink() ->
+    Bulk  = 8 * 1024 * 1024,
+    Small = 512,
+    Msgs  = 128,
+    LSA   = which_local_socket_addr(inet),
+
+    {ok, L} = socket:open(inet, stream, tcp),
+    ok = socket:bind(L, LSA#{port => 0}),
+    ok = socket:listen(L),
+    {ok, SSA}     = socket:sockname(L),
+    {ok, Default} = socket:getopt(L, otp, rcvbuf),
+
+    Client = aori_client(SSA),
+    {ok, S} = socket:accept(L),
+
+    i("drive the socket up to the adaptation ceiling "
+      "(configured rcvbuf ~w)", [Default]),
+    aori_ask(Client, {send, Bulk}),
+    {Off1, MaxChunk1} = aori_drain(S, Bulk, 0, 0),
+    #{configured := Default, adapted := Adapted} = aori_rbuf(S),
+    i("max chunk ~w, adapted ~w", [MaxChunk1, Adapted]),
+    if
+        (MaxChunk1 > Default) andalso (Adapted > Default) ->
+            ok;
+        true ->
+            exit({no_adaptation, MaxChunk1, Adapted, Default})
+    end,
+
+    i("trickle ~w messages of ~w bytes, one at a time", [Msgs, Small]),
+    Off2 = aors_trickle(Client, S, Off1, Small, Msgs),
+    #{configured := Default,
+      adapted    := AdaptedAfter,
+      held       := HeldAfter} = aori_rbuf(S),
+    i("after trickle: adapted ~w, held ~w", [AdaptedAfter, HeldAfter]),
+    if
+        AdaptedAfter =:= Default ->
+            ok;
+        true ->
+            exit({no_shrink, AdaptedAfter, Default, Adapted})
+    end,
+    if
+        HeldAfter =< Default ->
+            ok;
+        true ->
+            exit({buffer_not_released, HeldAfter, Default})
+    end,
+
+    i("resume bulk traffic and verify the buffer grows again"),
+    aori_ask(Client, {send, Bulk}),
+    {_Off3, MaxChunk2} = aori_drain(S, Bulk, Off2, 0),
+    i("max chunk after shrink: ~w", [MaxChunk2]),
+    if
+        MaxChunk2 > Default ->
+            ok;
+        true ->
+            exit({no_regrowth, MaxChunk2, Default})
+    end,
+
+    %% The adapted size stays internal
+    {ok, Default} = socket:getopt(S, otp, rcvbuf),
+
+    aor_stop_client(Client),
+    _ = socket:close(S),
+    _ = socket:close(L),
+    ok.
+
+%% Each message is sent and read back before the next is sent, so that
+%% every read is a small one.
+aors_trickle(_Client, _S, Off, _Small, 0) ->
+    Off;
+aors_trickle(Client, S, Off, Small, N) ->
+    aori_ask(Client, {send, Small}),
+    {Off1, _MaxChunk} = aori_drain(S, Small, Off, 0),
+    aors_trickle(Client, S, Off1, Small, N - 1).
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% The buffer that a recv with Length = 0 on a stream socket adapts to
+%% the traffic is kept on the socket between calls, so that a socket
+%% which is waiting for data does not have to allocate one when the data
+%% finally arrives. A socket that has been driven up to the adaptation
+%% ceiling and then goes quiet must not keep that (large) buffer: an
+%% idle socket may hold no more than the configured rcvbuf.
+%%
+%% What it must *not* do is reclaim the memory by giving up the
+%% adaptation - the adapted size has to survive the idle period, or the
+%% next burst starts over from the configured size. So both are checked:
+%% 'held' falls back to the configured size, 'adapted' does not move,
+%% and traffic that resumes is still read in adapted-size chunks with
+%% the bytes intact across the buffer change.
+%%
+%% Adaptation is not implemented on Windows.
+api_opt_adaptive_otp_rcvbuf_idle(_Config) when is_list(_Config) ->
+    ?TT(?SECS(60)),
+    tc_try(?FUNCTION_NAME,
+           fun() ->
+                   has_support_ipv4(),
+                   is_not_windows()
+           end,
+           fun() ->
+                   api_opt_adaptive_otp_rcvbuf_idle()
+           end).
+
+api_opt_adaptive_otp_rcvbuf_idle() ->
+    Bulk = 8 * 1024 * 1024,
+    Wake = 256 * 1024,
+    LSA  = which_local_socket_addr(inet),
+
+    {ok, L} = socket:open(inet, stream, tcp),
+    ok = socket:bind(L, LSA#{port => 0}),
+    ok = socket:listen(L),
+    {ok, SSA}     = socket:sockname(L),
+    {ok, Default} = socket:getopt(L, otp, rcvbuf),
+
+    Client = aori_client(SSA),
+    {ok, S} = socket:accept(L),
+
+    i("drive the socket up to the adaptation ceiling "
+      "(configured rcvbuf ~w)", [Default]),
+    aori_ask(Client, {send, Bulk}),
+    {Off1, MaxChunk1} = aori_drain(S, Bulk, 0, 0),
+    #{configured := Default, adapted := Adapted} = aori_rbuf(S),
+    i("max chunk ~w, adapted ~w", [MaxChunk1, Adapted]),
+    if
+        (MaxChunk1 > Default) andalso (Adapted > Default) ->
+            ok;
+        true ->
+            exit({no_adaptation, MaxChunk1, Adapted, Default})
+    end,
+
+    i("let the socket go idle: a recv that finds nothing"),
+    {error, timeout} = socket:recv(S, 0, ?SECS(1)),
+    #{configured := Default,
+      adapted    := AdaptedIdle,
+      held       := HeldIdle} = aori_rbuf(S),
+    i("idle: adapted ~w, held ~w", [AdaptedIdle, HeldIdle]),
+    if
+        HeldIdle =< Default ->
+            ok;
+        true ->
+            exit({buffer_not_released, HeldIdle, Default, AdaptedIdle})
+    end,
+    %% The memory is what should have been reclaimed, not the adaptation
+    if
+        AdaptedIdle =:= Adapted ->
+            ok;
+        true ->
+            exit({adaptation_lost, AdaptedIdle, Adapted})
+    end,
+
+    i("resume traffic and verify the bytes across the buffer change"),
+    aori_ask(Client, {send, Wake}),
+    {_Off2, MaxChunk2} = aori_drain(S, Wake, Off1, 0),
+    i("max chunk after idle: ~w", [MaxChunk2]),
+    if
+        MaxChunk2 > Default ->
+            ok;
+        true ->
+            exit({no_readaptation, MaxChunk2, Default})
+    end,
+
+    %% The adapted size stays internal, shrink or no shrink
+    {ok, Default} = socket:getopt(S, otp, rcvbuf),
+
+    aor_stop_client(Client),
+    _ = socket:close(S),
+    _ = socket:close(L),
+    ok.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% The same property as api_opt_adaptive_otp_rcvbuf_idle, but measured
+%% as memory over many sockets rather than read off one socket, since
+%% that is the shape the problem actually has: a lot of connections that
+%% saw a burst and went quiet.
+%%
+%% Every process is collected before sampling. Without that the sample
+%% is dominated by drained data that has not been collected yet, which
+%% is several times larger than the effect being measured.
+api_opt_adaptive_otp_rcvbuf_idle_mem(_Config) when is_list(_Config) ->
+    ?TT(?SECS(120)),
+    tc_try(?FUNCTION_NAME,
+           fun() ->
+                   has_support_ipv4(),
+                   is_not_windows()
+           end,
+           fun() ->
+                   api_opt_adaptive_otp_rcvbuf_idle_mem()
+           end).
+
+api_opt_adaptive_otp_rcvbuf_idle_mem() ->
+    N    = 32,
+    Bulk = 2 * 1024 * 1024,
+    LSA  = which_local_socket_addr(inet),
+
+    {ok, L} = socket:open(inet, stream, tcp),
+    ok = socket:bind(L, LSA#{port => 0}),
+    ok = socket:listen(L, N),
+    {ok, SSA}     = socket:sockname(L),
+    {ok, Default} = socket:getopt(L, otp, rcvbuf),
+
+    i("establish ~w connections", [N]),
+    Conns = [begin
+                 C = aori_client(SSA),
+                 {ok, S} = socket:accept(L, ?SECS(10)),
+                 %% One recv on an empty socket, so the baseline below
+                 %% already includes a configured-size buffer per socket
+                 %% and the delta is only what adaptation added
+                 {error, timeout} = socket:recv(S, 0, 0),
+                 {C, S}
+             end || _ <- lists:seq(1, N)],
+
+    Base = aori_binary_memory(),
+    i("baseline binary memory with ~w idle sockets: ~w bytes", [N, Base]),
+
+    i("drive every connection up to the adaptation ceiling"),
+    Adapted =
+        [begin
+             aori_ask(C, {send, Bulk}),
+             {_Off, _Max} = aori_drain(S, Bulk, 0, 0),
+             %% Leave it the way an idle server connection is left:
+             %% a recv that found nothing
+             {error, timeout} = socket:recv(S, 0, ?SECS(1)),
+             maps:get(adapted, aori_rbuf(S))
+         end || {C, S} <- Conns],
+
+    Ceiling = lists:sum(Adapted),
+    Allowed = N * Default * 4,
+    i("adapted: min ~w max ~w sum ~w (allowed after idle: ~w)",
+      [lists:min(Adapted), lists:max(Adapted), Ceiling, Allowed]),
+    if
+        %% Only assert when the ramp is large enough for the assertion
+        %% to mean anything. A machine too loaded to adapt skips rather
+        %% than fails.
+        Ceiling >= 4 * Allowed ->
+            ok;
+        true ->
+            skip({no_adaptation, Ceiling, Allowed, Default})
+    end,
+
+    After = aori_binary_memory(),
+    Delta = After - Base,
+    i("binary memory when idle: ~w (baseline ~w, delta ~w, allowed ~w; "
+      "sockets keeping their adapted buffers would hold ~w)",
+      [After, Base, Delta, Allowed, Ceiling]),
+    if
+        Delta =< Allowed ->
+            ok;
+        true ->
+            exit({buffer_not_released, Delta, Allowed, Ceiling})
+    end,
+
+    [begin aor_stop_client(C), _ = socket:close(S) end || {C, S} <- Conns],
+    _ = socket:close(L),
+    ok.
+
+
+aori_ask({Pid, _MRef}, Msg) ->
+    Pid ! {self(), Msg},
+    ok.
+
+aori_rbuf(S) ->
+    #{rbuf := RBuf} = socket:info(S),
+    RBuf.
+
+%% Collect every process before sampling, so that what is left is memory
+%% the runtime is holding rather than received binaries that simply have
+%% not been collected yet.
+aori_binary_memory() ->
+    ok = aori_gc_all(),
+    ok = aori_gc_all(),
+    erlang:memory(binary).
+
+aori_gc_all() ->
+    Ref = make_ref(),
+    Cnt = length([P || P <- erlang:processes(),
+                       async =:= erlang:garbage_collect(P, [{async, Ref}])]),
+    aori_await_gc(Ref, Cnt).
+
+aori_await_gc(_Ref, 0) ->
+    ok;
+aori_await_gc(Ref, Cnt) ->
+    receive
+        {garbage_collect, Ref, _} ->
+            aori_await_gc(Ref, Cnt - 1)
+    after ?SECS(10) ->
+            ok
+    end.
+
+%% A client that sends on command, so that a connection can be driven,
+%% left idle, and then driven again. It keeps its own stream offset so
+%% that both sides stay in step across the idle period.
+aori_client(SSA) ->
+    Self = self(),
+    spawn_monitor(
+      fun() ->
+              {ok, S} = socket:open(inet, stream, tcp),
+              ok = socket:connect(S, SSA),
+              aori_client_loop(Self, S, 0)
+      end).
+
+aori_client_loop(Owner, S, Off) ->
+    receive
+        {Owner, {send, Bytes}} ->
+            aori_client_loop(Owner, S, aori_client_send(S, Off, Bytes));
+        {Owner, stop} ->
+            _ = socket:close(S),
+            exit(normal)
+    end.
+
+aori_client_send(_S, Off, Bytes) when Bytes =< 0 ->
+    Off;
+aori_client_send(S, Off, Bytes) ->
+    Sz = min(64 * 1024, Bytes),
+    ok = socket:send(S, aori_data(Off, Sz)),
+    aori_client_send(S, Off + Sz, Bytes - Sz).
+
+%% Sz bytes of the stream, starting at offset Off. The stream is a
+%% repeating 0..255 ramp, so a chunk that has lost, duplicated or
+%% reordered bytes fails to match rather than merely being the wrong
+%% length.
+aori_data(Off, Sz) ->
+    Unit  = list_to_binary(lists:seq(0, 255)),
+    Start = Off rem 256,
+    binary:part(binary:copy(Unit, (Start + Sz) div 256 + 1), Start, Sz).
+
+aori_drain(_S, Bytes, Off, MaxChunk) when Bytes =< 0 ->
+    {Off, MaxChunk};
+aori_drain(S, Bytes, Off, MaxChunk) ->
+    {ok, Data} = socket:recv(S, 0, ?SECS(10)),
+    Sz = byte_size(Data),
+    case aori_data(Off, Sz) of
+        Data ->
+            aori_drain(S, Bytes - Sz, Off + Sz, max(Sz, MaxChunk));
+        _ ->
+            exit({corrupt_stream, Off, Sz})
+    end.
 
 
 

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -200,6 +200,7 @@
          api_opt_simple_otp_options/1,
          api_opt_simple_otp_meta_option/1,
          api_opt_simple_otp_rcvbuf_option/1,
+         api_opt_adaptive_otp_rcvbuf_option/1,
          api_opt_simple_otp_controlling_process/1,
          api_opt_sock_acceptconn_udp/1,
          api_opt_sock_acceptconn_tcp/1,
@@ -510,6 +511,7 @@ api_options_otp_cases() ->
      api_opt_simple_otp_options,
      api_opt_simple_otp_meta_option,
      api_opt_simple_otp_rcvbuf_option,
+     api_opt_adaptive_otp_rcvbuf_option,
      api_opt_simple_otp_controlling_process
     ].
 
@@ -12021,6 +12023,137 @@ api_opt_simple_otp_rcvbuf_option() ->
 
     i("await evaluator(s)"),
     ok = ?SEV_AWAIT_FINISH([Server, Client, Tester]).
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% The buffer used by a recv with Length = 0 on a stream socket adapts
+%% to the traffic, unless the (otp) rcvbuf option has been set, in
+%% which case that size is used (and bounds the returned chunks) as
+%% before. Dgram sockets read into the configured size as before.
+%% Adaptation is not implemented on Windows.
+api_opt_adaptive_otp_rcvbuf_option(_Config) when is_list(_Config) ->
+    ?TT(?SECS(30)),
+    tc_try(?FUNCTION_NAME,
+           fun() ->
+                   has_support_ipv4(),
+                   is_not_windows()
+           end,
+           fun() ->
+                   api_opt_adaptive_otp_rcvbuf_option()
+           end).
+
+api_opt_adaptive_otp_rcvbuf_option() ->
+    LSA = which_local_socket_addr(inet),
+
+    {ok, L} = socket:open(inet, stream, tcp),
+    ok = socket:bind(L, LSA#{port => 0}),
+    ok = socket:listen(L),
+    {ok, SSA}     = socket:sockname(L),
+    {ok, Default} = socket:getopt(L, otp, rcvbuf),
+
+    i("verify the buffer adapts to bulk traffic (default rcvbuf ~w)",
+      [Default]),
+    Bulk    = 64 * 1024 * 1024,
+    Client1 = aor_stream_client(SSA, Bulk),
+    {ok, S1} = socket:accept(L),
+    MaxChunk1 = aor_drain(S1, Bulk, 0),
+    i("max chunk: ~w", [MaxChunk1]),
+    if
+        MaxChunk1 > Default ->
+            ok;
+        true ->
+            exit({no_adaptation, MaxChunk1, Default})
+    end,
+    %% The adapted size is internal; getopt reports the configured size
+    {ok, Default} = socket:getopt(S1, otp, rcvbuf),
+    aor_stop_client(Client1),
+    _ = socket:close(S1),
+
+    i("verify an explicitly set rcvbuf bounds the chunks"),
+    Pinned  = 2048,
+    Bulk2   = 8 * 1024 * 1024,
+    Client2 = aor_stream_client(SSA, Bulk2),
+    {ok, S2} = socket:accept(L),
+    ok = socket:setopt(S2, otp, rcvbuf, Pinned),
+    MaxChunk2 = aor_drain(S2, Bulk2, 0),
+    i("max chunk: ~w", [MaxChunk2]),
+    if
+        MaxChunk2 =< Pinned ->
+            ok;
+        true ->
+            exit({not_pinned, MaxChunk2, Pinned})
+    end,
+    aor_stop_client(Client2),
+    _ = socket:close(S2),
+    _ = socket:close(L),
+
+    i("verify a dgram socket does not adapt"),
+    {ok, U} = socket:open(inet, dgram, udp),
+    ok = socket:bind(U, LSA#{port => 0}),
+    {ok, USA} = socket:sockname(U),
+    {ok, C}   = socket:open(inet, dgram, udp),
+    ok = socket:setopt(C, socket, sndbuf, 64 * 1024),
+    %% Datagrams that exactly fill the buffer would grow it if
+    %% adaptation was (wrongly) applied to dgram sockets
+    Fill = binary:copy(<<$x>>, Default),
+    Send = fun(Data) ->
+                   case socket:sendto(C, Data, USA) of
+                       ok                -> ok;
+                       {error, emsgsize} -> skip("dgram size not supported")
+                   end
+           end,
+    [begin
+         ok = Send(Fill),
+         {ok, D} = socket:recv(U, 0, ?SECS(5)),
+         Default = byte_size(D)
+     end || _ <- lists:seq(1, 8)],
+    %% An oversized datagram is still truncated at the configured size
+    ok = Send(binary:copy(<<$y>>, Default + 4096)),
+    {ok, T} = socket:recv(U, 0, ?SECS(5)),
+    i("oversized dgram read back as ~w bytes", [byte_size(T)]),
+    Default = byte_size(T),
+    _ = socket:close(C),
+    _ = socket:close(U),
+    ok.
+
+aor_stream_client(SSA, Bytes) ->
+    Self = self(),
+    spawn_monitor(
+      fun() ->
+              {ok, S} = socket:open(inet, stream, tcp),
+              ok = socket:connect(S, SSA),
+              Chunk = binary:copy(<<$x>>, 1024 * 1024),
+              aor_send(S, Chunk, Bytes),
+              receive
+                  {Self, stop} ->
+                      _ = socket:close(S),
+                      exit(normal)
+              end
+      end).
+
+aor_send(_S, _Chunk, Bytes) when Bytes =< 0 ->
+    ok;
+aor_send(S, Chunk, Bytes) ->
+    ok = socket:send(S, Chunk),
+    aor_send(S, Chunk, Bytes - byte_size(Chunk)).
+
+aor_drain(_S, Bytes, MaxChunk) when Bytes =< 0 ->
+    MaxChunk;
+aor_drain(S, Bytes, MaxChunk) ->
+    {ok, Data} = socket:recv(S, 0, ?SECS(10)),
+    Sz = byte_size(Data),
+    aor_drain(S, Bytes - Sz, max(Sz, MaxChunk)).
+
+aor_stop_client({Pid, MRef}) ->
+    Pid ! {self(), stop},
+    receive
+        {'DOWN', MRef, process, Pid, normal} ->
+            ok;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            exit({client, Reason})
+    end.
 
 
 


### PR DESCRIPTION
Calling recv with Length 0 reads into a fixed 8 KB buffer unless
`{otp, rcvbuf}` is set, so bulk transfers drain in 8 KB sips. Now a read
that fills the buffer doubles it (capped at 256 KB) and it halves back
towards the default once an EWMA of the read sizes drops below a quarter
of the buffer. Only stream sockets adapt; dgram sockets keep reading into
the configured size so truncation stays predictable, and
recvfrom/recvmsg/recvmmsg are unaffected.

`{otp, rcvbuf}` gains the value `auto`, which is the initial state: the
default size, adapted to the traffic. Setting a size, or `default`, pins
the buffer like before, since the configured value bounds what a Length 0
recv may return, and `auto` turns adaptation back on. getopt still
reports the configured value rather than the adapted one;
`socket:info/1` reports both, plus the buffer currently held, under a new
`rbuf` key.

A grown buffer is released when the reader is about to wait for data, so
a connection that took a burst and then went quiet holds no more than the
configured size. 4000 such connections went from 866 MB of binary memory
to 7.6 MB.

Draining a local bulk stream went from 4.2 to ~7.5 GB/s (M2 Pro). Caps
past 256 KB measured slower (~6.0 GB/s at 1 MB), matching the review
comments about diminishing returns.
