### PR TITLE
Fix monitor of time_offset co-created with alias

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -5963,11 +5963,6 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
                 ASSERT(erts_monitor_is_origin(mon));
                 handle_persistent_mon_msg(c_p, &tracing, type, mon, sig,
                                           msg, next_nm_sig);
-
-                if ((mon->flags & ERTS_ML_STATE_ALIAS_MASK)
-                    == ERTS_ML_STATE_ALIAS_ONCE) {
-                    mon->flags &= ~ERTS_ML_STATE_ALIAS_MASK;
-                }
             }
             else {
                 cnt++;

--- a/erts/emulator/beam/erl_time_sup.c
+++ b/erts/emulator/beam/erl_time_sup.c
@@ -1999,7 +1999,7 @@ erts_demonitor_time_offset(ErtsMonitor *mon)
 typedef struct {
     Eterm pid;
     Eterm ref;
-    Eterm heap[ERTS_REF_THING_SIZE];
+    Eterm heap[ERTS_PID_REF_THING_SIZE];
 } ErtsTimeOffsetMonitorInfo;
 
 typedef struct {
@@ -2013,7 +2013,7 @@ save_time_offset_monitor(ErtsMonitor *mon, void *vcntxt, Sint reds)
     ErtsTimeOffsetMonitorContext *cntxt;
     ErtsMonitorData *mdp = erts_monitor_to_data(mon);
     Eterm *from_hp, *to_hp;
-    Uint mix;
+    Uint mix, sz;
     int hix;
 
     cntxt = (ErtsTimeOffsetMonitorContext *) vcntxt;
@@ -2022,11 +2022,13 @@ save_time_offset_monitor(ErtsMonitor *mon, void *vcntxt, Sint reds)
     cntxt->to_mon_info[mix].pid = mon->other.item;
     to_hp = &cntxt->to_mon_info[mix].heap[0];
 
-    ASSERT(is_internal_ordinary_ref(mdp->ref));
+    ASSERT(is_internal_ordinary_ref(mdp->ref)
+           || is_internal_pid_ref(mdp->ref));
     from_hp = internal_ref_val(mdp->ref);
-    ASSERT(thing_arityval(*from_hp) + 1 == ERTS_REF_THING_SIZE);
+    sz = thing_arityval(*from_hp) + 1;
+    ASSERT(sz <= ERTS_PID_REF_THING_SIZE);
 
-    for (hix = 0; hix < ERTS_REF_THING_SIZE; hix++)
+    for (hix = 0; hix < sz; hix++)
 	to_hp[hix] = from_hp[hix];
 
     cntxt->to_mon_info[mix].ref
@@ -2079,15 +2081,14 @@ send_time_offset_changed_notifications(void *new_offsetp)
 
     if (no_monitors) {
 	Eterm *hp, *patch_refp, new_offset_term, message_template;
-	Uint mix, hsz;
+        Uint mix, same_hsz;
 
 	/* Make message template */
 
 	hp = (Eterm *) (tmp + no_monitors*sizeof(ErtsTimeOffsetMonitorInfo));
 
-	hsz = 6; /* 5-tuple */
-	hsz += ERTS_REF_THING_SIZE;
-	hsz += ERTS_SINT64_HEAP_SIZE(new_offset);
+        same_hsz = 6; /* 5-tuple */
+        same_hsz += ERTS_SINT64_HEAP_SIZE(new_offset);
 
 	if (IS_SSMALL(new_offset))
 	    new_offset_term = make_small(new_offset);
@@ -2104,6 +2105,10 @@ send_time_offset_changed_notifications(void *new_offsetp)
 	ASSERT(*patch_refp == THE_NON_VALUE);
 
 	for (mix = 0; mix < no_monitors; mix++) {
+            Uint hsz = same_hsz;
+            Eterm *ref_hp = internal_ref_val(to_mon_info[mix].ref);
+            hsz += thing_arityval(*ref_hp) + 1;
+
             *patch_refp = to_mon_info[mix].ref;
             erts_proc_sig_send_monitor_time_offset_msg(*patch_refp,
                                                        to_mon_info[mix].pid,

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -102,6 +102,7 @@
          spawn_monitor_alias/1,
          demonitor_aliasmonitor/1,
          down_aliasmonitor/1,
+         monitor_time_offset_alias/1,
          monitor_tag/1,
          no_pid_wrap/1]).
 
@@ -196,6 +197,7 @@ groups() ->
      {alias, [],
       [alias_bif, monitor_alias, spawn_monitor_alias,
        demonitor_aliasmonitor, down_aliasmonitor,
+       monitor_time_offset_alias,
        dist_frag_alias, dist_frag_unaliased]}].
 
 init_per_suite(Config) ->
@@ -5358,6 +5360,84 @@ down_aliasmonitor(Config) when is_list(Config) ->
     %% remote use of the alias to stop working...
     RPid ! {alias, AliasMonitor},
     receive {alias_reply, AliasMonitor, RPid} -> ok end,
+    peer:stop(Peer),
+    ok.
+
+monitor_time_offset_alias(Config) when is_list(Config) ->
+    monitor_time_offset_alias_test(explicit_unalias),
+    monitor_time_offset_alias_test(demonitor),
+    monitor_time_offset_alias_test(reply_demonitor).
+
+monitor_time_offset_alias_test(Deactivate) ->
+    Me = self(),
+    {ok, Peer, Node} = ?CT_PEER(#{args => ["+C", "single_time_warp"]}),
+    TrySelfAlias = fun (Alias) ->
+                           Ref = make_ref(),
+                           Alias ! Ref,
+                           receive Ref -> active
+                           after 0 -> inactive
+                           end
+                   end,
+    Tester = spawn_link(Node,
+                        fun () ->
+                                MonAlias = monitor(time_offset, clock_service,
+                                                   [{alias, Deactivate}]),
+                                Me ! {self(), mon_alias, MonAlias},
+                                receive
+                                    {Me, finalize_time_offset} ->
+                                        ok
+                                end,
+                                preliminary = erlang:system_flag(time_offset, finalize),
+                                receive
+                                    {'CHANGE', MonAlias, time_offset, clock_service, _} ->
+                                        ok
+                                after
+                                    1000 ->
+                                        exit(missing_time_offset_change_message)
+                                end,
+                                Me ! {self(), finalized_time_offset},
+                                receive
+                                    {Me, alias_message} ->
+                                        Me ! {self(), alias_message}
+                                end,
+                                case Deactivate of
+                                    explicit_unalias ->
+                                        active = TrySelfAlias(MonAlias),
+                                        unalias(MonAlias);
+                                    demonitor ->
+                                        active = TrySelfAlias(MonAlias),
+                                        demonitor(MonAlias);
+                                    reply_demonitor ->
+                                        ok
+                                end,
+                                inactive = TrySelfAlias(MonAlias),
+                                receive
+                                    {Me, pid_message} ->
+                                        Me ! {self(), pid_message}
+                                end
+                        end),
+    Alias = receive
+                {Tester, mon_alias, MonAlias} ->
+                    MonAlias
+            end,
+    Tester ! {self(), finalize_time_offset},
+    receive
+        {Tester, finalized_time_offset} ->
+            ok
+    end,
+    Alias ! {self(), alias_message},
+    Tester ! {self(), pid_message},
+    receive
+        {Tester, alias_message} ->
+            ok;
+        {Tester, pid_message} ->
+            ct:fail(alias_did_not_work)
+    end,
+    receive
+        {Tester, pid_message} ->
+            ok
+    end,
+    unlink(Tester),
     peer:stop(Peer),
     ok.
 


### PR DESCRIPTION
A monitor of `time_offset` co-created with a process alias (`monitor(time_offset, clock_service, [{alias, _}])`) either crashed the runtime system or did not work. This bug was introduced in OTP 25.0.