### PR TITLE
ssl: Skip undecodable certificate_authorities names [maint-28 backport]

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -3459,7 +3459,13 @@ decode_psk_binders(<<?BYTE(Len), Binder:Len/binary, Rest/binary>>, Acc) ->
 decode_cert_auths(<<>>, Acc) ->
     lists:reverse(Acc);
 decode_cert_auths(<<?UINT16(Len), Auth:Len/binary, Rest/binary>>, Acc) ->
-    decode_cert_auths(Rest, [public_key:pkix_normalize_name(Auth) | Acc]).
+    try public_key:pkix_normalize_name(Auth) of
+        CertAuth ->
+            decode_cert_auths(Rest, [CertAuth | Acc])
+    catch
+        _:_ ->
+            decode_cert_auths(Rest, Acc)
+    end.
 
 %% encode/decode stream of certificate data to/from list of certificate data
 certs_to_list(ASN1Certs) ->

--- a/lib/ssl/test/ssl_handshake_SUITE.erl
+++ b/lib/ssl/test/ssl_handshake_SUITE.erl
@@ -55,7 +55,8 @@
          select_proper_tls_1_2_rsa_default_hashsign/1,
          ignore_hassign_extension_pre_tls_1_2/1,
          signature_algorithms/1,
-         drop_unassigned_signature_algorithms/1]).
+         drop_unassigned_signature_algorithms/1,
+         drop_undecodable_certificate_authorities/1]).
 
 %%--------------------------------------------------------------------
 %% Common Test interface functions -----------------------------------
@@ -70,7 +71,8 @@ all() -> [decode_hello_handshake,
 	  select_proper_tls_1_2_rsa_default_hashsign,
 	  ignore_hassign_extension_pre_tls_1_2,
 	  signature_algorithms,
-      drop_unassigned_signature_algorithms].
+          drop_unassigned_signature_algorithms,
+          drop_undecodable_certificate_authorities].
 
 %%--------------------------------------------------------------------
 init_per_suite(Config) ->
@@ -294,6 +296,26 @@ drop_unassigned_signature_algorithms(_Config) ->
         end,
         SigAlgs).
 
+drop_undecodable_certificate_authorities(_Config) ->
+    GoodAuth0 = {rdnSequence,
+                 [[{'AttributeTypeAndValue', ?'id-at-commonName',
+                    {utf8String, <<"Good CA">>}}]]},
+    GoodDN = public_key:pkix_encode('Name', GoodAuth0, otp),
+    BadDN = base64:decode(<<"MHAxCzAJBgNVBAYMAkJSMRMwEQYDVQQKDApJQ1AtQnJhc2lsMTQwMgY",
+                            "DVQQLDCtBdXRvcmlkYWRlIENlcnRpZmljYWRvcmEgUmFpeiBCcmFz",
+                            "aWxlaXJhIHY1MRYwFAYDVQQDDA1BQyBTeW5ndWxhcklE">>),
+    CertAuths = cert_auths_vector([BadDN, GoodDN]),
+    HashSigns = <<(ssl_cipher:signature_scheme({sha256, rsa})):16>>,
+    HashSignsLen = byte_size(HashSigns),
+    CertAuthsLen = byte_size(CertAuths),
+    CertReq = <<?BYTE(1), ?BYTE(?RSA_SIGN),
+                ?UINT16(HashSignsLen), HashSigns/binary,
+                ?UINT16(CertAuthsLen), CertAuths/binary>>,
+    GoodAuth = public_key:pkix_normalize_name(GoodAuth0),
+
+    #certificate_request{certificate_authorities = [GoodAuth]} =
+        ssl_handshake:decode_handshake(?TLS_1_2, ?CERTIFICATE_REQUEST, CertReq).
+
 
 %%--------------------------------------------------------------------
 %% Internal functions ------------------------------------------------
@@ -302,3 +324,9 @@ drop_unassigned_signature_algorithms(_Config) ->
 is_supported(Hash) ->
     Hashs = crypto:supports(hashs),
     lists:member(Hash, Hashs).
+
+cert_auths_vector(Auths) ->
+    list_to_binary([begin
+                        Len = byte_size(Auth),
+                        <<?UINT16(Len), Auth/binary>>
+                    end || Auth <- Auths]).


### PR DESCRIPTION
Backport of OTP-20327 (`352c8aa40e`, "ssl: Skip undecodable certificate_authorities names") to `maint-28`, as offered in #11595.

Cherry-picked with `-x`, so authorship stays with @ausimian and the origin is recorded in the commit. No changes to the patch: it applies cleanly on this base.

### Why it is worth backporting

The fix is on `maint` and ships in OTP 29.1, but no released OTP carries it. Anyone pinned to a patch line hits the original bug, and `maint` and `maint-29` both report `SSL_VSN = 11.7.5`, so the version string does not distinguish a fixed runtime from an unfixed one.

The practical effect is narrow but absolute: several Brazilian tax-authority endpoints (SEFAZ) require mTLS and advertise CA names that violate PKIX type constraints. On a runtime without this fix, 7 of the 27 Brazilian state endpoints complete a handshake; with it, all 27 do. Electronic invoicing is legally mandatory here, so for the affected states this is not degraded behaviour — the endpoints are simply unreachable from the BEAM.

### Verification

The test case that comes with the commit was compiled and executed against this branch's `ssl_handshake`, and against a stock OTP 29.0.6 for contrast:

| | `drop_undecodable_certificate_authorities` |
| --- | --- |
| stock OTP 29.0.6 | fails — `error:badmatch` |
| this branch | passes — malformed name skipped, valid name kept |

`ssl_handshake.erl` and `ssl_handshake_SUITE.erl` both compile on this base.

Separately, the same change compiled into OTP 29.0.6 and loaded ahead of the shipped module took the Brazilian endpoint count from 7 of 27 to 27 of 27 over real mTLS with an ICP-Brasil certificate.
