### PR TITLE
ssl: Fix windows IOCP socket path

### DIFF
--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -670,10 +670,11 @@ do_async_send(Transport, Socket, Handle, Nextstate, Result,
             {keep_state_and_data, []};
         {completion, _} ->
             BuffSz = iolist_size(MsgQ),
+            #async{low = OldLow} = Async0,
             #async{high = High} = Async1 = new_async(StateData),
             Sent  = sent_data(completion, BuffSz),
-            Async = Async1#async{q_rev = [MsgQ], size = BuffSz, sent = Sent},
-            case BuffSz < High of
+            Async = Async1#async{q_rev = [MsgQ], size = BuffSz, sent = Sent, low = OldLow},
+            case OldLow > 0 andalso BuffSz < High of
                 true ->
                     send_reply(From, ok),
                     {next_state, Nextstate, StateData#data{buff = Async}};

--- a/lib/ssl/src/tls_sender.erl
+++ b/lib/ssl/src/tls_sender.erl
@@ -670,10 +670,14 @@ do_async_send(Transport, Socket, Handle, Nextstate, Result,
             {keep_state_and_data, []};
         {completion, _} ->
             BuffSz = iolist_size(MsgQ),
+            #async{low = OldLow} = Async0,
             #async{high = High} = Async1 = new_async(StateData),
             Sent  = sent_data(completion, BuffSz),
-            Async = Async1#async{q_rev = [MsgQ], size = BuffSz, sent = Sent},
-            case BuffSz < High of
+            %% Low = 0 is used as a marker for (renegotiate, alert, post_handshake_data) events
+            %% to keep the sender in async_wait until the buffer fully drains,
+            %% thus preserve old 'OldLow'
+            Async = Async1#async{q_rev = [MsgQ], size = BuffSz, sent = Sent, low = OldLow},
+            case OldLow > 0 andalso BuffSz < High of
                 true ->
                     send_reply(From, ok),
                     {next_state, Nextstate, StateData#data{buff = Async}};


### PR DESCRIPTION
When events (renegotiate, alert, post_handshake_data) arrive during an async send, they are postponed and low is set to 0 as a signal to keep the sender in async_wait until the buffer fully drains.

In do_async_send/6, the {completion, _} branch called new_async/1 which overwrote low with the default (4096), losing the signal. This caused unnecessary state ping-pong between async_wait and connection on Windows (IOCP) when postponed events were pending.

Preserve low from the original async record and guard the transition to connection on low > 0.