### PR TITLE
stdlib: Reject repeated fields in external native record update

### DIFF
--- a/lib/stdlib/src/erl_lint.erl
+++ b/lib/stdlib/src/erl_lint.erl
@@ -3681,9 +3681,15 @@ check_fields(Fs, Flavor, Name, Fields, Vt0, St0, CheckFun, DiagFlavor) ->
               end, {[],[], St0}, Fs),
     {Uvt,St1}.
 
-check_field({record_field,_Af,_F,Val}, native, _Name, unknown,
+check_field({record_field,Af,{atom,_Aa,F},Val}, native, Name, unknown,
             Vt, St0, Rfs, CheckFun, _DiagFlavor) ->
-    {Rfs, CheckFun(Val, Vt, St0)};
+    %% External native records.
+    case member(F, Rfs) of
+        true ->
+            {Rfs,{[],add_error(Af, {redefine_field,Name,F}, St0)}};
+        false ->
+            {[F|Rfs], CheckFun(Val, Vt, St0)}
+    end;
 check_field({record_field,Af,{atom,Aa,F},Val}, Flavor, Name, Fields,
             Vt, St0, Rfs, CheckFun, DiagFlavor) ->
     case member(F, Rfs) of

--- a/lib/stdlib/test/erl_lint_SUITE.erl
+++ b/lib/stdlib/test/erl_lint_SUITE.erl
@@ -5903,6 +5903,13 @@ native_records(Conf) ->
                     {{2,35},erl_lint,{redefine_field,r2,a}},
                     {{3,30},erl_lint,{redefine_field,r3,a}}],
             []}},
+          {update_redefine_record_field,
+           <<"-record #a{a, b}.
+              update_local(A) -> A#a{a = 1, a = b}.
+              update_ext(B) -> B#ext:b{a = 1, a = b}.">>,
+           [],
+           {errors,[{{2,45},erl_lint,{redefine_field,a,a}},
+                    {{3,47},erl_lint,{redefine_field,{ext,b},a}}],[]}},
           {undefined_field_1,
            <<"-record #r{a=a, c=c}.
                mk() -> #r{a = a, b = b}.


### PR DESCRIPTION
If not rejected, this could cause internal consistency checks to fail.