### PR TITLE
erts: Zero the padding of the PCRE name table slots

### DIFF
--- a/erts/emulator/pcre/pcre_compile.c
+++ b/erts/emulator/pcre/pcre_compile.c
@@ -9003,7 +9003,13 @@ for (i = 0; i < cd->names_found; i++)
 
 PUT2(slot, 0, groupno);
 memcpy(slot + IMM2_SIZE, name, IN_UCHARS(length));
-slot[IMM2_SIZE + length] = 0;
+
+/* Add a terminating zero and fill the rest of the slot with zeroes so that
+the memory is all initialized. Otherwise valgrind moans about uninitialized
+memory when saving serialized compiled patterns. */
+
+memset(slot + IMM2_SIZE + length, 0,
+  IN_UCHARS(cd->name_entry_size - length - IMM2_SIZE));
 cd->names_found++;
 }
 


### PR DESCRIPTION
Every slot of the table of named subpatterns is `cd->name_entry_size` long, which is dictated by the longest name in the `pattern. add_name()` writes the group number, the name and a terminating zero, and leaves the rest of the slot untouched, so it keeps whatever the allocated block happened to hold.

That garbage becomes part of the compiled pattern, and therefore of everything that stores one. Elixir 1.18.1 compiles a ~r// sigil at compile time and keeps it as a literal in the .beam file, so a module holding a pattern whose named groups differ in length - "hours"/"minutes", "at"/"letter", "ntp_timestamp"/"tai_diff" - is compiled to different bytes in every build. It was found in the tzdata and phoenix_live_dashboard modules while working on reproducible builds for [trento-web](https://github.com/trento-project/web).

See https://reproducible-builds.org/ for why determinism matters.

This is the same memset from `add_name_to_table()` in `pcre2_compile_cgroup.c`

OTP 28 and later are not affected, as they bundle PCRE2 already.