### PR TITLE
Update mislabeled DO NOT example in efficiency guide

### DIFF
--- a/system/doc/efficiency_guide/binaryhandling.md
+++ b/system/doc/efficiency_guide/binaryhandling.md
@@ -61,7 +61,7 @@ rev_list_to_binary([], Acc) ->
 This is not efficient for long lists because the `Acc` binary is copied every
 time. One way to make the function more efficient is like this:
 
-**DO NOT**
+**DO**
 
 ```erlang
 rev_list_to_binary(List) ->


### PR DESCRIPTION
Based on the context, it seems to actually be a `DO` https://www.erlang.org/doc/system/binaryhandling.html.

It is followed by
> Note that in each of the DO examples, the binary to be appended to is always given as the first segment.
