### PR TITLE
crypto: Fix DH private key length type mismatch

### DIFF
--- a/lib/crypto/c_src/dh.c
+++ b/lib/crypto/c_src/dh.c
@@ -44,6 +44,7 @@ ERL_NIF_TERM dh_compute_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 ERL_NIF_TERM dh_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {/* (PrivKey|undefined, DHParams=[P,G], 0, Len|0) */
     ErlNifUInt64 len = 0;
+    uint64_t ossl_len = 0;
     int i = 0;
     OSSL_PARAM params[8];
     EVP_PKEY *pkey = NULL, *pkey_gen = NULL;
@@ -96,7 +97,8 @@ ERL_NIF_TERM dh_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
         if (len >= BN_num_bits(p_bn)) {
             len = BN_num_bits(p_bn) - 1;
         }
-        params[i++] = OSSL_PARAM_construct_uint64("priv_len", &len);
+        ossl_len = len;
+        params[i++] = OSSL_PARAM_construct_uint64("priv_len", &ossl_len);
     }
     
     /* End of parameter fetching */

--- a/lib/crypto/c_src/dh.c
+++ b/lib/crypto/c_src/dh.c
@@ -43,8 +43,10 @@ ERL_NIF_TERM dh_compute_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM arg
 /* Has 3_0 */
 ERL_NIF_TERM dh_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {/* (PrivKey|undefined, DHParams=[P,G], 0, Len|0) */
-    ErlNifUInt64 len = 0;
-    uint64_t ossl_len = 0;
+    union {
+        ErlNifUInt64 erl;
+        uint64_t ossl;
+    } len;
     int i = 0;
     OSSL_PARAM params[8];
     EVP_PKEY *pkey = NULL, *pkey_gen = NULL;
@@ -88,17 +90,16 @@ ERL_NIF_TERM dh_generate_key_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
     */
 
     /* argv[3] is the length of the private key that is to be generated */
-    if (!enif_get_uint64(env, argv[3], &len) ||
-        (len > LONG_MAX) ) {
+    if (!enif_get_uint64(env, argv[3], &len.erl) ||
+        (len.erl > LONG_MAX) ) {
         ret = EXCP_BADARG_N(env, 3, "Bad value of length element");
         goto done;
     }
-    else if (len) {
-        if (len >= BN_num_bits(p_bn)) {
-            len = BN_num_bits(p_bn) - 1;
+    else if (len.erl) {
+        if (len.erl >= BN_num_bits(p_bn)) {
+            len.erl = BN_num_bits(p_bn) - 1;
         }
-        ossl_len = len;
-        params[i++] = OSSL_PARAM_construct_uint64("priv_len", &ossl_len);
+        params[i++] = OSSL_PARAM_construct_uint64("priv_len", &len.ossl);
     }
     
     /* End of parameter fetching */

--- a/lib/crypto/test/crypto_SUITE.erl
+++ b/lib/crypto/test/crypto_SUITE.erl
@@ -2189,7 +2189,11 @@ do_generate_compute({dh, P, G}) ->
     {UserPub, UserPriv} = crypto:generate_key(dh, [P, G]),
     {HostPub, HostPriv} = crypto:generate_key(dh, [P, G]),
     SharedSecret = crypto:compute_key(dh, HostPub, UserPriv, [P, G]),
-    SharedSecret = crypto:compute_key(dh, UserPub, HostPriv, [P, G]).
+    SharedSecret = crypto:compute_key(dh, UserPub, HostPriv, [P, G]),
+    {UserPubWithLen, UserPrivWithLen} = crypto:generate_key(dh, [P, G, 224]),
+    {HostPubWithLen, HostPrivWithLen} = crypto:generate_key(dh, [P, G, 224]),
+    SharedSecretWithLen = crypto:compute_key(dh, HostPubWithLen, UserPrivWithLen, [P, G]),
+    SharedSecretWithLen = crypto:compute_key(dh, UserPubWithLen, HostPrivWithLen, [P, G]).
     
 do_compute({ecdh = Type, Pub, Priv, Curve, SharedSecret}) ->
     ct:log("~p ~p", [Type,Curve]),


### PR DESCRIPTION
`enif_get_uint64()` writes through an `ErlNifUInt64 *`, while
`OSSL_PARAM_construct_uint64()` builds a parameter pointing to `uint64_t`
storage. On macOS arm64, those are equally wide but distinct C types:
`ErlNifUInt64` is `unsigned long`, while `uint64_t` is `unsigned long long`.

Fixes #11511

