### PR TITLE
Property testing: Emulate EQC function generators that are missing in EQC Mini

### DIFF
--- a/lib/common_test/include/ct_property_test.hrl
+++ b/lib/common_test/include/ct_property_test.hrl
@@ -39,6 +39,11 @@
     -define(CT_SAFE_TERM(), ct_quickcheck_ext:safe_term()).
     -define(CT_SAFE_TUPLE(), ct_quickcheck_ext:safe_tuple()).
     -define(CT_EXISTING_ATOM(), ct_quickcheck_ext:existing_atom()).
+    -define(CT_FUNCTION0(RetGen), function0(RetGen)).
+    -define(CT_FUNCTION1(RetGen), function1(RetGen)).
+    -define(CT_FUNCTION2(RetGen), ct_quickcheck_ext:function2(RetGen)).
+    -define(CT_FUNCTION3(RetGen), ct_quickcheck_ext:function3(RetGen)).
+    -define(CT_FUNCTION4(RetGen), ct_quickcheck_ext:function4(RetGen)).
   -else.
     -ifdef(PROPER).
       -define(MOD_eqc, proper).
@@ -50,6 +55,11 @@
       -define(CT_SAFE_TERM(), ct_proper_ext:safe_term()).
       -define(CT_SAFE_TUPLE(), ct_proper_ext:safe_tuple()).
       -define(CT_EXISTING_ATOM(), ct_proper_ext:existing_atom()).
+      -define(CT_FUNCTION0(RetGen), function0(RetGen)).
+      -define(CT_FUNCTION1(RetGen), function1(RetGen)).
+      -define(CT_FUNCTION2(RetGen), function2(RetGen)).
+      -define(CT_FUNCTION3(RetGen), function3(RetGen)).
+      -define(CT_FUNCTION4(RetGen), function4(RetGen)).
     -else.
       -ifdef(TRIQ).
         -define(MOD_eqc, triq).

--- a/lib/common_test/proper_ext/ct_quickcheck_ext.erl
+++ b/lib/common_test/proper_ext/ct_quickcheck_ext.erl
@@ -38,6 +38,9 @@
 -compile([{nowarn_possibly_unsafe_function, {erlang, binary_to_term, 1}}]).
 
 -export([existing_atom/0]).
+-export([function2/1]).
+-export([function3/1]).
+-export([function4/1]).
 -export([safe_any/0]).
 -export([safe_atom/0]).
 -export([safe_list/0]).
@@ -61,6 +64,46 @@ safe_map() ->
 -spec safe_tuple() -> eqc_gen:gen(tuple()).
 safe_tuple() ->
     eqc_gen:bind(eqc_gen:list(safe_any()), fun(L) -> list_to_tuple(L) end).
+
+
+%% QuickCheck supports `function0`..`function4` generators, but
+%% QuickCheck Mini supports only `function0` and `function1`, so we
+%% need to emulate them.
+-spec function2(eqc_gen:gen(T)) -> eqc_gen:gen(fun((term(), term()) -> T)).
+function2(RetGen) ->
+    functionN(function2, RetGen).
+
+
+-spec function3(eqc_gen:gen(T)) ->
+          eqc_gen:gen(fun((term(), term(), term()) -> T)).
+function3(RetGen) ->
+    functionN(function3, RetGen).
+
+
+-spec function4(eqc_gen:gen(T)) ->
+          eqc_gen:gen(fun((term(), term(), term(), term()) -> T)).
+function4(RetGen) ->
+    functionN(function4, RetGen).
+
+functionN(Name, RetGen) ->
+    case has_generator(Name) of
+        true ->
+            eqc_gen:Name(RetGen);
+        false ->
+            eqc_gen:bind(eqc_gen:function1(RetGen),
+                         wrap(Name))
+    end.
+
+has_generator(Name) ->
+    {module, eqc_gen} = code:ensure_loaded(eqc_gen),
+    erlang:function_exported(eqc_gen, Name, 1).
+
+wrap(function2) ->
+    fun(F) -> fun(A, B) -> F({A, B}) end end;
+wrap(function3) ->
+    fun(F) -> fun(A, B, C) -> F({A, B, C}) end end;
+wrap(function4) ->
+    fun(F) -> fun(A, B, C, D) -> F({A, B, C, D}) end end.
 
 
 %% Atomlimit-safe atom generator.

--- a/lib/stdlib/test/property_test/base64_prop.erl
+++ b/lib/stdlib/test/property_test/base64_prop.erl
@@ -248,7 +248,7 @@ common_decode_malformed(DataGen, ModeGen, Fn) ->
                             [b64_char(Mode), b64_char(Mode), b64_char(Mode)]
                         ]
                     ),
-                    function1(bool())
+                    ?CT_FUNCTION1(bool())
                 },
                 {{NormalizedB64, insert_noise(NoisyB64, Malformings, InsertFn)}, Mode}
             )
@@ -310,7 +310,7 @@ b64(Mode) ->
 wsped_b64(Mode) ->
     ?LET(
         {B64, Wsps, InsertFn},
-        {b64(Mode), list(oneof([$\t, $\r, $\n, $\s])), function1(bool())},
+        {b64(Mode), list(oneof([$\t, $\r, $\n, $\s])), ?CT_FUNCTION1(bool())},
         {B64, insert_noise(B64, Wsps, InsertFn)}
     ).
 
@@ -327,7 +327,7 @@ non_b64_char(Mode) ->
 noisy_b64(Mode) ->
     ?LET(
         {{B64, WspedB64}, Noise, InsertFn},
-        {wsped_b64(Mode), non_empty(list(non_b64_char(Mode))), function1(bool())},
+        {wsped_b64(Mode), non_empty(list(non_b64_char(Mode))), ?CT_FUNCTION1(bool())},
         {B64, insert_noise(WspedB64, Noise, InsertFn)}
     ).
 

--- a/lib/stdlib/test/property_test/binary_prop.erl
+++ b/lib/stdlib/test/property_test/binary_prop.erl
@@ -811,7 +811,7 @@ gen_subjects_invalid() ->
 
 %% Generator for replacements
 gen_replacement() ->
-    oneof([binary(), function1(binary())]).
+    oneof([binary(), ?CT_FUNCTION1(binary())]).
 
 %% Generator for invalid replacements
 gen_replacement_invalid() ->

--- a/lib/stdlib/test/property_test/lists_prop.erl
+++ b/lib/stdlib/test/property_test/lists_prop.erl
@@ -147,7 +147,7 @@ prop_dropwhile() ->
         {Pred, InList, ExpList},
         ?LET(
             Fn,
-            function1(bool()),
+            ?CT_FUNCTION1(bool()),
             ?LET(
                 {L, {_, DL}},
                 gen_list_fold(
@@ -246,7 +246,7 @@ prop_filter() ->
         {Pred, InList, ExpList},
         ?LET(
             P,
-            function1(bool()),
+            ?CT_FUNCTION1(bool()),
             ?LET(
                 {L, F},
                 gen_list_fold(
@@ -271,7 +271,7 @@ prop_filtermap() ->
         {FilterMapFn, InList, ExpList},
         ?LET(
             Fn,
-            function1(oneof([true, false, {true, ?CT_SAFE_ANY()}])),
+            ?CT_FUNCTION1(oneof([true, false, {true, ?CT_SAFE_ANY()}])),
             ?LET(
                 {L, FM},
                 gen_list_fold(
@@ -305,7 +305,7 @@ prop_flatmap() ->
         {MapFn, InList, ExpList},
         ?LET(
             Fn,
-            function1(?CT_SAFE_LIST()),
+            ?CT_FUNCTION1(?CT_SAFE_LIST()),
             ?LET(
                 {L, FlatMapped},
                 gen_list_fold(
@@ -344,7 +344,7 @@ prop_foldl() ->
         {FoldFn, InList, Acc0, Exp},
         ?LET(
             {Fn, Acc0},
-            {function2(?CT_SAFE_ANY()), ?CT_SAFE_ANY()},
+            {?CT_FUNCTION2(?CT_SAFE_ANY()), ?CT_SAFE_ANY()},
             ?LET(
                 {L, V},
                 gen_list_fold(?CT_SAFE_ANY(), Fn, Acc0),
@@ -360,7 +360,7 @@ prop_foldr() ->
         {FoldFn, InList, Acc0, Exp},
         ?LET(
             {Fn, Acc0},
-            {function2(?CT_SAFE_ANY()), ?CT_SAFE_ANY()},
+            {?CT_FUNCTION2(?CT_SAFE_ANY()), ?CT_SAFE_ANY()},
             ?LET(
                 {L, V},
                 gen_list_fold(?CT_SAFE_ANY(), Fn, Acc0),
@@ -455,7 +455,7 @@ prop_keymap() ->
         {MapFn, N, InList, ExpList},
         ?LET(
             Fn,
-            function1(?CT_SAFE_ANY()),
+            ?CT_FUNCTION1(?CT_SAFE_ANY()),
             ?LET(
                 N,
                 choose(1, 5),
@@ -679,7 +679,7 @@ prop_map() ->
         {MapFn, InList, ExpList},
         ?LET(
             Fn,
-            function1(?CT_SAFE_ANY()),
+            ?CT_FUNCTION1(?CT_SAFE_ANY()),
             ?LET(
                 {L, M},
                 gen_list_fold(
@@ -701,8 +701,8 @@ prop_mapfoldl() ->
         {MapFoldFn, InList, Acc0, Exp},
         ?LET(
             {MapFn, FoldFn, Acc0},
-            {function1(?CT_SAFE_ANY()),
-             function2(?CT_SAFE_ANY()),
+            {?CT_FUNCTION1(?CT_SAFE_ANY()),
+             ?CT_FUNCTION2(?CT_SAFE_ANY()),
              ?CT_SAFE_ANY()},
             ?LET(
                 {L, MV},
@@ -725,8 +725,8 @@ prop_mapfoldr() ->
         {MapFoldFn, InList, Acc0, Exp},
         ?LET(
             {MapFn, FoldFn, Acc0},
-            {function1(?CT_SAFE_ANY()),
-             function2(?CT_SAFE_ANY()),
+            {?CT_FUNCTION1(?CT_SAFE_ANY()),
+             ?CT_FUNCTION2(?CT_SAFE_ANY()),
              ?CT_SAFE_ANY()},
             ?LET(
                 {L, MV},
@@ -952,7 +952,7 @@ prop_nthtail_outofrange() ->
 prop_partition() ->
     ?FORALL(
         {Pred, InList},
-        {function1(bool()), ?CT_SAFE_LIST()},
+        {?CT_FUNCTION1(bool()), ?CT_SAFE_LIST()},
         begin
             {Group1, Group2} = lists:partition(Pred, InList),
             check_partitioned(Pred, InList, Group1, Group2)
@@ -1115,7 +1115,7 @@ prop_split_outofrange() ->
 prop_splitwith() ->
     ?FORALL(
         {Pred, InList},
-        {function1(bool()), ?CT_SAFE_LIST()},
+        {?CT_FUNCTION1(bool()), ?CT_SAFE_LIST()},
         begin
             {Part1, Part2} = lists:splitwith(Pred, InList),
             check_splitwithed(Pred, InList, Part1, Part2)
@@ -1191,7 +1191,7 @@ prop_takewhile() ->
         {Pred, InList, ExpList},
         ?LET(
             Fn,
-            function1(bool()),
+            ?CT_FUNCTION1(bool()),
             ?LET(
                 {L, {_, TL}},
                 gen_list_fold(
@@ -1378,7 +1378,7 @@ prop_uniq_1() ->
 prop_uniq_2() ->
     ?FORALL(
         {UniqFn, InList},
-        {function1(oneof([a, b, c])), ?CT_SAFE_LIST()},
+        {?CT_FUNCTION1(oneof([a, b, c])), ?CT_SAFE_LIST()},
         check_uniqed(UniqFn, InList, lists:uniq(UniqFn, InList))
     ).
 
@@ -1562,7 +1562,7 @@ prop_zipwith_3() ->
         {ZipFn, InList1, InList2, ExpList},
         ?LET(
             Fn,
-            function2(?CT_SAFE_ANY()),
+            ?CT_FUNCTION2(?CT_SAFE_ANY()),
             ?LET(
                 {_, {L1, L2, Z}},
                 gen_list_fold(
@@ -1585,7 +1585,7 @@ prop_zipwith_4() ->
 		?LET(
 			{Extra, Fn},
 			{non_empty(?CT_SAFE_LIST()),
-			 function2(?CT_SAFE_ANY())},
+                         ?CT_FUNCTION2(?CT_SAFE_ANY())},
 			?LET(
 				{_, {L1, L2, Z}},
 				gen_list_fold(
@@ -1626,7 +1626,7 @@ prop_zipwith3_4() ->
         {ZipFn, InList1, InList2, InList3, ExpList},
         ?LET(
             Fn,
-            function3(?CT_SAFE_ANY()),
+            ?CT_FUNCTION3(?CT_SAFE_ANY()),
             ?LET(
                 {_, {L1, L2, L3, Z}},
                 gen_list_fold(
@@ -1651,7 +1651,7 @@ prop_zipwith3_5() ->
 		?LET(
 			{Extra, Fn},
 			{non_empty(?CT_SAFE_LIST()),
-			 function3(?CT_SAFE_ANY())},
+                         ?CT_FUNCTION3(?CT_SAFE_ANY())},
 			?LET(
 				{_, {L1, L2, L3, Z}},
 				gen_list_fold(
@@ -1833,7 +1833,7 @@ gen_list_deepfold(N, Level, L, FoldFn, Acc) ->
 gen_ordering_fun() ->
     ?LET(
         F,
-        function1(choose(1, 3)),
+        ?CT_FUNCTION1(choose(1, 3)),
         fun(T1, T2) ->
             F(T1) =< F(T2)
         end

--- a/lib/stdlib/test/property_test/sets_prop.erl
+++ b/lib/stdlib/test/property_test/sets_prop.erl
@@ -89,7 +89,7 @@ prop_filter() ->
 subprop_filter(Mod) ->
     ?FORALL(
         {{S0, M0}, Fun},
-        {gen_set(Mod), function1(bool())},
+        {gen_set(Mod), ?CT_FUNCTION1(bool())},
         is_equal(Mod:filter(Fun, S0),
                  model_filter(Fun, M0))
     ).
@@ -103,7 +103,7 @@ subprop_filtermap(Mod) ->
     ?FORALL(
         {{S0, M0}, Fun},
         {gen_set(Mod),
-         function1(oneof([true, false, {true, ?CT_SAFE_ANY()}]))},
+         ?CT_FUNCTION1(oneof([true, false, {true, ?CT_SAFE_ANY()}]))},
         is_equal(Mod:filtermap(wrap(Fun), S0),
                  model_filtermap(wrap(Fun), M0))
     ).
@@ -350,7 +350,7 @@ prop_map() ->
 subprop_map(Mod) ->
     ?FORALL(
         {{S0, M0}, Fun},
-        {gen_set(Mod), function1(?CT_SAFE_ANY())},
+        {gen_set(Mod), ?CT_FUNCTION1(?CT_SAFE_ANY())},
         is_equal(Mod:map(wrap(Fun), S0),
                  model_map(wrap(Fun), M0))
     ).
@@ -449,12 +449,12 @@ subprop_operations(Mod) ->
         {gen_set(Mod),
          list(oneof([{add_element, ?CT_SAFE_ANY()},
                      {del_element, ?CT_SAFE_ANY()},
-                     {filter, function1(bool())},
-                     {filtermap, function1(oneof([true,
+                     {filter, ?CT_FUNCTION1(bool())},
+                     {filtermap, ?CT_FUNCTION1(oneof([true,
                                                   false,
                                                   {true, ?CT_SAFE_ANY()}]))},
                      {intersection, gen_set(Mod)},
-                     {map, function1(?CT_SAFE_ANY())},
+                     {map, ?CT_FUNCTION1(?CT_SAFE_ANY())},
                      {subtract, gen_set(Mod)},
                      {union, gen_set(Mod)}]))},
         begin


### PR DESCRIPTION
This PR adds emulation for the `function2`...`function4` generators which are in QuickCheck (and PropEr) but absent in QuickCheck Mini.