### PR TITLE
ssl: Fix corner case for keylog_hs

### DIFF
--- a/lib/ssl/src/ssl_gen_statem.erl
+++ b/lib/ssl/src/ssl_gen_statem.erl
@@ -2316,12 +2316,11 @@ keylog_hs_alert(connection, #state{static_env = #static_env{role = client},
   when ?TLS_GTE(TlsVersion, ?TLS_1_3) ->
     #{server_handshake_traffic_secret := ServerHSSecret,
       security_parameters :=
-          #security_parameters{master_secret = {master_secret, STrafficSecret}
-                              }}
+          #security_parameters{application_traffic_secret = STrafficSecret}}
         = Read,
     #{client_handshake_traffic_secret := ClientHSSecret,
        security_parameters :=
-          #security_parameters{master_secret = {master_secret, CTrafficSecret},
+          #security_parameters{application_traffic_secret = CTrafficSecret,
                                client_random = ClientRandomBin,
                                client_early_data_secret = EarlySecret,
                                prf_algorithm = Prf
@@ -2365,7 +2364,7 @@ keylog_1_3_client_finished(Read, Write) ->
     #{server_handshake_traffic_secret := ServerHSSecret,
       security_parameters := #security_parameters{client_random = ClientRandomBin,
                                                   prf_algorithm = Prf,
-                                                  master_secret = {master_secret, TrafficSecret}
+                                                  application_traffic_secret = TrafficSecret
                                                  }}
         = Write,
     #{client_handshake_traffic_secret := ClientHSSecret,

--- a/lib/ssl/test/tls_1_3_version_SUITE.erl
+++ b/lib/ssl/test/tls_1_3_version_SUITE.erl
@@ -89,8 +89,7 @@
          client_keylog_on_alert/0,
          client_keylog_on_alert/1,
          keylog_hs_secret_order/0,
-         keylog_hs_secret_order/1
-        ]).
+         keylog_hs_secret_order/1]).
 
 
 %% Test callback
@@ -671,7 +670,18 @@ receive_client_keylog_for_server_cert_alert() ->
                                   "CLIENT_TRAFFIC_SECRET_0",
                                   "SERVER_TRAFFIC_SECRET_0"], CKeyLog) of
                 true ->
-                    ok;
+                    CTS = extract_secret("CLIENT_TRAFFIC_SECRET_0",  CKeyLog),
+                    STS = extract_secret("SERVER_TRAFFIC_SECRET_0",  CKeyLog),
+                    %% Before the fix, both were identical
+                    %% After the fix, they must be distinct.
+                    case CTS =/= STS of
+                        true ->
+                            ok;
+                        false ->
+                            ct:fail({traffic_secrets_identical,
+                                             [{client_traffic_secret_0, CTS},
+                                              {server_traffic_secret_0, STS}]})
+                    end;
                 false ->
                     ct:fail({client_received, CKeyLog})
             end
@@ -797,10 +807,10 @@ keylog_hs_secret_order(Config) when is_list(Config) ->
     %% Extract the secret value from each label on each side.
     %% The client-side path is known correct; the server-side
     %% had a swap bug — this cross-check detects it.
-    ServerCHS = extract_hs_secret("CLIENT_HANDSHAKE_TRAFFIC_SECRET", ServerKeyLog),
-    ServerSHS = extract_hs_secret("SERVER_HANDSHAKE_TRAFFIC_SECRET", ServerKeyLog),
-    ClientCHS = extract_hs_secret("CLIENT_HANDSHAKE_TRAFFIC_SECRET", ClientKeyLog),
-    ClientSHS = extract_hs_secret("SERVER_HANDSHAKE_TRAFFIC_SECRET", ClientKeyLog),
+    ServerCHS = extract_secret("CLIENT_HANDSHAKE_TRAFFIC_SECRET", ServerKeyLog),
+    ServerSHS = extract_secret("SERVER_HANDSHAKE_TRAFFIC_SECRET", ServerKeyLog),
+    ClientCHS = extract_secret("CLIENT_HANDSHAKE_TRAFFIC_SECRET", ClientKeyLog),
+    ClientSHS = extract_secret("SERVER_HANDSHAKE_TRAFFIC_SECRET", ClientKeyLog),
 
     %% The two secrets must be different (sanity) and both sides
     %% must agree on which secret belongs to which label.
@@ -820,7 +830,7 @@ keylog_hs_secret_order(Config) when is_list(Config) ->
 %% Internal functions and callbacks -----------------------------------
 %%--------------------------------------------------------------------
 
-extract_hs_secret(Prefix, KeyLog) ->
+extract_secret(Prefix, KeyLog) ->
     Flat = [lists:flatten(L) || L <- KeyLog],
     case [L || L <- Flat, lists:prefix(Prefix, L)] of
         [Line] ->


### PR DESCRIPTION
If the server aborts the handshake after the client is already in connection, this may happen in TLS-1.3, the keylog_hs callback received the wrong values in its keylog-input of the traffic secrets. These are needed to decrypt the servers alert.

This fix is relevant only for debugging using the keylog_hs option and has no impact on normal TLS usage.