### PR TITLE
Fix erroneously created alias on spawn_request() noconnection

### DIFF
--- a/erts/emulator/beam/erl_proc_sig_queue.c
+++ b/erts/emulator/beam/erl_proc_sig_queue.c
@@ -4495,10 +4495,6 @@ convert_to_down_message(Process *c_p,
          */
 
         tag = save_heap_frag_eterm(c_p, mp, &mdep->u.name);
-        
-        /* Restore to normal monitor */
-        ASSERT(mdep->u.name == NIL);
-        mdp->origin.flags &= ~ERTS_ML_FLGS_SPAWN;
 
         ref = STORE_NC(&hp, ohp, mdp->ref);
         
@@ -5914,7 +5910,8 @@ erts_proc_sig_handle_incoming(Process *c_p, erts_aint32_t *statep,
                     erts_monitor_release(tmon);
             }
             else {
-                switch (omon->flags & ERTS_ML_STATE_ALIAS_MASK) {
+                switch (omon->flags & (ERTS_ML_STATE_ALIAS_MASK
+                                       | ERTS_ML_FLG_SPAWN_PENDING)) {
                 case ERTS_ML_STATE_ALIAS_UNALIAS: {
                     ErtsMonitorData *amdp;
                     ASSERT(is_internal_pid_ref(mdp->ref));

--- a/erts/emulator/test/process_SUITE.erl
+++ b/erts/emulator/test/process_SUITE.erl
@@ -5176,6 +5176,49 @@ spawn_monitor_alias(Config) when is_list(Config) ->
     spawn_monitor_alias_test(Peer3, Node3, spawn_request, normal),
     {ok, Peer4, Node4} = ?CT_PEER(),
     spawn_monitor_alias_test(Peer4, Node4, spawn_request, make_ref()),
+
+    %% Make sure we don't get a monitor alias if a spawn_request fails on noconnect...
+
+    {ok, Peer5, Node5} = ?CT_PEER(#{args => ["-kernel", "connect_all", "false"]}),
+    {ok, Peer6, Node6} = ?CT_PEER(#{args => ["-kernel", "connect_all", "false"]}),
+
+    ThisNode = node(),
+    ok = erpc:call(Node5, net_kernel, allow, [[ThisNode]]),
+    {ok, [ThisNode]} = erpc:call(Node5, net_kernel, allowed, []),
+    ok = erpc:call(Node6, net_kernel, allow, [[ThisNode]]),
+    {ok, [ThisNode]} = erpc:call(Node6, net_kernel, allowed, []),
+
+    wait_until(fun () ->
+                       _ = erpc:call(Node5, erlang, disconnect_node, [Node6]),
+                       _ = erpc:call(Node6, erlang, disconnect_node, [Node5]),
+                       Res5 = erpc:call(Node5, erlang, nodes, []),
+                       Res6 = erpc:call(Node6, erlang, nodes, []),
+                       Res5 == [ThisNode] andalso Res6 == [ThisNode]
+               end),
+
+    MonAliasFun =
+        fun (UnaliasOpt) ->
+                fun () ->
+                        erlang:yield(),
+                        MAF = spawn_request(Node6, fun () -> ok end,
+                                            [{monitor, [{alias, UnaliasOpt}]}]),
+                        MAF ! should_not_be_delivered_1,
+                        [{spawn_reply, MAF, ResType, Result}] = recv_msgs(1),
+                        error = ResType,
+                        noconnection = Result,
+                        MAF ! should_not_be_delivered_2,
+                        self() ! should_be_delivered,
+                        [should_be_delivered] = recv_msgs(1),
+                        ok
+                end
+        end,
+
+    ok = erpc:call(Node5, MonAliasFun(explicit_unalias)),
+    ok = erpc:call(Node5, MonAliasFun(reply_demonitor)),
+    ok = erpc:call(Node5, MonAliasFun(demonitor)),
+
+    peer:stop(Peer5),
+    peer:stop(Peer6),
     ok.
 
 spawn_monitor_alias_test(Peer, Node, SpawnType, ExitReason) ->
@@ -5293,6 +5336,29 @@ spawn_monitor_alias_test(Peer, Node, SpawnType, ExitReason) ->
     M_5 = monitor(process, P5),
     P5 ! {alias, MA5},
     [{MA5,1},{'DOWN', M_5, _, _, ExitReason}] = recv_msgs(2),
+
+    if SpawnType == spawn_request ->
+            %% Make sure we don't get a monitor alias if a spawn_request fails on badopt...
+            MonAliasFun =
+                fun (UnaliasOpt) ->
+                        erlang:yield(),
+                        MAF = spawn_request(Node, fun () -> ok end,
+                                            [{monitor, [{alias, UnaliasOpt}]}, invalid_opt]),
+                        MAF ! should_not_be_delivered_1,
+                        [{spawn_reply, MAF, ResType, Result}] = recv_msgs(1),
+                        error = ResType,
+                        badopt = Result,
+                        MAF ! should_not_be_delivered_2,
+                        self() ! should_be_delivered,
+                        [should_be_delivered] = recv_msgs(1),
+                        ok
+                end,
+            MonAliasFun(explicit_unalias),
+            MonAliasFun(reply_demonitor),
+            MonAliasFun(demonitor);
+       true ->
+            ok
+    end,
 
     case Node == node() of
         true ->


### PR DESCRIPTION
A process alias was erroneously created when a remote `spawn_request()` operation with a `{monitor, [{alias, explicit_unalias}]}` option failed with `noconnection` reason.