### PR TITLE
kernel: Fix send_timeout_active deadlock on large socket buffers

### DIFF
--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -7121,12 +7121,14 @@ oki({ok, V}) -> V;
 oki(E)       -> E.
 
 setup_active_timeout_sink(Config, RNode, Addr, Timeout, AutoClose) ->
+    BufSz = 16 * 1024,
     ListenOpts =  [binary,
                    {ifaddr,             Addr},
 		   {active,             false},
 		   {packet,             0},
 		   {nodelay,            true},
 		   {keepalive,          true},
+                   {sndbuf,             BufSz},
 		   {send_timeout,       Timeout},
 		   {send_timeout_close, AutoClose}],
     {ok, L} = ?LISTEN(Config, 0, ListenOpts),
@@ -7147,7 +7149,9 @@ setup_active_timeout_sink(Config, RNode, Addr, Timeout, AutoClose) ->
 	     end,
     {ok, C} = Remote(fun() ->
 			     ?CONNECT(Config, Addr, Port, [{ip,     Addr},
-			                                   {active, false}])
+                                                           {active, false},
+                                                           {recbuf, BufSz div 2},
+                                                           {sndbuf, BufSz div 2}])
 		     end),
     {ok, A} = gen_tcp:accept(L),
     gen_tcp:send(A, "Hello"),


### PR DESCRIPTION
Adjust send buffer similarly to 300fefecb850de2baa5 to avoid live-lock.