### PR TITLE
Remove deprecated `catch` in test utils

### DIFF
--- a/erts/emulator/test/erts_test_utils.erl
+++ b/erts/emulator/test/erts_test_utils.erl
@@ -36,7 +36,6 @@
          ept_check_leaked_nodes/1]).
 
 
-
 -define(VERSION_MAGIC,       131).
 
 -define(ATOM_EXT,            100).
@@ -118,22 +117,25 @@ enc_creation(_Num, _Ser, Creation) ->
 mk_ext_pid({NodeName, Creation}, Number, Serial) when is_atom(NodeName) ->
     mk_ext_pid({atom_to_list(NodeName), Creation}, Number, Serial);
 mk_ext_pid({NodeName, Creation}, Number, Serial) ->
-    case catch binary_to_term(list_to_binary([?VERSION_MAGIC,
-					      pid_tag(Number, Serial, Creation),
-					      ?ATOM_EXT,
-					      uint16_be(length(NodeName)),
-					      NodeName,
-					      uint32_be(Number),
-					      uint32_be(Serial),
-					      enc_creation(Number, Serial, Creation)])) of
-	Pid when is_pid(Pid) ->
-	    Pid;
-	{'EXIT', {badarg, uint32_be, _}} ->
-	    exit({badarg, mk_pid, [{NodeName, Creation}, Number, Serial]});
-	{'EXIT', {badarg, _}} ->
-	    exit({badarg, mk_pid, [{NodeName, Creation}, Number, Serial]});
-	Other ->
-	    exit({unexpected_binary_to_term_result, Other})
+    try
+        binary_to_term(list_to_binary([?VERSION_MAGIC,
+                                       pid_tag(Number, Serial, Creation),
+                                       ?ATOM_EXT,
+                                       uint16_be(length(NodeName)),
+                                       NodeName,
+                                       uint32_be(Number),
+                                       uint32_be(Serial),
+                                       enc_creation(Number, Serial, Creation)]))
+    of
+        Pid when is_pid(Pid) ->
+            Pid;
+        Other ->
+            exit({unexpected_binary_to_term_result, Other})
+    catch
+        exit:{badarg, uint32_be, _} ->
+            exit({badarg, mk_pid, [{NodeName, Creation}, Number, Serial]});
+        error:badarg ->
+            exit({badarg, mk_pid, [{NodeName, Creation}, Number, Serial]})
     end.
 
 port_tag(_Num, bad_creation) ->
@@ -148,24 +150,29 @@ port_tag(_Num, _Creation) ->
 mk_ext_port({NodeName, Creation}, Number) when is_atom(NodeName) ->
     mk_ext_port({atom_to_list(NodeName), Creation}, Number);
 mk_ext_port({NodeName, Creation}, Number) ->
-    case catch binary_to_term(list_to_binary([?VERSION_MAGIC,
-					      port_tag(Number, Creation),
-					      ?ATOM_EXT,
-					      uint16_be(length(NodeName)),
-					      NodeName,
-					      case Number > ?OLD_MAX_PIDS_PORTS of
-						  true -> uint64_be(Number);
-						  false -> uint32_be(Number)
-					      end,
-					      enc_creation(Number, Creation)])) of
+    try
+        binary_to_term(list_to_binary([?VERSION_MAGIC,
+                                       port_tag(Number, Creation),
+                                       ?ATOM_EXT,
+                                       uint16_be(length(NodeName)),
+                                       NodeName,
+                                       case Number > ?OLD_MAX_PIDS_PORTS of
+                                           true -> uint64_be(Number);
+                                           false -> uint32_be(Number)
+                                       end,
+                                       enc_creation(Number, Creation)]))
+    of
 	Port when is_port(Port) ->
 	    Port;
-	{'EXIT', {badarg, Uint, _}} when Uint == uint64_be; Uint == uint32_be ->
-	    exit({badarg, mk_port, [{NodeName, Creation}, Number]});
-	{'EXIT', {badarg, _}} ->
-	    exit({badarg, mk_port, [{NodeName, Creation}, Number]});
 	Other ->
 	    exit({unexpected_binary_to_term_result, Other})
+    catch
+        exit:{badarg, uint64_be, _} ->
+            exit({badarg, mk_port, [{NodeName, Creation}, Number]});
+        exit:{badarg, uint32_be, _} ->
+            exit({badarg, mk_port, [{NodeName, Creation}, Number]});
+        error:badarg ->
+            exit({badarg, mk_port, [{NodeName, Creation}, Number]})
     end.
 
 ref_tag(_Nums, bad_creation) -> ?NEW_REFERENCE_EXT;
@@ -178,56 +185,62 @@ mk_ext_ref({NodeName, Creation}, Numbers) when is_atom(NodeName),
 mk_ext_ref({NodeName, Creation}, [Number]) when is_list(NodeName),
                                                 Creation =< 3,
                                                 is_integer(Number) ->
-    case catch binary_to_term(list_to_binary([?VERSION_MAGIC,
-                                              ?REFERENCE_EXT,
-                                              ?ATOM_EXT,
-                                              uint16_be(length(NodeName)),
-                                              NodeName,
-                                              uint32_be(Number),
-                                              uint8(Creation)])) of
+    try
+        binary_to_term(list_to_binary([?VERSION_MAGIC,
+                                       ?REFERENCE_EXT,
+                                       ?ATOM_EXT,
+                                       uint16_be(length(NodeName)),
+                                       NodeName,
+                                       uint32_be(Number),
+                                       uint8(Creation)]))
+    of
         Ref when is_reference(Ref) ->
             Ref;
-        {'EXIT', {badarg, _}} ->
-            exit({badarg, mk_ref, [{NodeName, Creation}, [Number]]});
         Other ->
             exit({unexpected_binary_to_term_result, Other})
+    catch
+        error:badarg ->
+            exit({badarg, mk_ref, [{NodeName, Creation}, [Number]]})
     end;
 mk_ext_ref({NodeName, Creation}, Numbers) when is_list(NodeName),
                                                is_list(Numbers) ->
-    case catch binary_to_term(list_to_binary([?VERSION_MAGIC,
-					      ref_tag(Numbers, Creation),
-					      uint16_be(length(Numbers)),
-					      ?ATOM_EXT,
-					      uint16_be(length(NodeName)),
-					      NodeName,
-					      enc_creation(Numbers, Creation),
-					      lists:map(fun (N) ->
-								uint32_be(N)
-							end,
-							Numbers)])) of
+    try
+        binary_to_term(list_to_binary([?VERSION_MAGIC,
+                                       ref_tag(Numbers, Creation),
+                                       uint16_be(length(Numbers)),
+                                       ?ATOM_EXT,
+                                       uint16_be(length(NodeName)),
+                                       NodeName,
+                                       enc_creation(Numbers, Creation),
+                                       lists:map(fun(N) ->
+                                                     uint32_be(N)
+                                                 end,
+                                                 Numbers)]))
+    of
 	Ref when is_reference(Ref) ->
 	    Ref;
-	{'EXIT', {badarg, _}} ->
-	    exit({badarg, mk_ref, [{NodeName, Creation}, Numbers]});
-	Other ->
-	    exit({unexpected_binary_to_term_result, Other})
+        Other ->
+            exit({unexpected_binary_to_term_result, Other})
+    catch
+        error:badarg ->
+            exit({badarg, mk_ref, [{NodeName, Creation}, Numbers]})
     end.
 
 
 available_internal_state(Bool) when Bool == true; Bool == false ->
-    case {Bool,
-          (catch erts_debug:get_internal_state(available_internal_state))} of
-        {true, true} ->
-            true;
-        {false, true} ->
-            erts_debug:set_internal_state(available_internal_state, false),
-            true;
-        {true, _} ->
-            erts_debug:set_internal_state(available_internal_state, true),
-            false;
-        {false, _} ->
-            false
-    end.
+    CurAIS = try
+                 erts_debug:get_internal_state(available_internal_state)
+             catch
+                 _:_ ->
+                     false
+             end,
+    if
+        Bool xor CurAIS ->
+            erts_debug:set_internal_state(available_internal_state, Bool);
+        true ->
+            ok
+    end,
+    CurAIS.
 
 
 %%
@@ -258,14 +271,12 @@ check_node_dist(Fail, NodeRefs, DistRefs) ->
 
 
 check_nd_refc({ThisNodeName, ThisCreation}, NodeRefs, DistRefs, Fail) ->
-    case catch begin
-                   check_refc(ThisNodeName,ThisCreation,"node table",NodeRefs),
-                   check_refc(ThisNodeName,ThisCreation,"dist table",DistRefs),
-                   ok
-               end of
-        ok ->
-            ok;
-        {'EXIT', Reason} ->
+    try
+        check_refc(ThisNodeName,ThisCreation,"node table",NodeRefs),
+        check_refc(ThisNodeName,ThisCreation,"dist table",DistRefs),
+        ok
+    catch
+        exit:Reason ->
             {Y,Mo,D} = date(),
             {H,Mi,S} = time(),
             ErrMsg = io_lib:format("~n"

--- a/lib/kernel/test/rtnode.erl
+++ b/lib/kernel/test/rtnode.erl
@@ -53,7 +53,13 @@ run(Commands, Nodename, ErlPrefix) ->
 run(Commands, Nodename, ErlPrefix, Args) ->
     case start(Nodename, ErlPrefix, Args) of
         {ok, _SPid, CPid, Node, RTState} ->
-            Res = catch send_commands(Node, CPid, Commands, 1),
+            Res = try
+                      send_commands(Node, CPid, Commands, 1)
+                  catch
+                      throw:X -> X;
+                      exit:X -> {'EXIT', X};
+                      error:X:ST -> {'EXIT', {X, ST}}
+                  end,
             Logs = stop(RTState),
             case Res of
                 ok ->
@@ -100,7 +106,7 @@ stop({CPid, SPid, ToErl, Tempdir}) ->
     unlink(SPid),
     case stop_runerl_node(CPid) of
         {error,_} ->
-            catch stop_try_harder(ToErl, Tempdir, SPid);
+            try stop_try_harder(ToErl, Tempdir, SPid) catch _:_ -> ok end;
         _ ->
             ok
     end,
@@ -408,7 +414,7 @@ toerl_loop(#{port := Port} = State0) ->
     end.
 
 kill_emulator(#{spid := SPid, port := Port}) when is_pid(SPid) ->
-    catch peer:stop(SPid),
+    try peer:stop(SPid) catch _:_ -> ok end,
     wait_for_eof(Port);
 kill_emulator(#{port := Port}) ->
     %% If the line happens to end in a ".", issuing "init:stop()."

--- a/lib/kernel/test/shell_test_lib.erl
+++ b/lib/kernel/test/shell_test_lib.erl
@@ -204,7 +204,7 @@ setup_tty(Config) ->
     end.
 
 stop_tty(Term) ->
-    catch peer:stop(Term#tmux.peer),
+    _ = try peer:stop(Term#tmux.peer) catch _:_ -> ok end,
     ct:log("~ts",[get_content(Term, "-e")]),
     [ct:log("~ts",[get_content(Term#tmux{ name = Term#tmux.ssh_server_name }, "-e")])
         || Term#tmux.ssh_server_name =/= undefined],

--- a/lib/stdlib/test/dummy_via.erl
+++ b/lib/stdlib/test/dummy_via.erl
@@ -8,9 +8,9 @@
 
 reset() ->
     P = whereis(?MODULE),
-    catch unlink(P),
+    _ = try unlink(P) catch _:_ -> ok end,
     Ref = erlang:monitor(process, P),
-    catch exit(P, kill),
+    _ = try exit(P, kill) catch _:_ -> ok end,
     receive {'DOWN',Ref,_,_,_} -> ok end,
     Me = self(),
     Pid = spawn_link(fun() ->
@@ -87,7 +87,7 @@ handle_request({whereis_name, Name}, Reg) ->
 handle_request({unregister_name, Name}, Reg) ->
     case lists:keyfind(Name, 1, Reg) of
 	{_, _, Ref} ->
-	    catch erlang:demonitor(Ref);
+            _ = try erlang:demonitor(Ref) catch _:_ -> ok end;
 	_ ->
 	    ok
     end,

--- a/lib/stdlib/test/dummy_via.erl
+++ b/lib/stdlib/test/dummy_via.erl
@@ -1,3 +1,24 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 1996-2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
 -module(dummy_via).
 -export([reset/0,
 	 register_name/2,

--- a/lib/stdlib/test/run_old_pcre1_tests.erl
+++ b/lib/stdlib/test/run_old_pcre1_tests.erl
@@ -97,13 +97,16 @@ test([{RE0,Line,Options0,Tests}|T],PreCompile,XMode,REAsList) ->
            end,
     case Cres of
 	{ok,P} ->
-	    case (catch testrun(RE,P,Tests,ExecOptions,PreCompile,CompOpts,XMode)) of
+            try
+                testrun(RE,P,Tests,ExecOptions,PreCompile,CompOpts,XMode)
+            of
 		N when is_integer(N) ->
-		    N + test(T,PreCompile,XMode,REAsList);
-		limit ->
+                    N + test(T,PreCompile,XMode,REAsList)
+            catch
+                throw:limit ->
 		    io:format("Error limit reached.~n"),
 		    1;
-		skip ->
+                throw:skip ->
 		    case get(skipped) of
 			N when is_integer(N) ->
 			    put(skipped,N+1);
@@ -581,7 +584,9 @@ backslash_end(<<_,R/binary>>) ->
 
 stru2([{Line,<<$ ,Rest/binary>>} | T],U) ->
     %% A challenge
-    case  (catch responses(T,U)) of
+    try
+        responses(T,U)
+    of
 	{NewT,Rlist} ->
 	    {NewNewT,StrList} = stru2(NewT,U),
 	    %% Hack...
@@ -609,8 +614,9 @@ stru2([{Line,<<$ ,Rest/binary>>} | T],U) ->
 		UList ->
 		    info("WARNING(~w): the exec-option(s) ~p are unsupported, skipping challenge.~n",[Line,UList]),
 		    {NewNewT,StrList}
-	    end;
-	fail ->
+            end
+    catch
+        throw:fail ->
 	    NewT = skip_until_empty(T),
 	    {NewT,[]}
     end;
@@ -971,7 +977,9 @@ dumponesplit(F,{RE,Line,O,TS}) ->
 	 {NO,_} = pick_exec_options(O++Op),
 	 SSS = opt_to_string(NO),
 	 LLL = unicode:characters_to_list(RE),
-	 case (catch iolist_to_binary(LLL)) of
+         try
+             iolist_to_binary(LLL)
+         of
 	     X when is_binary(X) -> 
 		 io:format(F,"perl -e '$x = join(\":\",split(/~s/~s,\"~s\")); "
 			   "$x =~~ s/\\\\/\\\\\\\\/g; $x =~~ s/\\\"/\\\\\"/g; "
@@ -1007,6 +1015,8 @@ dumponesplit(F,{RE,Line,O,TS}) ->
 			    dsafe2(safe(RE)),
 			    NO]);
 	     _ -> io:format("Found fishy character at line ~w~n",[Line])
+         catch
+             _:_ -> io:format("Found fishy character at line ~w~n",[Line])
 	 end
      end ||
 	{Str,_,Op,_} <- TS].
@@ -1058,10 +1068,14 @@ dumpone(F,{RE,Line,O,TS}) ->
 	 SSS = opt_to_string(NO),
 	 RS = ranstring(),
 	 LLL = unicode:characters_to_list(RE),
-	 case (catch iolist_to_binary(LLL)) of
+         try
+             iolist_to_binary(LLL)
+         of
 	     X when is_binary(X) -> io:format(F,"perl -e '$x = \"~s\"; $x =~~ s/~s/~s/~s; $x =~~ s/\\\\/\\\\\\\\/g; $x =~~ s/\\\"/\\\\\"/g; print \"    <<\\\"$x\\\">> = iolist_to_binary(re:replace(\\\"~s\\\",\\\"~s\\\",\\\"~s\\\",~p)), \\n\";'~n",[ysafe(safe(Str)),zsafe(safe(RE)),perlify(binary_to_list(RS)),SSS,dsafe(safe(Str)),dsafe(safe(RE)),xsafe(RS),NO]),
 	 io:format(F,"perl -e '$x = \"~s\"; $x =~~ s/~s/~s/g~s; $x =~~ s/\\\\/\\\\\\\\/g; $x =~~ s/\\\"/\\\\\"/g; print \"    <<\\\"$x\\\">> = iolist_to_binary(re:replace(\\\"~s\\\",\\\"~s\\\",\\\"~s\\\",~p)), \\n\";'~n",[ysafe(safe(Str)),zsafe(safe(RE)),perlify(binary_to_list(RS)),SSS,dsafe(safe(Str)),dsafe(safe(RE)),xsafe(RS),NO++[global]]);
 	     _ -> io:format("Found fishy character at line ~w~n",[Line])
+         catch
+             _:_ -> io:format("Found fishy character at line ~w~n",[Line])
 	 end
      end ||
 	{Str,_,Op,_} <- TS].

--- a/lib/stdlib/test/run_pcre_tests.erl
+++ b/lib/stdlib/test/run_pcre_tests.erl
@@ -1193,7 +1193,9 @@ dumponesplit(F,{run,RE,Line,O,TS}) ->
 	 {NO,_} = pick_exec_options(O++Op),
 	 SSS = opt_to_string(NO),
 	 LLL = unicode:characters_to_list(RE),
-	 case (catch iolist_to_binary(LLL)) of
+         try
+             iolist_to_binary(LLL)
+         of
 	     X when is_binary(X) ->
 		 io:format(F, ScriptFormat,
 			   [zsafe(safe(RE)),
@@ -1220,6 +1222,8 @@ dumponesplit(F,{run,RE,Line,O,TS}) ->
 			    dsafe2(safe(RE)),
 			    NO]);
 	     _ -> io:format("Found fishy character at line ~w~n",[Line])
+         catch
+             _:_ -> io:format("Found fishy character at line ~w~n",[Line])
 	 end
      end ||
 	{Str,_,Op,_} <- TS].
@@ -1296,7 +1300,9 @@ dumpone(F,{run,RE,Line,O,TS}) ->
 	 SSS = opt_to_string(NO),
 	 RS = ranstring(),
 	 LLL = unicode:characters_to_list(RE),
-	 case (catch iolist_to_binary(LLL)) of
+         try
+             iolist_to_binary(LLL)
+         of
 	     X when is_binary(X) ->
                  io:format(F, ScriptFormat, [ysafe(safe(Str)),
                                              zsafe(safe(RE)),
@@ -1315,7 +1321,9 @@ dumpone(F,{run,RE,Line,O,TS}) ->
                                              dsafe(safe(RE)),
                                              xsafe(RS),
                                              NO++[global]]);
-	     _ -> io:format("Found fishy character at line ~w~n",[Line])
+             _ -> io:format("Found fishy character at line ~w~n",[Line])
+         catch
+             _:_ -> io:format("Found fishy character at line ~w~n",[Line])
 	 end
      end ||
 	{Str,_,Op,_} <- TS].


### PR DESCRIPTION
When running tests for a specific application (like `stdlib`), a few test utils/libs are recompiled. Some of them contained usages of the deprecated `catch` and thereby caused warnings. This PR removes those usages and eliminates the warnings.