### PR TITLE
Multiple small fixes for kernel tests

### DIFF
--- a/lib/kernel/test/code_SUITE.erl
+++ b/lib/kernel/test/code_SUITE.erl
@@ -1645,11 +1645,15 @@ create_big_script(Config,Local) ->
 	      Leftover <- UnloadFix,
 	      lists:keymember(Leftover,1,InitialApplications) ],
     %% Now we should have only "real" applications...
-    [application:load(list_to_atom(Y))
+    OtpApps = [list_to_atom(Y)
 	|| {match,[Y]} <- [re:run(X,code:lib_dir()++"/"++"([^/-]*).*/ebin",
 		[{capture,[1],list},unicode]) ||
 	    X <- code:get_path()],filter_app(Y,Local)],
-    Apps = [ {N,V} || {N,_,V} <- application:loaded_applications()],
+    [application:load(App) || App <- OtpApps],
+    %% Applications outside of OTP may be loaded by the environment the
+    %% test runs in, and they do not belong in the release.
+    Apps = [ {N,V} || {N,_,V} <- application:loaded_applications(),
+                      lists:member(N,OtpApps)],
     {ok,Fd} = file:open(Name ++ ".rel", [write]),
     io:format(Fd,
 		    "{release, {\"Test release 3\", \"P2A\"}, \n"

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -158,13 +158,19 @@ init_per_testcase(TC, Config) when TC == hostnames;
     file:write_file("hostnames_nodedir/ignore_core_files",""),
     Config;
 init_per_testcase(epmd_reconnect, Config) ->
+    SavedEpmdPort = os:getenv("ERL_EPMD_PORT"),
+    true = os:unsetenv("ERL_EPMD_PORT"),
     [] = os:cmd(?ALT_EPMD_CMD++" -relaxed_command_check -daemon"),
-    Config;
+    [{saved_erl_epmd_port, SavedEpmdPort} | Config];
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     Config.
 
-end_per_testcase(epmd_reconnect, _Config) ->
+end_per_testcase(epmd_reconnect, Config) ->
     os:cmd(?ALT_EPMD_CMD++" -kill"),
+    case ?config(saved_erl_epmd_port, Config) of
+        false -> ok;
+        SavedEpmdPort -> true = os:putenv("ERL_EPMD_PORT", SavedEpmdPort)
+    end,
     ok;
 end_per_testcase(_Func, _Config) ->
     ok.

--- a/lib/kernel/test/erl_distribution_SUITE.erl
+++ b/lib/kernel/test/erl_distribution_SUITE.erl
@@ -84,8 +84,6 @@
          wait_node_down/1]).
 
 -define(DUMMY_NODE,dummy@test01).
--define(ALT_EPMD_PORT, "12321").
--define(ALT_EPMD_CMD, "epmd -port "++?ALT_EPMD_PORT).
 
 %%-----------------------------------------------------------------
 %% The distribution is mainly tested in the big old test_suite.
@@ -160,13 +158,17 @@ init_per_testcase(TC, Config) when TC == hostnames;
 init_per_testcase(epmd_reconnect, Config) ->
     SavedEpmdPort = os:getenv("ERL_EPMD_PORT"),
     true = os:unsetenv("ERL_EPMD_PORT"),
-    [] = os:cmd(?ALT_EPMD_CMD++" -relaxed_command_check -daemon"),
-    [{saved_erl_epmd_port, SavedEpmdPort} | Config];
+    {ok, Socket} = gen_tcp:listen(0, []),
+    {ok, Port} = inet:port(Socket),
+    ok = gen_tcp:close(Socket),
+    EpmdPort = integer_to_list(Port),
+    [] = os:cmd("epmd -port "++EpmdPort++" -relaxed_command_check -daemon"),
+    [{epmd_port, EpmdPort}, {saved_erl_epmd_port, SavedEpmdPort} | Config];
 init_per_testcase(Func, Config) when is_atom(Func), is_list(Config) ->
     Config.
 
 end_per_testcase(epmd_reconnect, Config) ->
-    os:cmd(?ALT_EPMD_CMD++" -kill"),
+    os:cmd("epmd -port "++?config(epmd_port, Config)++" -kill"),
     case ?config(saved_erl_epmd_port, Config) of
         false -> ok;
         SavedEpmdPort -> true = os:putenv("ERL_EPMD_PORT", SavedEpmdPort)
@@ -522,10 +524,11 @@ epmd_reconnect(Config) when is_list(Config) ->
     NodeNames = [N1,N2,N3] = get_nodenames(3, ?FUNCTION_NAME),
     Nodes = [atom_to_list(full_node_name(NN)) || NN <- NodeNames],
 
-    DCfg = "-epmd_port "++?ALT_EPMD_PORT,
+    EpmdPort = ?config(epmd_port, Config),
+    DCfg = "-epmd_port "++EpmdPort,
 
     {_N1F,Port1} = start_node_unconnected(DCfg, N1, ?MODULE, run_remote_test,
-					["epmd_reconnect_do", atom_to_list(node()), "1" | Nodes]),
+                                        ["epmd_reconnect_do", atom_to_list(node()), "1", EpmdPort | Nodes]),
     {_N2F,Port2} = start_node_unconnected(DCfg, N2, ?MODULE, run_remote_test,
 					["epmd_reconnect_do", atom_to_list(node()), "2" | Nodes]),
     {_N3F,Port3} = start_node_unconnected(DCfg, N3, ?MODULE, run_remote_test,
@@ -550,12 +553,13 @@ reap_ports(Ports) ->
             end
     end.
     
-epmd_reconnect_do(_Node, ["1", Node1, Node2, Node3]) ->
+epmd_reconnect_do(_Node, ["1", EpmdPort, Node1, Node2, Node3]) ->
     Names = [Name || Name <- [hd(string:tokens(Node, "@")) || Node <- [Node1, Node2, Node3]]],
     %% wait until all nodes are registered
     ok = wait_for_names(Names),
-    "Killed" ++_ = os:cmd(?ALT_EPMD_CMD++" -kill"),
-    open_port({spawn, ?ALT_EPMD_CMD}, []),
+    EpmdCmd = "epmd -port "++EpmdPort,
+    "Killed" ++_ = os:cmd(EpmdCmd++" -kill"),
+    open_port({spawn, EpmdCmd}, []),
     %% check that all nodes reregister with epmd
     ok = wait_for_names(Names),
     lists:foreach(fun(Node) ->

--- a/lib/kernel/test/file_SUITE.erl
+++ b/lib/kernel/test/file_SUITE.erl
@@ -854,7 +854,7 @@ untranslatable_names_1(Config) ->
     after
 	catch peer:stop(Peer),
 	file:set_cwd(OldCwd),
-	[file:delete(F) || {_,F} <- untranslatable_names()],
+        [file:delete(filename:join(Dir, F)) || {_,F} <- untranslatable_names()],
 	file:del_dir(Dir)
     end,
     ok.
@@ -890,7 +890,7 @@ untranslatable_names_error_1(Config) ->
     after
 	catch peer:stop(Peer),
 	file:set_cwd(OldCwd),
-	[file:delete(F) || {_,F} <- untranslatable_names()],
+        [file:delete(filename:join(Dir, F)) || {_,F} <- untranslatable_names()],
 	file:del_dir(Dir)
     end,
     ok.
@@ -4045,47 +4045,51 @@ otp_10852_1(Config) ->
     {ok, Peer, Node} = ?CT_PEER(["+fnu"]),
     Dir = proplists:get_value(priv_dir, Config),
     B = filename:join(Dir, <<"\xE4">>),
-    ok = rpc_call(Node, get_cwd, [B]),
-    {error, no_translation} = rpc_call(Node, set_cwd, [B]),
-    ok = rpc_call(Node, delete, [B]),
-    ok = rpc_call(Node, rename, [B, B]),
-    ok = rpc_call(Node, read_file_info, [B]),
-    ok = rpc_call(Node, read_link_info, [B]),
-    ok = rpc_call(Node, read_link, [B]),
-    ok = rpc_call(Node, write_file_info, [B,#file_info{}]),
-    ok = rpc_call(Node, list_dir, [B]),
-    ok = rpc_call(Node, list_dir_all, [B]),
-    ok = rpc_call(Node, read_file, [B]),
-    ok = rpc_call(Node, make_link, [B,B]),
-    case rpc_call(Node, make_symlink, [B,B]) of
-        {error, eilseq} ->
-            %% Some versions of OS X refuse to create files with illegal names.
-            {unix,darwin} = os:type();
-        {error, eperm} ->
-            %% The test user might not have permission to create symlinks.
-            {win32,_} = os:type();
-        ok ->
-            ok
+    try
+        ok = rpc_call(Node, get_cwd, [B]),
+        {error, no_translation} = rpc_call(Node, set_cwd, [B]),
+        ok = rpc_call(Node, delete, [B]),
+        ok = rpc_call(Node, rename, [B, B]),
+        ok = rpc_call(Node, read_file_info, [B]),
+        ok = rpc_call(Node, read_link_info, [B]),
+        ok = rpc_call(Node, read_link, [B]),
+        ok = rpc_call(Node, write_file_info, [B,#file_info{}]),
+        ok = rpc_call(Node, list_dir, [B]),
+        ok = rpc_call(Node, list_dir_all, [B]),
+        ok = rpc_call(Node, read_file, [B]),
+        ok = rpc_call(Node, make_link, [B,B]),
+        case rpc_call(Node, make_symlink, [B,B]) of
+            {error, eilseq} ->
+                %% Some versions of OS X refuse to create files with illegal names.
+                {unix,darwin} = os:type();
+            {error, eperm} ->
+                %% The test user might not have permission to create symlinks.
+                {win32,_} = os:type();
+            ok ->
+                ok
+        end,
+        ok = rpc_call(Node, delete, [B]),
+        case rpc_call(Node, make_dir, [B]) of
+            {error, eilseq} ->
+                {unix,darwin} = os:type();
+            ok ->
+                ok
+        end,
+        ok = rpc_call(Node, del_dir, [B]),
+        case rpc_call(Node, write_file, [B,B]) of
+            {error, eilseq} ->
+                {unix,darwin} = os:type();
+            ok ->
+                {ok, Fd} = rpc_call(Node, open, [B,[read]]),
+                ok = rpc_call(Node, close, [Fd]),
+                {ok,0} = rpc_call(Node, copy, [B,B]),
+                {ok, Fd2, B} = rpc_call(Node, path_open, [["."], B, [read]]),
+                ok = rpc_call(Node, close, [Fd2])
+        end
+    after
+        file:delete(B),
+        peer:stop(Peer)
     end,
-    ok = rpc_call(Node, delete, [B]),
-    case rpc_call(Node, make_dir, [B]) of
-        {error, eilseq} ->
-            {unix,darwin} = os:type();
-        ok ->
-            ok
-    end,
-    ok = rpc_call(Node, del_dir, [B]),
-    case rpc_call(Node, write_file, [B,B]) of
-        {error, eilseq} ->
-            {unix,darwin} = os:type();
-        ok ->
-            {ok, Fd} = rpc_call(Node, open, [B,[read]]),
-            ok = rpc_call(Node, close, [Fd]),
-            {ok,0} = rpc_call(Node, copy, [B,B]),
-            {ok, Fd2, B} = rpc_call(Node, path_open, [["."], B, [read]]),
-            ok = rpc_call(Node, close, [Fd2])
-    end,
-    peer:stop(Peer),
     ok.
 
 rpc_call(N, F, As) ->

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -842,7 +842,10 @@ close_with_pending_output(Config) when is_list(Config) ->
     ?TC_TRY(?FUNCTION_NAME, Pre, TC, Post).
 
 do_close_with_pending_output(Node, Config) ->
-    {ok, Addr}      = ?WHICH_LOCAL_ADDR(inet),
+    Addr = case ?WHICH_LOCAL_ADDR(inet) of
+               {ok, LocalAddr} -> LocalAddr;
+               {error, Reason} -> throw({skip, Reason})
+           end,
     ?P("~w -> try create listen socket", [?FUNCTION_NAME]),
     {ok, L}         = ?LISTEN(Config, 0, [binary, {ip, Addr}, {active, false}]),
     ?P("~w -> try get port", [?FUNCTION_NAME]),
@@ -8588,7 +8591,10 @@ wait(Mref) ->
 %% Test that send error works correctly for delay_send
 delay_send_error(Config) ->
     ?P("create listen socket"),
-    {ok, Addr} = ?WHICH_LOCAL_ADDR(inet),
+    Addr = case ?WHICH_LOCAL_ADDR(inet) of
+               {ok, LocalAddr} -> LocalAddr;
+               {error, Reason} -> throw({skip, Reason})
+           end,
     {ok, L}    = ?LISTEN(Config, 0, [{ip,        Addr},
                                      {reuseaddr, true},
                                      {packet,    1},
@@ -9694,7 +9700,7 @@ otp_18357(Config) when is_list(Config) ->
                               [?FUNCTION_NAME, Name, Addr]),
                            #{name => Name, addr => Addr};
                        {error, Reason} ->
-                           {skip, ?F("Failed get local address: ~p", [Reason])}
+                           throw({skip, ?F("Failed get local address: ~p", [Reason])})
                    end
            end,
     Case = fun(State) -> do_otp_18357(State) end,

--- a/lib/kernel/test/gen_tcp_misc_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_misc_SUITE.erl
@@ -7152,6 +7152,7 @@ setup_active_timeout_sink(Config, RNode, Addr, Timeout, AutoClose) ->
 	     end,
     {ok, C} = Remote(fun() ->
 			     ?CONNECT(Config, Addr, Port, [{ip,     Addr},
+                                                           {recbuf, 8192},
 			                                   {active, false}])
 		     end),
     {ok, A} = gen_tcp:accept(L),
@@ -7261,6 +7262,7 @@ do_send_timeout_resume(Config, RNode, BlockPow) ->
         [inet,
          binary,
          {backlog, 2},
+         {recbuf,  BlockSize bsr 1},
          {active,  false}],
     ConnectOpts =
         [inet,

--- a/lib/kernel/test/gen_tcp_socket_SUITE.erl
+++ b/lib/kernel/test/gen_tcp_socket_SUITE.erl
@@ -85,6 +85,7 @@ init_per_suite(Config) ->
 	    case socket:is_supported(protocols, tcp) of
 		true ->
 		    ct:pal("socket:info():~n    ~p~n", [socket:info()]),
+                    kernel_test_lib:has_support_ipv4(),
 		    {ok, BindAddr} = kernel_test_lib:which_local_addr(?DOMAIN),
 		    [{bind_addr, #{ family => ?DOMAIN, addr   => BindAddr }}
 		    | Config];

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -399,7 +399,7 @@ init_per_group(otp18323 = _GroupName, Config) ->
         true ->
             {skip, "Inet Drv specific bugs"};
         false ->
-            ok
+            Config
     end;
 init_per_group(_GroupName, Config) ->
     Config.

--- a/lib/kernel/test/gen_udp_SUITE.erl
+++ b/lib/kernel/test/gen_udp_SUITE.erl
@@ -294,6 +294,7 @@ end_per_suite(Config0) ->
     Config1.
 
 init_per_group(inet_backend_default = _GroupName, Config) ->
+    ?LIB:has_support_ipv4(),
     ?P("~w(~w) -> check explicit inet-backend when"
        "~n   Config: ~p", [?FUNCTION_NAME, _GroupName, Config]),
     case ?EXPLICIT_INET_BACKEND(Config) of

--- a/lib/kernel/test/interactive_shell_SUITE.erl
+++ b/lib/kernel/test/interactive_shell_SUITE.erl
@@ -533,7 +533,7 @@ shell_format(Config) ->
         %% Note, erl_pp puts 7 spaces before X
         shell_test_lib:check_content(Term1, "fun\\(X\\) ->\\s*..        X\\s*.. end."),
         shell_test_lib:send_tty(Term1, "Down"),
-        shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term1)," -x ",200]),
+        shell_test_lib:tmux(Term1, ["resize-window -t ",shell_test_lib:tty_name(Term1)," -x ",200]),
         timer:sleep(1000),
         shell_test_lib:send_tty(Term1, "shell:format_shell_func(\"emacs -batch \${file} -l \"\n"),
         shell_test_lib:send_tty(Term1, EmacsFormat),
@@ -881,9 +881,9 @@ shell_update_window_unicode_wrap(Config) ->
              shell_test_lib:check_content(Term,"> a*$"),
              shell_test_lib:send_tty(Term,[U,"aaaaa"]),
              shell_test_lib:check_content(Term,["> a* ?\n",U,"aaaaa$"]),
-             shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",Cols+1]),
+             shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",Cols+1]),
              shell_test_lib:check_content(Term,["> a*",U,"\naaaaa$"]),
-             shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",Cols]),
+             shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",Cols]),
              shell_test_lib:check_content(Term,["> a* ?\n",U,"aaaaa$"]),
              shell_test_lib:send_tty(Term,"Enter")
          end || U <- hard_unicode()]
@@ -1043,12 +1043,12 @@ shell_update_window(Config) ->
                 shell_test_lib:send_tty(Term,Text),
                 shell_test_lib:check_content(Term,Text),
                 shell_test_lib:check_location(Term, {0, width(Text)}),
-                shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",width(Text)+Col+1]),
+                shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",width(Text)+Col+1]),
                 shell_test_lib:send_tty(Term,"a"),
                 shell_test_lib:check_location(Term, {0, -Col}),
                 shell_test_lib:send_tty(Term,"BSpace"),
                 shell_test_lib:check_location(Term, {-1, width(Text)}),
-                shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",width(Text)+Col]),
+                shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",width(Text)+Col]),
                 %% When resizing, tmux does not xnfix the cursor, so it will remain
                 %% at the previous locations
                 shell_test_lib:check_location(Term, {-1, width(Text)}),
@@ -1062,7 +1062,7 @@ shell_update_window(Config) ->
                 %% {-1, width(Text)} instead.
                 shell_test_lib:check_location(Term, [{0, -Col}, {-1, width(Text)}]),
 
-                shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",width(Text) div 2 + Col]),
+                shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x ",width(Text) div 2 + Col]),
 
                 %% Depending on what happened with the cursor above, the line will be
                 %% different here.
@@ -1075,7 +1075,7 @@ shell_update_window(Config) ->
     end.
 shell_small_window_multiline_navigation(Config) ->
     Term0 = start_tty(Config),
-    shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term0)," -x ",30, " -y ", 6]),
+    shell_test_lib:tmux(Term0, ["resize-window -t ",shell_test_lib:tty_name(Term0)," -x ",30, " -y ", 6]),
     {Row, Col} = shell_test_lib:get_location(Term0),
     Term = Term0#tmux{orig_location = {Row, Col}},
     Text = ("xbcdefghijklmabcdefghijklm\n"++
@@ -1245,7 +1245,7 @@ shell_expand_location_below(Config) ->
     {ok,_,Bin} = compile:forms(Forms, [debug_info]),
 
     try
-        shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
+        shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
         Cols = 80,
 
         %% First check that basic completion works
@@ -1286,7 +1286,7 @@ shell_expand_location_below(Config) ->
                           {module, long_module} = code:load_binary(long_module, "long_module.beam", Bin)
                   end),
         shell_test_lib:check_content(Term, "3>"),
-        shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -y 50"]),
+        shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -y 50"]),
         timer:sleep(1000), %% Sleep to make sure window has resized
         Result = 61,
         Rows1 = 48,
@@ -1328,7 +1328,7 @@ shell_expand_location_below(Config) ->
 
         %% We resize the terminal to make everything fit and test that
         %% expand below displays everything
-        shell_test_lib:tmux(["resize-window -t ", shell_test_lib:tty_name(Term), " -y ", integer_to_list(Row+10)]),
+        shell_test_lib:tmux(Term, ["resize-window -t ", shell_test_lib:tty_name(Term), " -y ", integer_to_list(Row+10)]),
         timer:sleep(1000), %% Sleep to make sure window has resized
         shell_test_lib:send_tty(Term, "\t\t"),
         shell_test_lib:check_content(Term, "3> long_module:" ++ FunctionName ++ "\nFunctions(\n|.)*a_long_function_name99\\($"),
@@ -1372,7 +1372,7 @@ shell_expand_location_above(Config) ->
     Term = start_tty([{args,["-stdlib","shell_expand_location","above"]}|Config]),
 
     try
-        shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
+        shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
         shell_test_lib:send_tty(Term, "escript:"),
         shell_test_lib:send_tty(Term, "\t"),
         shell_test_lib:check_location(Term, {0, width("escript:")}),
@@ -1555,7 +1555,7 @@ external_editor(Config) ->
         _ ->
             Term = start_tty(Config),
             try
-                shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
+                shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
                 shell_test_lib:send_tty(Term,"os:putenv(\"EDITOR\",\"nano\").\n"),
                 shell_test_lib:send_tty(Term, "\"some text with\nnewline in it\""),
                 shell_test_lib:check_content(Term,"3> \"some text with\\s*\n.+\\s*newline in it\""),
@@ -1585,7 +1585,7 @@ external_editor_visual(Config) ->
         _ ->
             Term = start_tty(Config),
             try
-                shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
+                shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
                 shell_test_lib:send_tty(Term,"os:putenv(\"EDITOR\",\"nano\").\n"),
                 shell_test_lib:check_content(Term, "3>"),
                 shell_test_lib:send_tty(Term,"os:putenv(\"VISUAL\",\"vim -u DEFAULTS -U NONE -i NONE\").\n"),
@@ -1617,7 +1617,7 @@ external_editor_unicode(Config) ->
         _ ->
             Term = start_tty(Config),
             try
-                shell_test_lib:tmux(["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
+                shell_test_lib:tmux(Term, ["resize-window -t ",shell_test_lib:tty_name(Term)," -x 80"]),
                 shell_test_lib:send_tty(Term,"os:putenv(\"EDITOR\",\"nano\").\n"),
                 shell_test_lib:send_tty(Term, hard_unicode()),
                 shell_test_lib:check_content(Term,"3> " ++ hard_unicode_match(Config)),
@@ -1660,18 +1660,19 @@ shell_standard_error_nlcr(Config) ->
 shell_suspend(Config) ->
 
     Name = peer:random_name(proplists:get_value(tc_path,Config)),
+    Socket = proplists:get_value(tmux_socket, Config),
     %% In order to suspend `erl` we need it to run in a shell that has job control
     %% so we start the peer within a tmux window instead of having it be the original
     %% process.
-    os:cmd("tmux new-window -n " ++ Name ++ " -d -- bash --norc"),
+    shell_test_lib:tmux(Socket, "new-window -n " ++ Name ++ " -d -- bash --norc"),
 
     Peer = #{ name => Name,
               post_process_args =>
-                        fun(["new-window","-n",_,"-d","--"|CmdAndArgs]) ->
+                        fun(["-L",_,"new-window","-n",_,"-d","--"|CmdAndArgs]) ->
                                 FlatCmdAndArgs =
                                       lists:join(
                                         " ",[[$',A,$'] || A <- CmdAndArgs]),
-                                ["send","-t",Name,lists:flatten(FlatCmdAndArgs),"Enter"]
+                                ["-L",Socket,"send","-t",Name,lists:flatten(FlatCmdAndArgs),"Enter"]
                         end
             },
 
@@ -1706,15 +1707,16 @@ shell_full_queue(Config) ->
     %% that program in order to block writing to stdout for a while.
 
     Name = peer:random_name(proplists:get_value(tc_path,Config)),
-    os:cmd("tmux new-window -n " ++ Name ++ " -d -- bash --norc"),
+    Socket = proplists:get_value(tmux_socket, Config),
+    shell_test_lib:tmux(Socket, "new-window -n " ++ Name ++ " -d -- bash --norc"),
 
     Peer = #{ name => Name,
               post_process_args =>
-                        fun(["new-window","-n",_,"-d","--"|CmdAndArgs]) ->
+                        fun(["-L",_,"new-window","-n",_,"-d","--"|CmdAndArgs]) ->
                                 FlatCmdAndArgs = ["unbuffer -p "] ++
                                       lists:join(
                                         " ",[[$',A,$'] || A <- CmdAndArgs]),
-                                ["send","-t",Name,lists:flatten(FlatCmdAndArgs),"Enter"]
+                                ["-L",Socket,"send","-t",Name,lists:flatten(FlatCmdAndArgs),"Enter"]
                         end
             },
 
@@ -1769,15 +1771,15 @@ shell_full_queue(Config) ->
         ok
     end,
     Name2 = peer:random_name(proplists:get_value(tc_path,Config))++"_2",
-    os:cmd("tmux new-window -n " ++ Name2 ++ " -d -- bash --norc"),
+    shell_test_lib:tmux(Socket, "new-window -n " ++ Name2 ++ " -d -- bash --norc"),
 
     Peer2 = #{ name => Name2,
               post_process_args =>
-                        fun(["new-window","-n",_,"-d","--"|CmdAndArgs]) ->
+                        fun(["-L",_,"new-window","-n",_,"-d","--"|CmdAndArgs]) ->
                                 FlatCmdAndArgs = ["unbuffer -p "] ++
                                       lists:join(
                                         " ",[[$',A,$'] || A <- CmdAndArgs]),
-                                ["send","-t",Name2,lists:flatten(FlatCmdAndArgs),"Enter"]
+                                ["-L",Socket,"send","-t",Name2,lists:flatten(FlatCmdAndArgs),"Enter"]
                         end
             },
 
@@ -1797,11 +1799,11 @@ shell_full_queue(Config) ->
         shell_test_lib:send_tty(Term1, "Enter"),
         shell_test_lib:check_content(
           fun() ->
-                  shell_test_lib:tmux(["capture-pane -p -S - -E - -t ",shell_test_lib:tty_name(Term1)])
+                  shell_test_lib:tmux(Term1, ["capture-pane -p -S - -E - -t ",shell_test_lib:tty_name(Term1)])
           end, lists:flatten([lists:duplicate(Cols,$c) ++ "\n" ||
                                  _ <- lists:seq(1,(Bytes) div Cols)]
                              ++ [lists:duplicate((Bytes) rem Cols,$c)])),
-        ct:log("~ts",[shell_test_lib:tmux(["capture-pane -p -S - -E - -t ",shell_test_lib:tty_name(Term)])]),
+        ct:log("~ts",[shell_test_lib:tmux(Term, ["capture-pane -p -S - -E - -t ",shell_test_lib:tty_name(Term)])]),
         ok
     after
         shell_test_lib:stop_tty(Term1),

--- a/lib/kernel/test/kernel_test_lib.erl
+++ b/lib/kernel/test/kernel_test_lib.erl
@@ -521,6 +521,8 @@ linux_process_os_release4(_Tag, _Value) ->
 
 linux_distro_str_to_distro_id("Debian" ++ _) ->
     debian;
+linux_distro_str_to_distro_id("CentOS" ++ _) ->
+    fedora;
 linux_distro_str_to_distro_id("Fedora" ++ _) ->
     fedora;
 linux_distro_str_to_distro_id("Linux Mint" ++ _) ->

--- a/lib/kernel/test/logger_std_h_SUITE.erl
+++ b/lib/kernel/test/logger_std_h_SUITE.erl
@@ -299,6 +299,9 @@ errors(Config) ->
                 erofs ->
                     %% Happens on OS X
                     ok;
+                eperm ->
+                    %% Returned on macOS.
+                    ok;
                 eacces ->
                     ok
             end

--- a/lib/kernel/test/net_SUITE.erl
+++ b/lib/kernel/test/net_SUITE.erl
@@ -92,7 +92,8 @@ suite() ->
 
 all() -> 
     Groups = [{api, "ENET_TEST_API", include}],
-    [use_group(Group, Env, Default) || {Group, Env, Default} <- Groups].
+    [Spec || {Group, Env, Default} <- Groups,
+             Spec <- use_group(Group, Env, Default)].
 
 use_group(Group, Env, Default) ->
 	case os:getenv(Env) of

--- a/lib/kernel/test/rpc_SUITE.erl
+++ b/lib/kernel/test/rpc_SUITE.erl
@@ -59,7 +59,7 @@ suite() ->
 
 all() -> 
     [off_heap, call, call_reqtmo, block_call, multicall,
-     multicall_timeout, call_reqtmo, multicall_dies,
+     multicall_timeout, multicall_reqtmo, multicall_dies,
      multicall_node_dies, called_dies, called_node_dies,
      called_throws, call_benchmark, async_call,
      call_against_old_node,

--- a/lib/kernel/test/shell_test_lib.erl
+++ b/lib/kernel/test/shell_test_lib.erl
@@ -31,7 +31,7 @@
          stop_tmux/1,
          setup_tty/1,
          stop_tty/1,
-         tmux/1,
+         tmux/2,
          rpc/2,
          rpc/4,
          set_tty_prompt/2,
@@ -53,34 +53,36 @@
 
 %% Put this in init_per_xxx in the test you're writing
 start_tmux(Config) ->
-    case string:split(shell_test_lib:tmux("-V")," ") of
+    case string:split(string:trim(os:cmd("tmux -V"))," ") of
         ["tmux",[Num,$.|_]] when Num >= $3, Num =< $9 ->
-            shell_test_lib:tmux("kill-session"),
+            Socket = "erl_shell_test_" ++ os:getpid() ++ "_"
+                ++ integer_to_list(erlang:unique_integer([positive])),
             W = proplists:get_value(width, Config, 50),
             H = proplists:get_value(height, Config, 60),
-            "" = shell_test_lib:tmux("-u new-session -x " ++integer_to_list(W)++" -y "
-                                     ++integer_to_list(H)++" -d"),
-            ["" = shell_test_lib:tmux(["set-environment '",Name,"' '",Value,"'"])
-             || {Name,Value} <- os:env()],
-            Config;
+            "" = tmux(Socket, "-u new-session -x " ++integer_to_list(W)++" -y "
+                      ++integer_to_list(H)++" -d"),
+            ["" = tmux(Socket, ["set-environment '",Name,"' '",Value,"'"])
+             || {Name,Value} <- os:env(), not lists:prefix("TMUX", Name)],
+            [{tmux_socket, Socket} | Config];
         ["tmux", Vsn] ->
             {skip, "invalid tmux version " ++ Vsn ++ ". Need vsn 3 or later"};
         Error ->
             {skip, "tmux not installed " ++ Error}
     end.
 
-stop_tmux(_Config) ->
-    Windows = string:split(shell_test_lib:tmux("list-windows"), "\n", all),
+stop_tmux(Config) ->
+    Socket = proplists:get_value(tmux_socket, Config),
+    Windows = string:split(tmux(Socket, "list-windows"), "\n", all),
     lists:foreach(
       fun(W) ->
               case string:split(W, " ", all) of
                   ["0:" | _] -> ok;
                   [No, _Name | _] ->
-                      "" = os:cmd(["tmux select-window -t ", string:split(No,":")]),
-                      ct:log("~ts~n~ts",[W, os:cmd(lists:concat(["tmux capture-pane -p -e"]))])
+                      "" = tmux(Socket, ["select-window -t ", string:split(No,":")]),
+                      ct:log("~ts~n~ts",[W, tmux(Socket, "capture-pane -p -e")])
               end
       end, Windows),
-%    "" = os:cmd("tmux kill-session")
+    "" = tmux(Socket, "kill-server"),
     ok.
 
 %% Setup a TTY, or a ssh server and client but do not type anything in terminal (except password)
@@ -88,6 +90,7 @@ stop_tmux(_Config) ->
                  {env, [{Key :: string(), Value :: string()}]} |
                  {args, [string()]}]) -> term().
 setup_tty(Config) ->
+    Socket = proplists:get_value(tmux_socket, Config),
     ClientName = maps:get(name,proplists:get_value(peer, Config, #{}),
                     peer:random_name(proplists:get_value(tc_path, Config))),
     
@@ -124,7 +127,7 @@ setup_tty(Config) ->
     DefaultPeerArgs = #{ name => Name,
                          exec =>
                              {os:find_executable("tmux"),
-                              ["new-window","-n",Name,"-d","--"] ++ ExecArgs },
+                              ["-L",Socket,"new-window","-n",Name,"-d","--"] ++ ExecArgs },
 
                          args => ["-pz",filename:dirname(code:which(?MODULE)),
                                   "-connect_all","false",
@@ -158,7 +161,7 @@ setup_tty(Config) ->
           end),
     unlink(Peer),
 
-    "" = tmux(["set-option -t ",Name," remain-on-exit on"]),
+    "" = tmux(Socket, ["set-option -t ",Name," remain-on-exit on"]),
 
     %% We start tracing on the remote node in order to help debugging
     TraceLog = filename:join(proplists:get_value(priv_dir,Config),Name++".trace"),
@@ -177,7 +180,7 @@ setup_tty(Config) ->
                   monitor(process, Self),
                   receive _ -> ok end
           end),
-    Tmux = #tmux{ peer = Peer, node = Node, name = ClientName },
+    Tmux = #tmux{ peer = Peer, node = Node, name = ClientName, socket = Socket },
     if IsSsh ->
             rpc(Tmux, fun() ->
                 ssh:start(),
@@ -189,13 +192,13 @@ setup_tty(Config) ->
                                                 {user_dir, PrivDir},
                                                 {password, "bar"}])
             end),
-            os:cmd(os:find_executable("tmux") ++ " new-window -n " ++ ClientName ++ " -d -- "++
+            tmux(Socket, "new-window -n " ++ ClientName ++ " -d -- "++
                 "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null localhost -p 8989 -l foo"),
-            "" = tmux(["set-option -t ",ClientName," remain-on-exit on"]),
+            "" = tmux(Socket, ["set-option -t ",ClientName," remain-on-exit on"]),
 
             timer:sleep(2000),
             check_content(Tmux,"Enter password for \"foo\""),
-            "" = tmux("send -t " ++ ClientName ++ " bar Enter"),
+            "" = tmux(Socket, "send -t " ++ ClientName ++ " bar Enter"),
             timer:sleep(1000),
             check_content(Tmux,"\\d+\n?>"),
             Tmux#tmux{ ssh_server_name = Name };
@@ -211,10 +214,12 @@ stop_tty(Term) ->
 %    "" = tmux("kill-window -t " ++ Term#tmux.name),
     ok.
 
-tmux([Cmd|_] = Command) when is_list(Cmd) ->
-    tmux(lists:concat(Command));
-tmux(Command) ->
-    string:trim(os:cmd(["tmux ",Command])).
+tmux(Ref, [Cmd|_] = Command) when is_list(Cmd) ->
+    tmux(Ref, lists:concat(Command));
+tmux(#tmux{ socket = Socket }, Command) ->
+    tmux(Socket, Command);
+tmux(Socket, Command) ->
+    string:trim(os:cmd(["TMUX= TMUX_PANE= tmux -L ",Socket," ",Command])).
 
 rpc(#tmux{ node = N }, Fun) ->
     erpc:call(N, Fun).
@@ -244,12 +249,12 @@ send_tty(Term, "Home") ->
 send_tty(Term, "End") ->
     send_tty(Term,"Escape"),
     send_tty(Term,"OF");
-send_tty(#tmux{ name = Name } = _Term,Value) ->
+send_tty(#tmux{ name = Name } = Term,Value) ->
     [Head | Quotes] = string:split(Value, "'", all),
-    "" = tmux("send -t " ++ Name ++ " '" ++ Head ++ "'"),
+    "" = tmux(Term, "send -t " ++ Name ++ " '" ++ Head ++ "'"),
     [begin
-            "" = tmux("send -t " ++ Name ++ " \"'\""),
-            "" = tmux("send -t " ++ Name ++ " '" ++ V ++ "'")
+            "" = tmux(Term, "send -t " ++ Name ++ " \"'\""),
+            "" = tmux(Term, "send -t " ++ Name ++ " '" ++ V ++ "'")
         end || V <- Quotes].
 
 %% We use send_stdin for testing of things that we cannot sent via
@@ -281,12 +286,12 @@ check_location(#tmux{ orig_location = {OrigRow, OrigCol} = Orig } = Term,
     end.
 
 get_location(Term) ->
-    RowAndCol = tmux("display -pF '#{cursor_y} #{cursor_x}' -t "++Term#tmux.name),
+    RowAndCol = tmux(Term, "display -pF '#{cursor_y} #{cursor_x}' -t "++Term#tmux.name),
     [Row, Col] = string:lexemes(string:trim(RowAndCol,both)," "),
     {list_to_integer(Row), list_to_integer(Col)}.
 
 get_window_size(Term) ->
-    RowAndCol = tmux("display -pF '#{window_height} #{window_width}' -t "++Term#tmux.name),
+    RowAndCol = tmux(Term, "display -pF '#{window_height} #{window_width}' -t "++Term#tmux.name),
     [Row, Col] = string:lexemes(string:trim(RowAndCol,both)," "),
     {list_to_integer(Row), list_to_integer(Col)}.
 
@@ -348,8 +353,8 @@ check_content(Term, Match, Opts, Attempt) ->
 
 get_content(Term) ->
     get_content(Term, "").
-get_content(#tmux{ name = Name }, Args) ->
-    Content = unicode:characters_to_binary(tmux("capture-pane -p " ++ Args ++ " -t " ++ Name)),
+get_content(#tmux{ name = Name } = Term, Args) ->
+    Content = unicode:characters_to_binary(tmux(Term, "capture-pane -p " ++ Args ++ " -t " ++ Name)),
     case string:split(Content,"a.\na") of
         [_Ignore,C] ->
             C;

--- a/lib/kernel/test/shell_test_lib.hrl
+++ b/lib/kernel/test/shell_test_lib.hrl
@@ -23,6 +23,6 @@
 -ifndef(shell_test_lib).
 -define(shell_test_lib, true).
 
--record(tmux, {peer, node, name, ssh_server_name, orig_location }).
+-record(tmux, {peer, node, name, ssh_server_name, orig_location, socket }).
 
 -endif.

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -10297,6 +10297,7 @@ ioctl_nread(_Config) when is_list(_Config) ->
     ?TT(?SECS(5)),
     tc_try(?FUNCTION_NAME,
            fun() ->
+                   has_support_ipv4(),
                    has_support_ioctl_requests(),
                    has_support_ioctl_nread()
            end,

--- a/lib/kernel/test/socket_SUITE.erl
+++ b/lib/kernel/test/socket_SUITE.erl
@@ -228,7 +228,8 @@ all() ->
 	      {socket_close, "ESOCK_TEST_SOCK_CLOSE", include},
 	      {tickets,      "ESOCK_TEST_TICKETS",    include},
 	      {batch_cases,  "ESOCK_TEST_BATCH",      include}],
-    [use_group(Group, Env, Default) || {Group, Env, Default} <- Groups].
+    [Spec || {Group, Env, Default} <- Groups,
+             Spec <- use_group(Group, Env, Default)].
 
 use_group(_Group, undefined, exclude) ->
     [];

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -1606,12 +1606,12 @@ do_api_b_open_and_maybe_close_raw(InitState) ->
                            end
                    end},
          #{desc => "close socket",
-           cmd  => fun(#{socket := Sock} = State) ->
+           cmd  => fun(#{sock := Sock} = State) ->
                            ?SEV_IPRINT("try socket close"),
                            case socket:close(Sock) of
                                ok ->
                                    ?SEV_IPRINT("socket closed"),
-                                   {ok, maps:remote(sock, State)};
+                                   {ok, maps:remove(sock, State)};
                                {error, Reason} = ERROR ->
                                    ?SEV_EPRINT("close failed:"
                                                "~n   Reason: ~p", [Reason]),

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -311,7 +311,8 @@ all() ->
               {options,                "ESOCK_TEST_API_OPTS",     include},
               {operation_with_timeout, "ESOCK_TEST_API_OPWTO",    include}
              ],
-    [use_group(Group, Env, Default) || {Group, Env, Default} <- Groups].
+    [Spec || {Group, Env, Default} <- Groups,
+             Spec <- use_group(Group, Env, Default)].
 
 use_group(_Group, undefined, exclude) ->
     [];

--- a/lib/kernel/test/socket_api_SUITE.erl
+++ b/lib/kernel/test/socket_api_SUITE.erl
@@ -5353,6 +5353,7 @@ api_ffd_open_connect_and_open_wod_and_send_tcp6(_Config) when is_list(_Config) -
 api_ffd_open_connect_and_open_wd_and_send_tcp4(_Config) when is_list(_Config) ->
     ?TT(?SECS(5)),
     tc_try(api_ffd_open_connect_and_open_wd_and_send_tcp4,
+           fun() -> has_support_ipv4() end,
            fun() ->
                    InitState = #{domain   => inet,
                                  type     => stream,

--- a/lib/kernel/test/wrap_log_reader_SUITE.erl
+++ b/lib/kernel/test/wrap_log_reader_SUITE.erl
@@ -162,7 +162,7 @@ test_one(File) ->
 %% Two filled index files.
 two_filled(Conf) when is_list(Conf) ->
     Dir = ?privdir(Conf),
-    File = list_to_atom(join(Dir, "sune.LOG")),
+    File = join(Dir, "sune.LOG"),
     delete_files(File),
     start(),
 


### PR DESCRIPTION
This is in the same spirita as #11488 but for` kernel` test. The goal here is to ensure they can run under other build systems (e.g. `buck`), and different running environments, etc. 

The issues fixed follow patterns like:
  * Add missing precondition checks. E.g. suites that skip when no IPv4 addresses are available in most, but not all testcases.
  * Ensure `ct_suite` callbacks follow their specs.
  * Test runners (like buck2's) may add extra conditions (setting ERL_EPMD_PORT for isolation, starting additional applications) that shouldn't affect test execution.
  * Avoid converting paths to atoms unnecessarily, to avoid hitting system limits.
  * Avoid bad interactions with the host: like hardwiring ports in tests or killing the tmux session running the test.
