### PR TITLE
A new `versions` module and improved documentation of OTP version scheme

### DIFF
--- a/lib/runtime_tools/src/Makefile
+++ b/lib/runtime_tools/src/Makefile
@@ -49,7 +49,8 @@ MODULES= \
 	observer_backend \
 	ttb_autostart\
 	scheduler\
-	msacc
+	msacc \
+	versions
 
 HRL_FILES= ../include/observer_backend.hrl
 

--- a/lib/runtime_tools/src/runtime_tools.app.src
+++ b/lib/runtime_tools/src/runtime_tools.app.src
@@ -25,7 +25,7 @@
     {modules,      [appmon_info, dbg,observer_backend,runtime_tools,
                     runtime_tools_sup,erts_alloc_config,
 		    ttb_autostart,dyntrace,system_information,
-                    scheduler, instrument,
+                    scheduler, instrument, versions,
                     msacc]},
     {registered,   [runtime_tools_sup]},
     {applications, [kernel, stdlib]},

--- a/lib/runtime_tools/src/versions.erl
+++ b/lib/runtime_tools/src/versions.erl
@@ -1,0 +1,383 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(versions).
+-moduledoc """
+Utility functions for versions using the
+[OTP Versions Scheme](`e:system:versions.md#version-scheme`).
+""".
+-moduledoc(#{since => "OTP @OTP-20352@"}).
+
+-export_type([vsn_string/0, vsn_list/0, vsn_branch_string/0]).
+
+-doc """
+A version string formatted according to the
+[OTP Versions Scheme](`e:system:versions.md#version-scheme`).
+
+The string should be formatted as `<V(1)>.<V(2)> ... <V(N)>` where:
+*   each `<V(X)>` component is the string representation of a non-negative
+    decimal integer. No leading `0` digits except for the number zero which
+    should be exactly one `0` digit.
+*   each `<V(X)>` component is separated by a dot (`.`) character. No leading
+    or trailing dot characters are allowed.
+*   at least the `<V(1)>` and `<V(2)>` components exist.
+*   trailing `0` are only allowed in the `<V(1)>` and `<V(2)>` components.
+
+See the [OTP Versions Scheme](`e:system:versions.md#version-scheme`) for
+more information about versions.
+""".
+-type vsn_string() :: unicode:chardata().
+
+-doc """
+A branch identifier identifying a specific branch in a version tree.
+
+The branch identifier format differs from the `t:vsn_string/0` type in that:
+*   trailing `0` components are allowed.
+*   it is always ended by a trailing dot (`.`) after the last component.
+*   no branch identifiers with less than three components exist except for
+    `~"0."` which identifies the trunk of the tree.
+
+See the [OTP Versions Scheme](`e:system:versions.md#version-scheme`) for
+more information about branches.
+""".
+-type vsn_branch_string() :: unicode:chardata().
+
+-doc """
+A list representation of the `t:vsn_string/0` type.
+
+A list of components of actual non-negative integers as elements in the list
+separated as elements instead of by the dot character. The order of the
+components, amount of components, and content of the components is the same as
+ for the `t:vsn_string/0` type.
+""".
+-type vsn_list() :: [non_neg_integer()].
+
+-export([branch/1, branch_base/1, check/1, compare/2,
+         list_check/1, list_compare/2, list_to_string/1, string_to_list/1]).
+
+-doc """
+Calculates the branch identifier of the branch that the version `V` exists on.
+
+Returns the branch identifier, of the type described in the
+ [OTP Versions Scheme](`e:system:versions.md#version-scheme`),
+that the version `V` exists on. If the version `V` exists on the trunk of the
+tree, `~"0."` is returned.
+
+Note that the returned branch identifier does not correspond to any of the
+branch names used in the OTP git repository.
+
+A `badarg` `error` exception will be thrown if the version is not a valid
+version adhering to the description of the `t:vsn_string/0` type.
+
+## Examples
+```erlang
+1> versions:branch(~"18.0").
+<<"0.">>
+2> versions:branch(~"18.2.4").
+<<"0.">>
+3> versions:branch(~"18.2.4.1").
+<<"18.2.4.">>
+4> versions:branch(~"18.2.4.0.1").
+<<"18.2.4.0.">>
+```
+""".
+-spec branch(V :: vsn_string()) -> vsn_branch_string().
+branch(V) ->
+    try
+        case vs2vl(V) of
+            [_, _] -> ~"0.";
+            [_, _, _] -> ~"0.";
+            VL -> c2b([vl2vs(lists:reverse(tl(lists:reverse(VL))), true), $.])
+        end
+    catch _:_ ->
+            error(badarg, [V])
+    end.
+
+-doc """
+Calculates the base version of the branch `B`.
+
+Returns the version which is the base version of the branch identified by the
+argument. If the passed argument identifies the trunk of the version tree
+(`"~0."`), the base version returned is `~"0.0"`.
+
+A `badarg` `error` exception will be thrown if the branch identifier is not a
+valid branch identifier adhering to the description of the
+`t:vsn_branch_string/0` type.
+
+## Examples
+```erlang
+1> versions:branch_base(~"0.").
+<<"0.0">>
+2> versions:branch_base(~"18.2.4.").
+<<"18.2.4">>
+3> versions:branch_base(~"18.2.4.0.").
+<<"18.2.4">>
+```
+""".
+-spec branch_base(B :: vsn_branch_string()) -> vsn_string().
+branch_base(B) ->
+    try
+        case bs2rbl(B) of
+            [0] ->
+                ~"0.0";
+            RBL ->
+                vl2vs(case lists:reverse(drop_zeros(RBL)) of
+                          [X] -> [X,0];
+                          Xs -> Xs
+                      end,
+                      false)
+        end
+    catch _:_ ->
+            error(badarg, [B])
+    end.
+
+-doc """
+Checks whether or not the version `V` is a valid version.
+
+Returns true if the version is a valid version adhering to the description
+of the `t:vsn_string/0` type; otherwise `false`.
+
+Examples:
+```erlang
+1> versions:check(~"30.0").
+true
+2> versions:check(~"30.0.1").
+true
+3> versions:check(~"30.0.1.2").
+true
+4> versions:check(~"30.0.1.").
+false
+5> versions:check(~"30.0-rc1").
+false
+```
+""".
+-spec check(V :: vsn_string()) -> 'true' | 'false'.
+check(V) ->
+    try _ = vs2vl(V), true
+    catch _:_ -> false
+    end.
+
+-doc """
+Compares the versions `V1` and `V2`. The return value tells you how `V1`
+compares to `V2`.
+
+The return value:
+*   `same` tells you that `V1` is the *same* as `V2`.
+*   `ancestor` tells you that `V1` is an *ancestor* of `V2`.
+*   `descendant` tells you that `V1` is a *descendant* of `V2`.
+*   `undefined` tells you that the order between `V1` and `V2` is *undefined*.
+
+A `badarg` `error` exception will be thrown if a version is not a valid
+version adhering to the description of the `t:vsn_string/0` type.
+
+See the description of the
+[order between versions](`e:system:versions.md#order-of-versions`) in the OTP
+version scheme for more information.
+
+## Examples
+```erlang
+1> versions:compare(~"23.3", ~"23.3").
+same
+2> versions:compare(~"23.3", ~"23.2.7").
+descendant
+3> versions:compare(~"23.2.7", ~"23.3").
+ancestor
+4> versions:compare(~"23.2.7.1", ~"23.3").
+undefined
+```
+""".
+-spec compare(V1 :: vsn_string(), V2 :: vsn_string()) ->
+          'same' | 'ancestor' | 'descendant' | 'undefined'.
+compare(V1, V2) ->
+    try cmp(vs2vl(V1), vs2vl(V2))
+    catch _:_ -> error(badarg, [V1, V2])
+    end.
+
+-doc """
+Checks whether or not the version `VL` is a valid version list representation.
+
+Returns true if the version is a valid version adhering to the description
+of the `t:vsn_list/0` type; otherwise `false`.
+""".
+-spec list_check(VL :: vsn_list()) -> 'true' | 'false'.
+list_check(VL) ->
+    try _ = chk_vl(VL), true
+    catch _:_ -> false
+    end.
+
+-doc """
+Compare two versions on the version list format.
+
+Works exactly the same way as `compare/2` with the only difference that the
+versions passed as input are represented using the `t:vsn_list/0` type instead
+of using the `t:vsn_string/0` type.
+
+A `badarg` `error` exception will be thrown if a version is not a valid
+version adhering to the description of the `t:vsn_list/0` type.
+
+## Examples
+```erlang
+1> versions:list_compare([23, 3], [23, 3]).
+same
+2> versions:list_compare([23, 3], [23, 2, 7]).
+descendant
+3> versions:list_compare([23, 2, 7], [23, 3]).
+ancestor
+4> versions:list_compare([23, 2, 7, 1], [23, 3]).
+undefined
+```
+""".
+-spec list_compare(VL1 :: vsn_list(), VL2 :: vsn_list()) ->
+          'same' | 'ancestor' | 'descendant' | 'undefined'.
+list_compare(VL1, VL2) ->
+    try cmp(chk_vl(VL1), chk_vl(VL2))
+    catch _:_ -> error(badarg, [VL1, VL2])
+    end.
+
+-doc """
+Convert a version from the `t:vsn_list/0` type to the `t:vsn_string/0` type.
+
+A `badarg` `error` exception will be thrown if the version is not a valid
+version adhering to the description of the `t:vsn_list/0` type.
+""".
+-spec list_to_string(VL :: vsn_list()) -> vsn_string().
+list_to_string(VL) ->
+    try vl2vs(VL, false)
+    catch _:_ -> error(badarg, [VL])
+    end.
+
+-doc """
+Convert a version from the `t:vsn_string/0` type to the `t:vsn_list/0` type.
+
+A `badarg` `error` exception will be thrown if the version is not a valid
+version adhering to the description of the `t:vsn_string/0` type.
+""".
+-spec string_to_list(V :: vsn_string()) -> vsn_list().
+string_to_list(V) ->
+    try vs2vl(V)
+    catch _:_ -> error(badarg, [V])
+    end.
+
+%%%
+%%% Internal helper functions
+%%%
+
+%% Branch string to reversed branch list
+bs2rbl(B) -> bsplit2bl(string:split(B, ~".", all), 0, []).
+
+%% Branch split list to branch list
+bsplit2bl([X], N, RXs) ->
+    true = string:is_empty(X), %% from the trailing dot
+    %% The only valid branch identifier for the trunk is "0."
+    _ = if N == 1 -> [0] = RXs; %% The trunk
+           N == 2 -> error(invalid_branch_id);
+           true -> ok
+        end,
+    RXs;
+bsplit2bl([X|Xs], N, RXs) ->
+    I = str2int(X),
+    true = I >= 0,
+    bsplit2bl(Xs, N+1, [I | RXs]).
+
+%% Version string to version list
+vs2vl(V) -> il2vl([str2int(X) || X <:- string:split(V, ~".", all)]).
+
+%% String to integer
+str2int(S) ->
+    BS = c2b(S),
+    case BS of
+        <<"0"/utf8, _/utf8, _/binary>> -> error(leading_zero_in_integer);
+        _ -> ok
+    end,
+    {I, R} = string:to_integer(BS),
+    true = string:is_empty(R),
+    I.
+
+%% Integer list to version list: Check syntax and drop all trailing zeros
+il2vl([X, Y] = VL) when X >= 0, Y >= 0 -> VL;
+il2vl([X, Y, Z] = VL) when X >= 0, Y >= 0, Z > 0 -> VL;
+il2vl([X, Y, Z | [_|_] = Vs] = VL) when X >= 0, Y >= 0, Z >= 0 -> chk_i(Vs), VL.
+
+%% Check components past normal versions
+chk_i([]) -> ok;
+chk_i([0]) -> error(trailing_zero);
+chk_i([X|Xs]) when X >= 0 -> chk_i(Xs).
+
+%% Compare version lists (the core of compare/2 and list_compare/2)
+%% Input must be valid version lists; otherwise, incorrect result
+%% will be produced.
+cmp(V1, V2) -> cmp(V1, V2, 1).
+
+cmp([XY|Xs], [XY|Ys], N) -> cmp(Xs, Ys, N+1);
+cmp([], [], _N) -> same;
+cmp([], [_Y|_Ys], _N) -> ancestor;
+cmp([_X|_Xs], [], _N) -> descendant;
+%% X on trunk and X < Y
+cmp([X, _X2], [Y|_Ys], 1) when X < Y -> ancestor;
+cmp([X, _X2, _X3], [Y|_Ys], 1) when X < Y -> ancestor;
+cmp([X], [Y|_Ys], 2) when X < Y -> ancestor;
+cmp([X, _X2], [Y|_Ys], 2) when X < Y -> ancestor;
+%% Y on trunk and X > Y
+cmp([X|_Xs], [Y, _Y1], 1) when X > Y -> descendant;
+cmp([X|_Xs], [Y, _Y1, _Y2], 1) when X > Y -> descendant;
+cmp([X|_Xs], [Y], 2) when X > Y -> descendant;
+cmp([X|_Xs], [Y, _Y1], 2) when X > Y -> descendant;
+%% X last component (perhaps also on trunk) and X < Y
+cmp([X], [Y|_Ys], N) when X < Y, N >= 3 -> ancestor;
+%% Y last component (perhaps also on trunk) and X > Y
+cmp([X|_Xs], [Y], N) when X > Y, N >= 3 -> descendant;
+cmp(_Xs, _Ys, _N) -> undefined.
+
+%% Check that list is a valid version list
+chk_vl([V1, V2 | Vs] = VL) when is_integer(V1), V1 >= 0,
+                                is_integer(V2), V2 >= 0 ->
+    true = chk_vl_tail(Vs),
+    VL.
+
+chk_vl_tail([]) -> true;
+chk_vl_tail([V]) -> true = (is_integer(V) andalso V > 0);
+chk_vl_tail([V|Vs]) -> true = (is_integer(V) andalso V >= 0), chk_vl_tail(Vs).
+
+%% Version list to version string
+vl2vs([V1, V2 | Vs], TZ) when is_integer(V1), V1 >= 0,
+                               is_integer(V2), V2 >= 0 ->
+    c2b([integer_to_binary(V1), $., integer_to_binary(V2) | vl2vs_tail(Vs,TZ)]).
+
+vl2vs_tail([], _TZ) ->
+    [];
+vl2vs_tail([V], false) ->
+    true = (is_integer(V) andalso V > 0),
+    [$., integer_to_binary(V)];
+vl2vs_tail([V], true) ->
+    true = (is_integer(V) andalso V >= 0),
+    [$., integer_to_binary(V)];
+vl2vs_tail([V|Vs], TZ) ->
+    true = (is_integer(V) andalso V >= 0),
+    [$., integer_to_binary(V) | vl2vs_tail(Vs, TZ)].
+
+%% drop all zeros in the head
+drop_zeros([0|Xs]) ->
+    drop_zeros(Xs);
+drop_zeros(Xs) ->
+    Xs.
+
+% Characters to binary
+c2b(L) -> unicode:characters_to_binary(L).

--- a/lib/runtime_tools/test/Makefile
+++ b/lib/runtime_tools/test/Makefile
@@ -32,6 +32,7 @@ MODULES =  \
 	scheduler_SUITE \
 	msacc_SUITE \
 	observer_backend_SUITE \
+	versions_SUITE \
 	zzz_SUITE
 
 ERL_FILES= $(MODULES:%=%.erl)
@@ -88,5 +89,6 @@ release_tests_spec: make_emakefile
 	chmod -R u+w "$(RELSYSDIR)"
 	@tar cf - *_SUITE_data | (cd "$(RELSYSDIR)"; tar xf -)
 	$(INSTALL_DATA) $(ERL_TOP)/make/otp_version_tickets "$(RELSYSDIR)/system_information_SUITE_data"
+	$(INSTALL_DATA) $(ERL_TOP)/otp_versions.table "$(RELSYSDIR)/versions_SUITE_data/otp_versions.table"
 
 release_docs_spec:

--- a/lib/runtime_tools/test/versions_SUITE.erl
+++ b/lib/runtime_tools/test/versions_SUITE.erl
@@ -1,0 +1,270 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+-module(versions_SUITE).
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, suite/0]).
+
+%% Test cases
+-export([check_misc/1, compare/1, branch_base/1, branch/1, doctests/1]).
+
+suite() ->
+    [{ct_hooks,[ts_install_cth]},
+     {timetrap, {minutes, 1}}].
+
+all() ->
+    [check_misc, compare, branch_base, branch, doctests].
+
+check_misc(Config) when is_list(Config) ->
+    lists:foreach(fun (V) ->
+                          check_misc_version(V)
+                  end, valid_versions(Config)),
+    check_bad_vstr("27"),
+    check_bad_vlist([27]),
+    check_bad_vstr(""),
+    check_bad_vlist([]),
+    check_bad_vstr("30.0-rc1"),
+    check_bad_vstr("31.2.7.4.05"),
+    check_bad_vstr("031.2.7.4.5"),
+    check_bad_vstr("31.2.007.4.5"),
+    check_bad_vstr("31.2.007"),
+    check_bad_vstr("31.02"),
+    check_bad_vstr("0031.2"),
+    ok.
+
+compare(Config) when is_list(Config) ->
+    ancestor = check_cmp(~"0.0", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"0.3", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"0.3.1", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"0.3.1.1", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"17.0", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"35.2.7", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"35.3", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"35.3.1", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"35.3.1.2", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"35.3.0.1", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"35.3.0.2", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"35.3.0.3", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"35.3.0.4", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"35.3.0.2.1", ~"35.3.0.2.2"),
+    same = check_cmp(~"35.3.0.2.2", ~"35.3.0.2.2"),
+    descendant = check_cmp(~"35.3.0.2.3", ~"35.3.0.2.2"),
+    descendant = check_cmp(~"35.3.0.2.3.1", ~"35.3.0.2.2"),
+    descendant = check_cmp(~"35.3.0.2.4", ~"35.3.0.2.2"),
+    descendant = check_cmp(~"35.3.0.2.65.114.256", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"40.0", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"40.0.1", ~"35.3.0.2.2"),
+    undefined = check_cmp(~"40.0.1.2", ~"35.3.0.2.2"),
+    ancestor = check_cmp(~"18.2.4", ~"18.2.4.1"),
+    ancestor = check_cmp(~"18.2.4", ~"18.2.4.0.1"),
+    undefined = check_cmp(~"18.2.4.1", ~"18.2.4.0.1"),
+    undefined = check_cmp(~"18.2.4.1", ~"18.3"),
+    undefined = check_cmp(~"18.2.4.0.1", ~"18.3"),
+    ok.
+
+branch_base(Config) when is_list(Config) ->
+    ~"0.0" = versions:branch_base(~"0."),
+    ~"35.3.1" = versions:branch_base(~"35.3.1."),
+    ~"35.3" = versions:branch_base(~"35.3.0."),
+    ~"35.3.0.2" = versions:branch_base(~"35.3.0.2."),
+    ~"35.3.0.2.3" = versions:branch_base(~"35.3.0.2.3."),
+    ~"40.0" = versions:branch_base(~"40.0.0."),
+    ~"40.0" = versions:branch_base(~"40.0.0.0."),
+    ~"40.0" = versions:branch_base(~"40.0.0.0.0."),
+    ~"18.2.4" = versions:branch_base(~"18.2.4."),
+    ~"18.2.4" = versions:branch_base(~"18.2.4.0."),
+    ~"18.2.4" = versions:branch_base(~"18.2.4.0.0."),
+    ~"0.0" = versions:branch_base(versions:branch(~"0.0")),
+    ok.
+
+branch(Config) when is_list(Config) ->
+    ~"0." = versions:branch(~"0.0"),
+    ~"0." = versions:branch(~"0.3"),
+    ~"0." = versions:branch(~"0.3.1"),
+    ~"0." = versions:branch(~"17.0"),
+    ~"0." = versions:branch(~"35.2.7"),
+    ~"0." = versions:branch(~"35.3"),
+    ~"35.3.1." = versions:branch(~"35.3.1.1"),
+    ~"35.3.1." = versions:branch(~"35.3.1.2"),
+    ~"35.3.0." = versions:branch(~"35.3.0.1"),
+    ~"35.3.0." = versions:branch(~"35.3.0.2"),
+    ~"35.3.0.2." = versions:branch(~"35.3.0.2.3"),
+    ~"35.3.0.2." = versions:branch(~"35.3.0.2.2"),
+    ~"35.3.0.2.3." = versions:branch(~"35.3.0.2.3.1"),
+    ~"35.3.0.2.3." = versions:branch(~"35.3.0.2.3.2"),
+    ~"40.0.0." = versions:branch(~"40.0.0.1"),
+    ~"40.0.0.0." = versions:branch(~"40.0.0.0.1"),
+    ~"40.0.0.0.0." = versions:branch(~"40.0.0.0.0.1"),
+    ~"18.2.4." = versions:branch(~"18.2.4.1"),
+    ~"18.2.4.0." = versions:branch(~"18.2.4.0.1"),
+    ~"18.2.4.0.0." = versions:branch(~"18.2.4.0.0.1"),
+    ok.
+
+doctests(Config) when is_list(Config) ->
+    ct_doctest:module(versions, [{missing_tests,
+                                  [{list_check, 1},
+                                   {list_to_string, 1},
+                                   {string_to_list, 1}]}]).
+
+check_misc_version(V) ->
+    true = versions:check(V),
+    VL = versions:string_to_list(V),
+    VL = versions:string_to_list(c2l(V)),
+    true = versions:list_check(VL),
+    V = versions:list_to_string(VL),
+    same = check_cmp(V, c2l(V)),
+    same = check_cmp(c2l(V), V),
+    check_cmp(V, VL, ~"24.0", [24,0]),
+    check_cmp(V, VL, ~"17.0.1", [17,0,1]),
+    check_cmp(V, VL, ~"22.3.4.12", [22,3,4,12]),
+    check_cmp(V, VL, ~"23.2.7.2", [23,2,7,2]),
+    B = versions:branch(V),
+    try
+        _ = versions:branch_base(V),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    try
+        _ = versions:branch(B),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    false = versions:check(B),
+    BV = versions:branch_base(B),
+    if V == ~"0.0" -> same = check_cmp(BV, V);
+       V == "0.0" -> same = check_cmp(BV, V);
+       true -> ancestor = check_cmp(BV, V)
+    end,
+    true = versions:check(BV),
+    check_bad_vstr(c2b([~".", V])),
+    check_bad_vstr(c2b([~"-2.", V])),
+    check_bad_vstr(c2b([~"a.", V])),
+    check_bad_vstr(c2b([V, ~"."])),
+    check_bad_vstr(c2b([V, ~".0"])),
+    check_bad_vstr(c2b([V, ~".-1.3"])),
+    check_bad_vstr(c2b([V, ~".a.8"])),
+    check_bad_vlist(['.' | VL]),
+    check_bad_vlist([-2 | VL]),
+    check_bad_vlist([a | VL]),
+    check_bad_vlist(VL ++ ['.']),
+    check_bad_vlist(VL ++ [0]),
+    check_bad_vlist(VL ++ [-1, 3]),
+    check_bad_vlist(VL ++ [a, 8]),
+    ok.
+
+check_cmp(V1, V2) ->
+    check_cmp(V1, versions:string_to_list(V1),
+              V2, versions:string_to_list(V2)).
+
+check_cmp(V1, VL1, V2, VL2) ->
+    Res1 = versions:compare(V1, V2),
+    Res1 = versions:list_compare(VL1, VL2),
+    Res2 = versions:compare(V2, V1),
+    Res2 = versions:list_compare(VL2, VL1),
+    case Res1 of
+        same -> same = Res2;
+        ancestor -> descendant = Res2;
+        descendant -> ancestor = Res2;
+        undefined -> undefined = Res2
+    end,
+    Res1.
+
+check_bad_vstr(BV) ->
+    false = versions:check(BV),
+    try
+        _ = versions:compare(~"17.0", BV),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    try
+        _ = versions:compare(BV, ~"17.0"),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    try
+        _ = versions:branch(BV),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    try
+        _ = versions:string_to_list(BV),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end.
+
+check_bad_vlist(BV) ->
+    false = versions:list_check(BV),
+    try
+        _ = versions:list_compare([17,0], BV),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    try
+        _ = versions:list_compare(BV, [17,0]),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end,
+    try
+        _ = versions:list_to_string(BV),
+        error(unexpected_success)
+    catch
+        error:badarg ->
+            ok
+    end.
+
+
+valid_versions(Config) ->
+    DataDir = proplists:get_value(data_dir, Config),
+    {ok, Content} = file:read_file(filename:join([DataDir, "otp_versions.table"])),
+    lists:foldl(fun (~":", Acc) ->
+                        Acc;
+                    (~"#", Acc) ->
+                        Acc;
+                    (~":\n", Acc) ->
+                        Acc;
+                    (AppVer, Acc) ->
+                        [_, Ver] = binary:split(AppVer, ~"-"),
+                        [Ver | Acc]
+                end, [], binary:split(Content, <<" ">>, [global,trim])).
+
+
+c2b(Cs) ->
+    unicode:characters_to_binary(Cs).
+
+c2l(Cs) ->
+    unicode:characters_to_list(Cs).

--- a/system/doc/Makefile
+++ b/system/doc/Makefile
@@ -35,7 +35,7 @@ RELSYS_HTMLDIR= $(RELEASE_PATH)/doc/system
 # Correctly copy assets
 # ----------------------------------------------------
 GUIDES=$(shell awk -F: '{print $$1}' guides)
-ASSETS_SRC=$(foreach guide, $(GUIDES), $(wildcard $(guide)/assets/*.gif) $(wildcard $(guide)/assets/*.png) $(wildcard $(guide)/assets/*.svg))
+ASSETS_SRC=$(foreach guide, $(GUIDES), $(wildcard $(guide)/assets/*.gif) $(wildcard $(guide)/assets/*.png) $(wildcard $(guide)/assets/*.svg)) $(ERL_TOP)/lib/runtime_tools/src/versions.erl
 ASSETS=$(foreach asset, $(ASSETS_SRC), assets/$(notdir $(asset)))
 
 HTML_DEPS=$(foreach guide, $(GUIDES), $(wildcard $(guide)/*.md))

--- a/system/doc/system_principles/versions.md
+++ b/system/doc/system_principles/versions.md
@@ -30,6 +30,8 @@ the OTP version. The OTP version as a concept was introduced in OTP 17. The
 version scheme used is described in detail in
 [Version Scheme](versions.md#version_scheme).
 
+[](){: #set-of-applications }
+
 OTP of a specific version is a set of applications of specific versions. The
 application versions identified by an OTP version correspond to application
 versions that have been tested together by the Erlang/OTP team at Ericsson AB.
@@ -37,9 +39,6 @@ An OTP system can, however, be put together with applications from different OTP
 versions. Such a combination of application versions has not been tested by the
 Erlang/OTP team. It is therefore _always preferred to use OTP applications from
 one single OTP version_.
-
-Release candidates have an `-rc<N>` suffix. The suffix `-rc0` is used during
-development up to the first release candidate.
 
 ### Retrieving Current OTP Version
 
@@ -109,41 +108,93 @@ to various questions like:
 The above commands give a bit more information than the exact answers, but
 adequate information when manually searching for answers to these questions.
 
-## Application Version
-
-As of OTP 17.0 application versions use the same [version
-scheme](versions.md#version_scheme) as the OTP version, except that
-application versions never include the `-rc<N>` suffix. Also
-note that a major increment in an application version does not
-necessarily imply a major increment of the OTP version. This depends
-on whether the major change in the application is considered a
-major change for OTP as a whole or not.
-
 [](){: #version_scheme }
 
 ## Version Scheme
 
-> #### Change {: .info }
->
-> The version scheme was changed as of OTP 17.0.
-> [A list of application versions used in OTP 17.0](versions.md#otp_17_0_app_versions)
-> is included at the end of this section.
+Versions that adhere to the OTP versions scheme explicitly form a tree. The
+version numbers themselves are the only information needed in order to
+identify how the versions relate to each other.
 
-Normally, a version is constructed as `<Major>.<Minor>.<Patch>`, where
-`<Major>` is the most significant part. However, versions with more than three
-dot-separated parts are possible.
+A version on the trunk of the tree, or main track, is constructed as
+`<Major>.<Minor>.<Patch>`, where `<Major>` is the most significant
+component. The dot-separated components consist of non-negative integers. If
+there exist trailing components equaling `0` less significant than
+`<Minor>`, they are omitted. The three normal parts
+`<Major>.<Minor>.<Patch>` are changed as follows:
 
-The dot-separated parts consist of non-negative integers. If all parts
-less significant than `<Minor>` equal `0`, they are omitted. The
-three normal parts `<Major>.<Minor>.<Patch>` are changed as follows:
+- `<Major>` - Incremented when major changes, including incompatibilities, are
+    made.
+- `<Minor>` - Incremented when new functionality is added.
+- `<Patch>` - Incremented when pure bug fixes are made.
 
-- `<Major>` - Increases when major changes, including incompatibilities, are
-  made.
-- `<Minor>` - Increases when new functionality is added.
-- `<Patch>` - Increases when pure bug fixes are made.
+When creating a new version on the trunk of the version tree:
+1.  one component is incremented by `1`.
+2.  all components of lower significance than the incremented component are set
+    to `0`.
+3.  the <Patch> component is omitted if it was set to `0`.
 
-When a part in the version number increases, all less significant parts are set
-to `0`.
+The root of the version tree is always located on the trunk of the version
+tree, but there is no fixed version that the root of the tree must have. The
+version that is the root will vary from version tree to version tree.
+
+### Branches
+
+A version with more than 3 components exists on a branch that has branched off
+from the trunk of the tree, or another branch. Such a version looks like
+`<V(0)>.<V(1)>. ... .<V(N-1)>.<V(N)>` where `<V(0)>` is the most
+significant component and `<V(N)>` is the least significant component.
+The branch that the version exists on can be identified by
+`<V(0)>.<V(1)>. ... .<V(N-1)>.` (note the dot at the end) **not** omitting
+any trailing components equaling `0`. `<V(N)>` is a sequence number on that
+branch. For the first version on a branch, `<V(N)>` always equals `1`. `<V(N)>`
+is always incremented by `1` for each new version on the branch. There are
+never any trailing `0` components on a version existing on a branch.
+
+When a new branch is created and one or more branches already branch out from
+the same base version, the new branch identifier is created by appending `0.`
+to the end of the already existing branch identifier with the most components
+that branch out from that same base version. Below is an example where we have
+two branches branching out from the same base version `18.2.4`. When the
+branch `18.2.4.0.` was created, the branch `18.2.4.` already existed. If
+we were to create yet another branch based on `18.2.4`, it would get the
+branch identifier `18.2.4.0.0.`.
+
+```mermaid
+flowchart BT
+
+    Pre:::hidden==>18.2.4:::trunk
+    18.2.4:::trunk==>18.3:::trunk
+    18.3:::trunk==>Post:::hidden
+    18.2.4:::trunk-->18.2.4.1:::branch
+    18.2.4:::trunk-->18.2.4.0.1:::branch
+
+    classDef trunk fill:#90EE90,color:#000000,stroke-width:0px;
+    classDef branch fill:#D3D3D3,color:#000000,stroke-width:0px;
+    classDef hidden display: none;
+```
+
+The version on which a branch is based is obtained by omitting the least
+significant components whose values are `0`, except for the `V(0)` and
+`V(1)` components, from the branch identifier and removing any trailing
+dots.
+
+When branching out from a version on the trunk of the version tree where the
+third component has been omitted due to being `0`, it is added in the branch
+identifier. Here is an example of this scenario:
+
+```mermaid
+flowchart BT
+
+    Pre:::hidden==>28.5:::trunk
+    28.5:::trunk==>29.0:::trunk
+    29.0:::trunk==>Post:::hidden
+    28.5:::trunk-->28.5.0.1:::branch
+    28.5.0.1:::branch-->Post2:::hidden
+    classDef trunk fill:#90EE90,color:#000000,stroke-width:0px;
+    classDef branch fill:#D3D3D3,color:#000000,stroke-width:0px;
+    classDef hidden display: none;
+```
 
 An application version or an OTP version identifies source code versions. That
 is, it implies nothing about how the application or OTP has been built.
@@ -151,36 +202,193 @@ is, it implies nothing about how the application or OTP has been built.
 ### Order of Versions
 
 Version numbers in general are only partially ordered. However, normal version
-numbers (with three parts) as of OTP 17.0 have a total or linear order. This
-applies both to normal OTP versions and normal application versions.
+numbers (with a maximum of three components), on the trunk of the version tree,
+as of OTP 17.0 have a total linear order. This applies both to normal OTP
+versions and normal application versions. Note that you can only compare
+versions that come from the same version tree. It makes no sense comparing,
+for example, OTP versions with ERTS versions which are two different version
+trees.
 
-When comparing two version numbers with a defined order, one compares
-each part as standard integers, starting from the most significant
-part and moving towards the less significant parts. The order is
-determined by the first parts of the same significance that differ. A
-larger OTP version encompasses all changes present in a smaller OTP
-version. The same principle applies to application versions.
+All versions have an order against themselves, all of their ancestors and
+all of their descendants, but against other versions the order is undefined.
+The possible return values of the `versions:compare/2` function are
+therefore: `same`, `ancestor`, `descendant` and `undefined`.
 
-Versions can have more than three parts, resulting in partial
-ordering. Such versions are only used when branching off from another
-branch. When an extra part (apart from the normal three parts) is added to
-a version number, a new branch of versions is made. The new branch has
-a linear order against the base version. However, versions on
-different branches have no order, and therefore one can only conclude
-that they all include what is included in their closest common
-ancestor. When branching multiple times from the same base version,
-`0` parts are added between the base version and the least significant
-`1` part until a unique version is found. Versions that have an order
-can be compared as described in the previous paragraph.
+If a version `V1` compares to a version `V2` as:
+*   `same`, then `V2` compares to `V1` as `same`.
+*   `ancestor`, then `V2` compares to `V1` as `descendant`.
+*   `descendant`, then `V2` compares to `V1` as `ancestor`.
+*   `undefined`, then `V2` compares to `V1` as `undefined`.
 
-An example of branched versions: The version `6.0.2.1` is a branched version
-from the base version `6.0.2`. Versions of the form `6.0.2.<X>` can be compared
-with normal versions smaller than or equal to `6.0.2`, and other versions on the
-form `6.0.2.<X>`. The version `6.0.2.1` will include all changes in `6.0.2`.
-However, `6.0.3` will most likely _not_ include all changes in `6.0.2.1` (note
-that these versions have no order). A second branched version from the base
-version `6.0.2` will be version `6.0.2.0.1`, and a third branched version will
-be `6.0.2.0.0.1`.
+In the following example we can see how a number of versions are ordered against
+the version `35.3.0.2.2`.
+
+Color coding of frames in the below example:
+
+```mermaid
+flowchart LR
+    A[same]:::same ~~~ B[descendant]:::descendant
+    B ~~~ C[ancestor]:::ancestor
+    C ~~~ D[undefined]:::undefined
+
+    classDef same fill:#FFFFFF,stroke:#048BD9,color:#000000,stroke-width:10px;
+    classDef ancestor fill:#FFFFFF,stroke:#FFFF00,color:#000000,stroke-width:10px;
+    classDef descendant fill:#FFFFFF,stroke:#56D904,color:#000000,stroke-width:10px;
+    classDef undefined fill:#FFFFFF,stroke:#D90428,color:#000000,stroke-width:10px;
+    classDef hidden display: none;
+```
+
+Color coding of canvases in the below example:
+
+```mermaid
+flowchart LR
+    A[The Trunk]:::trunk ~~~ B[Branch 35.3.0.]:::branch1
+    B ~~~ C[Branch 35.3.0.2.]:::branch2
+    C ~~~ D[Branch 35.3.0.2.3.]:::branch3
+
+    classDef trunk fill:#90EE90,stroke:#FFFFFF,color:#000000,stroke-width:0px;
+    classDef branch1 fill:#7D7A7A,stroke:#FFFFFF,color:#FFFFFF,stroke-width:0px;
+    classDef branch2 fill:#D3D3D3,stroke:#FFFFFF,color:#000000,stroke-width:0px;
+    classDef branch3 fill:#F5F5F5,stroke:#FFFFFF,color:#000000,stroke-width:0px;
+    classDef hidden display: none;
+```
+
+Example:
+```mermaid
+flowchart BT
+
+    PRE:::hidden ==> A[35.2.7 - ancestor]:::ancestor_trunk
+    A ==> B[35.3 - ancestor]:::ancestor_trunk
+    B:::ancestor_trunk ==> C[35.3.1 - undefined]:::undefined_trunk
+    C:::undefined_trunk ==> POST:::hidden
+    B:::ancestor_trunk --> D[35.3.0.1 - ancestor]:::ancestor_branch1
+    D --> E[35.3.0.2 - ancestor]:::ancestor_branch1
+    E --> F[35.3.0.3 - undefined]:::undefined_branch1
+    F --> G[35.3.0.4 - undefined]:::undefined_branch1
+    E --> I[35.3.0.2.1 - ancestor]:::ancestor_branch2
+    I --> J[35.3.0.2.2 - same]:::the_version
+    J --> K[35.3.0.2.3 - descendant]:::descendant_branch2
+    K --> L[35.3.0.2.4 - descendant]:::descendant_branch2
+    K --> M[35.3.0.2.3.1 - descendant]:::descendant_branch3
+
+    classDef the_version fill:#D3D3D3,stroke:#048BD9,color:#000000,stroke-width:10px;
+    classDef ancestor_trunk fill:#90EE90,stroke:#FFFF00,color:#000000,stroke-width:10px;
+    classDef undefined_trunk fill:#90EE90,stroke:#D90428,color:#000000,stroke-width:10px;
+    classDef ancestor_branch1 fill:#7D7A7A,stroke:#FFFF00,color:#FFFFFF,stroke-width:10px;
+    classDef undefined_branch1 fill:#7D7A7A,stroke:#D90428,color:#FFFFFF,stroke-width:10px;
+    classDef descendant_branch2 fill:#D3D3D3,stroke:#56D904,color:#000000,stroke-width:10px;
+    classDef ancestor_branch2 fill:#D3D3D3,stroke:#FFFF00,color:#000000,stroke-width:10px;
+    classDef descendant_branch3 fill:#F5F5F5,stroke:#56D904,color:#000000,stroke-width:10px;
+
+    classDef hidden display: none;
+```
+
+#### Algorithm for Comparing Versions
+
+When comparing two versions, one compares the components from the most
+significant to the least significant component in the same position. While
+components are equal in both versions, one continues to the next components
+of the versions. When that is no longer possible:
+
+1.  If one runs out of components for both versions, the versions are the
+    **same**.
+
+2.  If one runs out of components for one version while there still are
+    components left for the other version, the version with less components is
+    an **ancestor** of the other version.
+
+3.  If the component of one version is less than the component of the other
+    version, and if the version with the smaller component either:
+
+    1.  comes from a normal version (maximum 3 components in total), or
+    2.  does not come from a normal version, but the smaller component is the
+        last component of its version
+
+    then, the version with the smaller component is an **ancestor** of the other
+    version.
+
+4. If none of the above is true, the order is **undefined**.
+
+This algorithm is used by the `versions:compare/2` and `versions:list_compare/2`
+functions in the `m:versions` module. The core of the algorithm is implemented
+in the internal `cmp()` functions in [versions.erl](assets/versions.erl). Note
+that the `cmp()` functions assume that the input versions are already properly
+validated versions of the type `t:versions:vsn_list/0` before it is called and
+will otherwise produce incorrect result.
+
+#### What can the Order be Used for
+
+When looking at two versions with a defined order, you know that the version
+comparing as a *descendant* of the other version is based on the code in the
+other version. For example, if a vulnerability was fixed in a version comparing
+as an *ancestor* of a specific version, the fix is included in that specific
+version as well (unless the vulnerability has mistakenly been reintroduced by
+the changes made between the versions). When looking at two versions with an
+*undefined* order, you cannot draw any such conclusions.
+
+When making a change that you want to merge into multiple OTP branches you want
+to base that change on a version that compares as a common *ancestor* to
+versions on all branches that you intend to merge to. If the base version for
+the change is based on a version that has an *undefined* order to versions on a
+branch that you intend to merge to, you might include changes in that branch
+that should not be included when merging. For example, when making a bugfix that
+should be included in `maint-27`, `maint-28` and `maint-29` you typically want
+to base the topic branch for that change on OTP version `27.3.4` which is the
+latest version on the trunk of the OTP version tree that has a defined order
+against the versions of all of those branches (see the
+[OTP Versions Tree](http://www.erlang.org/download/otp_versions_tree.html)
+page). Other *ancestor* versions to `27.3.4` are, of course, also ok to use as
+base version.
+
+### OTP Versions
+
+> #### Change {: .info }
+>
+> The [version scheme](versions.md#version_scheme) was changed as of OTP 17.0.
+> [A list of application versions used in OTP 17.0](versions.md#otp_17_0_app_versions)
+> is included at the end of this section.
+
+The root of the tree is OTP 17.0. The trunk of the tree corresponds to the
+main track where new versions are released for the latest OTP release. The
+latest version on the trunk of the tree corresponds to the head of the
+maintenance branch of the latest release.
+
+[](){: #release-candidates }
+
+#### OTP Release Candidates
+
+> #### Warning {: .warning }
+>
+> Release candidates are **only** intended to be used for testing an OTP release
+> while it is under development and **must never** be used in production.
+
+Release candidates have a `-rc<N>` suffix. The suffix `-rc0` is used during
+development up to the first release candidate. "Versions" with `-rc<N>` suffix
+are not proper versions and do not adhere to the
+[version scheme](versions.md#version_scheme). They are only used in order to
+identify code that we want users to test during development of a new
+[OTP release](versions.md#releases_and_patches).
+
+Application versions very often stay the same in the release candidates as in
+the actual release, even though the code of these applications very often is
+different in a release candidate compared to the actual OTP release. Application
+versions used have also not stabilized in the release candidates. In some cases,
+application versions have been stepped backwards in the actual release compared
+to what was in the release candidate. That is, OTP release candidates do *not*
+identify
+[a set of applications of specific versions](versions.md#set-of-applications).
+
+[](){: #application-version }
+
+### Application Versions
+
+As of OTP 17.0 application versions use the same
+[version scheme](versions.md#version_scheme) as the
+[OTP versions](versions.md#otp-versions), except that application versions
+never include the `-rc<N>` suffix. Also note that a major increment in an
+application version does not necessarily imply a major increment of the OTP
+version, but often do. This depends on whether the major change in the
+application is considered a major change for OTP as a whole or not.
 
 [](){: #releases_and_patches }
 


### PR DESCRIPTION
A new [`versions`](https://erlang.org/github-pr/11556/lib/runtime_tools-2.4/doc/html/versions.html) module has been added to the `runtime_tools` application containing functions for, e.g., comparing, versions that adhere to the OTP versions scheme.

The documentation of the [OTP version scheme](https://erlang.org/github-pr/11556/doc/system/versions.html#version-scheme) has also been improved.