### PR TITLE
tools: Honor set_on_spawn for tprof rootsets

### DIFF
--- a/lib/tools/src/tprof.erl
+++ b/lib/tools/src/tprof.erl
@@ -706,8 +706,6 @@ enable_trace(Spec, Options) ->
 enable_trace(Server, Spec, Options) ->
     enable_session_trace(get_session(Server), Spec, Options).
 
-enable_session_trace(Session, Spec) ->
-    enable_session_trace(Session, Spec, default_trace_options()).
 enable_session_trace(Session, Procs, Options) when Procs =:= all; Procs =:= new; Procs =:= existing ->
     trace:process(Session, Procs, true, trace_options(Options));
 enable_session_trace(Session, {Children, PidOrName}, Options) when Children =:= children; Children =:= all_children ->
@@ -1402,7 +1400,7 @@ ad_hoc_run(Session, What, Options, Map, Type) ->
     %% enable tracing for items in the rootset
     RootSet = maps:get(rootset, Options, []),
     %% ignore errors when setting up rootset trace
-    _ = enable_session_trace(Session, RootSet),
+    _ = enable_session_trace(Session, RootSet, Options),
 
     %% spawn a separate process to run the user-supplied MFA
     %% if RootSet is 'all' or 'new', skip the trace flags

--- a/lib/tools/test/tprof_SUITE.erl
+++ b/lib/tools/test/tprof_SUITE.erl
@@ -309,7 +309,29 @@ rootset(Config) when is_list(Config) ->
     {ok, ProfAll} = tprof:profile(Fun, #{rootset => all, report => return, type => call_memory}),
     %% at least tprof, pg2 and new profiled processes are traced
     ?assert(map_size(tprof:inspect(ProfAll)) >= 3),
-    gen_server:stop(Scope).
+    gen_server:stop(Scope),
+
+    %% Processes spawned by a rootset process must honor set_on_spawn too.
+    Root = spawn_link(fun() ->
+        receive
+            {spawn_child, From} ->
+                _ = lists:seq(1, 32),
+                {Child, MRef} = spawn_monitor(fun() -> lists:seq(1, 32) end),
+                receive
+                    {'DOWN', MRef, process, Child, normal} ->
+                        From ! {spawned, Child}
+                end
+        end
+    end),
+    {Child, NoSpawnProfile} = tprof:profile(
+        fun() ->
+            Root ! {spawn_child, self()},
+            receive {spawned, Pid} -> Pid end
+        end, #{rootset => [Root], set_on_spawn => false,
+               pattern => {lists, seq_loop, 3}, report => return, type => call_memory}),
+    Inspected = tprof:inspect(NoSpawnProfile),
+    ?assert(maps:is_key(Root, Inspected)),
+    ?assertNot(maps:is_key(Child, Inspected)).
 
 set_on_spawn() ->
     [{doc, "Tests tprof running with extra spawned processes"}].


### PR DESCRIPTION
Pass ad-hoc profiling options when enabling rootset tracing so `set_on_spawn => false` is honored. Remove the now-unused default-options wrapper and add regression coverage verifying that the rootset process remains traced while its spawned child is excluded.

Tests: `tprof_SUITE` (23 passed).