### PR TITLE
erl_parse: Fix abstract/1 to handle unicode binary strings

### DIFF
--- a/lib/stdlib/src/erl_parse.yrl
+++ b/lib/stdlib/src/erl_parse.yrl
@@ -2015,11 +2015,12 @@ annotation contains the location given by option `location` or by option `line`.
 Option `location` overrides option `line`. If neither option `location` nor
 option `line` is given, `0` is used as location.
 
-Option `Encoding` is used for selecting which integer lists to be considered as
-strings. The default is to use the encoding returned by function
-`epp:default_encoding/0`. Value `none` means that no integer lists are
-considered as strings. `encoding_func()` is called with one integer of a list at
-a time; if it returns `true` for every integer, the list is considered a string.
+Option `Encoding` is used for selecting which integer lists or binaries to
+be considered as strings. The default is to use the encoding returned by function
+`epp:default_encoding/0`. Value `none` means that nothing is considered a string.
+`encoding_func()` is called with one character of a list or binary at
+a time; if it returns `true` for every character, the list or binary is considered
+a string. For binaries it is the decoded utf-8 character that is passed to `encoding_func()`. If the binary is not valid utf-8, it is not considered a string.
 """.
 -doc(#{since => <<"OTP R16B01">>}).
 -spec abstract(Data, Options) -> AbsTerm when
@@ -2049,14 +2050,9 @@ abstract(T, Location) ->
     Anno = erl_anno:new(Location),
     abstract(T, Anno, enc_func(epp:default_encoding())).
 
--define(UNICODE(C),
-         (C < 16#D800 orelse
-          C > 16#DFFF andalso C < 16#FFFE orelse
-          C > 16#FFFF andalso C =< 16#10FFFF)).
-
-enc_func(latin1) -> fun(C) -> C < 256 end;
-enc_func(unicode) -> fun(C) -> ?UNICODE(C) end;
-enc_func(utf8) -> fun(C) -> ?UNICODE(C) end;
+enc_func(latin1) -> fun(C) -> io_lib:printable_latin1_list([C]) end;
+enc_func(unicode) -> fun(C) -> io_lib:printable_unicode_list([C]) end;
+enc_func(utf8) -> enc_func(unicode);
 enc_func(none) -> none;
 enc_func(Fun) when is_function(Fun, 1) -> Fun;
 enc_func(Term) -> erlang:error({badarg, Term}).
@@ -2065,6 +2061,23 @@ abstract(T, A, _E) when is_integer(T) -> {integer,A,T};
 abstract(T, A, _E) when is_float(T) -> {float,A,T};
 abstract(T, A, _E) when is_atom(T) -> {atom,A,T};
 abstract([], A, _E) -> {nil,A};
+abstract(B, A, E) when is_binary(B), is_function(E) ->
+    maybe
+        List = unicode:characters_to_list(B, utf8),
+        true ?= is_list(List),
+        {string, _, String} ?= abstract_list(List, [], A, E),
+        Encoding =
+            case is_ascii_string(String) of
+                true ->
+                    default;
+                false ->
+                    [utf8]
+            end,
+        {bin, A, [{bin_element, A, {string, A, String}, default, Encoding}]}
+    else
+        _ ->
+            {bin, A, [abstract_byte(Byte, A) || Byte <- binary_to_list(B)]}
+    end;
 abstract(B, A, _E) when is_bitstring(B) ->
     {bin, A, [abstract_byte(Byte, A) || Byte <- bitstring_to_list(B)]};
 abstract([H|T], A, none=E) ->
@@ -2087,6 +2100,9 @@ abstract(Fun, A, E) when is_function(Fun) ->
                         abstract(F, A, E),
                         abstract(Arity, A, E)}}
     end.
+
+is_ascii_string(L) ->
+    lists:all(fun(C) -> C >= 0 andalso C < 128 end, L).
 
 abstract_list([H|T], String, A, E) ->
     case is_integer(H) andalso H >= 0 andalso E(H) of

--- a/lib/stdlib/test/erl_pp_SUITE.erl
+++ b/lib/stdlib/test/erl_pp_SUITE.erl
@@ -53,6 +53,7 @@
           form_vars/1,
 	  quoted_atom_types/1,
           native_records/1,
+          unicode_binary_attributes/1,
 
 	  otp_6321/1, otp_6911/1, otp_6914/1, otp_8150/1, otp_8238/1,
 	  otp_8473/1, otp_8522/1, otp_8567/1, otp_8664/1, otp_9147/1,
@@ -85,7 +86,10 @@ groups() ->
        messages, maps_syntax, quoted_atom_types,
        format_options, form_vars, native_records
     ]},
-     {attributes, [], [misc_attrs, import_export, dialyzer_attrs]},
+     {attributes, [], [misc_attrs,
+                       import_export,
+                       dialyzer_attrs,
+                       unicode_binary_attributes]},
      {tickets, [],
       [otp_6321, otp_6911, otp_6914, otp_8150, otp_8238,
        otp_8473, otp_8522, otp_8567, otp_8664, otp_9147,
@@ -1434,6 +1438,22 @@ eep58(_Config) ->
 
     ok.
 
+unicode_binary_attributes(_) ->
+
+    assert_same(~s'-doc(<<"">>).\n'),
+    assert_same(~s'-doc(<<"abc">>).\n'),
+    assert_same(~s'-doc(<<255>>).\n'),
+    assert_same(~s'-doc(<<"åäö"/utf8>>).\n', [{encoding,unicode}]),
+    assert_same(~s'-doc(<<"😀"/utf8>>).\n', [{encoding,unicode}]),
+    assert_same(~s'-doc(<<255>>).\n', [{encoding,unicode}]),
+
+    %% åäö in latin1 is not valid unicode, so it is printed as bytes.
+    assert_same(~s'-doc(<<229,228,246>>).\n', [{encoding,latin1}]),
+    assert_same(~s'-doc(<<240,159,152,128>>).\n', [{encoding,latin1}]),
+
+
+    ok.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 compile(Config, Tests) ->
@@ -1623,8 +1643,11 @@ filename(Name, Config) ->
 fail() ->
     ct:fail(failed).
 
-assert_same(Expected) when is_list(Expected) ->
-    Actual = binary_to_list(iolist_to_binary(parse_and_pp_forms(Expected, []))),
+assert_same(Expected) ->
+    assert_same(Expected, []).
+
+assert_same(Expected, Options) when is_list(Expected) ->
+    Actual = unicode:characters_to_list(unicode:characters_to_binary(parse_and_pp_forms(Expected, Options))),
     case Expected == Actual of
       true -> ok;
       false -> error({Expected, Actual})

--- a/lib/stdlib/test/erl_scan_SUITE.erl
+++ b/lib/stdlib/test/erl_scan_SUITE.erl
@@ -1280,7 +1280,10 @@ otp_10302(Config) when is_list(Config) ->
              erl_parse_abstract([{a} | b], Opts2),
          {string,Line,"str"} = erl_parse_abstract("str", Opts2),
          {string,Line,[97,1024,99]} =
-             erl_parse_abstract("a"++[1024]++"c", Opts2)
+             erl_parse_abstract("a"++[1024]++"c", Opts2),
+         {bin,Line,
+          [{bin_element,Line,{string,Line,[97,1024,99]},default,[utf8]}]} =
+             erl_parse_abstract(unicode:characters_to_binary("a"++[1024]++"c"), Opts2)
      end || Opts2 <- [[{encoding,unicode},{line,Line}],
                       [{encoding,utf8},{line,Line}]]],
 
@@ -1288,6 +1291,22 @@ otp_10302(Config) when is_list(Config) ->
      {integer,0,97},
      {cons,0,{integer,0,1024},{string,0,"c"}}} =
         erl_parse_abstract("a"++[1024]++"c", [{encoding,latin1}]),
+    {bin,0,
+     [{bin_element,0,{integer,0,97},default,default},
+      {bin_element,0,{integer,0,208},default,default},
+      {bin_element,0,{integer,0,128},default,default},
+      {bin_element,0,{integer,0,99},default,default}]} =
+        erl_parse_abstract(unicode:characters_to_binary("a"++[1024]++"c"), [{encoding,latin1}]),
+    {bin,0,
+     [{bin_element,0,{integer,0,255},default,default}]} =
+        erl_parse_abstract(<<255>>, [{encoding,utf8}]),
+    {bin,0,
+     [{bin_element,0,{integer,0,0},default,default}]} =
+        erl_parse_abstract(<<0>>, [{encoding,utf8}]),
+    {bin,0,
+     [{bin_element,0,{string,0,[128512]},default,[utf8]}]} =
+        erl_parse_abstract(<<"😀"/utf8>>, [{encoding,utf8}]),
+
     ok.
 
 %% OTP-10990. Floating point number in input string.


### PR DESCRIPTION
Before this fix a unicode binary string would be returned as a set of bytes instead of the optimizes binary string representation. This would cause erl_pp and other to print bytes instead of strings for printable unicode binaries.