### PR TITLE
ssl: Fix argument swap bug for keylog debugging functionality

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -2274,7 +2274,7 @@ keylog_hs_alert(negotiated, #state{static_env = #static_env{role = server},
                                                   prf_algorithm = Prf
                                                  }
      } = Read,
-    {keylog_hs_1_3(ClientRandomBin, Prf, EarlySecret, ServerHSSecret, ClientHSSecret),
+    {keylog_hs_1_3(ClientRandomBin, Prf, EarlySecret, ClientHSSecret, ServerHSSecret),
      ClientRandomBin};
 keylog_hs_alert(wait_eoed, #state{static_env = #static_env{role = server},
                                   connection_env =
@@ -2357,7 +2357,7 @@ keylog_1_3_client_finished(Read, Write) ->
       security_parameters :=
           #security_parameters{client_early_data_secret = EarlySecret}
      } = Read,
-    {keylog_hs_1_3(ClientRandomBin, Prf, EarlySecret, ServerHSSecret, ClientHSSecret) ++
+    {keylog_hs_1_3(ClientRandomBin, Prf, EarlySecret, ClientHSSecret, ServerHSSecret) ++
          ssl_logger:keylog_traffic_1_3(server, ClientRandomBin, Prf, TrafficSecret, 0),
      ClientRandomBin}.
 

--- a/lib/ssl/test/tls_1_3_version_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_version_SUITE.erl
@@ -87,7 +87,9 @@
          keylog_on_alert/0,
          keylog_on_alert/1,
          client_keylog_on_alert/0,
-         client_keylog_on_alert/1
+         client_keylog_on_alert/1,
+         keylog_hs_secret_order/0,
+         keylog_hs_secret_order/1
         ]).
 
 
@@ -127,7 +129,8 @@ tls_1_3_1_2_tests() ->
      client_cert_fail_alert_active,
      client_cert_fail_alert_passive,
      keylog_on_alert,
-     client_keylog_on_alert
+     client_keylog_on_alert,
+     keylog_hs_secret_order
     ].
 legacy_tests() ->
     [tls_client_tls10_server,
@@ -732,9 +735,95 @@ client_keylog_on_alert(Config) when is_list(Config) ->
     %% Execute in other process and let test case detect key-log message.
     spawn_link(ClientFun),
     receive_client_keylog_for_client_cert_alert().
+
+keylog_hs_secret_order() ->
+    [{doc, "Verify that keylog_hs callback on the server reports "
+      "CLIENT/SERVER_HANDSHAKE_TRAFFIC_SECRET under the correct "
+      "labels by cross-checking with the client's keylog output"}].
+
+keylog_hs_secret_order(Config) when is_list(Config) ->
+    ssl:clear_pem_cache(),
+    {_, ServerNode, Hostname} = ssl_test_lib:run_where(Config),
+    ClientOpts0 = ssl_test_lib:ssl_options(extra_client, client_cert_opts, Config),
+    ServerOpts0 = ssl_test_lib:ssl_options(extra_server, server_cert_opts, Config),
+    PrivDir = proplists:get_value(priv_dir, Config),
+
+    %% Create a bad client cert — the server will reject it after
+    %% handshake traffic secrets have been derived on both sides.
+    NewClientCertFile = filename:join(PrivDir, "client_invalid_cert_order.pem"),
+    create_bad_client_certfile(NewClientCertFile, ClientOpts0),
+
+    Me = self(),
+    ServerHsFun = fun(Info) -> Me ! {server_hs_keylog, Info} end,
+    ClientHsFun = fun(Info) -> Me ! {client_hs_keylog, Info} end,
+
+    ServerOpts = [{versions, ['tlsv1.3']},
+                  {verify, verify_peer},
+                  {fail_if_no_peer_cert, true},
+                  {keep_secrets, {keylog_hs, ServerHsFun}}
+                  | ServerOpts0],
+    ClientOpts = [{versions, ['tlsv1.3']},
+                  {active, false},
+                  {certfile, NewClientCertFile},
+                  {keep_secrets, {keylog_hs, ClientHsFun}}
+                  | proplists:delete(certfile, ClientOpts0)],
+
+    Server = ssl_test_lib:start_server([{node, ServerNode}, {port, 0},
+                                        {from, self()},
+                                        {mfa, {ssl_test_lib, no_result, []}},
+                                        {options, ServerOpts}]),
+    Port = ssl_test_lib:inet_port(Server),
+
+    spawn_link(fun() ->
+                       ssl:connect(Hostname, Port, ClientOpts)
+               end),
+
+    %% Both sides fire keylog_hs on the alert. Collect both.
+    ServerKeyLog = receive
+                       {server_hs_keylog, #{items := S}} -> S
+                   after 5000 -> ct:fail(server_keylog_timeout)
+                   end,
+    ClientKeyLog = receive
+                       {client_hs_keylog, #{items := C}} -> C
+                   after 5000 -> ct:fail(client_keylog_timeout)
+                   end,
+
+    %% Extract the secret value from each label on each side.
+    %% The client-side path is known correct; the server-side
+    %% had a swap bug — this cross-check detects it.
+    ServerCHS = extract_hs_secret("CLIENT_HANDSHAKE_TRAFFIC_SECRET", ServerKeyLog),
+    ServerSHS = extract_hs_secret("SERVER_HANDSHAKE_TRAFFIC_SECRET", ServerKeyLog),
+    ClientCHS = extract_hs_secret("CLIENT_HANDSHAKE_TRAFFIC_SECRET", ClientKeyLog),
+    ClientSHS = extract_hs_secret("SERVER_HANDSHAKE_TRAFFIC_SECRET", ClientKeyLog),
+
+    %% The two secrets must be different (sanity) and both sides
+    %% must agree on which secret belongs to which label.
+    true = (ClientCHS =/= ClientSHS),
+    case {ServerCHS =:= ClientCHS, ServerSHS =:= ClientSHS} of
+        {true, true} ->
+            ok;
+        _ ->
+            ct:fail({handshake_secrets_swapped,
+                     [{server_client_hs_secret, ServerCHS},
+                      {client_client_hs_secret, ClientCHS},
+                      {server_server_hs_secret, ServerSHS},
+                      {client_server_hs_secret, ClientSHS}]})
+    end.
+
 %%--------------------------------------------------------------------
 %% Internal functions and callbacks -----------------------------------
 %%--------------------------------------------------------------------
+
+extract_hs_secret(Prefix, KeyLog) ->
+    Flat = [lists:flatten(L) || L <- KeyLog],
+    case [L || L <- Flat, lists:prefix(Prefix, L)] of
+        [Line] ->
+            %% Format: "LABEL <hex_random> <hex_secret>"
+            Tokens = string:tokens(Line, " "),
+            lists:last(Tokens);
+        [] ->
+            ct:fail({keylog_prefix_not_found, Prefix, Flat})
+    end.
 
 middlebox_test(Mode, Expected, ClientOpts, ServerOpts, Config) ->
     {ClientNode, ServerNode, Hostname} = ssl_test_lib:run_where(Config),


### PR DESCRIPTION
Add sanity check that would have caught this bug, but is not fool proof.

Solves ERIERL-1354