### PR TITLE
erts: charge enif_make_resource_binary() payload to the virtual binary heap

### DIFF
--- a/erts/emulator/beam/erl_binary.h
+++ b/erts/emulator/beam/erl_binary.h
@@ -46,6 +46,13 @@ enum binary_flags {
      * copying to another process, must clear these flags. */
     BIN_FLAG_WRITABLE =         (1 << 2),
     BIN_FLAG_ACTIVE_WRITER =    (1 << 3),
+
+    /* Set on a NIF resource's magic binary when the resource keeps alive
+     * memory that ERTS did not allocate -- the payloads passed to
+     * enif_make_resource_binary(). Lets the GC sweep skip the resource
+     * lookup for the overwhelming majority of binaries, which have no
+     * such payload. Valid iff BIN_FLAG_MAGIC is also set. */
+    BIN_FLAG_EXTERNAL_PAYLOAD = (1 << 4),
 };
 
 #define ERTS_BINARY_STRUCT_ALIGNMENT

--- a/erts/emulator/beam/erl_gc.c
+++ b/erts/emulator/beam/erl_gc.c
@@ -3044,6 +3044,9 @@ sweep_off_heap(Process *p, int fullsweep)
                          (BIN_FLAG_WRITABLE | BIN_FLAG_ACTIVE_WRITER)));
 
                 overhead = refc_binary->orig_size;
+                if (refc_binary->intern.flags & BIN_FLAG_EXTERNAL_PAYLOAD) {
+                    overhead += erts_resource_external_bytes(refc_binary);
+                }
                 to_new_heap = !ErtsInArea(ptr, oheap, oheap_sz);
                 ASSERT(to_new_heap == !seen_mature || (!to_new_heap && (seen_mature=1)));
 
@@ -3168,6 +3171,9 @@ sweep_off_heap(Process *p, int fullsweep)
 
             br = (BinRef*)boxed_val(br->thing_word);
             overhead = (br->val)->orig_size;
+            if ((br->val)->intern.flags & BIN_FLAG_EXTERNAL_PAYLOAD) {
+                overhead += erts_resource_external_bytes(br->val);
+            }
 
             *prev = (struct erl_off_heap_header*) br;
             ASSERT(br->thing_word == HEADER_BIN_REF);

--- a/erts/emulator/beam/erl_nif.c
+++ b/erts/emulator/beam/erl_nif.c
@@ -3142,6 +3142,7 @@ void* enif_alloc_resource(ErlNifResourceType* type, size_t data_sz)
 
     ASSERT(type->owner && type->next && type->prev); /* not allowed in load/upgrade */
     resource->type = type;
+    resource->external_bytes = 0;
     erts_refc_inc(&bin->intern.refc, 1);
 #ifdef DEBUG
     erts_refc_init(&resource->nif_refc, 1);
@@ -3209,17 +3210,48 @@ ERL_NIF_TERM enif_make_resource_binary(ErlNifEnv* env, void* obj,
     ErtsResource* resource = DATA_TO_RESOURCE(obj);
     ErtsBinary* bin = ERTS_MAGIC_BIN_FROM_UNALIGNED_DATA(resource);
     Eterm* hp;
+    ERL_NIF_TERM result;
 
     erts_refc_inc(&bin->binary.intern.refc, 1);
 
+    /* The payload is not ERTS-allocated, so the Binary we hand to
+     * erts_wrap_refc_bitstring below (the magic binary wrapping the
+     * resource) does not describe it and the process would exert no
+     * binary GC pressure however much it holds. Record the size on the
+     * resource so the GC sweep can charge it. A resource may back
+     * several binaries; keep the largest. */
+    if ((Uint)size > resource->external_bytes) {
+        resource->external_bytes = (Uint)size;
+        /* Benign race: concurrent calls for the same resource may each
+         * set this, but the bit is idempotent and nothing else writes
+         * flags on a magic binary after creation. */
+        bin->binary.intern.flags |= BIN_FLAG_EXTERNAL_PAYLOAD;
+    }
+
     hp = alloc_heap(env, ERL_REFC_BITS_SIZE);
-    return erts_wrap_refc_bitstring(&MSO(env->proc).first,
-                                    &MSO(env->proc).overhead,
-                                    &hp,
-                                    &bin->binary,
-                                    (byte*)data,
-                                    0,
-                                    NBITS(size));
+    result = erts_wrap_refc_bitstring(&MSO(env->proc).first,
+                                      &MSO(env->proc).overhead,
+                                      &hp,
+                                      &bin->binary,
+                                      (byte*)data,
+                                      0,
+                                      NBITS(size));
+
+    /* Charge it now too; the sweep will recompute (and overwrite) this at
+     * the next GC, but until then the pressure should reflect reality. */
+    MSO(env->proc).overhead += size / sizeof(Eterm);
+
+    return result;
+}
+
+Uint erts_resource_external_bytes(Binary *bin)
+{
+    /* Callers gate on BIN_FLAG_EXTERNAL_PAYLOAD, which is only ever set
+     * on a resource's magic binary, so this is off the GC's hot path. */
+    ASSERT(bin->intern.flags & BIN_FLAG_MAGIC);
+    ASSERT(ERTS_MAGIC_BIN_DESTRUCTOR(bin) == NIF_RESOURCE_DTOR);
+
+    return ((ErtsResource*) ERTS_MAGIC_BIN_UNALIGNED_DATA(bin))->external_bytes;
 }
 
 int enif_get_resource(ErlNifEnv* env, ERL_NIF_TERM term, ErlNifResourceType* type,

--- a/erts/emulator/beam/global.h
+++ b/erts/emulator/beam/global.h
@@ -102,6 +102,21 @@ typedef struct ErtsResource_
     byte align__[4];
 # endif
 #endif
+    /* Bytes of memory this resource keeps alive that ERTS did not
+     * allocate and therefore cannot size -- the payloads handed to
+     * enif_make_resource_binary(). Charged to the virtual binary heap so
+     * a process holding such binaries exerts GC pressure proportional to
+     * what it really holds. A resource may back several binaries of
+     * different sizes, so this is the largest seen: the virtual heap only
+     * ever triggers GC earlier, making over-estimation safe and
+     * under-estimation the bug. */
+    Uint external_bytes;
+#ifdef ARCH_32
+    /* *DO NOT USE* only for alignment: erl_nif_init() asserts that
+     * offsetof(ErtsResource,data) % 8 == ERTS_MAGIC_BIN_BYTES_TO_ALIGN,
+     * so 'data' must not move by half a word. */
+    byte align2__[4];
+#endif
     char data[1];
 }ErtsResource;
 
@@ -109,6 +124,10 @@ typedef struct ErtsResource_
 #define erts_resource_ref_size(P) ERTS_MAGIC_REF_THING_SIZE
 
 extern Eterm erts_bld_resource_ref(Eterm** hp, ErlOffHeap*, ErtsResource*);
+
+/* Payload bytes kept alive by a resource binary's resource, or 0 if this
+ * Binary is not a NIF resource. Used by the GC sweep. */
+Uint erts_resource_external_bytes(Binary *bin);
 
 extern ErtsCodePtr erts_call_nif_early(Process* c_p, const ErtsCodeInfo* ci);
 extern void erts_pre_nif(struct enif_environment_t*, Process*,

--- a/erts/emulator/test/nif_SUITE.erl
+++ b/erts/emulator/test/nif_SUITE.erl
@@ -55,6 +55,7 @@
 	 maps/1,
 	 api_macros/1,
 	 from_array/1, iolist_as_binary/1, resource/1, resource_binary/1,
+	 resource_binary_vheap/1,
 	 resource_takeover/1,
 	 t_dynamic_resource_call/1,
 	 threading/1, send/1, send2/1, send3/1, send_threaded/1,
@@ -237,6 +238,7 @@ all() ->
      get_atom, get_atom_length, make_new_atoms, make_existing_atoms,
      maps, api_macros, from_array,
      iolist_as_binary, resource, resource_binary,
+     resource_binary_vheap,
      threading, send, send2, send3,
      send_threaded, neg, is_checks, get_length, make_atom,
      make_string,reverse_list_test,
@@ -2483,6 +2485,51 @@ resource_binary_do() ->
     ResInfo = get_resource(binary_resource_type,ResBin1),
     ResInfo = get_resource(binary_resource_type,ResBin2),
     ResInfo.
+
+%% enif_make_resource_binary() must charge the payload to the process's
+%% virtual binary heap. The payload is not ERTS-allocated, so nothing else
+%% accounts for it: without this a process can hold gigabytes of resource
+%% binaries while reporting bin_vheap_size ~0, exert no GC pressure, and
+%% never be collected. Regression from 24ef4cbaed "erts: Refactor
+%% bitstring (binary) handling" (first released in OTP 27.0); before that
+%% the function did OH_OVERHEAD(ohp, size / sizeof(Eterm)) explicitly.
+resource_binary_vheap(Config) when is_list(Config) ->
+    ensure_lib_loaded(Config, 1),
+    Size = 1 bsl 20,
+    Payload = <<0:(Size*8)>>,
+    N = 16,
+
+    erlang:garbage_collect(),
+    Before = bin_vheap_total(),
+
+    %% Keep every binary live for the duration of the measurement.
+    Held = [begin
+                {_Ptr, ResBin} = make_new_resource_binary(Payload),
+                Size = byte_size(ResBin),
+                ResBin
+            end || _ <- lists:seq(1, N)],
+    N = length(Held),
+
+    After = bin_vheap_total(),
+    Grew = (After - Before) * erlang:system_info(wordsize),
+
+    %% N MiB of payload is live; allow generous slack for GC timing and
+    %% for the young/old heap split, but nothing like a factor of 1000.
+    Expected = (N * Size) div 2,
+    true = (Grew >= Expected) orelse
+        ct:fail({vheap_did_not_grow, {grew, Grew}, {expected_at_least, Expected}}),
+
+    %% Keep Held alive past the measurement.
+    _ = erlang:phash2(Held),
+    ok.
+
+%% Virtual binary heap across both generations -- the GC sweep splits
+%% young/old, so a long-lived binary lands in bin_old_vheap_size.
+bin_vheap_total() ->
+    {garbage_collection_info, Info} =
+        process_info(self(), garbage_collection_info),
+    proplists:get_value(bin_vheap_size, Info) +
+        proplists:get_value(bin_old_vheap_size, Info).
 
 %% Test resource takeover by module upgrade
 resource_takeover(Config) when is_list(Config) ->    


### PR DESCRIPTION
## The bug

`enif_make_resource_binary()` does not charge the payload to the calling process's
virtual binary heap. It charges the size of the *magic binary wrapping the
`ErtsResource`* — a few words — instead of the `size` bytes it was handed.

The payload is not ERTS-allocated, so nothing else accounts for it either. A process
can therefore hold gigabytes of resource binaries while exerting essentially no
binary GC pressure, and they are not collected until some unrelated GC happens by.

This contradicts the documented contract:

> Each process has a virtual binary heap associated with it that has the size of all
> the current off-heap binaries that the process has references to.

### Reproduction

The included test allocates 16 MiB of live resource binaries and inspects
`bin_vheap_size + bin_old_vheap_size`. Without the fix:

```
{vheap_did_not_grow, {grew, 896}, {expected_at_least, 8388608}}
```

**896 bytes charged for 16 MiB of live payload** — roughly 18,700x under. On a debug
build it is the only failure in the 87-case `nif_SUITE`.

### Cause

A regression from 24ef4cbaed ("erts: Refactor bitstring (binary) handling"), first
released in **OTP 27.0**. Before that commit the function did:

```c
OH_OVERHEAD(ohp, size / sizeof(Eterm));
```

i.e. it charged the payload explicitly, and the old `ProcBin` carried `pb->size` so
the GC sweep read the same figure. The refactor replaced this with
`erts_wrap_refc_bitstring()`, which derives overhead from the passed `Binary *` —
and `enif_make_resource_binary()` passes `&bin->binary`, the magic wrapper, not the
data. The payload size arrives separately as `NBITS(size)` and is dropped.

Note that a creation-time charge alone is **not** sufficient: `sweep_off_heap()`
recomputes overhead from `orig_size` for every live `BinRef` and then *assigns*
`MSO(p).overhead`, so any charge made at creation is wiped at the process's first GC.

### Real-world impact

Found in a video pipeline where decoded frames reach the BEAM via
`enif_make_resource_binary()`. Frame memory grew to ~6.4 GB, of which ~5 GB was
uncollected garbage a forced `erlang:garbage_collect/1` reclaimed immediately.
With this change the same workload sits at 275-570 MB. Anything returning large
payloads this way on OTP >= 27 is affected.

## This PR

- `ErtsResource` gains `external_bytes`, recorded by `enif_make_resource_binary()`.
- Both `sweep_off_heap()` sites add it, so the charge survives GC.
- `BIN_FLAG_EXTERNAL_PAYLOAD` keeps the resource lookup off the GC's hot path — the
  common case is one flag test on a word already being read.
- Regression test in `nif_SUITE`.

Because one resource may back several binaries of different sizes,
`external_bytes` is the largest seen. The virtual heap only ever triggers GC
*earlier*, so an over-estimate is safe where the current under-estimate is not.

## Question for reviewers: would you prefer the `BinRef` route?

We are not close enough to the runtime's priorities to judge this, so we would
rather ask than guess.

The **faithful** restoration of the pre-27 behaviour would be to put the payload
size back on the reference — `ProcBin` had exactly that in `pb->size`, and today's
`BinRef` has no equivalent. That would be *exact* per binary, would remove both the
resource lookup and the flag bit, and would need no `max()` approximation.

The cost is a word on every off-heap binary reference in the VM (`BinRef` is
currently 3 words: `thing_word`, `val`, `next`), which is why we did not simply do
it — it seemed presumptuous to change heap layout for everyone to fix a case that
only affects NIF resources.

If you would prefer that shape, we are happy to redo it that way.

## Other things a reviewer may want to change

1. **`flags` read-modify-write.** `bin->binary.intern.flags |= BIN_FLAG_EXTERNAL_PAYLOAD`
   is a plain non-atomic RMW on a field the GC reads from other schedulers. We
   believe it is benign — nothing else writes `flags` on a magic binary after
   creation, the bit is idempotent, and a lost update only under-charges one binary
   until the next call — but it is a data race by the letter of the memory model.
   An atomic OR, or setting the bit unconditionally in `enif_alloc_resource()`,
   would both remove the question. Same applies to `external_bytes` itself.
2. **The creation-time charge is deliberately kept** so pressure is correct
   *between* collections; the sweep recomputes it. It is commented, but may read as
   double-counting at first glance.
3. **`ERTS_USED_MAGIC_REF_THING_HEADER__` in the sweep is untouched** — a resource
   reached via `enif_make_resource()` rather than a resource binary still charges
   only `orig_size`. Deliberately minimal, but arguably inconsistent.

## Testing

Built and tested on `master` (`./configure --without-javac && make -j32`, OTP 30 /
erts 17.0.6), opt and debug:

| Suite | Result |
|---|---|
| `nif_SUITE` | 87 ok, 0 failed |
| `dirty_nif_SUITE` | 35 ok, 0 failed |
| `gc_SUITE` | 10 ok, 0 failed |
| `binary_SUITE` | 53 ok, 0 failed, 2 skipped |
| `bs_construct_SUITE` | 30 ok, 0 failed, 1 skipped |
| `bs_match_bin_SUITE` | 9 ok, 0 failed |
| `bs_bit_binaries_SUITE` | 11 ok, 0 failed |

235 ok / 0 failed / 3 skipped; skips are environmental and pre-existing. The new
test was confirmed to **fail** on an unpatched emulator (numbers above) as well as
pass on a patched one.

Two caveats we would rather state than have you find:

- This branch is based on `maint` per CONTRIBUTING, but the **build and test runs
  above were on the `master` version of the same commit**, which cherry-picked
  cleanly. We have not separately built `maint`.
- `erl_nif_init()` asserts
  `offsetof(ErtsResource,data) % 8 == ERTS_MAGIC_BIN_BYTES_TO_ALIGN`, so on 32-bit a
  bare `Uint` would move `data` and break the build. There is an `ARCH_32` pad for
  this, **untested on real 32-bit hardware** — it is a compile-time assert, so CI
  will say immediately if we got it wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8xtBkL9NzdvRcv5YXw3hr
