### PR TITLE
erts: Accept directly when not the current acceptor

### DIFF
--- a/erts/emulator/nifs/unix/unix_socket_syncio.c
+++ b/erts/emulator/nifs/unix/unix_socket_syncio.c
@@ -2448,12 +2448,63 @@ ERL_NIF_TERM essio_accept(ErlNifEnv*       env,
             return essio_accept_accepting_current(env, descP, sockRef, accRef);
 
         } else {
+            SOCKET accSock;
+            int    save_errno;
 
-            /* Not the "current acceptor", so (maybe) push onto queue */
+            /* Not the "current acceptor".
+             *
+             * Try to accept before parking this caller on the acceptor queue.
+             * If a connection is already pending there is no reason to make
+             * this caller wait for the current acceptor to hand over the
+             * baton: that handover costs a pollset update, a poll wakeup, a
+             * message and a reschedule for every single connection, which is
+             * why adding acceptors to a listening socket has made it slower
+             * rather than faster.
+             *
+             * accept() on a listening socket may be called from several
+             * processes at once; the kernel hands each caller a distinct
+             * connection. If this call takes the connection that the current
+             * acceptor was woken for, that acceptor sees EAGAIN, which it
+             * already handles - a spurious poll trigger produces exactly the
+             * same thing.
+             */
 
             SSDBG( descP,
                    ("UNIX-ESSIO",
-                    "essio_accept_accepting {%d} -> *not* current acceptor\r\n",
+                    "essio_accept_accepting {%d} -> *not* current acceptor - "
+                    "try accept anyway\r\n",
+                    descP->sock) );
+
+            ESOCK_CNT_INC(env, descP, sockRef,
+                          esock_atom_acc_tries, &descP->accTries, 1);
+
+            accSock = sock_accept(descP->sock, NULL, NULL);
+
+            if (! ESOCK_IS_ERROR(accSock))
+                return essio_accept_listening_accept(env, descP, sockRef,
+                                                     accSock, caller);
+
+            save_errno = sock_errno();
+
+            if ((save_errno != ERRNO_BLOCK) && (save_errno != EAGAIN)) {
+
+                SSDBG( descP,
+                       ("UNIX-ESSIO",
+                        "essio_accept_accepting {%d} -> errno: %d\r\n",
+                        descP->sock, save_errno) );
+
+                ESOCK_CNT_INC(env, descP, sockRef,
+                              esock_atom_acc_fails, &descP->accFails, 1);
+
+                return esock_make_error_errno(env, save_errno);
+            }
+
+            /* Nothing pending - queue up behind the current acceptor */
+
+            SSDBG( descP,
+                   ("UNIX-ESSIO",
+                    "essio_accept_accepting {%d} -> nothing pending - "
+                    "enqueue\r\n",
                     descP->sock) );
 
             return essio_accept_accepting_other(env, descP, accRef, caller);


### PR DESCRIPTION
Only the current acceptor may call `accept()` on a listening socket. Other
acceptors are queued, and every successful accept activates the next queued
one, which costs a pollset update, a poll wakeup, a message and a reschedule
per connection. So adding acceptors to a listening socket makes it slower
rather than faster.

Accepting 10k connections on one listening socket:

```
1 acceptor    74,268 accepts/s
8 acceptors    8,002 accepts/s
8 acceptors   65,934 accepts/s   with this patch
```

This tries `accept()` before parking a non-current acceptor on the queue. On
EAGAIN the caller is queued as before; other errors are returned the same way
the current acceptor path returns them.

`accept()` can be called from several processes at once and the kernel gives
each caller a distinct connection. A caller that takes the connection the
current acceptor was woken for leaves it with EAGAIN, which it already
handles, since a spurious poll trigger looks the same.

The single acceptor path is unchanged. The new branch sits behind
`COMPARE_PIDS(&descP->currentAcceptor.pid, &caller) != 0`, which cannot hold
when only one process accepts on the socket.

The reader and writer queues use the same handover and are left alone: there
the serialization is needed, since concurrent partial writes or stream reads
on one socket would interleave data.

Numbers are medians of 7 paired runs on Linux/aarch64. socket_SUITE accept
cases pass (`otp18240_accept_mon_leak_tcp4`, `otp16359_maccept_tcp4`,
`sc_lc_acceptor_response_tcp4`, `otp19482_simple_multi_small`,
`otp19482_simple_multi_medium`) and socket_api_SUITE shows no new failures.
