### PR TITLE
emulator: Remove deprecated `catch` in number test suites

### DIFF
--- a/erts/emulator/test/Makefile
+++ b/erts/emulator/test/Makefile
@@ -180,6 +180,8 @@ STDLIB_MODULES=error_info_lib
 ERL_FILES= $(MODULES:%=%.erl) \
 	$(STDLIB_MODULES:%=$(ERL_TOP)/lib/stdlib/test/%.erl)
 
+HRL_FILES= erts_test_utils.hrl
+
 TARGET_FILES = $(MODULES:%=$(EBIN)/%.$(EMULATOR))
 
 KERNEL_MODULES=gen_tcp_dist
@@ -254,6 +256,7 @@ release_tests_spec: make_emakefile
 	$(INSTALL_DIR) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(EMAKEFILE) $(TEST_SPEC_FILES) \
 		$(ERL_FILES) "$(RELSYSDIR)"
+	$(INSTALL_DATA) $(HRL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(NO_OPT_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(KERNEL_ERL_FILES) "$(RELSYSDIR)"
 	$(INSTALL_DATA) $(STRIPPED_TYPES_ERL_FILES) "$(RELSYSDIR)"

--- a/erts/emulator/test/beam_literals_SUITE.erl
+++ b/erts/emulator/test/beam_literals_SUITE.erl
@@ -31,6 +31,7 @@
 	 increment/1]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 suite() -> [{ct_hooks,[ts_install_cth]}].
 
@@ -219,11 +220,10 @@ badmatch(Config) when is_list(Config) ->
     %% We are satisfied if we can load this module and run it.
     Big = id(32984798729847892498297824872982972978239874),
     Float = id(3.1415927),
-    catch a = Big,
-    catch b = Float,
-    {'EXIT',{{badmatch,3879373498378993387},_}} =
-	   (catch c = 3879373498378993387),
-    {'EXIT',{{badmatch,7.0},_}} = (catch d = 7.0),
+    ?assertError({badmatch,_}, a = Big),
+    ?assertError({badmatch,_}, b = Float),
+    ?assertError({badmatch,3879373498378993387}, c = 3879373498378993387),
+    ?assertError({badmatch,7.0}, d = 7.0),
     case Big of
         Big -> ok
     end,
@@ -233,12 +233,12 @@ badmatch(Config) when is_list(Config) ->
     ok.
 
 case_clause(Config) when is_list(Config) ->
-    {'EXIT',{{case_clause,337.0},_}} = (catch case_clause_float()),
-    {'EXIT',{{try_clause,42.0},_}} = (catch try_case_clause_float()),
-    {'EXIT',{{case_clause,37932749837839747383847398743789348734987},_}} =
-	(catch case_clause_big()),
-    {'EXIT',{{try_clause,977387349872349870423364354398566348},_}} =
-	(catch try_case_clause_big()),
+    ?assertError({case_clause,337.0}, case_clause_float()),
+    ?assertError({try_clause,42.0}, try_case_clause_float()),
+    ?assertError({case_clause,37932749837839747383847398743789348734987},
+                  case_clause_big()),
+    ?assertError({try_clause,977387349872349870423364354398566348},
+                  try_case_clause_big()),
     ok.
 
 case_clause_float() ->
@@ -558,7 +558,7 @@ increment(Config) when is_list(Config) ->
 
     %% Test error handling for the i_increment instruction.
     Bad = id(bad),
-    {'EXIT',{badarith,_}} = (catch Bad + 42),
+    ?assertError(badarith, Bad + 42),
 
     %% Small operands, but a big result.
     Res32 = 1 bsl 27,

--- a/erts/emulator/test/big_SUITE.erl
+++ b/erts/emulator/test/big_SUITE.erl
@@ -348,9 +348,9 @@ big_float_1(Config) when is_list(Config) ->
 big_float_2(Config) when is_list(Config) ->
     F = id(1.7e308),
     I = trunc(F),
-    {'EXIT', _} = (catch 1/(2*I)),
+    ?assertError(_, 1/(2*I)),
     _Ignore = 2/I,
-    {'EXIT', _} = (catch 4/(2*I)),
+    ?assertError(_, 4/(2*I)),
     ok.
 
 %% Converting a bignum to a float must give the nearest representable
@@ -417,10 +417,7 @@ correctly_rounded(I) ->
 
 %% OTP-3256
 shift_limit_1(Config) when is_list(Config) ->
-    case catch (id(1) bsl 100000000) of
-	      {'EXIT', {system_limit, _}} ->
-		  ok
-	  end,
+    ?assertError(system_limit, (id(1) bsl 100000000)),
     ok.
 
 powmod(Config) when is_list(Config) ->
@@ -447,15 +444,15 @@ powmod(A, B, C) ->
 
 system_limit(Config) when is_list(Config) ->
     Maxbig = maxbig(),
-    {'EXIT',{system_limit,_}} = (catch Maxbig+1),
-    {'EXIT',{system_limit,_}} = (catch -Maxbig-1),
-    {'EXIT',{system_limit,_}} = (catch 2*Maxbig),
-    {'EXIT',{system_limit,_}} = (catch bnot Maxbig),
-    {'EXIT',{system_limit,_}} = (catch apply(erlang, id('bnot'), [Maxbig])),
-    {'EXIT',{system_limit,_}} = (catch Maxbig bsl 2),
-    {'EXIT',{system_limit,_}} = (catch apply(erlang, id('bsl'), [Maxbig,2])),
-    {'EXIT',{system_limit,_}} = (catch id(1) bsl (1 bsl 45)),
-    {'EXIT',{system_limit,_}} = (catch id(1) bsl (1 bsl 69)),
+    ?assertError(system_limit, Maxbig+1),
+    ?assertError(system_limit, -Maxbig-1),
+    ?assertError(system_limit, 2*Maxbig),
+    ?assertError(system_limit, bnot Maxbig),
+    ?assertError(system_limit, apply(erlang, id('bnot'), [Maxbig])),
+    ?assertError(system_limit, Maxbig bsl 2),
+    ?assertError(system_limit, apply(erlang, id('bsl'), [Maxbig,2])),
+    ?assertError(system_limit, id(1) bsl (1 bsl 45)),
+    ?assertError(system_limit, id(1) bsl (1 bsl 69)),
 
     ?assertError(system_limit, Maxbig bxor -1),
     ?assertError(system_limit, apply(erlang, id('bxor'), [Maxbig,-1])),
@@ -486,7 +483,7 @@ maxbig() ->
     erlang:system_info(max_integer).
 
 toobig(Config) when is_list(Config) ->
-    {'EXIT',{{badmatch,_},_}} = (catch toobig()),
+    ?assertError({badmatch,_}, toobig()),
     ok.
 
 toobig() ->

--- a/erts/emulator/test/erts_test_utils.erl
+++ b/erts/emulator/test/erts_test_utils.erl
@@ -31,6 +31,7 @@
 -export([mk_ext_pid/3,
          mk_ext_port/2,
          mk_ext_ref/2,
+         assert_error_stack/3,
          available_internal_state/1,
          check_node_dist/0, check_node_dist/1, check_node_dist/3,
          ept_check_leaked_nodes/1]).
@@ -242,6 +243,34 @@ available_internal_state(Bool) when Bool == true; Bool == false ->
     end,
     CurAIS.
 
+%% Helper for ?AssertErrorStack().
+assert_error_stack(ErrorFun, StackFun, ExprFun) ->
+    try ExprFun() of
+        Result ->
+            error({unexpected_success,Result})
+    catch
+        error:Error:Stack ->
+            case {ErrorFun(Error),StackFun(Stack)} of
+                {ok,ok} ->
+                    ok;
+                {ActualError,ActualStack} ->
+                    Args = case ActualError of
+                               ok ->
+                                   [];
+                               _ ->
+                                   [{unexpected_error, Error},
+                                    {expected, ActualError}]
+                           end ++
+                        case ActualStack of
+                            ok ->
+                                [];
+                            _ ->
+                                [{unexpected_stack, Stack},
+                                 {expected_stack, ActualStack}]
+                        end,
+                    error(assertException, Args)
+            end
+    end.
 
 %%
 %% Check reference counters for node- and dist entries.

--- a/erts/emulator/test/erts_test_utils.hrl
+++ b/erts/emulator/test/erts_test_utils.hrl
@@ -1,0 +1,38 @@
+%%
+%% %CopyrightBegin%
+%%
+%% SPDX-License-Identifier: Apache-2.0
+%%
+%% Copyright Ericsson AB 2026. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% %CopyrightEnd%
+%%
+
+%% Same as AssertErrorStack in test_lib.hrl
+-define(AssertErrorStack(Error, Stack, Expr),
+        erts_test_utils:assert_error_stack(
+          fun(__Error__) ->
+                  case __Error__ of
+                      Error -> ok;
+                      (_) -> ??Error
+                  end
+          end,
+          fun(__Stack__) ->
+                  case __Stack__ of
+                      Stack -> ok;
+                      (_) -> ??Stack
+                  end
+          end,
+          fun() -> Expr end)).

--- a/erts/emulator/test/float_SUITE.erl
+++ b/erts/emulator/test/float_SUITE.erl
@@ -23,6 +23,7 @@
 -module(float_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -export([all/0, suite/0, groups/0,
          init_per_testcase/2, end_per_testcase/2,
@@ -61,7 +62,7 @@ otp_7178(Config) when is_list(Config) ->
     true = (X < 0.00000001) and (X > -0.00000001),
     Y = list_to_float("1.0e-325325325"),
     true = (Y < 0.00000001) and (Y > -0.00000001),
-    {'EXIT', {badarg,_}} = (catch list_to_float("1.0e83291083210")),
+    ?assertError(badarg, list_to_float("1.0e83291083210")),
     ok.
 
 negative_zero(Config) when is_list(Config) ->
@@ -97,13 +98,13 @@ do_negative_zero(Op, Ops) ->
 
 fpe(Config) when is_list(Config) ->
     0.0 = math:log(1.0),
-    {'EXIT', {badarith, _}} = (catch math:log(-1.0)),
+    ?assertError(badarith, math:log(-1.0)),
     0.0 = math:log(1.0),
-    {'EXIT', {badarith, _}} = (catch math:log(0.0)),
+    ?assertError(badarith, math:log(0.0)),
     0.0 = math:log(1.0),
-    {'EXIT',{badarith,_}} = (catch 3.23e133 * id(3.57e257)),
+    ?assertError(badarith, 3.23e133 * id(3.57e257)),
     0.0 = math:log(1.0),
-    {'EXIT',{badarith,_}} = (catch 5.0/id(0.0)),
+    ?assertError(badarith, 5.0/id(0.0)),
     0.0 = math:log(1.0),
     ok.
 
@@ -186,7 +187,7 @@ match(Config) when is_list(Config) ->
     one = match_1(1.0),
     two = match_1(2.0),
     a_lot = match_1(1000.0),
-    {'EXIT',_} = (catch match_1(0.5)),
+    ?assertError(_, match_1(0.5)),
     ok.
 
 match_1(1.0) -> one;
@@ -317,14 +318,14 @@ hidden_inf(Config) when is_list(Config) ->
     ok.
 
 hidden_inf_1(A, B, Zero, Huge) ->
-    {'EXIT',{badarith,_}} = (catch (B / (A / Zero))),
-    {'EXIT',{badarith,_}} = (catch (B * (A / Zero))),
-    {'EXIT',{badarith,_}} = (catch (B / (Huge * Huge))),
-    {'EXIT',{badarith,_}} = (catch (B * (Huge * Huge))),
-    {'EXIT',{badarith,_}} = (catch (B / (Huge + Huge))),
-    {'EXIT',{badarith,_}} = (catch (B * (Huge + Huge))),
-    {'EXIT',{badarith,_}} = (catch (B / (-Huge - Huge))),
-    {'EXIT',{badarith,_}} = (catch (B * (-Huge - Huge))).
+    ?assertError(badarith, (B / (A / Zero))),
+    ?assertError(badarith, (B * (A / Zero))),
+    ?assertError(badarith, (B / (Huge * Huge))),
+    ?assertError(badarith, (B * (Huge * Huge))),
+    ?assertError(badarith, (B / (Huge + Huge))),
+    ?assertError(badarith, (B * (Huge + Huge))),
+    ?assertError(badarith, (B / (-Huge - Huge))),
+    ?assertError(badarith, (B * (-Huge - Huge))).
 
 %% Improve code coverage in our different arithmetic functions
 %% and make sure they yield consistent results.
@@ -377,8 +378,8 @@ do_bin_ops(A, B) ->
 
 op_add(A, B) ->
     Info = [A,B],
-    R = unify(catch A + B, Info),
-    R = unify(my_apply(erlang,'+',[A,B]), Info),
+    R = unify(fun() -> A + B end, Info),
+    R = unify(fun() -> my_apply(erlang,'+',[A,B]) end, Info),
     case R of
         _ when A + B == element(1,R) -> ok;
         {{'EXIT',badarith}, Info} -> ok
@@ -386,8 +387,8 @@ op_add(A, B) ->
 
 op_sub(A, B) ->
     Info = [A,B],
-    R = unify(catch A - B, Info),
-    R = unify(my_apply(erlang,'-',[A,B]), Info),
+    R = unify(fun() -> A - B end, Info),
+    R = unify(fun() -> my_apply(erlang,'-',[A,B]) end, Info),
     case R of
         _ when A - B == element(1,R) -> ok;
         {{'EXIT',badarith}, Info} -> ok
@@ -395,8 +396,8 @@ op_sub(A, B) ->
 
 op_mul(A, B) ->
     Info = [A,B],
-    R = unify(catch A * B, Info),
-    R = unify(my_apply(erlang,'*',[A,B]), Info),
+    R = unify(fun() -> A * B end, Info),
+    R = unify(fun() -> my_apply(erlang,'*',[A,B]) end, Info),
     case R of
         _ when A * B == element(1,R) -> ok;
         {{'EXIT',badarith}, Info} -> ok
@@ -404,22 +405,24 @@ op_mul(A, B) ->
 
 op_div(A, B) ->
     Info = [A,B],
-    R = unify(catch A / B, Info),
-    R = unify(my_apply(erlang,'/',[A,B]), Info),
+    R = unify(fun() -> A / B end, Info),
+    R = unify(fun() -> my_apply(erlang,'/',[A,B]) end, Info),
     case R of
         _ when A / B == element(1,R) -> ok;
         {{'EXIT',badarith}, Info} -> ok
     end.
 
 my_apply(M, F, A) ->
-    catch apply(id(M), id(F), A).
+    apply(id(M), id(F), A).
 
-% Unify exceptions be removing stack traces.
+% Unify exceptions by removing stack traces
 % and add argument info to make it easier to debug failed matches.
-unify({'EXIT',{Reason,_Stack}}, Info) ->
-    {{'EXIT', Reason}, Info};
-unify(Other, Info) ->
-    {Other, Info}.
+unify(Fun, Info) ->
+    try Fun() of
+        Value -> {Value, Info}
+    catch
+        error:Reason -> {{'EXIT', Reason}, Info}
+    end.
 
 
 -define(epsilon, 1.0e-20).

--- a/erts/emulator/test/num_bif_SUITE.erl
+++ b/erts/emulator/test/num_bif_SUITE.erl
@@ -115,7 +115,7 @@ t_float(Config) when is_list(Config) ->
 
     %% Extremely big bignums.
     Big = id(list_to_integer(id(lists:duplicate(2000, $1)))),
-    {'EXIT', {badarg, _}} = (catch float(Big)),
+    ?assertError(badarg, float(Big)),
 
     ok.
 
@@ -133,24 +133,22 @@ t_float_to_string(Config) when is_list(Config) ->
     test_fts("1.00000000000000000000e+00",1.0,  []),
     test_fts("-1.00000000000000000000e+00",-1.0, []),
     test_fts("-1.00000000000000000000",-1.0, [{decimals, 20}]),
-    {'EXIT', {badarg, _}} = (catch float_to_list(1.0,  [{decimals, -1}])),
-    {'EXIT', {badarg, _}} = (catch float_to_list(1.0,  [{decimals, 254}])),
-    {'EXIT', {badarg, _}} = (catch float_to_list(1.0,  [{scientific, 250}])),
-    {'EXIT', {badarg, _}} = (catch float_to_list(1.0e+300, [{decimals, 1}])),
-    {'EXIT', {badarg, _}} = (catch float_to_binary(1.0,  [{decimals, -1}])),
-    {'EXIT', {badarg, _}} = (catch float_to_binary(1.0,  [{decimals, 254}])),
-    {'EXIT', {badarg, _}} = (catch float_to_binary(1.0,  [{scientific, 250}])),
-    {'EXIT', {badarg, _}} = (catch float_to_binary(1.0e+300, [{decimals, 1}])),
+    ?assertError(badarg, float_to_list(1.0,  [{decimals, -1}])),
+    ?assertError(badarg, float_to_list(1.0,  [{decimals, 254}])),
+    ?assertError(badarg, float_to_list(1.0,  [{scientific, 250}])),
+    ?assertError(badarg, float_to_list(1.0e+300, [{decimals, 1}])),
+    ?assertError(badarg, float_to_binary(1.0,  [{decimals, -1}])),
+    ?assertError(badarg, float_to_binary(1.0,  [{decimals, 254}])),
+    ?assertError(badarg, float_to_binary(1.0,  [{scientific, 250}])),
+    ?assertError(badarg, float_to_binary(1.0e+300, [{decimals, 1}])),
     test_fts("1.0e+300",1.0e+300, [{scientific, 1}]),
     test_fts("1.0",1.0,  [{decimals,   249}, compact]),
     test_fts("1",1.0,[{decimals,0}]),
     test_fts("2",1.9,[{decimals,0}]),
     test_fts("123456789012345680.0",123456789012345678.0,
 	     [{decimals, 236}, compact]),
-    {'EXIT', {badarg, _}} = (catch float_to_list(
-				     123456789012345678.0, [{decimals, 237}])),
-    {'EXIT', {badarg, _}} = (catch float_to_binary(
-				     123456789012345678.0, [{decimals, 237}])),
+    ?assertError(badarg, float_to_list(123456789012345678.0, [{decimals, 237}])),
+    ?assertError(badarg, float_to_binary(123456789012345678.0, [{decimals, 237}])),
     test_fts("1." ++ lists:duplicate(249, $0) ++ "e+00",
 	     1.0,  [{scientific, 249}, compact]),
 
@@ -377,14 +375,14 @@ t_string_to_float_safe(Config) when is_list(Config) ->
     test_stf(127.5,"127.5"),
     test_stf(-199.5,"-199.5"),
 
-    {'EXIT',{badarg,_}} = (catch list_to_float(id("0"))),
-    {'EXIT',{badarg,_}} = (catch list_to_float(id("0..0"))),
-    {'EXIT',{badarg,_}} = (catch list_to_float(id("0e12"))),
-    {'EXIT',{badarg,_}} = (catch list_to_float(id("--0.0"))),
-    {'EXIT',{badarg,_}} = (catch binary_to_float(id(<<"0">>))),
-    {'EXIT',{badarg,_}} = (catch binary_to_float(id(<<"0..0">>))),
-    {'EXIT',{badarg,_}} = (catch binary_to_float(id(<<"0e12">>))),
-    {'EXIT',{badarg,_}} = (catch binary_to_float(id(<<"--0.0">>))),
+    ?assertError(badarg, list_to_float(id("0"))),
+    ?assertError(badarg, list_to_float(id("0..0"))),
+    ?assertError(badarg, list_to_float(id("0e12"))),
+    ?assertError(badarg, list_to_float(id("--0.0"))),
+    ?assertError(badarg, binary_to_float(id(<<"0">>))),
+    ?assertError(badarg, binary_to_float(id(<<"0..0">>))),
+    ?assertError(badarg, binary_to_float(id(<<"0e12">>))),
+    ?assertError(badarg, binary_to_float(id(<<"--0.0">>))),
 
     UBin = <<0:3,(id(<<"0.0">>))/binary,0:5>>,
     <<_:3,UnAlignedBin:3/binary,0:5>> = id(UBin),
@@ -402,11 +400,10 @@ t_string_to_float_safe(Config) when is_list(Config) ->
 t_string_to_float_risky(Config) when is_list(Config) ->
     Many_Ones = lists:duplicate(25000, id($1)),
     id(list_to_float("2."++Many_Ones)),
-    {'EXIT', {badarg, _}} = (catch list_to_float("2"++Many_Ones)),
+    ?assertError(badarg, list_to_float("2"++Many_Ones)),
 
     id(binary_to_float(list_to_binary("2."++Many_Ones))),
-    {'EXIT', {badarg, _}} = (catch binary_to_float(
-				     list_to_binary("2"++Many_Ones))),
+    ?assertError(badarg, binary_to_float(list_to_binary("2"++Many_Ones))),
     ok.
 
 test_stf(Expect,List) ->
@@ -575,11 +572,9 @@ t_integer_to_string(Config) when is_list(Config) ->
 
     %% Invalid types
     lists:foreach(fun(Value) ->
-			  {'EXIT', {badarg, _}} =
-			      (catch erlang:integer_to_binary(Value)),
-			  {'EXIT', {badarg, _}} =
-			      (catch erlang:integer_to_list(Value))
-		  end,[atom,1.2,0.0,[$1,[$2]]]),
+                          ?assertError(badarg, erlang:integer_to_binary(Value)),
+                          ?assertError(badarg, erlang:integer_to_list(Value))
+                  end,[atom,1.2,0.0,[$1,[$2]]]),
 
     %% Base-2 integers
     test_its("0", 0, 2),
@@ -603,11 +598,9 @@ t_integer_to_string(Config) when is_list(Config) ->
     634681 = byte_size(Str),
 
     lists:foreach(fun(Value) ->
-			  {'EXIT', {badarg, _}} =
-			      (catch erlang:integer_to_binary(Value, 8)),
-			  {'EXIT', {badarg, _}} =
-			      (catch erlang:integer_to_list(Value, 8))
-		  end,[atom,1.2,0.0,[$1,[$2]]]),
+                          ?assertError(badarg, erlang:integer_to_binary(Value, 8)),
+                          ?assertError(badarg, erlang:integer_to_list(Value, 8))
+                  end,[atom,1.2,0.0,[$1,[$2]]]),
 
     ok.
 
@@ -730,26 +723,20 @@ t_string_to_integer(Config) when is_list(Config) ->
 
     %% Invalid types
     lists:foreach(fun(Value) ->
-			  {'EXIT', {badarg, _}} =
-			      (catch bin_to_int(Value)),
-			  {'EXIT', {badarg, _}} =
-			      (catch list_to_integer(Value))
+                      ?assertError(badarg, bin_to_int(Value)),
+                      ?assertError(badarg, list_to_integer(Value))
 		  end,[atom,1.2,0.0,[$1,[$2]]]),
 
     %% Default base error cases
     lists:foreach(fun(Value) ->
-			  {'EXIT', {badarg, _}} =
-			      (catch bin_to_int(list_to_binary(Value))),
-			  {'EXIT', {badarg, _}} =
-			      (catch list_to_integer(Value))
+                      ?assertError(badarg, bin_to_int(list_to_binary(Value))),
+                      ?assertError(badarg, list_to_integer(Value))
 		  end,["1.0"," 1"," -1","","+"]),
 
     %% Custom base error cases
     lists:foreach(fun({Value,Base}) ->
-			  {'EXIT', {badarg, _}} =
-			      (catch binary_to_integer(list_to_binary(Value), Base)),
-			  {'EXIT', {badarg, _}} =
-			      (catch list_to_integer(Value, Base))
+                      ?assertError(badarg, binary_to_integer(list_to_binary(Value), Base)),
+                      ?assertError(badarg, list_to_integer(Value, Base))
 		  end,
                   [{" 1",1},{" 1",37},{"2",2},{"B",11},{"b",11},{":", 16},
                    {"1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111z",16},
@@ -766,9 +753,9 @@ t_string_to_integer(Config) when is_list(Config) ->
 
     %% System limit
     Digits = lists:duplicate(3_000_000, $9),
-    {'EXIT',{system_limit,_}} = catch list_to_integer(Digits),
+    ?assertError(system_limit, list_to_integer(Digits)),
     _ = erlang:garbage_collect(),
-    {'EXIT',{system_limit,_}} = catch list_to_integer(Digits, 16),
+    ?assertError(system_limit, list_to_integer(Digits, 16)),
     _ = erlang:garbage_collect(),
     {error,system_limit} = string:to_integer(Digits),
     _ = erlang:garbage_collect(),

--- a/erts/emulator/test/op_SUITE.erl
+++ b/erts/emulator/test/op_SUITE.erl
@@ -23,6 +23,7 @@
 -module(op_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -export([all/0, suite/0,
          bsl_bsr/1,logical/1,t_not/1,relop_simple/1,relop/1,
@@ -66,37 +67,37 @@ bsl_bsr_const(A) ->
     BSL = id('bsl'),
     BSR = id('bsr'),
 
-    bsl_bsr_compare_results((catch erlang:BSL(1, A)), (catch 1 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSL(3, A)), (catch 3 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSL(7, A)), (catch 7 bsl A)),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(1, A) end, fun() -> 1 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(3, A) end, fun() -> 3 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(7, A) end, fun() -> 7 bsl A end),
 
-    bsl_bsr_compare_results((catch erlang:BSL(A, 1)), (catch A bsl 1)),
-    bsl_bsr_compare_results((catch erlang:BSL(A, 3)), (catch A bsl 3)),
-    bsl_bsr_compare_results((catch erlang:BSL(A, 7)), (catch A bsl 7)),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(A, 1) end, fun() -> A bsl 1 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(A, 3) end, fun() -> A bsl 3 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(A, 7) end, fun() -> A bsl 7 end),
 
-    bsl_bsr_compare_results((catch erlang:BSL(-2, A)), (catch -2 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSL(-4, A)), (catch -4 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSL(-8, A)), (catch -8 bsl A)),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(-2, A) end, fun() -> -2 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(-4, A) end, fun() -> -4 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(-8, A) end, fun() -> -8 bsl A end),
 
-    bsl_bsr_compare_results((catch erlang:BSL(A, -2)), (catch A bsl -2)),
-    bsl_bsr_compare_results((catch erlang:BSL(A, -4)), (catch A bsl -4)),
-    bsl_bsr_compare_results((catch erlang:BSL(A, -8)), (catch A bsl -8)),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(A, -2) end, fun() -> A bsl -2 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(A, -4) end, fun() -> A bsl -4 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(A, -8) end, fun() -> A bsl -8 end),
 
-    bsl_bsr_compare_results((catch erlang:BSR(1, A)), (catch 1 bsr A)),
-    bsl_bsr_compare_results((catch erlang:BSR(3, A)), (catch 3 bsr A)),
-    bsl_bsr_compare_results((catch erlang:BSR(7, A)), (catch 7 bsr A)),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(1, A) end, fun() -> 1 bsr A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(3, A) end, fun() -> 3 bsr A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(7, A) end, fun() -> 7 bsr A end),
 
-    bsl_bsr_compare_results((catch erlang:BSR(A, 1)), (catch A bsr 1)),
-    bsl_bsr_compare_results((catch erlang:BSR(A, 3)), (catch A bsr 3)),
-    bsl_bsr_compare_results((catch erlang:BSR(A, 7)), (catch A bsr 7)),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(A, 1) end, fun() -> A bsr 1 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(A, 3) end, fun() -> A bsr 3 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(A, 7) end, fun() -> A bsr 7 end),
 
-    bsl_bsr_compare_results((catch erlang:BSR(-2, A)), (catch -2 bsr A)),
-    bsl_bsr_compare_results((catch erlang:BSR(-4, A)), (catch -4 bsr A)),
-    bsl_bsr_compare_results((catch erlang:BSR(-8, A)), (catch -8 bsr A)),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(-2, A) end, fun() -> -2 bsr A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(-4, A) end, fun() -> -4 bsr A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(-8, A) end, fun() -> -8 bsr A end),
 
-    bsl_bsr_compare_results((catch erlang:BSR(A, -2)), (catch A bsr -2)),
-    bsl_bsr_compare_results((catch erlang:BSR(A, -4)), (catch A bsr -4)),
-    bsl_bsr_compare_results((catch erlang:BSR(A, -8)), (catch A bsr -8)),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(A, -2) end, fun() -> A bsr -2 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(A, -4) end, fun() -> A bsr -4 end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(A, -8) end, fun() -> A bsr -8 end),
 
 
     %% These numbers can be shifted left one or zero times while remaining a
@@ -106,26 +107,25 @@ bsl_bsr_const(A) ->
     HighEdge32 = (1 bsl (32 - 6)) - 1,
     LowEdge32 = -(1 bsl (32 - 6)),
 
-    bsl_bsr_compare_results((catch erlang:BSL(HighEdge32, A)), (catch HighEdge32 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSL(LowEdge32, A)), (catch LowEdge32 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSR(HighEdge32, A)), (catch HighEdge32 bsr A)),
-    bsl_bsr_compare_results((catch erlang:BSR(LowEdge32, A)), (catch LowEdge32 bsr A)),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(HighEdge32, A) end, fun() -> HighEdge32 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(LowEdge32, A) end, fun() -> LowEdge32 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(HighEdge32, A) end, fun() -> HighEdge32 bsr A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(LowEdge32, A) end, fun() -> LowEdge32 bsr A end),
 
     HighEdge64 = (1 bsl (64 - 6)) - 1,
     LowEdge64 = -(1 bsl (64 - 6)),
 
-    bsl_bsr_compare_results((catch erlang:BSL(HighEdge64, A)), (catch HighEdge64 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSL(LowEdge64, A)), (catch LowEdge64 bsl A)),
-    bsl_bsr_compare_results((catch erlang:BSR(HighEdge64, A)), (catch HighEdge64 bsr A)),
-    bsl_bsr_compare_results((catch erlang:BSR(LowEdge64, A)), (catch LowEdge64 bsr A)),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(HighEdge64, A) end, fun() -> HighEdge64 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSL(LowEdge64, A) end, fun() -> LowEdge64 bsl A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(HighEdge64, A) end, fun() -> HighEdge64 bsr A end),
+    bsl_bsr_compare_results(fun() -> erlang:BSR(LowEdge64, A) end, fun() -> LowEdge64 bsr A end),
 
     ok.
 
-bsl_bsr_compare_results(Same, Same) ->
-    ok;
-bsl_bsr_compare_results({'EXIT',{Reason,[_|_]}}, {'EXIT',{Reason,[_|_]}}) ->
-    %% The applied and inlined implementations may differ in whether they include
-    %% the operator as the top element of the stack.
+bsl_bsr_compare_results(Fun1, Fun2) ->
+    R1 = try Fun1() catch Class1:Reason1 -> {Class1, Reason1} end,
+    R2 = try Fun2() catch Class2:Reason2 -> {Class2, Reason2} end,
+    true = R1 =:= R2,
     ok.
 
 %% Test the logical operators and internal BIFs.
@@ -549,12 +549,13 @@ guard_expr({Op,X,Y}) ->
     {E,{Op,value(X),value(Y)},Res}.
 
 run_function(Mod, Name) ->
-    case catch Mod:Name() of
-        {'EXIT',Reason} ->
-            io:format("~p", [get(last)]),
-            ct:fail({'EXIT',Reason});
+    try Mod:Name() of
         _Other ->
             ok
+    catch
+        _:Reason ->
+            io:format("~p", [get(last)]),
+            ct:fail({'EXIT',Reason})
     end.
 
 guard_test({E,Expr,Res}, Tail) ->
@@ -601,9 +602,12 @@ make_function(Name, Body) ->
 
 eval(E0) ->
     E = erl_parse:new_anno(E0),
-    case catch erl_eval:exprs(E, []) of
-        {'EXIT',Reason} -> {'EXIT',Reason};
+    try erl_eval:exprs(E, []) of
         {value,Val,_Bs} -> Val
+    catch
+        throw:Reason -> Reason;
+        exit:Reason -> {'EXIT',Reason};
+        error:Reason:Stk -> {'EXIT',{Reason,Stk}}
     end.
 
 unsafe_fusing(_Config) ->

--- a/erts/emulator/test/small_SUITE.erl
+++ b/erts/emulator/test/small_SUITE.erl
@@ -34,6 +34,8 @@
 -export([mul_add/0, division/0]).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include("erts_test_utils.hrl").
 
 suite() ->
     [{ct_hooks,[ts_install_cth]},
@@ -237,7 +239,7 @@ test_addition([], _) ->
     ok.
 
 bad_arith(F, A, B) ->
-    {'EXIT',{badarith,_}} = catch F(number1, A, B),
+    ?assertError(badarith, F(number1, A, B)),
     ok.
 
 %% Test that the JIT only omits the overflow check when it's safe.
@@ -714,11 +716,11 @@ test_mul_add_exceptions() ->
     error = madd(id(7), id(b), id(3), id(whatever)),
     error = madd(id(7), id(15), id(c), id(whatever)),
 
-    {'EXIT',{badarith,[{erlang,'*',[a,2],_}|_]}} = catch madd(id(a), id(2), id(0)),
-    {'EXIT',{badarith,[{erlang,'*',[a,2],_}|_]}} = catch madd(id(a), id(2), id(42)),
-    {'EXIT',{badarith,[{erlang,'*',[a,2],_}|_]}} = catch madd(id(a), id(2), id(c)),
-    {'EXIT',{badarith,[{erlang,'*',[3,b],_}|_]}} = catch madd(id(3), id(b), id(c)),
-    {'EXIT',{badarith,[{erlang,'+',[6,c],_}|_]}} = catch madd(id(2), id(3), id(c)),
+    ?AssertErrorStack(badarith, [{erlang,'*',[a,2],_}|_], madd(id(a), id(2), id(0))),
+    ?AssertErrorStack(badarith, [{erlang,'*',[a,2],_}|_], madd(id(a), id(2), id(42))),
+    ?AssertErrorStack(badarith, [{erlang,'*',[a,2],_}|_], madd(id(a), id(2), id(c))),
+    ?AssertErrorStack(badarith, [{erlang,'*',[3,b],_}|_], madd(id(3), id(b), id(c))),
+    ?AssertErrorStack(badarith, [{erlang,'+',[6,c],_}|_], madd(id(2), id(3), id(c))),
 
     ok.
 
@@ -1102,11 +1104,11 @@ test_bitwise(_Config) ->
     ok.
 
 expect_fc(Fun) ->
-    {'EXIT',{function_clause,_}} = catch Fun(id(bad)),
+    ?assertError(function_clause, Fun(id(bad))),
     ok.
 
 expect_badarith(Fun) ->
-    {'EXIT',{badarith,_}} = catch Fun(id(bad)),
+    ?assertError(badarith, Fun(id(bad))),
     ok.
 
 bitwise_gen_pairs() ->
@@ -1262,7 +1264,7 @@ test_bsl([{Name,{N,S}}|T], Mod) ->
                         ok
                 end;
             S < 0 ->
-                {'EXIT', {function_clause,_}} = catch Mod:Name(N, S)
+                ?assertError(function_clause, Mod:Name(N, S))
         end
     catch
         C:R:Stk ->
@@ -1375,7 +1377,7 @@ element(_Config) ->
     zero = element_1(0+4),
     one = element_1(1+4),
 
-    {'EXIT',{badarith,_}} = catch element_1(id(a)),
+    ?assertError(badarith, element_1(id(a))),
 
     %% Test element_2: Test that it fails for 0.
     one = element_2(1),
@@ -1386,9 +1388,9 @@ element(_Config) ->
     two = element_2(2+4),
     three = element_2(3+4),
 
-    {'EXIT',{badarg,[{erlang,element,[0,{one,two,three}],_}|_]}} =
-        catch element_2(id(0)),
-    {'EXIT',{badarith,_}} = catch element_2(id(b)),
+    ?AssertErrorStack(badarg, [{erlang,element,[0,{one,two,three}],_}|_],
+                      element_2(id(0))),
+    ?assertError(badarith, element_2(id(b))),
 
     %% Test element_3: Test that if fails for integers less than 1.
     one = element_3(1),
@@ -1399,11 +1401,11 @@ element(_Config) ->
     two = element_3(2+4),
     three = element_3(3+4),
 
-    {'EXIT',{badarg,[{erlang,element,[0,{one,two,three}],_}|_]}} =
-        catch element_3(id(0)),
-    {'EXIT',{badarg,_}} = catch element_3(id(-1)),
-    {'EXIT',{badarg,_}} = catch element_3(id(-999)),
-    {'EXIT',{badarith,_}} = catch element_3(id(c)),
+    ?AssertErrorStack(badarg, [{erlang,element,[0,{one,two,three}],_}|_],
+                      element_3(id(0))),
+    ?assertError(badarg, element_3(id(-1))),
+    ?assertError(badarg, element_3(id(-999))),
+    ?assertError(badarith, element_3(id(c))),
 
     %% Test element_4: Test that it fails for integers outside of the range 1..3.
     one = element_4(1),
@@ -1414,14 +1416,14 @@ element(_Config) ->
     two = element_4(2+8),
     three = element_4(3+8),
 
-    {'EXIT',{badarg,[{erlang,element,[0,{one,two,three}],_}|_]}} =
-        catch element_4(id(0)),
-    {'EXIT',{badarg,[{erlang,element,[5,{one,two,three}],_}|_]}} =
-        catch element_4(id(5)),
-    {'EXIT',{badarg,_}} = catch element_4(id(-1)),
-    {'EXIT',{badarg,[{erlang,element,[-7,{one,two,three}],_}|_]}} =
-        catch element_4(id(-999)),
-    {'EXIT',{badarith,_}} = catch element_4(id(d)),
+    ?AssertErrorStack(badarg, [{erlang,element,[0,{one,two,three}],_}|_],
+                      element_4(id(0))),
+    ?AssertErrorStack(badarg, [{erlang,element,[5,{one,two,three}],_}|_],
+                      element_4(id(5))),
+    ?assertError(badarg, element_4(id(-1))),
+    ?AssertErrorStack(badarg, [{erlang,element,[-7,{one,two,three}],_}|_],
+                      element_4(id(-999))),
+    ?assertError(badarith, element_4(id(d))),
 
     %% Test element_5: Test that it fails for integers outside of the
     %% range 0..3.
@@ -1435,11 +1437,11 @@ element(_Config) ->
     two = element_5(2+8),
     three = element_5(3+8),
 
-    {'EXIT',{badarg,[{erlang,element,[5,{zero,one,two,three}],_}|_]}} =
-        catch element_5(id(4)),
-    {'EXIT',{badarg,[{erlang,element,[0,{zero,one,two,three}],_}|_]}} =
-        catch element_5(id(-1)),
-    {'EXIT',{badarith,_}} = catch element_5(id(e)),
+    ?AssertErrorStack(badarg, [{erlang,element,[5,{zero,one,two,three}],_}|_],
+                      element_5(id(4))),
+    ?AssertErrorStack(badarg, [{erlang,element,[0,{zero,one,two,three}],_}|_],
+                      element_5(id(-1))),
+    ?assertError(badarith, element_5(id(e))),
 
     %% element_6: Test that it fails for values outside of 0..3.
     zero = element_6(0),
@@ -1447,10 +1449,10 @@ element(_Config) ->
     two = element_6(2),
     three = element_6(3),
 
-    {'EXIT',{badarg,[{erlang,element,[5,{zero,one,two,three}],_}|_]}} =
-        catch element_6(id(4)),
-    {'EXIT',{badarg,[{erlang,element,[0,{zero,one,two,three}],_}|_]}} =
-        catch element_6(id(-1)),
+    ?AssertErrorStack(badarg, [{erlang,element,[5,{zero,one,two,three}],_}|_],
+                      element_6(id(4))),
+    ?AssertErrorStack(badarg, [{erlang,element,[0,{zero,one,two,three}],_}|_],
+                      element_6(id(-1))),
 
     %% Test element_7: Test that it fails for values outside of 1..3.
     one = element_7(1),
@@ -1461,11 +1463,11 @@ element(_Config) ->
     two = element_7(2+5),
     three = element_7(3+5),
 
-    {'EXIT',{badarg,[{erlang,element,[0,{one,two,three}],_}|_]}} =
-        catch element_7(id(0)),
-    {'EXIT',{badarg,[{erlang,element,[4,{one,two,three}],_}|_]}} =
-        catch element_7(id(4)),
-    {'EXIT',{badarith,_}} = catch element_7(id(f)),
+    ?AssertErrorStack(badarg, [{erlang,element,[0,{one,two,three}],_}|_],
+                      element_7(id(0))),
+    ?AssertErrorStack(badarg, [{erlang,element,[4,{one,two,three}],_}|_],
+                      element_7(id(4))),
+    ?assertError(badarith, element_7(id(f))),
 
     %% element_8: Test that it works in a guard.
     ok = element_8(id(1), id(a)),


### PR DESCRIPTION
Also add `erts_test_utils.hrl`, which is the same as compiler's `test_lib.hrl`.