### PR TITLE
erl_interface: Fix buffer leak and state corruption on ei_x_buff real…

### DIFF
--- a/lib/erl_interface/src/misc/ei_x_encode.c
+++ b/lib/erl_interface/src/misc/ei_x_encode.c
@@ -69,9 +69,13 @@ int x_fix_buff(ei_x_buff* x, int szneeded)
 {
     int sz = szneeded + ei_x_extra;
     if (sz > x->buffsz) {
-	sz += ei_x_extra;	/* to avoid reallocating each and every time */
-	x->buffsz = sz;
-	x->buff = ei_realloc(x->buff, sz);
+        char* newbuff;
+        sz += ei_x_extra;       /* to avoid reallocating each and every time */
+        newbuff = ei_realloc(x->buff, sz);
+        if (newbuff == NULL)
+            return 0;           /* leave x->buff and x->buffsz intact on failure */
+        x->buff = newbuff;
+        x->buffsz = sz;
     }
     return x->buff != NULL;
 }


### PR DESCRIPTION
…loc failure

`x_fix_buff()` grew the `ei_x_buff` by assigning the result of `ei_realloc()`
directly back into `x->buff`, after having already updated `x->buffsz` to the
requested size:

```
    x->buffsz = sz;
    x->buff = ei_realloc(x->buff, sz);
```

When `ei_realloc()` fails it returns `NULL` without freeing the original
block. The old assignment therefore overwrote the only pointer to that
block (leaking it) and left the `ei_x_buff` in an inconsistent state:
`x->buff == NULL` while `x->buffsz` claimed sz bytes were available. A caller
that inspected buffsz, retried, or freed the buffer after the failed grow
acted on that false state.

Realloc into a temporary, and only commit `x->buff` and `x->buffsz` once the
allocation has succeeded. On failure the buffer and its size are left
untouched, so the `ei_x_buff` remains valid and truthful and the caller
still owns the original block. The success path is unchanged.