### PR TITLE
kernel: document how to bind a distributed node to loopback

### DIFF
--- a/lib/kernel/doc/kernel_app.md
+++ b/lib/kernel/doc/kernel_app.md
@@ -249,6 +249,85 @@ For more information about configuration parameters, see file
   specifies which one to listen on. For the type definition of `ip_address()`,
   see `m:inet`.
 
+  To accept incoming distribution connections only from the local host, for
+  example for a development node or a tool that only needs a local remote
+  shell (`-remsh`), set this parameter to a loopback address and give the node
+  a name whose host part resolves to that address. Example for IPv4:
+
+  ```text
+  erl -name mynode@127.0.0.1 \
+      -kernel inet_dist_use_interface '{127,0,0,1}' \
+      -env ERL_EPMD_ADDRESS 127.0.0.1
+  ```
+
+  A shell on that node is then opened with:
+
+  ```text
+  erl -name shell@127.0.0.1 -dist_listen false -remsh mynode@127.0.0.1
+  ```
+
+  For IPv6 the loopback address is `::1`, and both the node and the shell need
+  `-proto_dist inet6_tcp`, as a node using the IPv4 carrier cannot connect to
+  an IPv6 node:
+
+  ```text
+  erl -proto_dist inet6_tcp -name mynode@::1 \
+      -kernel inet_dist_use_interface '{0,0,0,0,0,0,0,1}' \
+      -env ERL_EPMD_ADDRESS ::1
+
+  erl -proto_dist inet6_tcp -name shell@::1 -dist_listen false \
+      -remsh mynode@::1
+  ```
+
+  Each part of the example has its own effect:
+
+  - **`inet_dist_use_interface`** - Binds the listening socket to the given
+    address. The node name alone does not; a node started with only
+    `-name mynode@127.0.0.1` still listens on all interfaces. Only incoming
+    connections are restricted: the node can still connect to other nodes, and
+    such a connection carries traffic in both directions. To also limit which
+    nodes this node may connect to, see `net_kernel:allow/1`.
+
+  - **The node name** - Its host part must resolve to the address the listener
+    is bound to, as that is the address other nodes, including a remote shell,
+    connect to; a connection to any other address is refused, even another
+    loopback address such as `127.0.1.1`. A short name without a host part
+    (`-sname mynode`) uses the host's own hostname, so whether the node can be
+    reached depends on what that hostname resolves to; a name whose host part
+    is an IP address, as in the example, needs no name resolution. A short name
+    with an explicit host part, `-sname mynode@localhost`, works where
+    `localhost` resolves to `127.0.0.1`, and is then reached with a plain
+    `erl -remsh mynode@localhost`.
+
+  - **The shell node** - Must use the same kind of node name, long (`-name`)
+    or short (`-sname`), as the node it connects to.
+    [`-remsh`](`e:erts:erl_cmd.md#remsh`) without `-name` or `-sname` starts
+    a short-named node with a
+    [dynamic node name](`e:system:distributed.md#dyn_node_name`), which cannot
+    connect to a long-named node, so `erl -remsh mynode@127.0.0.1` alone is
+    refused. `-dist_listen false` keeps the shell node from opening a listening
+    socket of its own; without it, the shell node itself listens on all
+    interfaces. A dynamic node name implies `-dist_listen false`, so the plain
+    `erl -remsh mynode@localhost` above does not need the flag.
+
+  - **`ERL_EPMD_ADDRESS`** - Keeps [`epmd`](`e:erts:epmd_cmd.md`) from
+    answering on other interfaces, so the name and port of the node cannot be
+    looked up from the network; `epmd` listens on both `127.0.0.1` and `::1`,
+    regardless of which one is given. It does not affect the listener of the
+    node, and it only applies when this node is the one that starts the
+    daemon. An `epmd` that is already running keeps the addresses it was
+    started with, and the node registers with it without any warning; the node
+    is then still confined by `inet_dist_use_interface`, but its name and port
+    remain visible through `epmd`. To confine `epmd` as well, stop the running
+    daemon and start one with the address before starting the node, for
+    example `epmd -address 127.0.0.1 -daemon`.
+
+  > #### Warning {: .warning }
+  >
+  > Binding to loopback limits who can reach the node; it does not replace the
+  > cookie. Any local process that knows the cookie can still connect to the
+  > node. See [Security](`e:system:distributed.md#security`).
+
 - **`inet_dist_listen_min = First`{: #inet_dist_listen }  
   `inet_dist_listen_max = Last`**  
   Defines the `First..Last` port range for the listener socket of a distributed


### PR DESCRIPTION
## Why

The `inet_dist_use_interface` entry in `kernel_app.md` is two sentences and only
mentions hosts with "many network interfaces". Nowhere in the distribution docs is
it explained how to run a node that accepts distribution connections only from
the local host, which of the involved settings does what, or why the obvious
attempts fail (the hostname behind a plain `-sname` may resolve to an address
the listener is not bound to; a plain `erl -remsh` cannot connect to a
long-named node).

The practical consequence is that tools that only need *local* distribution
(editor language servers, debuggers, development nodes) ship with the cluster
default: distribution listener on all interfaces, epmd on all interfaces, and a
guessable cookie. With a guessable cookie that combination is reachable from
the network, and it has happened:

- **GHSA-573p-mcvv-hchg** (VS Code Erlang extension,
  https://github.com/pgourlain/vscode_erlang/security/advisories/GHSA-573p-mcvv-hchg):
  the LSP, debugger and distribution sockets listened on `0.0.0.0` with a
  predictable cookie. Fixed in 1.1.5 with the settings this change documents
  (`-name node@127.0.0.1`, `inet_dist_use_interface {127,0,0,1}`,
  `ERL_EPMD_ADDRESS=127.0.0.1`). Write-up:
  https://erts-sched.github.io/security/vscode-erlang-loopback-rce/
- The same class hit **Apache CouchDB (CVE-2022-24706)**: distribution port on
  all interfaces, advertised by epmd, default cookie `monster`. CouchDB 3.2.2
  refuses to start with that cookie and, in addition, its binary packages bind
  epmd and the distribution port to `127.0.0.1` / `::1`; the entry documents
  the binding, and its Warning says why the cookie still matters.

This PR does not change any default or behavior. It documents, in the
`inet_dist_use_interface` entry, how to confine incoming distribution to
loopback, what each setting does and does not do, and the limit (binding is
not authentication).

## What the entry now says

1. `inet_dist_use_interface` binds the listener to the given address; the node
   name alone does not. It restricts incoming connections only; outgoing
   connections still work and are bidirectional (`net_kernel:allow/1` to limit
   which nodes this node may connect to).
2. The host part of the name must resolve to the bound address; any other
   address, even `127.0.1.1`, is refused. `-sname mynode` depends on hostname
   resolution; a host part that is an IP address does not.
   `-sname mynode@localhost` works where `localhost` is `127.0.0.1`, and then a
   plain `erl -remsh` works.
3. The shell node must use the same kind of node name, long or short. A plain
   `erl -remsh` starts a short-named node with a dynamic node name, which
   cannot reach a long-named one; the documented client is
   `erl -name shell@127.0.0.1 -dist_listen false -remsh mynode@127.0.0.1`, and
   without `-dist_listen false` the shell node itself listens on all
   interfaces.
4. `ERL_EPMD_ADDRESS` only affects an epmd started by this node, never the
   node's listener; an already-running epmd keeps its addresses and the node
   registers silently. Remedy: stop it and start `epmd -address 127.0.0.1
   -daemon` before starting the node.
5. IPv6, as a parallel example: `-proto_dist inet6_tcp` on both the node and
   the shell (an IPv4-carrier node cannot connect to an IPv6 node),
   `-name mynode@::1`, `inet_dist_use_interface {0,0,0,0,0,0,0,1}`,
   `ERL_EPMD_ADDRESS ::1`; epmd listens on both `127.0.0.1` and `::1`,
   regardless of which one is given.
6. Warning: loopback limits who can reach the node; it does not replace the
   cookie.

## What was measured

Environment: Linux host (`one`, IPv4 `10.0.0.203/24`, a global IPv6 address,
IPv6 enabled). OTP 27.3.4.17 (erts 15.2.7.13) natively and in the official
`erlang:27` Docker image; OTP 28.5.0.6 (erts 16.4.0.6) and OTP 29.0.6
(erts 17.0.6, the version of `maint`) in the official `erlang:28` and
`erlang:29` images. The images ran with `--network host`, so the same
interfaces and addresses as the host. Rows 8, 9 and 23 edit `/etc/hosts`
(23 also `/etc/resolv.conf`) and were run only in the images; the native run
reports them as "not measured". A private epmd on port 4370
(`export ERL_EPMD_PORT=4370`) was used throughout, so the system epmd on 4369
was never involved; every test node is stopped and the private epmd killed at
the end of each run (`measure.sh` cleanup trap).

The host runs a local firewall (`ufw` active). To rule it out: (a) every
"refused" row (5, 6, 8, 9) has a control on the same path that succeeds, the
same name with an unbound listener connects, over the LAN IPv4 address and over
the global IPv6 address, and row 19 connects out over the LAN address, so
refusals are attributable to the socket binding, not to filtering; (b) the
whole matrix except row 6 (it needs a global IPv6 address) was repeated on
OTP 27, 28 and 29 in a Docker container with its own network namespace (bridge
network, `172.17.0.2`, where the host's firewall rules do not apply). Every row
came out the same, with
one expected difference: the container hostname resolves to `172.17.0.2`, so
row 7 there is row 9's setup and gives row 9's result (`false` with the
loopback listener, `true` with the unbound control), which is what the entry's
`-sname mynode` sentence describes.

The script that produced every row, and its captured outputs per version and
network setup, are public and re-runnable:
https://github.com/erts-sched/otp-loopback-node-measurements
(`./measure.sh` on any OTP; `./run-docker.sh 27 28 29` for the official
images; only `bash`, `erl` and `epmd` needed). Sockets are read from inside the
BEAM (`inet:sockname/1`; `:::P` is the IPv6 wildcard, `::1:P` the IPv6
loopback) and epmd is reported by which addresses answer a connect, not by
bound address.

Every sentence in the entry maps to a row below. Every row was measured on
OTP 27, 28 and 29 with the same outcome; the outputs are in `results/` of the
repository. `P` is the node's distribution port. "Loopback listener" means
`inet_dist_use_interface` set to `{127,0,0,1}` or `{0,0,0,0,0,0,0,1}`;
"unbound listener" means the same node without the parameter, i.e. bound to
the wildcard address (rows 1 and 2), what the entry calls "listens on all
interfaces". "Recipe node" (rows 11-13) is the IPv4 example of the entry
started verbatim.

| # | Setup | Result |
|---|-------|--------|
| 1 | `-name n@127.0.0.1` alone | listener `0.0.0.0:P` |
| 2 | `-proto_dist inet6_tcp -name n@::1` alone | listener `:::P` (IPv6 wildcard) |
| 3 | 1 + `inet_dist_use_interface {127,0,0,1}` | listener `127.0.0.1:P`; local node with the cookie: `net_adm:ping` → `pong` |
| 4 | 2 + `inet_dist_use_interface {0,0,0,0,0,0,0,1}` | listener `::1:P`; local IPv6 node: `pong` |
| 5 | `-name n@10.0.0.203` + loopback listener | `pang` (name resolves to an address the listener is not bound to); same name, unbound listener: `pong` |
| 6 | `-name n@<global IPv6>` + `::1` listener | `pang`; same name, unbound listener: `pong` |
| 7 | `-sname n` where hostname → `127.0.0.1` (this host's `/etc/hosts`) + loopback listener, `-sname` client | `connect_node` → `true` |
| 8 | `-sname n` where hostname → `127.0.1.1` (Debian-style, container `/etc/hosts` edited) + loopback listener | `false`; unbound listener: `true` |
| 9 | `-sname n` where hostname → `10.0.0.203` + loopback listener | `false`; unbound listener: `true` |
| 10 | `-sname n@localhost` + loopback listener, plain `erl -remsh n@localhost` | remote prompt `(n@localhost)1>`; `localhost` → `127.0.0.1` |
| 11 | recipe node, plain `erl -remsh mynode@127.0.0.1` | `Could not connect to "mynode@127.0.0.1"`; client `-sname undefined`: `connect_node` → `false` |
| 12 | recipe node, `erl -name shell@127.0.0.1 -remsh mynode@127.0.0.1` | remote prompt shown; but the shell node itself listens on `0.0.0.0:P` |
| 13 | recipe node, `erl -name shell@127.0.0.1 -dist_listen false -remsh mynode@127.0.0.1` | remote prompt shown; the shell node has no listening socket |
| 14 | epmd started by the node, no `ERL_EPMD_ADDRESS` | epmd answers on `127.0.0.1`, `::1`, the LAN IPv4 and the global IPv6 address; the node's listener is still `127.0.0.1:P` (node not reachable, only its name and port) |
| 15 | epmd started by the node with `-env ERL_EPMD_ADDRESS 127.0.0.1` | epmd answers on `127.0.0.1` and `::1`, refuses the LAN and global IPv6 addresses (loopback of both families: `epmd_cmd.md` says only that "the loopback address" is implicitly added, `epmd_srv.c` adds `INADDR_LOOPBACK` and `in6addr_loopback`) |
| 16 | fresh epmd with `ERL_EPMD_ADDRESS=::1` | same as row 15 |
| 17 | epmd already running on all interfaces, node started with the loopback listener and `-env ERL_EPMD_ADDRESS 127.0.0.1` | epmd unchanged (still answers on every address); the node starts and registers with no output; its listener is `127.0.0.1:P` |
| 18 | `epmd -address 127.0.0.1 -daemon` started before the node | epmd answers on `127.0.0.1` and `::1` only; the node registers; a loopback client connects |
| 19 | loopback-bound node `net_kernel:connect_node('other@10.0.0.203')`, the peer listening on `0.0.0.0:P` | `true`; dist socket `10.0.0.203:x` ↔ `10.0.0.203:P`; the peer's `rpc:call` back into the node returns the node's own OS pid |
| 20 | row 19 after `net_kernel:allow(['nobody@127.0.0.1'])` | `connect_node` → `false` |
| 21 | the IPv6 example verbatim (`-proto_dist inet6_tcp -name mynode@::1`, `{0,0,0,0,0,0,0,1}`, `-env ERL_EPMD_ADDRESS ::1`, epmd started by the node) | listener `::1:P`; epmd answers on `127.0.0.1` and `::1` only |
| 22 | IPv6 shell `erl -proto_dist inet6_tcp -name shell@::1 -dist_listen false -remsh mynode@::1` | remote prompt `(mynode@::1)1>`; no listening socket; an IPv4-carrier client `-name shell4@127.0.0.1` → `connect_node` → `false` |
| 23 | `-sname n` where the hostname is in neither `/etc/hosts` nor DNS (container: entry removed, resolver pointed at an unreachable address) + loopback listener | `inet:getaddr` → `{127,0,0,1}` via `inet:gethostbyname_self/2`; `connect_node` → `true` |

Rows 1-4 and 21-22 are the "name alone does not bind" and IPv6 parts; 5-9 and
23 the "must resolve to the bound address" and hostname sentences; 10-13 the
shell paragraph; 14-18 the `ERL_EPMD_ADDRESS` paragraph (17 is the "still
confined" clause); 19-20 the "only incoming" sentence; row 3 is also the basis
of the Warning (a local node with the cookie connects).

## Notes for reviewers (from `inet.erl`)

- The example tuples match the documented type: `{127,0,0,1}` is
  `ip4_address()`, `{0,0,0,0,0,0,0,1}` is `ip6_address()`.
- The atom `loopback` also works as `inet_dist_use_interface`, because the
  value is passed straight into the listen socket's `{ip, _}` option, which
  `inet` accepts as `ip_address() | any | loopback`. Measured on OTP 27, 28
  and 29 (row 24 of the repository's table; not in the table above because the
  entry does not use it): with `inet_tcp` the listener is `127.0.0.1:P`, with
  `inet6_tcp` it is `::1:P`. It is **not** used in the entry, since the
  documented type of the parameter is `ip_address()` only. If you would rather
  document it as supported, extending the type to `ip_address() | loopback`
  would make one example cover both families; that is your call, not something
  a docs PR should decide.
- `inet:gethostbyname_self/2` (`inet.erl`, the clause commented "This is the
  final fallback that pretends /etc/hosts has got a line for the hostname on
  the loopback address") resolves the host's own hostname to the loopback
  address when it is in neither `/etc/hosts` nor DNS. This is one more way
  `-sname mynode` can end up on `127.0.0.1`; see rows 7-9 and 23 for the
  resolutions measured. The entry's wording ("depends on what that hostname
  resolves to") covers it without naming any of them.

## Not measured, and why

- **A second physical host.** Single-host lab. "Reachable from the network" is
  read from the bound address of the listening socket (`inet:sockname/1` in
  the script) and from connecting to the host's own LAN address (rows 5, 8, 9,
  19), which takes the same path a remote host would. The in-the-wild
  confirmations are GHSA-573p-mcvv-hchg and CVE-2022-24706 above.
- **Windows and macOS.** Linux only. Hostname resolution (rows 7-9, 23) is
  OS- and configuration-specific, which is exactly why the entry recommends the
  literal address over `-sname`.
- **`-sname mynode@localhost` over IPv6.** Not run. `inet:getaddr("localhost",
  inet6)` returned `nxdomain` on the host and `::1` in the bridge containers,
  so the IPv6 paragraph uses the literal `::1` only and makes no claim about
  `localhost`.
- **Other distribution carriers** (`inet_tls_dist`, custom `-proto_dist`
  modules). Not measured; the entry only describes `inet_tcp` and `inet6_tcp`.
- **Doc rendering.** The ex_doc build was not run locally (it needs a full OTP
  build). The markdown uses only constructs already present in this file
  (bullet continuation, `Example:` + fenced `text`, nested bullets with a bold
  lead, `> #### Warning {: .warning }`, `` `e:erts:...` `` and
  `` `e:system:...` `` links, `mod:fun/arity` references). Link targets
  verified to exist: `erl_cmd.md` anchor `{: #remsh }`, `distributed.md`
  anchors `{: #dyn_node_name }` and heading `## Security`, `epmd_cmd.md`.
- **Versions before OTP 27.** Not measured. The entry uses two features that
  arrived in OTP 23.0: `-dist_listen false`, in the documented shell command,
  and `-remsh` without `-name` or `-sname`, in the plain
  `erl -remsh mynode@localhost` and in the "starts a short-named node"
  sentence (per `erl_cmd.md`, which also requires the target node to run
  OTP 23 or later for that form).

## Known interaction (measured earlier, outside this PR)

epmd adds the loopback address of both families when `ERL_EPMD_ADDRESS` is
set (row 15; `epmd_cmd.md` says "the loopback address", the pair comes from
`epmd_srv.c` and was measured on every version above). On a host with IPv6
disabled, OTP 27.3.4.15, 28.5.0.4 and 29.0.4 fail to start such an epmd because
the `::1` bind fails (erlang/otp#11402, fixed in the next patch of each branch,
OTP-20275). Measured in Docker with `net.ipv6.conf.all.disable_ipv6=1` on
2026-09-06: 27.3.4.15 fails, 27.3.4.17 starts. Not a doc matter, mentioned so
reviewers reproducing on those exact patches are not surprised.

## To reproduce

The quickest way is the repository above: `git clone`, then `./measure.sh`
(any OTP, ~2 minutes, private epmd port) or `./run-docker.sh 27 28 29`. A
hand check of the three central claims, same user (same `~/.erlang.cookie`),
Linux:

```text
export ERL_EPMD_PORT=4370          # keep the system epmd out of it
port() { sleep 1; epmd -names | awk -v n="$1" '$2==n{print $NF}'; }

# 1. name alone: the listener is on all interfaces
erl -noshell -name t1@127.0.0.1 -eval 'timer:sleep(5000), halt().' &
ss -ltn | grep ":$(port t1) "                    # -> 0.0.0.0:P

# 2. with inet_dist_use_interface: loopback only; the documented shell connects,
#    a plain -remsh (short-named) does not
erl -noshell -name t2@127.0.0.1 -kernel inet_dist_use_interface '{127,0,0,1}' \
    -eval 'timer:sleep(60000), halt().' &
ss -ltn | grep ":$(port t2) "                    # -> 127.0.0.1:P
erl -remsh t2@127.0.0.1                          # -> Could not connect
erl -name shell@127.0.0.1 -dist_listen false -remsh t2@127.0.0.1   # -> (t2@127.0.0.1)1>
                                                 #    leave with q(). (stops t2)

# 3. a name that resolves to an address the listener is not bound to is refused
erl -noshell -name t3@<LAN-IP> -kernel inet_dist_use_interface '{127,0,0,1}' \
    -eval 'timer:sleep(5000), halt().' & sleep 1
erl -noshell -name p@127.0.0.1 -dist_listen false \
    -eval 'io:format("~p~n",[net_adm:ping('"'"'t3@<LAN-IP>'"'"')]), halt().'    # -> pang
```

## Related, not changed by this PR

- #8694 (open): with `-sname`, the host part of the node name itself depends
  on the order of `/etc/hosts` lines (`abc@localhost` vs `abc@zen`). One more
  reason the entry recommends a name whose host part is a literal address.
- #1075 / #1422 (open since 2016/2017): propose removing epmd's implicit
  binding of the loopback addresses. The entry describes the current
  behavior (row 15); if that ever changes, only the sentence "`epmd` listens
  on both `127.0.0.1` and `::1`, regardless of which one is given" needs to
  follow.
- #11402 (fixed in 27.3.4.16, 28.5.0.5, 29.0.5): the IPv4-only failure of
  that implicit `::1` bind, see "Known interaction" above.

No open PR touches `kernel_app.md`, `distributed.md` or `epmd_cmd.md`.

## Scope

Docs only: `lib/kernel/doc/kernel_app.md`, the `inet_dist_use_interface` entry.
DCO signed.

