### PR TITLE
erts: Only translate \r\n on character devices in fd ports

### DIFF
--- a/erts/emulator/sys/win32/sys.c
+++ b/erts/emulator/sys/win32/sys.c
@@ -2179,7 +2179,11 @@ fd_start(ErlDrvPort port_num, char* name, SysDriverOpts* opts)
 	    return ERL_DRV_ERROR_GENERAL;
 	}
 	
-	dp->in.flags = DF_XLAT_CR;
+        /* If input is a terminal, we translate \r\n to \n */
+        if (GetFileType((HANDLE)opts->ifd) == FILE_TYPE_CHAR) {
+            dp->in.flags = DF_XLAT_CR;
+        }
+        
 	if (is_std_error) {
 	    dp->out.flags |= DF_DROP_IF_INVH; /* Just drop messages if stderror
 						 is an invalid handle */


### PR DESCRIPTION
If the input handle is a pipe or something different we don't want to do any translation at all, but if it is a character device we translate \r\n to \n so that it mimics how terminals on Linux works a little bit better. As open_port fd is not used anymore for the normal erlang terminal this change only effects thirdparty usage which usually is from pipes that do not want any translation to happen.

Closes #10258