### PR TITLE
mnesia: Release table fixes when coordinator dies

### DIFF
--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -659,6 +659,7 @@ recover_coordinator(Tid, Etabs) ->
 	    Protocol = asym_trans,
 	    tell_outcome(Tid, Protocol, node(), CheckNodes, TellNodes)
     end,
+    clear_fixtable(Etabs),
     erase_ets_tabs(Etabs),
     transaction_terminated(Tid),
     mnesia_locker:release_tid(Tid).

--- a/lib/mnesia/src/mnesia_tm.erl
+++ b/lib/mnesia/src/mnesia_tm.erl
@@ -655,6 +655,7 @@ recover_coordinator(Tid, Etabs) ->
 	    Protocol = asym_trans,
 	    tell_outcome(Tid, Protocol, node(), CheckNodes, TellNodes)
     end,
+    clear_fixtable(Etabs),
     erase_ets_tabs(Etabs),
     transaction_terminated(Tid),
     mnesia_locker:release_tid(Tid).

--- a/lib/mnesia/test/mnesia_atomicity_test.erl
+++ b/lib/mnesia/test/mnesia_atomicity_test.erl
@@ -35,6 +35,7 @@
          runtime_error_in_middle_of_trans/1,
          mnesia_down_during_infinite_trans/1,
          kill_self_in_middle_of_trans/1, throw_in_middle_of_trans/1,
+         fixtable_released_when_coordinator_dies/1,
          lock_waiter_sw_r/1, lock_waiter_sw_rt/1, lock_waiter_sw_wt/1,
          lock_waiter_wr_r/1, lock_waiter_srw_r/1, lock_waiter_sw_sw/1,
          lock_waiter_sw_w/1, lock_waiter_sw_wr/1, lock_waiter_sw_srw/1,
@@ -68,6 +69,7 @@ all() ->
     [explicit_abort_in_middle_of_trans,
      runtime_error_in_middle_of_trans,
      kill_self_in_middle_of_trans, throw_in_middle_of_trans,
+     fixtable_released_when_coordinator_dies,
      {group, mnesia_down_in_middle_of_trans}].
 
 groups() ->
@@ -257,6 +259,25 @@ kill_self_in_middle_of_trans(Config) when is_list(Config) ->
     ?match_receive({B, ok}),
     B ! end_trans,
     ?match_receive({B, {atomic, end_trans}}),
+
+    ?verify_mnesia(Nodes, []).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+fixtable_released_when_coordinator_dies(doc) ->
+    ["A table fixed by a transaction is unfixed when the coordinator dies"];
+fixtable_released_when_coordinator_dies(suite) -> [];
+fixtable_released_when_coordinator_dies(Config) when is_list(Config) ->
+    [Node1] = Nodes = ?acquire_nodes(1, Config),
+    Ram = fixtable_released_ram,
+    Disc = fixtable_released_disc,
+
+    ?match({atomic, ok}, mnesia:create_table([{name, Ram}, {type, set},
+                                              {ram_copies, [Node1]}])),
+    ?match({atomic, ok}, mnesia:create_table([{name, Disc}, {type, set},
+                                              {disc_only_copies, [Node1]}])),
+
+    check_fixtable_release(Ram),
+    check_fixtable_release(Disc),
 
     ?verify_mnesia(Nodes, []).
 
@@ -825,3 +846,42 @@ sync_tid_release() ->
     sys:get_status(whereis(mnesia_locker)),
     ok.
 
+check_fixtable_release(Tab) ->
+    ?match(ok, mnesia:dirty_write({Tab, 1, a})),
+
+    %% a transaction that ends by itself releases its fixes
+    ?match({atomic, ok},
+           mnesia:transaction(fun() -> mnesia:first(Tab), ok end)),
+    ?match({Tab, false}, {Tab, wait_until_fixed(Tab, false)}),
+
+    %% and so must a coordinator that is killed while holding one
+    Coord = spawn(fun() ->
+                          mnesia:transaction(
+                            fun() ->
+                                    mnesia:first(Tab),
+                                    timer:sleep(infinity)
+                            end)
+                  end),
+    ?match({Tab, true}, {Tab, wait_until_fixed(Tab, true)}),
+    exit(Coord, kill),
+    ?match({Tab, false}, {Tab, wait_until_fixed(Tab, false)}).
+
+%% The fix is released asynchronously
+wait_until_fixed(Tab, Expected) ->
+    wait_until_fixed(Tab, Expected, 100).
+
+wait_until_fixed(Tab, _Expected, 0) ->
+    is_fixed(Tab, mnesia:table_info(Tab, storage_type));
+wait_until_fixed(Tab, Expected, N) ->
+    case is_fixed(Tab, mnesia:table_info(Tab, storage_type)) of
+        Expected ->
+            Expected;
+        _ ->
+            timer:sleep(50),
+            wait_until_fixed(Tab, Expected, N - 1)
+    end.
+
+is_fixed(Tab, disc_only_copies) ->
+    dets:info(Tab, safe_fixed_monotonic_time) =/= false;
+is_fixed(Tab, _Storage) ->
+    ets:info(Tab, safe_fixed_monotonic_time) =/= false.

--- a/lib/mnesia/test/mnesia_atomicity_test.erl
+++ b/lib/mnesia/test/mnesia_atomicity_test.erl
@@ -31,6 +31,7 @@
          runtime_error_in_middle_of_trans/1,
          mnesia_down_during_infinite_trans/1,
          kill_self_in_middle_of_trans/1, throw_in_middle_of_trans/1,
+         fixtable_released_when_coordinator_dies/1,
          lock_waiter_sw_r/1, lock_waiter_sw_rt/1, lock_waiter_sw_wt/1,
          lock_waiter_wr_r/1, lock_waiter_srw_r/1, lock_waiter_sw_sw/1,
          lock_waiter_sw_w/1, lock_waiter_sw_wr/1, lock_waiter_sw_srw/1,
@@ -64,6 +65,7 @@ all() ->
     [explicit_abort_in_middle_of_trans,
      runtime_error_in_middle_of_trans,
      kill_self_in_middle_of_trans, throw_in_middle_of_trans,
+     fixtable_released_when_coordinator_dies,
      {group, mnesia_down_in_middle_of_trans}].
 
 groups() ->
@@ -253,6 +255,25 @@ kill_self_in_middle_of_trans(Config) when is_list(Config) ->
     ?match_receive({B, ok}),
     B ! end_trans,
     ?match_receive({B, {atomic, end_trans}}),
+
+    ?verify_mnesia(Nodes, []).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+fixtable_released_when_coordinator_dies(doc) ->
+    ["A table fixed by a transaction is unfixed when the coordinator dies"];
+fixtable_released_when_coordinator_dies(suite) -> [];
+fixtable_released_when_coordinator_dies(Config) when is_list(Config) ->
+    [Node1] = Nodes = ?acquire_nodes(1, Config),
+    Ram = fixtable_released_ram,
+    Disc = fixtable_released_disc,
+
+    ?match({atomic, ok}, mnesia:create_table([{name, Ram}, {type, set},
+                                              {ram_copies, [Node1]}])),
+    ?match({atomic, ok}, mnesia:create_table([{name, Disc}, {type, set},
+                                              {disc_only_copies, [Node1]}])),
+
+    check_fixtable_release(Ram),
+    check_fixtable_release(Disc),
 
     ?verify_mnesia(Nodes, []).
 
@@ -821,3 +842,42 @@ sync_tid_release() ->
     sys:get_status(whereis(mnesia_locker)),
     ok.
 
+check_fixtable_release(Tab) ->
+    ?match(ok, mnesia:dirty_write({Tab, 1, a})),
+
+    %% a transaction that ends by itself releases its fixes
+    ?match({atomic, ok},
+           mnesia:transaction(fun() -> mnesia:first(Tab), ok end)),
+    ?match({Tab, false}, {Tab, wait_until_fixed(Tab, false)}),
+
+    %% and so must a coordinator that is killed while holding one
+    Coord = spawn(fun() ->
+                          mnesia:transaction(
+                            fun() ->
+                                    mnesia:first(Tab),
+                                    timer:sleep(infinity)
+                            end)
+                  end),
+    ?match({Tab, true}, {Tab, wait_until_fixed(Tab, true)}),
+    exit(Coord, kill),
+    ?match({Tab, false}, {Tab, wait_until_fixed(Tab, false)}).
+
+%% The fix is released asynchronously
+wait_until_fixed(Tab, Expected) ->
+    wait_until_fixed(Tab, Expected, 100).
+
+wait_until_fixed(Tab, _Expected, 0) ->
+    is_fixed(Tab, mnesia:table_info(Tab, storage_type));
+wait_until_fixed(Tab, Expected, N) ->
+    case is_fixed(Tab, mnesia:table_info(Tab, storage_type)) of
+        Expected ->
+            Expected;
+        _ ->
+            timer:sleep(50),
+            wait_until_fixed(Tab, Expected, N - 1)
+    end.
+
+is_fixed(Tab, disc_only_copies) ->
+    dets:info(Tab, safe_fixed_monotonic_time) =/= false;
+is_fixed(Tab, _Storage) ->
+    ets:info(Tab, safe_fixed_monotonic_time) =/= false.


### PR DESCRIPTION
### Summary

A transaction that iterates a table leaks a `safe_fixtable` hold whenever its
coordinator dies abnormally. The table stays fixed for the lifetime of the node.

`mnesia:first/1`, `last/1`, `next/2`, `prev/2`, `select` and `select_reverse`
on anything but an `ordered_set` route through `do_fixtable/2`, which asks
`mnesia_tm` to fix the table. The fix is therefore taken **by the `mnesia_tm`
process**, not by the coordinator, so the automatic release that
`ets:safe_fixtable/2` and `dets:safe_fixtable/2` perform when the fixing process
dies never fires: `mnesia_tm` outlives the transaction. `mnesia_tm` has to
release the fix explicitly.

The normal termination path does that when it handles `{delete_transaction, Tid}`
(`mnesia_tm.erl:411`), but `recover_coordinator/2` never did.

An application cannot work around this, because the client process never owned
the fix.

### Which failures leak

Everything originating inside the transaction fun is handled correctly; only
signals arriving from outside the coordinator leak:

| failure mode | result |
| --- | --- |
| normal commit | clean |
| `mnesia:abort/1` | clean |
| exception in the fun | clean |
| `throw` in the fun | clean |
| lock conflict, transaction restarted | clean |
| `exit(Pid, kill)` | **leak** |
| `exit(Pid, shutdown)` | **leak** |
| linked parent dies, coordinator not trapping exits | **leak** |

### Impact

A fixed table never reclaims the space of deleted objects, so this is not merely
a leaked handle.

With one leaked fix, a `disc_only_copies` table under steady-state churn
(20000 rows deleted and 20000 reinserted per cycle, row count constant) grew
from 19 197 280 to 177 473 872 bytes over four cycles, roughly 39.5 MB per
cycle without bound. The same table with no leaked fix stayed flat at
19 402 600 bytes.

An `ets`-backed table retains every deleted tuple under a sliding-window
workload, 5.2x the clean control after four cycles at identical row count.

Two properties worth noting:

- The damage is **binary per table, not cumulative**. One leaked fix and fifty
  produce byte-identical results, since fixation is a refcount and the retained
  garbage depends on churn while fixed. A single kill is enough to disable space
  reclamation on a table permanently.
- The obvious workaround does not cover the worst case. `ordered_set` avoids the
  fix entirely, but mnesia rejects `ordered_set` with `disc_only_copies`
  (`{not_supported, ordered_set, disc_only_copies}`).

It is silent: no crash, no error return, and the only log is a `verbose/2`
"Coordinator died" that does not mention fixtables.

### Reproduction

```erlang
mnesia:create_table(foo, [{type, set}, {ram_copies, [node()]}]),
P = spawn(fun() -> mnesia:transaction(
        fun() -> mnesia:first(foo), timer:sleep(infinity) end) end),
timer:sleep(100),
exit(P, kill),
timer:sleep(100),

%% the table is still fixed, by the mnesia_tm process
{_, [{_, 1}]} = ets:info(foo, safe_fixed_monotonic_time).
```

### Age

The mechanism was introduced whole in mnesia 4.2 (OTP R10B, 2004-10-05) and was
already asymmetric there: `clear_fixtable` was wired into the
`delete_transaction` path but not into `recover_coordinator/2`. mnesia 4.1.12
(R9C-2) has neither `do_fixtable` nor `clear_fixtable`.

`git log -S'clear_fixtable' -- lib/mnesia/src/mnesia_tm.erl` returns a single
commit, `84adefa` "The R13B03 release", the initial import, so the defect
predates the git history.

### The change

One line in `recover_coordinator/2`, placed before `erase_ets_tabs/1` because
`clear_fixtable/1` reads the store that `erase_ets_tabs/1` destroys. This is the
same order the normal path uses.

Nested transactions are covered, because `copy_ets/2` copies the parent store
into each nested store, so `hd(Etabs)` carries all accumulated `fixtable`
entries.

### Test

`fixtable_released_when_coordinator_dies/1` in `mnesia_atomicity_test`, covering
both `ram_copies` and `disc_only_copies`. It asserts that a transaction ending by
itself releases its fix, that a fix is actually taken before the kill, and that
it is released after the coordinator is killed.

Verified to fail before the change (2 assertion failures, one per storage type)
and pass after it.

### Verification

- `mnesia_atomicity_test` 55/55 with the change, 54/55 without it (the new case
  being the failure)
- `mnesia_trans_access_test` 40/40, `mnesia_isolation_test` 48/48,
  `mnesia_evil_coverage_test` 55/55, identical with and without the change

Performance: `recover_coordinator/2` has a single caller, `handle_exit/3`,
reached only on abnormal coordinator death, so the normal transaction path is
untouched. Measured over 4 VM runs of 7 reps each, hot-path transaction
throughput is unchanged within run-to-run variance. The cold path costs
+1.9 us per abnormally terminated coordinator holding no fix (one
`ets:lookup/2` returning `[]`) and +5.9 us when a fix is held, which is the
release work that was previously skipped. `mnesia_tm` still recovers roughly
31 000 killed coordinators per second.

### Not addressed here

`mnesia.erl` takes the fix and records it in the transaction store in two
separate statements. A coordinator killed between them leaves a hold that
`clear_fixtable/1` cannot see, because it was never recorded. I confirmed the
window is reachable by widening it artificially, but it needs a different and
more invasive fix, so it is deliberately left out of this change.

### Caveats

Tested against an installed OTP 29.0.1 / mnesia 4.26 rather than a from-source
OTP tree, driving the suites through `mnesia_test_lib:eval_test_case/3`.
`./otp_build check` has therefore not been run.
