### PR TITLE
erts: Skip pollset update on scheduler-polled re-arm

### DIFF
--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -1409,6 +1409,17 @@ enif_select_x(ErlNifEnv* env,
 #endif
     }
 
+#if ERTS_POLL_USE_SCHEDULER_POLLING
+    if (on && ctl_op == ERTS_POLL_OP_MOD && ctl_events == ERTS_POLL_EV_IN
+        && state->flags & ERTS_EV_FLAG_IN_SCHEDULER) {
+        /* Re-arming a read select on an fd that is still registered
+         * for IN in the scheduler pollset. Neither pollset changes:
+         * IN stays enabled where it is, and the events carried by the
+         * normal pollset are not touched by this call. */
+        new_events = state->active_events;
+    }
+    else
+#endif
     if (ctl_events || ctl_op == ERTS_POLL_OP_DEL) {
 
         new_events = erts_io_control_wakeup(state,

--- a/erts/emulator/sys/common/erl_check_io.c
+++ b/erts/emulator/sys/common/erl_check_io.c
@@ -2148,7 +2148,18 @@ erts_check_io(ErtsPollThread *psi, ErtsMonotonicTime timeout_time, bool needs_th
                         state->driver.nif->err.mp = NULL;
                     }
                 }
-                state->events &= ~revents;
+#if ERTS_POLL_USE_SCHEDULER_POLLING
+                /* An FD migrated to the scheduler pollset stays
+                 * registered for IN across triggers; keeping the event
+                 * in state->events lets the re-arming enif_select
+                 * become a no-op instead of a pollset update. Repeat
+                 * messages are already prevented by in.pid being
+                 * cleared above. */
+                if (state->flags & ERTS_EV_FLAG_IN_SCHEDULER)
+                    state->events &= ~(revents & ~ERTS_POLL_EV_IN);
+                else
+#endif
+                    state->events &= ~revents;
             }
             else if (revents & ERTS_POLL_EV_NVAL) {
                 bad_fd_in_pollset(state, NIL, NIL);


### PR DESCRIPTION
Since the scheduler pollset migration for enif_select (OTP 28), an fd
that keeps getting re-armed for reads by the same process is moved to
the scheduler pollset, where it stays registered for IN events and
re-arming is meant to be free. That never happens in practice: the
control path is entered on every re-arm and, while the scheduler
pollset part is already short-circuited, it still falls through to an
epoll_ctl(MOD) with an empty event set on the normal pollset. One
syscall per wakeup, changing nothing.

This skips the pollset update when re-arming a read select on an fd
that is enabled in the scheduler pollset. Nothing changes in either
pollset in that case: IN stays enabled in the scheduler pollset and
the normal pollset only carries the other events, which the call does
not touch. The trigger handler still clears IN from state->events, so
an fd that stops being re-armed migrates back to a poll thread as
before, and cancel/stop still go through the control path.

With a pipelined request/response socket NIF workload (64 callers,
16 connections), epoll_ctl calls drop from one per wakeup (~156k per
350k requests) to connection setup only (~240), worth ~2% end-to-end
throughput on 8 cores.