### PR TITLE
ssh: Close leaked SFTP connection in ssh_algorithms_SUITE

### DIFF
--- a/lib/ssh/test/ssh_algorithms_SUITE.erl
+++ b/lib/ssh/test/ssh_algorithms_SUITE.erl
@@ -301,7 +301,8 @@ simple_sftp(Config) ->
                {kex,_} -> [{preferred_algorithms,AlgEntries}];
                _ -> [{modify_algorithms,[{append,AlgEntries}]}]
            end,
-    ssh_test_lib:std_simple_sftp(Host, Port, Config, Opts).
+    {true, ConnectionRef} = ssh_test_lib:std_simple_sftp(Host, Port, Config, Opts),
+    ssh:close(ConnectionRef).
 
 %%--------------------------------------------------------------------
 %% A simple exec call


### PR DESCRIPTION
simple_sftp/1 did not close the connection returned by std_simple_sftp/4. With the shared daemon introduced in 876eba0270, leaked connections accumulated over the full suite run (~244 sockets), exhausting file descriptors on NetBSD and causing emfile errors in subsequent test cases.