### PR TITLE
Avoid signed int overflows

### DIFF
--- a/erts/emulator/beam/packet_parser.c
+++ b/erts/emulator/beam/packet_parser.c
@@ -481,14 +481,14 @@ more:
     return 0;
 
 remain:
-    {
-        int tlen = hlen + plen;
-	if ((max_plen != 0 && plen > max_plen)
-	    || tlen < (int)hlen) { /* wrap-around protection */
-	    return -1;
-	}
-	return tlen;
-    }		
+    ASSERT(INT_MAX >= hlen);
+    if (max_plen == 0) {
+        max_plen = INT_MAX - hlen;
+    }
+    if (plen > max_plen) {
+        return -1;
+    }
+    return hlen + plen;
 
 done:
     return plen;

--- a/erts/emulator/drivers/common/inet_drv.c
+++ b/erts/emulator/drivers/common/inet_drv.c
@@ -11465,7 +11465,12 @@ static int tcp_expand_buffer(tcp_descriptor* desc, int len)
     int offs1;
     int offs2;
     int used = desc->i_ptr_start - desc->i_buf->orig_bytes;
-    int ulen = used + len;
+    int ulen;
+
+    if (len > INT_MAX - used) {
+        return -1;
+    }
+    ulen = used + len;
 
     if (desc->i_bufsz >= ulen) /* packet will fit */
 	return 0;

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -109,7 +109,8 @@
          otp_18883/1,
 	 otp_18707/1,
          otp_19560_inet/1, otp_19560_inet6/1,
-         send_block_unblock/1
+         send_block_unblock/1,
+         cve_2026_75538/1
 	]).
 
 %% Internal exports.
@@ -239,7 +240,8 @@ all_std_cases() ->
      {group, socket_monitor},
      otp_17492,
      otp_18707,
-     send_block_unblock
+     send_block_unblock,
+     cve_2026_75538
     ].
 
 ticket_cases() ->
@@ -9824,6 +9826,90 @@ payload(0, Bin) -> Bin;
 payload(N, Bin) ->
     C = rand:uniform($z - $0 + 1) + $0,
     payload(N - 1, <<Bin/binary, C>>).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+cve_2026_75538(Config) when is_list(Config) ->
+    %%
+    %% Test in a peer node since when it fails the node crashes
+    %%
+    {ok, Peer, Node} =
+        test_server:start_peer([], ?MODULE, ?FUNCTION_NAME),
+
+    try
+        _ = process_flag(trap_exit, true),
+
+        Ref    = make_ref(),
+        Pid = spawn_link(Node, fun () -> exit({Ref,cve_2026_75538_test()}) end),
+        receive
+            {'EXIT', Pid, {Ref, ok}} ->
+                ok;
+            {'EXIT', Pid, Other} ->
+                error({'EXIT', Other})
+        end,
+
+        case flush([]) of
+            [] ->
+                ok;
+            Garbage ->
+                error({garbage, Garbage})
+        end
+
+    after
+        try peer:stop(Peer)
+        catch _ : _ -> ok
+        end
+    end.
+
+cve_2026_75538_test() ->
+    %% Buffer overflow in inet_drv for {packet,4}
+    %% when receiving a packet of size just below INT_MAX
+
+    %% A 1 KB binary
+    BinK = binary:copy(<<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>>, 16*4),
+    %% A 16 MB binary
+    Bulk = binary:copy(BinK, 16 bsl 10),
+
+    %% A packet of size 4 followed by an attack packet
+    Data = <<4:32, 1,2,3,4, 16#7FFF_FFFB:32, Bulk/binary>>,
+    %%
+    %% The first small packet lingers in the receive buffer,
+    %% and the calculation in tcp_expand_buffer with the resulting
+    %% length 16#7FFF_FFFF (16#7FFF_FFFB + 4 (header size))
+    %% plus the lingering packet size 5 will overflow to a negative
+    %% number which is less than the currently allocated size,
+    %% so the buffer is not expanded.
+    %%
+    %% After this the Bulk data is received into the small initial buffer
+    %% and destroys allocator metadata and subsequent blocks.
+    %%
+    %% The Bulk Data should be large enough to overwrite most of the VM
+    %% after the inet_drv buffer, so it should crash.
+
+    Parent = self(),
+    _ = spawn_link( % Watchdog
+          fun () ->
+                  receive
+                  after 20_000 ->
+                          exit(Parent, timeout)
+                  end
+          end),
+    {ok, L} = gen_tcp:listen(0, [{packet,4}, {active, true}]),
+    {ok, Port} = inet:port(L),
+    {ok, C} = gen_tcp:connect({127,0,0,1}, Port, []),
+    {ok, A} = gen_tcp:accept(L),
+    ok = gen_tcp:close(L),
+    ok = gen_tcp:send(C, Data),
+    gen_tcp:close(C),
+    receive {tcp, A, [1,2,3,4]} -> ok end,
+    receive {tcp_error, A, emsgsize} -> ok end,
+    receive {tcp_closed, A} -> ok end,
+    gen_tcp:close(A),
+    case flush([]) of
+        [] -> ok;
+        Garbage ->
+            exit({peer_garbage, Garbage})
+    end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This is a patch for [CVE-2026-75538](https://cna.erlef.org/cves/CVE-2026-75538.html).

See the security advisory [GHSA-8m6r-2pj2-25pm](https://github.com/erlang/otp/security/advisories/GHSA-8m6r-2pj2-25pm): A Signed Length Overflow in Erlang/OTP's inet TCP Driver Overflows the Receive Buffer Into BEAM VM Memory From an Unauthenticated Peer